### PR TITLE
Plugin Install Button: replace undefined _onClick function with handleClick

### DIFF
--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -36,7 +36,7 @@ const PluginInstallNotice = ( { isEmbed, warningText, children } ) => {
 	const disabledInfoLabel = useRef();
 	const infoPopover = useRef();
 	const togglePopover = ( event ) => {
-		infoPopover.current._onClick( event );
+		infoPopover.current.handleClick( event );
 	};
 	return (
 		<div className={ classNames( { 'plugin-install-button__install': true, embed: isEmbed } ) }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1689329772430579-slack-C04U5A26MJB

## Proposed Changes

* Replaced undefined `_onClick` function with `handleClick`. The function name was changed in https://github.com/Automattic/wp-calypso/pull/13600/files#diff-4cacc26df6494a51f1cb49cdefb7c3886a2cfa90d3f7cb7e8ad1b00e2ddb8e5fL74 and obviously the code in question didn't have much usage.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/advanced-wp-reset`
* Click Manage Sites
* Click the text reading **INCOMPATIBLE PLUGIN**  ( not the **i** button )
* The popover should appear ( while it doesn't appear in production due to `_onClick` being undefined

![CleanShot 2023-07-19 at 21 02 15@2x](https://github.com/Automattic/wp-calypso/assets/12430020/25fcbbd8-5fa2-4251-829f-84525751a967)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?