### PR TITLE
Hosting onboarding: Add home view checklist task to continue checking out abandoned plans in cart.

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -149,6 +149,19 @@ export const getTask = (
 				isSkippable: true,
 			};
 			break;
+		case CHECKLIST_KNOWN_TASKS.CART_ITEMS_ABANDONED:
+			taskData = {
+				timing: 5,
+				title: translate( 'Unlock all the benefits of managed hosting' ),
+				description: translate(
+					'Complete your checkout to unlock all the benefits of managed hosting, including daily backups, security scanning, and more.'
+				),
+				actionText: translate( 'Go to checkout' ),
+				actionUrl: `/checkout/${ siteSlug }`,
+				actionDisableOnComplete: false,
+				isSkippable: true,
+			};
+			break;
 		case CHECKLIST_KNOWN_TASKS.WOOCOMMERCE_SETUP:
 			taskData = {
 				timing: 7,

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -152,9 +152,9 @@ export const getTask = (
 		case CHECKLIST_KNOWN_TASKS.CART_ITEMS_ABANDONED:
 			taskData = {
 				timing: 5,
-				title: translate( 'Unlock all the benefits of managed hosting' ),
+				title: translate( 'Complete checkout' ),
 				description: translate(
-					'Complete your checkout to unlock all the benefits of managed hosting, including daily backups, security scanning, and more.'
+					'Unlock all the benefits of managed hosting, including unmetered bandwidth, multisite management, and realtime backups.'
 				),
 				actionText: translate( 'Go to checkout' ),
 				actionUrl: `/checkout/${ siteSlug }`,

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -32,6 +32,7 @@ export const CHECKLIST_KNOWN_TASKS = {
 	POST_SHARING_ENABLED: 'post_sharing_enabled',
 	INSTALL_CUSTOM_PLUGIN: 'install_custom_plugin',
 	SETUP_SSH: 'setup_ssh',
+	CART_ITEMS_ABANDONED: 'cart_items_abandoned',
 };
 
 // Transform the response to a data / schema calypso understands, eg filter out unknown tasks


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/2811

## Proposed Changes

There are times when a user goes through the process of purchasing a plan but abandoned the purchase leaving the items in the cart. This PR adds an additional checklist item on the home view to remind them of items and provide a CTA to quickly checkout those items.

* Add new `CART_ITEMS_ABANDONED` checklist task

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Pre-req: 
* Apply patch D116494-code

* Create a site with business or ecommerce plan then abandoned the plan in the cart.
* Verify the abandoned cart checklist item is shown.
![image](https://github.com/Automattic/wp-calypso/assets/47489215/4dc57d4b-9ad5-44c0-bc9b-10795516a6a9)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?