### PR TITLE
Partner Portal: update the tabs styles on the "Licenses" page to be consistent throughout the Jetpack Cloud.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-search/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-search/index.tsx
@@ -1,0 +1,38 @@
+import { useTranslate } from 'i18n-calypso';
+import { useContext } from 'react';
+import Search from 'calypso/components/search';
+import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
+import UrlSearch from 'calypso/lib/url-search';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+interface Props {
+	doSearch: ( query: string ) => void; // prop coming from UrlSearch
+}
+
+const LicenseSearch = ( { doSearch }: Props ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const { search } = useContext( LicenseListContext );
+
+	const onSearch = ( query: string ) => {
+		dispatch( recordTracksEvent( 'calypso_partner_portal_license_list_search', { query } ) );
+		doSearch( query );
+	};
+
+	return (
+		<Search
+			pinned
+			hideFocus
+			isOpen
+			initialValue={ search }
+			hideClose={ ! search }
+			onSearch={ onSearch }
+			placeholder={ translate( 'Search licenses' ) }
+			delaySearch={ true }
+		/>
+	);
+};
+
+export default UrlSearch( LicenseSearch );

--- a/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
@@ -1,28 +1,21 @@
 import { useTranslate } from 'i18n-calypso';
 import { useContext } from 'react';
 import Count from 'calypso/components/count';
-import Search from 'calypso/components/search';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
 import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { internalToPublicLicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
-import UrlSearch from 'calypso/lib/url-search';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getLicenseCounts } from 'calypso/state/partner-portal/licenses/selectors';
 import './style.scss';
 
