### PR TITLE
use transferrability to show appropriate errors

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -125,7 +125,7 @@ export function DomainCodePair( {
 		if ( shouldReportError && ! valid && message ) {
 			recordTracksEvent( 'calypso_domain_transfer_domain_error', {
 				domain,
-				error: errorStatus ? errorStatus : message,
+				error: errorStatus ? errorStatus : String( message ),
 			} );
 		}
 	}, [ shouldReportError, valid, domain, message, errorStatus ] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -68,7 +68,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 	const availabilityNotice = getAvailabilityNotice(
 		domain,
 		validationResult?.status,
-		null,
+		validationResult,
 		true,
 		'_blank',
 		validationResult?.tld

--- a/client/landing/stepper/hooks/use-is-domain-code-valid.ts
+++ b/client/landing/stepper/hooks/use-is-domain-code-valid.ts
@@ -63,7 +63,7 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 						tld: availability.tld,
 						status: availability.status,
 						unlocked: false,
-						transferrability: availability?.transferrability ?? null,
+						transferrability: availability.transferrability,
 					};
 				}
 
@@ -79,6 +79,7 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 					unlocked: true,
 					auth_code_valid: response.success,
 					status: availability.status,
+					transferrability: availability.transferrability
 					raw_price: availability.raw_price,
 					sale_cost: availability.sale_cost,
 					currency_code: availability.currency_code,

--- a/client/landing/stepper/hooks/use-is-domain-code-valid.ts
+++ b/client/landing/stepper/hooks/use-is-domain-code-valid.ts
@@ -79,7 +79,7 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 					unlocked: true,
 					auth_code_valid: response.success,
 					status: availability.status,
-					transferrability: availability.transferrability
+					transferrability: availability.transferrability,
 					raw_price: availability.raw_price,
 					sale_cost: availability.sale_cost,
 					currency_code: availability.currency_code,

--- a/client/landing/stepper/hooks/use-is-domain-code-valid.ts
+++ b/client/landing/stepper/hooks/use-is-domain-code-valid.ts
@@ -63,6 +63,7 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 						tld: availability.tld,
 						status: availability.status,
 						unlocked: false,
+						transferrability: availability?.transferrability ?? null,
 					};
 				}
 

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -37,6 +37,11 @@ function getAvailabilityNotice(
 	let message;
 	let severity = 'error';
 
+	if ( isForTransferOnly && errorData?.transferrability ) {
+		// If we are getting messages for transfers, use the transferrability status
+		error = errorData?.transferrability;
+	}
+
 	switch ( error ) {
 		case domainAvailability.REGISTERED:
 			message = translate(


### PR DESCRIPTION
## Related to:
* Automattic/dotcom-forge#3071
* pb6Nl-gI2-p2#comment-103274

## Issue
When we are checking whether a domain is transferable or not, we are checking the `status`, but instead, we should be checking `transferability`. This results in showing the user an invalid error message when a mapped domain is NOT transferable (e.g. because of a transfer lock, within the initial 60 days of registering a domain, etc).

## Proposed Changes
When we are checking for errors while initiating a domain transfer process, we always use the transferability status rather than the domain status to determine the appropriate error message to show.

## Testing Instructions
* Map/Connect a domain to one of your sites.
* Make sure that domain is NOT transferable. That can be done by setting a transfer lock or trying a newly registered domain, for example.
* navigate to `https://wordpress.com/setup/domain-transfer/domains`.
* Trying filling in the information for that domain then check the error message shown.

## Before
<img width="765" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1080253/3abc9492-27b4-4f56-a893-2a697f285383">

## After
<img width="759" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1080253/bb5805ca-1a1e-4180-9a75-f3997a80732b">