### PR TITLE
Add presales chat bubble to domain transfer

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -2,6 +2,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import TransferDomains from './domains';
 import type { Step } from '../../types';
@@ -11,6 +12,8 @@ import './styles.scss';
 const Intro: Step = function Intro( { navigation, flow } ) {
 	const { submit, goBack } = navigation;
 	const { __ } = useI18n();
+
+	usePresalesChat( 'wpcom' );
 
 	const handleSubmit = () => {
 		submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
@@ -2,6 +2,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
 import IntroStep from './intro';
 import type { Step } from '../../types';
 
@@ -10,6 +11,8 @@ import './styles.scss';
 const Intro: Step = function Intro( { navigation } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
+
+	usePresalesChat( 'wpcom' );
 
 	const handleSubmit = () => {
 		submit?.();

--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -1,4 +1,8 @@
-import { useMessagingAvailability, useZendeskMessaging } from '@automattic/help-center/src/hooks';
+import {
+	useChatStatus,
+	useMessagingAvailability,
+	useZendeskMessaging,
+} from '@automattic/help-center/src/hooks';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -36,7 +40,8 @@ function getGroupName( keyType: KeyType ) {
 
 export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabilityCheck = false ) {
 	const isEnglishLocale = useIsEnglishLocale();
-	const isEligibleForPresalesChat = enabled && isEnglishLocale;
+	const { canConnectToZendesk } = useChatStatus();
+	const isEligibleForPresalesChat = enabled && isEnglishLocale && canConnectToZendesk;
 
 	const group = getGroupName( keyType );
 

--- a/packages/help-center/src/hooks/use-chat-status.ts
+++ b/packages/help-center/src/hooks/use-chat-status.ts
@@ -27,7 +27,7 @@ export default function useChatStatus(
 	const { status: zendeskStatus } = useZendeskConfig( isEligibleForChat );
 
 	return {
-		canConnectToZendesk: zendeskStatus !== 'error',
+		canConnectToZendesk: zendeskStatus !== 'error' && zendeskStatus !== 'loading',
 		hasActiveChats,
 		isChatAvailable: Boolean( chatAvailability?.is_available ),
 		isEligibleForChat,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3096

## Proposed Changes

* Added presales chat bubble to `/setup/domain-transfer/domains`
* Added presales chat bubble to `/setup/domain-transfer/intro`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/domain-transfer/intro`
* Chat bubble shows up
* Go to `/setup/domain-transfer/domains`

![desktop](https://github.com/Automattic/wp-calypso/assets/6586048/36fdba28-d3f0-46e9-9a3a-428af3790c0d)

![mobile](https://github.com/Automattic/wp-calypso/assets/6586048/95ec2983-d5f6-49ff-aafe-1630fdae6cd6)