### PR TITLE
Domain transfer: Add Help Center to Stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -123,6 +123,7 @@ const domainTransfer: Flow = {
 
 		return { goBack, submit };
 	},
+	hasHelpCenter: true,
 };
 
 export default domainTransfer;

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -110,6 +110,7 @@ export type Flow = {
 	 * A hook that is called in the flow's root at every render. You can use this hook to setup side-effects, call other hooks, etc..
 	 */
 	useSideEffect?: UseSideEffectHook< ReturnType< Flow[ 'useSteps' ] > >;
+	hasHelpCenter?: boolean;
 };
 
 export type StepProps = {

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -134,6 +134,9 @@ window.AppBoot = async () => {
 					{ 'development' === process.env.NODE_ENV && (
 						<AsyncLoad require="calypso/components/webpack-build-monitor" placeholder={ null } />
 					) }
+					{ flow.hasHelpCenter && (
+						<AsyncLoad require="./stepper-help-center" placeholder={ null } />
+					) }
 				</QueryClientProvider>
 			</Provider>
 		</CalypsoI18nProvider>,

--- a/client/landing/stepper/stepper-help-center.tsx
+++ b/client/landing/stepper/stepper-help-center.tsx
@@ -1,0 +1,84 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Gridicon } from '@automattic/components';
+import { HelpCenter, HelpCenterSelect } from '@automattic/data-stores';
+import HelpCenterComponent from '@automattic/help-center';
+import styled from '@emotion/styled';
+import { Button } from '@wordpress/components';
+import {
+	useDispatch as useDataStoreDispatch,
+	useSelect as useDataStoreSelect,
+} from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+const ContactContainer = styled.div`
+	display: flex;
+	align-items: center;
+	column-gap: 8px;
+	font-size: 14px;
+	line-height: 20px;
+	font-weight: 500;
+	position: absolute;
+	top: 20px;
+	right: 20px;
+	label {
+		color: var( --studio-gray-60 );
+	}
+	button.thank-you-help-center {
+		text-decoration: underline;
+	}
+	.gridicon {
+		display: block;
+		fill: var( --studio-gray-60 );
+	}
+	label,
+	span {
+		display: none;
+	}
+	@media ( min-width: 600px ) {
+		.gridicon {
+			display: none;
+		}
+		label,
+		span {
+			display: block;
+		}
+	}
+`;
+
+export default function StepperHelpCenter() {
+	const translate = useTranslate();
+
+	const { setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const isShowingHelpCenter = useDataStoreSelect(
+		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
+		[]
+	);
+	const toggleHelpCenter = () => {
+		recordTracksEvent( `calypso_thank_you_inlinehelp_${ isShowingHelpCenter ? 'close' : 'show' }`, {
+			force_site_id: true,
+			location: 'thank-you-help-center',
+		} );
+
+		setShowHelpCenter( ! isShowingHelpCenter );
+	};
+
+	const handleClose = useCallback( () => {
+		setShowHelpCenter( false );
+	}, [ setShowHelpCenter ] );
+
+	return (
+		<>
+			<HelpCenterComponent handleClose={ handleClose } />
+			<ContactContainer>
+				<label>{ translate( 'Need extra help?' ) }</label>
+				<Button className="thank-you-help-center" variant="link" onClick={ toggleHelpCenter }>
+					<Gridicon icon="help-outline" />
+					<span>{ translate( 'Visit Help Center' ) }</span>
+				</Button>
+			</ContactContainer>
+		</>
+	);
+}

--- a/client/layout/masterbar/gravatar.scss
+++ b/client/layout/masterbar/gravatar.scss
@@ -3,7 +3,7 @@
 
 .gravatar-masterbar {
 	position: absolute;
-	padding: 18px 20px;
+	padding: 18px 21px;
 	z-index: z-index("root", ".masterbar");
 
 	@include break-mobile {


### PR DESCRIPTION
This adds the Help Center to any Stepper flow that wants it.

### Testing
1. Go to /setup/domain-transfer.
2. You should see it on the top right.
3. Test on mobile, all should look good.