### PR TITLE
Remove logged out discover redirect

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -685,14 +685,6 @@ function wpcomPages( app ) {
 		res.redirect( redirectUrl );
 	} );
 
-	app.get( '/discover', function ( req, res, next ) {
-		if ( ! req.context.isLoggedIn && calypsoEnv !== 'development' ) {
-			res.redirect( config( 'discover_logged_out_redirect_url' ) );
-		} else {
-			next();
-		}
-	} );
-
 	app.get( '/plans', function ( req, res, next ) {
 		if ( ! req.context.isLoggedIn ) {
 			const queryFor = req.query?.for;

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -164,7 +164,6 @@ const buildApp = ( environment ) => {
 					port: 3000,
 					env_id: environment,
 					rtl: false,
-					discover_logged_out_redirect_url: 'http://discover.url/',
 					i18n_default_locale_slug: 'en',
 					favicon_url: 'http://favicon.url/',
 					enable_all_sections: true,
@@ -1006,13 +1005,6 @@ describe( 'main app', () => {
 				const { response } = await app.run( { request: { url: `/sites/my-site/${ section }` } } );
 				expect( response.redirect ).toHaveBeenCalledWith( url );
 			} );
-		} );
-	} );
-
-	describe( 'Route /discover', () => {
-		it( 'redirects to discover url for anonymous users', async () => {
-			const { response } = await app.run( { request: { url: '/discover' } } );
-			expect( response.redirect ).toHaveBeenCalledWith( 'http://discover.url/' );
 		} );
 	} );
 

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -9,7 +9,6 @@
 	"discover_blog_id": 53424024,
 	"discover_feed_id": 41325786,
 	"daily_post_blog_id": 489937,
-	"discover_logged_out_redirect_url": false,
 	"facebook_api_key": false,
 	"features": {},
 	"google_analytics_key": false,

--- a/config/development.json
+++ b/config/development.json
@@ -21,7 +21,6 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
-	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -9,7 +9,6 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
-	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,

--- a/config/production.json
+++ b/config/production.json
@@ -9,7 +9,6 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
-	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"facebook_app_id": "2373049596",
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",

--- a/config/stage.json
+++ b/config/stage.json
@@ -9,7 +9,6 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
-	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",

--- a/config/test.json
+++ b/config/test.json
@@ -21,7 +21,6 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
-	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -9,7 +9,6 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
-	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Removes the logged out discover redirect, so that logged out users can now visit `/discover` without being redirected elsewhere.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Logged out /discover should work on the calypso.live link now.
* Smoke test /discover

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
