### PR TITLE
Signup: Ignore sessionStorage exceptions in client/signup

### DIFF
--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -20,31 +20,64 @@ export const clearSignupDestinationCookie = () => {
 	document.cookie = cookie.serialize( 'wpcom_signup_complete_destination', '', options );
 };
 
+/**
+ * Ignore fatals when trying to access window.sessionStorage so that we do not
+ * see them logged in Sentry. Please don't use this for anything else.
+ */
+function ignoreFatalsForSessionStorage( callback ) {
+	try {
+		return callback();
+	} catch {
+		// Do nothing.
+		return undefined;
+	}
+}
+
 export const getSignupCompleteSlug = () =>
-	sessionStorage?.getItem( 'wpcom_signup_complete_site_slug' );
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.getItem( 'wpcom_signup_complete_site_slug' )
+	);
 export const setSignupCompleteSlug = ( value ) =>
-	sessionStorage?.setItem( 'wpcom_signup_complete_site_slug', value );
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.setItem( 'wpcom_signup_complete_site_slug', value )
+	);
 export const wasSignupCheckoutPageUnloaded = () =>
-	sessionStorage?.getItem( 'was_signup_checkout_page_unloaded' );
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.getItem( 'was_signup_checkout_page_unloaded' )
+	);
 export const setSignupCheckoutPageUnloaded = ( value ) =>
-	sessionStorage?.setItem( 'was_signup_checkout_page_unloaded', value );
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.setItem( 'was_signup_checkout_page_unloaded', value )
+	);
 export const getSignupCompleteFlowName = () =>
-	sessionStorage?.getItem( 'wpcom_signup_complete_flow_name' );
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.getItem( 'wpcom_signup_complete_flow_name' )
+	);
 export const setSignupCompleteFlowName = ( value ) =>
-	sessionStorage?.setItem( 'wpcom_signup_complete_flow_name', value );
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.setItem( 'wpcom_signup_complete_flow_name', value )
+	);
 export const clearSignupCompleteFlowName = () =>
-	sessionStorage?.removeItem( 'wpcom_signup_complete_flow_name' );
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.removeItem( 'wpcom_signup_complete_flow_name' )
+	);
 export const getSignupCompleteFlowNameAndClear = () => {
 	const value = getSignupCompleteFlowName();
 	clearSignupCompleteFlowName();
 	return value;
 };
 export const getSignupCompleteStepName = () =>
-	sessionStorage?.getItem( 'wpcom_signup_complete_step_name' );
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.getItem( 'wpcom_signup_complete_step_name' )
+	);
 export const setSignupCompleteStepName = ( value ) =>
-	sessionStorage?.setItem( 'wpcom_signup_complete_step_name', value );
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.setItem( 'wpcom_signup_complete_step_name', value )
+	);
 export const clearSignupCompleteStepName = () =>
-	sessionStorage?.removeItem( 'wpcom_signup_complete_step_name' );
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.removeItem( 'wpcom_signup_complete_step_name' )
+	);
 export const getSignupCompleteStepNameAndClear = () => {
 	const value = getSignupCompleteStepName();
 	clearSignupCompleteStepName();


### PR DESCRIPTION
## Proposed Changes

This is similar to https://github.com/Automattic/wp-calypso/pull/79311 where some `localStorage` errors were explicitly ignored to prevent them from being reported to Sentry, except this one handles `sessionStorage` errors (they're nearly all `The operation is insecure.`; example: p1689815947832599-slack-C04U5A26MJB).

## Testing Instructions

Just a sanity check to make sure this doesn't break the signup storage utils functions.