### PR TITLE
Launchpad: Add the "Earn money with your Newsletter" task completion logic

### DIFF
--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -1,3 +1,4 @@
+import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { localize } from 'i18n-calypso';
 import { capitalize, find } from 'lodash';
 import PropTypes from 'prop-types';
@@ -34,6 +35,14 @@ class EarningsMain extends Component {
 		site: PropTypes.object,
 		query: PropTypes.object,
 	};
+
+	constructor( props ) {
+		super( props );
+		// Mark the task as done
+		updateLaunchpadSettings( props.siteSlug, {
+			checklist_statuses: { earn_money: true },
+		} );
+	}
 
 	getSelectedText() {
 		const selected = find( this.getFilters(), { path: this.props.path } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79699

## Proposed Changes

This PR adds the "Earn money with your Newsletter" task completion logic. The task should be marked as complete when the user access the "Earn" page(/earn/{SITE_SLUG}).

More context: p1689792405641869-slack-C057AH42XQD

Note: This should be deployed after https://github.com/Automattic/jetpack/pull/32000

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR or use the calypso.live link.
* Follow the testing instructions on https://github.com/Automattic/jetpack/pull/32000
* Create a new site by navigating to `/setup/newsletter/intro`
* Go through the setup flow
* With the Network tab open, navigate to `/earn/{SITE_SLUG}`
* Look for the `wpcom/v2/sites/{SITE_SLUG}/launchpad?_envelope=1` and check that it was successful 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?