### PR TITLE
New hosted site: add progress bar at the top of the page

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -1,7 +1,6 @@
 import { ProgressBar } from '@automattic/components';
 import {
 	CONNECT_DOMAIN_FLOW,
-	isNewHostedSiteCreationFlow,
 	isTransferringHostedSiteCreationFlow,
 	SITE_SETUP_FLOW,
 } from '@automattic/onboarding';
@@ -33,7 +32,6 @@ const StepRoute = ( {
 		// See https://github.com/Automattic/wp-calypso/pull/73653
 		if (
 			[ SITE_SETUP_FLOW, CONNECT_DOMAIN_FLOW ].includes( flow.name ) ||
-			isNewHostedSiteCreationFlow( flow.name ) ||
 			isTransferringHostedSiteCreationFlow( flow.name )
 		) {
 			return null;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -66,6 +66,7 @@ button {
  * Site Setup
  */
 .onboarding-media,
+.new-hosted-site,
 .import-hosted-site,
 .site-setup,
 .import-focused,

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -7,6 +7,7 @@ import {
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
+import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { Flow, ProvidedDependencies } from './internals/types';
@@ -34,7 +35,8 @@ const hosting: Flow = {
 		];
 	},
 	useStepNavigation( _currentStepSlug, navigate ) {
-		const { setSiteTitle, setPlanCartItem, setSiteGeoAffinity } = useDispatch( ONBOARD_STORE );
+		const { setStepProgress, setSiteTitle, setPlanCartItem, setSiteGeoAffinity } =
+			useDispatch( ONBOARD_STORE );
 		const { siteGeoAffinity, planCartItem } = useSelect(
 			( select ) => ( {
 				siteGeoAffinity: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteGeoAffinity(),
@@ -42,6 +44,12 @@ const hosting: Flow = {
 			} ),
 			[]
 		);
+
+		const flowProgress = useSiteSetupFlowProgress( _currentStepSlug, 'host' );
+
+		if ( flowProgress ) {
+			setStepProgress( flowProgress );
+		}
 
 		const flowName = this.name;
 

--- a/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
+++ b/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
@@ -22,6 +22,21 @@ export function useSiteSetupFlowProgress( currentStep: string, intent: string ) 
 	}
 
 	switch ( intent ) {
+		case 'host':
+			switch ( currentStep ) {
+				case 'options':
+					middleProgress = { progress: 1, count: 3 };
+					break;
+				case 'plans':
+					middleProgress = { progress: 2, count: 3 };
+					break;
+				case 'processing':
+					middleProgress = { progress: 3, count: 3 };
+					break;
+			}
+
+			break;
+
 		case SiteIntent.Write: {
 			switch ( currentStep ) {
 				case 'options':


### PR DESCRIPTION
## Proposed Changes

Let's add the progress bar at the top so that the user know in which state in the flow they are.

| Site options | Plan picker | Processing |
| ------------ | ----------- | ----------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/a8bf388e-0a61-4016-8e9c-c648d6e7fb80) | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/98bf8c85-51e4-4ca7-a01c-87ba0a4eeaf4) | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/81d2d773-ea5d-4f3b-a546-66d178c72894) |

## Testing Instructions

Browse `/setup/new-hosted-site` and verify that there is a clear step progression bar at the top of the page