### PR TITLE
Remove subscribe modal feature flag

### DIFF
--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -81,7 +80,7 @@ export const NewsletterSettingsSection = ( {
 					disabled={ disabled }
 				/>
 			</Card>
-			{ isEnabled( 'newsletter/subscribe-modal' ) && isNewsletterSite && (
+			{ isNewsletterSite && (
 				<Card className="site-settings__card">
 					<SubscribeModalSetting
 						value={ sm_enabled }

--- a/config/development.json
+++ b/config/development.json
@@ -124,7 +124,6 @@
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"newsletter/stats": true,
-		"newsletter/subscribe-modal": true,
 		"oauth": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

**This PR should not be merged until AFTER [this PR to remove the Jetpack feature flag](https://github.com/Automattic/jetpack/pull/32002) is deployed.**

## Proposed Changes

- Removes the feature flag for the Subscribe Modal.
- As a result, we will show a *setting* to enable that feature in all environments. 
- This PR should not be merged until AFTER [this PR to remove the Jetpack feature flag](https://github.com/Automattic/jetpack/pull/32002) is deployed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Assuming the [Jetpack PR has been deployed](https://github.com/Automattic/jetpack/pull/32002)...**

1) Create a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro
2) Go to Settings > Reading > Newsletters, and confirm the option to enable the subcribe modal shows.
3) Enable the option. Go to a single blog post on the frontend of your test site, and confirm the modal loads. 
4) The modal option should only show on Newsletter sites for now. To confirm this, go to a WP.com simple site that does NOT have site_intent set to newsletter, go to Settings > Reading > Newsletters, and confirm the option to enable the subcribe modal does NOT show. Also go to a single blog post on the front end, and confirm the modal does not load. 

**You can also test this PR before the [Jetpack PR has been deployed](https://github.com/Automattic/jetpack/pull/32002).**

1) Create a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro
2) Load the Jetpack branch in your sandbox by running `bin/jetpack-downloader test jetpack upddate/remove-subscribe-modal-feature-flag`. Sandbox public-api and the domain of your test site. If you've tested the Subscribe modal before, and have enabled the feature in 0-sandbox.php or elsewhere, remove that to ensure realistic test conditions. 
3) Go to Settings > Reading > Newsletters, and confirm the option to enable the subcribe modal shows.
4) Enable the option. Go to a single blog post on the frontend of your test site, and confirm the modal loads. 
5) The modal option should only show on Newsletter sites for now. To confirm this, go to a WP.com simple site that does NOT have site_intent set to newsletter, go to Settings > Reading > Newsletters, and confirm the option to enable the subcribe modal does NOT show. Also go to a single blog post on the front end, and confirm the modal does not load. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
