### PR TITLE
Stats: add purchase redirection support for Odyssey

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -643,7 +643,11 @@ export function emailSummary( context, next ) {
 
 export function purchase( context, next ) {
 	context.primary = (
-		<AsyncLoad require="calypso/my-sites/stats/stats-purchase" placeholder={ PageLoading } />
+		<AsyncLoad
+			require="calypso/my-sites/stats/stats-purchase"
+			placeholder={ PageLoading }
+			query={ context.query }
+		/>
 	);
 	next();
 }

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -43,7 +43,7 @@ const DoYouLoveJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
 			: recordTracksEvent(
 					'calypso_stats_do_you_love_jetpack_stats_notice_support_button_clicked'
 			  );
-		// TODO: use Jetpack Redirects for more precise tracking.
+		// TODO: use Jetpack Redirects for more precise tracking for Odyssey.
 		// Allow some time for the event to be recorded before redirecting.
 		setTimeout(
 			() => ( window.location.href = getStatsPurchaseURL( siteId, isOdysseyStats ) ),

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -11,10 +11,11 @@ import { StatsNoticeProps } from './types';
 
 const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) => {
 	const from = isOdysseyStats ? 'jetpack' : 'calypso';
-	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/paid-stats&from=${ from }`;
+	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/paid-stats&from=${ from }-stats-upgrade-notice`;
 	if ( ! isOdysseyStats ) {
 		return purchasePath;
 	}
+	// We use absolute path here as it runs in Odyssey as well.
 	return `https://wordpress.com${ purchasePath }`;
 };
 

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -9,9 +9,9 @@ import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice
 import useNoticeVisibilityQuery from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { StatsNoticeProps } from './types';
 
-const getStatsPurchaseURL = ( siteId: number | null ) => {
-	const purchasePath = `/stats/purchase/${ siteId }`;
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) => {
+	const from = isOdysseyStats ? 'jetpack' : 'calypso';
+	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/paid-stats&from=${ from }`;
 	if ( ! isOdysseyStats ) {
 		return purchasePath;
 	}
@@ -43,8 +43,12 @@ const DoYouLoveJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
 			: recordTracksEvent(
 					'calypso_stats_do_you_love_jetpack_stats_notice_support_button_clicked'
 			  );
+		// TODO: use Jetpack Redirects for more precise tracking.
 		// Allow some time for the event to be recorded before redirecting.
-		setTimeout( () => ( window.location.href = getStatsPurchaseURL( siteId ) ), 250 );
+		setTimeout(
+			() => ( window.location.href = getStatsPurchaseURL( siteId, isOdysseyStats ) ),
+			250
+		);
 	};
 
 	useEffect( () => {

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -76,8 +76,8 @@ export default function StatsNotices( {
 
 	return supportNewStatsNotices ? (
 		<>
-			<NewStatsNotices siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
 			<PostPurchaseNotices siteId={ siteId } statsPurchaseSuccess={ statsPurchaseSuccess } />
+			<NewStatsNotices siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
 		</>
 	) : (
 		<LegacyStatsNotices siteId={ siteId } />

--- a/client/my-sites/stats/stats-page-view-tracker/index.tsx
+++ b/client/my-sites/stats/stats-page-view-tracker/index.tsx
@@ -9,6 +9,7 @@ export interface StatsPageViewTrackerProps {
 	title: string;
 	properties?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 	options?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+	from?: string;
 }
 
 // This component will pass through all properties to PageViewTracker from the analytics library.

--- a/client/my-sites/stats/stats-page-view-tracker/use-tracks.tsx
+++ b/client/my-sites/stats/stats-page-view-tracker/use-tracks.tsx
@@ -26,6 +26,7 @@ export default function useTracks( {
 
 	// These are the props from the useSelector calls in StatsPageViewTracker.
 	selectedSiteId,
+	...restProps
 }: useTracksProps ) {
 	const dispatch = useDispatch() as ThunkDispatch< Store, void, AnyAction >;
 
@@ -42,6 +43,7 @@ export default function useTracks( {
 			path,
 			properties,
 			title,
+			...restProps,
 		};
 
 		debug( `Recording: "${ title }" at "${ path }"` );

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -62,7 +62,11 @@ const StatsPurchasePage = ( { query }: { query: { redirect_uri: string; from: st
 	return (
 		<Main fullWidthLayout>
 			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
-			<PageViewTracker path="/stats/purchase/:site" title="Stats > Purchase" />
+			<PageViewTracker
+				path="/stats/purchase/:site"
+				title="Stats > Purchase"
+				options={ { from: query.from } }
+			/>
 			<div className="stats">
 				<QueryProductsList />
 				{

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -30,7 +30,7 @@ const isProductOwned = ( ownedProducts: SiteProduct[] | null, searchedProduct: s
 		.includes( searchedProduct );
 };
 
-const StatsPurchasePage = ( { query } ) => {
+const StatsPurchasePage = ( { query }: { query: { redirect_uri: string; from: string } } ) => {
 	const translate = useTranslate();
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -30,7 +30,7 @@ const isProductOwned = ( ownedProducts: SiteProduct[] | null, searchedProduct: s
 		.includes( searchedProduct );
 };
 
-const StatsPurchasePage = () => {
+const StatsPurchasePage = ( { query } ) => {
 	const translate = useTranslate();
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -82,6 +82,9 @@ const StatsPurchasePage = () => {
 							siteSlug={ siteSlug }
 							commercialProduct={ commercialProduct }
 							pwywProduct={ pwywProduct }
+							siteId={ siteId }
+							redirectUri={ query.redirect_uri ?? '' }
+							from={ query.from ?? '' }
 						/>
 					</>
 				) }

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -65,7 +65,7 @@ const StatsPurchasePage = ( { query }: { query: { redirect_uri: string; from: st
 			<PageViewTracker
 				path="/stats/purchase/:site"
 				title="Stats > Purchase"
-				options={ { from: query.from } }
+				from={ query.from ?? '' }
 			/>
 			<div className="stats">
 				<QueryProductsList />

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -40,10 +40,10 @@ const getRedirectUrl = ( {
 	redirectUri?: string;
 	siteSlug: string;
 } ) => {
-	const isFromJetpack = from.startsWith( 'jetpack' );
+	const isStartedFromJetpackSite = from.startsWith( 'jetpack' );
 	const statsPurchaseSuccess = type === 'free' ? 'free' : 'paid';
 
-	if ( ! isFromJetpack ) {
+	if ( ! isStartedFromJetpackSite ) {
 		redirectUri = addPurchaseTypeToUri(
 			redirectUri || `/stats/day/${ siteSlug }`,
 			statsPurchaseSuccess

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -51,7 +51,7 @@ const getRedirectUrl = ( {
 		return redirectUri;
 	}
 	redirectUri = addPurchaseTypeToUri( redirectUri || 'admin.php?page=stats', statsPurchaseSuccess );
-	return adminUrl + redirectUri;
+	return adminUrl + redirectUri.replace( /^\//, '' );
 };
 
 const gotoCheckoutPage = ( {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -6,20 +6,15 @@ import {
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 const getStatsPurchaseURL = ( siteSlug: string, product: string, redirectUrl: string ) => {
-	const checkoutUrl = new URL( 'https://wordpress.com/checkout/' );
-	const checkoutProductUrl = new URL( `${ checkoutUrl }${ siteSlug }/${ product }` );
+	const checkoutProductUrl = new URL(
+		`/checkout/${ siteSlug }/${ product }`,
+		window.location.origin
+	);
 
 	// Add redirect_to parameter
-	if ( redirectUrl ) {
-		checkoutProductUrl.searchParams.set( 'redirect_to', redirectUrl ); // TODO: add a redirect URL with query parameter showing proper success/fail banner
-	} else {
-		checkoutProductUrl.searchParams.set(
-			'redirect_to',
-			`https://wordpress.com/stats/${ siteSlug }`
-		);
-	}
+	checkoutProductUrl.searchParams.set( 'redirect_to', redirectUrl );
 
