### PR TITLE
Domain Transfer: Tweaks to checkout thank you

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -102,8 +102,8 @@ export class CheckoutThankYouHeader extends PureComponent {
 				<>
 					<div>
 						{ _n(
-							"We got it from here! We'll send an email when your newly transferred domain is ready to use.",
-							"We got it from here! We'll send an email when your newly transferred domains are ready to use.",
+							"We got it from here! We'll send an email when your domain is ready to use.",
+							"We got it from here! We'll send an email when your domains are ready to use.",
 							purchases?.length
 						) }
 					</div>

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -100,18 +100,18 @@ export class CheckoutThankYouHeader extends PureComponent {
 		if ( this.isBulkDomainTransfer() ) {
 			return (
 				<>
-					<span>
+					<div>
 						{ _n(
-							"We got it from here! We'll let you know when your newly transferred domain is ready to use.",
-							"We got it from here! We'll let you know when your newly transferred domains are ready to use.",
+							"We got it from here! We'll send an email when your newly transferred domain is ready to use.",
+							"We got it from here! We'll send an email when your newly transferred domains are ready to use.",
 							purchases?.length
 						) }
-					</span>{ ' ' }
-					<span>
+					</div>
+					<div>
 						{ translate( '{{strong}}It may take up to 5-10 days.{{/strong}}', {
 							components: { strong: <strong /> },
 						} ) }
-					</span>
+					</div>
 				</>
 			);
 		}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/DomainsTransferredList.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/DomainsTransferredList.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { connect } from 'react-redux';
 import { domainManagementRoot, domainManagementTransferIn } from 'calypso/my-sites/domains/paths';
@@ -23,21 +24,22 @@ const DomainsTransferredList = ( { purchases, manageDomainUrl }: Props ) => {
 	return (
 		<>
 			<div className="domain-header-buttons">
-				<a
+				<Button
 					href="/setup/domain-transfer"
 					onClick={ () => handleUserClick( '/setup/domain-transfer' ) }
-					className="components-button is-secondary"
+					className="is-secondary"
 				>
 					{ __( 'Transfer more domains' ) }
-				</a>
+				</Button>
 
-				<a
+				<Button
 					href={ manageDomainUrl }
-					className="components-button is-primary manage-all-domains"
+					className="manage-all-domains"
 					onClick={ () => handleUserClick( '/domains/manage' ) }
+					variant="primary"
 				>
 					{ _n( 'Manage your domain', 'Manage your domains', purchases?.length ?? 0 ) }
-				</a>
+				</Button>
 			</div>
 			<div className="domain-complete-summary">
 				<ul className="domain-complete-list">

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/style.scss
@@ -144,7 +144,7 @@
 				display: block;
 
 				>div {
-					padding: 0 20px;
+					padding: 0 25px;
 					margin-bottom: 50px;
 					justify-content: space-between;
 					flex-wrap: nowrap;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/style.scss
@@ -13,39 +13,30 @@
 			.domain-header-buttons {
 				margin-top: 32px;
 
-				a {
-					border-radius: 4px;
-					font-weight: 500;
-					font-size: 0.875rem;
-					padding: 10px 24px;
-					height: 48px;
-				}
-
 				.is-secondary {
+					border: 1px solid var(--studio-gray-10);
+					box-shadow: none;
+					color: var(--studio-gray-100);
 					margin-right: 20px;
-					border: 1px solid #c3c4c7;
-					box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
 
 					@media (max-width: $break-medium ) {
 						margin-right: 0;
 					}
 
 					&:hover {
-						color: unset;
-						box-shadow: none;
+						border: 1px solid var(--studio-gray-70);
 					}
 				}
 
-				.is-primary {
-					white-space: nowrap;
-					background: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
-					color: var(--wp-components-color-accent-inverted, #fff);
-					text-decoration: none;
-					text-shadow: none;
-					outline: 1px solid transparent;
-				}
-
 				.components-button {
+					border-radius: 4px;
+					font-weight: 500;
+					font-size: 0.875rem;
+					height: 48px;
+					justify-content: center;
+					padding: 10px 24px;
+					width: 240px;
+
 					@media (max-width: $break-medium ) {
 						width: 100%;
 						justify-content: center;
@@ -53,24 +44,11 @@
 				}
 
 				.manage-all-domains {
-					justify-content: center;
 					color: var(--black-white-white, #fff);
-					height: 48px;
-					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-					border-radius: 0.25rem;
 					background: var(--blue-blue-50, #0675c4);
-					font-size: 0.875rem;
-					width: 240px;
 
 					&:hover {
 						background: var(--studio-blue-60);
-					}
-
-					&:disabled {
-						/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-						border-radius: 0.25rem;
-						background: var(--gray-gray-5, #dcdcde);
-						opacity: 1;
 					}
 
 					@media (max-width: $break-medium ) {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/style.scss
@@ -11,7 +11,7 @@
 	.checkout-thank-you__header {
 		.checkout-thank-you__header-content {
 			.domain-header-buttons {
-				margin-top: 40px;
+				margin-top: 32px;
 
 				a {
 					border-radius: 4px;
@@ -84,7 +84,7 @@
 				display: flex;
 				flex-direction: column;
 				justify-content: center;
-				margin-top: 50px;
+				margin-top: 32px;
 
 				@media (max-width: $break-medium ) {
 					margin-top: 30px;
@@ -156,6 +156,7 @@
 					}
 
 					div.purchase-detail {
+						flex: 1;
 						width: unset;
 						max-width: unset;
 					}


### PR DESCRIPTION
## Proposed Changes

Addresses feedback for the domain transfer thank you page. See p1689954855366369-slack-C05CT832K2T

## Testing Instructions

* Checkout branch
* Go to `/checkout/thank-you/no-site/RECEIPT_ID` where receipt ID is a receipt that has domain transfers
* Verify changes against punch list in Slack, including the following:

- Make sure buttons match the correct styles. For hovers, check here.
- The visit Help Center link should have the same blue as the button: blue-50
- Reducing spacing between the subtitle and buttons to 32px, and buttons to domains list to also 32px.
- More space between the domains list and the help boxes (60px)
- The two help boxes should have the same width (right now, the right one is wider), and we should remove the padding left and right so it matches the list.
- Copy suggestion:
"We got it from here! We'll send an email when your newly transferred domain is ready to use. 
It may take up to 5-10 days."
- Ensure the last sentence in bold takes its own line (not truncated).

Note: A minor change was made to the copy for the subheader and to align the help content with the content inside the card list as opposed to removing passing. Both were discussed with @kellychoffman in the same thread.

<img width="967" alt="Screenshot 2023-07-21 at 6 38 40 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/a60b5930-4ab9-4cbe-9629-71a48b176e63">
<img width="1269" alt="Screenshot 2023-07-21 at 6 35 25 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/51514eb5-9b94-4df8-921d-dfdc8bdd1c60">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?