### PR TITLE
Update @wordpress/components dependency to v25.3.0

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -73,7 +73,7 @@
 		"@wordpress/base-styles": "^4.27.0",
 		"@wordpress/block-editor": "^12.3.0",
 		"@wordpress/blocks": "^12.12.0",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/compose": "^6.12.0",
 		"@wordpress/data": "^9.5.0",
 		"@wordpress/data-controls": "^3.4.0",

--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -36,7 +36,7 @@
 		"@wordpress/base-styles": "^4.27.0",
 		"@wordpress/block-editor": "^12.3.0",
 		"@wordpress/blocks": "^12.12.0",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/element": "^5.13.0",
 		"@wordpress/i18n": "^4.36.0",
 		"classnames": "^2.3.2",

--- a/apps/o2-blocks/package.json
+++ b/apps/o2-blocks/package.json
@@ -26,7 +26,7 @@
 		"@wordpress/base-styles": "^4.27.0",
 		"@wordpress/block-editor": "^12.3.0",
 		"@wordpress/blocks": "^12.12.0",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/data": "^9.5.0",
 		"@wordpress/editor": "^13.12.0",
 		"@wordpress/element": "^5.13.0",

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -28,7 +28,7 @@
 		"@wordpress/base-styles": "^4.27.0",
 		"@wordpress/block-editor": "^12.3.0",
 		"@wordpress/blocks": "^12.12.0",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/compose": "^6.12.0",
 		"@wordpress/data": "^9.5.0",
 		"@wordpress/dom-ready": "^3.36.0",

--- a/client/package.json
+++ b/client/package.json
@@ -81,7 +81,7 @@
 		"@wordpress/api-fetch": "^6.33.0",
 		"@wordpress/base-styles": "^4.27.0",
 		"@wordpress/blocks": "^12.12.0",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/compose": "^6.12.0",
 		"@wordpress/data": "^9.5.0",
 		"@wordpress/dom": "^3.36.0",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
 		"@types/validator": "^13.7.1",
 		"@types/webpack-env": "^1.16.3",
 		"@wordpress/base-styles": "^4.27.0",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/data": "^9.5.0",
 		"@wordpress/element": "^5.13.0",
 		"@wordpress/i18n": "^4.36.0",

--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
 		"@wordpress/block-serialization-spec-parser": "4.36.0",
 		"@wordpress/blocks": "12.12.0",
 		"@wordpress/browserslist-config": "5.19.0",
-		"@wordpress/components": "25.1.0",
+		"@wordpress/components": "25.3.0",
 		"@wordpress/compose": "6.12.0",
 		"@wordpress/core-data": "6.12.0",
 		"@wordpress/create-block-tutorial-template": "2.24.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -33,7 +33,7 @@
 		"@automattic/search": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@wordpress/base-styles": "^4.27.0",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/icons": "^9.26.0",
 		"@wordpress/react-i18n": "^3.33.0",
 		"canvas-confetti": "^1.6.0",

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -37,7 +37,7 @@
 		"@automattic/typography": "workspace:^",
 		"@automattic/viewport": "workspace:^",
 		"@tanstack/react-query": "^4.29.1",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/react-i18n": "^3.33.0",
 		"@wordpress/url": "^3.37.0",
 		"classnames": "^2.3.1",

--- a/packages/design-preview/package.json
+++ b/packages/design-preview/package.json
@@ -34,7 +34,7 @@
 		"@automattic/global-styles": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/onboarding": "workspace:^",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/html-entities": "^3.36.0",
 		"@wordpress/icons": "^9.26.0",
 		"@wordpress/react-i18n": "^3.33.0",

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -36,7 +36,7 @@
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@wordpress/base-styles": "^4.27.0",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/compose": "^6.12.0",
 		"@wordpress/icons": "^9.26.0",
 		"@wordpress/react-i18n": "^3.33.0",

--- a/packages/global-styles/package.json
+++ b/packages/global-styles/package.json
@@ -34,7 +34,7 @@
 		"@tanstack/react-query": "^4.29.1",
 		"@wordpress/block-editor": "^12.3.0",
 		"@wordpress/block-library": "^8.12.0",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/compose": "^6.12.0",
 		"@wordpress/keycodes": "^3.36.0",
 		"@wordpress/private-apis": "^0.18.0",

