### PR TITLE
Domain Transfer: Remove customer margin-bottom on label

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -257,10 +257,6 @@
 
 			@media (max-width: $break-medium ) {
 				display: block;
-
-				&.is-first-row {
-					margin-bottom: 8px;
-				}
 			}
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -252,7 +252,6 @@
 
 			&.is-first-row {
 				display: inline-block;
-				margin-bottom: 16px;
 				white-space: nowrap;
 			}
 


### PR DESCRIPTION
## Proposed Changes

Remove custom label margin-bottom following feedback from @pablohoneyhoney here: p9Jlb4-8kT-p2#comment-8644. This makes the margin-bottom 5px, standard across Calypso, instead of 16px.


> The space between the labels and fields are to lofty, need to be closer.


<img width="1280" alt="Screenshot 2023-07-19 at 4 53 56 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/97cf3d9a-92f5-4211-8f2c-c49bd0416f03">
<img width="596" alt="Screenshot 2023-07-19 at 4 53 18 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/0c15fb6e-cd30-4c2e-99f1-872d50fbbc0b">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Go to `/setup/domain-transfer/domains` verify labels are closer to inputs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?