### PR TITLE
Checkout: Pass caught calypso checkout load errors to Sentry

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/analytics.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/analytics.ts
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { logToLogstash } from 'calypso/lib/logstash';
+import { captureException } from 'calypso/lib/sentry';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	translateCheckoutPaymentMethodToWpcomPaymentMethod,
@@ -20,6 +21,7 @@ export function logStashLoadErrorEvent(
 	error: Error,
 	additionalData: Record< string, string | number | undefined > = {}
 ): Promise< void > {
+	captureException( error );
 	return logStashEvent( 'composite checkout load error', {
 		...additionalData,
 		type: errorType,


### PR DESCRIPTION
## Proposed Changes

We use Sentry to report fatal errors in the calypso codebase. However, errors in checkout are caught by the `CheckoutErrorBoundary` components so they do not make it to Sentry. They are logged for us, but since they use minimized JS stack traces they often do not have enough data to debug.

Just like https://github.com/Automattic/wp-calypso/pull/63634, this PR adds code so that errors caught by the checkout error boundaries also report those errors to Sentry.

## Testing Instructions

We don't know how to test this but since https://github.com/Automattic/wp-calypso/pull/63634 hasn't had any problems, this should also be safe.