### PR TITLE
Flaky E2E: Wait for domain overlay SVG to get suggested domain.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/my-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/my-home-page.ts
@@ -92,7 +92,7 @@ export class MyHomePage {
 		const svgLocator = this.anchor.locator( '.domain-upsell-illustration svg' );
 
 		// But, innerText doesn't work on SVG nodes, so we need this locator to actually fetch the text.
-		const parentDivLocator = this.anchor.locator( '.domain-upsell-illustration ' );
+		const parentDivLocator = this.anchor.locator( '.domain-upsell-illustration' );
 		try {
 			await svgLocator.waitFor();
 			return await parentDivLocator.innerText();

--- a/packages/calypso-e2e/src/lib/pages/my-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/my-home-page.ts
@@ -85,10 +85,17 @@ export class MyHomePage {
 	 * @returns {string} Suggested domain. Empty string if not found.
 	 */
 	async getSuggestedUpsellDomain(): Promise< string > {
-		const locator = this.anchor.locator( '.domain-upsell-illustration' );
+		// It's important to wait for an actual svg element to be present.
+		// The handling here is a little funky. We take a blank palceholder img, then we
+		// draw an SVG with just the text on top of it.
+		// There's a race condition where the placeholder img can render before the the text svg does.
+		const svgLocator = this.anchor.locator( '.domain-upsell-illustration svg' );
+
+		// But, innerText doesn't work on SVG nodes, so we need this locator to actually fetch the text.
+		const parentDivLocator = this.anchor.locator( '.domain-upsell-illustration ' );
 		try {
-			await locator.waitFor();
-			return await locator.innerText();
+			await svgLocator.waitFor();
+			return await parentDivLocator.innerText();
 		} catch {
 			return '';
 		}


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #79619 

## Proposed Changes

The `domain-upsell__my-home.ts` test would on occasion hit a pretty gnarly race condition.

In short, when we load the suggested domain, we first load an `img` element with the placeholder browser image.
Then, we render an `svg` over that placeholder image that adds the suggested domain text.

In slow resource conditions, there is a race condition where the Playwright script would try to read the `innerText` right between those two steps! 😱 

The solution is to first wait for that overlay `svg`.

## Testing Instructions

All tests should pass in CI 👍 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