-interface Props {
-	doSearch: ( query: string ) => void;
-	getSearchOpen: () => boolean;
-}
-
-function LicenseStateFilter( { doSearch }: Props ) {
+function LicenseStateFilter() {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const { filter, search } = useContext( LicenseListContext );
+	const { filter } = useContext( LicenseListContext );
 	const counts = useSelector( getLicenseCounts );
 	const basePath = '/partner-portal/licenses/';
 
@@ -64,13 +57,9 @@ function LicenseStateFilter( { doSearch }: Props ) {
 
 	const selectedItem = navItems.find( ( i ) => i.selected ) || navItems[ 0 ];
 
-	const onSearch = ( query: string ) => {
-		dispatch( recordTracksEvent( 'calypso_partner_portal_license_list_search', { query } ) );
-		doSearch( query );
-	};
-
 	return (
 		<SectionNav
+			applyUpdatedStyles
 			selectedText={
 				<span>
 					{ selectedItem.label }
@@ -80,26 +69,13 @@ function LicenseStateFilter( { doSearch }: Props ) {
 			selectedCount={ selectedItem.count }
 			className="license-state-filter"
 		>
-			<NavTabs
-				label={ translate( 'State' ) }
-				selectedText={ selectedItem.label }
-				selectedCount={ selectedItem.count }
-			>
+			<NavTabs selectedText={ selectedItem.label } selectedCount={ selectedItem.count }>
 				{ navItems.map( ( props ) => (
 					<NavItem { ...props } compactCount={ true } />
 				) ) }
 			</NavTabs>
-
-			<Search
-				pinned
-				fitsContainer
-				initialValue={ search }
-				onSearch={ onSearch }
-				placeholder={ translate( 'Search licenses' ) }
-				delaySearch={ true }
-			/>
 		</SectionNav>
 	);
 }
 
-export default UrlSearch( LicenseStateFilter );
+export default LicenseStateFilter;

--- a/client/jetpack-cloud/sections/partner-portal/license-state-filter/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-state-filter/style.scss
@@ -1,3 +1,45 @@
-.license-state-filter .section-nav__mobile-header-text .count {
-	margin-left: 8px;
+.license-state-filter {
+	.section-nav__mobile-header-text .count {
+		margin-left: 8px;
+	}
+
+	.select-dropdown__item.is-selected .count {
+		color: var(--color-text);
+	}
+
+	.select-dropdown__header {
+		border-width: 0;
+
+		.count {
+			top: 12.5px;
+		}
+
+		@include breakpoint-deprecated( ">660px" ) {
+			border-width: 1px;
+		}
+	}
+
+	.section-nav-tabs.is-dropdown {
+		width: 100%;
+		margin: 0 0 1px 0;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			margin-block-end: 12px;
+		}
+	}
+
+	.select-dropdown__options {
+		margin-inline: -1px;
+	}
+
+	.section-nav-tabs__dropdown .select-dropdown__container {
+		max-width: unset;
+		width: 100%;
+	}
+
+	.section-nav-tabs__dropdown {
+		// Since the search below the dropdown has z-index: 22,
+		// we need to make sure the dropdown is above it
+		z-index: 23;
+	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -23,6 +23,7 @@ import {
 import { showAgencyDashboard } from 'calypso/state/partner-portal/partner/selectors';
 import Layout from '../../layout';
 import LayoutHeader from '../../layout/header';
+import LicenseSearch from '../../license-search';
 import OnboardingWidget from '../onboarding-widget';
 
 import './style.scss';
@@ -75,30 +76,38 @@ export default function Licenses( {
 			) }
 			<SiteAddLicenseNotification />
 
-			<LayoutHeader>
-				<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>
+			<LicenseListContext.Provider value={ context }>
+				<div className="licenses__container">
+					<div className="licenses__header-container">
+						<div className="licenses__header">
+							<LayoutHeader>
+								<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>
 
-				<SelectPartnerKeyDropdown />
+								<SelectPartnerKeyDropdown />
 
-				<Button
-					href="/partner-portal/issue-license"
-					onClick={ onIssueNewLicenseClick }
-					primary
-					style={ { marginLeft: 'auto' } }
-				>
-					{ translate( 'Issue New License' ) }
-				</Button>
-			</LayoutHeader>
+								<Button
+									href="/partner-portal/issue-license"
+									onClick={ onIssueNewLicenseClick }
+									primary
+									style={ { marginLeft: 'auto' } }
+								>
+									{ translate( 'Issue New License' ) }
+								</Button>
+							</LayoutHeader>
+						</div>
+						<LicenseStateFilter />
+					</div>
+				</div>
 
-			{ showEmptyStateContent ? (
-				<OnboardingWidget isLicensesPage />
-			) : (
-				<LicenseListContext.Provider value={ context }>
-					<LicenseStateFilter />
-
-					<LicenseList />
-				</LicenseListContext.Provider>
-			) }
+				{ showEmptyStateContent ? (
+					<OnboardingWidget isLicensesPage />
+				) : (
+					<div className="licenses__content">
+						<LicenseSearch />
+						<LicenseList />
+					</div>
+				) }
+			</LicenseListContext.Provider>
 		</Layout>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
@@ -13,12 +13,8 @@
 	.partner-portal-layout__container {
 		display: flex;
 		flex-direction: column;
-		// The -111px is to undo the padding of .layout__content (79px + 32px) & partner-portal-layout__container (6px + 6px)
-		min-height: calc(100vh - 123px);
-
-		@include break-xlarge {
-			padding: 6px 0;
-		}
+		// The -111px is to undo the padding of .layout__content (79px + 32px)
+		min-height: calc(100vh - 111px);
 	}
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .licenses {
 	header.current-section {
 		padding: 0 16px;
@@ -5,5 +8,44 @@
 		button {
 			padding: 20px 8px;
 		}
+	}
+
+	.partner-portal-layout__container {
+		display: flex;
+		flex-direction: column;
+		// The -111px is to undo the padding of .layout__content (79px + 32px) & partner-portal-layout__container (6px + 6px)
+		min-height: calc(100vh - 123px);
+
+		@include break-xlarge {
+			padding: 6px 0;
+		}
+	}
+}
+
+.licenses__header-container {
+	@include breakpoint-deprecated( ">660px" ) {
+		// We need these negative margin values because we want to make the container full-width,
+		// but our element is inside a limited-width parent.
+		margin-inline: -73px;
+		padding-inline: 73px;
+		border-bottom: 1px solid var(--color-primary-5);
+	}
+}
+
+.licenses__content {
+	flex: 1 1 100%;
+	padding-block-start: 8px;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		padding: 16px 73px;
+		// We need these negative margin values because we want to make the container full-width,
+		// but our element is inside a limited-width parent.
+		margin: 0 -73px -73px;
+		background: rgba(255, 255, 255, 0.5);
+	}
+
+	.search {
+		box-shadow: 0 0 0 1px var(--color-neutral-5);
+		margin-block-end: 8px;
 	}
 }


### PR DESCRIPTION
Related to 1199980337313591-as-1202596470052186

## Proposed Changes

This PR updates the tabs styles on the "Licenses" page to be consistent throughout the Jetpack Cloud.

#### Testing Instructions

**Instructions**

1. Run `add/enhance-cloud-tabs-styling-on-licenses-page` and `yarn start-jetpack-cloud` or open the Jetpack live link.
2. Open http://jetpack.cloud.localhost:3000/
3. Click on the **Licensing** top nav -> Verify the styles look consistent with the Dashboard page on different screen sizes.
4. Verify the search works as expected. Please note: You need to enter the exact license key for the search to work.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>

![mobile (29)](https://github.com/Automattic/wp-calypso/assets/10586875/b75f1442-337d-42c8-89d0-f410219ef30b)
</td>
<td>

![mobile (28)](https://github.com/Automattic/wp-calypso/assets/10586875/43883526-6857-413e-a2fa-319f280b4e0b)
</td>
</tr>
<tr>
<td>

![mobile (30)](https://github.com/Automattic/wp-calypso/assets/10586875/bd0fde2d-f05b-45a2-abe4-e551413bf2a9)
</td>
<td>

![mobile (26)](https://github.com/Automattic/wp-calypso/assets/10586875/3345e34c-4a77-4615-b4d9-b0e928f1f507)
</td>
</tr>
<tr>
<td>

![mobile (31)](https://github.com/Automattic/wp-calypso/assets/10586875/6829c989-c19c-4798-9b74-7541dfb7df71)
</td>
<td>

![mobile (27)](https://github.com/Automattic/wp-calypso/assets/10586875/01048a9d-f5a5-463f-97ac-7da4867595db)
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?