### PR TITLE
Checkout: Send checkout error boundary error.cause to Sentry if set

### DIFF
--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -19,6 +19,7 @@ import { convertErrorToString } from './composite-checkout/lib/analytics';
 import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
 
 const logCheckoutError = ( error: Error ) => {
+	captureException( error.cause ? error.cause : error );
 	logToLogstash( {
 		feature: 'calypso_client',
 		message: 'composite checkout load error',
@@ -29,7 +30,6 @@ const logCheckoutError = ( error: Error ) => {
 			message: convertErrorToString( error ),
 		},
 	} );
-	captureException( error );
 };
 
 const CheckoutMainWrapperStyles = styled.div`

--- a/client/my-sites/checkout/composite-checkout/lib/analytics.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/analytics.ts
@@ -21,7 +21,7 @@ export function logStashLoadErrorEvent(
 	error: Error,
 	additionalData: Record< string, string | number | undefined > = {}
 ): Promise< void > {
-	captureException( error );
+	captureException( error.cause ? error.cause : error );
 	return logStashEvent( 'composite checkout load error', {
 		...additionalData,
 		type: errorType,


### PR DESCRIPTION
## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/79712 and https://github.com/Automattic/wp-calypso/pull/63634 pass errors caught by the React error boundaries in checkout to Sentry for better reporting. However, in https://github.com/Automattic/wp-calypso/pull/75293 we record the original error itself as the `cause` property. This has been useful for our logstash reporting but is less useful in Sentry which works best on a single error.

In this PR we modify the calls to Sentry's `captureException()` to pass the `cause` if there is one instead of the wrapping error.

## Testing Instructions

None should be needed.