### PR TITLE
Checkout: Add full-screen overlay when submitting is slow

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-slow-processing-notice.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-slow-processing-notice.tsx
@@ -25,7 +25,8 @@ const SubmittingTitle = styled.div`
 	margin: 0;
 `;
 
-export function CheckoutSubmittingFullPage() {
+export function CheckoutSlowProcessingNotice() {
+	// This component will display its notice after this timeout is reached.
 	const showLoadingInfoThresholdMs = 4000;
 	const [ shouldShowLoadingInfo, setShowLoadingInfo ] = useState( false );
 	useEffect( () => {

--- a/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
@@ -26,7 +26,7 @@ const SubmittingTitle = styled.div`
 `;
 
 export function CheckoutSubmittingFullPage() {
-	const showLoadingInfoThresholdMs = 2000;
+	const showLoadingInfoThresholdMs = 3000;
 	const [ shouldShowLoadingInfo, setShowLoadingInfo ] = useState( false );
 	useEffect( () => {
 		const timer = setTimeout( () => {

--- a/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
@@ -12,7 +12,6 @@ const SubmittingWrapper = styled.div`
 	width: 100%;
 	z-index: 100000;
 	margin: 0;
-	padding: 1em;
 	padding-top: 32vh;
 	text-align: center;
 `;

--- a/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
@@ -1,0 +1,28 @@
+import { LoadingContent } from '@automattic/composite-checkout';
+import { useEffect, useState } from 'react';
+
+export function CheckoutSubmittingFullPage() {
+	const showLoadingInfoThresholdMs = 2000;
+	const [ shouldShowLoadingInfo, setShowLoadingInfo ] = useState( false );
+	useEffect( () => {
+		const timer = setTimeout( () => {
+			setShowLoadingInfo( true );
+		}, showLoadingInfoThresholdMs );
+		return () => {
+			clearTimeout( timer );
+		};
+	}, [] );
+
+	if ( ! shouldShowLoadingInfo ) {
+		return null;
+	}
+
+	return (
+		<>
+			<div>
+				<h2>Still submitting, please wait…</h2>
+			</div>
+			<LoadingContent />
+		</>
+	);
+}

--- a/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 
 const SubmittingWrapper = styled.div`
-	position: absolute;
+	position: fixed;
 	left: 0;
 	top: 0;
 	background: white;

--- a/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
@@ -46,7 +46,7 @@ export function CheckoutSubmittingFullPage() {
 	return (
 		<SubmittingWrapper>
 			<SubmittingTitle>
-				{ translate( "Almost there – we're currently finalizing your order." ) }
+				{ translate( 'Completing the transaction, please wait a few more moments…' ) }
 			</SubmittingTitle>
 			<LoadingEllipsis />
 		</SubmittingWrapper>

--- a/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
@@ -26,7 +26,7 @@ const SubmittingTitle = styled.div`
 `;
 
 export function CheckoutSubmittingFullPage() {
-	const showLoadingInfoThresholdMs = 3000;
+	const showLoadingInfoThresholdMs = 4000;
 	const [ shouldShowLoadingInfo, setShowLoadingInfo ] = useState( false );
 	useEffect( () => {
 		const timer = setTimeout( () => {

--- a/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
@@ -44,9 +44,7 @@ export function CheckoutSubmittingFullPage() {
 
 	return (
 		<SubmittingWrapper>
-			<SubmittingTitle>
-				{ translate( 'Completing the transaction, please wait a few more moments…' ) }
-			</SubmittingTitle>
+			<SubmittingTitle>{ translate( 'Processing…' ) }</SubmittingTitle>
 			<LoadingEllipsis />
 		</SubmittingWrapper>
 	);

--- a/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-submitting-full-page.tsx
@@ -1,5 +1,30 @@
-import { LoadingContent } from '@automattic/composite-checkout';
+import { styled } from '@automattic/wpcom-checkout';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+
+const SubmittingWrapper = styled.div`
+	position: absolute;
+	left: 0;
+	top: 0;
+	background: white;
+	height: 100%;
+	width: 100%;
+	z-index: 100000;
+	margin: 0;
+	padding: 1em;
+	padding-top: 32vh;
+	text-align: center;
+`;
+
+const SubmittingTitle = styled.div`
+	font-family: 'Recoleta', 'Noto Serif', Georgia, 'Times New Roman', Times, serif;
+	font-size: 1.625rem;
+	line-height: 40px;
+	text-align: center;
+	vertical-align: middle;
+	margin: 0;
+`;
 
 export function CheckoutSubmittingFullPage() {
 	const showLoadingInfoThresholdMs = 2000;
@@ -12,17 +37,18 @@ export function CheckoutSubmittingFullPage() {
 			clearTimeout( timer );
 		};
 	}, [] );
+	const translate = useTranslate();
 
 	if ( ! shouldShowLoadingInfo ) {
 		return null;
 	}
 
 	return (
-		<>
-			<div>
-				<h2>Still submitting, please wait…</h2>
-			</div>
-			<LoadingContent />
-		</>
+		<SubmittingWrapper>
+			<SubmittingTitle>
+				{ translate( "Almost there – we're currently finalizing your order." ) }
+			</SubmittingTitle>
+			<LoadingEllipsis />
+		</SubmittingWrapper>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -68,7 +68,7 @@ import { CheckoutCompleteRedirecting } from './checkout-complete-redirecting';
 import CheckoutHelpLink from './checkout-help-link';
 import CheckoutNextSteps from './checkout-next-steps';
 import { CheckoutSidebarPlanUpsell } from './checkout-sidebar-plan-upsell';
-import { CheckoutSubmittingFullPage } from './checkout-submitting-full-page';
+import { CheckoutSlowProcessingNotice } from './checkout-slow-processing-notice';
 import { EmptyCart, shouldShowEmptyCartPage } from './empty-cart';
 import PaymentMethodStepContent from './payment-method-step';
 import SecondaryCartPromotions from './secondary-cart-promotions';
@@ -382,7 +382,7 @@ export default function WPCheckout( {
 		<WPCheckoutWrapper>
 			<WPCheckoutSidebarContent>
 				{ isLoading && <LoadingSidebarContent /> }
-				{ formStatus === FormStatus.SUBMITTING && <CheckoutSubmittingFullPage /> }
+				{ formStatus === FormStatus.SUBMITTING && <CheckoutSlowProcessingNotice /> }
 				{ ! isLoading && (
 					<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
 						<CheckoutErrorBoundary

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -68,6 +68,7 @@ import { CheckoutCompleteRedirecting } from './checkout-complete-redirecting';
 import CheckoutHelpLink from './checkout-help-link';
 import CheckoutNextSteps from './checkout-next-steps';
 import { CheckoutSidebarPlanUpsell } from './checkout-sidebar-plan-upsell';
+import { CheckoutSubmittingFullPage } from './checkout-submitting-full-page';
 import { EmptyCart, shouldShowEmptyCartPage } from './empty-cart';
 import PaymentMethodStepContent from './payment-method-step';
 import SecondaryCartPromotions from './secondary-cart-promotions';
@@ -381,6 +382,7 @@ export default function WPCheckout( {
 		<WPCheckoutWrapper>
 			<WPCheckoutSidebarContent>
 				{ isLoading && <LoadingSidebarContent /> }
+				{ formStatus === FormStatus.SUBMITTING && <CheckoutSubmittingFullPage /> }
 				{ ! isLoading && (
 					<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
 						<CheckoutErrorBoundary


### PR DESCRIPTION
## Proposed Changes

When a user presses the button to submit checkout, it disables the form and displays a "Pending…" text and animation over the submit button while the payment processor function operates; most of the time this involves a single API call to the `/me/transactions` endpoint. After that point, either an error is displayed and the form is reenabled, or the page is redirected somewhere else (either a payment partner's site or the "pending" page which in turn redirects to the post-checkout page). 

However, in some cases (like a cart with many domain products) the payment processor function (ie: the transactions endpoint) can be quite slow. If that happens, the user does not get much feedback that anything is happening.

In this PR we add a new overlay component which appears while checkout is submitting if the submission takes more than 4 seconds (this should hopefully be rare). The overlay is full-screen and covers all other UI and its design is similar to the "pending" page (which you can see more about [here](https://github.com/Automattic/wp-calypso/pull/66101)). This is not a perfect solution but it should help users to wait for the transaction to complete.

In the following video, I've decreased the timeout to 2 seconds for demonstrative purposes. The "Pending…" overlay is what this PR adds.

https://github.com/Automattic/wp-calypso/assets/2036909/ce67925b-831a-4720-a665-a6ca4794f73f

Fixes https://github.com/Automattic/wp-calypso/issues/79553

## Testing Instructions

- Sandbox the API if you want to use a [Stripe test card](https://stripe.com/docs/testing).
- Add a product to your cart and visit checkout.
- I suggest you use a test card that will fail the transaction (eg: `4000000000000002`) so you don't have to complete the purchase to see this change.
- Now you need to slow down the transactions endpoint. One way to test this is to use your browser's devtools to artificially slow down the network to make the transactions endpoint slow. However, with my browser I couldn't make it slow enough to get a 3 second delay, so another option is to edit the code to decrease the threshold (`showLoadingInfoThresholdMs`) down to 1000ms instead.
- Complete the checkout form and press the submit button at the bottom.
- Verify that the button at first just reads "Processing…" before showing the new overlay.
- Verify that if the card failed, the overlay vanishes and you are returned to checkout.