### PR TITLE
Domain Transfer: Move DNS records import below CTA

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -220,11 +220,20 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 					{ __( 'Add more' ) }
 				</Button>
 			) }
+			<div className="bulk-domain-transfer__cta-container">
+				<Button
+					disabled={ numberOfValidDomains === 0 || ! allGood }
+					className="bulk-domain-transfer__cta"
+					onClick={ handleAddTransfer }
+				>
+					{ getTransferButtonText() }
+				</Button>
+			</div>
 			{ numberOfValidDomains > 0 && (
-				<>
+				<div className="bulk-domain-transfer__import-dns-records">
 					<FormLabel
 						htmlFor="import-dns-records"
-						className="bulk-domain-transfer__import-dns-records"
+						className="bulk-domain-transfer__import-dns-records-label"
 					>
 						<FormInputCheckbox
 							id="import-dns-records"
@@ -235,17 +244,8 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 						/>
 						<span>{ __( 'Import DNS records from these domains' ) }</span>
 					</FormLabel>
-				</>
+				</div>
 			) }
-			<div className="bulk-domain-transfer__cta-container">
-				<Button
-					disabled={ numberOfValidDomains === 0 || ! allGood }
-					className="bulk-domain-transfer__cta"
-					onClick={ handleAddTransfer }
-				>
-					{ getTransferButtonText() }
-				</Button>
-			</div>
 			{ isEnabled( 'domain-transfer/faq' ) && (
 				<div className="bulk-domain-transfer__faqs">
 					<DomainTransferFAQ />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -91,7 +91,7 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 	const { setPendingAction, setDomainsTransferData, setShouldImportDomainTransferDnsRecords } =
 		useDispatch( ONBOARD_STORE );
 
-	const { __ } = useI18n();
+	const { __, _n } = useI18n();
 
 	const filledDomainValues = Object.values( domainsState ).filter( ( x ) => x.domain && x.auth );
 	const allGood = filledDomainValues.every( ( { valid } ) => valid );
@@ -242,7 +242,13 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 							} }
 							checked={ storedDomainsState.shouldImportDnsRecords }
 						/>
-						<span>{ __( 'Import DNS records from these domains' ) }</span>
+						<span>
+							{ _n(
+								'Import DNS records from this domain',
+								'Import DNS records from these domains',
+								domainCount
+							) }
+						</span>
 					</FormLabel>
 				</div>
 			) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -414,6 +414,8 @@
 
 			.form-checkbox + span {
 				display: inline;
+				margin-left: 0.5rem;
+				vertical-align: middle;
 			}
 
 			@media (max-width: $break-medium ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -408,6 +408,10 @@
 				float: none;
 			}
 
+			.form-label {
+				display: inline;
+			}
+
 			.form-checkbox + span {
 				display: inline;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -402,16 +402,25 @@
 		}
 
 		.bulk-domain-transfer__import-dns-records {
-			margin-bottom: 42px;
+			text-align: center;
+
+			.form-checkbox {
+				float: none;
+			}
+
+			.form-checkbox + span {
+				display: inline;
+			}
+
+			@media (max-width: $break-medium ) {
+				margin-bottom: 50px;
+			}
 		}
 
 		.bulk-domain-transfer__cta-container {
 			display: flex;
 			justify-content: center;
-
-			@media (max-width: $break-medium ) {
-				margin-bottom: 50px;
-			}
+			margin-bottom: 32px;
 
 			.bulk-domain-transfer__cta {
 				justify-content: center;


### PR DESCRIPTION
## Proposed Changes

- From feedback in a recent walkthrough p9Jlb4-8kT-p2, we should move the checkbox below the CTA. This PR accomplishes that.

Note: I was unsure of the margins. Feel free to change them.

## Testing Instructions

* Checkout PR
* Go to `/setup/domain-transfer`
* Enter in one domain and auth code
* Ensure that checkbox is below CTA, centered, and has singular text
* Enter in another domain
* Ensure that checkbox now has plural text

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?