### PR TITLE
Help center e2e: wait for search-specific request

### DIFF
--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -131,7 +131,23 @@ export class SupportComponent {
 	 * @param {string} text Search keyword to be entered into the search field.
 	 */
 	async search( text: string ): Promise< void > {
-		await this.anchor.getByPlaceholder( 'Search for help' ).fill( text );
+		await Promise.all( [
+			// If you don't wait for the request specific to your search, you can actually
+			// go fast enough to act on default or old results!
+			this.page.waitForResponse(
+				( response ) => {
+					return (
+						response.request().url().includes( '/help/search/wpcom' ) &&
+						response
+							.request()
+							.url()
+							.includes( `query=${ encodeURIComponent( text ) }` )
+					);
+				},
+				{ timeout: 15 * 1000 }
+			),
+			this.anchor.getByPlaceholder( 'Search for help' ).fill( text ),
+		] );
 
 		// Wait for the search results to populate.
 		// For any query (valid or invalid), the Recommended resources will populate,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

We're still get help center spec failures of different kinds. If you look at them, the result is that we're still clicking on bad articles, namely the broken one in #79576, and sometimes ones that are direct links (instead of embedded content).

... and none of these articles have anything to do with our search of "posts"!! What gives?!?!

Turns out that Playwright was going so fast that we were acting on the results before the search even fired and returned -- i.e. the default articles, or the ones from the prior search. 😒 

Now, we do a query-specific wait, so we can be sure that our new request has fired.

This will give us _much_ more consistent doc search results!

## Testing Instructions

All CI checks should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
