### PR TITLE
Bulk Domain Checkout Thank you: Refactor use of isBulkDomainTransfer

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -98,7 +98,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 			);
 		}
 
-		if ( isBulkDomainTransfer() ) {
+		if ( isBulkDomainTransfer( purchases ) ) {
 			return (
 				<>
 					<span>
@@ -539,7 +539,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 	getHeaderText() {
 		const { purchases, _n } = this.props;
 
-		if ( isBulkDomainTransfer() ) {
+		if ( isBulkDomainTransfer( purchases ) ) {
 			return _n(
 				'Your domain transfer has started',
 				'Your domain transfers has started',

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -40,6 +40,7 @@ import getCheckoutUpgradeIntent from '../../../state/selectors/get-checkout-upgr
 import './style.scss';
 import Product from './redesign-v2/sections/Product';
 import getHeading from './redesign-v2/sections/get-heading';
+import { isBulkDomainTransfer } from './utils';
 
 export class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
@@ -97,7 +98,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 			);
 		}
 
-		if ( this.isBulkDomainTransfer() ) {
+		if ( isBulkDomainTransfer() ) {
 			return (
 				<>
 					<span>
@@ -441,11 +442,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 		);
 	}
 
-	isBulkDomainTransfer() {
-		const { purchases } = this.props;
-		return purchases?.every( isDomainTransfer );
-	}
-
 	getSearchButtonProps() {
 		const { translate, selectedSite, jetpackSearchCustomizeUrl, jetpackSearchDashboardUrl } =
 			this.props;
@@ -543,7 +539,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 	getHeaderText() {
 		const { purchases, _n } = this.props;
 
-		if ( this.isBulkDomainTransfer() ) {
+		if ( isBulkDomainTransfer() ) {
 			return _n(
 				'Your domain transfer has started',
 				'Your domain transfers has started',
@@ -603,7 +599,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 								primaryPurchase={ primaryPurchase }
 								siteID={ selectedSite?.ID }
 								purchases={ this.props.purchases }
-								isBulkDomainTransfer={ this.isBulkDomainTransfer() }
 							/>
 						) }
 						{ this.props.children }

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/CheckoutMasterbar.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/CheckoutMasterbar.tsx
@@ -6,18 +6,15 @@ import MasterbarStyled from '../masterbar-styled';
 type HeaderProps = {
 	siteId?: number;
 	siteSlug: string | null;
-	isBulkDomainTransfer: boolean;
 };
 
-const CheckoutMasterbar = ( { siteId, siteSlug, isBulkDomainTransfer }: HeaderProps ) => {
+const CheckoutMasterbar = ( { siteId, siteSlug }: HeaderProps ) => {
 	const { __ } = useI18n();
 
-	if ( isBulkDomainTransfer ) {
+	if ( ! siteId ) {
 		return (
 			<MasterbarStyled
-				onClick={ () => {
-					return;
-				} }
+				onClick={ () => page( `/home/${ siteSlug ?? '' }` ) }
 				backText=""
 				canGoBack={ false }
 				showContact={ true }
@@ -25,21 +22,17 @@ const CheckoutMasterbar = ( { siteId, siteSlug, isBulkDomainTransfer }: HeaderPr
 		);
 	}
 
-	if ( siteId ) {
-		return (
-			<>
-				<QuerySitePurchases siteId={ siteId } />
-				<MasterbarStyled
-					onClick={ () => page( `/home/${ siteSlug ?? '' }` ) }
-					backText={ __( 'Back to dashboard' ) }
-					canGoBack={ true }
-					showContact={ true }
-				/>
-			</>
-		);
-	}
-
-	return null;
+	return (
+		<>
+			<QuerySitePurchases siteId={ siteId } />
+			<MasterbarStyled
+				onClick={ () => page( `/home/${ siteSlug ?? '' }` ) }
+				backText={ __( 'Back to dashboard' ) }
+				canGoBack={ true }
+				showContact={ true }
+			/>
+		</>
+	);
 };
 
 export default CheckoutMasterbar;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/Footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/Footer.tsx
@@ -1,8 +1,10 @@
+import { isBulkDomainTransfer } from '../../utils';
 import BulkDomainTransferFooter from './footer/BulkDomainTransferFooter';
 import PlanFooter from './footer/PlanFooter';
+import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
-const Footer = ( { isBulkDomainFlow }: { isBulkDomainFlow: boolean } ) => {
-	if ( isBulkDomainFlow ) {
+const Footer = ( { purchases }: { purchases: ReceiptPurchase[] } ) => {
+	if ( isBulkDomainTransfer( purchases ) ) {
 		return <BulkDomainTransferFooter />;
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/Product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/Product.tsx
@@ -1,3 +1,4 @@
+import { isBulkDomainTransfer } from '../../utils';
 import DomainsTransferredList from './product/DomainsTransferredList';
 import ProductPlan, { ProductPlanProps } from './product/ProductPlan';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
@@ -7,9 +8,8 @@ const Product = ( {
 	primaryPurchase,
 	siteID,
 	purchases,
-	isBulkDomainTransfer,
-}: ProductPlanProps & { purchases: ReceiptPurchase[]; isBulkDomainTransfer: boolean } ) => {
-	if ( isBulkDomainTransfer ) {
+}: ProductPlanProps & { purchases: ReceiptPurchase[] } ) => {
+	if ( isBulkDomainTransfer( purchases ) ) {
 		return <DomainsTransferredList purchases={ purchases } />;
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/test/is-redesign-v2.js
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/test/is-redesign-v2.js
@@ -1,5 +1,5 @@
 import { findPlansKeys, GROUP_WPCOM } from '@automattic/calypso-products';
-import isRedesignV2 from '../is-redesign-v2';
+import { isRedesignV2 } from '../utils';
 
 describe( 'isRedesignV2', () => {
 	it( 'should return false if there is a failed purchase', () => {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
@@ -1,5 +1,7 @@
-import { isDomainTransfer, isWpComPlan } from '@automattic/calypso-products';
+import { isWpComPlan } from '@automattic/calypso-products';
+import { ReceiptPurchase } from 'calypso/state/receipts/types';
 import { CheckoutThankYouCombinedProps, getFailedPurchases, getPurchases } from '..';
+import { isBulkDomainTransfer } from '../utils';
 
 /**
  * Determines whether the current checkout flow is for a redesign V2 purchase.
@@ -7,7 +9,7 @@ import { CheckoutThankYouCombinedProps, getFailedPurchases, getPurchases } from 
  *
  * @returns {boolean} True if the checkout flow is for a redesign V2 purchase, false otherwise.
  */
-const isRedesignV2 = ( props: CheckoutThankYouCombinedProps ) => {
+export const isRedesignV2 = ( props: CheckoutThankYouCombinedProps ) => {
 	// Fallback to old design when there is a failed purchase.
 	const failedPurchases = getFailedPurchases( props );
 	if ( failedPurchases.length > 0 ) {
@@ -17,7 +19,7 @@ const isRedesignV2 = ( props: CheckoutThankYouCombinedProps ) => {
 	const purchases = getPurchases( props );
 
 	// We are in the bulk domain transfer flow.
-	if ( purchases.every( isDomainTransfer ) ) {
+	if ( isBulkDomainTransfer( purchases ) ) {
 		return true;
 	}
 
@@ -27,4 +29,11 @@ const isRedesignV2 = ( props: CheckoutThankYouCombinedProps ) => {
 	}
 	return false;
 };
-export default isRedesignV2;
+
+export function shouldShowConfettiExplosion( purchases: ReceiptPurchase[] ) {
+	if ( isBulkDomainTransfer( purchases ) ) {
+		return false;
+	}
+
+	return true;
+}

--- a/client/my-sites/checkout/checkout-thank-you/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/utils.ts
@@ -5,6 +5,7 @@ import {
 	JETPACK_SOCIAL_PRODUCTS,
 	JETPACK_SEARCH_PRODUCTS,
 	JETPACK_VIDEOPRESS_PRODUCTS,
+	isDomainTransfer,
 } from '@automattic/calypso-products';
 import JetpackBackupPluginImage from 'calypso/assets/images/jetpack/jetpack-plugin-image-backup.svg';
 import JetpackBoostPluginImage from 'calypso/assets/images/jetpack/jetpack-plugin-image-boost.svg';
@@ -13,6 +14,7 @@ import JetpackSocialPluginImage from 'calypso/assets/images/jetpack/jetpack-plug
 import JetpackVideopressPluginImage from 'calypso/assets/images/jetpack/jetpack-plugin-image-videopress.svg';
 import JetpackPluginImage from 'calypso/assets/images/jetpack/licensing-activation-plugin-install.svg';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
+import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
 const buildKeyValuePairByProductSlugs = (
 	productSlugs: ReadonlyArray< string >,
@@ -86,4 +88,8 @@ export function getDomainManagementUrl(
 	domain: string | undefined
 ): string {
 	return domain ? domainManagementEdit( slug, domain ) : domainManagementList( slug );
+}
+
+export function isBulkDomainTransfer( purchases: ReceiptPurchase[] ): boolean {
+	return purchases?.every( isDomainTransfer );
 }


### PR DESCRIPTION
[Context](https://github.com/Automattic/wp-calypso/pull/79546#discussion_r1270212427)

In [this PR](https://github.com/Automattic/wp-calypso/pull/79546) we shifted to use the checkout thank you page for the bulk domain transfer flow.

In this PR we refactor the prop drilling of `isBulkDomainTransfer` and move things around a little.

## Testing
1. Try the normal checkout flow, all should be working. Try buying a premium plan.
2. With a receipt of a domain transfer, check it on `/checkout/thank-you/no-site/[receipt-id]`

