### PR TITLE
Hardcode GS to personal plan

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -586,54 +586,12 @@ function wpcom_is_previewing_global_styles( ?int $user_id = null ) {
  * @param  int $blog_id Blog ID.
  * @return bool Whether the site has access to Global Styles with a Personal plan.
  */
-function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) {
+function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
 		return false;
 	}
-
-	if ( ! $blog_id ) {
-		$blog_id = get_current_blog_id();
-	}
-
-	$cache_key                          = "global-styles-on-personal-$blog_id";
-	$found_in_cache                     = false;
-	$has_global_styles_in_personal_plan = wp_cache_get( $cache_key, 'a8c_experiments', false, $found_in_cache );
-	if ( $found_in_cache ) {
-		return $has_global_styles_in_personal_plan;
-	}
-
-	$owner_id = wpcom_get_blog_owner( $blog_id );
-	if ( ! $owner_id ) {
-		return false;
-	}
-
-	$owner = get_userdata( $owner_id );
-	if ( ! $owner ) {
-		return false;
-	}
-
-	$experiment_assignment              = \ExPlat\assign_user( 'calypso_global_styles_personal_v2', $owner );
-	$has_global_styles_in_personal_plan = 'treatment' === $experiment_assignment;
-	// Cache the experiment assignment to prevent duplicate DB queries in the frontend.
-	wp_cache_set( $cache_key, $has_global_styles_in_personal_plan, 'a8c_experiments', MONTH_IN_SECONDS );
-	return $has_global_styles_in_personal_plan;
-}
-
-/**
- * Checks whether the site has a Personal plan.
- *
- * @param  int $blog_id Blog ID.
- * @return bool Whether the site has a Personal plan.
- */
-function wpcom_site_has_personal_plan( $blog_id ) {
-	$personal_plans = array_filter(
-		wpcom_get_site_purchases( $blog_id ),
-		function ( $purchase ) {
-			return strpos( $purchase->product_slug, 'personal-bundle' ) === 0;
-		}
-	);
-
-	return ! empty( $personal_plans );
+	// Following the experiment, all sites with a Personal plan have access to Global Styles.
+	return true;
 }
 
 /**
@@ -651,27 +609,5 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 		return true;
 	}
 
-	if ( wpcom_site_has_feature( WPCOM_Features::GLOBAL_STYLES, $blog_id ) ) {
-		return true;
-	}
-
-	if ( wpcom_site_has_global_styles_in_personal_plan( $blog_id ) ) {
-		/*
-		 * Flag site so users of the treatment group with a Personal plan can always have access
-		 * to Global Styles, even if the experiment has finished without including Global Styles
-		 * in the Personal plan.
-		 */
-		$has_personal_plan = wpcom_site_has_personal_plan( $blog_id );
-		$note              = 'See https://wp.me/paYJgx-3yE';
-		if ( $has_personal_plan ) {
-			if ( ! wpcom_global_styles_has_blog_sticker( 'wpcom-global-styles-personal-plan', $blog_id ) ) {
-				add_blog_sticker( 'wpcom-global-styles-personal-plan', $note, null, $blog_id );
-			}
-		} else {
-			remove_blog_sticker( 'wpcom-global-styles-personal-plan', $note, null, $blog_id );
-		}
-		return $has_personal_plan;
-	}
-
-	return false;
+	return wpcom_site_has_feature( WPCOM_Features::GLOBAL_STYLES, $blog_id );
 }


### PR DESCRIPTION
DO NOT MERGE! Pending the conclusion of 21298-explat-experiment where we decide to deploy the treatment. Leaving this is as a Draft PR to discourage accidental merges
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3062

## Proposed Changes

* Hardcode that `wpcom_site_has_global_styles_in_personal_plan` and hence the global-styles/status API will always return true, meaning that global styles is available in the personal plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure your site says that GS is part of the premium plan
* Apply D116546-code to sandbox
* Follow instructions to deploy this ETK change to sandbox
* Ensure that you see global styles on personal plan in the editor
* Check that the `wpcom/v2/sites/$SITE/global-styles/status` api includes `globalStylesInPersonalPlan: true` in its results 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?