### PR TITLE
Jetpack Cloud: Show an appropriate loading/disabled state when issuing a bundle license

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import LicenseBundleCard from 'calypso/jetpack-cloud/sections/partner-portal/license-bundle-card';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
@@ -122,8 +122,11 @@ export default function IssueMultipleLicensesForm( {
 
 	const { submitForm, isReady } = useSubmitForm( selectedSite, suggestedProductSlugs );
 
+	const [ selectedBundle, setSelectedBundle ] = useState< APIProductFamilyProduct | null >( null );
 	const onSelectBundle = useCallback(
 		( product: APIProductFamilyProduct ) => {
+			setSelectedBundle( product );
+
 			// People aren't allowed to select anything else after selecting a bundle;
 			// thus, after someone selects a bundle, we immediately clear any existing
 			// selections and issue a license for the bundle
@@ -226,6 +229,8 @@ export default function IssueMultipleLicensesForm( {
 							<LicenseBundleCard
 								key={ productOption.slug }
 								product={ productOption }
+								isBusy={ ! isReady && selectedBundle?.slug === productOption.slug }
+								isDisabled={ ! isReady && selectedBundle?.slug !== productOption.slug }
 								onSelectProduct={ onSelectBundle }
 								tabIndex={ 100 + ( products?.length || 0 ) + i }
 							/>

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
@@ -12,28 +12,30 @@ import { getProductTitle, LICENSE_INFO_MODAL_ID } from '../utils';
 
 import './style.scss';
 
-interface Props {
+type Props = {
+	isBusy: boolean;
+	isDisabled: boolean;
 	tabIndex: number;
 	product: APIProductFamilyProduct;
-	onSelectProduct: ( value: APIProductFamilyProduct ) => void | null;
-}
+	onSelectProduct?: ( value: APIProductFamilyProduct ) => void;
+};
 
-export default function LicenseBundleCard( props: Props ) {
-	const { setParams, resetParams, getParamValue } = useURLQueryParams();
-	const modalParamValue = getParamValue( LICENSE_INFO_MODAL_ID );
-
-	const { tabIndex, product, onSelectProduct } = props;
-	const productTitle = getProductTitle( product.name );
-	const [ showLightbox, setShowLightbox ] = useState( modalParamValue === product.slug );
+const LicenseBundleCard = ( {
+	isBusy = false,
+	isDisabled = false,
+	tabIndex,
+	product,
+	onSelectProduct,
+}: Props ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const onSelect = useCallback( () => {
-		onSelectProduct( product );
-	}, [ onSelectProduct, product ] );
-
+	const productTitle = getProductTitle( product.name );
 	const { description: productDescription } = useProductDescription( product.slug );
 
+	const { setParams, resetParams, getParamValue } = useURLQueryParams();
+	const modalParamValue = getParamValue( LICENSE_INFO_MODAL_ID );
+	const [ showLightbox, setShowLightbox ] = useState( modalParamValue === product.slug );
 	const onShowLightbox = useCallback(
 		( e: React.MouseEvent< HTMLElement > ) => {
 			e.stopPropagation();
@@ -60,6 +62,10 @@ export default function LicenseBundleCard( props: Props ) {
 		setShowLightbox( false );
 	}, [ resetParams ] );
 
+	const onSelect = useCallback( () => {
+		onSelectProduct?.( product );
+	}, [ onSelectProduct, product ] );
+
 	return (
 		<>
 			<div className="license-bundle-card">
@@ -77,6 +83,8 @@ export default function LicenseBundleCard( props: Props ) {
 					</div>
 					<Button
 						primary
+						busy={ isBusy }
+						disabled={ isDisabled }
 						className="license-bundle-card__select-license"
 						onClick={ onSelect }
 						tabIndex={ tabIndex }
@@ -96,8 +104,6 @@ export default function LicenseBundleCard( props: Props ) {
 			) }
 		</>
 	);
-}
-
-LicenseBundleCard.defaultProps = {
-	onSelectProduct: null,
 };
+
+export default LicenseBundleCard;


### PR DESCRIPTION
As discovered in #78701, when selecting a bundle to provision on the Jetpack Cloud dashboard, there's a significant delay between clicking the button and any action happening on the page. This PR attempts to alleviate the confusion people might face when they see this, by giving the button a loading state immediately when it's clicked. Other bundles' buttons are also rendered in a disabled state.

Related to -- and depends on -- #78701.

## Proposed Changes

* Add new props `isBusy` and `isDisabled` to `LicenseBundleCard`, and pass these values to the underlying `Button` component.
* In `IssueMultipleLicensesForm`:
  * track the state of which bundle (if any) is selected;
  * when a bundle is clicked, set the selected bundle state;
  * pass values of `isBusy` and `isDisabled` to `LicenseBundleCard` components, based on whether the bundle was selected and whether the mutation is busy.

## Testing Instructions

1. In your testing environment, visit the dashboard in Jetpack Cloud (`/dashboard`).
2. Click the `...` menu for a site that does not have a bundle associated with it.
3. Click "Issue new license."
4. Select any bundle on the next page.
5. Verify that upon selecting a bundle, the selected bundle's button renders a loading state, and the other bundles' buttons are disabled.
6. Verify the bundle license is correctly provisioned, with the same behavior as production/staging.

https://github.com/Automattic/wp-calypso/assets/670067/1e14c3be-72a7-4074-9ab1-d048493a4a44