### PR TITLE
[Odie] Experiment preparations bottom interaction

### DIFF
--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -93,15 +93,35 @@ const OdieAssistantProvider = ( {
 		} );
 	}, [ sectionName, siteId ] );
 
-	const addMessage = ( message: Message ) => {
+	const updatePlaceholderMessage = ( message: Message ) => {
 		setMessages( ( prevMessages ) => {
-			const newMessages = [ ...prevMessages, message ];
+			const newMessages = prevMessages.slice( 0, -1 ).concat( message );
 			setChat( ( prevChat ) => ( {
 				...prevChat,
 				messages: newMessages,
 			} ) );
 			return newMessages;
 		} );
+	};
+
+	const addMessage = ( message: Message ) => {
+		setMessages( ( prevMessages ) => {
+			const lastMessage = prevMessages[ prevMessages.length - 1 ];
+			// If the last message is placeholder type, replace it with the new message
+			if ( lastMessage?.type === 'placeholder' ) {
+				return [ ...prevMessages.slice( 0, -1 ), message ];
+			}
+			// Otherwise, add the new message
+			return [ ...prevMessages, message ];
+		} );
+
+		setChat( ( prevChat ) => ( {
+			...prevChat,
+			messages:
+				prevChat.messages[ prevChat.messages.length - 1 ].type === 'placeholder'
+					? [ ...prevChat.messages.slice( 0, -1 ), message ]
+					: [ ...prevChat.messages, message ],
+		} ) );
 	};
 
 	return (
@@ -125,7 +145,7 @@ const OdieAssistantProvider = ( {
 			} }
 		>
 			{ children }
-			<OdieAssistant />
+			<OdieAssistant botNameSlug="wapuu" simple />
 		</OdieAssistantContext.Provider>
 	);
 };

--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -93,17 +93,6 @@ const OdieAssistantProvider = ( {
 		} );
 	}, [ sectionName, siteId ] );
 
