### PR TITLE
Stats: fix non-USD checkout total

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -202,7 +202,7 @@ const PersonalPurchase = ( {
 							siteSlug,
 							adminUrl,
 							redirectUri,
-							price: subscriptionValue,
+							price: subscriptionValue / 2, //A step is half of the smallest unit
 						} )
 					}
 				>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -6,7 +6,7 @@ import { Button, CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
-import { COMPONENT_CLASS_NAME } from './stats-purchase-wizard';
+import { COMPONENT_CLASS_NAME, MIN_STEP_SPLITS } from './stats-purchase-wizard';
 
 interface PersonalPurchaseProps {
 	subscriptionValue: number;
@@ -202,7 +202,7 @@ const PersonalPurchase = ( {
 							siteSlug,
 							adminUrl,
 							redirectUri,
-							price: subscriptionValue / 2, //A step is half of the smallest unit
+							price: subscriptionValue / MIN_STEP_SPLITS,
 						} )
 					}
 				>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -6,7 +6,7 @@ import { Button, CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
-import { COMPONENT_CLASS_NAME, PRICING_CONFIG } from './stats-purchase-wizard';
+import { COMPONENT_CLASS_NAME } from './stats-purchase-wizard';
 
 interface PersonalPurchaseProps {
 	subscriptionValue: number;
@@ -15,7 +15,7 @@ interface PersonalPurchaseProps {
 	currencyCode: string;
 	siteSlug: string;
 	sliderSettings: {
-		sliderStep: number;
+		sliderStepPrice: number;
 		maxSliderPrice: number;
 		uiEmojiHeartTier: number;
 		uiImageCelebrationTier: number;
@@ -40,7 +40,10 @@ const PersonalPurchase = ( {
 	const [ isAdsChecked, setAdsChecked ] = useState( false );
 	const [ isSellingChecked, setSellingChecked ] = useState( false );
 	const [ isBusinessChecked, setBusinessChecked ] = useState( false );
-	const { sliderStep, maxSliderPrice, uiEmojiHeartTier, uiImageCelebrationTier } = sliderSettings;
+	const { sliderStepPrice, maxSliderPrice, uiEmojiHeartTier, uiImageCelebrationTier } =
+		sliderSettings;
+
+	const [ defaultStartingValue ] = useState( subscriptionValue );
 
 	const sliderLabel = ( ( props, state ) => {
 		let emoji;
@@ -57,7 +60,10 @@ const PersonalPurchase = ( {
 			<div { ...props }>
 				{ translate( '%(value)s/month', {
 					args: {
-						value: formatCurrency( state?.valueNow || subscriptionValue, currencyCode ),
+						value: formatCurrency(
+							( state?.valueNow || subscriptionValue ) * sliderStepPrice,
+							currencyCode
+						),
 					},
 					comment: 'Price per month selected by the user via the pricing slider',
 				} ) }
@@ -86,14 +92,13 @@ const PersonalPurchase = ( {
 				value={ subscriptionValue }
 				renderThumb={ sliderLabel }
 				onChange={ setSubscriptionValue }
-				maxValue={ maxSliderPrice }
-				step={ sliderStep }
+				maxValue={ Math.floor( maxSliderPrice / sliderStepPrice ) }
 			/>
 
 			<p className={ `${ COMPONENT_CLASS_NAME }__average-price` }>
 				{ translate( 'Our users pay %(value)s per month on average', {
 					args: {
-						value: formatCurrency( PRICING_CONFIG.AVERAGE_PRICE_INFO, currencyCode ),
+						value: formatCurrency( defaultStartingValue * sliderStepPrice, currencyCode ),
 					},
 				} ) }
 			</p>
@@ -203,7 +208,7 @@ const PersonalPurchase = ( {
 				>
 					{ translate( 'Get Jetpack Stats for %(value)s per month', {
 						args: {
-							value: formatCurrency( subscriptionValue, currencyCode ),
+							value: formatCurrency( subscriptionValue * sliderStepPrice, currencyCode ),
 						},
 					} ) }
 				</Button>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -42,9 +42,10 @@ const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redire
 	const sliderStepPrice = pwywProduct.cost / 2; //A step is half of the smallest unit
 
 	const steps = Math.floor( maxSliderPrice / sliderStepPrice );
+	// We need the exact position, otherwise the caculated pricing would not be the same as the one in the slider.
 	const defaultStartingValue = Math.ceil( steps * DEFAULT_STARTING_FRACTION );
-	const uiEmojiHeartTier = Math.ceil( steps * UI_EMOJI_HEART_TIER_THRESHOLD );
-	const uiImageCelebrationTier = Math.ceil( steps * UI_IMAGE_CELEBRATION_TIER_THRESHOLD );
+	const uiEmojiHeartTier = steps * UI_EMOJI_HEART_TIER_THRESHOLD;
+	const uiImageCelebrationTier = steps * UI_IMAGE_CELEBRATION_TIER_THRESHOLD;
 
 	const [ subscriptionValue, setSubscriptionValue ] = useState( defaultStartingValue );
 	const [ wizardStep, setWizardStep ] = useState( SCREEN_TYPE_SELECTION );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -17,10 +17,9 @@ const SCREEN_PURCHASE = 1;
 const TYPE_PERSONAL = 'Personal';
 const TYPE_COMMERCIAL = 'Commercial';
 
-// TODO: Get pricing config from an API
-const PRICING_CONFIG = {
-	AVERAGE_PRICE_INFO: 6, // used to display how much a users pays on average (below price slider)
-};
+const DEFAULT_STARTING_FRACTION = 0.6;
+const UI_EMOJI_HEART_TIER_THRESHOLD = 0.5;
+const UI_IMAGE_CELEBRATION_TIER_THRESHOLD = 0.8;
 
 const TitleNode = ( { label, indicatorNumber, active } ) => {
 	return (
@@ -40,13 +39,14 @@ const TitleNode = ( { label, indicatorNumber, active } ) => {
 const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redirectUri, from } ) => {
 	const commercialPlanPrice = commercialProduct?.cost;
 	const maxSliderPrice = commercialProduct.cost;
-	const sliderStep = pwywProduct.cost / 2;
+	const sliderStepPrice = pwywProduct.cost / 2;
 
-	const defaultStartingPrice = commercialPlanPrice * 0.6; // default position for PWYW slider // TODO: replace with AVERAGE_PRICE_INFO when it's dynamic
-	const uiEmojiHeartTier = commercialPlanPrice * 0.5; // value when slider emoji is changed to a heart emoji
-	const uiImageCelebrationTier = commercialPlanPrice * 0.8; // minimal price that enables image celebration image
+	const steps = Math.floor( maxSliderPrice / sliderStepPrice );
+	const defaultStartingValue = Math.ceil( steps * DEFAULT_STARTING_FRACTION );
+	const uiEmojiHeartTier = Math.ceil( steps * UI_EMOJI_HEART_TIER_THRESHOLD );
+	const uiImageCelebrationTier = Math.ceil( steps * UI_IMAGE_CELEBRATION_TIER_THRESHOLD );
 
-	const [ subscriptionValue, setSubscriptionValue ] = useState( defaultStartingPrice );
+	const [ subscriptionValue, setSubscriptionValue ] = useState( defaultStartingValue );
 	const [ wizardStep, setWizardStep ] = useState( SCREEN_TYPE_SELECTION );
 	const [ siteType, setSiteType ] = useState( null );
 	const translate = useTranslate();
@@ -163,7 +163,7 @@ const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redire
 											currencyCode={ pwywProduct.currency_code }
 											siteSlug={ siteSlug }
 											sliderSettings={ {
-												sliderStep,
+												sliderStepPrice,
 												maxSliderPrice,
 												uiEmojiHeartTier,
 												uiImageCelebrationTier,
@@ -224,4 +224,4 @@ const StatsPurchaseWizard = ( {
 	);
 };
 
-export { StatsPurchaseWizard as default, COMPONENT_CLASS_NAME, PRICING_CONFIG };
+export { StatsPurchaseWizard as default, COMPONENT_CLASS_NAME };

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -46,7 +46,7 @@ const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redire
 
 	const steps = Math.floor( maxSliderPrice / sliderStepPrice );
 	// We need the exact position, otherwise the caculated pricing would not be the same as the one in the slider.
-	const defaultStartingValue = Math.ceil( steps * DEFAULT_STARTING_FRACTION );
+	const defaultStartingValue = Math.floor( steps * DEFAULT_STARTING_FRACTION );
 	const uiEmojiHeartTier = steps * UI_EMOJI_HEART_TIER_THRESHOLD;
 	const uiImageCelebrationTier = steps * UI_IMAGE_CELEBRATION_TIER_THRESHOLD;
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -39,7 +39,7 @@ const TitleNode = ( { label, indicatorNumber, active } ) => {
 const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redirectUri, from } ) => {
 	const commercialPlanPrice = commercialProduct?.cost;
 	const maxSliderPrice = commercialProduct.cost;
-	const sliderStepPrice = pwywProduct.cost / 2;
+	const sliderStepPrice = pwywProduct.cost / 2; //A step is half of the smallest unit
 
 	const steps = Math.floor( maxSliderPrice / sliderStepPrice );
 	const defaultStartingValue = Math.ceil( steps * DEFAULT_STARTING_FRACTION );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -21,6 +21,9 @@ const DEFAULT_STARTING_FRACTION = 0.6;
 const UI_EMOJI_HEART_TIER_THRESHOLD = 0.5;
 const UI_IMAGE_CELEBRATION_TIER_THRESHOLD = 0.8;
 
+// A step price is half of the smallest unit
+const MIN_STEP_SPLITS = 2;
+
 const TitleNode = ( { label, indicatorNumber, active } ) => {
 	return (
 		<>
@@ -39,7 +42,7 @@ const TitleNode = ( { label, indicatorNumber, active } ) => {
 const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redirectUri, from } ) => {
 	const commercialPlanPrice = commercialProduct?.cost;
 	const maxSliderPrice = commercialProduct.cost;
-	const sliderStepPrice = pwywProduct.cost / 2; //A step is half of the smallest unit
+	const sliderStepPrice = pwywProduct.cost / MIN_STEP_SPLITS;
 
 	const steps = Math.floor( maxSliderPrice / sliderStepPrice );
 	// We need the exact position, otherwise the caculated pricing would not be the same as the one in the slider.
@@ -225,4 +228,4 @@ const StatsPurchaseWizard = ( {
 	);
 };
 
-export { StatsPurchaseWizard as default, COMPONENT_CLASS_NAME };
+export { StatsPurchaseWizard as default, COMPONENT_CLASS_NAME, MIN_STEP_SPLITS };

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -5,7 +5,6 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
 import statsPurchaseBackgroundSVG from 'calypso/assets/images/stats/purchase-background.svg';
 import { useSelector } from 'calypso/state';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import CommercialPurchase from './stats-purchase-commercial';
 import PersonalPurchase from './stats-purchase-personal';
@@ -51,7 +50,6 @@ const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redire
 	const [ wizardStep, setWizardStep ] = useState( SCREEN_TYPE_SELECTION );
 	const [ siteType, setSiteType ] = useState( null );
 	const translate = useTranslate();
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 
 	const personalLabel = translate( 'Personal site' );
@@ -162,7 +160,7 @@ const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redire
 											subscriptionValue={ subscriptionValue }
 											setSubscriptionValue={ setSubscriptionValue }
 											handlePlanSwap={ ( e ) => handlePlanSwap( e ) }
-											currencyCode={ currencyCode }
+											currencyCode={ pwywProduct.currency_code }
 											siteSlug={ siteSlug }
 											sliderSettings={ {
 												sliderStep,
@@ -177,7 +175,7 @@ const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redire
 									) : (
 										<CommercialPurchase
 											planValue={ commercialProduct.cost }
-											currencyCode={ currencyCode }
+											currencyCode={ commercialProduct.currency_code }
 											siteSlug={ siteSlug }
 											commercialProduct={ commercialProduct }
 											adminUrl={ adminUrl }


### PR DESCRIPTION
Related to 3 & 4 in p1689922600860689-slack-C0438NHCLSY

## Proposed Changes

* Use integer for slider positions to avoid roudings
* Pass correct quantity to the checkout page

## Testing Instructions

* Change your currency to a currency other than USD ( you could do from Store Admin )
* Open Calypso Live `/stats/purchase/${your-site}`
* Choose Personal Site
* Ensure the the pricing matches in the three places

![image](https://github.com/Automattic/wp-calypso/assets/1425433/06b5da0a-a9cd-44c7-8191-14b674d9c4fa)

- Move the slider
- Ensure the pricing in the slider matches the one in the button
- Click `Get Jetpack Stats for xxx per month`
- Ensure the total on the checkout page matches the monthly pricing (hundredth position might be a little bit off)

<img width="689" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/beac7c04-de0a-4332-8e47-f084058a59f8">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?