### PR TITLE
Redirect /help/courses to wordpress.com/learn/courses

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -835,7 +835,7 @@ function wpcomPages( app ) {
 
 	// Redirects from /help/courses to https://wordpress.com/learn/courses.
 	app.get( '/help/courses', function ( req, res ) {
-		const redirectUrl = 'https://wordpress.com/learn/courses';
+		const redirectUrl = '/learn/courses';
 		res.redirect( 301, redirectUrl );
 	} );
 }

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -835,7 +835,7 @@ function wpcomPages( app ) {
 
 	// Redirects from /help/courses to https://wordpress.com/learn/courses.
 	app.get( '/help/courses', function ( req, res ) {
-		const redirectUrl = '/learn/courses';
+		const redirectUrl = 'https://wordpress.com/learn/courses';
 		res.redirect( 301, redirectUrl );
 	} );
 }

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -832,6 +832,11 @@ function wpcomPages( app ) {
 		const redirectUrl = '/setup/domain-transfer';
 		res.redirect( 301, redirectUrl );
 	} );
+
+	app.get( '/help/courses', function ( req, res ) {
+		const redirectUrl = 'https://wordpress.com/learn/courses';
+		res.redirect( 301, redirectUrl );
+	} );
 }
 
 export default function pages() {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -833,6 +833,7 @@ function wpcomPages( app ) {
 		res.redirect( 301, redirectUrl );
 	} );
 
+	// Redirects from /help/courses to https://wordpress.com/learn/courses.
 	app.get( '/help/courses', function ( req, res ) {
 		const redirectUrl = 'https://wordpress.com/learn/courses';
 		res.redirect( 301, redirectUrl );


### PR DESCRIPTION
The content in `/help/courses` is stale, so we redirect to `wordpress.com/learn/courses`

## Testing
1. Live link and visit `/help/courses`
2. You should land in `wordpress.com/learn/courses`


Fixes https://github.com/Automattic/wp-calypso/issues/59055