### PR TITLE
Checkout: Fix phone number bug for Dominican Republic and more

### DIFF
--- a/client/components/phone-input/data.js
+++ b/client/components/phone-input/data.js
@@ -1647,13 +1647,11 @@ export const countries = {
 	},
 	DO: {
 		isoCode: 'DO',
-		dialCode: '18[024]9',
-		countryDialCode: '1',
-		regionCode: '8[024]9',
+		dialCode: '1',
 		areaCodes: [ '809', '829', '849' ],
 		nationalPrefix: '1',
 		priority: 3,
-		patternRegion: 'DO',
+		patternRegion: 'US',
 	},
 	DZ: {
 		isoCode: 'DZ',
@@ -1778,9 +1776,8 @@ export const countries = {
 	},
 	EH: {
 		isoCode: 'EH',
-		dialCode: '212528[89]',
+		dialCode: '212',
 		countryDialCode: '212',
-		regionCode: '528[89]',
 		nationalPrefix: '0',
 	},
 	ER: {
@@ -4565,13 +4562,12 @@ export const countries = {
 	},
 	PR: {
 		isoCode: 'PR',
-		dialCode: '1787|939',
+		dialCode: '1',
 		countryDialCode: '1',
-		regionCode: '787|939',
 		areaCodes: [ '787', '939' ],
 		nationalPrefix: '1',
 		priority: 1,
-		patternRegion: 'PR',
+		patternRegion: 'US',
 	},
 	PS: {
 		isoCode: 'PS',
@@ -4690,9 +4686,8 @@ export const countries = {
 	},
 	RE: {
 		isoCode: 'RE',
-		dialCode: '262262|69|8',
+		dialCode: '262',
 		countryDialCode: '262',
-		regionCode: '262|69|8',
 		nationalPrefix: '0',
 		patterns: [
 			{
@@ -5909,9 +5904,8 @@ export const countries = {
 	},
 	YT: {
 		isoCode: 'YT',
-		dialCode: '262269|63',
+		dialCode: '262',
 		countryDialCode: '262',
-		regionCode: '269|63',
 		nationalPrefix: '0',
 	},
 	ZA: {

--- a/client/components/phone-input/data.js
+++ b/client/components/phone-input/data.js
@@ -23,6 +23,7 @@ export const countries = {
 		isoCode: 'TF',
 		dialCode: '262',
 		nationalPrefix: '0',
+		priority: 1,
 	},
 	HM: {
 		isoCode: 'HM',
@@ -1779,6 +1780,7 @@ export const countries = {
 		dialCode: '212',
 		countryDialCode: '212',
 		nationalPrefix: '0',
+		priority: 1,
 	},
 	ER: {
 		isoCode: 'ER',
@@ -3528,6 +3530,7 @@ export const countries = {
 		isoCode: 'MA',
 		dialCode: '212',
 		nationalPrefix: '0',
+		priority: 1,
 		patterns: [
 			{
 				match: '([5-7]\\d{2})(\\d{6})',
@@ -4689,6 +4692,7 @@ export const countries = {
 		dialCode: '262',
 		countryDialCode: '262',
 		nationalPrefix: '0',
+		priority: 1,
 		patterns: [
 			{
 				match: '([268]\\d{2})(\\d{2})(\\d{2})(\\d{2})',
@@ -5907,6 +5911,7 @@ export const countries = {
 		dialCode: '262',
 		countryDialCode: '262',
 		nationalPrefix: '0',
+		priority: 1,
 	},
 	ZA: {
 		isoCode: 'ZA',
@@ -6144,7 +6149,7 @@ export const dialCodeMap = {
 	95: [ 'MM' ],
 	98: [ 'IR' ],
 	211: [ 'SS' ],
-	212: [ 'MA' ],
+	212: [ 'MA, EH' ],
 	213: [ 'DZ' ],
 	216: [ 'TN' ],
 	218: [ 'LY' ],
@@ -6189,7 +6194,7 @@ export const dialCodeMap = {
 	258: [ 'MZ' ],
 	260: [ 'ZM' ],
 	261: [ 'MG' ],
-	262: [ 'TF' ],
+	262: [ 'TF, RE, YT' ],
 	263: [ 'ZW' ],
 	264: [ 'NA' ],
 	265: [ 'MW' ],

--- a/client/components/phone-input/test/phone-number__format-number.test.js
+++ b/client/components/phone-input/test/phone-number__format-number.test.js
@@ -8,6 +8,7 @@ describe( 'International Format', () => {
 		{ number: '+5555912345678', country: 'BR', expected: '+55 55 91234-5678' },
 		{ number: '+393911711711', country: 'IT', expected: '+39 391 171 1711' },
 		{ number: '+919100123456', country: 'IN', expected: '+91 91001 23456' },
+		{ number: '+18096865700', country: 'DO', expected: '+1 809-686-5700' },
 	] )( `Format full length numbers for $country`, function ( { number, country, expected } ) {
 		const result = formatNumber( number, countries[ country ] );
 		expect( result ).toEqual( expected );


### PR DESCRIPTION
As reported in [this issue](https://github.com/Automattic/wp-calypso/issues/79459), there is a bug in the phone field for a few different countries.

Once a customer changes their country to Dominican Republic, Puerto Rico, Mayotte, Reunion, or Western Sahara we run into a strange formatting issue. Examples can be found in the above issue.

What appears to happen is that the phone number prefix is replaced with the newly selected country's prefix, but the prefix is formatted incorrectly. Additionally, on each rerender (i.e. after the country select switches or each subsequent keystroke that changes the phoneNumber prop in state) the phone number is re-saved with the prefix added to it. Each rerender adds an additional copy of the prefix to the front of the number.

Example:

```
+1 610 731 4456 --> Switch from US to DO (Dominican Republic)
+1 8[024]9 731 4456 --> Add a character to the end
+1 8[024]9 80249731 44567 --> Remove a character
+1 8[024]9 8024980249731 4567. --> and so on...
```


Related to #79459 

## Proposed Changes

I tracked this down to how we use the dialCode in the `country` data file that is passed around in the `phone-number.tsx` file when we format the phone number on country or text change.

The issue appears to be related to how these particular countries include special characters for some sort of interpolation or referencing of the area code within the dialCode, but it doesn't appear that this sort of work is used in our implementation of the phone number formatter, nor is it used for any other country in the list. 

```	
        DO: {
		isoCode: 'DO',
		dialCode: '18[024]9',
		countryDialCode: '1',
		regionCode: '8[024]9',
		areaCodes: [ '809', '829', '849' ],
		nationalPrefix: '1',
		priority: 3,
		patternRegion: 'DO',
	},
```

Note that the dialCode includes the numbers we see in the bugged phone number formatting.

By updating these strings to use correct dialCodes, such as '1' for NANP numbers like the DO, the formatting begins to behave as expected.

## Testing Instructions
* Go to checkout, then edit your contact information.
* Set country to US or CAN, then add a phone number
* Change country to Dominican, Puerto Rico, Mayotte, Reunion, or Western Sahara
* Ensure that the formatter only changes the prefix at the beginning of your number, not the number itself
* Ensure that there is no additional repeating of the dialCode as seen in the bugged footage in the original issue

