### PR TITLE
Fix discover 'latest' stream

### DIFF
--- a/client/reader/discover/discover-navigation.js
+++ b/client/reader/discover/discover-navigation.js
@@ -6,7 +6,7 @@ import { useRef } from 'react';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
-import { DEFAULT_TAB } from './helper';
+import { DEFAULT_TAB, LATEST_TAB } from './helper';
 
 import './discover-navigation.scss';
 
@@ -104,9 +104,9 @@ const DiscoverNavigation = ( { recommendedTags, selectedTab, setSelectedTab, wid
 						{ translate( 'Recommended' ) }
 					</SegmentedControl.Item>
 					<SegmentedControl.Item
-						key="latest"
-						selected={ 'latest' === selectedTab }
-						onClick={ () => menuTabClick( 'latest' ) }
+						key={ LATEST_TAB }
+						selected={ LATEST_TAB === selectedTab }
+						onClick={ () => menuTabClick( LATEST_TAB ) }
 					>
 						{ translate( 'Latest' ) }
 					</SegmentedControl.Item>

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -5,6 +5,7 @@ import { getSiteUrl as readerRouteGetSiteUrl } from 'calypso/reader/route';
 
 const DEFAULT_DISCOVER_TAGS = [ 'dailyprompt', 'wordpress' ];
 export const DEFAULT_TAB = 'recommended';
+export const LATEST_TAB = 'latest';
 /**
  * Filters tags data and returns the tags intended to be loaded by the discover pages recommended
  * section. If tags is null, we return an empty array as we have yet to recieve the users followed
@@ -35,7 +36,7 @@ export function getDiscoverStreamTags( tags, isLoggedIn ) {
 export function buildDiscoverStreamKey( selectedTab, tags ) {
 	let streamKey = `discover:${ selectedTab }`;
 	// We want a different stream key for recommended depending on the followed tags that are available.
-	if ( selectedTab === DEFAULT_TAB ) {
+	if ( selectedTab === DEFAULT_TAB || selectedTab === LATEST_TAB ) {
 		// Ensures a different key depending on the users stream tags list. So the stream can update
 		// when the user follows/unfollows other tags. Sort the list first so the key is the same
 		// per same tags followed. This is necessary since we load a default tag list when none are
@@ -53,7 +54,10 @@ export function buildDiscoverStreamKey( selectedTab, tags ) {
  * @returns {Array} An array of tag slugs.
  */
 export function getTagsFromStreamKey( streamKey = '' ) {
-	if ( streamKey.includes( 'discover:recommended' ) ) {
+	if (
+		streamKey.includes( `discover:${ DEFAULT_TAB }` ) ||
+		streamKey.includes( `discover:${ LATEST_TAB }` )
+	) {
 		const tags = streamKey.split( '--' );
 		tags.shift();
 		return tags;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* With recent changes in https://github.com/Automattic/wp-calypso/pull/79558 we changed to relying on the stream key for determining tags for the 'recommended' feed. We forgot to add the 'latest' tab to this handling as well. This resulted in the latest stream not loading as no tags were sent in the request. Here we add the latest tab to have the same stream key and tag handling, and the stream should once again work as expected.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* verify the 'latest' tab in /discover loads as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