--- a/packages/help-center/package.json
+++ b/packages/help-center/package.json
@@ -38,7 +38,7 @@
 		"@popperjs/core": "^2.10.2",
 		"@tanstack/react-query": "^4.29.1",
 		"@wordpress/base-styles": "^4.27.0",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/i18n": "^4.36.0",
 		"@wordpress/icons": "^9.26.0",
 		"@wordpress/primitives": "^3.34.0",

--- a/packages/language-picker/package.json
+++ b/packages/language-picker/package.json
@@ -31,7 +31,7 @@
 		"@automattic/search": "workspace:^",
 		"@babel/runtime": "^7.17.2",
 		"@wordpress/base-styles": "^4.27.0",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/i18n": "^4.36.0",
 		"@wordpress/react-i18n": "^3.33.0"
 	},

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/data": "^9.5.0",
 		"@wordpress/icons": "^9.26.0",
 		"@wordpress/react-i18n": "^3.33.0",

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -31,7 +31,7 @@
 		"@automattic/typography": "workspace:^",
 		"@wordpress/block-editor": "^12.3.0",
 		"@wordpress/blocks": "^12.12.0",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/compose": "^6.12.0",
 		"@wordpress/element": "^5.13.0",
 		"@wordpress/i18n": "^4.36.0",

--- a/packages/plans-grid/package.json
+++ b/packages/plans-grid/package.json
@@ -32,7 +32,7 @@
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/onboarding": "workspace:^",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/compose": "^6.12.0",
 		"@wordpress/icons": "^9.26.0",
 		"@wordpress/react-i18n": "^3.33.0",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -30,7 +30,7 @@
 		"@automattic/typography": "workspace:^",
 		"@babel/runtime": "^7.17.2",
 		"@wordpress/base-styles": "^4.27.0",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/compose": "^6.12.0",
 		"@wordpress/icons": "^9.26.0",
 		"@wordpress/react-i18n": "^3.33.0",

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"@emotion/react": "^11.4.1",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/element": "^5.13.0",
 		"@wordpress/i18n": "^4.36.0",
 		"classnames": "^2.3.1",

--- a/packages/subscriber/package.json
+++ b/packages/subscriber/package.json
@@ -35,7 +35,7 @@
 		"@automattic/viewport-react": "workspace:^",
 		"@popperjs/core": "^2.10.2",
 		"@wordpress/base-styles": "^4.27.0",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/dom": "^3.36.0",
 		"@wordpress/element": "^5.13.0",
 		"@wordpress/i18n": "^4.36.0",

--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -35,7 +35,7 @@
 		"@automattic/viewport-react": "workspace:^",
 		"@popperjs/core": "^2.10.2",
 		"@wordpress/base-styles": "^4.27.0",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/dom": "^3.36.0",
 		"@wordpress/element": "^5.13.0",
 		"@wordpress/i18n": "^4.36.0",

--- a/packages/whats-new/package.json
+++ b/packages/whats-new/package.json
@@ -41,7 +41,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@tanstack/react-query": "^4.29.1",
-		"@wordpress/components": "^25.1.0",
+		"@wordpress/components": "^25.3.0",
 		"@wordpress/element": "^5.13.0",
 		"@wordpress/i18n": "^4.36.0",
 		"@wordpress/keycodes": "^3.36.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,7 +485,7 @@ __metadata:
     "@types/canvas-confetti": ^1.6.0
     "@types/react-slider": ^1.3.1
     "@wordpress/base-styles": ^4.27.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/icons": ^9.26.0
     "@wordpress/react-i18n": ^3.33.0
     canvas-confetti: ^1.6.0
@@ -631,7 +631,7 @@ __metadata:
     "@tanstack/react-query": ^4.29.1
     "@testing-library/jest-dom": ^5.16.5
     "@testing-library/react": ^14.0.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/react-i18n": ^3.33.0
     "@wordpress/url": ^3.37.0
     classnames: ^2.3.1
@@ -668,7 +668,7 @@ __metadata:
     "@automattic/onboarding": "workspace:^"
     "@testing-library/jest-dom": ^5.16.5
     "@testing-library/react": ^14.0.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/html-entities": ^3.36.0
     "@wordpress/icons": ^9.26.0
     "@wordpress/react-i18n": ^3.33.0
