### PR TITLE
Domains list: allow Status sorting in both directions

### DIFF
--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -346,6 +346,7 @@ class AllDomains extends Component {
 				label: translate( 'Status' ),
 				isSortable: true,
 				initialSortOrder: -1,
+				supportsOrderSwitching: false,
 				sortFunctions: [
 					( first, second, sortOrder ) => {
 						const { listStatusWeight: firstStatusWeight } = resolveDomainStatus(

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -346,7 +346,7 @@ class AllDomains extends Component {
 				label: translate( 'Status' ),
 				isSortable: true,
 				initialSortOrder: -1,
-				supportsOrderSwitching: false,
+				supportsOrderSwitching: true,
 				sortFunctions: [
 					( first, second, sortOrder ) => {
 						const { listStatusWeight: firstStatusWeight } = resolveDomainStatus(

--- a/client/my-sites/domains/domain-management/list/domains-table-header.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table-header.jsx
@@ -56,7 +56,7 @@ class DomainsTableHeader extends PureComponent {
 	};
 
 	renderSortIcon( column, sortKey, sortOrder ) {
-		if ( ! column?.isSortable || ! column?.supportsOrderSwitching ) {
+		if ( ! column?.isSortable ) {
 			return null;
 		}
 

--- a/client/my-sites/domains/domain-management/list/domains-table-header.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table-header.jsx
@@ -56,7 +56,7 @@ class DomainsTableHeader extends PureComponent {
 	};
 
 	renderSortIcon( column, sortKey, sortOrder ) {
-		if ( ! column?.isSortable ) {
+		if ( ! column?.isSortable || ! column?.supportsOrderSwitching ) {
 			return null;
 		}
 

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -130,6 +130,7 @@ export class SiteDomains extends Component {
 				label: translate( 'Status' ),
 				isSortable: true,
 				initialSortOrder: -1,
+				supportsOrderSwitching: false,
 				sortFunctions: [
 					( first, second, sortOrder ) => {
 						const { listStatusWeight: firstStatusWeight } = resolveDomainStatus(

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -130,7 +130,7 @@ export class SiteDomains extends Component {
 				label: translate( 'Status' ),
 				isSortable: true,
 				initialSortOrder: -1,
-				supportsOrderSwitching: false,
+				supportsOrderSwitching: true,
 				sortFunctions: [
 					( first, second, sortOrder ) => {
 						const { listStatusWeight: firstStatusWeight } = resolveDomainStatus(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3013#top

## Proposed Changes

* Use the existing `supportsOrderSwitching` prop to allow sorting in both directions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit /domains/manage and click around the table headers. Check that you can sort by Status in both directions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
