### PR TITLE
Google Ads: Move bulk domain transfer tracking to checkout complete page

### DIFF
--- a/client/lib/analytics/record-purchase.js
+++ b/client/lib/analytics/record-purchase.js
@@ -1,9 +1,6 @@
 import { recordOrder } from 'calypso/lib/analytics/ad-tracking';
 import { costToUSD } from 'calypso/lib/analytics/utils';
-import { hasTransferProduct } from '../cart-values/cart-items';
-import { debug, TRACKING_IDS } from './ad-tracking/constants';
 import { gaRecordEvent } from './ga';
-import { mayWeTrackByTracker } from './tracker-buckets';
 
 export async function recordPurchase( { cart, orderId, sitePlanSlug } ) {
 	if ( cart.total_cost >= 0.01 ) {
@@ -19,23 +16,5 @@ export async function recordPurchase( { cart, orderId, sitePlanSlug } ) {
 
 		// Marketing
 		recordOrder( cart, orderId, sitePlanSlug );
-	}
-
-	if ( hasTransferProduct( cart ) && mayWeTrackByTracker( 'googleAds' ) ) {
-		const params = [
-			'event',
-			'conversion',
-			{
-				send_to: TRACKING_IDS.wpcomGoogleAdsGtagDomainTransferPurchase,
-				transaction_id: orderId,
-			},
-		];
-		debug( 'recordOrderInGoogleAds: WPCom Domain Transfer Purchase', params );
-		window.gtag( ...params );
-
-		// The page redirect to the domain transfer success page happens too quickly and
-		// cancels the conversion event before it's fired. We delay execution by 1 second
-		// to ensure that the conversion event is recorded
-		return new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
 	}
 }

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -38,7 +38,9 @@ import Notice from 'calypso/components/notice';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import WpAdminAutoLogin from 'calypso/components/wpadmin-auto-login';
+import { debug, TRACKING_IDS } from 'calypso/lib/analytics/ad-tracking/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { mayWeTrackByTracker } from 'calypso/lib/analytics/tracker-buckets';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getFeatureByKey } from 'calypso/lib/plans/features-list';
 import { isExternal } from 'calypso/lib/url';
@@ -244,6 +246,16 @@ export class CheckoutThankYou extends Component<
 			import( 'calypso/landing/stepper/stores' ).then( ( imports ) =>
 				dispatch( imports.ONBOARD_STORE ).resetOnboardStore()
 			);
+
+			if ( mayWeTrackByTracker( 'googleAds' ) ) {
+				const params: [ 'event', 'conversion', { send_to: string } ] = [
+					'event',
+					'conversion',
+					{ send_to: TRACKING_IDS.wpcomGoogleAdsGtagDomainTransferPurchase } as { send_to: string },
+				];
+				debug( 'recordOrderInGoogleAds: WPCom Domain Transfer Purchase', params );
+				window.gtag( ...params );
+			}
 		}
 
 		recordTracksEvent( 'calypso_checkout_thank_you_view' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/79500#issuecomment-1642229459

## Proposed Changes

[We were previously tracking google analytics immediately after users purchased bulk domains](https://github.com/Automattic/wp-calypso/pull/79445). This, however, caused issues, because, at times, the tracking event would be cancelled because the page would redirect so quickly. [We patched the problem temporarily by delaying page redirect for 1 second](https://github.com/Automattic/wp-calypso/pull/79500#issuecomment-1642229459).

As a longer term solution, we've moved the tracking event to the checkout complete page, which _is not_ redirected to any other pages.

* Removes google tracking from record-purchase.js callback
* Instead fires off google tracking event when user lands on checkout complete page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Enable the `ad-tracking` and `cookie-banner` flag in development.json
* `yarn && yarn start`
* Ensure that correct Privacy settings are disabled
  * Make sure that browser `doNotTrack` setting is disabled. For example, in chrome, [follow these instructions to disable](https://support.google.com/chrome/answer/2790761?hl=en&co=GENIE.Platform%3DDesktop).
  * Enable the "Share information with our analytics tool about your use of services while logged in to your WordPress.com account" toggle in `/me` under the `Privacy` tab
  * From what I can tell, that should be enough to address all potential privacy blocks, but I might have missed something. There may be other settings that need to be disabled in your environment. The logic is outlined in [this file](https://github.com/Automattic/wp-calypso/blob/7b73d26cb9e233370224799b1e40cf359142f6c1/client/lib/analytics/tracker-buckets.ts#L131-L132) under the `mayWeTrackByTracker` method
* Navigate to http://calypso.localhost:3000/setup/domain-transfer/domains
  * There are two ways to handle testing the actual domain transfer:
    1. Transfer the domain and cancel the transfer with your original domain registrar afterwards ( p1689366128054469-slack-C05CT832K2T ) 
    2. Change backend logic to permit an incorrect auth transfer code. Submit incorrect code, wait for system retries to complete, and then delete the transfer request in wordpress.com/domains/manage p1689594886918239-slack-C0BNMNMNG
  * Enter domain to transfer
  * Enter auth code ( you can enter fake auth codes by following these instructions
  * Click on transfer button
* Click on Pay $0 now
* Verify that the google ads conversion event was fired by checking the dev network tab for the `googleadservices.com/pagead/conversion/946162814` fetch request

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?