### PR TITLE
Payments Modal: Fix Advanced options

### DIFF
--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -348,7 +348,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					</FormSettingExplanation>
 				</FormFieldset>
 				<FoldableCard
-					header={ translate( 'Advanced Options' ) }
+					header={ translate( 'Advanced options' ) }
 					hideSummary
 					className="memberships__dialog-advanced-options"
 				>

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -315,11 +315,13 @@
 .memberships__dialog-sections {
 	display: grid;
 	grid-template: "item" 1fr / 1fr;
+
+	* {
+		font-size: $font-body-small;
+	}
+
 	@include break-medium {
 		min-width: 580px;
-	}
-	.form-setting-explanation {
-		font-size: $font-body-small;
 	}
 	.memberships__dialog-advanced-options {
 		width: 100%;
@@ -337,10 +339,16 @@
 		.foldable-card__main {
 			display: block;
 			font-weight: 600;
-			font-size: $font-body-small;
 			.foldable-card__action {
 				right: unset;
 			}
+		}
+		fieldset {
+			margin-bottom: 0;
+		}
+
+		.foldable-card__expand .gridicon {
+			fill: var(--color-text);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #79688 and #79689

## Proposed Changes

#### After
<img width="718" alt="Screenshot 2023-07-20 at 17 49 59" src="https://github.com/Automattic/wp-calypso/assets/104869/aca71e04-9e79-4676-9f82-ef048e7cbf18">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
