### PR TITLE
Payments Modal: Show Edit notice on price change

### DIFF
--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -124,6 +124,8 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	const [ editedSchedule, setEditedSchedule ] = useState( product?.renewal_schedule ?? '1 month' );
 	const [ focusedName, setFocusedName ] = useState( false );
 
+	const [ editedPrice, setEditedPrice ] = useState( false );
+
 	const isValidCurrencyAmount = ( currency, price ) =>
 		price >= minimumCurrencyTransactionAmount( currency, connectedAccountDefaultCurrency );
 
@@ -150,6 +152,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	const handleCurrencyChange = ( event ) => {
 		const { value: currency } = event.currentTarget;
 		setCurrentCurrency( currency );
+		setEditedPrice( true );
 	};
 	const handlePriceChange = ( event ) => {
 		const value = parseFloat( event.currentTarget.value );
@@ -157,6 +160,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		if ( '' === event.currentTarget.value || ! isNaN( value ) ) {
 			setCurrentPrice( event.currentTarget.value );
 		}
+		setEditedPrice( true );
 	};
 	const handlePayWhatYouWant = ( newValue ) => setEditedPayWhatYouWant( newValue );
 	const handleMultiplePerUser = ( newValue ) => setEditedMultiplePerUser( newValue );
@@ -270,7 +274,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						<FormInputValidation isError text={ translate( 'Please input a name.' ) } />
 					) }
 				</FormFieldset>
-				{ editing && (
+				{ editing && editedPrice && (
 					<Notice
 						text={ translate(
 							'Updating the price will not affect existing subscribers, who will pay what they were originally charged on renewal.'

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -351,6 +351,10 @@
 			fill: var(--color-text);
 		}
 	}
+
+	.notice__content {
+		max-width: 500px;
+	}
 }
 
 .memberships__dialog-section {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/78959#issuecomment-1635454519

## Proposed Changes

* Make the notice show up only on price or currency change

## Testing Instructions

* Use the calypso live branch and navigate to `/earn/payments-plans/yoursite.wordpress.com`
* Edit a plan – change the price or the currency

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
