### PR TITLE
Domain transfer: Fix CTA button color

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -375,39 +375,6 @@
 				margin-bottom: 50px;
 			}
 		}
-
-		.bulk-domain-transfer__cta-container {
-			display: flex;
-			justify-content: center;
-			margin-bottom: 32px;
-
-			.bulk-domain-transfer__cta {
-				justify-content: center;
-				color: var(--black-white-white, #fff);
-				height: 48px;
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-				border-radius: 0.25rem;
-				background: var(--blue-blue-50, #0675c4);
-				font-size: 0.875rem;
-				width: 240px;
-
-				&:hover {
-					background: var(--studio-blue-60);
-				}
-
-				&:disabled {
-					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-					border-radius: 0.25rem;
-					background: var(--gray-gray-5, #dcdcde);
-					opacity: 1;
-				}
-
-				@media (max-width: $break-medium ) {
-					width: 100%;
-				}
-			}
-		}
-
 	}
 
 	.domains__domain-info-and-validation {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
@@ -62,8 +62,8 @@ const Intro: React.FC< Props > = ( { onSubmit } ) => {
 				preventWidows={ preventWidows }
 				onSelect={ onSubmit }
 			/>
-			<div style={ { display: 'flex', justifyContent: 'center' } }>
-				<Button variant="primary" onClick={ onSubmit }>
+			<div className="bulk-domain-transfer__cta-container">
+				<Button className="bulk-domain-transfer__cta" onClick={ onSubmit }>
 					{ __( 'Get Started' ) }
 				</Button>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -16,6 +16,40 @@ $heading-font-family: "SF Pro Display", $sans;
 		display: none;
 	}
 
+	// Same style also on transfer-domains step
+	.bulk-domain-transfer__cta-container {
+		display: flex;
+		justify-content: center;
+		margin-bottom: 32px;
+
+		.bulk-domain-transfer__cta {
+			justify-content: center;
+			color: var(--black-white-white, #fff);
+			height: 48px;
+			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+			border-radius: 0.25rem;
+			background: var(--blue-blue-50, #0675c4);
+			font-size: 0.875rem;
+			width: 240px;
+			font-weight: 500;
+
+			&:hover {
+				background: var(--studio-blue-60);
+			}
+
+			&:disabled {
+				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+				border-radius: 0.25rem;
+				background: var(--gray-gray-5, #dcdcde);
+				opacity: 1;
+			}
+
+			@media (max-width: $break-medium ) {
+				width: 100%;
+			}
+		}
+	}
+
 	&.intro {
 		padding: 0;
 
@@ -78,8 +112,6 @@ $heading-font-family: "SF Pro Display", $sans;
 			}
 
 			.step-container__content {
-
-
 				flex-shrink: 0;
 
 				.select-items {
@@ -118,20 +150,6 @@ $heading-font-family: "SF Pro Display", $sans;
 					.select-items__item-learn-more {
 						text-decoration: underline;
 						color: var(--studio-gray-60);
-					}
-				}
-
-				.components-button {
-					border-radius: 4px;
-					font-size: $font-body-small;
-					font-weight: 500;
-					justify-content: center;
-					padding-bottom: 26px;
-					padding-top: 26px;
-					width: 187px;
-
-					@media (max-width: $break-medium ) {
-						width: 100%;
 					}
 				}
 			}


### PR DESCRIPTION
## Proposed Changes

Fix the button color and unify the same style on buttons no step 1 and 2.
Context p9Jlb4-8kT-p2#comment-8667

<img width="641" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/558a6b76-661b-484f-a734-ce35ac05619c">


## Testing Instructions

- Pull and run this branch or use live link
- Navigate to `/setup/domain-transfer` and check if the buttons match the [design](mbuq4o5QxohQpBU9YoexXo-fi-719_21329)