### PR TITLE
Add sensitive pixels options and ad_details cookie data to checkout endpoint

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -141,7 +141,7 @@ function addRegistrationDataToGSuiteCartProduct(
  * @returns String with the value of the sensitive_pixel_options cookie, or an empty string if the cookie is not present.
  */
 function getConversionValuesFromCookies(): { ad_details: string; sensitive_pixel_options: string } {
-	const cookies = cookie.parse( document.cookie );
+	const cookies = typeof document !== 'undefined' ? cookie.parse( document.cookie ) : {};
 	return {
 		ad_details: cookies.ad_details || '',
 		sensitive_pixel_options: cookies.sensitive_pixel_options || '', // sensitive_pixel_options

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -3,6 +3,7 @@ import {
 	isGSuiteOrGoogleWorkspaceProductSlug,
 } from '@automattic/calypso-products';
 import { isValueTruthy, getTotalLineItemFromCart } from '@automattic/wpcom-checkout';
+import cookie from 'cookie';
 import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import {
 	readWPCOMPaymentMethodClass,
@@ -134,6 +135,19 @@ function addRegistrationDataToGSuiteCartProduct(
 	};
 }
 
+/**
+ * This function is used to get the value of the sensitive_pixel_options cookie.
+ *
+ * @returns String with the value of the sensitive_pixel_options cookie, or an empty string if the cookie is not present.
+ */
+function getConversionValuesFromCookies(): { ad_details: string; sensitive_pixel_options: string } {
+	const cookies = cookie.parse( document.cookie );
+	return {
+		ad_details: cookies.ad_details || '',
+		sensitive_pixel_options: cookies.sensitive_pixel_options || '', // sensitive_pixel_options
+	};
+}
+
 export function createTransactionEndpointRequestPayload( {
 	cart,
 	country,
@@ -192,5 +206,6 @@ export function createTransactionEndpointRequestPayload( {
 			eventSource,
 		},
 		tos: getToSAcceptancePayload(),
+		ad_conversion: getConversionValuesFromCookies(),
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
@@ -59,6 +59,10 @@ describe( 'existingCardProcessor', () => {
 			path: '/',
 			viewport: '0x0',
 		},
+		ad_conversion: {
+			ad_details: '',
+			sensitive_pixel_options: '',
+		},
 	};
 
 	it( 'throws an error if there is no storedDetailsId passed', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
@@ -62,6 +62,10 @@ describe( 'freePurchaseProcessor', () => {
 			path: '/',
 			viewport: '0x0',
 		},
+		ad_conversion: {
+			ad_details: '',
+			sensitive_pixel_options: '',
+		},
 	};
 
 	it( 'sends the correct data to the endpoint with no site and one product', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
@@ -52,6 +52,10 @@ describe( 'genericRedirectProcessor', () => {
 			path: '/',
 			viewport: '0x0',
 		},
+		ad_conversion: {
+			ad_details: '',
+			sensitive_pixel_options: '',
+		},
 	};
 
 	it( 'sends the correct data to the endpoint with no site and one product', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
@@ -143,6 +143,10 @@ describe( 'multiPartnerCardProcessor', () => {
 			path: '/',
 			viewport: '0x0',
 		},
+		ad_conversion: {
+			ad_details: '',
+			sensitive_pixel_options: '',
+		},
 	};
 
 	const basicExpectedEbanxRequest = {

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -283,6 +283,10 @@ describe( 'payPalExpressProcessor', () => {
 				path: '/checkout/no-site',
 				viewport: '0x0',
 			},
+			ad_conversion: {
+				ad_details: '',
+				sensitive_pixel_options: '',
+			},
 		} );
 	} );
 
@@ -315,6 +319,10 @@ describe( 'payPalExpressProcessor', () => {
 				locale: 'en',
 				path: '/checkout/no-site',
 				viewport: '0x0',
+			},
+			ad_conversion: {
+				ad_details: '',
+				sensitive_pixel_options: '',
 			},
 		} );
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -55,6 +55,10 @@ describe( 'payPalExpressProcessor', () => {
 			path: '/',
 			viewport: '0x0',
 		},
+		ad_conversion: {
+			ad_details: '',
+			sensitive_pixel_options: '',
+		},
 	};
 
 	beforeEach( () => {

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -55,10 +55,6 @@ describe( 'payPalExpressProcessor', () => {
 			path: '/',
 			viewport: '0x0',
 		},
-		ad_conversion: {
-			ad_details: '',
-			sensitive_pixel_options: '',
-		},
 	};
 
 	beforeEach( () => {
@@ -283,10 +279,6 @@ describe( 'payPalExpressProcessor', () => {
 				path: '/checkout/no-site',
 				viewport: '0x0',
 			},
-			ad_conversion: {
-				ad_details: '',
-				sensitive_pixel_options: '',
-			},
 		} );
 	} );
 
@@ -319,10 +311,6 @@ describe( 'payPalExpressProcessor', () => {
 				locale: 'en',
 				path: '/checkout/no-site',
 				viewport: '0x0',
-			},
-			ad_conversion: {
-				ad_details: '',
-				sensitive_pixel_options: '',
 			},
 		} );
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
@@ -55,6 +55,10 @@ describe( 'weChatProcessor', () => {
 			path: '/',
 			viewport: '0x0',
 		},
+		ad_conversion: {
+			ad_details: '',
+			sensitive_pixel_options: '',
+		},
 	};
 
 	const redirect_url = 'https://test-redirect-url';

--- a/client/my-sites/checkout/composite-checkout/test/web-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/web-pay-processor.ts
@@ -52,6 +52,10 @@ describe( 'webPayProcessor', () => {
 			path: '/',
 			viewport: '0x0',
 		},
+		ad_conversion: {
+			ad_details: '',
+			sensitive_pixel_options: '',
+		},
 	};
 
 	it( 'throws an error if there is no stripe object', async () => {

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -114,12 +114,18 @@ export type WPCOMTransactionEndpointRequestPayload = {
 	payment: WPCOMTransactionEndpointPaymentDetails;
 	domainDetails?: DomainContactDetails;
 	tos?: ToSAcceptanceTrackingDetails;
+	ad_conversion?: AdConversionDetails;
 };
 
 export type ToSAcceptanceTrackingDetails = {
 	path: string;
 	locale: string;
 	viewport: string;
+};
+
+export type AdConversionDetails = {
+	ad_details: string;
+	sensitive_pixel_options: string; // sensitive_pixel_options
 };
 
 export type WPCOMTransactionEndpointPaymentDetails = {
@@ -222,6 +228,7 @@ export type PayPalExpressEndpointRequestPayload = {
 	country: string;
 	postalCode: string;
 	tos?: ToSAcceptanceTrackingDetails;
+	ad_conversion?: AdConversionDetails;
 };
 
 export type PayPalExpressEndpointResponse = unknown;


### PR DESCRIPTION
## Proposed Changes

More info: 1858-gh-Automattic/martech, pduY5I-uS-p2#comment-359

This adds the sensitive_pixel_options & the ad_details cookie data (conversion data) to the payload to the transaction checkout endpoint

The payload is included under the ad_conversion key and contains:

- ad_details - utm parameters and fbclid
- sensitive_pixel_options - ad cookie tracking data

![Screen Shot 2023-07-19 at 11 50 13 PM](https://github.com/Automattic/wp-calypso/assets/233879/7e4fdbce-aaa8-4b36-bc90-01a273cec639)


## Testing Instructions

1. Sandbox public-api.wordpress.com
2. Apply the patches from D116525-code so that the conversion payload gets processed
3. Open the Network tab with Preserve Logs enabled
4. Open the calypso page with these query parameters appended: ?flags=a8c-analytics.on&utm_source=facebook&utm_campaign=test&fbclid=abcd12341234
5. proceed to the checkout page with 
6. fill in the details
7. click on Pay
8. make sure the request to /me/transactions contains the ad_conversion property



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
