### PR TITLE
Reader: Fix post card with missing comments

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -202,7 +202,7 @@ class ReaderPostCard extends Component {
 					title={ title }
 					isDiscover={ isDiscover }
 					postByline={ postByline }
-					commentIds={ postKey.comments ?? [] }
+					commentIds={ postKey?.comments ?? [] }
 					onClick={ this.handleCardClick }
 				/>
 			);


### PR DESCRIPTION
## Proposed Changes

Fixing an error that occurs when comments are missing inside the reader post card component. We previously added a default, but we also need to handle the case when `postKey` is not defined for some reason.

## Testing Instructions

Verify that a post without comments and with comments still displays its comments correctly.
