### PR TITLE
Domains Transfers: Move trash/refresh to the validation text

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -133,12 +133,13 @@ export function DomainCodePair( {
 
 	const domainActions = (
 		<>
+			&nbsp;
 			<Button
 				// Disable the delete button on initial state meaning. no domain, no auth and one row.
 				disabled={ ! domain && ! auth && domainCount === 1 }
 				onClick={ () => onRemove( id ) }
 			>
-				<span className="delete-label">{ __( 'Delete' ) }</span>
+				<span className="delete-label">{ __( 'Discard Domain' ) }</span>
 			</Button>
 			<Button
 				title={ __( 'Refresh' ) }
@@ -221,23 +222,19 @@ export function DomainCodePair( {
 						/>
 						{ domainInputFieldIcon( valid, shouldReportError ) }
 					</FormFieldset>
+					{ ( shouldReportError || ( message && loading ) ) && (
+						<div className="domains__domain-validation is-mobile">
+							{ shouldReportError && (
+								<FormInputValidation
+									isError={ ! valid }
+									text={ message }
+									children={ domainActions }
+								></FormInputValidation>
+							) }
+							{ message && loading && <FormExplanation>{ message }</FormExplanation> }
+						</div>
+					) }
 				</div>
-				{ ( shouldReportError || ( message && loading ) ) && (
-					<div className="domains__domain-validation is-mobile">
-						{ shouldReportError && (
-							<FormInputValidation
-								isError={ ! valid }
-								text={ message }
-								children={ domainActions }
-							></FormInputValidation>
-						) }
-						{ message && loading && (
-							<div>
-								<FormExplanation>{ message }</FormExplanation>
-							</div>
-						) }
-					</div>
-				) }
 				<div className="domains__domain-price">
 					<FormFieldset>
 						<FormLabel

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -2,11 +2,10 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FormInputValidation } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { Button, Icon } from '@wordpress/components';
-import { check, trash, closeSmall } from '@wordpress/icons';
+import { check, closeSmall } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useEffect } from 'react';
-import Gridicon from 'calypso/../packages/components/src/gridicon';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -132,6 +131,27 @@ export function DomainCodePair( {
 		}
 	}, [ shouldReportError, valid, domain, message, errorStatus ] );
 
+	const domainActions = (
+		<>
+			<Button
+				// Disable the delete button on initial state meaning. no domain, no auth and one row.
+				disabled={ ! domain && ! auth && domainCount === 1 }
+				onClick={ () => onRemove( id ) }
+			>
+				<span className="delete-label">{ __( 'Delete' ) }</span>
+			</Button>
+			<Button
+				title={ __( 'Refresh' ) }
+				disabled={ ! refetch }
+				onClick={ () => refetch?.() }
+				className={ classnames( 'domains__domain-refresh', {
+					'is-invisible-field': ! refetch,
+				} ) }
+			>
+				<span className="refresh-label">{ __( 'Refresh' ) }</span>
+			</Button>
+		</>
+	);
 	return (
 		<div className="domains__domain-info-and-validation">
 			<div className="domains__domain-info">
@@ -205,7 +225,11 @@ export function DomainCodePair( {
 				{ ( shouldReportError || ( message && loading ) ) && (
 					<div className="domains__domain-validation is-mobile">
 						{ shouldReportError && (
-							<FormInputValidation isError={ ! valid } text={ message }></FormInputValidation>
+							<FormInputValidation
+								isError={ ! valid }
+								text={ message }
+								children={ domainActions }
+							></FormInputValidation>
 						) }
 						{ message && loading && (
 							<div>
@@ -231,36 +255,14 @@ export function DomainCodePair( {
 						/>
 					</FormFieldset>
 				</div>
-				<div className="domains__domain-controls">
-					<div className="domains__domain-delete">
-						<Button
-							// Disable the delete button on initial state meaning. no domain, no auth and one row.
-							disabled={ ! domain && ! auth && domainCount === 1 }
-							icon={ trash }
-							onClick={ () => onRemove( id ) }
-						>
-							<span className="delete-label">{ __( 'Delete' ) }</span>
-						</Button>
-					</div>
-					<div
-						className={ classnames( 'domains__domain-refresh', {
-							'is-invisible-field': ! refetch,
-						} ) }
-					>
-						<Button
-							icon={ <Gridicon icon="sync" width={ 24 } height={ 24 } /> }
-							title={ __( 'Refresh' ) }
-							disabled={ ! refetch }
-							onClick={ () => refetch?.() }
-						>
-							<span className="refresh-label">{ __( 'Refresh' ) }</span>
-						</Button>
-					</div>
-				</div>
 			</div>
 			<div className="domains__domain-validation is-desktop">
 				{ shouldReportError && (
-					<FormInputValidation isError={ ! valid } text={ message }></FormInputValidation>
+					<FormInputValidation
+						isError={ ! valid }
+						text={ message }
+						children={ domainActions }
+					></FormInputValidation>
 				) }
 				{ message && loading && (
 					<div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -155,10 +155,9 @@
 	}
 
 	.domains__domain-validation {
-		margin-top: 12px;
-
 		&.is-mobile {
 			display: none;
+			margin-top: 5px;
 		}
 
 		&.is-desktop {
@@ -418,6 +417,11 @@
 
 			a {
 				text-decoration: underline;
+			}
+
+			// Remove left-padding for first button to minimize padding when line wraps on mobile.
+			button:first-of-type {
+				padding-left: 0;
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -317,57 +317,6 @@
 		}
 	}
 
-
-	.domains__domain-controls {
-		display: flex;
-		gap: 16px;
-		flex: 1;
-
-		button {
-			&:hover {
-				color: var(--wp-components-color-accent, var(--wp-admin-theme-color, var(--studio-blue-60)));
-			}
-		}
-
-		@media (min-width: $break-medium ) {
-			margin-left: -25px;
-		}
-
-		.domains__domain-refresh {
-			button {
-				cursor: pointer;
-
-				.refresh-label {
-					margin-left: 4px;
-				}
-			}
-
-			.refresh-label {
-				display: none;
-			}
-
-			@media (max-width: $break-medium ) {
-				.refresh-label {
-					display: block;
-				}
-			}
-		}
-
-		.domains__domain-delete {
-			.delete-label {
-				display: none;
-			}
-
-			@media (max-width: $break-medium ) {
-				order: 1;
-
-				.delete-label {
-					display: block;
-				}
-			}
-		}
-	}
-
 	.bulk-domain-transfer__container {
 
 		.bulk-domain-transfer__add-domain {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -165,6 +165,11 @@
 			display: block;
 		}
 
+		button {
+			padding: 0 5px;
+			text-decoration: underline;
+		}
+
 		@media (max-width: $break-medium ) {
 			margin-top: 0;
 
@@ -179,7 +184,7 @@
 	}
 
 	.domains__domain-domain {
-		flex: 7;
+		flex: 8;
 	}
 
 	.domains__domain-key {
@@ -196,7 +201,7 @@
 	}
 
 	.domains__domain-price {
-		flex: 2;
+		flex: 1;
 
 		.domains__domain-price-number {
 			align-items: center;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3135

## Proposed Changes

Remove the trash & refresh icons, and I moved them to the validation info as text, and make the price column smaller.

| Mobile | Desktop |
| --- | --- |
|  ![image](https://github.com/Automattic/wp-calypso/assets/1126811/b31a344b-efac-4ead-ae33-b351d202bee6) | ![image](https://github.com/Automattic/wp-calypso/assets/1126811/30f0c512-a70d-4a17-82af-a894d98d74bf) |

## Testing Instructions

* Go to `/setup/domain-transfer/domains`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
