### PR TITLE
Domains Transfer: screen 1 copy changes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
@@ -22,7 +22,7 @@ const Intro: Step = function Intro( { navigation } ) {
 			formattedHeader={
 				<FormattedHeader
 					id="domain-transfer-header"
-					headerText={ __( 'Domain Transfer Center' ) }
+					headerText={ __( 'Transfer your domains' ) }
 					subHeaderText={ __(
 						'Follow these 3 simple steps to transfer your domains to WordPress.com.'
 					) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
@@ -1,4 +1,3 @@
-import { localizeUrl } from '@automattic/i18n-utils';
 import { IntentScreen } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { Icon, unlock, plus, payment } from '@wordpress/icons';
@@ -23,19 +22,9 @@ const Intro: React.FC< Props > = ( { onSubmit } ) => {
 							<>
 								<p>
 									{ __(
-										"Your current registrar's domain management interface should have an option for you to remove the lock."
+										"Head to your current registrar's domain management settings, where you'll find the authorization code to unlock your domain."
 									) }
 								</p>
-								<a
-									href={ localizeUrl(
-										'https://wordpress.com/support/domains/incoming-domain-transfer/'
-									) }
-									target="_blank"
-									rel="noopener noreferrer"
-									className="select-items__item-learn-more"
-								>
-									{ __( 'Learn more' ) }
-								</a>
 							</>
 						),
 						icon: <Icon icon={ unlock } />,
@@ -49,19 +38,9 @@ const Intro: React.FC< Props > = ( { onSubmit } ) => {
 							<>
 								<p>
 									{ __(
-										'Add all domain names (along with their authorization codes) to start the transfer.'
+										'In the next step, add your domains and authorization codes and begin the transfer.'
 									) }
 								</p>
-								<a
-									href={ localizeUrl(
-										'https://wordpress.com/support/domains/incoming-domain-transfer/'
-									) }
-									target="_blank"
-									rel="noopener noreferrer"
-									className="select-items__item-learn-more"
-								>
-									{ __( 'Learn more' ) }
-								</a>
 							</>
 						),
 						icon: <Icon icon={ plus } />,
@@ -71,7 +50,9 @@ const Intro: React.FC< Props > = ( { onSubmit } ) => {
 					{
 						key: 'finalize',
 						title: __( 'Checkout' ),
-						description: <p>{ __( 'Add your contact and payment details.' ) }</p>,
+						description: (
+							<p>{ __( "Review your payment details and you're ready to start the transfer." ) }</p>
+						),
 						icon: <Icon icon={ payment } />,
 						value: 'finalize',
 						actionText: null,
@@ -82,8 +63,8 @@ const Intro: React.FC< Props > = ( { onSubmit } ) => {
 				onSelect={ onSubmit }
 			/>
 			<div style={ { display: 'flex', justifyContent: 'center' } }>
-				<Button isPrimary onClick={ onSubmit }>
-					{ __( "I'm ready!" ) }
+				<Button variant="primary" onClick={ onSubmit }>
+					{ __( 'Get started' ) }
 				</Button>
 			</div>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -124,7 +124,8 @@ $heading-font-family: "SF Pro Display", $sans;
 					justify-content: center;
 					padding-bottom: 26px;
 					padding-top: 26px;
-					width: 187px;
+					width: 200px;
+					height: 48px;
 
 					@media (max-width: $break-medium ) {
 						width: 100%;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -84,6 +84,7 @@ $heading-font-family: "SF Pro Display", $sans;
 					padding-right: 0;
 
 					.select-items__item {
+						width: 460px;
 						padding: 24px;
 
 						@media (max-width: $break-medium ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -122,8 +122,7 @@ $heading-font-family: "SF Pro Display", $sans;
 					font-size: $font-body-small;
 					font-weight: 500;
 					justify-content: center;
-					padding-bottom: 26px;
-					padding-top: 26px;
+					padding: 10px 24px;
 					width: 200px;
 					height: 48px;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -123,7 +123,7 @@ $heading-font-family: "SF Pro Display", $sans;
 					font-weight: 500;
 					justify-content: center;
 					padding: 10px 24px;
-					width: 200px;
+					width: 240px;
 					height: 48px;
 
 					@media (max-width: $break-medium ) {


### PR DESCRIPTION
## Proposed Changes

This applies the copy changes from the latest round of testing ( p9Jlb4-8kT-p2 ). Specifically for the first screen of the Domains Transfer flow.

<img width="1921" alt="Markup 2023-07-19 at 14 38 30" src="https://github.com/Automattic/wp-calypso/assets/33258733/3033baba-4a64-4e8b-8cd4-11f11c22400f">

## Testing Instructions

* Open Calypso live link
* Go to `/setup/domain-transfer/intro`
* Verify all changes from the P2 thread have been accounted for.