### PR TITLE
chore: fix typo for `root_domain_provider` value being `unkwnown`.

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
@@ -31,7 +31,7 @@ const ConnectDomainStepOwnershipAuthCode = ( {
 					.isAvailable( { apiVersion: '1.3', is_cart_pre_check: false } );
 				setRootDomainProvider( availability.root_domain_provider );
 			} catch {
-				setRootDomainProvider( 'unkwnown' );
+				setRootDomainProvider( 'unknown' );
 			}
 		} )();
 	} );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/79598.

## Proposed Changes

This PR fixes the typo described in the above issue.

## Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Calypso E2E (desktop)
  - [ ] Calypso E2E (mobile)

Additionally, ensure the value returned by the `is-available` API call has the proper value `root_domain_provider`: `unknown` set.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