-	const updatePlaceholderMessage = ( message: Message ) => {
-		setMessages( ( prevMessages ) => {
-			const newMessages = prevMessages.slice( 0, -1 ).concat( message );
-			setChat( ( prevChat ) => ( {
-				...prevChat,
-				messages: newMessages,
-			} ) );
-			return newMessages;
-		} );
-	};
-
 	const addMessage = ( message: Message ) => {
 		setMessages( ( prevMessages ) => {
 			const lastMessage = prevMessages[ prevMessages.length - 1 ];

--- a/client/odie/index.tsx
+++ b/client/odie/index.tsx
@@ -158,9 +158,9 @@ const OdieAssistant = ( props: OdieAssistantProps ) => {
 		<div
 			className={ classnames( 'chatbox', {
 				'chatbox-show': isVisible && ! simple,
-				'chatbox-show-simple': ! isVisible && simple,
-				'chatbox-show-full': isVisible && simple,
 				'chatbox-hide': ! isVisible && ! simple,
+				'chatbox-show-vertical': isVisible && simple,
+				'chatbox-hide-vertical': ! isVisible && simple,
 				'using-environment-badge': environmentBadge,
 			} ) }
 		>
@@ -176,16 +176,15 @@ const OdieAssistant = ( props: OdieAssistantProps ) => {
 					'Wapuu Assistant'
 				) : (
 					<>
-						<Button className="chatbox-header-button" onClick={ handleToggleVisibility }>
+						<button className="chatbox-header-button" onClick={ handleToggleVisibility }>
 							<span
-								className={ classnames( 'chat-chevron', {
-									'chatbox-attention': ! userInteracted,
+								className={ classnames( {
+									'chatbox-attention': ! userInteracted || isNudging,
 								} ) }
 							>
-								{ isVisible ? '❯' : '❮' }
+								Wapuu Assistant
 							</span>
-						</Button>
-						Wapuu Assistant
+						</button>
 					</>
 				) }
 			</div>

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from '@wordpress/components';
 import { RefObject } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import CustomALink from './custom-a-link';
@@ -23,17 +24,23 @@ const ChatMessage = ( { message, isLast, messageEndRef }: ChatMessageProps ) => 
 				isUser ? 'odyssus-chatbox-message-user' : 'odyssus-chatbox-message-wapuu'
 			}` }
 		>
-			<AsyncLoad
-				require="react-markdown"
-				placeholder={ null }
-				transformLinkUri={ uriTransformer }
-				components={ {
-					a: CustomALink,
-				} }
-			>
-				{ message.content }
-			</AsyncLoad>
-			<LikeDislikeButtons isUser={ isUser } messageType={ message.type } />
+			{ message.type === 'placeholder' ? (
+				<Spinner />
+			) : (
+				<>
+					<AsyncLoad
+						require="react-markdown"
+						placeholder={ null }
+						transformLinkUri={ uriTransformer }
+						components={ {
+							a: CustomALink,
+						} }
+					>
+						{ message.content }
+					</AsyncLoad>
+					<LikeDislikeButtons isUser={ isUser } messageType={ message.type } />
+				</>
+			) }
 		</div>
 	);
 };

--- a/client/odie/style.scss
+++ b/client/odie/style.scss
@@ -18,10 +18,6 @@
 
 .chatbox-header {
 	width: 100%;
-	font-size: large;
-	font-weight: normal;
-	text-align: left;
-	line-height: 62px;
 	background-color: #23282d;
 	color: #fff;
 	border-radius: 4px;
@@ -164,24 +160,14 @@
 	bottom: 64px;
 }
 
-.chatbox-show-simple {
-	transform: translateX(calc(100% - 25px)); /* When chatbox is partially visible */
-	transition: transform 0.5s ease-in-out;
+/* When chatbox is hidden */
+.chatbox-hide-vertical {
+	transform: translateY(calc(100% + 5px));
 }
 
-.chatbox-show-full {
-	transform: translateX(0); /* When chatbox is fully visible */
-	transition: transform 0.5s ease-in-out;
-}
-
-.chatbox-header-button {
-	outline: none !important;
-}
-
-div.chatbox-header > button {
-	box-shadow: none !important;
-	padding-left: 6px;
-	padding-right: 16px;
+/* When chatbox is visible */
+.chatbox-show-vertical {
+	transform: translateY(0);
 }
 
 @keyframes fadeToColor {
@@ -208,6 +194,16 @@ div.chatbox-header > button {
 	animation: fadeToColor 4s linear infinite;
 }
 
-.chat-chevron {
+.chatbox-header-button {
 	color: #ece6f6;
+	border: none;
+	outline: none;
+	padding: 0;
+	cursor: pointer;
+	background: none;
+	font-size: large;
+	font-weight: normal;
+	text-align: left;
+	line-height: 62px;
+	width: 100%;
 }

--- a/client/odie/style.scss
+++ b/client/odie/style.scss
@@ -74,6 +74,7 @@
 }
 
 .chatbox-input {
+	padding-left: 8px;
 	width: 80%;
 }
 
@@ -161,4 +162,52 @@
 
 .using-environment-badge {
 	bottom: 64px;
+}
+
+.chatbox-show-simple {
+	transform: translateX(calc(100% - 25px)); /* When chatbox is partially visible */
+	transition: transform 0.5s ease-in-out;
+}
+
+.chatbox-show-full {
+	transform: translateX(0); /* When chatbox is fully visible */
+	transition: transform 0.5s ease-in-out;
+}
+
+.chatbox-header-button {
+	outline: none !important;
+}
+
+div.chatbox-header > button {
+	box-shadow: none !important;
+	padding-left: 6px;
+	padding-right: 16px;
+}
+
+@keyframes fadeToColor {
+	0%,
+	10%,
+	30%,
+	50%,
+	70% {
+		color: #ece6f6;
+	}
+	20%,
+	40%,
+	60% {
+		color: #007cba;
+	}
+	80%,
+	90%,
+	100% {
+		color: #ece6f6;
+	}
+}
+
+.chatbox-attention {
+	animation: fadeToColor 4s linear infinite;
+}
+
+.chat-chevron {
+	color: #ece6f6;
 }

--- a/client/odie/style.scss
+++ b/client/odie/style.scss
@@ -22,6 +22,7 @@
 	color: #fff;
 	border-radius: 4px;
 	text-indent: 16px;
+	line-height: 62px;
 }
 
 .chatbox-show {
@@ -204,6 +205,5 @@
 	font-size: large;
 	font-weight: normal;
 	text-align: left;
-	line-height: 62px;
 	width: 100%;
 }

--- a/client/odie/types/index.ts
+++ b/client/odie/types/index.ts
@@ -14,7 +14,7 @@ export type Nudge = {
 
 export type MessageRole = 'user' | 'bot';
 
-export type MessageType = 'message' | 'action' | 'meta' | 'error';
+export type MessageType = 'message' | 'action' | 'meta' | 'error' | 'placeholder';
 
 export type Message = {
 	content: string;


### PR DESCRIPTION
## Proposed Changes

Removing Wapuu images meanwhile, we get requested ones.

## Testing Instructions

Go to upgrades
Enable the feature flag odie

Play around with the chatbox clicking on the header.

![pr-animation-no-wapuu](https://github.com/Automattic/wp-calypso/assets/5689927/d29f6dd4-9b4a-4155-b8d6-c07133a65458)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
