### PR TITLE
Fix bug where input text component would get cleared

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/index.tsx
@@ -48,7 +48,9 @@ const FreeSetup: Step = function FreeSetup( { navigation } ) {
 			const file = new File( [ base64ImageToBlob( siteLogo ) ], 'site-logo.png' );
 			setSelectedFile( file );
 		}
-	}, [ state ] );
+		// These are the actual dependencies, not the state object.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ state.siteTitle, state.siteDescription, state.siteLogo ] );
 
 	const handleSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();


### PR DESCRIPTION
The pre-release test failed on trunk because the site title text component on `setup/free/freeSetup` didn't get filled. I tested the page, and observed that the first character entered in the text box was dropped, but subsequent characters were entered. I think this is failing the test.

The root cause is this `useEffect` hook ran a second time:

1. Load the page, and this hook runs
2. Enter a single character in the site title text box
3. The hook runs again, clearing the text
4. Enter more characters
5. The hook does not run again, meaning the text is saved

I don't know why #78711 caused it though, since it doesn't seem to be related to the TextBox component -- the useEffect hook just runs a second time for some reason. The purpose of the hook (from what I can tell) is to sync initial data from the redux store into local state. It would technically then overwrite local state if the redux store changes, but i don't think the local components are designed to update that store. 

An easy solution is to only run the hook when the specific data it needs from the object changes, rather than when the entire object changes.

cc @edanzer for visibility