### PR TITLE
Hosted site flow: add tailored processing copies

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
@@ -1,5 +1,9 @@
 import { Onboard } from '@automattic/data-stores';
-import { isWooExpressFlow } from '@automattic/onboarding';
+import {
+	isNewHostedSiteCreationFlow,
+	isTransferringHostedSiteCreationFlow,
+	isWooExpressFlow,
+} from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import WooPurpleHeart from 'calypso/assets/images/onboarding/woo-purple-heart.png';
@@ -17,6 +21,21 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 		( select ) => ( select( STEPPER_INTERNAL_STORE ) as StepperInternalSelect ).getStepData(),
 		[]
 	);
+
+	if ( flow && isNewHostedSiteCreationFlow( flow ) ) {
+		return [ { title: __( 'Creating your site' ), duration: Infinity } ];
+	}
+
+	if ( flow && isTransferringHostedSiteCreationFlow( flow ) ) {
+		return [
+			{ title: __( 'Laying the foundations' ), duration: 3500 },
+			{ title: __( 'Warming up CPUs' ), duration: 2000 },
+			{ title: __( 'Installing WordPress' ), duration: 2000 },
+			{ title: __( 'Securing your data' ), duration: 3500 },
+			{ title: __( 'Distributing your site worldwide' ), duration: 3500 },
+			{ title: __( 'Closing the loop' ), duration: 5000 },
+		];
+	}
 
 	if ( flow === 'copy-site' ) {
 		return [

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
@@ -28,12 +28,12 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 
 	if ( flow && isTransferringHostedSiteCreationFlow( flow ) ) {
 		return [
-			{ title: __( 'Laying the foundations' ), duration: 3500 },
-			{ title: __( 'Warming up CPUs' ), duration: 2000 },
-			{ title: __( 'Installing WordPress' ), duration: 2000 },
-			{ title: __( 'Securing your data' ), duration: 3500 },
-			{ title: __( 'Distributing your site worldwide' ), duration: 3500 },
-			{ title: __( 'Closing the loop' ), duration: 5000 },
+			{ title: __( 'Laying the foundations' ), duration: 5000 },
+			{ title: __( 'Warming up CPUs' ), duration: 3000 },
+			{ title: __( 'Installing WordPress' ), duration: 3000 },
+			{ title: __( 'Securing your data' ), duration: 5000 },
+			{ title: __( 'Distributing your site worldwide' ), duration: 5000 },
+			{ title: __( 'Closing the loop' ), duration: Infinity },
 		];
 	}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/2812.

## Proposed Changes

This PR adds processing copies that are more inline with the hosted sites intentions. It hardcodes the "Creating your site" copy when setting up the free site before checkout, but creates more tailored messages when the site is being transferred to Atomic.

## Testing Instructions

Browse `/setup/new-hosted-site` and submit the options step. You should see the "Creating your site" processing copy briefly show up:

![image](https://github.com/Automattic/wp-calypso/assets/26530524/4363d533-43d9-4e43-b682-0cfcea709016)

After checkout, you should see the new messages:

- Laying the foundations
- Warming up CPUs (related to our high-frequency CPUs)
- Installing WordPress
- Securing your data (security section)
- Distributing your site worldwide (global CDN)
- Closing the loop

https://github.com/Automattic/wp-calypso/assets/26530524/27ea74ce-61dc-4161-a1d3-3255ef2a0b0c