### PR TITLE
Jetpack Partner Portal: minor enhancements to the Licenses page

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -233,26 +233,25 @@ export default function IssueMultipleLicensesForm( {
 					</div>
 				</>
 			) }
-			{ config.isEnabled( 'jetpack/pro-dashboard-woo-extensions' ) && wooExtensions && (
+			{ config.isEnabled( 'jetpack/pro-dashboard-woo-extensions' ) && wooExtensions.length > 0 && (
 				<>
 					<hr className="issue-multiple-licenses-form__separator" />
 					<p className="issue-multiple-licenses-form__description">
 						{ translate( 'WooCommerce Extensions:' ) }
 					</p>
 					<div className="issue-multiple-licenses-form__bottom">
-						{ wooExtensions &&
-							wooExtensions.map( ( productOption, i ) => (
-								<LicenseProductCard
-									isMultiSelect
-									key={ productOption.slug }
-									product={ productOption }
-									onSelectProduct={ onSelectProduct }
-									isSelected={ selectedProductSlugs.includes( productOption.slug ) }
-									isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
-									tabIndex={ 100 + i }
-									suggestedProduct={ suggestedProduct }
-								/>
-							) ) }
+						{ wooExtensions.map( ( productOption, i ) => (
+							<LicenseProductCard
+								isMultiSelect
+								key={ productOption.slug }
+								product={ productOption }
+								onSelectProduct={ onSelectProduct }
+								isSelected={ selectedProductSlugs.includes( productOption.slug ) }
+								isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
+								tabIndex={ 100 + i }
+								suggestedProduct={ suggestedProduct }
+							/>
+						) ) }
 					</div>
 				</>
 			) }

--- a/client/jetpack-cloud/sections/partner-portal/license-search/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-search/index.tsx
@@ -29,7 +29,7 @@ const LicenseSearch = ( { doSearch }: Props ) => {
 			initialValue={ search }
 			hideClose={ ! search }
 			onSearch={ onSearch }
-			placeholder={ translate( 'Search licenses' ) }
+			placeholder={ translate( 'Search by license code' ) }
 			delaySearch={ true }
 		/>
 	);


### PR DESCRIPTION
## Proposed Changes

This PR makes some enhancements to the "Licenses" page.

- Rename the placeholder from "Search licenses" to "Search by license code"
- Show the "WooCommerce Extensions" section only if there are WooCommerce extensions available. 

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/url-support-open-license-info-popup` and `yarn start-jetpack-cloud` or open the Jetpack Cloud live link. 
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on the "Licenses" top nav > Verify that the placeholder is changed to "Search by license code".

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="870" alt="Screenshot 2023-07-21 at 12 24 58 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/884c3b60-25c8-4107-b929-689fb25e8fd8">
</td>
<td>
<img width="870" alt="Screenshot 2023-07-21 at 12 25 11 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/82327d7a-abf9-457e-a9fe-05dd569bbb23"></td>
</tr>
</table>

4. Click on the "Issue New License" button > Verify that you don't see the "WooCommerce Extensions" section 

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1455" alt="Screenshot 2023-07-21 at 12 24 26 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2463f69b-c932-4156-99ec-6a301f8eea38"></td>
<td>
<img width="1455" alt="Screenshot 2023-07-21 at 12 24 12 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8ea7da86-7802-4d71-b766-84b92d26d147"></td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
