### PR TITLE
Plans 2023: Change `isMobile` prop to `isTableCell` in `Container`

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -72,20 +72,20 @@ import type { IAppState } from 'calypso/state/types';
 import './style.scss';
 
 type PlanRowOptions = {
-	isMobile?: boolean;
+	isTableCell?: boolean;
 };
 
 const Container = (
 	props: (
 		| React.HTMLAttributes< HTMLDivElement >
 		| React.HTMLAttributes< HTMLTableCellElement >
-	 ) & { isMobile?: boolean; scope?: string }
+	 ) & { isTableCell?: boolean; scope?: string }
 ) => {
-	const { children, isMobile, ...otherProps } = props;
-	return isMobile ? (
-		<div { ...otherProps }>{ children }</div>
-	) : (
+	const { children, isTableCell, ...otherProps } = props;
+	return isTableCell ? (
 		<td { ...otherProps }>{ children }</td>
+	) : (
+		<div { ...otherProps }>{ children }</div>
 	);
 };
 
@@ -141,9 +141,9 @@ const PlanLogo: React.FunctionComponent< {
 	renderedPlans: PlanSlug[];
 	planIndex: number;
 	planProperties: PlanProperties;
-	isMobile?: boolean;
+	isTableCell?: boolean;
 	isInSignup?: boolean;
-} > = ( { renderedPlans, planProperties, planIndex, isMobile, isInSignup } ) => {
+} > = ( { renderedPlans, planProperties, planIndex, isTableCell, isInSignup } ) => {
 	const { planRecords } = usePlansGridContext();
 	const { planName, current } = planProperties;
 	const translate = useTranslate();
@@ -173,7 +173,7 @@ const PlanLogo: React.FunctionComponent< {
 	const shouldShowWooLogo = isEcommercePlan( planName ) && ! isWooExpressPlan( planName );
 
 	return (
-		<Container key={ planName } className={ tableItemClasses } isMobile={ isMobile }>
+		<Container key={ planName } className={ tableItemClasses } isTableCell={ isTableCell }>
 			<PopularBadge
 				isInSignup={ isInSignup }
 				planName={ planName }
@@ -356,16 +356,22 @@ export class PlanFeatures2023Grid extends Component<
 					{ translate( 'Available plans to choose from' ) }
 				</caption>
 				<tbody>
-					<tr>{ this.renderPlanLogos( planPropertiesToRender ) }</tr>
-					<tr>{ this.renderPlanHeaders( planPropertiesToRender ) }</tr>
-					<tr>{ this.renderPlanTagline( planPropertiesToRender ) }</tr>
-					<tr>{ this.renderPlanPrice( planPropertiesToRender ) }</tr>
-					<tr>{ this.renderBillingTimeframe( planPropertiesToRender ) }</tr>
-					<tr>{ this.renderTopButtons( planPropertiesToRender ) }</tr>
-					<tr>{ this.maybeRenderRefundNotice( planPropertiesToRender ) }</tr>
-					<tr>{ this.renderPreviousFeaturesIncludedTitle( planPropertiesToRender ) }</tr>
-					<tr>{ this.renderPlanFeaturesList( planPropertiesToRender ) }</tr>
-					<tr>{ this.renderPlanStorageOptions( planPropertiesToRender ) }</tr>
+					<tr>{ this.renderPlanLogos( planPropertiesToRender, { isTableCell: true } ) }</tr>
+					<tr>{ this.renderPlanHeaders( planPropertiesToRender, { isTableCell: true } ) }</tr>
+					<tr>{ this.renderPlanTagline( planPropertiesToRender, { isTableCell: true } ) }</tr>
+					<tr>{ this.renderPlanPrice( planPropertiesToRender, { isTableCell: true } ) }</tr>
+					<tr>{ this.renderBillingTimeframe( planPropertiesToRender, { isTableCell: true } ) }</tr>
+					<tr>{ this.renderTopButtons( planPropertiesToRender, { isTableCell: true } ) }</tr>
+					<tr>{ this.maybeRenderRefundNotice( planPropertiesToRender, { isTableCell: true } ) }</tr>
+					<tr>
+						{ this.renderPreviousFeaturesIncludedTitle( planPropertiesToRender, {
+							isTableCell: true,
+						} ) }
+					</tr>
+					<tr>{ this.renderPlanFeaturesList( planPropertiesToRender, { isTableCell: true } ) }</tr>
+					<tr>
+						{ this.renderPlanStorageOptions( planPropertiesToRender, { isTableCell: true } ) }
+					</tr>
 				</tbody>
 			</table>
 		);
@@ -430,14 +436,14 @@ export class PlanFeatures2023Grid extends Component<
 				);
 				const planCardJsx = (
 					<div className={ planCardClasses } key={ `${ properties.planName }-${ index }` }>
-						{ this.renderPlanLogos( [ properties ], { isMobile: true } ) }
-						{ this.renderPlanHeaders( [ properties ], { isMobile: true } ) }
-						{ this.renderPlanTagline( [ properties ], { isMobile: true } ) }
-						{ this.renderPlanPrice( [ properties ], { isMobile: true } ) }
-						{ this.renderBillingTimeframe( [ properties ], { isMobile: true } ) }
+						{ this.renderPlanLogos( [ properties ] ) }
+						{ this.renderPlanHeaders( [ properties ] ) }
+						{ this.renderPlanTagline( [ properties ] ) }
+						{ this.renderPlanPrice( [ properties ] ) }
+						{ this.renderBillingTimeframe( [ properties ] ) }
 						{ this.renderMobileFreeDomain( properties.planName, properties.isMonthlyPlan ) }
-						{ this.renderTopButtons( [ properties ], { isMobile: true } ) }
-						{ this.maybeRenderRefundNotice( [ properties ], { isMobile: true } ) }
+						{ this.renderTopButtons( [ properties ] ) }
+						{ this.maybeRenderRefundNotice( [ properties ] ) }
 						<CardContainer
 							header={ translate( 'Show all features' ) }
 							planName={ properties.planName }
@@ -447,11 +453,9 @@ export class PlanFeatures2023Grid extends Component<
 								properties.features.some( ( feature ) => feature.getSlug() === selectedFeature )
 							}
 						>
-							{ this.renderPreviousFeaturesIncludedTitle( [ properties ], {
-								isMobile: true,
-							} ) }
-							{ this.renderPlanFeaturesList( [ properties ], { isMobile: true } ) }
-							{ this.renderPlanStorageOptions( [ properties ], { isMobile: true } ) }
+							{ this.renderPreviousFeaturesIncludedTitle( [ properties ] ) }
+							{ this.renderPlanFeaturesList( [ properties ] ) }
+							{ this.renderPlanStorageOptions( [ properties ] ) }
 						</CardContainer>
 					</div>
 				);
@@ -480,12 +484,12 @@ export class PlanFeatures2023Grid extends Component<
 		return (
 			<div className="plan-features-2023-grid__plan-spotlight">
 				<div className={ spotlightPlanClasses }>
-					{ this.renderPlanLogos( [ spotlightPlanProperties ], { isMobile: true } ) }
-					{ this.renderPlanHeaders( [ spotlightPlanProperties ], { isMobile: true } ) }
-					{ this.renderPlanTagline( [ spotlightPlanProperties ], { isMobile: true } ) }
-					{ this.renderPlanPrice( [ spotlightPlanProperties ], { isMobile: true } ) }
-					{ this.renderBillingTimeframe( [ spotlightPlanProperties ], { isMobile: true } ) }
-					{ this.renderTopButtons( [ spotlightPlanProperties ], { isMobile: true } ) }
+					{ this.renderPlanLogos( [ spotlightPlanProperties ] ) }
+					{ this.renderPlanHeaders( [ spotlightPlanProperties ] ) }
+					{ this.renderPlanTagline( [ spotlightPlanProperties ] ) }
+					{ this.renderPlanPrice( [ spotlightPlanProperties ] ) }
+					{ this.renderBillingTimeframe( [ spotlightPlanProperties ] ) }
+					{ this.renderTopButtons( [ spotlightPlanProperties ] ) }
 				</div>
 			</div>
 		);
@@ -541,7 +545,7 @@ export class PlanFeatures2023Grid extends Component<
 						scope="col"
 						key={ planName }
 						className={ classes }
-						isMobile={ options?.isMobile }
+						isTableCell={ options?.isTableCell }
 					>
 						{ ! hasNoPrice && (
 							<PlanFeatures2023GridHeaderPrice
@@ -575,7 +579,7 @@ export class PlanFeatures2023Grid extends Component<
 				);
 
 				return (
-					<Container className={ classes } isMobile={ options?.isMobile } key={ planName }>
+					<Container className={ classes } isTableCell={ options?.isTableCell } key={ planName }>
 						<PlanFeatures2023GridBillingTimeframe
 							isMonthlyPlan={ isMonthlyPlan }
 							planName={ planName }
@@ -600,7 +604,7 @@ export class PlanFeatures2023Grid extends Component<
 					planIndex={ index }
 					renderedPlans={ renderedPlans.map( ( { planName } ) => planName ) }
 					planProperties={ properties }
-					isMobile={ options?.isMobile }
+					isTableCell={ options?.isTableCell }
 					isInSignup={ isInSignup }
 				/>
 			);
@@ -621,7 +625,7 @@ export class PlanFeatures2023Grid extends Component<
 					<Container
 						key={ planName }
 						className="plan-features-2023-grid__table-item"
-						isMobile={ options?.isMobile }
+						isTableCell={ options?.isTableCell }
 					>
 						<header className={ headerClasses }>
 							<h4 className="plan-features-2023-grid__header-title">
@@ -643,7 +647,7 @@ export class PlanFeatures2023Grid extends Component<
 					<Container
 						key={ planName }
 						className="plan-features-2023-grid__table-item"
-						isMobile={ options?.isMobile }
+						isTableCell={ options?.isTableCell }
 					>
 						<div className="plan-features-2023-grid__header-tagline">{ tagline }</div>
 					</Container>
@@ -707,7 +711,7 @@ export class PlanFeatures2023Grid extends Component<
 				}
 
 				return (
-					<Container key={ planName } className={ classes } isMobile={ options?.isMobile }>
+					<Container key={ planName } className={ classes } isTableCell={ options?.isTableCell }>
 						<PlanFeatures2023GridActions
 							manageHref={ manageHref }
 							canUserPurchasePlan={ canUserPurchasePlan }
@@ -746,7 +750,7 @@ export class PlanFeatures2023Grid extends Component<
 				<Container
 					key={ planProperties.planName }
 					className="plan-features-2023-grid__table-item"
-					isMobile={ options?.isMobile }
+					isTableCell={ options?.isTableCell }
 				>
 					{ ! isFreePlan( planProperties.planName ) && (
 						<div
@@ -812,11 +816,11 @@ export class PlanFeatures2023Grid extends Component<
 					getPlanClass( planName )
 				);
 				const rowspanProp =
-					! options?.isMobile && shouldRenderEnterpriseLogos ? { rowSpan: '2' } : {};
+					options?.isTableCell && shouldRenderEnterpriseLogos ? { rowSpan: '2' } : {};
 				return (
 					<Container
 						key={ planName }
-						isMobile={ options?.isMobile }
+						isTableCell={ options?.isTableCell }
 						className="plan-features-2023-grid__table-item"
 						{ ...rowspanProp }
 					>
@@ -848,7 +852,7 @@ export class PlanFeatures2023Grid extends Component<
 				return (
 					<Container
 						key={ `${ planName }-${ mapIndex }` }
-						isMobile={ options?.isMobile }
+						isTableCell={ options?.isTableCell }
 						className="plan-features-2023-grid__table-item"
 					>
 						<PlanFeatures2023GridFeatures
@@ -887,7 +891,7 @@ export class PlanFeatures2023Grid extends Component<
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( properties ) => {
-				if ( options?.isMobile && isWpcomEnterpriseGridPlan( properties.planName ) ) {
+				if ( ! options?.isTableCell && isWpcomEnterpriseGridPlan( properties.planName ) ) {
 					return null;
 				}
 
@@ -907,7 +911,7 @@ export class PlanFeatures2023Grid extends Component<
 					<Container
 						key={ planName }
 						className="plan-features-2023-grid__table-item plan-features-2023-grid__storage"
-						isMobile={ options?.isMobile }
+						isTableCell={ options?.isTableCell }
 					>
 						{ storageOptions.length ? (
 							<div className="plan-features-2023-grid__storage-title">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/78845#discussion_r1253248178

## Proposed Changes

* This PR removes the `isMobile` prop and adds an `isTableCell` prop in the `Container` component.
* If the `isTableCell` prop is passed as `true`, then the `Container` will be rendered as a `<td>` else, it will be rendered as a `<div>`.
* Changing the default rendering from `td` to `div` is in anticipation of a future refactor where we can refactor the `table` based view to a more flexible `div` based view.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans`.
* Confirm that the desktop, tablet and mobile views are rendered correctly and there are no console errors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
