### PR TITLE
Domain transfers : Add a domain screen updates

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -134,9 +134,9 @@ export function DomainCodePair( {
 		}
 	}, [ shouldReportError, valid, domain, message, errorStatus ] );
 
-	const domainActions = (
+	const domainActions = ( inputValidationTextDisplayed = true ) => (
 		<>
-			&nbsp;
+			{ inputValidationTextDisplayed ? <span>&nbsp;</span> : '' }
 			<Button
 				// Disable the delete button on initial state meaning. no domain, no auth and one row.
 				disabled={ ! domain && ! auth && domainCount === 1 }
@@ -234,7 +234,7 @@ export function DomainCodePair( {
 							<FormInputValidation
 								isError={ ! valid }
 								text={ message }
-								children={ domainActions }
+								children={ domainActions( true ) }
 							></FormInputValidation>
 						) }
 						{ message && loading && (
@@ -250,7 +250,7 @@ export function DomainCodePair( {
 								isError={ false }
 								text=""
 								isMuted={ true }
-								children={ domainCount > 1 && domainActions }
+								children={ domainCount > 1 && domainActions( false ) }
 							/>
 						) }
 					</div>
@@ -278,7 +278,7 @@ export function DomainCodePair( {
 					<FormInputValidation
 						isError={ ! valid }
 						text={ message }
-						children={ domainActions }
+						children={ domainActions( true ) }
 					></FormInputValidation>
 				) }
 				{ message && loading && (
@@ -294,7 +294,7 @@ export function DomainCodePair( {
 						isError={ false }
 						isMuted={ true }
 						text=""
-						children={ domainCount > 1 && domainActions }
+						children={ domainCount > 1 && domainActions( false ) }
 					/>
 				) }
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -175,6 +175,8 @@ export function DomainCodePair( {
 							disabled={ valid }
 							id={ id }
 							value={ domain }
+							className="domains__domain-name-input-field"
+							placeholder={ __( 'Please enter the domain name and authorization code.' ) }
 							onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
 								onChange( id, {
 									domain: event.target.value.trim().toLowerCase(),
@@ -247,7 +249,6 @@ export function DomainCodePair( {
 							<FormInputValidation
 								isError={ false }
 								isMuted={ true }
-								text={ __( 'Please enter the domain name and authorization code.' ) }
 								children={ domainCount > 1 && domainActions }
 							/>
 						) }
@@ -291,7 +292,6 @@ export function DomainCodePair( {
 					<FormInputValidation
 						isError={ false }
 						isMuted={ true }
-						text={ __( 'Please enter the domain name and authorization code.' ) }
 						children={ domainCount > 1 && domainActions }
 					/>
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -248,6 +248,7 @@ export function DomainCodePair( {
 						{ ! shouldReportError && ! loading && (
 							<FormInputValidation
 								isError={ false }
+								text=""
 								isMuted={ true }
 								children={ domainCount > 1 && domainActions }
 							/>
@@ -292,6 +293,7 @@ export function DomainCodePair( {
 					<FormInputValidation
 						isError={ false }
 						isMuted={ true }
+						text=""
 						children={ domainCount > 1 && domainActions }
 					/>
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -182,10 +182,21 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 
 		const totalPrice = getTotalPrice( domainsState );
 		if ( totalPrice ) {
+			const formattedTotalPrice = getFormattedTotalPrice( domainsState );
+
+			if ( numberOfValidDomains > 1 ) {
+				return sprintf(
+					/* translators: %1$s Number of valid domains, %2$s: total price formatted */
+					__( 'Transfer %1$s domains for %2$s' ),
+					numberOfValidDomains,
+					formattedTotalPrice
+				);
+			}
+
 			return sprintf(
 				/* translators: %s: total price formatted */
 				__( 'Transfer for %s' ),
-				getFormattedTotalPrice( domainsState )
+				formattedTotalPrice
 			);
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -1,3 +1,4 @@
+import { hasTranslation } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -15,6 +16,17 @@ const Intro: Step = function Intro( { navigation, flow } ) {
 	const handleSubmit = () => {
 		submit?.();
 	};
+
+	const getTranslatedSubHeaderText = hasTranslation(
+		'Enter your domain names and authorization codes below. You can transfer up to fifty domains at a time.'
+	)
+		? __(
+				'Enter your domain names and authorization codes below. You can transfer up to fifty domains at a time.'
+		  )
+		: __(
+				'Enter your domain names and authorization codes below. You can transfer up to 50 domains at a time.'
+		  );
+
 	return (
 		<StepContainer
 			flowName={ flow }
@@ -28,11 +40,7 @@ const Intro: Step = function Intro( { navigation, flow } ) {
 					headerText={ __( 'Add your domains' ) }
 					subHeaderText={
 						<>
-							<span>
-								{ __(
-									'Enter your domain names and authorization codes below. You can transfer up to fifty domains at a time.'
-								) }
-							</span>
+							<span>{ getTranslatedSubHeaderText }</span>
 						</>
 					}
 					align="center"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -30,7 +30,7 @@ const Intro: Step = function Intro( { navigation, flow } ) {
 						<>
 							<span>
 								{ __(
-									'Enter your domain names and authorization codes below. You can transfer up to 50 domains at a time.'
+									'Enter your domain names and authorization codes below. You can transfer up to fifty domains at a time.'
 								) }
 							</span>
 						</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -1,3 +1,4 @@
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { hasTranslation } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
@@ -12,20 +13,22 @@ import './styles.scss';
 const Intro: Step = function Intro( { navigation, flow } ) {
 	const { submit, goBack } = navigation;
 	const { __ } = useI18n();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const handleSubmit = () => {
 		submit?.();
 	};
 
-	const getTranslatedSubHeaderText = hasTranslation(
-		'Enter your domain names and authorization codes below. You can transfer up to fifty domains at a time.'
-	)
-		? __(
-				'Enter your domain names and authorization codes below. You can transfer up to fifty domains at a time.'
-		  )
-		: __(
-				'Enter your domain names and authorization codes below. You can transfer up to 50 domains at a time.'
-		  );
+	const getTranslatedSubHeaderText =
+		hasTranslation(
+			'Enter your domain names and authorization codes below. You can transfer up to fifty domains at a time.'
+		) || isEnglishLocale
+			? __(
+					'Enter your domain names and authorization codes below. You can transfer up to fifty domains at a time.'
+			  )
+			: __(
+					'Enter your domain names and authorization codes below. You can transfer up to 50 domains at a time.'
+			  );
 
 	return (
 		<StepContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -169,6 +169,13 @@
 			text-decoration: underline;
 		}
 
+
+		.components-button:has(.delete-label),
+		.components-button:has(.refresh-label) {
+			color: var(--gray-gray-100, #101517);
+			text-decoration-color: var(--gray-gray-100, #101517);
+		}
+
 		.is-muted.is-checking-domain {
 			@keyframes animate-dots {
 				0% {
@@ -201,11 +208,20 @@
 	}
 
 	.domains__domain-domain {
-		flex: 8;
+		flex: 0 0 420px;
+
+		.form-text-input::placeholder {
+			color: var(--gray-gray-20, #a7aaad);
+			font-size: 0.875rem;
+		}
+
+		@media (max-width: $break-medium ) {
+			flex: 1;
+		}
 	}
 
 	.domains__domain-key {
-		flex: 3;
+		flex: 0 0 240px;
 
 		.info-popover {
 			margin-left: 5px;
@@ -214,6 +230,10 @@
 
 		.info-popover:focus {
 			outline: 1px solid var(--studio-blue-50);
+		}
+
+		@media (max-width: $break-medium ) {
+			flex: 1;
 		}
 	}
 
@@ -337,13 +357,21 @@
 	.bulk-domain-transfer__container {
 
 		.bulk-domain-transfer__add-domain {
+			padding-left: 0;
 			font-size: 0.875rem;
 			font-weight: 500;
 			color: #0675c4;
 			margin-bottom: 22px;
 			margin-top: 2px;
+			overflow: hidden;
+
 			&:hover {
 				text-decoration: underline;
+			}
+
+			svg {
+				margin-left: -6px;
+				margin-right: 0;
 			}
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -79,7 +79,6 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		return {
 			valid: true,
 			loading: false,
-			message: __( 'This domain is unlocked and ready to be transferred.' ),
 			rawPrice: validationResult.raw_price,
 			saleCost: validationResult.sale_cost,
 			currencyCode: validationResult.currency_code,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1689953627135289-slack-C05CT832K2T

## Proposed Changes

* Update `Domain name` input field to 420px and `Authorization code` input field width to 240px on desktop viewport.
* Add `Please enter the domain name and authorization code` placeholder for Domain name input field when input is empty.
* Remove validation message under Domain Name input field when domain is validated.
* Change `Clear domain` and `Try domain` color.
* Change subtitle copy from (50 to _fifty_)
* Update to display `Transfer X domains for X$`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch or use live link
* Navigate to `/setup/domain-transfer/domains`
* Verify proposed changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?