### PR TITLE
Show support links in Help Center instead of modal

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/woocommerce-landing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/woocommerce-landing-page.ts
@@ -4,8 +4,8 @@ const selectors = {
 	start: '.woocommerce .empty-content button:text("Start a new store")',
 	installer: '.is-woocommerce-install',
 	learnMore: '.woocommerce span:text("Learn more")',
-	supportDialog: '.support-article-dialog',
-	supportDialogClose: '.support-article-dialog button:text("Close")',
+	helpCenter: '.help-center__container',
+	helpCenterClose: '.help-center__container .help-center-header__close',
 };
 
 /**
@@ -26,14 +26,14 @@ export class WoocommerceLandingPage {
 	 */
 	async openLearnMore(): Promise< void > {
 		await this.page.click( selectors.learnMore );
-		await this.page.waitForSelector( selectors.supportDialog );
+		await this.page.waitForSelector( selectors.helpCenter );
 	}
 
 	/**
 	 * Click the Close button
 	 */
 	async closeLearnMore(): Promise< void > {
-		await this.page.click( selectors.supportDialogClose );
+		await this.page.click( selectors.helpCenterClose );
 	}
 
 	/**

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -130,6 +130,15 @@ export const setShowMessagingChat = function* () {
 	yield resetStore();
 };
 
+export const setShowSupportDoc = function* ( link: string, postId: number ) {
+	const params = new URLSearchParams( {
+		link,
+		postId: String( postId ),
+	} );
+	yield setInitialRoute( `/post/?${ params }` );
+	yield setShowHelpCenter( true );
+};
+
 export type HelpCenterAction =
 	| ReturnType<
 			| typeof setShowMessagingLauncher

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -1,4 +1,3 @@
-import { InitialEntry } from '@remix-run/router';
 import { apiFetch } from '@wordpress/data-controls';
 import { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { GeneratorReturnType } from '../mapped-types';
@@ -49,7 +48,7 @@ export const setUnreadCount = ( count: number ) =>
 		count,
 	} as const );
 
-export const setInitialRoute = ( route?: InitialEntry ) =>
+export const setInitialRoute = ( route?: string ) =>
 	( {
 		type: 'HELP_CENTER_SET_INITIAL_ROUTE',
 		route,
@@ -134,6 +133,7 @@ export const setShowSupportDoc = function* ( link: string, postId: number ) {
 	const params = new URLSearchParams( {
 		link,
 		postId: String( postId ),
+		cacheBuster: String( Date.now() ),
 	} );
 	yield setInitialRoute( `/post/?${ params }` );
 	yield setShowHelpCenter( true );

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -1,4 +1,3 @@
-import { InitialEntry } from '@remix-run/router';
 import { combineReducers } from '@wordpress/data';
 import { SiteDetails } from '../site';
 import type { HelpCenterAction } from './actions';
@@ -108,7 +107,7 @@ const userDeclaredSite: Reducer< SiteDetails | undefined, HelpCenterAction > = (
 	return state;
 };
 
-const initialRoute: Reducer< InitialEntry | undefined, HelpCenterAction > = ( state, action ) => {
+const initialRoute: Reducer< string | undefined, HelpCenterAction > = ( state, action ) => {
 	if ( action.type === 'HELP_CENTER_SET_INITIAL_ROUTE' ) {
 		return action.route;
 	}

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -4,22 +4,26 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CardBody } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import classnames from 'classnames';
 import { useSelector } from 'react-redux';
-import { Route, Routes, useLocation } from 'react-router-dom';
+import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { getSectionName } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
  */
+import { HELP_CENTER_STORE } from '../stores';
 import { HelpCenterContactForm } from './help-center-contact-form';
 import { HelpCenterContactPage } from './help-center-contact-page';
 import { HelpCenterEmbedResult } from './help-center-embed-result';
 import { HelpCenterSearch } from './help-center-search';
 import { SuccessScreen } from './ticket-success-screen';
+import type { HelpCenterSelect } from '@automattic/data-stores';
 
 const HelpCenterContent: React.FC = () => {
 	const location = useLocation();
+	const navigate = useNavigate();
 	const className = classnames( 'help-center__container-content' );
 	const containerRef = useRef< HTMLDivElement >( null );
 	const section = useSelector( getSectionName );
@@ -33,6 +37,19 @@ const HelpCenterContent: React.FC = () => {
 			location: 'help-center',
 		} );
 	}, [ location, section ] );
+
+	const { initialRoute } = useSelect(
+		( select ) => ( {
+			initialRoute: ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getInitialRoute(),
+		} ),
+		[]
+	);
+
+	useEffect( () => {
+		if ( initialRoute ) {
+			navigate( initialRoute );
+		}
+	}, [ initialRoute ] );
 
 	// reset the scroll location on navigation, TODO: unless there's an anchor
 	useEffect( () => {


### PR DESCRIPTION
As suggested in pbvpgB-3o7-p2

If a user clicks on a support doc link in Calypso, a new modal (or tab) is opened with it. This takes the user away from the context they’re need that information the most. Thanks to Vertex's work on Help Center, we can instead show those pages the Help Center. This will keep the user in the Calypso context, while giving them a better UX. The floating window of Help Center can be moved around and stays as they navigate Calypso and, for example, follow the steps on the support doc.

I've used the existing `InlineSupportLink` component that is used across Calypso (though, not consistently). It has been introduced in 2018 in https://github.com/Automattic/wp-calypso/pull/26347, and fits perfectly our needs.

This change will make the support doc modal and related code obsolete - I'll remove it in a separate PR, once we verify this approach does not have any negative side-effects or use cases we did not consider.

While working on this, I noticed a regression - Help Center disappears when the view is changed (eg. you go from Home to Upgrades). I've created a separate PR to address that: https://github.com/Automattic/wp-calypso/pull/79742.

## Proposed Changes

* Use Help Center instead of a modal to display support docs.

## Testing Instructions

- Find a support link (usually it's the "Learn more" ones) and click on it - it should open the Help Center and its contents should be loaded.
- Verify that the `Back` button in Help Center works as expected - takes you to the root of its navigation.