### PR TITLE
Jetpack Cloud Agency Dashboard: add issue license and add new site buttons to resting state

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -191,6 +191,27 @@ export default function SitesOverview() {
 		} );
 	}, [ selectedLicensesSiteId, selectedLicenses ] );
 
+	const renderAddSiteIssueLicenseButtons = () => {
+		// do stuff
+		return (
+			<div className="sites-overview__add-site-issue-license-buttons">
+				<Button
+					className="sites-overview__issue-license-button"
+					href="/partner-portal/issue-license"
+				>
+					{ translate( 'Issue License' ) }
+				</Button>
+				<Button
+					primary
+					className="sites-overview__add-site-button"
+					href="https://wordpress.com/jetpack/connect"
+				>
+					{ translate( 'Add New Site' ) }
+				</Button>
+			</div>
+		);
+	};
+
 	const renderIssueLicenseButton = () => {
 		return (
 			<div className="sites-overview__licenses-buttons">
@@ -229,14 +250,17 @@ export default function SitesOverview() {
 		);
 	};
 
-	const showIssueLicenseButtonsLargeScreen =
-		isWithinBreakpoint( '>960px' ) && selectedLicensesCount > 0;
+	// const showIssueLicenseButtonsLargeScreen =
+	// 	isWithinBreakpoint( '>960px' ) && selectedLicensesCount < 1;
 
 	return (
 		<div className="sites-overview">
 			<DocumentHead title={ pageTitle } />
 			<SidebarNavigation sectionTitle={ pageTitle } />
 			<div className="sites-overview__container">
+				{ isWithinBreakpoint( '<960px' ) &&
+					selectedLicensesCount < 1 &&
+					renderAddSiteIssueLicenseButtons() }
 				<div className="sites-overview__tabs">
 					<div className="sites-overview__content-wrapper">
 						<SiteSurveyBanner isDashboardView />
@@ -244,10 +268,15 @@ export default function SitesOverview() {
 						<SiteDowntimeMonitoringUpgradeBanner />
 
 						{ data?.sites && <SiteAddLicenseNotification /> }
+						{ /* { console.log( 'license counter', selectedLicensesCount ) } */ }
 						<SiteContentHeader
-							content={ renderIssueLicenseButton() }
+							content={
+								selectedLicensesCount > 0
+									? renderIssueLicenseButton()
+									: renderAddSiteIssueLicenseButtons()
+							}
 							pageTitle={ pageTitle }
-							showStickyContent={ !! showIssueLicenseButtonsLargeScreen }
+							showStickyContent={ true }
 						/>
 						<SectionNav
 							applyUpdatedStyles

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -199,7 +199,7 @@ export default function SitesOverview() {
 					href="/partner-portal/issue-license"
 					onClick={ () =>
 						dispatch(
-							recordTracksEvent( 'calypso_jetpack_agency_dashboard_issue_license_button_click', {} )
+							recordTracksEvent( 'calypso_jetpack_agency_dashboard_issue_license_button_click' )
 						)
 					}
 				>
@@ -207,11 +207,10 @@ export default function SitesOverview() {
 				</Button>
 				<Button
 					primary
-					className="sites-overview__add-site-button"
 					href="https://wordpress.com/jetpack/connect"
 					onClick={ () =>
 						dispatch(
-							recordTracksEvent( 'calypso_jetpack_agency_dashboard_add_site_button_click', {} )
+							recordTracksEvent( 'calypso_jetpack_agency_dashboard_add_site_button_click' )
 						)
 					}
 				>
@@ -278,11 +277,11 @@ export default function SitesOverview() {
 								// don't render content on mobile, we don't need it
 								selectedLicensesCount > 0 && isWithinBreakpoint( '>960px' )
 									? renderIssueLicenseButton()
-									: renderAddSiteIssueLicenseButtons()
+									: isWithinBreakpoint( '>960px' ) && renderAddSiteIssueLicenseButtons()
 							}
 							pageTitle={ pageTitle }
 							// Only renderIssueLicenseButton should be sticky.
-							showStickyContent={ selectedLicensesCount > 0 }
+							showStickyContent={ selectedLicensesCount > 0 && isWithinBreakpoint( '>960px' ) }
 						/>
 						<SectionNav
 							applyUpdatedStyles

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -274,6 +274,7 @@ export default function SitesOverview() {
 						<SiteDowntimeMonitoringUpgradeBanner />
 
 						{ data?.sites && <SiteAddLicenseNotification /> }
+
 						<SiteContentHeader
 							content={
 								selectedLicensesCount > 0
@@ -281,6 +282,7 @@ export default function SitesOverview() {
 									: renderAddSiteIssueLicenseButtons()
 							}
 							pageTitle={ pageTitle }
+							// Only renderIssueLicenseButton should be sticky.
 							showStickyContent={ selectedLicensesCount > 0 }
 						/>
 						<SectionNav

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -281,7 +281,7 @@ export default function SitesOverview() {
 							}
 							pageTitle={ pageTitle }
 							// Only renderIssueLicenseButton should be sticky.
-							showStickyContent={ ( selectedLicensesCount > 0 && isLargeScreen ) || false }
+							showStickyContent={ !! ( selectedLicensesCount > 0 && isLargeScreen ) }
 						/>
 
 						{

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -284,7 +284,10 @@ export default function SitesOverview() {
 							showStickyContent={ selectedLicensesCount > 0 && isLargeScreen }
 						/>
 
-						{ ! isLargeScreen && selectedLicensesCount < 1 && renderAddSiteIssueLicenseButtons() }
+						{
+							// Render the add site and issue license buttons on mobile as a different component.
+							! isLargeScreen && renderAddSiteIssueLicenseButtons()
+						}
 						<SectionNav
 							applyUpdatedStyles
 							selectedText={

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -258,14 +258,13 @@ export default function SitesOverview() {
 		);
 	};
 
+	const isLargeScreen = isWithinBreakpoint( '>960px' );
+
 	return (
 		<div className="sites-overview">
 			<DocumentHead title={ pageTitle } />
 			<SidebarNavigation sectionTitle={ pageTitle } />
 			<div className="sites-overview__container">
-				{ isWithinBreakpoint( '<960px' ) &&
-					selectedLicensesCount < 1 &&
-					renderAddSiteIssueLicenseButtons() }
 				<div className="sites-overview__tabs">
 					<div className="sites-overview__content-wrapper">
 						<SiteSurveyBanner isDashboardView />
@@ -275,14 +274,17 @@ export default function SitesOverview() {
 						<SiteContentHeader
 							content={
 								// don't render content on mobile, we don't need it
-								selectedLicensesCount > 0 && isWithinBreakpoint( '>960px' )
+								isLargeScreen &&
+								( selectedLicensesCount > 0
 									? renderIssueLicenseButton()
-									: isWithinBreakpoint( '>960px' ) && renderAddSiteIssueLicenseButtons()
+									: renderAddSiteIssueLicenseButtons() )
 							}
 							pageTitle={ pageTitle }
 							// Only renderIssueLicenseButton should be sticky.
-							showStickyContent={ selectedLicensesCount > 0 && isWithinBreakpoint( '>960px' ) }
+							showStickyContent={ selectedLicensesCount > 0 && isLargeScreen }
 						/>
+
+						{ ! isLargeScreen && selectedLicensesCount < 1 && renderAddSiteIssueLicenseButtons() }
 						<SectionNav
 							applyUpdatedStyles
 							selectedText={
@@ -347,7 +349,7 @@ export default function SitesOverview() {
 					</div>
 				</div>
 			</div>
-			{ isWithinBreakpoint( '<960px' ) && selectedLicensesCount > 0 && (
+			{ ! isLargeScreen && selectedLicensesCount > 0 && (
 				<div className="sites-overview__issue-licenses-button-small-screen">
 					{ renderIssueLicenseButton() }
 				</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -192,6 +192,10 @@ export default function SitesOverview() {
 	}, [ selectedLicensesSiteId, selectedLicenses ] );
 
 	const renderAddSiteIssueLicenseButtons = () => {
+		if ( emptyState ) {
+			return null;
+		}
+
 		return (
 			<div className="sites-overview__add-site-issue-license-buttons">
 				<Button

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -191,7 +191,10 @@ export default function SitesOverview() {
 		} );
 	}, [ selectedLicensesSiteId, selectedLicenses ] );
 
-	const renderAddSiteIssueLicenseButtons = () => {
+	const AddSiteIssueLicenseButtons = () => {
+		const dispatch = useDispatch();
+		const translate = useTranslate();
+
 		return (
 			<div className="sites-overview__add-site-issue-license-buttons">
 				<Button
@@ -275,9 +278,11 @@ export default function SitesOverview() {
 							content={
 								// render content only on large screens, The buttons for small scren have their own section
 								isLargeScreen &&
-								( selectedLicensesCount > 0
-									? renderIssueLicenseButton()
-									: renderAddSiteIssueLicenseButtons() )
+								( selectedLicensesCount > 0 ? (
+									renderIssueLicenseButton()
+								) : (
+									<AddSiteIssueLicenseButtons />
+								) )
 							}
 							pageTitle={ pageTitle }
 							// Only renderIssueLicenseButton should be sticky.
@@ -286,7 +291,7 @@ export default function SitesOverview() {
 
 						{
 							// Render the add site and issue license buttons on mobile as a different component.
-							! isLargeScreen && renderAddSiteIssueLicenseButtons()
+							! isLargeScreen && <AddSiteIssueLicenseButtons />
 						}
 						<SectionNav
 							applyUpdatedStyles

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -259,10 +259,6 @@ export default function SitesOverview() {
 		);
 	};
 
-	// const showIssueLicenseButtonsLargeScreen =
-	// 	isWithinBreakpoint( '>960px' ) && selectedLicensesCount < 1;
-	// console.log( 'selectedLicensesCounts', selectedLicensesCount );
-
 	return (
 		<div className="sites-overview">
 			<DocumentHead title={ pageTitle } />

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -192,10 +192,6 @@ export default function SitesOverview() {
 	}, [ selectedLicensesSiteId, selectedLicenses ] );
 
 	const renderAddSiteIssueLicenseButtons = () => {
-		if ( emptyState ) {
-			return null;
-		}
-
 		return (
 			<div className="sites-overview__add-site-issue-license-buttons">
 				<Button
@@ -268,7 +264,6 @@ export default function SitesOverview() {
 			<DocumentHead title={ pageTitle } />
 			<SidebarNavigation sectionTitle={ pageTitle } />
 			<div className="sites-overview__container">
-				{ /* render the buttons in the body if on mobile */ }
 				{ isWithinBreakpoint( '<960px' ) &&
 					selectedLicensesCount < 1 &&
 					renderAddSiteIssueLicenseButtons() }
@@ -277,23 +272,18 @@ export default function SitesOverview() {
 						<SiteSurveyBanner isDashboardView />
 						<SiteWelcomeBanner isDashboardView />
 						<SiteDowntimeMonitoringUpgradeBanner />
-
 						{ data?.sites && <SiteAddLicenseNotification /> }
-
-						{ /* only render component on large screens */ }
-						{ isWithinBreakpoint( '>960px' ) && (
-							<SiteContentHeader
-								content={
-									selectedLicensesCount > 0
-										? renderIssueLicenseButton()
-										: renderAddSiteIssueLicenseButtons()
-								}
-								pageTitle={ pageTitle }
-								// Only renderIssueLicenseButton should be sticky.
-								showStickyContent={ selectedLicensesCount > 0 }
-							/>
-						) }
-
+						<SiteContentHeader
+							content={
+								// don't render content on mobile, we don't need it
+								selectedLicensesCount > 0 && isWithinBreakpoint( '>960px' )
+									? renderIssueLicenseButton()
+									: renderAddSiteIssueLicenseButtons()
+							}
+							pageTitle={ pageTitle }
+							// Only renderIssueLicenseButton should be sticky.
+							showStickyContent={ selectedLicensesCount > 0 }
+						/>
 						<SectionNav
 							applyUpdatedStyles
 							selectedText={

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -264,6 +264,7 @@ export default function SitesOverview() {
 			<DocumentHead title={ pageTitle } />
 			<SidebarNavigation sectionTitle={ pageTitle } />
 			<div className="sites-overview__container">
+				{ /* render the buttons in the body if on mobile */ }
 				{ isWithinBreakpoint( '<960px' ) &&
 					selectedLicensesCount < 1 &&
 					renderAddSiteIssueLicenseButtons() }
@@ -275,16 +276,20 @@ export default function SitesOverview() {
 
 						{ data?.sites && <SiteAddLicenseNotification /> }
 
-						<SiteContentHeader
-							content={
-								selectedLicensesCount > 0
-									? renderIssueLicenseButton()
-									: renderAddSiteIssueLicenseButtons()
-							}
-							pageTitle={ pageTitle }
-							// Only renderIssueLicenseButton should be sticky.
-							showStickyContent={ selectedLicensesCount > 0 }
-						/>
+						{ /* only render component on large screens */ }
+						{ isWithinBreakpoint( '>960px' ) && (
+							<SiteContentHeader
+								content={
+									selectedLicensesCount > 0
+										? renderIssueLicenseButton()
+										: renderAddSiteIssueLicenseButtons()
+								}
+								pageTitle={ pageTitle }
+								// Only renderIssueLicenseButton should be sticky.
+								showStickyContent={ selectedLicensesCount > 0 }
+							/>
+						) }
+
 						<SectionNav
 							applyUpdatedStyles
 							selectedText={

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -273,7 +273,7 @@ export default function SitesOverview() {
 						{ data?.sites && <SiteAddLicenseNotification /> }
 						<SiteContentHeader
 							content={
-								// don't render content on mobile, we don't need it
+								// render content only on large screens, The buttons for small scren have their own section
 								isLargeScreen &&
 								( selectedLicensesCount > 0
 									? renderIssueLicenseButton()

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -281,7 +281,7 @@ export default function SitesOverview() {
 							}
 							pageTitle={ pageTitle }
 							// Only renderIssueLicenseButton should be sticky.
-							showStickyContent={ selectedLicensesCount > 0 && isLargeScreen }
+							showStickyContent={ ( selectedLicensesCount > 0 && isLargeScreen ) || false }
 						/>
 
 						{

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -192,21 +192,30 @@ export default function SitesOverview() {
 	}, [ selectedLicensesSiteId, selectedLicenses ] );
 
 	const renderAddSiteIssueLicenseButtons = () => {
-		// do stuff
 		return (
 			<div className="sites-overview__add-site-issue-license-buttons">
 				<Button
 					className="sites-overview__issue-license-button"
 					href="/partner-portal/issue-license"
+					onClick={ () =>
+						dispatch(
+							recordTracksEvent( 'calypso_jetpack_agency_dashboard_issue_license_button_click', {} )
+						)
+					}
 				>
-					{ translate( 'Issue License' ) }
+					{ translate( 'Issue License', { context: 'button label' } ) }
 				</Button>
 				<Button
 					primary
 					className="sites-overview__add-site-button"
 					href="https://wordpress.com/jetpack/connect"
+					onClick={ () =>
+						dispatch(
+							recordTracksEvent( 'calypso_jetpack_agency_dashboard_add_site_button_click', {} )
+						)
+					}
 				>
-					{ translate( 'Add New Site' ) }
+					{ translate( 'Add New Site', { context: 'button label' } ) }
 				</Button>
 			</div>
 		);
@@ -252,6 +261,7 @@ export default function SitesOverview() {
 
 	// const showIssueLicenseButtonsLargeScreen =
 	// 	isWithinBreakpoint( '>960px' ) && selectedLicensesCount < 1;
+	// console.log( 'selectedLicensesCounts', selectedLicensesCount );
 
 	return (
 		<div className="sites-overview">
@@ -268,7 +278,6 @@ export default function SitesOverview() {
 						<SiteDowntimeMonitoringUpgradeBanner />
 
 						{ data?.sites && <SiteAddLicenseNotification /> }
-						{ /* { console.log( 'license counter', selectedLicensesCount ) } */ }
 						<SiteContentHeader
 							content={
 								selectedLicensesCount > 0
@@ -276,7 +285,7 @@ export default function SitesOverview() {
 									: renderAddSiteIssueLicenseButtons()
 							}
 							pageTitle={ pageTitle }
-							showStickyContent={ true }
+							showStickyContent={ selectedLicensesCount > 0 }
 						/>
 						<SectionNav
 							applyUpdatedStyles

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
@@ -31,7 +31,7 @@ export default function SiteContentHeader( { content, pageTitle, showStickyConte
 					</div>
 				</div>
 
-				{ showStickyContent && content }
+				{ content }
 			</div>
 		</div>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -100,6 +100,43 @@
 		text-underline-offset: 3px;
 	}
 }
+
+
+.sites-overview__add-site-issue-license-buttons {
+	margin: 0 -32px -32px;
+	padding: 8px 48px;
+	flex: 1 1 100%;
+
+	button,
+	a {
+		font-size: 1rem;
+		display: block;
+		width: 100%;
+		box-sizing: border-box;
+	}
+
+	.sites-overview__issue-license-button {
+		margin-inline-end: 0;
+		margin-bottom: 8px;
+	}
+	@include breakpoint-deprecated( ">660px" ) {
+		display: inline-flex;
+		flex: auto;
+		justify-content: flex-end;
+		button,
+		a {
+			display: inline-block;
+			width: auto;
+			max-height: 2.5rem;
+		}
+
+		.sites-overview__issue-license-button {
+			// margin-inline-end: 32px;
+			margin-right: 8px;
+		}
+	}
+}
+
 .sites-overview__status-select-license,
 .sites-overview__status-unselect-license {
 	max-width: 100%;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -50,7 +50,7 @@
 	}
 
 	.sites-overview__issue-license-button {
-		margin-inline-end: 0;
+		margin-right: 0;
 		margin-bottom: 8px;
 	}
 	@include break-large {
@@ -67,7 +67,6 @@
 		}
 
 		.sites-overview__issue-license-button {
-			margin-inline-end: 32px;
 			margin-right: 8px;
 			margin-bottom: 8px;
 		}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -120,19 +120,23 @@
 		margin-bottom: 8px;
 	}
 	@include breakpoint-deprecated( ">660px" ) {
-		display: inline-flex;
-		flex: auto;
-		justify-content: flex-end;
+		margin: unset;
+		padding: unset;
+		flex: none;
+		margin-left: auto;
+		display: inline-block;
+		max-height: 40px;
 		button,
 		a {
 			display: inline-block;
 			width: auto;
-			max-height: 2.5rem;
+			font-size: 1rem;
 		}
 
 		.sites-overview__issue-license-button {
-			// margin-inline-end: 32px;
+			margin-inline-end: 32px;
 			margin-right: 8px;
+			margin-bottom: 8px;
 		}
 	}
 }
@@ -424,6 +428,7 @@
 	}
 
 	@include breakpoint-deprecated( ">660px" ) {
+		margin-right: 48px;
 		left: var(--sidebar-width-min);
 		padding: 0.5rem;
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -35,6 +35,44 @@
 		border-bottom: 1px solid var(--color-primary-5);
 	}
 }
+.sites-overview__add-site-issue-license-buttons {
+	// We need these negative margin values because we want to make the container full-width,
+	// but our element is inside a limited-width parent.
+	margin: 0 -32px 8px;
+	padding: 8px 48px;
+
+	button,
+	a {
+		font-size: 1rem;
+		display: block;
+		width: 100%;
+		box-sizing: border-box;
+	}
+
+	.sites-overview__issue-license-button {
+		margin-inline-end: 0;
+		margin-bottom: 8px;
+	}
+	@include breakpoint-deprecated( ">660px" ) {
+		margin: unset;
+		padding: unset;
+		flex: none;
+		margin-left: auto;
+		display: inline-block;
+		max-height: 40px;
+		button,
+		a {
+			display: inline-block;
+			width: auto;
+		}
+
+		.sites-overview__issue-license-button {
+			margin-inline-end: 32px;
+			margin-right: 8px;
+			margin-bottom: 8px;
+		}
+	}
+}
 .sites-overview__content {
 	// We need these negative margin values because we want to make the container full-width,
 	// but our element is inside a limited-width parent.
@@ -101,45 +139,6 @@
 	}
 }
 
-
-.sites-overview__add-site-issue-license-buttons {
-	margin: 0 -32px -32px;
-	padding: 8px 48px;
-	flex: 1 1 100%;
-	max-height: 8rem;
-
-	button,
-	a {
-		font-size: 1rem;
-		display: block;
-		width: 100%;
-		box-sizing: border-box;
-	}
-
-	.sites-overview__issue-license-button {
-		margin-inline-end: 0;
-		margin-bottom: 8px;
-	}
-	@include breakpoint-deprecated( ">660px" ) {
-		margin: unset;
-		padding: unset;
-		flex: none;
-		margin-left: auto;
-		display: inline-block;
-		max-height: 40px;
-		button,
-		a {
-			display: inline-block;
-			width: auto;
-		}
-
-		.sites-overview__issue-license-button {
-			margin-inline-end: 32px;
-			margin-right: 8px;
-			margin-bottom: 8px;
-		}
-	}
-}
 
 .sites-overview__status-select-license,
 .sites-overview__status-unselect-license {
@@ -428,7 +427,6 @@
 	}
 
 	@include breakpoint-deprecated( ">660px" ) {
-		margin-right: 48px;
 		left: var(--sidebar-width-min);
 		padding: 0.5rem;
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -106,6 +106,7 @@
 	margin: 0 -32px -32px;
 	padding: 8px 48px;
 	flex: 1 1 100%;
+	max-height: 8rem;
 
 	button,
 	a {
@@ -130,7 +131,6 @@
 		a {
 			display: inline-block;
 			width: auto;
-			font-size: 1rem;
 		}
 
 		.sites-overview__issue-license-button {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -53,7 +53,7 @@
 		margin-inline-end: 0;
 		margin-bottom: 8px;
 	}
-	@include breakpoint-deprecated( ">960px" ) {
+	@include break-large {
 		margin: unset;
 		padding: unset;
 		flex: none;
@@ -79,7 +79,7 @@
 	margin: 0 -32px -32px;
 	padding: 8px 48px;
 	flex: 1 1 100%;
-	@include breakpoint-deprecated( ">660px" ) {
+	@include break-large {
 		padding: 16px 48px;
 		background: rgba(255, 255, 255, 0.5);
 		margin: 0 -32px -38px;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -53,7 +53,7 @@
 		margin-inline-end: 0;
 		margin-bottom: 8px;
 	}
-	@include breakpoint-deprecated( ">660px" ) {
+	@include breakpoint-deprecated( ">960px" ) {
 		margin: unset;
 		padding: unset;
 		flex: none;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -138,8 +138,6 @@
 		text-underline-offset: 3px;
 	}
 }
-
-
 .sites-overview__status-select-license,
 .sites-overview__status-unselect-license {
 	max-width: 100%;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 1199980337313591-as-1204977192508984/f

## Proposed Changes

* We have been asked to add a new set of buttons that display in the "default" view of the dashboard
* The buttons are add new site and issue a license
* The add new site button goes to wordpress.com/jetpack/connect
* The issue license page goes to the licenses tab on the dashboard.
* On desktop, the buttons appear in the same location as the existing Add x Licenses button
* On mobile, the buttons appear in a new section above the sites list tab
* This is a new section, but some things had to be altered in the code to make it happen.
* A section had to be added to the mobile version
* The existing buttons on desktop were sticky and appeared conditionally.
* The header component that housed the buttons was configured to only show sticky content. I removed that restriction so it would show whatever content was called for.
* Added conditions in the render to display the new buttons when no license was selected, removed a variable to detect screen size and if licenses were selected as it seemed unnecessary based on the new way of doing things.

The new buttons in pictures:

![Screenshot 2023-07-25 at 9 20 04 AM](https://github.com/Automattic/wp-calypso/assets/12895386/bf9a544c-c10c-41e8-a33e-9ad8e9ae48dd)
![Screenshot 2023-07-25 at 9 19 21 AM](https://github.com/Automattic/wp-calypso/assets/12895386/85b1b9b6-80eb-45ff-9bf9-1533079d2404)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Your account must be an agency partner to see the dashboard
* Head over to the Jetpack Cloud Link (or check out this PR and run locally, I won't judge)
* You should automatically be redirected to /dashboard
* Observe the new buttons.  Click each to verify add site goes to wordpress.com/jetpack/connect and issue license goes to the license tab.
* Next to one of your sites, click the add button in one of the columns.  The original add x licenses button should now show in the same place as the new ones
* Do the same on the mobile view (or desktop if you started with mobile)
* Expand a site and click add next to one of the available features, the new buttons should go away and the add x licenses should appear at the bottom of the page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?