### PR TITLE
Remove flow progress from domain transfers flow

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -1,6 +1,6 @@
 import { useLocale } from '@automattic/i18n-utils';
-import { useFlowProgress, DOMAIN_TRANSFER } from '@automattic/onboarding';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { DOMAIN_TRANSFER } from '@automattic/onboarding';
+import { useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
@@ -10,7 +10,7 @@ import {
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { USER_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import {
 	Flow,
@@ -56,14 +56,11 @@ const domainTransfer: Flow = {
 
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const flowName = this.name;
-		const { setStepProgress } = useDispatch( ONBOARD_STORE );
-		const flowProgress = useFlowProgress( { stepName: _currentStepSlug, flowName } );
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
 		const locale = useLocale();
-		setStepProgress( flowProgress );
 
 		const logInUrl =
 			locale && locale !== 'en'

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -11,10 +11,6 @@
 	align-items: center;
 	gap: 30px;
 
-	.flow-progress.progress-bar {
-		display: none;
-	}
-
 	button:disabled {
 		pointer-events: none;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -12,10 +12,6 @@ $heading-font-family: "SF Pro Display", $sans;
 	display: flex;
 	align-items: center;
 
-	.flow-progress.progress-bar {
-		display: none;
-	}
-
 	// Same style also on transfer-domains step
 	.bulk-domain-transfer__cta-container {
 		display: flex;

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -6,7 +6,6 @@ import {
 	FREE_FLOW,
 	COPY_SITE_FLOW,
 	ONBOARDING_PM_FLOW,
-	DOMAIN_TRANSFER,
 } from '../utils/flows';
 
 /* eslint-disable no-restricted-imports */
@@ -100,12 +99,6 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		processing: 4,
 		/** Phantom step that is outside stepper */
 		checkout: 5,
-	},
-	[ DOMAIN_TRANSFER ]: {
-		user: 0,
-		intro: 1,
-		domains: 2,
-		processing: 3,
 	},
 };
 


### PR DESCRIPTION
Reverts #79629 and removes `useFlowProgress` usage instead.

Related to https://github.com/Automattic/dotcom-forge/issues/3160

## Proposed Changes

noop - Reverts #79629 and removes `useFlowProgress` usage instead.

## Testing Instructions

- http://calypso.localhost:3000/setup/domain-transfer/intro
- Should continue to **not** see the progress bar at the top of the page.

![Screenshot(75)](https://github.com/Automattic/wp-calypso/assets/811776/d032647b-af54-460f-b197-4c916f270fb4)

