### PR TITLE
Fix `_wp-components-overrides.scss` by increasing selector specifity

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -11,16 +11,14 @@
 }
 
 /* @wordpress/components Button overrides */
-a.components-button,
-button.components-button {
+.components-button {
 	&,
 	&:hover:not(:disabled) {
 		color: var(--color-neutral-70);
 	}
 }
 
-a.components-button.is-primary,
-button.components-button.is-primary {
+.components-button.is-primary {
 	background-color: var(--color-accent);
 	border-color: var(--color-accent);
 	color: var(--color-text-inverted);
@@ -42,8 +40,7 @@ button.components-button.is-primary {
 	}
 }
 
-a.components-button.is-secondary,
-button.components-button.is-secondary {
+.components-button.is-secondary {
 	background-color: var(--color-surface);
 	color: var(--color-neutral-70);
 	box-shadow: inset 0 0 0 1px var(--color-neutral-10);
@@ -67,8 +64,7 @@ button.components-button.is-secondary {
 	}
 }
 
-a.components-button.is-tertiary,
-button.components-button.is-tertiary {
+.components-button.is-tertiary {
 	color: var(--color-accent);
 
 	&:active:not(:disabled),

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -11,14 +11,16 @@
 }
 
 /* @wordpress/components Button overrides */
-.components-button {
+a.components-button,
+button.components-button {
 	&,
 	&:hover:not(:disabled) {
 		color: var(--color-neutral-70);
 	}
 }
 
-.components-button.is-primary {
+a.components-button.is-primary,
+button.components-button.is-primary {
 	background-color: var(--color-accent);
 	border-color: var(--color-accent);
 	color: var(--color-text-inverted);
@@ -40,7 +42,8 @@
 	}
 }
 
-.components-button.is-secondary {
+a.components-button.is-secondary,
+button.components-button.is-secondary {
 	background-color: var(--color-surface);
 	color: var(--color-neutral-70);
 	box-shadow: inset 0 0 0 1px var(--color-neutral-10);
@@ -64,7 +67,8 @@
 	}
 }
 
-.components-button.is-tertiary {
+a.components-button.is-tertiary,
+button.components-button.is-tertiary {
 	color: var(--color-accent);
 
 	&:active:not(:disabled),

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -8,6 +8,14 @@
 @import "@automattic/onboarding/styles/variables";
 @import "@automattic/components/src/styles/typography";
 
+// WordPress.org components no longer user blue-50 as primary color.
+// This changes the primary color to blue-50 to match the WordPress.com colors.
+:root {
+	--wp-components-color-accent: var(--studio-blue-50);
+	--wp-components-color-accent-darker-20: var(--studio-blue-60);
+	--wp-components-color-accent-darker-10: var(--studio-blue-60);
+}
+
 /**
  * General onboarding styling
  */

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -8,6 +8,14 @@
 @import "@automattic/onboarding/styles/variables";
 @import "@automattic/components/src/styles/typography";
 
+// WordPress.org components no longer use blue-50 as the primary color.
+// This changes the primary color to blue-50 to conform to the WordPress.com colors.
+:root {
+	--wp-components-color-accent: var(--studio-blue-50);
+	--wp-components-color-accent-darker-20: var(--studio-blue-60);
+	--wp-components-color-accent-darker-10: var(--studio-blue-60);
+}
+
 /**
  * General onboarding styling
  */

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -8,8 +8,8 @@
 @import "@automattic/onboarding/styles/variables";
 @import "@automattic/components/src/styles/typography";
 
-// WordPress.org components no longer user blue-50 as primary color.
-// This changes the primary color to blue-50 to match the WordPress.com colors.
+// WordPress.org components no longer use blue-50 as the primary color.
+// This changes the primary color to blue-50 to conform to the WordPress.com colors.
 :root {
 	--wp-components-color-accent: var(--studio-blue-50);
 	--wp-components-color-accent-darker-20: var(--studio-blue-60);

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -8,14 +8,6 @@
 @import "@automattic/onboarding/styles/variables";
 @import "@automattic/components/src/styles/typography";
 
-// WordPress.org components no longer use blue-50 as the primary color.
-// This changes the primary color to blue-50 to conform to the WordPress.com colors.
-:root {
-	--wp-components-color-accent: var(--studio-blue-50);
-	--wp-components-color-accent-darker-20: var(--studio-blue-60);
-	--wp-components-color-accent-darker-10: var(--studio-blue-60);
-}
-
 /**
  * General onboarding styling
  */

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -218,6 +218,7 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 				<Button
 					disabled={ numberOfValidDomains === 0 || ! allGood }
 					className="bulk-domain-transfer__cta"
+					variant="primary"
 					onClick={ handleAddTransfer }
 				>
 					{ getTransferButtonText() }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -33,11 +33,6 @@
 		box-shadow: unset;
 	}
 
-	.components-button:active:not(:disabled) {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
-		outline: 3px solid transparent;
-	}
-
 	&.domains {
 		padding: 0;
 		width: 754px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -413,4 +413,10 @@
 		width: 150px;
 		@include placeholder();
 	}
+
+	button.components-button.bulk-domain-transfer__cta {
+		&:disabled {
+			background: var(--studio-gray-5);
+		}
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
@@ -63,12 +63,7 @@ const Intro: React.FC< Props > = ( { onSubmit } ) => {
 				onSelect={ onSubmit }
 			/>
 			<div className="bulk-domain-transfer__cta-container">
-				<Button
-					variant="primary"
-					__next40pxDefaultSize
-					className="bulk-domain-transfer__cta"
-					onClick={ onSubmit }
-				>
+				<Button variant="primary" className="bulk-domain-transfer__cta" onClick={ onSubmit }>
 					{ __( 'Get Started' ) }
 				</Button>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
@@ -63,7 +63,12 @@ const Intro: React.FC< Props > = ( { onSubmit } ) => {
 				onSelect={ onSubmit }
 			/>
 			<div className="bulk-domain-transfer__cta-container">
-				<Button className="bulk-domain-transfer__cta" onClick={ onSubmit }>
+				<Button
+					variant="primary"
+					__next40pxDefaultSize
+					className="bulk-domain-transfer__cta"
+					onClick={ onSubmit }
+				>
 					{ __( 'Get Started' ) }
 				</Button>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -4,6 +4,12 @@
 $font-family: "SF Pro Text", $sans;
 $heading-font-family: "SF Pro Display", $sans;
 
+:root {
+	--wp-components-color-accent: var(--studio-blue-50);
+	--wp-components-color-accent-darker-20: var(--studio-blue-60);
+	--wp-components-color-accent-darker-10: var(--studio-blue-60);
+}
+
 .domain-transfer {
 	height: 100%;
 	padding: 60px 0 0;
@@ -23,26 +29,10 @@ $heading-font-family: "SF Pro Display", $sans;
 		margin-bottom: 32px;
 
 		.bulk-domain-transfer__cta {
-			justify-content: center;
-			color: var(--black-white-white, #fff);
 			height: 48px;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-			border-radius: 0.25rem;
-			background: var(--blue-blue-50, #0675c4);
-			font-size: 0.875rem;
 			width: 240px;
 			font-weight: 500;
-
-			&:hover {
-				background: var(--studio-blue-60);
-			}
-
-			&:disabled {
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-				border-radius: 0.25rem;
-				background: var(--gray-gray-5, #dcdcde);
-				opacity: 1;
-			}
+			justify-content: center;
 
 			@media (max-width: $break-medium ) {
 				width: 100%;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -4,12 +4,6 @@
 $font-family: "SF Pro Text", $sans;
 $heading-font-family: "SF Pro Display", $sans;
 
-:root {
-	--wp-components-color-accent: var(--studio-blue-50);
-	--wp-components-color-accent-darker-20: var(--studio-blue-60);
-	--wp-components-color-accent-darker-10: var(--studio-blue-60);
-}
-
 .domain-transfer {
 	height: 100%;
 	padding: 60px 0 0;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -27,6 +27,7 @@ $heading-font-family: "SF Pro Display", $sans;
 			width: 240px;
 			font-weight: 500;
 			justify-content: center;
+			border-radius: 4px;
 
 			@media (max-width: $break-medium ) {
 				width: 100%;


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/79692/.

This PR increases the selectors in `wp-components-overrides` in make wp.com styles take precedence over wp.org styles (that come from `@wordpress/components`.

This PR will fix all Stepper flows.


#### Testing

1. Go to /setup/domain-transfer.
2. Check the first two steps.
3. The buttons should have blue-50 and should have good hover state.

---
1. Go to /setup/link-in-bio.
2. Check the second step.
3. The buttons should have blue-50 and should have good hover state.


