### PR TITLE
Update the deferred setup domain transfer notification message

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -1,12 +1,12 @@
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import moment from 'moment';
+import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import { isExpiringSoon } from 'calypso/lib/domains/utils/is-expiring-soon';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils/is-recently-registered';
 import { shouldRenderExpiringCreditCard, handleRenewNowClick } from 'calypso/lib/purchases';
 import {
 	SETTING_PRIMARY_DOMAIN,
-	INCOMING_DOMAIN_TRANSFER_STATUSES,
 	INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS,
 	GDPR_POLICIES,
 	DOMAIN_EXPIRATION,
@@ -15,6 +15,7 @@ import {
 	domainManagementEdit,
 	domainManagementEditContactInfo,
 	domainMappingSetup,
+	domainUseMyDomain,
 } from 'calypso/my-sites/domains/paths';
 import { transferStatus, type as domainTypes, gdprConsentStatus } from './constants';
 import type { ResponseDomain } from './types';
@@ -566,14 +567,16 @@ export function resolveDomainStatus(
 					status: translate( 'Complete setup' ),
 					icon: 'info',
 					noticeText: translate(
-						'Please follow {{a}}these instructions{{/a}} to start the transfer.',
+						'You need to {{a}}start the domain transfer{{/a}} for your domain.',
 						{
 							components: {
 								a: (
 									<a
-										href={ localizeUrl( INCOMING_DOMAIN_TRANSFER_STATUSES ) }
-										rel="noopener noreferrer"
-										target="_blank"
+										href={ domainUseMyDomain(
+											siteSlug as string,
+											domain.name,
+											useMyDomainInputMode.startPendingTransfer
+										) }
 									/>
 								),
 							},


### PR DESCRIPTION
We got a report that the notification for domain transfer that needs to be initiated manually is confusing as it sends you to a support page for domain transfers but not for this specific case of domain transfer. So instead of doing that we'll send you to the domain transfer initialization screen - we show all the information in there anyways so it makes much more sense to do that.

In a different task we're working on improving the failed domain transfer messaging and statuses so we'll handle those cases better than now.

Related to https://github.com/Automattic/nomado-issues/issues/222

## Proposed Changes

* Update the message we show for domains that are pending for the customer to initialise them to be clearer - "You need to {{a}}start the domain transfer{{/a}} for your domain"

## Testing Instructions

* Apply the PR, get a failed transfer domain on your account and visit /domains/manage - you should be able to click on the "stsart the domain transfer" link that would lead you to the correct place with instructions on how to unlock your domain and provide auth code

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
