### PR TITLE
Checkout: Add meta for domain transfer line items in checkout

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -774,8 +774,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 						} ),
 						interval: translate( 'billed annually' ),
 					},
-					comment:
-						'product type and billing interval, separated by a colon. ex: ".blog domain registration: billed annually" or "Premium .blog domain registration: billed annually"',
+					comment: 'Domain transfer and billing interval, separated by a colon. ',
 				} ) }
 			</>
 		);

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -742,6 +742,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 
 	const isDomainRegistration = product.is_domain_registration;
 	const isDomainMapping = productSlug === 'domain_map';
+	const isDomainTransfer = productSlug === 'domain_transfer';
 
 	if ( ( isDomainRegistration || isDomainMapping ) && product.months_per_bill_period === 12 ) {
 		const premiumLabel = product.extra?.premium ? translate( 'Premium' ) : '';
@@ -756,6 +757,25 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 					},
 					comment:
 						'premium label, product type and billing interval, separated by a colon. ex: ".blog domain registration: billed annually" or "Premium .blog domain registration: billed annually"',
+				} ) }
+			</>
+		);
+	}
+
+	if ( isDomainTransfer ) {
+		return (
+			<>
+				{ translate( ' %(sublabel)s: %(interval)s %(cost)s ', {
+					args: {
+						sublabel: sublabel,
+						cost: formatCurrency( product.item_original_cost_integer, product.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+						interval: translate( 'billed annually' ),
+					},
+					comment:
+						'product type and billing interval, separated by a colon. ex: ".blog domain registration: billed annually" or "Premium .blog domain registration: billed annually"',
 				} ) }
 			</>
 		);


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/79554

## Proposed Changes

After adding a domain transfer product to the cart we currently see minimal meta information on the checkout:

![YJLLpo.png](https://github.com/Automattic/wp-calypso/assets/552016/908b7718-ba40-46a4-b8c9-01b1db548e96)

This PR aims to add price and renewal details with the checkout page, similar to when adding a plan to the cart:


![h2hOpj.png](https://github.com/Automattic/wp-calypso/assets/552016/3a9625da-06d7-44ad-bfea-4891d1820866)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox your API
* Apply the PR
* Start the calypso and visit this page that allows you to add a domain name for transfer http://calypso.localhost:3000/setup/domain-transfer/domains
* If you do not have an unlocked domain and auth code, please ping directly and I will provide you one
* Enter the domain name to transfer located on another registrar along with the auth code and click the `Transfer` button
* We should then land on the checkout page where you should see the Domain transfer product in the cart along with information highlighted above with an arrow.