### PR TITLE
My Sites: Clear selected site on /domains/manage

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -454,6 +454,7 @@ export function noSite( context, next ) {
 	const isDomainOnlyFlow = context.query?.isDomainOnly === '1' || ! siteFragment;
 	const isJetpackCheckoutFlow = context.pathname.includes( '/checkout/jetpack' );
 	const isAkismetCheckoutFlow = context.pathname.includes( '/checkout/akismet' );
+	const isDomainsManage = context.pathname === '/domains/manage/';
 	const isGiftCheckoutFlow = context.pathname.includes( '/gift/' );
 	const isRenewal = context.pathname.includes( '/renew/' );
 
@@ -462,6 +463,7 @@ export function noSite( context, next ) {
 		! isJetpackCheckoutFlow &&
 		! isAkismetCheckoutFlow &&
 		! isGiftCheckoutFlow &&
+		! isDomainsManage &&
 		// We allow renewals without a site through because we want to show these
 		// users an error message on the checkout page.
 		! isRenewal &&

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -7,6 +7,7 @@ import {
 	sites,
 	wpForTeamsGeneralNotSupportedRedirect,
 	stagingSiteNotSupportedRedirect,
+	noSite,
 } from 'calypso/my-sites/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
@@ -141,6 +142,7 @@ export default function () {
 
 	page(
 		paths.domainManagementRoot(),
+		noSite,
 		...getCommonHandlers( { noSitePath: false, noSiteSelection: true } ),
 		domainManagementController.domainManagementListAllSites,
 		makeLayout,


### PR DESCRIPTION
## Proposed Changes

Clear selected site when landing on /domains/manage. This prevents issues with showing the wrong sidebar and content for previously selected sites.

This was especially an issue when previously looking at a Jetpack site then navigating to /domains/manage.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout patch
* Go to /domains/manage
* Verify you see list view
* Click on a domain only domain
* Verify you see information for that domain and the sidebar is specific to that domain
* Navigate back to /domains/manage
* Click on a domain attached to a site
* Verify that you see the standards sites sidebar
* Navigate back to /domains/manage
* In site selector, select a Jetpack site
* Ensure that you see a notice that you cannot apply domains to a Jetpack site (This should be addressed separately).
* Navigate back to /domains/manage
* Ensure that you see the the domains management list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
