### PR TITLE
Happy Blocks: Add webinars inner page header style

### DIFF
--- a/apps/happy-blocks/block-library/universal-header/header.scss
+++ b/apps/happy-blocks/block-library/universal-header/header.scss
@@ -169,51 +169,51 @@ body.archive {
 		}
 	}
 
-	&.happy-blocks-header__learn {
-		margin-top: 120px;
-		margin-bottom: 70px;
+	&.happy-blocks-header {
+		&.is-learn {
+			margin-top: 120px;
+			margin-bottom: 70px;
 
-		@media ( max-width: $breakpoint-mobile ) {
-			margin: 56px 0;
-		}
-
-		.happy-blocks-global-header-site__title {
-			display: flex;
-			flex-direction: column;
-
-			.happy-blocks-global-header-site__title__wrapper {
-				margin-bottom: 32px;
+			@media ( max-width: $breakpoint-mobile ) {
+				margin: 56px 0;
 			}
 
-			h1 {
-				font-size: rem(70px);
-				line-height: 76px;
-				@media ( max-width: $breakpoint-mobile ) {
-					font-size: rem(50px);
-					line-height: 57px;
-				}
-			}
-			// subtitle
-			p {
-				margin-top: 16px;
-				font-size: rem(18px);
-				line-height: 26px;
-				@media ( max-width: $breakpoint-mobile ) {
-					font-size: 1rem;
-					line-height: 24px;
-				}
-
-			}
-			// search bar
-			form {
+			.happy-blocks-global-header-site__title {
 				display: flex;
-				justify-content: start;
+				flex-direction: column;
 
-				.happy-blocks-search__inside-wrapper {
-					input {
-						background-color: var(--studio-gray-0);
+				.happy-blocks-global-header-site__title__wrapper {
+					margin-bottom: 32px;
+				}
+
+				h1 {
+					font-size: rem(70px);
+					line-height: 76px;
+					@media ( max-width: $breakpoint-mobile ) {
+						font-size: rem(50px);
+						line-height: 57px;
 					}
 				}
+				// subtitle
+				p {
+					margin-top: 16px;
+					font-size: rem(18px);
+					line-height: 26px;
+					@media ( max-width: $breakpoint-mobile ) {
+						font-size: 1rem;
+						line-height: 24px;
+					}
+				}
+				// search bar
+				form {
+					display: flex;
+					justify-content: start;
+				}
+			}
+		}
+		.happy-blocks-search__inside-wrapper {
+			input {
+				background-color: var(--studio-gray-0);
 			}
 		}
 	}

--- a/apps/happy-blocks/block-library/universal-header/index.php
+++ b/apps/happy-blocks/block-library/universal-header/index.php
@@ -16,24 +16,8 @@ if ( ! isset( $args ) ) {
 	$args = array();
 }
 
-$happy_blocks_current_tab = $args['active_tab'];
-
-$happy_blocks_tabs = array(
-	'learn'   => array(
-		'title' => __( 'Learn', 'happy-blocks' ),
-		'url'   => 'https://wordpress.com/learn/',
-	),
-	'support' => array(
-		'title' => __( 'Support', 'happy-blocks' ),
-		'url'   => localized_wpcom_url( 'https://wordpress.com/support/' ),
-	),
-	'forums'  => array(
-		'title' => __( 'Forums', 'happy-blocks' ),
-		'url'   => localized_wpcom_url( 'https://wordpress.com/forums/' ),
-	),
-);
-
-$happy_blocks_is_english = ( 0 === stripos( get_locale(), 'en' ) );
+$happy_blocks_current_page = $args['active_page'];
+$happy_blocks_is_english   = ( 0 === stripos( get_locale(), 'en' ) );
 ?>
 <div id="lpc-header-nav" class="lpc lpc-header-nav">
 	<div class="x-root lpc-header-nav-wrapper">
@@ -434,7 +418,7 @@ $happy_blocks_is_english = ( 0 === stripos( get_locale(), 'en' ) );
 		</div>
 	</div>
 </div>
-<div class="happy-blocks-mini-search happy-blocks-header__<?php echo esc_html( $args['active_tab'] ); ?>">
+<div class="happy-blocks-mini-search happy-blocks-header is-<?php echo esc_html( $happy_blocks_current_page ); ?>">
 	<div class="happy-blocks-search-container">
 		<div class="happy-blocks-global-header-site__title">
 			<?php if ( $args['include_site_title'] ) : ?>


### PR DESCRIPTION
## Proposed Changes

On /learn, the webinars page has a different header (title, subtitle, and layout) than the home page, this PR handles it.

Learn Homepage:
<img width="2041" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/a46878d1-9228-4a82-8846-1437a17103d4">


Webinars Page:
<img width="2037" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/e936a7d6-ecc7-4b3f-aa2c-7530bfe06e37">

**The content bellow webinars will be removed on wpsupport3 repo.**

## Testing Instructions

1st step:
- Sandbox learn.wordpress.com and wordpress.com
- Pull this branch
- Navigate to /wp-calypso/apps/happy-blocks and run yarn dev --sync to sync with your sandbox

2nd step:
- Follow the instruction on this [PR](https://github.com/Automattic/wpsupport3/pull/481).
- It should match the designs and keep /support looking the same.

