### PR TITLE
Discover feed - prevent tags sidebar from showing when recommended feed loads.

### DIFF
--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -53,18 +53,21 @@ const DiscoverStream = ( props ) => {
 	);
 	const streamKey = buildDiscoverStreamKey( selectedTab, recommendedStreamTags );
 
-	const streamSidebar = () =>
-		( isDefaultTab || selectedTab === 'latest' ) && recommendedSites?.length ? (
-			<>
-				<h2>{ translate( 'Popular Sites' ) }</h2>
-				<ReaderPopularSitesSidebar
-					items={ recommendedSites }
-					followSource={ READER_DISCOVER_POPULAR_SITES }
-				/>
-			</>
-		) : (
-			<ReaderTagSidebar tag={ selectedTab } />
-		);
+	const streamSidebar = () => {
+		if ( ( isDefaultTab || selectedTab === 'latest' ) && recommendedSites?.length ) {
+			return (
+				<>
+					<h2>{ translate( 'Popular Sites' ) }</h2>
+					<ReaderPopularSitesSidebar
+						items={ recommendedSites }
+						followSource={ READER_DISCOVER_POPULAR_SITES }
+					/>
+				</>
+			);
+		} else if ( ! ( isDefaultTab || selectedTab === 'latest' ) ) {
+			return <ReaderTagSidebar tag={ selectedTab } />;
+		}
+	};
 
 	const streamProps = {
 		...props,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Currently when loading the discover page, the tags sidebar is shown while the recommended sites are fetched:
![tags-sidebar](https://github.com/Automattic/wp-calypso/assets/28742426/15b60b0c-6375-42cd-bb79-836642871cfb)

* This PR prevents this from happening, and hides the sidebar on Recommended and Latest (which shouldnt show the tags sidebars anyways) until loaded.
![hide-sidebar-until-load](https://github.com/Automattic/wp-calypso/assets/28742426/bfd5254f-eebc-4ae7-8cba-1062184cfeda)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
