### PR TITLE
`useEdgeCacheQuery`: remove `on*` handlers

### DIFF
--- a/client/my-sites/hosting/cache-card/index.js
+++ b/client/my-sites/hosting/cache-card/index.js
@@ -70,7 +70,7 @@ export const CacheCard = ( {
 		isLoading: getEdgeCacheLoading,
 		data: isEdgeCacheActive,
 		isInitialLoading: getEdgeCacheInitialLoading,
-	} = useEdgeCacheQuery( siteId, {} );
+	} = useEdgeCacheQuery( siteId );
 
 	const isEdgeCacheEligible = ! isPrivate && ! isComingSoon;
 

--- a/client/my-sites/hosting/cache-card/use-edge-cache.ts
+++ b/client/my-sites/hosting/cache-card/use-edge-cache.ts
@@ -1,12 +1,9 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
 export const USE_EDGE_CACHE_QUERY_KEY = 'edge-cache-key';
 
-export const useEdgeCacheQuery = (
-	siteId: number,
-	options: UseQueryOptions< boolean, unknown, boolean >
-) => {
+export const useEdgeCacheQuery = ( siteId: number ) => {
 	return useQuery< boolean, unknown, boolean >( {
 		queryKey: [ USE_EDGE_CACHE_QUERY_KEY, siteId ],
 		queryFn: () =>
@@ -21,7 +18,5 @@ export const useEdgeCacheQuery = (
 		meta: {
 			persist: false,
 		},
-		onSuccess: options?.onSuccess,
-		onError: options?.onError,
 	} );
 };


### PR DESCRIPTION
## Proposed Changes

With the upcoming v5 of RQ `onSuccess`, `onError`, `onSettled` are removed. This PR removes those handlers from `useEdgeCacheQuery` (they weren't used at all) in preparation for the upgrade.

## Testing Instructions

* On a site with hosting features enabled go to `/hosting-config/:site`
* Verify at the bottom the in-/active status of the global edge cache is shown as expected
