### PR TITLE
Performance: Tweak some descriptions based on feedback

### DIFF
--- a/client/my-sites/site-settings/cloudflare.js
+++ b/client/my-sites/site-settings/cloudflare.js
@@ -43,7 +43,9 @@ const Cloudflare = () => {
 								<p className="site-settings__cloudflare-title">
 									{ translate( 'Jetpack Site Accelerator' ) }
 								</p>
-								<p>{ translate( 'Comes built-in with WordPress.com Business plans.' ) }</p>
+								<p>
+									{ translate( 'The CDN that comes built-in with WordPress.com Business plans' ) }
+								</p>
 								<p>
 									<a
 										onClick={ recordClick }
@@ -77,7 +79,7 @@ const Cloudflare = () => {
 								</p>
 								<p>
 									{ translate(
-										'An alternative to Jetpack CDN, with security-focused plans available for sites with a custom domain enabled.'
+										'An alternative to Jetpack Site Accelerator, with security-focused plans available for sites with a custom domain enabled.'
 									) }
 								</p>
 								<p>

--- a/client/my-sites/site-settings/cloudflare.js
+++ b/client/my-sites/site-settings/cloudflare.js
@@ -44,7 +44,7 @@ const Cloudflare = () => {
 									{ translate( 'Jetpack Site Accelerator' ) }
 								</p>
 								<p>
-									{ translate( 'The CDN that comes built-in with WordPress.com Business plans' ) }
+									{ translate( 'The CDN that comes built-in with WordPress.com Business plans.' ) }
 								</p>
 								<p>
 									<a


### PR DESCRIPTION
From pdKhl6-2mb-p2#comment-3549

## Proposed Changes

Tweaks some descriptions based on feedback:

<img width="750" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/df32f581-11aa-47ca-9d66-faf41e686f45">

## Testing Instructions

1. Navigate to the Performance page.
2. Verify the descriptions appear as expected.