### PR TITLE
Detect and set the users currency

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -6,10 +6,12 @@ import { check, closeSmall } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormInput from 'calypso/components/forms/form-text-input';
 import InfoPopover from 'calypso/components/info-popover';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { useValidationMessage } from './use-validation-message';
 
 type Props = {
@@ -104,13 +106,15 @@ export function DomainCodePair( {
 
 	const validation = useValidationMessage( domain, auth, hasDuplicates );
 
+	const userCurrencyCode = useSelector( getCurrentUserCurrencyCode ) || 'USD';
+
 	const {
 		valid,
 		loading,
 		message,
 		rawPrice = 0,
 		saleCost,
-		currencyCode = 'USD',
+		currencyCode = userCurrencyCode,
 		refetch,
 		errorStatus,
 	} = validation;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -10,6 +10,7 @@ import { plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useState } from 'react';
 import { v4 as uuid } from 'uuid';
+import QueryPlans from 'calypso/components/data/query-plans';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
 import { domainTransfer } from 'calypso/lib/cart-values/cart-items';
@@ -193,6 +194,8 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 
 	return (
 		<div className="bulk-domain-transfer__container">
+			{ /* QueryPlans required by getCurrentUserCurrencyCode in DomainCodePair */ }
+			<QueryPlans />
 			{ Object.entries( domainsState ).map( ( [ key, domain ], index ) => (
 				<DomainCodePair
 					key={ key }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3094

## Proposed Changes

* Queries plan data during the domain transfer step in order to set the users currency for displaying  the 0 state.
* There is a slight delay while querying plan data that a $0 is shown but I think this is acceptable, the alternative is to hide the price entirely until plan data loads but I found swapping out $0 to be less noticeable.

## Testing Instructions

* http://calypso.localhost:3000/setup/domain-transfer/domains
* Change your users currency via store admin and reload the domains step. The default currency should be seen even when the price is $0 (before any domain is entered)

Before

![Screenshot(73)](https://github.com/Automattic/wp-calypso/assets/811776/52756c5e-f993-47e1-bfa3-7b05583ef198)

After

![Screenshot(72)](https://github.com/Automattic/wp-calypso/assets/811776/47ce1eb8-94d0-4102-893e-4f65932953d6)
