### PR TITLE
Domain Transfer: Dedupe logic for total price

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -39,23 +39,6 @@ const defaultState: DomainTransferForm = {
 	},
 };
 
-const getFormattedTotalPrice = ( state: DomainTransferData ) => {
-	if ( Object.keys( state ).length > 0 ) {
-		const currencyCode = Object.values( state )[ 0 ].currencyCode;
-		const totalPrice = Object.values( state ).reduce( ( total, currentDomain ) => {
-			if ( currentDomain.saleCost || currentDomain.saleCost === 0 ) {
-				return total + currentDomain.saleCost;
-			}
-
-			return total + currentDomain.rawPrice;
-		}, 0 );
-
-		return formatCurrency( totalPrice, currencyCode ?? 'USD', { stripZeros: true } );
-	}
-
-	return 0;
-};
-
 const getTotalPrice = ( state: DomainTransferData ) => {
 	if ( Object.keys( state ).length > 0 ) {
 		return Object.values( state ).reduce( ( total, currentDomain ) => {
@@ -65,6 +48,17 @@ const getTotalPrice = ( state: DomainTransferData ) => {
 
 			return total + currentDomain.rawPrice;
 		}, 0 );
+	}
+
+	return 0;
+};
+
+const getFormattedTotalPrice = ( state: DomainTransferData ) => {
+	if ( Object.keys( state ).length > 0 ) {
+		const currencyCode = Object.values( state )[ 0 ].currencyCode;
+		const totalPrice = getTotalPrice( state );
+
+		return formatCurrency( totalPrice, currencyCode ?? 'USD', { stripZeros: true } );
 	}
 
 	return 0;


### PR DESCRIPTION
## Proposed Changes

Following up from #79650, this PR dedupes logic for calculating the price.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Go to `/setup/domain-transfer`
* Enter in multiple domains
* Ensure that price is calculated on button and for each domain
* Change language
* Ensure that price is formatted

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
