### PR TITLE
Domains Transfers: Move the total price to the Transfer button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -180,6 +180,23 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 		setDomainsTransferData( newDomainsState );
 	}
 
+	function getTransferButtonText() {
+		if ( numberOfValidDomains === 0 ) {
+			return __( 'Transfer' );
+		}
+
+		const totalPrice = getTotalPrice( domainsState );
+		if ( totalPrice ) {
+			return sprintf(
+				/* translators: %s: total price formatted */
+				__( 'Transfer for %s' ),
+				getFormattedTotalPrice( domainsState )
+			);
+		}
+
+		return __( 'Transfer for free' );
+	}
+
 	return (
 		<div className="bulk-domain-transfer__container">
 			{ Object.entries( domainsState ).map( ( [ key, domain ], index ) => (
@@ -226,15 +243,7 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 					className="bulk-domain-transfer__cta"
 					onClick={ handleAddTransfer }
 				>
-					{ numberOfValidDomains === 0
-						? __( 'Transfer' )
-						: sprintf(
-								/* translators: %s: total price formatted */
-								__( 'Transfer for %s' ),
-								getTotalPrice( domainsState )
-									? getFormattedTotalPrice( domainsState )
-									: __( 'free' )
-						  ) }
+					{ getTransferButtonText() }
 				</Button>
 			</div>
 			{ isEnabled( 'domain-transfer/faq' ) && (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -226,13 +226,15 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 					className="bulk-domain-transfer__cta"
 					onClick={ handleAddTransfer }
 				>
-					{ getTotalPrice( domainsState )
-						? sprintf(
+					{ numberOfValidDomains === 0
+						? __( 'Transfer' )
+						: sprintf(
 								/* translators: %s: total price formatted */
 								__( 'Transfer for %s' ),
-								getFormattedTotalPrice( domainsState )
-						  )
-						: __( 'Transfer for free' ) }
+								getTotalPrice( domainsState )
+									? getFormattedTotalPrice( domainsState )
+									: __( 'free' )
+						  ) }
 				</Button>
 			</div>
 			{ isEnabled( 'domain-transfer/faq' ) && (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -56,6 +56,20 @@ const getFormattedTotalPrice = ( state: DomainTransferData ) => {
 	return 0;
 };
 
+const getTotalPrice = ( state: DomainTransferData ) => {
+	if ( Object.keys( state ).length > 0 ) {
+		return Object.values( state ).reduce( ( total, currentDomain ) => {
+			if ( currentDomain.saleCost || currentDomain.saleCost === 0 ) {
+				return total + currentDomain.saleCost;
+			}
+
+			return total + currentDomain.rawPrice;
+		}, 0 );
+	}
+
+	return 0;
+};
+
 const Domains: React.FC< Props > = ( { onSubmit } ) => {
 	const [ enabledDataLossWarning, setEnabledDataLossWarning ] = useState( true );
 
@@ -77,7 +91,7 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 	const { setPendingAction, setDomainsTransferData, setShouldImportDomainTransferDnsRecords } =
 		useDispatch( ONBOARD_STORE );
 
-	const { __, _n } = useI18n();
+	const { __ } = useI18n();
 
 	const filledDomainValues = Object.values( domainsState ).filter( ( x ) => x.domain && x.auth );
 	const allGood = filledDomainValues.every( ( { valid } ) => valid );
@@ -191,11 +205,6 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 			) }
 			{ numberOfValidDomains > 0 && (
 				<>
-					<div className="bulk-domain-transfer__total-price">
-						<div>{ __( 'Total' ) }</div>
-						<div>{ getFormattedTotalPrice( domainsState ) }</div>
-					</div>
-
 					<FormLabel
 						htmlFor="import-dns-records"
 						className="bulk-domain-transfer__import-dns-records"
@@ -217,13 +226,13 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 					className="bulk-domain-transfer__cta"
 					onClick={ handleAddTransfer }
 				>
-					{ numberOfValidDomains === 0
-						? __( 'Transfer' )
-						: sprintf(
-								/* translators: %s: number valid domains */
-								_n( 'Transfer %s domain', 'Transfer %s domains', numberOfValidDomains ),
-								numberOfValidDomains
-						  ) }
+					{ getTotalPrice( domainsState )
+						? sprintf(
+								/* translators: %s: total price formatted */
+								__( 'Transfer for %s' ),
+								getFormattedTotalPrice( domainsState )
+						  )
+						: __( 'Transfer for free' ) }
 				</Button>
 			</div>
 			{ isEnabled( 'domain-transfer/faq' ) && (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -405,29 +405,6 @@
 			}
 		}
 
-		.bulk-domain-transfer__total-price {
-			display: flex;
-			justify-content: space-between;
-			border-top: 1px solid rgba(220, 220, 222, 0.64);
-			border-bottom: 1px solid rgba(220, 220, 222, 0.64);
-			font-weight: 500;
-			padding: 20px 0;
-			margin-bottom: 20px;
-
-			div:nth-of-type(1) {
-				flex: 9;
-			}
-
-			div:nth-of-type(2) {
-				flex: 3;
-				margin-left: 4px;
-
-				@media (max-width: $break-medium ) {
-					text-align: right;
-				}
-			}
-		}
-
 		.bulk-domain-transfer__import-dns-records {
 			margin-bottom: 42px;
 		}


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3135

## Proposed Changes

- Remove the Total price field
- Add the price to the Transfer button
- When price is 0, it shows `Transfer for free`
- When price is > 0, it shows `Transfer for $price`

## Testing Instructions

* Go to `/setup/domain-transfer/domains`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
