### PR TITLE
Plans 2023: Check if ecommerce is current plan for legacy storage label

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -1009,13 +1009,17 @@ const ConnectedPlanFeatures2023Grid = connect(
 					);
 				}
 
+				const isCurrentPlan = currentSitePlanSlug === plan;
 				const product_name_short =
 					isWpcomEnterpriseGridPlan( plan ) && planConstantObj.getPathSlug
 						? planConstantObj.getPathSlug()
 						: planObject?.product_name_short ?? '';
 				const storageOptions =
 					( planConstantObj.get2023PricingGridSignupStorageOptions &&
-						planConstantObj.get2023PricingGridSignupStorageOptions( showLegacyStorageFeature ) ) ||
+						planConstantObj.get2023PricingGridSignupStorageOptions(
+							showLegacyStorageFeature,
+							isCurrentPlan
+						) ) ||
 					[];
 
 				const availableForPurchase =
@@ -1035,7 +1039,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 					tagline,
 					storageOptions,
 					cartItemForPlan: getCartItemForPlan( plan ),
-					current: currentSitePlanSlug === plan,
+					current: isCurrentPlan,
 					isVisible: visiblePlans.indexOf( plan ) !== -1,
 					billingPeriod: planObject?.bill_period,
 					currencyCode: planObject?.currency_code,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1013,8 +1013,8 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_PAYMENT_TRANSACTION_FEES_0,
 	],
 	get2023PricingGridSignupJetpackFeatures: () => [],
-	get2023PricingGridSignupStorageOptions: ( showLegacyStorageFeature ) => {
-		if ( showLegacyStorageFeature ) {
+	get2023PricingGridSignupStorageOptions: ( showLegacyStorageFeature, isCurrentPlan ) => {
+		if ( showLegacyStorageFeature && isCurrentPlan ) {
 			return [ FEATURE_200GB_STORAGE ];
 		}
 

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -228,7 +228,10 @@ export type Plan = BillingTerm & {
 	 */
 	get2023PlanComparisonConditionalFeatures?: () => Feature[];
 
-	get2023PricingGridSignupStorageOptions?: ( showLegacyStorageFeature?: boolean ) => Feature[];
+	get2023PricingGridSignupStorageOptions?: (
+		showLegacyStorageFeature?: boolean,
+		isCurrentPlan?: boolean
+	) => Feature[];
 	getProductId: () => number;
 	getPathSlug?: () => string;
 	getStoreSlug: () => PlanSlug;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to  https://github.com/Automattic/wp-calypso/pull/79458#issuecomment-1640373753 + https://github.com/Automattic/martech/issues/1906

## Proposed Changes

* Display 50GB storage feature for ecommerce upgrades from a business Plan

## Screenshots
### On a legacy business plan
<img width="1496" alt="Screenshot 2023-07-19 at 6 44 18 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/b1ec255e-7996-4557-86cf-29d39ad52732">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out branch
* `yarn && yarn start`
* Navigate to calypso.localhost:3000/start
* Verify that the storage feature label in the features grid _and_ plans comparison grid is 50GB for business and ecommerce plans
* Verify that, for legacy sites ( Ex. a site created several weeks ago or even earlier ), on the `/plans` page, the features grid _and_ plans comparison grid is, if on a business plan, 200GB
* Verify that, if on a legacy business plan, the ecommerce upgrade displays 50GB of storage
* Verify that, if on a legacy ecommerce business plan, the ecommerce upgrade displays 200GB of storage

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
