### PR TITLE
GS on Personal A/B: Remove experiment & support treatment sites

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/api/class-global-styles-status-rest-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/api/class-global-styles-status-rest-api.php
@@ -65,9 +65,8 @@ class Global_Styles_Status_Rest_API extends WP_REST_Controller {
 	 */
 	public function get_global_styles_info() {
 		return array(
-			'globalStylesInUse'          => wpcom_global_styles_in_use(),
-			'shouldLimitGlobalStyles'    => wpcom_should_limit_global_styles(),
-			'globalStylesInPersonalPlan' => wpcom_site_has_global_styles_in_personal_plan(),
+			'globalStylesInUse'       => wpcom_global_styles_in_use(),
+			'shouldLimitGlobalStyles' => wpcom_should_limit_global_styles(),
 		);
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -566,6 +566,23 @@ function wpcom_is_previewing_global_styles( ?int $user_id = null ) {
 }
 
 /**
+ * Checks whether the site has a Personal plan.
+ *
+ * @param  int $blog_id Blog ID.
+ * @return bool Whether the site has a Personal plan.
+ */
+function wpcom_site_has_personal_plan( $blog_id ) {
+	$personal_plans = array_filter(
+		wpcom_get_site_purchases( $blog_id ),
+		function ( $purchase ) {
+			return strpos( $purchase->product_slug, 'personal-bundle' ) === 0;
+		}
+	);
+
+	return ! empty( $personal_plans );
+}
+
+/**
  * Checks whether the site has a plan that grants access to the Global Styles feature.
  *
  * @param  int $blog_id Blog ID.
@@ -586,7 +603,7 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 
 	// Users who bought a Personal plan during the GS on Personal experiment should
 	// retain access to Global Styles.
-	if ( has_blog_sticker( 'wpcom-global-styles-personal-plan', $blog_id ) ) {
+	if ( has_blog_sticker( 'wpcom-global-styles-personal-plan', $blog_id ) && wpcom_site_has_personal_plan( $blog_id ) ) {
 		return true;
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -603,8 +603,15 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 
 	// Users who bought a Personal plan during the GS on Personal experiment should
 	// retain access to Global Styles.
-	if ( has_blog_sticker( 'wpcom-global-styles-personal-plan', $blog_id ) && wpcom_site_has_personal_plan( $blog_id ) ) {
-		return true;
+	if ( has_blog_sticker( 'wpcom-global-styles-personal-plan', $blog_id ) ) {
+		if ( wpcom_site_has_personal_plan( $blog_id ) ) {
+			return true;
+		} else {
+			$note = 'Automated sticker. See https://wp.me/paYJgx-3yE';
+			$user = 'a8c'; // A non-empty string avoids storing the current user as author of the sticker change.
+			remove_blog_sticker( 'wpcom-global-styles-personal-plan', $note, $user, $blog_id );
+			return false;
+		}
 	}
 
 	return false;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -566,16 +566,6 @@ function wpcom_is_previewing_global_styles( ?int $user_id = null ) {
 }
 
 /**
- * Checks whether the site has access to Global Styles with a Personal plan as part of an A/B test.
- *
- * @param  int $blog_id Blog ID.
- * @return bool Whether the site has access to Global Styles with a Personal plan.
- */
-function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-	return false;
-}
-
-/**
  * Checks whether the site has a plan that grants access to the Global Styles feature.
  *
  * @param  int $blog_id Blog ID.
@@ -594,7 +584,7 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 		return true;
 	}
 
-	// Users who bought a personal plan during the personal/premium experiment should
+	// Users who bought a Personal plan during the GS on Personal experiment should
 	// retain access to Global Styles.
 	if ( has_blog_sticker( 'wpcom-global-styles-personal-plan', $blog_id ) ) {
 		return true;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -603,7 +603,7 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 
 	// Users who bought a Personal plan during the GS on Personal experiment should
 	// retain access to Global Styles.
-	if ( has_blog_sticker( 'wpcom-global-styles-personal-plan', $blog_id ) ) {
+	if ( wpcom_global_styles_has_blog_sticker( 'wpcom-global-styles-personal-plan', $blog_id ) ) {
 		if ( wpcom_site_has_personal_plan( $blog_id ) ) {
 			return true;
 		} else {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3062
Requires https://github.com/Automattic/wp-calypso/pull/81139

## Proposed Changes

Global Styles is back to being part of the Premium plan rather than being in an A/B test between Personal and Premium. To support sites who had bought the personal plan during the test due to being on that side of the experiment a sticker is checked to see if they have eligibility for global styles.

## Testing Instructions

1. Apply these changes to your sandbox
2. Sandbox a site with a Personal plan
3. Add the `wpcom_site_has_global_styles_feature` sticker to the sandboxed site
4. Visit the front-end of your site, you should retain access to global styles with no upgrade message. 
5. Remove the Personal plan and visit the frontend again
6. Check the blog stickers and make sure the `wpcom_site_has_global_styles_feature` sticker has been removed 