-	return checkoutProductUrl.toString();
+	return checkoutProductUrl.pathname + checkoutProductUrl.search;
 };
 
 const getYearlyPrice = ( monthlyPrice: number ) => {
@@ -27,31 +22,53 @@ const getYearlyPrice = ( monthlyPrice: number ) => {
 };
 
 const addPurchaseTypeToUri = ( uri: string, statsPurchaseSuccess: string ) => {
-	const url = new URL( uri, 'https://wordpress.com' );
+	const url = new URL( uri, window.location.origin );
 	url.searchParams.set( 'statsPurchaseSuccess', statsPurchaseSuccess );
 	return url.pathname + url.search;
 };
 
-const getRedirectUrl = ( from: string, type: string, adminUrl?: string, redirectUri?: string ) => {
+const getRedirectUrl = ( {
+	from,
+	type,
+	adminUrl,
+	redirectUri,
+	siteSlug,
+}: {
+	from: string;
+	type: string;
+	adminUrl?: string;
+	redirectUri?: string;
+	siteSlug: string;
+} ) => {
 	const isFromJetpack = from.startsWith( 'jetpack' );
 	const statsPurchaseSuccess = type === 'free' ? 'free' : 'paid';
+
 	if ( ! isFromJetpack ) {
-		// TODO: add siteSlug to the redirect URL
-		redirectUri = addPurchaseTypeToUri( redirectUri || '/stats/day', statsPurchaseSuccess );
+		redirectUri = addPurchaseTypeToUri(
+			redirectUri || `/stats/day/${ siteSlug }`,
+			statsPurchaseSuccess
+		);
 		return redirectUri;
 	}
 	redirectUri = addPurchaseTypeToUri( redirectUri || 'admin.php?page=stats', statsPurchaseSuccess );
 	return adminUrl + redirectUri;
 };
 
-const gotoCheckoutPage = (
-	from: string,
-	type: 'pwyw' | 'free' | 'commercial',
-	siteSlug: string,
-	adminUrl?: string,
-	redirectUri?: string,
-	price?: number
-) => {
+const gotoCheckoutPage = ( {
+	from,
+	type,
+	siteSlug,
+	adminUrl,
+	redirectUri,
+	price,
+}: {
+	from: string;
+	type: 'pwyw' | 'free' | 'commercial';
+	siteSlug: string;
+	adminUrl?: string;
+	redirectUri?: string;
+	price?: number;
+} ) => {
 	let eventName = '';
 	let product: string;
 
@@ -76,7 +93,7 @@ const gotoCheckoutPage = (
 
 	recordTracksEvent( `calypso_stats_${ eventName }_purchase_button_clicked` );
 
-	const redirectUrl = getRedirectUrl( from, type, adminUrl, redirectUri );
+	const redirectUrl = getRedirectUrl( { from, type, adminUrl, redirectUri, siteSlug } );
 
 	// Allow some time for the event to be recorded before redirecting.
 	setTimeout(

--- a/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
@@ -88,7 +88,9 @@ const CommercialPurchase = ( {
 
 			<Button
 				variant="primary"
-				onClick={ () => gotoCheckoutPage( from, 'commercial', siteSlug, adminUrl, redirectUri ) }
+				onClick={ () =>
+					gotoCheckoutPage( { from, type: 'commercial', siteSlug, adminUrl, redirectUri } )
+				}
 			>
 				{ translate( 'Get Jetpack Stats for %(value)s per month', {
 					args: {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
@@ -11,9 +11,19 @@ interface CommercialPurchaseProps {
 	planValue: number;
 	currencyCode: string;
 	siteSlug: string;
+	adminUrl: string;
+	redirectUri: string;
+	from: string;
 }
 
-const CommercialPurchase = ( { planValue, currencyCode, siteSlug }: CommercialPurchaseProps ) => {
+const CommercialPurchase = ( {
+	planValue,
+	currencyCode,
+	siteSlug,
+	adminUrl,
+	redirectUri,
+	from,
+}: CommercialPurchaseProps ) => {
 	const translate = useTranslate();
 	const planPriceObject = getCurrencyObject( planValue, currencyCode );
 
@@ -76,7 +86,10 @@ const CommercialPurchase = ( { planValue, currencyCode, siteSlug }: CommercialPu
 				) }
 			</p>
 
-			<Button variant="primary" onClick={ () => gotoCheckoutPage( 'commercial', siteSlug ) }>
+			<Button
+				variant="primary"
+				onClick={ () => gotoCheckoutPage( from, 'commercial', siteSlug, adminUrl, redirectUri ) }
+			>
 				{ translate( 'Get Jetpack Stats for %(value)s per month', {
 					args: {
 						value: formatCurrency( planValue, currencyCode ),

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -177,7 +177,9 @@ const PersonalPurchase = ( {
 				<Button
 					variant="primary"
 					disabled={ ! isAdsChecked || ! isSellingChecked || ! isBusinessChecked }
-					onClick={ () => gotoCheckoutPage( from, 'free', siteSlug, adminUrl, redirectUri ) }
+					onClick={ () =>
+						gotoCheckoutPage( { from, type: 'free', siteSlug, adminUrl, redirectUri } )
+					}
 				>
 					{ translate( 'Continue with Jetpack Stats for free' ) }
 				</Button>
@@ -185,7 +187,14 @@ const PersonalPurchase = ( {
 				<Button
 					variant="primary"
 					onClick={ () =>
-						gotoCheckoutPage( from, 'pwyw', siteSlug, adminUrl, redirectUri, subscriptionValue )
+						gotoCheckoutPage( {
+							from,
+							type: 'pwyw',
+							siteSlug,
+							adminUrl,
+							redirectUri,
+							price: subscriptionValue,
+						} )
 					}
 				>
 					{ translate( 'Get Jetpack Stats for %(value)s per month', {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -16,6 +16,9 @@ interface PersonalPurchaseProps {
 	siteSlug: string;
 	sliderStep: number;
 	maxSliderPrice: number;
+	adminUrl: string;
+	redirectUri: string;
+	from: string;
 }
 
 const PersonalPurchase = ( {
@@ -26,6 +29,9 @@ const PersonalPurchase = ( {
 	siteSlug,
 	sliderStep,
 	maxSliderPrice,
+	adminUrl,
+	redirectUri,
+	from,
 }: PersonalPurchaseProps ) => {
 	const translate = useTranslate();
 	const [ isAdsChecked, setAdsChecked ] = useState( false );
@@ -171,14 +177,16 @@ const PersonalPurchase = ( {
 				<Button
 					variant="primary"
 					disabled={ ! isAdsChecked || ! isSellingChecked || ! isBusinessChecked }
-					onClick={ () => gotoCheckoutPage( 'free', siteSlug ) }
+					onClick={ () => gotoCheckoutPage( from, 'free', siteSlug, adminUrl, redirectUri ) }
 				>
 					{ translate( 'Continue with Jetpack Stats for free' ) }
 				</Button>
 			) : (
 				<Button
 					variant="primary"
-					onClick={ () => gotoCheckoutPage( 'pwyw', siteSlug, subscriptionValue ) }
+					onClick={ () =>
+						gotoCheckoutPage( from, 'pwyw', siteSlug, adminUrl, redirectUri, subscriptionValue )
+					}
 				>
 					{ translate( 'Get Jetpack Stats for %(value)s per month', {
 						args: {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -194,12 +194,14 @@ const ProductCard = ( { siteSlug, commercialProduct, pwywProduct } ) => {
 	);
 };
 
-const StatsPurchaseWizard = ( { siteSlug, commercialProduct, pwywProduct } ) => {
+const StatsPurchaseWizard = ( { siteSlug, commercialProduct, pwywProduct, query } ) => {
+	// redirectTo is a relative URI.
 	return (
 		<ProductCard
 			siteSlug={ siteSlug }
 			commercialProduct={ commercialProduct }
 			pwywProduct={ pwywProduct }
+			query={ query }
 		/>
 	);
 };

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -6,6 +6,7 @@ import React, { useState } from 'react';
 import statsPurchaseBackgroundSVG from 'calypso/assets/images/stats/purchase-background.svg';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import CommercialPurchase from './stats-purchase-commercial';
 import PersonalPurchase from './stats-purchase-personal';
 import StatsPurchaseSVG from './stats-purchase-svg';
@@ -41,7 +42,7 @@ const TitleNode = ( { label, indicatorNumber, active } ) => {
 	);
 };
 
-const ProductCard = ( { siteSlug, commercialProduct, pwywProduct } ) => {
+const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redirectUri, from } ) => {
 	const [ subscriptionValue, setSubscriptionValue ] = useState(
 		PRICING_CONFIG.DEFAULT_STARTING_PRICE
 	);
@@ -49,6 +50,7 @@ const ProductCard = ( { siteSlug, commercialProduct, pwywProduct } ) => {
 	const [ siteType, setSiteType ] = useState( null );
 	const translate = useTranslate();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 
 	const personalLabel = translate( 'Personal site' );
 	const commercialLabel = translate( 'Commercial site' );
@@ -165,6 +167,9 @@ const ProductCard = ( { siteSlug, commercialProduct, pwywProduct } ) => {
 											siteSlug={ siteSlug }
 											sliderStep={ sliderStep }
 											maxSliderPrice={ maxSliderPrice }
+											adminUrl={ adminUrl }
+											redirectUri={ redirectUri }
+											from={ from }
 										/>
 									) : (
 										<CommercialPurchase
@@ -172,6 +177,9 @@ const ProductCard = ( { siteSlug, commercialProduct, pwywProduct } ) => {
 											currencyCode={ currencyCode }
 											siteSlug={ siteSlug }
 											commercialProduct={ commercialProduct }
+											adminUrl={ adminUrl }
+											redirectUri={ redirectUri }
+											from={ from }
 										/>
 									) }
 								</PanelRow>
@@ -194,14 +202,23 @@ const ProductCard = ( { siteSlug, commercialProduct, pwywProduct } ) => {
 	);
 };
 
-const StatsPurchaseWizard = ( { siteSlug, commercialProduct, pwywProduct, query } ) => {
+const StatsPurchaseWizard = ( {
+	siteSlug,
+	siteId,
+	commercialProduct,
+	pwywProduct,
+	redirectUri,
+	from,
+} ) => {
 	// redirectTo is a relative URI.
 	return (
 		<ProductCard
 			siteSlug={ siteSlug }
+			siteId={ siteId }
 			commercialProduct={ commercialProduct }
 			pwywProduct={ pwywProduct }
-			query={ query }
+			redirectUri={ redirectUri }
+			from={ from }
 		/>
 	);
 };


### PR DESCRIPTION
## Proposed Changes

#### Purchase page
- Adds a `from` param which allows the redirection to Calypso or Jetpack accordingly
  - If the param `from` starts with `jetpack`, then it redirect to Odyssey Stats
  - Otherwise, it redirects to Calypso Stats
- Minor refactoring many params to objects for some functions
- Passes `from` and `redirect_uri` from top components down and adds support customizable `redirect_to` URL
- Record `from` to the page view so that we could have better understanding of how the entry points perform

#### Purchase success notices: 
- Removes feature flag as the notices are triggered by GET params

Known issues: notices for Simple and WoA sites are still not showing, which would be addressed in https://github.com/Automattic/wp-calypso/pull/79096.


## Testing Instructions

#### Test purchase from Calypso for Jetpack sites:

1. Remove any Stats purchase from `https://wordpress.com/purchases/subscriptions/${siteSlug}`
2. Purge notice status if previous dismissed:
  * Run `wpsh` in sandbox
  * Run `switch_to_blog($blog_id);`
  * Run `delete_option('stats_dashboard_options');`
3. Open live branch `/stats/day/${siteSlug}?flags=stats/stats-paid`
5. Ensure you see the upgrade notice
6. Click `Upgrade my Stats`

<img width="801" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/14815816-495b-44b5-a623-5a15cb80c2e3">


7. Ensure it redirects to the purchase page
8. Choose Personal
9. Slide to $0/month, check all the boxes and finish the purchase
10. Ensure you are redirected back to `/stats/day/${siteSlug}` on Calypso
11. Ensure upgrade success notice is showing (Free / Paid)

<img width="812" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/b0df2b47-fc6a-4c88-99f8-422c53c4bebf">

#### Repeat the above steps for PWYW and Commercial licenses.

#### Test purchase from Jetpack sites:

1. Remove any Stats purchase from `https://wordpress.com/purchases/subscriptions/${siteSlug}`
2. Purge notice status if previous dismissed:
  * Run `wpsh` in sandbox
  * Run `switch_to_blog($blog_id);`
  * Run `delete_option('stats_dashboard_options');`
3. Build Jetpack if necessary `jetpack build plugins/jetpack`
4. Build Odyssey Stats locally `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev`
3. Your local Jetpack site on `/stats/day/${siteSlug}flags=stats/paid-stats`
3. Open a connected Jetpack site `/wp-admin/admin.php?page=stats#!/stats/day/193141071?page=stats&flags=stats/paid-stats`
4. Ensure you see the upgrade notice
5. Click `Upgrade my Stats`
7. Ensure it redirects to the purchase page on https://wordpress.com
8. Replace the hostname with the hostname of the live branch (Please do NOT miss this step. If you are testing locally, please use `http://calypso.localhost:3000`)
9. Choose Personal
10. Slide to $0/month, check all the boxes and finish the purchase
11. Ensure you are redirected back to the Stats Dashboard of the Jetpack site
12. Ensure upgrade success notice is showing (Free / Paid)

#### Repeat the above steps for PWYW and Commercial licenses.

#### Upgrade from Free to PWYW
- Purchase a Free subscription
- Still see the upgrade banner
- Click `Upgrade my Stats`
- Ensure you could purchase PWYW

#### Upgrade from Free to Commercial
- Purchase a Free subscription
- Still see the upgrade banner
- Click `Upgrade my Stats`
- Ensure you could purchase Commercial

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
