### PR TITLE
Jetpack Settings: Fix staging site toggle label

### DIFF
--- a/client/components/jetpack-staging-sites-management/index.tsx
+++ b/client/components/jetpack-staging-sites-management/index.tsx
@@ -80,20 +80,18 @@ const JetpackStagingSitesManagement: FunctionComponent = () => {
 					<div className="setting-option">
 						<div className="setting-option__toggle">
 							<ToggleControl
+								label={ translate(
+									'{{strong}}Set this site as a Staging Site.{{/strong}} You will be able to copy any site to this staging site and test your changes safely.',
+									{
+										components: {
+											strong: <strong />,
+										},
+									}
+								) }
 								disabled={ isLoading }
 								checked={ isStaging }
 								onChange={ toggleStagingFlag }
 							/>
-						</div>
-						<div className="setting-option__description">
-							{ translate(
-								'{{strong}}Set this site as a Staging Site.{{/strong}} You will be able to copy any site to this staging site and test your changes safely.',
-								{
-									components: {
-										strong: <strong />,
-									},
-								}
-							) }
 						</div>
 					</div>
 				</Card>

--- a/client/components/jetpack-staging-sites-management/index.tsx
+++ b/client/components/jetpack-staging-sites-management/index.tsx
@@ -80,7 +80,6 @@ const JetpackStagingSitesManagement: FunctionComponent = () => {
 					<div className="setting-option">
 						<div className="setting-option__toggle">
 							<ToggleControl
-								label={ translate( 'Set staging site.' ) }
 								disabled={ isLoading }
 								checked={ isStaging }
 								onChange={ toggleStagingFlag }

--- a/client/components/jetpack-staging-sites-management/style.scss
+++ b/client/components/jetpack-staging-sites-management/style.scss
@@ -45,7 +45,7 @@
 	justify-content: space-between;
 	margin-bottom: 8px;
 
-	&__description {
+	.setting-option__toggle label {
 		font-size: 0.875rem;
 	}
 }


### PR DESCRIPTION
The `ToggleControl` component requires a `label` prop [according to its type definition](https://github.com/WordPress/gutenberg/blob/2ae13d0820f1fde82208647e4a8ab6baac38fb0c/packages/components/src/toggle-control/types.ts#L21), based on that, it was added the label prop in #78711 when updating `@wordpress/components` packages in Calypso.

The purpose of this PR is to move the toggle description to the `label` prop.

## Proposed Changes

* Move the Jetpack staging site setting toggle description into the `label` prop in `ToggleControl` component to remove redundant texts.

| Before | After |
|---|---|
| <img width="697" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/42cd5275-dff0-4aa9-a22e-57c69b8aa73f"> | <img width="697" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1488641/0f3bfde8-c66e-4472-a731-ad9c6389e881"> |

## Testing Instructions
* Using a site with Jetpack VaultPress Backup and server credentials configured, navigate to Jetpack Cloud's settings page and ensure the `Set up as staging site` setting looks like the `After` screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
