### PR TITLE
Plans 2023: extract the logics of querying for a suggested free domain into a hook.

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -23,7 +23,7 @@ const SubdomainSuggestion = styled.div`
 
 const FreePlanCustomDomainFeature: React.FC< {
 	paidDomainName: string;
-	isLoadingSuggestedFreeDomain: boolean;
+	isLoadingSuggestedFreeDomain?: boolean;
 	wpcomFreeDomainSuggestion?: DomainSuggestion;
 } > = ( { paidDomainName, isLoadingSuggestedFreeDomain, wpcomFreeDomainSuggestion } ) => {
 	return (

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -1,5 +1,4 @@
 import { getPlanClass, FEATURE_CUSTOM_DOMAIN, isFreePlan } from '@automattic/calypso-products';
-import { DomainSuggestions } from '@automattic/data-stores';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -7,6 +6,7 @@ import { LoadingPlaceHolder } from '../../plans-features-main/components/loading
 import { PlanFeaturesItem } from './item';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import type { TransformedFeatureObject } from '../types';
+import type { DomainSuggestion } from '@automattic/data-stores';
 
 const SubdomainSuggestion = styled.div`
 	.is-domain-name {
@@ -21,20 +21,16 @@ const SubdomainSuggestion = styled.div`
 	}
 `;
 
-const FreePlanCustomDomainFeature: React.FC< { paidDomainName: string } > = ( {
-	paidDomainName,
-} ) => {
-	const {
-		data: wordPressSubdomainSuggestions,
-		isInitialLoading,
-		isError,
-	} = DomainSuggestions.useGetWordPressSubdomain( paidDomainName );
-
+const FreePlanCustomDomainFeature: React.FC< {
+	paidDomainName: string;
+	isLoadingSuggestedFreeDomain: boolean;
+	wpcomFreeDomainSuggestion?: DomainSuggestion;
+} > = ( { paidDomainName, isLoadingSuggestedFreeDomain, wpcomFreeDomainSuggestion } ) => {
 	return (
 		<SubdomainSuggestion>
 			<div className="is-domain-name">{ paidDomainName }</div>
-			{ isInitialLoading && <LoadingPlaceHolder /> }
-			{ ! isError && <div>{ wordPressSubdomainSuggestions?.[ 0 ]?.domain_name }</div> }
+			{ isLoadingSuggestedFreeDomain && <LoadingPlaceHolder /> }
+			{ wpcomFreeDomainSuggestion && <div>{ wpcomFreeDomainSuggestion.domain_name }</div> }
 		</SubdomainSuggestion>
 	);
 };
@@ -43,9 +39,19 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	features: Array< TransformedFeatureObject >;
 	planName: string;
 	paidDomainName?: string;
+	isLoadingSuggestedFreeDomain?: boolean;
+	wpcomFreeDomainSuggestion?: DomainSuggestion;
 	hideUnavailableFeatures?: boolean;
 	selectedFeature?: string;
-} > = ( { features, planName, paidDomainName, hideUnavailableFeatures, selectedFeature } ) => {
+} > = ( {
+	features,
+	planName,
+	paidDomainName,
+	isLoadingSuggestedFreeDomain,
+	wpcomFreeDomainSuggestion,
+	hideUnavailableFeatures,
+	selectedFeature,
+} ) => {
 	const translate = useTranslate();
 	return (
 		<>
@@ -95,6 +101,8 @@ const PlanFeatures2023GridFeatures: React.FC< {
 											<FreePlanCustomDomainFeature
 												key={ key }
 												paidDomainName={ paidDomainName as string }
+												isLoadingSuggestedFreeDomain={ isLoadingSuggestedFreeDomain }
+												wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
 											/>
 										</Plans2023Tooltip>
 									) : (

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -6,7 +6,7 @@ import { LoadingPlaceHolder } from '../../plans-features-main/components/loading
 import { PlanFeaturesItem } from './item';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import type { TransformedFeatureObject } from '../types';
-import type { DomainSuggestion } from '@automattic/data-stores';
+import type { SingleFreeDomainSuggestion } from 'calypso/my-sites/plan-features-2023-grid/types';
 
 const SubdomainSuggestion = styled.div`
 	.is-domain-name {
@@ -23,14 +23,15 @@ const SubdomainSuggestion = styled.div`
 
 const FreePlanCustomDomainFeature: React.FC< {
 	paidDomainName: string;
-	isLoadingSuggestedFreeDomain?: boolean;
-	wpcomFreeDomainSuggestion?: DomainSuggestion;
-} > = ( { paidDomainName, isLoadingSuggestedFreeDomain, wpcomFreeDomainSuggestion } ) => {
+	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
+} > = ( { paidDomainName, wpcomFreeDomainSuggestion } ) => {
 	return (
 		<SubdomainSuggestion>
 			<div className="is-domain-name">{ paidDomainName }</div>
-			{ isLoadingSuggestedFreeDomain && <LoadingPlaceHolder /> }
-			{ wpcomFreeDomainSuggestion && <div>{ wpcomFreeDomainSuggestion.domain_name }</div> }
+			{ wpcomFreeDomainSuggestion.isLoading && <LoadingPlaceHolder /> }
+			{ wpcomFreeDomainSuggestion.entry && (
+				<div>{ wpcomFreeDomainSuggestion.entry.domain_name }</div>
+			) }
 		</SubdomainSuggestion>
 	);
 };
@@ -39,15 +40,13 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	features: Array< TransformedFeatureObject >;
 	planName: string;
 	paidDomainName?: string;
-	isLoadingSuggestedFreeDomain?: boolean;
-	wpcomFreeDomainSuggestion?: DomainSuggestion;
+	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
 	hideUnavailableFeatures?: boolean;
 	selectedFeature?: string;
 } > = ( {
 	features,
 	planName,
 	paidDomainName,
-	isLoadingSuggestedFreeDomain,
 	wpcomFreeDomainSuggestion,
 	hideUnavailableFeatures,
 	selectedFeature,
@@ -101,7 +100,6 @@ const PlanFeatures2023GridFeatures: React.FC< {
 											<FreePlanCustomDomainFeature
 												key={ key }
 												paidDomainName={ paidDomainName as string }
-												isLoadingSuggestedFreeDomain={ isLoadingSuggestedFreeDomain }
 												wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
 											/>
 										</Plans2023Tooltip>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -63,12 +63,11 @@ import PopularBadge from './components/popular-badge';
 import PlansGridContextProvider, { usePlansGridContext } from './grid-context';
 import useHighlightAdjacencyMatrix from './hooks/npm-ready/use-highlight-adjacency-matrix';
 import useIsLargeCurrency from './hooks/use-is-large-currency';
-import { PlanProperties, TransformedFeatureObject } from './types';
+import { PlanProperties, TransformedFeatureObject, SingleFreeDomainSuggestion } from './types';
 import { getStorageStringFromFeature } from './util';
 import type { PlansIntent } from './grid-context';
 import type { GridPlan } from './hooks/npm-ready/data-store/use-wpcom-plans-with-intent';
 import type { PlanActionOverrides } from './types';
-import type { DomainSuggestion } from '@automattic/data-stores';
 import type { IAppState } from 'calypso/state/types';
 import './style.scss';
 
@@ -101,9 +100,7 @@ export type PlanFeatures2023GridProps = {
 	onUpgradeClick?: ( cartItem?: MinimalRequestCartProduct | null ) => void;
 	flowName?: string | null;
 	paidDomainName?: string;
-	isLoadingSuggestedFreeDomain?: boolean;
-	wpcomFreeDomainSuggestion?: DomainSuggestion;
-	placeholder?: string;
+	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
 	intervalType?: string;
 	currentSitePlanSlug?: string | null;
 	hidePlansFeatureComparison?: boolean;
@@ -790,7 +787,6 @@ export class PlanFeatures2023Grid extends Component<
 	renderPlanFeaturesList( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
 		const {
 			paidDomainName,
-			isLoadingSuggestedFreeDomain,
 			wpcomFreeDomainSuggestion,
 			translate,
 			hideUnavailableFeatures,
@@ -816,7 +812,6 @@ export class PlanFeatures2023Grid extends Component<
 							features={ features }
 							planName={ planName }
 							paidDomainName={ paidDomainName }
-							isLoadingSuggestedFreeDomain={ isLoadingSuggestedFreeDomain }
 							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
 							hideUnavailableFeatures={ hideUnavailableFeatures }
 							selectedFeature={ selectedFeature }

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -68,6 +68,7 @@ import { getStorageStringFromFeature } from './util';
 import type { PlansIntent } from './grid-context';
 import type { GridPlan } from './hooks/npm-ready/data-store/use-wpcom-plans-with-intent';
 import type { PlanActionOverrides } from './types';
+import type { DomainSuggestion } from '@automattic/data-stores';
 import type { IAppState } from 'calypso/state/types';
 import './style.scss';
 
@@ -100,6 +101,9 @@ export type PlanFeatures2023GridProps = {
 	onUpgradeClick?: ( cartItem?: MinimalRequestCartProduct | null ) => void;
 	flowName?: string | null;
 	paidDomainName?: string;
+	isLoadingSuggestedFreeDomain?: boolean;
+	wpcomFreeDomainSuggestion?: DomainSuggestion;
+	placeholder?: string;
 	intervalType?: string;
 	currentSitePlanSlug?: string | null;
 	hidePlansFeatureComparison?: boolean;
@@ -784,7 +788,14 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderPlanFeaturesList( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
-		const { paidDomainName, translate, hideUnavailableFeatures, selectedFeature } = this.props;
+		const {
+			paidDomainName,
+			isLoadingSuggestedFreeDomain,
+			wpcomFreeDomainSuggestion,
+			translate,
+			hideUnavailableFeatures,
+			selectedFeature,
+		} = this.props;
 		const planProperties = planPropertiesObj.filter(
 			( properties ) =>
 				! isWpcomEnterpriseGridPlan( properties.planName ) &&
@@ -805,6 +816,8 @@ export class PlanFeatures2023Grid extends Component<
 							features={ features }
 							planName={ planName }
 							paidDomainName={ paidDomainName }
+							isLoadingSuggestedFreeDomain={ isLoadingSuggestedFreeDomain }
+							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
 							hideUnavailableFeatures={ hideUnavailableFeatures }
 							selectedFeature={ selectedFeature }
 						/>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -831,6 +831,7 @@ export class PlanFeatures2023Grid extends Component<
 							features={ jpFeatures }
 							planName={ planName }
 							paidDomainName={ paidDomainName }
+							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
 							hideUnavailableFeatures={ hideUnavailableFeatures }
 						/>
 					</Container>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -100,7 +100,7 @@ export type PlanFeatures2023GridProps = {
 	onUpgradeClick?: ( cartItem?: MinimalRequestCartProduct | null ) => void;
 	flowName?: string | null;
 	paidDomainName?: string;
-	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
+	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion; // used to show a wpcom free domain in the Free plan column when a paid domain is picked.
 	intervalType?: string;
 	currentSitePlanSlug?: string | null;
 	hidePlansFeatureComparison?: boolean;

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -29,6 +29,12 @@ export type PlanProperties = {
 	planActionOverrides?: PlanActionOverrides;
 };
 
+// FIXME:
+// As raised in https://github.com/Automattic/wp-calypso/pull/79678#discussion_r1273391589,
+// this name is not ideal for various reasons. "Single" is redundant, the data structure itself
+// also doesn't convey any restriction about whether it can only holds a `DomainSuggestion` from a free domain or not.
+// We need a better naming for the fact that it's a single DomainSuggestion together with a loading flag since
+// fetching for a domain suggestion is an async request.
 export type SingleFreeDomainSuggestion = {
 	isLoading: boolean;
 	entry?: DomainSuggestion;

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -1,5 +1,6 @@
 import { applyTestFiltersToPlansList, PlanSlug } from '@automattic/calypso-products';
 import { FeatureObject } from 'calypso/lib/plans/features-list';
+import type { DomainSuggestion } from '@automattic/data-stores';
 import type { TranslateResult } from 'i18n-calypso';
 
 export type TransformedFeatureObject = FeatureObject & {
@@ -26,6 +27,11 @@ export type PlanProperties = {
 	availableForPurchase: boolean;
 	current?: boolean;
 	planActionOverrides?: PlanActionOverrides;
+};
+
+export type SingleFreeDomainSuggestion = {
+	isLoading: boolean;
+	entry?: DomainSuggestion;
 };
 
 export interface PlanActionOverrides {

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -1,10 +1,8 @@
 import { PlanSlug, getPlan } from '@automattic/calypso-products';
 import { Button, Dialog } from '@automattic/components';
-import { DomainSuggestions } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector } from 'calypso/state';
@@ -121,27 +119,25 @@ const StyledButton = styled( Button )`
 
 export function FreePlanPaidDomainDialog( {
 	paidDomainName,
+	isLoadingSuggestedFreeDomain,
+	wpcomFreeDomainSuggestion,
 	suggestedPlanSlug,
 	onFreePlanSelected,
 	onPlanSelected,
 	onClose,
 }: {
 	paidDomainName: string;
+	isLoadingSuggestedFreeDomain: boolean;
+	wpcomFreeDomainSuggestion?: DomainSuggestion;
 	suggestedPlanSlug: PlanSlug;
 	onClose: () => void;
-	onFreePlanSelected: ( domainSuggestion: DomainSuggestion ) => void;
+	onFreePlanSelected: () => void;
 	onPlanSelected: () => void;
 } ) {
 	const translate = useTranslate();
-	const queryClient = useQueryClient();
 	const [ isBusy, setIsBusy ] = useState( false );
 	const planPrices = usePlanPrices( { planSlug: suggestedPlanSlug, returnMonthly: true } );
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const {
-		data: wordPressSubdomainSuggestions,
-		isInitialLoading,
-		isError,
-	} = DomainSuggestions.useGetWordPressSubdomain( paidDomainName );
 	const planTitle = getPlan( suggestedPlanSlug )?.getTitle();
 
 	function handlePaidPlanClick() {
@@ -151,13 +147,7 @@ export function FreePlanPaidDomainDialog( {
 
 	function handleFreeDomainClick() {
 		setIsBusy( true );
-		// Since this domain will not be available after it is selected, invalidate the cache.
-		queryClient.invalidateQueries(
-			DomainSuggestions.getDomainSuggestionsQueryKey( paidDomainName )
-		);
-		if ( wordPressSubdomainSuggestions && wordPressSubdomainSuggestions.length ) {
-			onFreePlanSelected( wordPressSubdomainSuggestions[ 0 ] );
-		}
+		onFreePlanSelected();
 	}
 
 	return (
@@ -208,11 +198,11 @@ export function FreePlanPaidDomainDialog( {
 					</RowWithBorder>
 					<Row>
 						<DomainName>
-							{ isInitialLoading && <LoadingPlaceHolder /> }
-							{ ! isError && <div>{ wordPressSubdomainSuggestions?.[ 0 ]?.domain_name }</div> }
+							{ isLoadingSuggestedFreeDomain && <LoadingPlaceHolder /> }
+							{ wpcomFreeDomainSuggestion && <div>{ wpcomFreeDomainSuggestion.domain_name }</div> }
 						</DomainName>
 						<StyledButton
-							disabled={ isInitialLoading || ! wordPressSubdomainSuggestions?.[ 0 ]?.domain_name }
+							disabled={ isLoadingSuggestedFreeDomain || ! wpcomFreeDomainSuggestion }
 							busy={ isBusy }
 							onClick={ handleFreeDomainClick }
 						>

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -9,7 +9,7 @@ import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import usePlanPrices from '../../plans/hooks/use-plan-prices';
 import { LoadingPlaceHolder } from './loading-placeholder';
-import type { DomainSuggestion } from '@automattic/data-stores';
+import type { SingleFreeDomainSuggestion } from 'calypso/my-sites/plan-features-2023-grid/types';
 
 const DialogContainer = styled.div`
 	padding: 24px;
@@ -119,7 +119,6 @@ const StyledButton = styled( Button )`
 
 export function FreePlanPaidDomainDialog( {
 	paidDomainName,
-	isLoadingSuggestedFreeDomain,
 	wpcomFreeDomainSuggestion,
 	suggestedPlanSlug,
 	onFreePlanSelected,
@@ -127,8 +126,7 @@ export function FreePlanPaidDomainDialog( {
 	onClose,
 }: {
 	paidDomainName: string;
-	isLoadingSuggestedFreeDomain: boolean;
-	wpcomFreeDomainSuggestion?: DomainSuggestion;
+	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
 	suggestedPlanSlug: PlanSlug;
 	onClose: () => void;
 	onFreePlanSelected: () => void;
@@ -198,11 +196,13 @@ export function FreePlanPaidDomainDialog( {
 					</RowWithBorder>
 					<Row>
 						<DomainName>
-							{ isLoadingSuggestedFreeDomain && <LoadingPlaceHolder /> }
-							{ wpcomFreeDomainSuggestion && <div>{ wpcomFreeDomainSuggestion.domain_name }</div> }
+							{ wpcomFreeDomainSuggestion.isLoading && <LoadingPlaceHolder /> }
+							{ wpcomFreeDomainSuggestion.entry && (
+								<div>{ wpcomFreeDomainSuggestion.entry.domain_name }</div>
+							) }
 						</DomainName>
 						<StyledButton
-							disabled={ isLoadingSuggestedFreeDomain || ! wpcomFreeDomainSuggestion }
+							disabled={ wpcomFreeDomainSuggestion.isLoading || ! wpcomFreeDomainSuggestion.entry }
 							busy={ isBusy }
 							onClick={ handleFreeDomainClick }
 						>

--- a/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
@@ -1,0 +1,22 @@
+import { DomainSuggestions } from '@automattic/data-stores';
+
+function useSuggestedFreeDomainFromPaidDomain( paidDomainName?: string ): {
+	isLoadingSuggestedFreeDomain: boolean;
+	wpcomFreeDomainSuggestion?: DomainSuggestions.DomainSuggestion;
+	invalidateDomainSuggestionCache: () => void;
+} {
+	const {
+		data: wordPressSubdomainSuggestions,
+		isInitialLoading,
+		isError,
+	} = DomainSuggestions.useGetWordPressSubdomain( paidDomainName || '' );
+
+	return {
+		isLoadingSuggestedFreeDomain: isInitialLoading,
+		wpcomFreeDomainSuggestion: ( ! isError && wordPressSubdomainSuggestions?.[ 0 ] ) || undefined,
+		invalidateDomainSuggestionCache: () =>
+			paidDomainName && DomainSuggestions.invalidateCache( paidDomainName ),
+	};
+}
+
+export default useSuggestedFreeDomainFromPaidDomain;

--- a/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
@@ -1,8 +1,8 @@
 import { DomainSuggestions } from '@automattic/data-stores';
+import type { SingleFreeDomainSuggestion } from 'calypso/my-sites/plan-features-2023-grid/types';
 
 export function useSuggestedFreeDomainFromPaidDomain( paidDomainName?: string ): {
-	isLoadingSuggestedFreeDomain: boolean;
-	wpcomFreeDomainSuggestion?: DomainSuggestions.DomainSuggestion;
+	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
 	invalidateDomainSuggestionCache: () => void;
 } {
 	const {
@@ -13,8 +13,10 @@ export function useSuggestedFreeDomainFromPaidDomain( paidDomainName?: string ):
 	} = DomainSuggestions.useGetWordPressSubdomain( paidDomainName || '' );
 
 	return {
-		isLoadingSuggestedFreeDomain: isInitialLoading,
-		wpcomFreeDomainSuggestion: ( ! isError && wordPressSubdomainSuggestions?.[ 0 ] ) || undefined,
+		wpcomFreeDomainSuggestion: {
+			isLoading: isInitialLoading,
+			entry: ( ! isError && wordPressSubdomainSuggestions?.[ 0 ] ) || undefined,
+		},
 		invalidateDomainSuggestionCache,
 	};
 }

--- a/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
@@ -1,6 +1,6 @@
 import { DomainSuggestions } from '@automattic/data-stores';
 
-function useSuggestedFreeDomainFromPaidDomain( paidDomainName?: string ): {
+export function useSuggestedFreeDomainFromPaidDomain( paidDomainName?: string ): {
 	isLoadingSuggestedFreeDomain: boolean;
 	wpcomFreeDomainSuggestion?: DomainSuggestions.DomainSuggestion;
 	invalidateDomainSuggestionCache: () => void;
@@ -9,13 +9,13 @@ function useSuggestedFreeDomainFromPaidDomain( paidDomainName?: string ): {
 		data: wordPressSubdomainSuggestions,
 		isInitialLoading,
 		isError,
+		invalidateCache: invalidateDomainSuggestionCache,
 	} = DomainSuggestions.useGetWordPressSubdomain( paidDomainName || '' );
 
 	return {
 		isLoadingSuggestedFreeDomain: isInitialLoading,
 		wpcomFreeDomainSuggestion: ( ! isError && wordPressSubdomainSuggestions?.[ 0 ] ) || undefined,
-		invalidateDomainSuggestionCache: () =>
-			paidDomainName && DomainSuggestions.invalidateCache( paidDomainName ),
+		invalidateDomainSuggestionCache,
 	};
 }
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -46,7 +46,10 @@ import type { PlansIntent } from '../plan-features-2023-grid/hooks/npm-ready/dat
 import type { DomainSuggestion } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { PlanFeatures2023GridProps } from 'calypso/my-sites/plan-features-2023-grid';
-import type { PlanActionOverrides } from 'calypso/my-sites/plan-features-2023-grid/types';
+import type {
+	PlanActionOverrides,
+	SingleFreeDomainSuggestion,
+} from 'calypso/my-sites/plan-features-2023-grid/types';
 import type { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import type { IAppState } from 'calypso/state/types';
 import './style.scss';
@@ -93,8 +96,7 @@ type OnboardingPricingGrid2023Props = PlansFeaturesMainProps & {
 	sitePlanSlug?: PlanSlug | null;
 	siteSlug?: string | null;
 	intent?: PlansIntent;
-	isLoadingSuggestedFreeDomain: boolean;
-	wpcomFreeDomainSuggestion?: DomainSuggestion;
+	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
 };
 
 const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
@@ -121,7 +123,6 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		planRecords,
 		visiblePlans,
 		paidDomainName,
-		isLoadingSuggestedFreeDomain,
 		wpcomFreeDomainSuggestion,
 		isInSignup,
 		isLaunchPage,
@@ -168,7 +169,6 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 
 	const asyncProps: PlanFeatures2023GridProps = {
 		paidDomainName,
-		isLoadingSuggestedFreeDomain,
 		wpcomFreeDomainSuggestion,
 		isInSignup,
 		isLaunchPage,
@@ -368,11 +368,8 @@ const PlansFeaturesMain = ( {
 		hidePlanSelector = true;
 	}
 
-	const {
-		isLoadingSuggestedFreeDomain,
-		wpcomFreeDomainSuggestion,
-		invalidateDomainSuggestionCache,
-	} = useSuggestedFreeDomainFromPaidDomain( paidDomainName );
+	const { wpcomFreeDomainSuggestion, invalidateDomainSuggestionCache } =
+		useSuggestedFreeDomainFromPaidDomain( paidDomainName );
 
 	const planTypeSelectorProps = {
 		basePlansPath,
@@ -400,15 +397,14 @@ const PlansFeaturesMain = ( {
 			{ paidDomainName && isFreePlanPaidDomainDialogOpen && (
 				<FreePlanPaidDomainDialog
 					paidDomainName={ paidDomainName }
-					isLoadingSuggestedFreeDomain={ isLoadingSuggestedFreeDomain }
 					wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
 					suggestedPlanSlug={ PLAN_PERSONAL }
 					onClose={ toggleIsFreePlanPaidDomainDialogOpen }
 					onFreePlanSelected={ () => {
 						// Since this domain will not be available after it is selected, invalidate the cache.
 						invalidateDomainSuggestionCache();
-						wpcomFreeDomainSuggestion &&
-							replacePaidDomainWithFreeDomain?.( wpcomFreeDomainSuggestion );
+						wpcomFreeDomainSuggestion.entry &&
+							replacePaidDomainWithFreeDomain?.( wpcomFreeDomainSuggestion.entry );
 						onUpgradeClick?.( null );
 					} }
 					onPlanSelected={ () => {
@@ -439,7 +435,6 @@ const PlansFeaturesMain = ( {
 						planRecords={ gridPlanRecords }
 						visiblePlans={ Object.keys( visiblePlans ) as PlanSlug[] }
 						paidDomainName={ paidDomainName }
-						isLoadingSuggestedFreeDomain={ isLoadingSuggestedFreeDomain }
 						wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
 						isInSignup={ isInSignup }
 						isLaunchPage={ isLaunchPage }

--- a/packages/data-stores/src/domain-suggestions/queries.ts
+++ b/packages/data-stores/src/domain-suggestions/queries.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { stringify } from 'qs';
 import wpcomProxyRequest from 'wpcom-proxy-request';
 import { getFormattedPrice, normalizeDomainSuggestionQuery } from './utils';
@@ -6,7 +6,7 @@ import type { DomainSuggestion, DomainSuggestionSelectorOptions } from './types'
 
 const STALE_TIME = 1000 * 60 * 5; // 5 minutes
 
-export function getDomainSuggestionsQueryKey(
+function getDomainSuggestionsQueryKey(
 	search: string,
 	options: DomainSuggestionSelectorOptions = {}
 ) {
@@ -18,8 +18,10 @@ export function useGetDomainSuggestions(
 	searchOptions: DomainSuggestionSelectorOptions = {},
 	queryOptions = {}
 ) {
-	return useQuery( {
-		queryKey: getDomainSuggestionsQueryKey( search, searchOptions ),
+	const queryKey = getDomainSuggestionsQueryKey( search, searchOptions );
+	const queryClient = useQueryClient();
+	const result = useQuery( {
+		queryKey,
 		queryFn: async () => {
 			const queryObject = normalizeDomainSuggestionQuery( search, searchOptions );
 			if ( ! queryObject.query ) {
@@ -53,6 +55,11 @@ export function useGetDomainSuggestions(
 		staleTime: STALE_TIME,
 		...queryOptions,
 	} );
+
+	return {
+		...result,
+		invalidateCache: () => queryClient.invalidateQueries( queryKey ),
+	};
 }
 
 /**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1794 and https://github.com/Automattic/wp-calypso/pull/78825

## Proposed Changes

This PR addresses [the review comment](https://github.com/Automattic/wp-calypso/pull/78825#discussion_r1261085874) from @chriskmnds separately, since it touches many places and domain-related thing is always sensitive :)

In general, it extracts the code querying for the suggested WPCOM free domain from a given paid domain into the hook, `use-suggested-free-domain-from-paid-domain`. It is defined and called at the `<PlansFeaturesMain />` level and its returned values are passed down the hierarchy from there, so that:

1. There is no hidden network depency hidden in the modal component and the feature component.
2. The code is DRY-er since the query is now consolidated in `<PlansFeaturesMain/>`
3. One extra thing is that it also exposes a method for invalidating cache. The abstraction used to be a bit leaky since the call site needs to access `react-query` directly to do so.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The following flows should work as expected:

* Select a paid domain -> select the Free plan -> see the modal -> pick the Personal plan
* Select a paid domain  -> select the Free plan -> see the modal -> pick the Free plan
* Select a free domain and then select any paid plan
* Select a paid domain and then select any paid plan

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
