### PR TITLE
Ensure Help Center does not disappear on view change

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -6,7 +6,7 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import { useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import { useEffect, Component } from 'react';
+import { useCallback, useEffect, Component } from 'react';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -90,6 +90,9 @@ function SidebarScrollSynchronizer() {
 function HelpCenterLoader( { sectionName, loadHelpCenter } ) {
 	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
 	const isDesktop = useBreakpoint( '>782px' );
+	const handleClose = useCallback( () => {
+		setShowHelpCenter( false );
+	}, [ setShowHelpCenter ] );
 
 	if ( ! loadHelpCenter ) {
 		return null;
@@ -99,9 +102,7 @@ function HelpCenterLoader( { sectionName, loadHelpCenter } ) {
 		<AsyncLoad
 			require="@automattic/help-center"
 			placeholder={ null }
-			handleClose={ () => {
-				setShowHelpCenter( false );
-			} }
+			handleClose={ handleClose }
 			// hide Calypso's version of the help-center on Desktop, because the Editor has its own help-center
 			hidden={ sectionName === 'gutenberg-editor' && isDesktop }
 		/>


### PR DESCRIPTION
I've run into this while working on #79741.

Looks similar root issue to
https://github.com/Automattic/wp-calypso/pull/78236. But with different side-effect - since `handleClose` changes on every view change, Help Center gets removed from DOM (and `handleClose` gets called to close it). Then it gets immediately re-added to DOM. But it does not get re-opened, of course. The result is that Help Center disappears if you switch views in Calypso, which is definitely not how it's intended to work.

This fixes the root issue, making sure that `handleClose` does not change on view change, thanks to useCallback.

Related to #78236

## Proposed Changes

* Wrap `handleClose` in `useCallback` when loading Help Center asynchronously. I've checked other places and seems this one was the only one left.

## Testing Instructions

- Load Calypso for any Simple site, open Help Center, navigate to a different path (go from Home to Upgrades, for example). Help Center should stay in view, no flicker, etc.
- If you switch from Calypso to wp-admin, it will not stay on, but that's a different, existing issue (or feature ;)).