### PR TITLE
Domain Transfer: Remove progress bar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-complete/styles.scss
@@ -1,6 +1,12 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/onboarding/styles/mixins";
 
+.domain-transfer.complete {
+	.flow-progress.progress-bar {
+		display: none;
+	}
+}
+
 .step-container.domain-transfer {
 	&.complete {
 		@media ( max-width: $break-medium ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -11,6 +11,10 @@
 	align-items: center;
 	gap: 30px;
 
+	.flow-progress.progress-bar {
+		display: none;
+	}
+
 	button:disabled {
 		pointer-events: none;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -12,6 +12,10 @@ $heading-font-family: "SF Pro Display", $sans;
 	display: flex;
 	align-items: center;
 
+	.flow-progress.progress-bar {
+		display: none;
+	}
+
 	&.intro {
 		padding: 0;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove progress bar from domain transfer flows.

Note: This approach follows that of other flows, which all seem to use CSS. We may want to find a way to remove this at the flow level though.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout patch
* Go to `/setup/domain-transfer` 
* Click to next step
* Go to `/setup/domain-transfer/processing` and `/setup/domain-transfer/complete` and verify no progress bar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