@@ -702,7 +702,7 @@ __metadata:
     "@testing-library/jest-dom": ^5.16.5
     "@testing-library/react": ^14.0.0
     "@wordpress/base-styles": ^4.27.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/compose": ^6.12.0
     "@wordpress/icons": ^9.26.0
     "@wordpress/react-i18n": ^3.33.0
@@ -809,7 +809,7 @@ __metadata:
     "@types/wordpress__block-library": ^2.6.1
     "@wordpress/block-editor": ^12.3.0
     "@wordpress/block-library": ^8.12.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/compose": ^6.12.0
     "@wordpress/keycodes": ^3.36.0
     "@wordpress/private-apis": ^0.18.0
@@ -849,7 +849,7 @@ __metadata:
     "@storybook/react": ^7.0.18
     "@tanstack/react-query": ^4.29.1
     "@wordpress/base-styles": ^4.27.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/i18n": ^4.36.0
     "@wordpress/icons": ^9.26.0
     "@wordpress/primitives": ^3.34.0
@@ -934,7 +934,7 @@ __metadata:
     "@automattic/search": "workspace:^"
     "@babel/runtime": ^7.17.2
     "@wordpress/base-styles": ^4.27.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/i18n": ^4.36.0
     "@wordpress/react-i18n": ^3.33.0
     typescript: ^4.7.4
@@ -1110,7 +1110,7 @@ __metadata:
     "@wordpress/base-styles": ^4.27.0
     "@wordpress/block-editor": ^12.3.0
     "@wordpress/blocks": ^12.12.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/data": ^9.5.0
     "@wordpress/editor": ^13.12.0
     "@wordpress/element": ^5.13.0
@@ -1194,7 +1194,7 @@ __metadata:
     "@automattic/typography": "workspace:^"
     "@testing-library/react": ^14.0.0
     "@wordpress/base-styles": ^4.27.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/data": ^9.5.0
     "@wordpress/icons": ^9.26.0
     "@wordpress/react-i18n": ^3.33.0
@@ -1227,7 +1227,7 @@ __metadata:
     "@testing-library/react": ^14.0.0
     "@wordpress/block-editor": ^12.3.0
     "@wordpress/blocks": ^12.12.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/compose": ^6.12.0
     "@wordpress/element": ^5.13.0
     "@wordpress/i18n": ^4.36.0
@@ -1256,7 +1256,7 @@ __metadata:
     "@automattic/onboarding": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@wordpress/base-styles": ^4.27.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/compose": ^6.12.0
     "@wordpress/icons": ^9.26.0
     "@wordpress/react-i18n": ^3.33.0
@@ -1349,7 +1349,7 @@ __metadata:
     "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.4.3
     "@wordpress/base-styles": ^4.27.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/compose": ^6.12.0
     "@wordpress/data": ^9.5.0
     "@wordpress/icons": ^9.26.0
@@ -1431,7 +1431,7 @@ __metadata:
     "@emotion/react": ^11.4.1
     "@testing-library/jest-dom": ^5.16.5
     "@testing-library/react": ^14.0.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/element": ^5.13.0
     "@wordpress/i18n": ^4.36.0
     classnames: ^2.3.1
@@ -1479,7 +1479,7 @@ __metadata:
     "@automattic/viewport-react": "workspace:^"
     "@popperjs/core": ^2.10.2
     "@wordpress/base-styles": ^4.27.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/dom": ^3.36.0
     "@wordpress/element": ^5.13.0
     "@wordpress/i18n": ^4.36.0
@@ -1512,7 +1512,7 @@ __metadata:
     "@storybook/cli": ^7.0.18
     "@storybook/react": ^7.0.18
     "@wordpress/base-styles": ^4.27.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/dom": ^3.36.0
     "@wordpress/element": ^5.13.0
     "@wordpress/i18n": ^4.36.0
@@ -1631,7 +1631,7 @@ __metadata:
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@tanstack/react-query": ^4.29.1
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/element": ^5.13.0
     "@wordpress/i18n": ^4.36.0
     "@wordpress/keycodes": ^3.36.0
