### PR TITLE
New hosted site: use hosting dictionary for site title suggestions

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
@@ -40,6 +40,9 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 	const [ shouldOverrideSiteTitle, setShouldOverrideSiteTitle ] = useState( false );
 
 	const { refetch, isFetching } = useGetSiteSuggestionsQuery( {
+		params: {
+			dictionary: 'hosting',
+		},
 		enabled: shouldOverrideSiteTitle,
 		refetchOnWindowFocus: false,
 		onSuccess: ( response ) => {

--- a/client/landing/stepper/hooks/use-get-site-suggestions-query.ts
+++ b/client/landing/stepper/hooks/use-get-site-suggestions-query.ts
@@ -10,29 +10,36 @@ type SuggestionsResponse =
 			success: false;
 	  };
 
-export const getSiteSuggestions = (): Promise< SuggestionsResponse > =>
-	wpcom.req.get( {
-		method: 'GET',
-		apiNamespace: 'wpcom/v2',
-		path: '/site-suggestions',
-	} );
+export const getSiteSuggestions = (
+	params?: Record< string, unknown >
+): Promise< SuggestionsResponse > =>
+	wpcom.req.get(
+		{
+			method: 'GET',
+			apiNamespace: 'wpcom/v2',
+			path: '/site-suggestions',
+		},
+		params
+	);
 
 export const useGetSiteSuggestionsQuery = ( {
+	params,
 	enabled,
 	onSuccess,
 	refetchOnWindowFocus,
 }: {
+	params?: Record< string, unknown >;
 	enabled: boolean;
 	onSuccess?: ( response: SuggestionsResponse ) => void;
 	refetchOnWindowFocus?: boolean;
 } ) =>
 	useQuery( {
 		cacheTime: 0,
-		queryFn: getSiteSuggestions,
+		queryFn: () => getSiteSuggestions( params ),
 		refetchOnWindowFocus,
 		enabled,
 		onSuccess,
-		queryKey: [ 'site-suggestions' ],
+		queryKey: [ 'site-suggestions', params ],
 		meta: {
 			persist: false,
 		},


### PR DESCRIPTION
## Proposed Changes

**DO NOT MERGE THIS PR UNTIL THE RELATED DIFF IS MERGED**

We are getting some weird autogenerated site titles in the site options step:

![image](https://github.com/Automattic/wp-calypso/assets/26530524/d3dee9fc-4926-41bf-8c5d-bda2e84ec05f)

Some examples are:
- Blue Triumph
- Classy Bread
- Very Pizza
- Tenacious Banana

I initially thought about removing the site title generator and let the user pick their own site title...

But it turns out that this button is called frequently: 38% (tracks/funnel/view/?44236/2023-06-19/to/2023-07-07) of the times that this page is visited. Something we can't neglect. So instead of removing it for the time being, let's make it better.

## Testing Instructions

1. Apply D116697-code to your sandbox;
2. Browse `/setup/new-hosted-site`;
3. Click "Generate" and verify that the names are computer science related.