### PR TITLE
Design Picker: Add themes Bute and Entry to the theme preview color block list

### DIFF
--- a/packages/design-preview/src/constants.ts
+++ b/packages/design-preview/src/constants.ts
@@ -1,6 +1,8 @@
 export const COLOR_VARIATIONS_BLOCK_LIST = [
 	'pub/aldente',
+	'pub/bute',
 	'pub/calyx',
+	'pub/entry',
 	'pub/jinjang',
 	'pub/loudness',
 	'pub/tenaz',


### PR DESCRIPTION
## Proposed Changes

Newly added themes Bute and Entry don't work well with the theme preview color palette. This PR add these themes to the block list.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the onboarding design picker `/setup/site-setup/designSetup?siteSlug=${site_slug}`
* Click on the themes Bute and Entry.
* Ensure that their previews only show font selection, without color selection.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
