### PR TITLE
Hosting onboarding: send the user directly to specified flow after login

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -200,7 +200,22 @@ function getDIFMSiteContentCollectionDestination( { siteSlug } ) {
 }
 
 function getHostingFlowDestination() {
-	return '/sites?hosting-flow=true';
+	let destination = '/sites';
+
+	const queryArgs = getQueryArgs();
+
+	if ( queryArgs.flow === 'new-hosted-site' ) {
+		destination = '/setup/new-hosted-site';
+	} else if ( queryArgs.flow === 'import-hosted-site' ) {
+		destination = '/setup/import-hosted-site';
+	}
+
+	return addQueryArgs(
+		{
+			'hosting-flow': true,
+		},
+		destination
+	);
 }
 
 const flows = generateFlows( {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3133.

## Proposed Changes

In https://github.com/Automattic/lohp-hosting/pull/29, we're modifying the CTA actions so that they link directly to the flow after signing up.

This PR introduces the part where the user is redirected according to the chosen flow (based off the CTA click.)

## Testing Instructions

Browse `/start/hosting`, login and check you're sent to `/sites?hosting-flow=true`. This is for backwards-compatibility until we deliver the modified /hosting page.

Browse `/start/hosting?flow=new-hosted-site`, login and check you're sent to `/setup/new-hosted-site?hosting-flow=true`

Browse `/start/hosting?flow=import-hosted-site`, login and check you're sent to `/setup/import-hosted-site?hosting-flow=true` 
