### PR TITLE
Checkout: Let JS serialize checkout error messages itself

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/analytics.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/analytics.ts
@@ -11,9 +11,9 @@ import type { CalypsoDispatch } from 'calypso/state/types';
 
 export function convertErrorToString( error: Error ): string {
 	if ( error.cause ) {
-		return `${ error.message }; Cause: ${ error.cause }; Stack: ${ error.stack }`;
+		return `${ error }; Cause: ${ error.cause }; Stack: ${ error.stack }`;
 	}
-	return `${ error.message }; Stack: ${ error.stack }`;
+	return `${ error }; Stack: ${ error.stack }`;
 }
 
 export function logStashLoadErrorEvent(

--- a/packages/composite-checkout/src/components/checkout-error-boundary.tsx
+++ b/packages/composite-checkout/src/components/checkout-error-boundary.tsx
@@ -21,7 +21,9 @@ export default class CheckoutErrorBoundary extends Component< CheckoutErrorBound
 	componentDidCatch( error: Error ): void {
 		if ( this.props.onError ) {
 			const errorContext =
-				typeof this.props.errorMessage === 'string' ? this.props.errorMessage : error.message;
+				typeof this.props.errorMessage === 'string' && this.props.errorMessage.length > 0
+					? this.props.errorMessage
+					: `${ error }`;
 			const errorWithCause = new Error( errorContext, { cause: error } );
 			this.props.onError( errorWithCause );
 		}


### PR DESCRIPTION
## Proposed Changes

Checkout's error boundaries capture and report error messages that occur within its components. However, some of the error's information is lost because we rely on `error.message`. There are some cases where `error.message` is not set (apparently?? according to our logs anyway). In addition, we lose the `name` of the error.

In this PR we modify our error boundary logging to let JS serialize the errors into strings instead of using the `message` property. So instead of logging something like `Cannot read properties of undefined (reading 'bar')`, we should see `TypeError: Cannot read properties of undefined (reading 'bar')`.

## Testing Instructions

We need to cause an error and verify that it gets logged. To do that, add an error to checkout in a locally running version of calypso on this branch like the following:

```diff
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -203,6 +203,8 @@ export default function WPCheckout( {
        const [ isSummaryVisible, setIsSummaryVisible ] = useState( false );
        const { formStatus } = useFormStatus();

+       throw new Error( 'this is a test' );
+
        const onReviewError = useCallback(
                ( error: Error ) =>
                        onPageLoadError( 'step_load', error, {
```

Then, visit checkout with your browser's network devtools open. Look for a connection to the `logstash` endpoint with a body that includes the message.