### PR TITLE
Stats: Support Stats card on the My Plan page

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -57,6 +57,9 @@ import {
 	PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_1TB_YEARLY,
 	PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_3TB_YEARLY,
 	PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_5TB_YEARLY,
+	PRODUCT_JETPACK_STATS_MONTHLY,
+	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
+	PRODUCT_JETPACK_STATS_FREE,
 } from './constants';
 import type { FAQ, SelectorProductFeaturesItem } from './types';
 import type { TranslateResult } from 'i18n-calypso';
@@ -153,6 +156,7 @@ export const getJetpackProductsDisplayNames = (): Record< string, TranslateResul
 	);
 	const backup = translate( 'VaultPress Backup' );
 	const search = translate( 'Site Search' );
+	const stats = translate( 'Stats' );
 	const scan = translate( 'Scan' );
 	const scanRealtime = (
 		<>
@@ -242,6 +246,9 @@ export const getJetpackProductsDisplayNames = (): Record< string, TranslateResul
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: search,
 		[ PRODUCT_WPCOM_SEARCH ]: search,
 		[ PRODUCT_WPCOM_SEARCH_MONTHLY ]: search,
+		[ PRODUCT_JETPACK_STATS_MONTHLY ]: stats,
+		[ PRODUCT_JETPACK_STATS_PWYW_YEARLY ]: stats,
+		[ PRODUCT_JETPACK_STATS_FREE ]: stats,
 		[ PRODUCT_JETPACK_SCAN ]: scan,
 		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: scan,
 		[ PRODUCT_JETPACK_SCAN_REALTIME ]: scanRealtime,
@@ -341,6 +348,9 @@ export const getJetpackProductsTaglines = (): Record<
 		'Your site is equipped with our intuitive and powerful AI.'
 	);
 	const searchTagline = translate( 'Recommended for sites with lots of products or content' );
+	const statsTagline = translate(
+		'With Jetpack Stats, you don’t need to be a data scientist to see how your site is performing.'
+	);
 	const scanTagline = translate( 'Protect your site' );
 	const scanOwnedTagline = translate( 'Your site is actively being scanned for malicious threats' );
 	const antiSpamTagline = translate( 'Block spam automatically' );
@@ -420,6 +430,9 @@ export const getJetpackProductsTaglines = (): Record<
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: { default: searchTagline },
 		[ PRODUCT_WPCOM_SEARCH ]: { default: searchTagline },
 		[ PRODUCT_WPCOM_SEARCH_MONTHLY ]: { default: searchTagline },
+		[ PRODUCT_JETPACK_STATS_MONTHLY ]: { default: statsTagline },
+		[ PRODUCT_JETPACK_STATS_PWYW_YEARLY ]: { default: statsTagline },
+		[ PRODUCT_JETPACK_STATS_FREE ]: { default: statsTagline },
 		[ PRODUCT_JETPACK_SCAN ]: {
 			default: scanTagline,
 			owned: scanOwnedTagline,

--- a/packages/components/src/product-icon/config.ts
+++ b/packages/components/src/product-icon/config.ts
@@ -9,6 +9,7 @@ import jetpackGoldenToken from './images/jetpack-golden-token.svg';
 import jetpackScan from './images/jetpack-scan.svg';
 import jetpackSearch from './images/jetpack-search.svg';
 import jetpackSocial from './images/jetpack-social.svg';
+import jetpackStats from './images/jetpack-stats.svg';
 import jetpackVideoPress from './images/jetpack-videopress.svg';
 import wpcomBlogger from './images/wpcom-blogger.svg';
 import wpcomBusiness from './images/wpcom-business.svg';
@@ -29,6 +30,7 @@ export const paths = {
 	'jetpack-professional': jetpackBundles,
 	'jetpack-scan': jetpackScan,
 	'jetpack-search': jetpackSearch,
+	'jetpack-stats': jetpackStats,
 	'jetpack-security': jetpackBundles,
 	'jetpack-social': jetpackSocial,
 	'jetpack-starter': jetpackBundles,
@@ -101,6 +103,9 @@ export type SupportedSlugs =
 	| 'jetpack_scan_realtime_monthly_v2'
 	| 'jetpack_search'
 	| 'jetpack_search_monthly'
+	| 'jetpack_stats_monthly'
+	| 'jetpack_stats_pwyw_yearly'
+	| 'jetpack_stats_free_yearly'
 	| 'jetpack_social'
 	| 'jetpack_social_monthly'
 	| 'wpcom_search'
@@ -210,6 +215,11 @@ export const iconToProductSlugMap: Record< keyof typeof paths, readonly Supporte
 		'wpcom_search_monthly',
 		'jetpack_search_v2',
 		'jetpack_search_monthly_v2',
+	],
+	'jetpack-stats': [
+		'jetpack_stats_monthly',
+		'jetpack_stats_pwyw_yearly',
+		'jetpack_stats_free_yearly',
 	],
 	'jetpack-anti-spam': [
 		'jetpack_anti_spam',

--- a/packages/components/src/product-icon/images/jetpack-stats.svg
+++ b/packages/components/src/product-icon/images/jetpack-stats.svg
@@ -1,0 +1,6 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="32" cy="32" r="32" fill="#069E08"/>
+<path d="M30.4 18H32.8V42H30.4V18Z" fill="white"/>
+<path d="M22 26H24.4V42H22V26Z" fill="white"/>
+<path d="M41.2 32.4H38.8V42H41.2V32.4Z" fill="white"/>
+</svg>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79402 

## Proposed Changes

* Patch icon, title, and tagLine for Stats card support on the My Plan page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jetpack site / Simple site / Atomic site.
* Purchase Jetpack Stats (Commercial license) for sites: `https://wordpress.com/checkout/{site-slug}/jetpack_stats_monthly`.
* Spin up the change with the Calypso Live link.
* Navigate to My Plan page: `/plans/my-plan/{site-slug}`.
* Ensure the Stats card displays as expected for the Jetpack site, Simple site, and Atomic site.

<img width="1072" alt="截圖 2023-07-20 下午11 13 57" src="https://github.com/Automattic/wp-calypso/assets/6869813/9e76c209-b3a0-46c0-a170-adf687ddefae">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
