### PR TITLE
ETK: Avoid wpcom-welcome-guide store unavailable because of the uncaught error

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -23,10 +23,16 @@ import VideoPressCelebrationModal from './video-celebration-modal';
 import WpcomNux from './welcome-modal/wpcom-nux';
 import LaunchWpcomWelcomeTour from './welcome-tour/tour-launch';
 
-const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-	'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
-	'@wordpress/edit-site'
-);
+let unlock;
+try {
+	unlock = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'@wordpress/edit-site'
+	).unlock;
+} catch ( error ) {
+	// eslint-disable-next-line no-console
+	console.error( 'Error: Unable to get the unlock api. Reason: %s', error );
+}
 
 function WelcomeTour() {
 	const [ showDraftPostModal ] = useState(
@@ -43,15 +49,19 @@ function WelcomeTour() {
 	} = useSelect( ( select ) => {
 		const welcomeGuideStoreSelect = select( 'automattic/wpcom-welcome-guide' );
 		const starterPageLayoutsStoreSelect = select( 'automattic/starter-page-layouts' );
-		const _canvasMode =
-			select( 'core/edit-site' ) && unlock( select( 'core/edit-site' ) ).getCanvasMode();
+		let canvasMode;
+		if ( unlock && select( 'core/edit-site' ) ) {
+			canvasMode =
+				select( 'core/edit-site' ) && unlock( select( 'core/edit-site' ) ).getCanvasMode();
+		}
+
 		return {
 			show: welcomeGuideStoreSelect.isWelcomeGuideShown(),
 			isLoaded: welcomeGuideStoreSelect.isWelcomeGuideStatusLoaded(),
 			variant: welcomeGuideStoreSelect.getWelcomeGuideVariant(),
 			isManuallyOpened: welcomeGuideStoreSelect.isWelcomeGuideManuallyOpened(),
 			isNewPageLayoutModalOpen: starterPageLayoutsStoreSelect?.isOpen(), // Handle the case where SPT is not initalized.
-			siteEditorCanvasMode: _canvasMode,
+			siteEditorCanvasMode: canvasMode,
 		};
 	}, [] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/79653, p1689775247526229-slack-C02FMH4G8

## Proposed Changes

* Sometimes Gutenberg doesn't allow you to re-register the module and throws an error (the new version allows it by default but it's not the version we use in this scenario). If so, the `wpcom-welcome-guide` store won't be registered because we didn't catch that error, and the store would be unavailable everywhere.
* So, this PR is proposing to add `try...catch` when we're trying to get the unlock api from the Gutenberg to catch the error and prevent the store from being unavailable.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Download the .zip artifact from the ETK teamcity build in this PR
* Upload that to an Atomic testing site with Gutenberg disabled and Woocommerce active (you might only need one of these)
* Go to the "new page" screen
* Close the SPT modal with the x button, and it should actually close
* Open the Welcome Tour via the `...` button on the top-right corner, and it should be opened correctly
* Open the Dev console and type `wp.data.select('automattic/wpcom-welcome-guide')`. You should get the actions of the `wpcom-welcome-guide` store correctly 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?