### PR TITLE
Paid Stats: remove purchase page feature gating

### DIFF
--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
@@ -54,9 +53,7 @@ export default function () {
 	statsPage( '/stats/insights', sites );
 
 	// Stat Purchase Page
-	if ( config.isEnabled( 'stats/paid-stats' ) ) {
-		statsPage( '/stats/purchase/:site', purchase );
-	}
+	statsPage( '/stats/purchase/:site', purchase );
 
 	// Stat Insights Page
 	statsPage( '/stats/insights/:site', insights );

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -10,7 +10,7 @@ import useNoticeVisibilityQuery from 'calypso/my-sites/stats/hooks/use-notice-vi
 import { StatsNoticeProps } from './types';
 
 const getStatsPurchaseURL = ( siteId: number | null ) => {
-	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/paid-stats`;
+	const purchasePath = `/stats/purchase/${ siteId }`;
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	if ( ! isOdysseyStats ) {
 		return purchasePath;

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { StatsNoticeProps } from './types';
 
 const getStatsPurchaseURL = ( siteId: number | null ) => {
-	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/paid-stats`;
+	const purchasePath = `/stats/purchase/${ siteId }`;
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	if ( ! isOdysseyStats ) {
 		return purchasePath;

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -44,10 +44,8 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => 
 
 const PostPurchaseNotices = ( { siteId, statsPurchaseSuccess }: PurchaseNoticesProps ) => {
 	// Check if the GET param is passed to show the Free or Paid plan purchase notices
-	const showFreePlanPurchaseSuccessNotice =
-		config.isEnabled( 'stats/paid-stats' ) && statsPurchaseSuccess === 'free';
-	const showPaidPlanPurchaseSuccessNotice =
-		config.isEnabled( 'stats/paid-stats' ) && statsPurchaseSuccess === 'paid';
+	const showFreePlanPurchaseSuccessNotice = statsPurchaseSuccess === 'free';
+	const showPaidPlanPurchaseSuccessNotice = statsPurchaseSuccess === 'paid';
 
 	return (
 		<>

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	PRODUCT_JETPACK_STATS_MONTHLY,
 	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
@@ -36,11 +35,6 @@ const StatsPurchasePage = () => {
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
-	const isPurchaseEnabled = config.isEnabled( 'stats/paid-stats' );
-
-	if ( ! isPurchaseEnabled ) {
-		page( '/stats', '/stats/day' );
-	}
 
 	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
 
@@ -63,9 +57,6 @@ const StatsPurchasePage = () => {
 		getProductBySlug( state, PRODUCT_JETPACK_STATS_PWYW_YEARLY )
 	) as ProductsList.ProductsListItem | null;
 
-	// eslint-disable-next-line no-console
-	console.log( 'product debug:', commercialProduct, pwywProduct );
-
 	const isLoading = ! commercialProduct || ! pwywProduct;
 
 	return (
@@ -87,13 +78,11 @@ const StatsPurchasePage = () => {
 								 }
 							</>
 						) }
-						{ isPurchaseEnabled && (
-							<StatsPurchaseWizard
-								siteSlug={ siteSlug }
-								commercialProduct={ commercialProduct }
-								pwywProduct={ pwywProduct }
-							/>
-						) }
+						<StatsPurchaseWizard
+							siteSlug={ siteSlug }
+							commercialProduct={ commercialProduct }
+							pwywProduct={ pwywProduct }
+						/>
 					</>
 				) }
 				<JetpackColophon />


### PR DESCRIPTION
## Proposed Changes

* Remove feature gating for the purchase page, as we have the entry points gated already
* Remove feature gating for purchase success notices as they are gated by GET params

## Testing Instructions

* Open Calypso Live `/stats/purchase/${siteSlug}`
* Ensure the page shows and works okay

<img width="1217" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/b88cc913-ae01-41f1-be3b-df3040f4f3da">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
