### PR TITLE
Domain Transfers: Update remove / refresh copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -143,7 +143,7 @@ export function DomainCodePair( {
 				onClick={ () => onRemove( id ) }
 				variant="link"
 			>
-				<span className="delete-label">{ __( 'Discard Domain' ) }</span>
+				<span className="delete-label">{ __( 'Clear domain' ) }</span>
 			</Button>
 			<Button
 				title={ __( 'Refresh' ) }
@@ -154,7 +154,7 @@ export function DomainCodePair( {
 				} ) }
 				variant="link"
 			>
-				<span className="refresh-label">{ __( 'Refresh' ) }</span>
+				<span className="refresh-label">{ __( 'Try again' ) }</span>
 			</Button>
 		</>
 	);


### PR DESCRIPTION
Slack conversation: p1689890689161659/1689806773.474909-slack-C9EJ7KSGH

## Proposed Changes

Change the Remove / Refresh buttons to `Clear domain` / `Try again`

| Mobile | Desktop |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/f42a4998-cf81-4ba9-85ae-2fe1580b9175) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/ae24d13e-3640-40d6-9cc1-1d04259516dd) |


## Testing Instructions

* Go to `/setup/domain-transfer/domains`
* Try to transfer a domain and get an error, you should see the two buttons


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?