### PR TITLE
Hardcode default GS available to personal

### DIFF
--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -3,22 +3,6 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import type { ExperimentAssignment } from '@automattic/explat-client';
-
-/*
- * We cannot import `loadExperimentAssignment` directly from 'calypso/lib/explat'
- * because it runs a side effect that produces an error on SSR contexts.
- */
-let loadExperimentAssignment = ( experimentName: string ): Promise< ExperimentAssignment > =>
-	Promise.resolve( { experimentName, variationName: null, retrievedTimestamp: 0, ttl: 0 } );
-if ( typeof window !== 'undefined' ) {
-	import( 'calypso/lib/explat' )
-		.then( ( module ) => {
-			loadExperimentAssignment = module.loadExperimentAssignment;
-		} )
-		// eslint-disable-next-line @typescript-eslint/no-empty-function
-		.catch( () => {} );
-}
 
 export type GlobalStylesStatus = {
 	shouldLimitGlobalStyles: boolean;
@@ -62,19 +46,16 @@ const getGlobalStylesInfoForSite = ( siteId: number | null ): Promise< GlobalSty
 		return Promise.resolve( {
 			shouldLimitGlobalStyles: true,
 			globalStylesInUse: false,
-			globalStylesInPersonalPlan: false,
+			globalStylesInPersonalPlan: true,
 		} );
 	}
 
 	if ( siteId === null ) {
-		return loadExperimentAssignment( 'calypso_global_styles_personal_v2' ).then(
-			( experimentAssignment ) =>
-				Promise.resolve( {
-					shouldLimitGlobalStyles: true,
-					globalStylesInUse: false,
-					globalStylesInPersonalPlan: experimentAssignment.variationName === 'treatment',
-				} )
-		);
+		return Promise.resolve( {
+			shouldLimitGlobalStyles: true,
+			globalStylesInUse: false,
+			globalStylesInPersonalPlan: true,
+		} );
 	}
 
 	return wpcom.req


### PR DESCRIPTION
DO NOT MERGE! Pending the conclusion of 21298-explat-experiment where we decide to deploy the treatment. Leaving this as a Draft PR to discourage accidental merges

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3062

## Proposed Changes

Global Styles is now part of the personal plan rather than being in an A/B test between Personal and Premium. To clean-up the code after the experiment, stop loading it and set the default values to match the hard-coded server values.

Future clean-up diffs will clean-up calypso more comprehensively.

## Testing Instructions

* In a private window go to /start
* Create a new user
* Make your way to the plans grid
* Observe that there are no requests to the explat API
* See that the personal plan includes Style Customization, not the premium plan

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?