### PR TITLE
Paid Stats: Add new card to the Addons page

### DIFF
--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -6,7 +6,7 @@ import { Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import type { AddOnMeta } from '../hooks/use-add-ons';
 
 type ActionPrimary = {
@@ -112,7 +112,7 @@ const useModifiedActionPrimary = (
 	addOnMeta: AddOnMeta
 ) => {
 	const translate = useTranslate();
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
 
 	// Add special handling for Jetpack Stats, which uses its own special purchase page.
 	if ( addOnMeta.productSlug === PRODUCT_JETPACK_STATS_PWYW_YEARLY ) {
@@ -120,7 +120,8 @@ const useModifiedActionPrimary = (
 			text: translate( 'Upgrade Stats' ),
 			handler: () => {
 				// Navigate to the stats purchase page, scrolled to the top.
-				page.show( `/stats/purchase/${ siteId }?flags=stats/paid-stats` );
+				// TODO: Remove "?flags=stats/paid-stats" once the new stats purchase page is live.
+				page.show( `/stats/purchase/${ siteSlug }?flags=stats/paid-stats` );
 				window.scrollTo( 0, 0 );
 			},
 		};

--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -1,16 +1,21 @@
-import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
+import { PRODUCT_JETPACK_STATS_PWYW_YEARLY, PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
 import { Badge, Button, Gridicon, Spinner } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Card, CardBody, CardFooter, CardHeader } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { AddOnMeta } from '../hooks/use-add-ons';
 
+type ActionPrimary = {
+	text: string;
+	handler: ( productSlug: string, quantity?: number ) => void;
+};
+
 export interface Props {
-	actionPrimary?: {
-		text: string;
-		handler: ( productSlug: string, quantity?: number ) => void;
-	};
+	actionPrimary?: ActionPrimary;
 	actionSecondary?: {
 		text: string;
 		handler: ( productSlug: string ) => void;
@@ -88,15 +93,53 @@ const Container = styled.div`
 	}
 `;
 
+const useAddonName = ( addOnMeta: AddOnMeta ) => {
+	const translate = useTranslate();
+
+	// Add special handling for Jetpack Stats, which actually encompasses three different products:
+	// - Jetpack Stats (free)
+	// - Jetpack Stats Personal (pay-what-you-want, yearly)
+	// - Jetpack Stats Commercial (fixed monthly price for now, monthly)
+	if ( addOnMeta.productSlug === PRODUCT_JETPACK_STATS_PWYW_YEARLY ) {
+		return translate( 'Jetpack Stats' );
+	}
+
+	return addOnMeta.name;
+};
+
+const useModifiedActionPrimary = (
+	actionPrimary: ActionPrimary | undefined,
+	addOnMeta: AddOnMeta
+) => {
+	const translate = useTranslate();
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+
+	// Add special handling for Jetpack Stats, which uses its own special purchase page.
+	if ( addOnMeta.productSlug === PRODUCT_JETPACK_STATS_PWYW_YEARLY ) {
+		return {
+			text: translate( 'Upgrade Stats' ),
+			handler: () => {
+				// Navigate to the stats purchase page, scrolled to the top.
+				page.show( `/stats/purchase/${ siteId }?flags=stats/paid-stats` );
+				window.scrollTo( 0, 0 );
+			},
+		};
+	}
+	return actionPrimary;
+};
+
 const AddOnCard = ( {
 	addOnMeta,
-	actionPrimary,
+	actionPrimary: actionPrimaryFromProps,
 	actionSecondary,
 	useAddOnAvailabilityStatus,
 	highlightFeatured,
 }: Props ) => {
 	const translate = useTranslate();
 	const availabilityStatus = useAddOnAvailabilityStatus?.( addOnMeta );
+	const name = useAddonName( addOnMeta );
+	const actionPrimary = useModifiedActionPrimary( actionPrimaryFromProps, addOnMeta );
+
 	const onActionPrimary = () => {
 		actionPrimary?.handler( addOnMeta.productSlug, addOnMeta.quantity );
 	};
@@ -127,7 +170,7 @@ const AddOnCard = ( {
 					</div>
 					<div className="add-ons-card__name-and-billing">
 						<div className="add-ons-card__name-tag">
-							<div className="add-ons-card__name">{ addOnMeta.name }</div>
+							<div className="add-ons-card__name">{ name }</div>
 							{ highlightFeatured && addOnMeta.featured && (
 								<Badge key="popular" type="info-green" className="add-ons-card__featured-badge">
 									{ translate( 'Popular' ) }

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -1,5 +1,6 @@
 import {
 	PRODUCT_JETPACK_AI_MONTHLY,
+	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
 	PRODUCT_WPCOM_CUSTOM_DESIGN,
 	PRODUCT_WPCOM_UNLIMITED_THEMES,
 	PRODUCT_1GB_SPACE,
@@ -20,6 +21,7 @@ import { usePastBillingTransactions } from 'calypso/state/sites/hooks/use-billin
 import { STORAGE_LIMIT } from '../constants';
 import customDesignIcon from '../icons/custom-design';
 import jetpackAIIcon from '../icons/jetpack-ai';
+import jetpackStatsIcon from '../icons/jetpack-stats';
 import spaceUpgradeIcon from '../icons/space-upgrade';
 import unlimitedThemesIcon from '../icons/unlimited-themes';
 import isStorageAddonEnabled from '../is-storage-addon-enabled';
@@ -94,6 +96,20 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 			),
 			featured: false,
 			purchased: false,
+		},
+		{
+			productSlug: PRODUCT_JETPACK_STATS_PWYW_YEARLY,
+			featureSlugs: useAddOnFeatureSlugs( PRODUCT_JETPACK_STATS_PWYW_YEARLY ),
+			icon: jetpackStatsIcon,
+			overrides: null,
+			displayCost: translate( 'Varies', {
+				comment:
+					'Used to describe price of Jetpack Stats, which can be either a pay-what-you-want product or fixed price product. In the future, it can also be a metered product.',
+			} ),
+			featured: true,
+			description: translate(
+				'Upgrade Jetpack Stats to unlock upcoming features, priority support, and an ad-free experience.'
+			),
 		},
 	];
 

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import {
+	FEATURE_STATS_PAID,
 	PRODUCT_JETPACK_AI_MONTHLY,
 	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
 	PRODUCT_WPCOM_CUSTOM_DESIGN,
@@ -160,6 +161,14 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 				if (
 					addOn.productSlug === PRODUCT_JETPACK_STATS_PWYW_YEARLY &&
 					! config.isEnabled( 'stats/paid-stats' )
+				) {
+					return false;
+				}
+
+				// remove Jetpack Stats add-on if the site already has a paid stats feature through a paid plan.
+				if (
+					addOn.productSlug === PRODUCT_JETPACK_STATS_PWYW_YEARLY &&
+					siteFeatures?.active?.includes( FEATURE_STATS_PAID )
 				) {
 					return false;
 				}

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	PRODUCT_JETPACK_AI_MONTHLY,
 	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
@@ -150,6 +151,15 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 				if (
 					addOn.productSlug === PRODUCT_JETPACK_AI_MONTHLY &&
 					siteFeatures?.active?.includes( WPCOM_FEATURES_AI_ASSISTANT )
+				) {
+					return false;
+				}
+
+				// TODO: Remove this check once paid stats is live.
+				// gate the Jetpack Stats add-on on a feature flag
+				if (
+					addOn.productSlug === PRODUCT_JETPACK_STATS_PWYW_YEARLY &&
+					! config.isEnabled( 'stats/paid-stats' )
 				) {
 					return false;
 				}

--- a/client/my-sites/add-ons/icons/jetpack-stats.tsx
+++ b/client/my-sites/add-ons/icons/jetpack-stats.tsx
@@ -1,0 +1,19 @@
+// Slightly modified version of 'calypso/assets/images/jetpack/jetpack-product-icon-stats.svg'.
+// Now includes a rounded rectangle background.
+
+import { SVG, Path } from '@wordpress/primitives';
+
+export default (
+	<SVG width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<Path
+			d="M0 6.44C0 4.16204 0 3.02306 0.450346 2.1561C0.829848 1.42553 1.42553 0.829848 2.1561 0.450346C3.02306 0 4.16204 0 6.44 0H37.56C39.838 0 40.9769 0 41.8439 0.450346C42.5745 0.829848 43.1702 1.42553 43.5497 2.1561C44 3.02306 44 4.16204 44 6.44V37.56C44 39.838 44 40.9769 43.5497 41.8439C43.1702 42.5745 42.5745 43.1702 41.8439 43.5497C40.9769 44 39.838 44 37.56 44H6.44C4.16204 44 3.02306 44 2.1561 43.5497C1.42553 43.1702 0.829848 42.5745 0.450346 41.8439C0 40.9769 0 39.838 0 37.56V6.44Z"
+			fill="#E9EFF5"
+		/>
+		<Path d="M21.25 15H22.75V30H21.25V15Z" fill="#0675C4" />
+		<Path d="M16 20H17.5V30H16V20Z" fill="#0675C4" />
+		<Path d="M28 24H26.5V30H28V24Z" fill="#0675C4" />
+		<Path d="M22.25 15H23.75V30H22.25V15Z" fill="#0675C4" />
+		<Path d="M17 20H18.5V30H17V20Z" fill="#0675C4" />
+		<Path d="M29 24H27.5V30H29V24Z" fill="#0675C4" />
+	</SVG>
+);

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -104,6 +104,7 @@ export const FEATURE_SITE_BACKUPS_AND_RESTORE = 'site-backups-and-restore';
 export const FEATURE_SECURITY_SETTINGS = 'security-settings';
 export const FEATURE_WOOP = 'woop';
 export const FEATURE_PREMIUM_THEMES = 'unlimited-premium-themes';
+export const FEATURE_STATS_PAID = 'stats-paid';
 
 // Jetpack features constants
 export const FEATURE_BLANK = 'blank-feature';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #79453.

## Proposed Changes

<img width="547" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/aa7d8f02-ba45-4d97-8dae-27b9775240ff">

* Adds Jetpack Stats to the Addons page behind the `stats/paid-stats` feature flag.

## Testing Instructions

* Open the live branch for this PR.

### Purchasing 

* For a Simple or Atomic site, navigate to the Addons page via Upgrades -> Addons.
* Add `?flags=stats/paid-stats` to your address bar.
* Ensure that you can see the new Jetpack Stats addon.
* Click on Upgrade Stats. 
* Ensure that you're taken to the new Stats Purchase page at `/stats/purchase/:siteSlug?flags=stats/paid-stats`

### Post-Purchase

* After purchasing Jetpack Stats PWYW or Commercial, return to Upgrades -> Addons.
* Add `?flags=stats/paid-stats` to your address bar.
* Ensure that the new Jetpack Stats addon no longer appears.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
