### PR TITLE
Fix the GlobalStylesContext type for typescript 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,6 +297,7 @@
 		"keytar@npm:7.7.0/node-addon-api": "3.1.0",
 		"lzma-native": "^8.0.5",
 		"node-abi": "3.35.0",
+		"@popperjs/core": "^2.11.6",
 		"@wordpress/a11y": "3.36.0",
 		"@wordpress/annotations": "2.35.0",
 		"@wordpress/api-fetch": "6.33.0",

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -31,7 +31,7 @@ interface DesignPreviewProps {
 	onSelectColorVariation: ( variation: GlobalStylesObject | null ) => void;
 	selectedFontVariation: GlobalStylesObject | null;
 	onSelectFontVariation: ( variation: GlobalStylesObject | null ) => void;
-	onGlobalStylesChange: ( globalStyles: GlobalStylesObject | null ) => void;
+	onGlobalStylesChange: ( globalStyles?: GlobalStylesObject | null ) => void;
 	limitGlobalStyles: boolean;
 	globalStylesInPersonalPlan: boolean;
 	onNavigatorPathChange?: ( path?: string ) => void;

--- a/packages/global-styles/src/components/global-styles-provider/index.tsx
+++ b/packages/global-styles/src/components/global-styles-provider/index.tsx
@@ -1,9 +1,10 @@
 import { useState, useMemo, useCallback } from 'react';
+import { DEFAULT_GLOBAL_STYLES } from '../../constants';
 import { GlobalStylesContext, mergeBaseAndUserConfigs } from '../../gutenberg-bridge';
 import { useGetGlobalStylesBaseConfig, useRegisterCoreBlocks } from '../../hooks';
-import type { GlobalStylesObject } from '../../types';
+import type { GlobalStylesObject, SetConfig, SetConfigCallback } from '../../types';
 
-const cleanEmptyObject = < T, >( object: T ) => {
+const cleanEmptyObject = < T extends Record< string, unknown > >( object: T | unknown ) => {
 	if ( object === null || typeof object !== 'object' || Array.isArray( object ) ) {
 		return object;
 	}
@@ -22,13 +23,13 @@ const useGlobalStylesUserConfig = (): [ boolean, GlobalStylesObject, SetConfig ]
 		styles: {},
 	} );
 	const setConfig = useCallback(
-		( callback ) => {
+		( callback: SetConfigCallback ) => {
 			setUserConfig( ( currentConfig ) => {
 				const updatedConfig = callback( currentConfig );
 				return {
 					styles: cleanEmptyObject( updatedConfig.styles ) || {},
 					settings: cleanEmptyObject( updatedConfig.settings ) || {},
-				};
+				} as GlobalStylesObject;
 			} );
 		},
 		[ setUserConfig ]
@@ -46,10 +47,13 @@ const useGlobalStylesBaseConfig = (
 
 const useGlobalStylesContext = ( siteId: number | string, stylesheet: string ) => {
 	const [ isUserConfigReady, userConfig, setUserConfig ] = useGlobalStylesUserConfig();
-	const [ isBaseConfigReady, baseConfig ] = useGlobalStylesBaseConfig( siteId, stylesheet );
+	const [ isBaseConfigReady, baseConfig = DEFAULT_GLOBAL_STYLES ] = useGlobalStylesBaseConfig(
+		siteId,
+		stylesheet
+	);
 	const mergedConfig = useMemo( () => {
 		if ( ! baseConfig || ! userConfig ) {
-			return {};
+			return DEFAULT_GLOBAL_STYLES;
 		}
 		return mergeBaseAndUserConfigs( baseConfig, userConfig );
 	}, [ userConfig, baseConfig ] );

--- a/packages/global-styles/src/constants.ts
+++ b/packages/global-styles/src/constants.ts
@@ -9,3 +9,8 @@ export const FONT_PREVIEW_HEIGHT = 74;
 export const DEFAULT_GLOBAL_STYLES_VARIATION_TITLE = 'default';
 export const DEFAULT_GLOBAL_STYLES_VARIATION_SLUG = 'default';
 export const SYSTEM_FONT_SLUG = 'system-font';
+
+export const DEFAULT_GLOBAL_STYLES = {
+	settings: {},
+	styles: {},
+};

--- a/packages/global-styles/src/gutenberg-bridge/index.tsx
+++ b/packages/global-styles/src/gutenberg-bridge/index.tsx
@@ -8,7 +8,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import deepmerge from 'deepmerge';
 import { isPlainObject } from 'is-plain-object';
-import type { GlobalStylesObject, GlobalStylesContext } from '../types';
+import type { GlobalStylesObject, GlobalStylesContextObject } from '../types';
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 	'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
@@ -24,7 +24,7 @@ const {
 	useGlobalStyle,
 } = unlock( blockEditorPrivateApis );
 
-const GlobalStylesContext: React.Context< GlobalStylesContext > = UntypedGSContext;
+const GlobalStylesContext: React.Context< GlobalStylesContextObject > = UntypedGSContext;
 
 const mergeBaseAndUserConfigs = ( base: GlobalStylesObject, user: GlobalStylesObject ) => {
 	return deepmerge( base, user, { isMergeableObject: isPlainObject } );

--- a/packages/global-styles/src/hooks/use-sync-global-styles-user-config.ts
+++ b/packages/global-styles/src/hooks/use-sync-global-styles-user-config.ts
@@ -4,11 +4,11 @@ import type { GlobalStylesObject } from '../types';
 
 const useSyncGlobalStylesUserConfig = (
 	globalStyles: GlobalStylesObject[],
-	onChange?: ( globalStyle: GlobalStylesObject ) => void
+	onChange?: ( globalStyle?: GlobalStylesObject | null ) => void
 ) => {
 	const { user, setUserConfig } = useContext( GlobalStylesContext );
 	useEffect( () => {
-		setUserConfig( () =>
+		setUserConfig?.( () =>
 			globalStyles
 				.filter( Boolean )
 				.reduce(

--- a/packages/global-styles/src/types.ts
+++ b/packages/global-styles/src/types.ts
@@ -18,15 +18,16 @@ export interface Typography {
 	lineHeight?: string;
 }
 
-export type SetConfig = ( callback: ( config: GlobalStylesObject ) => GlobalStylesObject ) => void;
+export type SetConfigCallback = ( config: GlobalStylesObject ) => GlobalStylesObject;
 
-export interface GlobalStylesContext {
-	user: GlobalStylesObject;
-	base?: GlobalStylesObject;
+export type SetConfig = ( callback: SetConfigCallback ) => void;
+
+export interface GlobalStylesContextObject {
+	user?: GlobalStylesObject;
+	base: GlobalStylesObject;
 	merged?: GlobalStylesObject;
 	setUserConfig?: SetConfig;
-	inline_css?: string;
-	isReady: boolean;
+	isReady?: boolean;
 }
 
 export interface GlobalStylesObject {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4605,13 +4605,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@popperjs/core@npm:^2.5.4":
-  version: 2.10.2
-  resolution: "@popperjs/core@npm:2.10.2"
-  checksum: a626a586586f4589b958d02af9fab3c14cf4a865d3bce26a9b46a847eca6d975567914a3eb643a12516bfb6813023c9eaa4b57c98eff8de625b500816d5f91ac
-  languageName: node
-  linkType: hard
-
 "@preact/signals-core@npm:^1.0.0, @preact/signals-core@npm:^1.2.3, @preact/signals-core@npm:^1.3.0":
   version: 1.3.0
   resolution: "@preact/signals-core@npm:1.3.0"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix types in the `@automattic/global-stypes` package
* Use the fixed version of the `@popperjs/core` package to resolve the error below. The `reakit` has a breaking changes, and I think it's not a great timing to upgrade it as well.
  ```
  node_modules/reakit/node_modules/@popperjs/core/lib/types.d.ts(123,34): error TS2344: Type 'Options' does not satisfy the constraint 'Obj'.
  node_modules/reakit/node_modules/@popperjs/core/lib/types.d.ts(124,39): error TS2344: Type 'Options' does not satisfy the constraint 'Obj'.
  ```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn build-packages` and you should not see the errors

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
