### PR TITLE
Assembler Flow: Set the default theme to Creatio

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
-import { PatternAssemblerCta, DEFAULT_ASSEMBLER_DESIGN } from '@automattic/design-picker';
+import { PatternAssemblerCta } from '@automattic/design-picker';
 import { WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { Icon, addTemplate, brush, cloudUpload } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
@@ -89,10 +89,7 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 		// they're on the small screen because the Assembler doesn't support the small screen yet.
 		if ( ! isLoggedIn || shouldGoToAssemblerStep ) {
 			const basePathname = isLoggedIn ? '/setup' : '/start';
-			const params = new URLSearchParams( {
-				ref: 'calypshowcase',
-				theme: DEFAULT_ASSEMBLER_DESIGN.slug,
-			} );
+			const params = new URLSearchParams( { ref: 'calypshowcase' } );
 
 			if ( selectedSite?.slug ) {
 				params.set( 'siteSlug', selectedSite.slug );

--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -6,7 +6,6 @@ import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
 import { getTheme } from 'calypso/state/themes/selectors';
-import { useQuery } from '../hooks/use-query';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
@@ -27,7 +26,7 @@ const withThemeAssemblerFlow: Flow = {
 			[]
 		);
 		const { setSelectedDesign, setIntent } = useDispatch( ONBOARD_STORE );
-		const selectedTheme = useQuery().get( 'theme' ) || DEFAULT_ASSEMBLER_DESIGN.slug;
+		const selectedTheme = DEFAULT_ASSEMBLER_DESIGN.slug;
 		const theme = useSelector( ( state ) => getTheme( state, 'wpcom', selectedTheme ) );
 
 		// We have to query theme for the Jetpack site.

--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -1,4 +1,5 @@
 import { Onboard } from '@automattic/data-stores';
+import { DEFAULT_ASSEMBLER_DESIGN } from '@automattic/design-picker';
 import { useFlowProgress, WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
@@ -26,7 +27,7 @@ const withThemeAssemblerFlow: Flow = {
 			[]
 		);
 		const { setSelectedDesign, setIntent } = useDispatch( ONBOARD_STORE );
-		const selectedTheme = useQuery().get( 'theme' );
+		const selectedTheme = useQuery().get( 'theme' ) || DEFAULT_ASSEMBLER_DESIGN.slug;
 		const theme = useSelector( ( state ) => getTheme( state, 'wpcom', selectedTheme ) );
 
 		// We have to query theme for the Jetpack site.

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,5 +1,4 @@
 import {
-	DEFAULT_ASSEMBLER_DESIGN,
 	PREMIUM_THEME,
 	DOT_ORG_THEME,
 	WOOCOMMERCE_THEME,
@@ -116,7 +115,7 @@ function getThankYouNoSiteDestination() {
 }
 
 function getChecklistThemeDestination( { flowName, siteSlug, themeParameter } ) {
-	if ( isSiteAssemblerFlow( flowName ) && themeParameter === DEFAULT_ASSEMBLER_DESIGN.slug ) {
+	if ( isSiteAssemblerFlow( flowName ) ) {
 		// Check whether to go to the assembler. If not, go to the site editor directly
 		if ( shouldGoToAssembler() ) {
 			return addQueryArgs(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79728

## Proposed Changes

* Before, the theme of the `with-theme-assembler` flow is from the `theme` of the query string but it's fragile. Hence, this PR is proposing to set up the default theme to the `Creatio` if it's not provided.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Logged-out Theme Showcase**

* Go to Theme Showcase without logged-in
* Scroll down to select the Assembler CTA
* Finish the sign-up, domain selection, and plan selection
* When you land on the Assembler screen, select Layout and Styles
* Continue
* Ensure the theme of your site is the `Creatio` now

**From the URL directly**

* Go to /start/with-theme-assembler
* Finish the sign-up, domain selection, and plan selection
* When you land on the Assembler screen, select Layout and Styles
* Continue
* Ensure the theme of your site is the `Creatio` now

**Logged-in Theme Showcase**

* Go to Theme Showcase
* Scroll down to select the Assembler CTA
* When you land on the Assembler screen, select Layout and Styles
* Continue
* Ensure the theme of your site is the `Creatio` now

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