@@ -1687,7 +1687,7 @@ __metadata:
     "@wordpress/base-styles": ^4.27.0
     "@wordpress/block-editor": ^12.3.0
     "@wordpress/blocks": ^12.12.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/compose": ^6.12.0
     "@wordpress/data": ^9.5.0
     "@wordpress/dependency-extraction-webpack-plugin": ^4.19.0
@@ -1782,7 +1782,7 @@ __metadata:
     "@wordpress/base-styles": ^4.27.0
     "@wordpress/block-editor": ^12.3.0
     "@wordpress/blocks": ^12.12.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/compose": ^6.12.0
     "@wordpress/data": ^9.5.0
     "@wordpress/data-controls": ^3.4.0
@@ -11353,7 +11353,7 @@ __metadata:
     "@wordpress/api-fetch": ^6.33.0
     "@wordpress/base-styles": ^4.27.0
     "@wordpress/blocks": ^12.12.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/compose": ^6.12.0
     "@wordpress/data": ^9.5.0
     "@wordpress/dom": ^3.36.0
@@ -17394,7 +17394,7 @@ __metadata:
     "@wordpress/base-styles": ^4.27.0
     "@wordpress/block-editor": ^12.3.0
     "@wordpress/blocks": ^12.12.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/element": ^5.13.0
     "@wordpress/i18n": ^4.36.0
     "@wordpress/readable-js-assets-webpack-plugin": ^2.19.0
@@ -31211,7 +31211,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.53.0
     "@typescript-eslint/parser": ^5.53.0
     "@wordpress/base-styles": ^4.27.0
-    "@wordpress/components": ^25.1.0
+    "@wordpress/components": ^25.3.0
     "@wordpress/data": ^9.5.0
     "@wordpress/element": ^5.13.0
     "@wordpress/eslint-plugin": ^14.8.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,6 +49,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ariakit/core@npm:0.2.7":
+  version: 0.2.7
+  resolution: "@ariakit/core@npm:0.2.7"
+  checksum: 34037157cc4ea267eb5110bb77e3951cb03a9d3f3459ebe63fe9737c03866bb081e1f38611799a6561d351a04e0b2a6818c77b61ff8482b1be1fc238390d6c83
+  languageName: node
+  linkType: hard
+
+"@ariakit/react-core@npm:0.2.12":
+  version: 0.2.12
+  resolution: "@ariakit/react-core@npm:0.2.12"
+  dependencies:
+    "@ariakit/core": 0.2.7
+    "@floating-ui/dom": ^1.0.0
+    use-sync-external-store: ^1.2.0
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  checksum: 817ad300addb04734e38bd31029a1aa8931443fd15bf8ee8c14bb39169c34f9042ede68f1ee8278282bae5f506afc7b652c3e9ea4e4f7f00ab82c67587427f72
+  languageName: node
+  linkType: hard
+
+"@ariakit/react@npm:^0.2.10":
+  version: 0.2.12
+  resolution: "@ariakit/react@npm:0.2.12"
+  dependencies:
+    "@ariakit/react-core": 0.2.12
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  checksum: 5529d1cbcd5a49c424a3dd929767ff54d85b8d5b174c53d5c430ee30c730d0ce5bbc6b15fe63b48c0b5fbfe90fd1d70dae797dd94f7f3f3038d74c6382037ab4
+  languageName: node
+  linkType: hard
+
 "@automattic/accessible-focus@workspace:^, @automattic/accessible-focus@workspace:packages/accessible-focus":
   version: 0.0.0-use.local
   resolution: "@automattic/accessible-focus@workspace:packages/accessible-focus"
@@ -8478,10 +8511,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/components@npm:25.1.0":
-  version: 25.1.0
-  resolution: "@wordpress/components@npm:25.1.0"
+"@wordpress/components@npm:25.3.0":
+  version: 25.3.0
+  resolution: "@wordpress/components@npm:25.3.0"
   dependencies:
+    "@ariakit/react": ^0.2.10
     "@babel/runtime": ^7.16.0
     "@emotion/cache": ^11.7.1
     "@emotion/css": ^11.7.1
@@ -8492,23 +8526,23 @@ __metadata:
     "@floating-ui/react-dom": 1.0.0
     "@radix-ui/react-dropdown-menu": ^2.0.4
     "@use-gesture/react": ^10.2.24
