### PR TITLE
Domains Transfers: Move trash/refresh to the validation text

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -8,7 +8,6 @@ import classnames from 'classnames';
 import { useEffect } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
-import FormExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormInput from 'calypso/components/forms/form-text-input';
 import InfoPopover from 'calypso/components/info-popover';
 import { useValidationMessage } from './use-validation-message';
@@ -232,12 +231,16 @@ export function DomainCodePair( {
 								children={ domainActions }
 							></FormInputValidation>
 						) }
-						{ message && loading && <FormExplanation>{ message }</FormExplanation> }
+						{ message && loading && (
+							<FormInputValidation text={ message } isError={ false } isMuted={ true } />
+						) }
 						{ ! shouldReportError && ! loading && (
-							<FormExplanation>
-								{ __( 'Please enter the domain name and authorization code.' ) }
-								{ domainCount > 1 && domainActions }
-							</FormExplanation>
+							<FormInputValidation
+								isError={ false }
+								isMuted={ true }
+								text={ __( 'Please enter the domain name and authorization code.' ) }
+								children={ domainCount > 1 && domainActions }
+							/>
 						) }
 					</div>
 				</div>
@@ -268,15 +271,15 @@ export function DomainCodePair( {
 					></FormInputValidation>
 				) }
 				{ message && loading && (
-					<div>
-						<FormExplanation>{ message }</FormExplanation>
-					</div>
+					<FormInputValidation text={ message } isError={ false } isMuted={ true } />
 				) }
 				{ ! shouldReportError && ! loading && (
-					<FormExplanation>
-						{ __( 'Please enter the domain name and authorization code.' ) }
-						{ domainCount > 1 && domainActions }
-					</FormExplanation>
+					<FormInputValidation
+						isError={ false }
+						isMuted={ true }
+						text={ __( 'Please enter the domain name and authorization code.' ) }
+						children={ domainCount > 1 && domainActions }
+					/>
 				) }
 			</div>
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -138,6 +138,7 @@ export function DomainCodePair( {
 				// Disable the delete button on initial state meaning. no domain, no auth and one row.
 				disabled={ ! domain && ! auth && domainCount === 1 }
 				onClick={ () => onRemove( id ) }
+				variant="link"
 			>
 				<span className="delete-label">{ __( 'Discard Domain' ) }</span>
 			</Button>
@@ -148,6 +149,7 @@ export function DomainCodePair( {
 				className={ classnames( 'domains__domain-refresh', {
 					'is-invisible-field': ! refetch,
 				} ) }
+				variant="link"
 			>
 				<span className="refresh-label">{ __( 'Refresh' ) }</span>
 			</Button>
@@ -222,18 +224,22 @@ export function DomainCodePair( {
 						/>
 						{ domainInputFieldIcon( valid, shouldReportError ) }
 					</FormFieldset>
-					{ ( shouldReportError || ( message && loading ) ) && (
-						<div className="domains__domain-validation is-mobile">
-							{ shouldReportError && (
-								<FormInputValidation
-									isError={ ! valid }
-									text={ message }
-									children={ domainActions }
-								></FormInputValidation>
-							) }
-							{ message && loading && <FormExplanation>{ message }</FormExplanation> }
-						</div>
-					) }
+					<div className="domains__domain-validation is-mobile">
+						{ shouldReportError && (
+							<FormInputValidation
+								isError={ ! valid }
+								text={ message }
+								children={ domainActions }
+							></FormInputValidation>
+						) }
+						{ message && loading && <FormExplanation>{ message }</FormExplanation> }
+						{ ! shouldReportError && ! loading && (
+							<FormExplanation>
+								{ __( 'Please enter the domain name and authorization code.' ) }
+								{ domainCount > 1 && domainActions }
+							</FormExplanation>
+						) }
+					</div>
 				</div>
 				<div className="domains__domain-price">
 					<FormFieldset>
@@ -265,6 +271,12 @@ export function DomainCodePair( {
 					<div>
 						<FormExplanation>{ message }</FormExplanation>
 					</div>
+				) }
+				{ ! shouldReportError && ! loading && (
+					<FormExplanation>
+						{ __( 'Please enter the domain name and authorization code.' ) }
+						{ domainCount > 1 && domainActions }
+					</FormExplanation>
 				) }
 			</div>
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -133,12 +133,13 @@ export function DomainCodePair( {
 
 	const domainActions = (
 		<>
+			&nbsp;
 			<Button
 				// Disable the delete button on initial state meaning. no domain, no auth and one row.
 				disabled={ ! domain && ! auth && domainCount === 1 }
 				onClick={ () => onRemove( id ) }
 			>
-				<span className="delete-label">{ __( 'Delete' ) }</span>
+				<span className="delete-label">{ __( 'Discard Domain' ) }</span>
 			</Button>
 			<Button
 				title={ __( 'Refresh' ) }
@@ -221,23 +222,19 @@ export function DomainCodePair( {
 						/>
 						{ domainInputFieldIcon( valid, shouldReportError ) }
 					</FormFieldset>
+					{ ( shouldReportError || ( message && loading ) ) && (
+						<div className="domains__domain-validation is-mobile">
+							{ shouldReportError && (
+								<FormInputValidation
+									isError={ ! valid }
+									text={ message }
+									children={ domainActions }
+								></FormInputValidation>
+							) }
+							{ message && loading && <FormExplanation>{ message }</FormExplanation> }
+						</div>
+					) }
 				</div>
-				{ ( shouldReportError || ( message && loading ) ) && (
-					<div className="domains__domain-validation is-mobile">
-						{ shouldReportError && (
-							<FormInputValidation
-								isError={ ! valid }
-								text={ message }
-								children={ domainActions }
-							></FormInputValidation>
-						) }
-						{ message && loading && (
-							<div>
-								<FormExplanation>{ message }</FormExplanation>
-							</div>
-						) }
-					</div>
-				) }
 				<div className="domains__domain-price">
 					<FormFieldset>
 						<FormLabel

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -2,11 +2,10 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FormInputValidation } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { Button, Icon } from '@wordpress/components';
-import { check, trash, closeSmall } from '@wordpress/icons';
+import { check, closeSmall } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useEffect } from 'react';
-import Gridicon from 'calypso/../packages/components/src/gridicon';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -132,6 +131,27 @@ export function DomainCodePair( {
 		}
 	}, [ shouldReportError, valid, domain, message, errorStatus ] );
 
+	const domainActions = (
+		<>
+			<Button
+				// Disable the delete button on initial state meaning. no domain, no auth and one row.
+				disabled={ ! domain && ! auth && domainCount === 1 }
+				onClick={ () => onRemove( id ) }
+			>
+				<span className="delete-label">{ __( 'Delete' ) }</span>
+			</Button>
+			<Button
+				title={ __( 'Refresh' ) }
+				disabled={ ! refetch }
+				onClick={ () => refetch?.() }
+				className={ classnames( 'domains__domain-refresh', {
+					'is-invisible-field': ! refetch,
+				} ) }
+			>
+				<span className="refresh-label">{ __( 'Refresh' ) }</span>
+			</Button>
+		</>
+	);
 	return (
 		<div className="domains__domain-info-and-validation">
 			<div className="domains__domain-info">
@@ -205,7 +225,11 @@ export function DomainCodePair( {
 				{ ( shouldReportError || ( message && loading ) ) && (
 					<div className="domains__domain-validation is-mobile">
 						{ shouldReportError && (
-							<FormInputValidation isError={ ! valid } text={ message }></FormInputValidation>
+							<FormInputValidation
+								isError={ ! valid }
+								text={ message }
+								children={ domainActions }
+							></FormInputValidation>
 						) }
 						{ message && loading && (
 							<div>
@@ -231,36 +255,14 @@ export function DomainCodePair( {
 						/>
 					</FormFieldset>
 				</div>
-				<div className="domains__domain-controls">
-					<div className="domains__domain-delete">
-						<Button
-							// Disable the delete button on initial state meaning. no domain, no auth and one row.
-							disabled={ ! domain && ! auth && domainCount === 1 }
-							icon={ trash }
-							onClick={ () => onRemove( id ) }
-						>
-							<span className="delete-label">{ __( 'Delete' ) }</span>
-						</Button>
-					</div>
-					<div
-						className={ classnames( 'domains__domain-refresh', {
-							'is-invisible-field': ! refetch,
-						} ) }
-					>
-						<Button
-							icon={ <Gridicon icon="sync" width={ 24 } height={ 24 } /> }
-							title={ __( 'Refresh' ) }
-							disabled={ ! refetch }
-							onClick={ () => refetch?.() }
-						>
-							<span className="refresh-label">{ __( 'Refresh' ) }</span>
-						</Button>
-					</div>
-				</div>
 			</div>
 			<div className="domains__domain-validation is-desktop">
 				{ shouldReportError && (
-					<FormInputValidation isError={ ! valid } text={ message }></FormInputValidation>
+					<FormInputValidation
+						isError={ ! valid }
+						text={ message }
+						children={ domainActions }
+					></FormInputValidation>
 				) }
 				{ message && loading && (
 					<div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -396,7 +396,7 @@
 	}
 
 	.domains__domain-info-and-validation {
-		margin-bottom: 12px;
+		margin-bottom: 20px;
 
 		@media (max-width: $break-medium ) {
 			margin-bottom: 32px;
@@ -408,6 +408,7 @@
 		}
 
 		.form-input-validation {
+			margin-top: 5px;
 			padding: 0;
 
 			// remove icon

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -155,10 +155,9 @@
 	}
 
 	.domains__domain-validation {
-		margin-top: 12px;
-
 		&.is-mobile {
 			display: none;
+			margin-top: 5px;
 		}
 
 		&.is-desktop {
@@ -418,6 +417,11 @@
 
 			a {
 				text-decoration: underline;
+			}
+
+			// Remove left-padding for first button to minimize padding when line wraps on mobile.
+			button:first-of-type {
+				padding-left: 0;
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -317,57 +317,6 @@
 		}
 	}
 
-
-	.domains__domain-controls {
-		display: flex;
-		gap: 16px;
-		flex: 1;
-
-		button {
-			&:hover {
-				color: var(--wp-components-color-accent, var(--wp-admin-theme-color, var(--studio-blue-60)));
-			}
-		}
-
-		@media (min-width: $break-medium ) {
-			margin-left: -25px;
-		}
-
-		.domains__domain-refresh {
-			button {
-				cursor: pointer;
-
-				.refresh-label {
-					margin-left: 4px;
-				}
-			}
-
-			.refresh-label {
-				display: none;
-			}
-
-			@media (max-width: $break-medium ) {
-				.refresh-label {
-					display: block;
-				}
-			}
-		}
-
-		.domains__domain-delete {
-			.delete-label {
-				display: none;
-			}
-
-			@media (max-width: $break-medium ) {
-				order: 1;
-
-				.delete-label {
-					display: block;
-				}
-			}
-		}
-	}
-
 	.bulk-domain-transfer__container {
 
 		.bulk-domain-transfer__add-domain {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -165,6 +165,11 @@
 			display: block;
 		}
 
+		button {
+			padding: 0 5px;
+			text-decoration: underline;
+		}
+
 		@media (max-width: $break-medium ) {
 			margin-top: 0;
 
@@ -179,7 +184,7 @@
 	}
 
 	.domains__domain-domain {
-		flex: 7;
+		flex: 8;
 	}
 
 	.domains__domain-key {
@@ -196,7 +201,7 @@
 	}
 
 	.domains__domain-price {
-		flex: 2;
+		flex: 1;
 
 		.domains__domain-price-number {
 			align-items: center;

--- a/packages/components/src/forms/form-input-validation/index.tsx
+++ b/packages/components/src/forms/form-input-validation/index.tsx
@@ -10,6 +10,7 @@ interface Props {
 	isWarning?: boolean;
 	isHidden?: boolean;
 	isValid?: boolean;
+	isMuted?: boolean;
 	text: ReactNode;
 	ariaLabel?: string;
 	icon?: string;
@@ -22,6 +23,7 @@ const FormInputValidation: React.FC< Props > = ( {
 	isError = false,
 	isWarning,
 	isHidden,
+	isMuted,
 	className,
 	ariaLabel = '',
 	text,
@@ -34,6 +36,7 @@ const FormInputValidation: React.FC< Props > = ( {
 		'is-warning': isWarning,
 		'is-error': isError,
 		'is-hidden': isHidden,
+		'is-muted': isMuted,
 	} );
 
 	const defaultIcon = isError || isWarning ? info : check;

--- a/packages/components/src/forms/form-input-validation/style.scss
+++ b/packages/components/src/forms/form-input-validation/style.scss
@@ -23,6 +23,10 @@
 		visibility: hidden;
 	}
 
+	&.is-muted {
+		color: var(--color-text-subtle);
+	}
+
 	.gridicon,
 	svg {
 		fill: currentcolor;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3135

Reopening after deploying and reverting #79649 after I realized there was a test case that we hadn't covered, which was how do we handle new rows that don't have entered data. We may need a default "validation" state for this case.

Note that this PR is no longer using the FormSettingExplanation component and is now using the FormFieldValidation component with a new `isMuted` property.` I noticed some minor layout shift that was occurring when the shift between explanation and validation occurred which really annoyed me. 😄 

## Proposed Changes

Remove the trash & refresh icons, and I moved them to the validation info as text, and make the price column smaller.

Note that this PR is no longer using the FormSettingExplanation component and has added a new `muted` property

| Mobile | Desktop |
| --- | --- |
|  ![image](https://github.com/Automattic/wp-calypso/assets/1126811/ba4e0473-9701-4d1a-9e8e-9759c6706ef9) | ![image](https://github.com/Automattic/wp-calypso/assets/1126811/c77d9213-a8b4-4da7-80a6-aa9e59755d67) |


## Testing Instructions

* Go to `/setup/domain-transfer/domains`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
