### PR TITLE
Updates to responsive search page

### DIFF
--- a/client/reader/components/reader-blank-suggestions/style.scss
+++ b/client/reader/components/reader-blank-suggestions/style.scss
@@ -16,6 +16,6 @@
 	}
 
 	@include breakpoint-deprecated( "<660px" ) {
-		padding: 16px;
+		padding: 16px 0 0;
 	}
 }

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -45,7 +45,7 @@ const SpacerDiv = withDimensions( ( { width, height } ) => (
 	<div
 		style={ {
 			width: `${ width }px`,
-			height: `${ height - 73 }px`,
+			height: `${ height - 38 }px`,
 		} }
 	/>
 ) );

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -71,7 +71,7 @@
 		margin-top: 20px;
 
 		.search__icon-navigation {
-			border-radius: 4px 0 0 4px;
+			border-radius: 4px;
 		}
 	}
 }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -60,16 +60,19 @@
 
 .search-stream__fixed-area .formatted-header.is-left-align.has-screen-options {
 	@media only screen and (max-width: 660px) {
-		margin-left: 0;
+		display: none;
 	}
 }
 
 .search-stream .search-stream__input-card.card {
 	margin-bottom: 0;
-	/* stylelint-disable-next-line scales/radii */
-	border-radius: 6px;
+	border-radius: 4px;
 	@include breakpoint-deprecated( "<660px" ) {
-		border-radius: 0;
+		margin-top: 20px;
+
+		.search__icon-navigation {
+			border-radius: 4px 0 0 4px;
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

I noticed a couple of issues with the responsive reader search page.

### Before

First, there was a lack of padding here:

![CleanShot 2023-07-21 at 15 20 54@2x](https://github.com/Automattic/wp-calypso/assets/5634774/c46b9a99-bf08-46ca-8c05-c13e34bc3a87)

Next, this whole area up here is fixed to the top. After adding the header to this page, it was taking up too much space at the top:

![CleanShot 2023-07-21 at 15 22 09@2x](https://github.com/Automattic/wp-calypso/assets/5634774/721fd575-e6e8-40fe-9c46-2c1ba68650c7)

### After

I removed the header at lower resolutions and adjusted the padding below the tabs:

![after](https://github.com/Automattic/wp-calypso/assets/5634774/eb2a6a93-acd5-4379-b6a9-61fe2aa8f243)

Desktop resolution still has the header though:

![CleanShot 2023-07-21 at 15 24 00](https://github.com/Automattic/wp-calypso/assets/5634774/591f1eaf-1f00-442a-84a3-aa387354a99b)

## Testing instructions

- Load this PR locally
- Head to http://calypso.localhost:3000/read/search
- Resize your browser