-    "@wordpress/a11y": ^3.35.0
-    "@wordpress/compose": ^6.12.0
-    "@wordpress/date": ^4.35.0
-    "@wordpress/deprecated": ^3.35.0
-    "@wordpress/dom": ^3.35.0
-    "@wordpress/element": ^5.12.0
-    "@wordpress/escape-html": ^2.35.0
-    "@wordpress/hooks": ^3.35.0
-    "@wordpress/html-entities": ^3.35.0
-    "@wordpress/i18n": ^4.35.0
-    "@wordpress/icons": ^9.26.0
-    "@wordpress/is-shallow-equal": ^4.35.0
-    "@wordpress/keycodes": ^3.35.0
-    "@wordpress/primitives": ^3.33.0
-    "@wordpress/private-apis": ^0.17.0
-    "@wordpress/rich-text": ^6.12.0
-    "@wordpress/warning": ^2.35.0
+    "@wordpress/a11y": ^3.37.0
+    "@wordpress/compose": ^6.14.0
+    "@wordpress/date": ^4.37.0
+    "@wordpress/deprecated": ^3.37.0
+    "@wordpress/dom": ^3.37.0
+    "@wordpress/element": ^5.14.0
+    "@wordpress/escape-html": ^2.37.0
+    "@wordpress/hooks": ^3.37.0
+    "@wordpress/html-entities": ^3.37.0
+    "@wordpress/i18n": ^4.37.0
+    "@wordpress/icons": ^9.28.0
+    "@wordpress/is-shallow-equal": ^4.37.0
+    "@wordpress/keycodes": ^3.37.0
+    "@wordpress/primitives": ^3.35.0
+    "@wordpress/private-apis": ^0.19.0
+    "@wordpress/rich-text": ^6.14.0
+    "@wordpress/warning": ^2.37.0
     change-case: ^4.1.2
     classnames: ^2.3.1
     colord: ^2.7.0
@@ -8517,7 +8551,7 @@ __metadata:
     dom-scroll-into-view: ^1.2.1
     downshift: ^6.0.15
     fast-deep-equal: ^3.1.3
-    framer-motion: ^10.11.6
+    framer-motion: ~10.11.6
     gradient-parser: ^0.1.5
     highlight-words-core: ^1.2.2
     is-plain-object: ^5.0.0
@@ -8533,7 +8567,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: d73e7e565e5d2bb387797a6af2de66f30688915fe4e8c02e9a3eb336333e5dba2fac3de4773b9a38bee146a081eb2e89d663ab02fe84fc45d245cdc9ed04ca92
+  checksum: 51c72d046c9d563494707a8008bac03e08babbd8d20547f033f28571ed58ca4bab67b5706126c72d0a0c59bcccd4cad19e638b8ebb9ae2dc3600b5639fba4bda
   languageName: node
   linkType: hard
 
@@ -16509,9 +16543,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framer-motion@npm:^10.11.6":
-  version: 10.12.17
-  resolution: "framer-motion@npm:10.12.17"
+"framer-motion@npm:~10.11.6":
+  version: 10.11.6
+  resolution: "framer-motion@npm:10.11.6"
   dependencies:
     "@emotion/is-prop-valid": ^0.8.2
     tslib: ^2.4.0
@@ -16526,7 +16560,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: d22f173d3de445ead6a784737803bd6316f6e3e78e8fba3cedc3b3f405471e966b190c0caff855f59905afc017c475225e26af69acb932180d0e4ac4d7c9fbdb
+  checksum: ae9cd16d0ca425ec81c65385b5b39a28e8d55c2e01159383fa903ce6854987e87526cd9bd59a14a19067844fa302edf2cd3a360a8b868cd40f98a96b909cbd76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Related to p1689818533964119-slack-C02FMH4G8
Closes https://github.com/Automattic/wp-calypso/issues/79668
Closes https://github.com/Automattic/wp-calypso/issues/79669

## Proposed Changes

Update @wordpress/components dependency to v25.3.0

## Testing Instructions

- Checkout latest trunk.
- Run `yarn run distclean`
- Run `nvm install && yarn`
- Run `yarn start`
- Ensure #79668 and #79669 are occurring as described.
- Checkout this branch
- `yarn`
- Wait until the build finishes.
- Ensure #79668 and #79669 have been fixed.