### PR TITLE
Remove unneded Stats call in calypso

### DIFF
--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -4,14 +4,13 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { BlazablePost, Campaign } from 'calypso/data/promote-post/types';
 import useCampaignsQueryPaged from 'calypso/data/promote-post/use-promote-post-campaigns-query-paged';
-import useCampaignsStatsQuery from 'calypso/data/promote-post/use-promote-post-campaigns-stats-query';
 import useCreditBalanceQuery from 'calypso/data/promote-post/use-promote-post-credit-balance-query';
 import usePostsQueryPaged, {
 	getSearchOptionsQueryParams,
@@ -25,7 +24,7 @@ import {
 	SORT_OPTIONS_DEFAULT,
 	SearchOptions,
 } from 'calypso/my-sites/promote-post-i2/components/search-bar';
-import { getPagedBlazeSearchData, unifyCampaigns } from 'calypso/my-sites/promote-post-i2/utils';
+import { getPagedBlazeSearchData } from 'calypso/my-sites/promote-post-i2/utils';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import CreditBalance from './components/credit-balance';
@@ -103,12 +102,6 @@ export default function PromotedPosts( { tab }: Props ) {
 	const { has_more_pages: campaignsHasMorePages, items: pagedCampaigns } = getPagedBlazeSearchData(
 		'campaigns',
 		campaignsData
-	);
-
-	const { data: campaignsStatsData } = useCampaignsStatsQuery( selectedSiteId ?? 0 );
-	const campaigns = useMemo(
-		() => unifyCampaigns( pagedCampaigns as Campaign[], campaignsStatsData ),
-		[ pagedCampaigns, campaignsStatsData ]
 	);
 
 	const { total_items: totalCampaignsUnfiltered } = getPagedBlazeSearchData(
@@ -270,7 +263,7 @@ export default function PromotedPosts( { tab }: Props ) {
 						handleSearchOptions={ setCampaignsSearchOptions }
 						totalCampaigns={ totalCampaignsUnfiltered || 0 }
 						hasMorePages={ campaignsHasMorePages }
-						campaigns={ campaigns as Campaign[] }
+						campaigns={ pagedCampaigns as Campaign[] }
 					/>
 				</>
 			) }

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
-import { BlazablePost, Campaign, CampaignStats } from 'calypso/data/promote-post/types';
+import { BlazablePost, Campaign } from 'calypso/data/promote-post/types';
 import {
 	PagedBlazeContentData,
 	PagedBlazeSearchResponse,
@@ -217,26 +217,6 @@ export function getAdvertisingDashboardPath( path: string ) {
 	const pathPrefix = config( 'advertising_dashboard_path_prefix' ) || '/advertising';
 	return `${ pathPrefix }${ path }`;
 }
-
-/**
- * Unifies the campaign list with the stats list
- *
- * @param {Campaign[]} campaigns List of campaigns
- * @param {CampaignStats[]} campaignsStats List of campaign stats
- * @returns A unified list of campaign with the stats
- */
-export const unifyCampaigns = (
-	campaigns: Campaign[] = [],
-	campaignsStats: CampaignStats[] = []
-) => {
-	return campaigns.map( ( campaign ) => {
-		const stats = campaignsStats.find( ( cs ) => cs.campaign_id === campaign.campaign_id );
-		return {
-			...campaign,
-			...( stats ? stats : {} ),
-		};
-	} );
-};
 
 export const getShortDateString = ( date: string ) => {
 	const timestamp = moment( Date.parse( date ) );


### PR DESCRIPTION
Related to #

## Proposed Changes

- Remove previous /stats call since now it is not needed. We obtain the stats from the DSP database instead of a different endpoint

## Testing Instructions
- Open the campaign list 
- Check that no /stats call is done in network tab (devtools)
- You still can see impressions and clicks

## Pre-merge Checklist
- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
