### PR TITLE
Premium themes: Fix upsell URL

### DIFF
--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -5,7 +5,7 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
-	FEATURE_PREMIUM_THEMES,
+	FEATURE_PREMIUM_THEMES_V2,
 } from '@automattic/calypso-products';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -35,7 +35,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 					<UpsellNudge
 						className="themes__showcase-banner"
 						event="calypso_themes_list_premium_themes"
-						feature={ FEATURE_PREMIUM_THEMES }
+						feature={ FEATURE_PREMIUM_THEMES_V2 }
 						plan={ PLAN_PREMIUM }
 						title={ translate( 'Unlock premium themes with our Premium and Business plans!' ) }
 						callToAction={ translate( 'Upgrade now' ) }

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -5,10 +5,8 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
-	WPCOM_FEATURES_PREMIUM_THEMES,
+	FEATURE_PREMIUM_THEMES,
 } from '@automattic/calypso-products';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n from 'i18n-calypso';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
@@ -29,23 +27,17 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 
 	const displayUpsellBanner = ! requestingSitePlans && currentPlan && ! isVip;
 	const upsellUrl = `/plans/${ siteSlug }`;
-	const isEnglishLocale = useIsEnglishLocale();
 	let upsellBanner = null;
 	if ( displayUpsellBanner ) {
 		if ( isEnabled( 'themes/premium' ) ) {
 			if ( [ PLAN_PERSONAL, PLAN_FREE ].includes( currentPlan.productSlug ) ) {
-				const bannerTitle =
-					isEnglishLocale ||
-					i18n.hasTranslation( 'Unlock premium themes with our Premium and Business plans!' )
-						? translate( 'Unlock premium themes with our Premium and Business plans!' )
-						: translate( 'Unlock ALL premium themes with our Premium and Business plans!' );
 				upsellBanner = (
 					<UpsellNudge
 						className="themes__showcase-banner"
 						event="calypso_themes_list_premium_themes"
-						feature={ WPCOM_FEATURES_PREMIUM_THEMES }
+						feature={ FEATURE_PREMIUM_THEMES }
 						plan={ PLAN_PREMIUM }
-						title={ bannerTitle }
+						title={ translate( 'Unlock premium themes with our Premium and Business plans!' ) }
 						callToAction={ translate( 'Upgrade now' ) }
 						showIcon={ true }
 					/>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/72770

## Proposed Changes

- Fixes the URL used by the premium themes upsell displayed in the theme showcase so the Free and Personal plans are excluded from the initial view.
- It also removes the translation check since the new copy was fully translated a long ago (https://translate.wordpress.com/projects/wpcom/-all-translated/243918/)

Before | After
--- | ---
<img width="1307" alt="Screenshot 2023-07-21 at 16 35 58" src="https://github.com/Automattic/wp-calypso/assets/1233880/28c23b3e-e550-4e03-9b56-73c52a895286"><img width="1258" alt="Screenshot 2023-07-21 at 16 36 49" src="https://github.com/Automattic/wp-calypso/assets/1233880/75504392-a15d-46b8-8f7b-f5deec0b7e24"> | <img width="1307" alt="Screenshot 2023-07-21 at 16 35 58" src="https://github.com/Automattic/wp-calypso/assets/1233880/28c23b3e-e550-4e03-9b56-73c52a895286"><img width="1223" alt="Screenshot 2023-07-21 at 16 51 37" src="https://github.com/Automattic/wp-calypso/assets/1233880/fb0c21c7-2c22-448d-98f4-8e8a239d86e1">




## Testing Instructions

- Use the Calypso live link below
- Go to `/themes` and pick a Free site
- Click on the "Upgrade now" button of the premium themes banner
- Make sure the plans grid does not include the Free and Personal plans
- Make sure the plans grid highlights the "Premium themes" feature