### PR TITLE
Checkout: Make disabled payment button accent different from main

### DIFF
--- a/packages/composite-checkout/src/lib/theme.ts
+++ b/packages/composite-checkout/src/lib/theme.ts
@@ -69,7 +69,7 @@ const theme: Theme = {
 		success: colorStudio.colors[ 'Green 30' ],
 		discount: colorStudio.colors[ 'Green 30' ],
 		disabledPaymentButtons: colorStudio.colors[ 'Gray 5' ],
-		disabledPaymentButtonsAccent: colorStudio.colors[ 'Gray 5' ],
+		disabledPaymentButtonsAccent: colorStudio.colors[ 'Gray 20' ],
 		disabledButtons: colorStudio.colors[ 'White' ],
 		borderColor: swatches.gray10,
 		borderColorLight: swatches.gray5,


### PR DESCRIPTION
## Proposed Changes

The "busy" animation for disabled buttons in checkout, added in https://github.com/Automattic/wp-calypso/pull/39816, is not being displayed.

I figured out what the problem is: the "busy" animation _is actually running_ but [the regular and accent color](https://github.com/Automattic/wp-calypso/blob/665ebc208a3924b68e2f9fc051551ad643ec5c68/packages/composite-checkout/src/lib/theme.ts#L71C1-L72) for disabled buttons were accidentally made the same in #77353 and therefore it looks like a static gray.

In this PR we change the accent color to something different to make the animation visible again.

Note: this affects all plain buttons in checkout, like the "Continue to payment" button between steps and the "Pay X now" button.

Before:

<img width="593" alt="Screenshot 2023-07-20 at 12 23 54 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/50949b3b-167a-4b30-9d25-4d6eb8dc4543">

After:

<img width="614" alt="Screenshot 2023-07-20 at 12 14 27 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/b8c789ea-9c00-4a3f-ae3b-e9ba8a8de831">

Fixes https://github.com/Automattic/wp-calypso/issues/79589

## Testing Instructions

- Visit checkout with a product in your cart.
- Select an existing or new credit card as the payment method.
- Click to submit the payment.
- Verify that you see the "Processing…" button animated.