### PR TITLE
Restrict zendesk chat from loading while 3rd party cookies are disabled

### DIFF
--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -1,4 +1,8 @@
-import { useMessagingAvailability, useZendeskMessaging } from '@automattic/help-center/src/hooks';
+import {
+	useChatStatus,
+	useMessagingAvailability,
+	useZendeskMessaging,
+} from '@automattic/help-center/src/hooks';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -36,7 +40,8 @@ function getGroupName( keyType: KeyType ) {
 
 export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabilityCheck = false ) {
 	const isEnglishLocale = useIsEnglishLocale();
-	const isEligibleForPresalesChat = enabled && isEnglishLocale;
+	const { canConnectToZendesk } = useChatStatus();
+	const isEligibleForPresalesChat = enabled && isEnglishLocale && canConnectToZendesk;
 
 	const group = getGroupName( keyType );
 

--- a/packages/help-center/src/hooks/use-chat-status.ts
+++ b/packages/help-center/src/hooks/use-chat-status.ts
@@ -27,7 +27,7 @@ export default function useChatStatus(
 	const { status: zendeskStatus } = useZendeskConfig( isEligibleForChat );
 
 	return {
-		canConnectToZendesk: zendeskStatus !== 'error',
+		canConnectToZendesk: zendeskStatus !== 'error' && zendeskStatus !== 'loading',
 		hasActiveChats,
 		isChatAvailable: Boolean( chatAvailability?.is_available ),
 		isEligibleForChat,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 3096-gh-Automattic/dotcom-forge#issuecomment-1645072332
Follow-up of https://github.com/Automattic/wp-calypso/pull/79679

## Proposed Changes

* Avoid loading the Zendesk bubble if 3rd party cookies are disabled

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On Firefox, [enable track protection](https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop#w_how-to-tell-when-firefox-is-protecting-you) for blocking Zendesk
* Open the new domain flows and ensure the bubble will not load
* Open the new domain flows on Chrome (without tracking protection active) and ensure it still loads as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?