### PR TITLE
Use optional chaining to fix SPT store close issue

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
@@ -107,8 +107,8 @@ export function PagePatternsPlugin( props: PagePatternsPluginProps ) {
 	}, [ areTipsEnabled, disableTips, isWelcomeGuideActive, toggleFeature ] );
 
 	const handleClose = useCallback( () => {
-		setUsedPageOrPatternsModal();
 		setOpenState( 'CLOSED' );
+		setUsedPageOrPatternsModal?.();
 	}, [ setOpenState, setUsedPageOrPatternsModal ] );
 
 	return (


### PR DESCRIPTION
## Proposed Changes
See p1689775247526229-slack-C02FMH4G8

Essentially, when Gutenberg is disabled and/or Woocommerce is enabled (can't remember which!), SPT will not close because `setUsedPageOrPatternsModal` is not defined. 

We tried to figure out _why_ it isn't defined, but haven't quite found the root cause. What we do know is that the store isn't ever available in this scenario, so it's not just the one dispatch function. E.g. the registration function never seems to get called. 

Beyond that, these ETK stores which select and dispatch from each other involve an _implicit dependency_ between two modules of ETK which are both loaded at different times. So there are never guarantees about when the store is available. We should take a look at these to make them more robust.

## Testing Instructions
1. Download the .zip artifact from the ETK teamcity build in this PR
2. Upload that to an Atomic testing site with Gutenberg disabled and Woocommerce active (you _might_ only need one of these)
3. go to the "new page" screen
4. close the SPT modal with the x button, and it should actually close
