### PR TITLE
Change DSP widget JS URL

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -33,7 +33,7 @@
 	"facebook_app_id": "611241942420191",
 	"livechat_support_locales": [ "en", "en-gb" ],
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
-	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": false,
 	"zendesk_presales_chat_key_akismet": false,

--- a/config/development.json
+++ b/config/development.json
@@ -23,7 +23,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
-	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",

--- a/config/production.json
+++ b/config/production.json
@@ -13,7 +13,7 @@
 	"facebook_app_id": "2373049596",
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
-	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",

--- a/config/stage.json
+++ b/config/stage.json
@@ -11,7 +11,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
-	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -11,7 +11,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
-	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",


### PR DESCRIPTION
## Proposed Changes

* Change the DSP widget URL, as we are moving it to a new location

## Testing Instructions

* Code review
* These changes will require a local instance of the DSP widget
* Checkout this branch locally, point calypso to your local widget by changing "dsp_widget_js_src" to `http://localhost:3004/widget.js` in `config/development.json` and then restart your local calypso instance
* Visit `http://calypso.localhost:3000/advertising/your-site.com`
* Press the "promote" button from the post list to launch the advertising widget
* Confirm that the widget works as expected

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
