### PR TITLE
Add the “Live Preview” button on the Theme Detail page

### DIFF
--- a/client/my-sites/theme/live-preview-button/index.jsx
+++ b/client/my-sites/theme/live-preview-button/index.jsx
@@ -21,21 +21,22 @@ export const LivePreviewButton = ( {
 	isActive,
 	isAtomic,
 	isExternallyManagedTheme,
+	isFullSiteEditingTheme,
 	isSimple,
 	isThemeInstalledOnAtomicSite,
 	isWporg,
-	showTryAndCustomize,
 	siteSlug,
 	stylesheet,
 	themeType,
+	themeId,
 } ) => {
 	// A user doesn't want to preview the active theme.
 	if ( isActive ) {
 		return null;
 	}
 
-	// Block Theme Previews do not support Classic themes.
-	if ( showTryAndCustomize ) {
+	// A theme should be FullSiteEditing compatible to use Block Theme Previews.
+	if ( ! isFullSiteEditingTheme ) {
 		return null;
 	}
 
@@ -75,8 +76,11 @@ export const LivePreviewButton = ( {
 		}
 	}
 
+	const themePath = isAtomic ? themeId : stylesheet;
+
 	return (
-		<Button href={ `https://${ siteSlug }/wp-admin/site-editor.php?theme_preview=${ stylesheet }` }>
+			href={ `https://${ siteSlug }/wp-admin/site-editor.php?wp_theme_preview=${ themePath }` }
+		>
 			Live Preview
 		</Button>
 	);

--- a/client/my-sites/theme/live-preview-button/index.jsx
+++ b/client/my-sites/theme/live-preview-button/index.jsx
@@ -1,0 +1,29 @@
+import { Button } from '@automattic/components';
+
+export const LivePreviewButton = ( {
+	isActive,
+	isAtomic,
+	isExternallyManagedTheme,
+	isWporg,
+	showTryAndCustomize,
+	siteSlug,
+	stylesheet,
+} ) => {
+	if ( isActive ) {
+		return null;
+	}
+	if ( showTryAndCustomize ) {
+		return null;
+	}
+	if ( isAtomic ) {
+		return null;
+	}
+	if ( isExternallyManagedTheme || isWporg ) {
+		return null;
+	}
+	return (
+		<Button href={ `https://${ siteSlug }/wp-admin/site-editor.php?theme_preview=${ stylesheet }` }>
+			Live Preview (PoC)
+		</Button>
+	);
+};

--- a/client/my-sites/theme/live-preview-button/index.jsx
+++ b/client/my-sites/theme/live-preview-button/index.jsx
@@ -91,6 +91,11 @@ export const LivePreviewButton = ( {
 		return null;
 	}
 
+	// Block Theme Previews need the theme installed on Atomic sites.
+	if ( isAtomic && ! isThemeInstalledOnAtomicSite ) {
+		return null;
+	}
+
 	if ( isSimple ) {
 		/**
 		 * Disable Live Preview for 3rd party themes, as Block Theme Previews need a theme installed.
@@ -108,11 +113,6 @@ export const LivePreviewButton = ( {
 		 * @see https://github.com/Automattic/wp-calypso/issues/79223
 		 */
 		if ( ! canUseTheme ) {
-			return null;
-		}
-	} else if ( isAtomic ) {
-		// Block Theme Previews need the theme installed on Atomic sites.
-		if ( ! isThemeInstalledOnAtomicSite ) {
 			return null;
 		}
 	}

--- a/client/my-sites/theme/live-preview-button/index.jsx
+++ b/client/my-sites/theme/live-preview-button/index.jsx
@@ -1,5 +1,22 @@
 import { Button } from '@automattic/components';
 
+/**
+ * Hardcoded list of themes that are not compatible with Block Theme Previews.
+ * This list should be removed once they are delisted/retired.
+ *
+ * TODO: Complete the list.
+ */
+const NOT_COMPATIBLE_THEMES = [ 'pub/appleton' ];
+
+const isNotCompatibleThemes = ( stylesheet ) => {
+	return NOT_COMPATIBLE_THEMES.includes( stylesheet );
+};
+
+/**
+ * Live Preview leveraging Gutenberg's Block Theme Previews
+ *
+ * @see pbxlJb-3Uv-p2
+ */
 export const LivePreviewButton = ( {
 	isActive,
 	isAtomic,
@@ -9,21 +26,48 @@ export const LivePreviewButton = ( {
 	siteSlug,
 	stylesheet,
 } ) => {
+	// A user doesn't want to preview the active theme.
 	if ( isActive ) {
 		return null;
 	}
+
+	// Block Theme Previews do not support Classic themes.
 	if ( showTryAndCustomize ) {
 		return null;
 	}
-	if ( isAtomic ) {
-		return null;
-	}
+
+	// Disable Live Preview for 3rd party themes, as Block Theme Previews need a theme installed.
 	if ( isExternallyManagedTheme || isWporg ) {
 		return null;
 	}
+
+	// Block Theme Previews need the theme installed.
+	// TODO: Check if the theme is installed.
+	const isInstalled = true;
+	if ( isAtomic && ! isInstalled ) {
+		return null;
+	}
+
+	/**
+	 * Disable Live Preview for Premium/WooCommerce themes.
+	 * This should be updated as we implement the flow for them.
+	 *
+	 * @see https://github.com/Automattic/wp-calypso/issues/79223
+	 */
+	// TODO:
+
+	/**
+	 * Block Theme Previews does not support themes with a static page as a homepage.
+	 *
+	 * @see pekYwv-284-p2#background
+	 */
+	if ( isNotCompatibleThemes( stylesheet ) ) {
+		return null;
+	}
+
 	return (
 		<Button href={ `https://${ siteSlug }/wp-admin/site-editor.php?theme_preview=${ stylesheet }` }>
-			Live Preview (PoC)
+			Live Preview
 		</Button>
 	);
 };

--- a/client/my-sites/theme/live-preview-button/index.jsx
+++ b/client/my-sites/theme/live-preview-button/index.jsx
@@ -58,6 +58,7 @@ const isNotCompatibleThemes = ( stylesheet ) => {
  * @see pbxlJb-3Uv-p2
  */
 export const LivePreviewButton = ( {
+	canUseTheme,
 	isActive,
 	isAtomic,
 	isExternallyManagedTheme,
@@ -67,7 +68,6 @@ export const LivePreviewButton = ( {
 	isWporg,
 	siteSlug,
 	stylesheet,
-	themeType,
 	themeId,
 	translate,
 } ) => {
@@ -101,13 +101,13 @@ export const LivePreviewButton = ( {
 		}
 
 		/**
-		 * Disable Live Preview for Premium/WooCommerce themes.
+		 * Disable Live Preview for themes that are not included in a plan.
 		 * This should be updated as we implement the flow for them.
 		 * Note that BTP works on Atomic sites if a theme is installed.
 		 *
 		 * @see https://github.com/Automattic/wp-calypso/issues/79223
 		 */
-		if ( themeType === 'premium' || themeType === 'woocommerce' ) {
+		if ( ! canUseTheme ) {
 			return null;
 		}
 	} else if ( isAtomic ) {

--- a/client/my-sites/theme/live-preview-button/index.jsx
+++ b/client/my-sites/theme/live-preview-button/index.jsx
@@ -55,6 +55,17 @@ const isNotCompatibleThemes = ( stylesheet ) => {
 /**
  * Live Preview leveraging Gutenberg's Block Theme Previews
  *
+ * The scenarios where the Live Preview does NOT support;
+ * - On both Simple and Atomic sites;
+ *   - If the theme is users' active theme.
+ *   - If the theme is not FullSiteEditing compatible.
+ *   - If the theme has a static page as a homepage.
+ * - On Atomic sites;
+ *   - If the theme is not installed on Atomic sites.
+ * - On Simple sites;
+ *   - If the theme is a 3rd party theme.
+ *   - If the theme is not included in a plan.
+ *
  * @see pbxlJb-3Uv-p2
  */
 export const LivePreviewButton = ( {

--- a/client/my-sites/theme/live-preview-button/index.jsx
+++ b/client/my-sites/theme/live-preview-button/index.jsx
@@ -2,11 +2,51 @@ import { Button } from '@automattic/components';
 
 /**
  * Hardcoded list of themes that are not compatible with Block Theme Previews.
- * This list should be removed once they are delisted/retired.
+ * This list should be removed once they are retired.
  *
- * TODO: Complete the list.
+ * @see pekYwv-284-p2
  */
-const NOT_COMPATIBLE_THEMES = [ 'pub/appleton' ];
+const NOT_COMPATIBLE_THEMES = [
+	'premium/alonso',
+	'premium/baxter',
+	'premium/byrne',
+	'premium/kerr',
+	'premium/munchies',
+	'premium/payton',
+	'premium/skivers',
+	'premium/thriving-artist',
+	'pub/ames',
+	'pub/antonia',
+	'pub/appleton',
+	'pub/arbutus',
+	'pub/attar',
+	'pub/barnett',
+	'pub/bennett',
+	'pub/calvin',
+	'pub/calyx',
+	'pub/course',
+	'pub/dorna',
+	'pub/farrow',
+	'pub/geologist-blue',
+	'pub/geologist-cream',
+	'pub/geologist-slate',
+	'pub/geologist-yellow',
+	'pub/hari',
+	'pub/heiwa',
+	'pub/jackson',
+	'pub/kingsley',
+	'pub/marl',
+	'pub/meraki',
+	'pub/quadrat-black',
+	'pub/quadrat-green',
+	'pub/quadrat-red',
+	'pub/quadrat-white',
+	'pub/quadrat-yellow',
+	'pub/quadrat',
+	'pub/russell',
+	'pub/seedlet-blocks',
+	'pub/winkel',
+];
 
 const isNotCompatibleThemes = ( stylesheet ) => {
 	return NOT_COMPATIBLE_THEMES.includes( stylesheet );
@@ -79,6 +119,7 @@ export const LivePreviewButton = ( {
 	const themePath = isAtomic ? themeId : stylesheet;
 
 	return (
+		<Button
 			href={ `https://${ siteSlug }/wp-admin/site-editor.php?wp_theme_preview=${ themePath }` }
 		>
 			Live Preview

--- a/client/my-sites/theme/live-preview-button/index.jsx
+++ b/client/my-sites/theme/live-preview-button/index.jsx
@@ -69,6 +69,7 @@ export const LivePreviewButton = ( {
 	stylesheet,
 	themeType,
 	themeId,
+	translate,
 } ) => {
 	// A user doesn't want to preview the active theme.
 	if ( isActive ) {
@@ -122,7 +123,7 @@ export const LivePreviewButton = ( {
 		<Button
 			href={ `https://${ siteSlug }/wp-admin/site-editor.php?wp_theme_preview=${ themePath }` }
 		>
-			Live Preview
+			{ translate( 'Live Preview' ) }
 		</Button>
 	);
 };

--- a/client/my-sites/theme/live-preview-button/index.jsx
+++ b/client/my-sites/theme/live-preview-button/index.jsx
@@ -21,10 +21,13 @@ export const LivePreviewButton = ( {
 	isActive,
 	isAtomic,
 	isExternallyManagedTheme,
+	isSimple,
+	isThemeInstalledOnAtomicSite,
 	isWporg,
 	showTryAndCustomize,
 	siteSlug,
 	stylesheet,
+	themeType,
 } ) => {
 	// A user doesn't want to preview the active theme.
 	if ( isActive ) {
@@ -36,33 +39,40 @@ export const LivePreviewButton = ( {
 		return null;
 	}
 
-	// Disable Live Preview for 3rd party themes, as Block Theme Previews need a theme installed.
-	if ( isExternallyManagedTheme || isWporg ) {
-		return null;
-	}
-
-	// Block Theme Previews need the theme installed.
-	// TODO: Check if the theme is installed.
-	const isInstalled = true;
-	if ( isAtomic && ! isInstalled ) {
-		return null;
-	}
-
 	/**
-	 * Disable Live Preview for Premium/WooCommerce themes.
-	 * This should be updated as we implement the flow for them.
-	 *
-	 * @see https://github.com/Automattic/wp-calypso/issues/79223
-	 */
-	// TODO:
-
-	/**
-	 * Block Theme Previews does not support themes with a static page as a homepage.
+	 * Block Theme Previews do not support themes with a static page as a homepage
+	 * as the Site Editor cannot control Reading Settings.
 	 *
 	 * @see pekYwv-284-p2#background
 	 */
 	if ( isNotCompatibleThemes( stylesheet ) ) {
 		return null;
+	}
+
+	if ( isSimple ) {
+		/**
+		 * Disable Live Preview for 3rd party themes, as Block Theme Previews need a theme installed.
+		 * Note that BTP works on Atomic sites if a theme is installed.
+		 */
+		if ( isExternallyManagedTheme || isWporg ) {
+			return null;
+		}
+
+		/**
+		 * Disable Live Preview for Premium/WooCommerce themes.
+		 * This should be updated as we implement the flow for them.
+		 * Note that BTP works on Atomic sites if a theme is installed.
+		 *
+		 * @see https://github.com/Automattic/wp-calypso/issues/79223
+		 */
+		if ( themeType === 'premium' || themeType === 'woocommerce' ) {
+			return null;
+		}
+	} else if ( isAtomic ) {
+		// Block Theme Previews need the theme installed on Atomic sites.
+		if ( ! isThemeInstalledOnAtomicSite ) {
+			return null;
+		}
 	}
 
 	return (

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -644,7 +644,7 @@ class ThemeSheet extends Component {
 						<span className="theme__sheet-main-info-tag">{ tag }</span>
 					</div>
 					<div className="theme__sheet-main-actions">
-						{ config.isEnabled( 'themes/block-theme-previews-poc' ) && (
+						{ config.isEnabled( 'themes/block-theme-previews' ) && (
 							<LivePreviewButton
 								isActive={ isActive }
 								isAtomic={ isAtomic }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -92,6 +92,7 @@ import {
 	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
 	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
 	isThemeActivationSyncStarted as getIsThemeActivationSyncStarted,
+	isFullSiteEditingTheme as getIsFullSiteEditingTheme,
 } from 'calypso/state/themes/selectors';
 import { getIsLoadingCart } from 'calypso/state/themes/selectors/get-is-loading-cart';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
@@ -627,6 +628,8 @@ class ThemeSheet extends Component {
 			themeType,
 			isSimple,
 			isThemeInstalledOnAtomicSite,
+			isFullSiteEditingTheme,
+			themeId,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
@@ -659,12 +662,14 @@ class ThemeSheet extends Component {
 								isActive={ isActive }
 								isAtomic={ isAtomic }
 								isExternallyManagedTheme={ isExternallyManagedTheme }
+								isFullSiteEditingTheme={ isFullSiteEditingTheme }
 								isSimple={ isSimple }
 								isThemeInstalledOnAtomicSite={ isThemeInstalledOnAtomicSite }
 								isWporg={ isWporg }
 								showTryAndCustomize={ showTryAndCustomize }
 								siteSlug={ siteSlug }
 								stylesheet={ stylesheet }
+								themeId={ themeId }
 								themeType={ themeType }
 							></LivePreviewButton>
 						) }
@@ -1564,6 +1569,10 @@ export default connect(
 
 		const isThemeInstalledOnAtomicSite = isAtomic && !! getTheme( state, siteId, themeId );
 
+		const isFullSiteEditingTheme = config.isEnabled( 'themes/block-theme-previews' )
+			? getIsFullSiteEditingTheme( state, themeId )
+			: undefined;
+
 		return {
 			...theme,
 			themeId,
@@ -1582,6 +1591,7 @@ export default connect(
 			isActive: isThemeActive( state, themeId, siteId ),
 			isJetpack,
 			isAtomic,
+			isFullSiteEditingTheme,
 			isStandaloneJetpack,
 			isVip: isVipSite( state, siteId ),
 			isPremium: isThemePremium( state, themeId ),

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -671,6 +671,7 @@ class ThemeSheet extends Component {
 								stylesheet={ stylesheet }
 								themeId={ themeId }
 								themeType={ themeType }
+								translate={ translate }
 							></LivePreviewButton>
 						) }
 						{ this.shouldRenderPreviewButton() && (

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1599,7 +1599,7 @@ export default connect(
 			forumUrl: getThemeForumUrl( state, themeId, siteId ),
 			hasUnlimitedPremiumThemes: siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),
 			showTryAndCustomize: shouldShowTryAndCustomize( state, themeId, siteId ),
-			canUseTheme: getCanUseTheme( state, themeId, siteId ),
+			canUseTheme: getCanUseTheme( state, siteId, themeId ),
 			canUserUploadThemes: siteHasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
 			// Remove the trailing slash because the page URL doesn't have one either.
 			canonicalUrl: localizeUrl( englishUrl, getLocaleSlug(), false ).replace( /\/$/, '' ),

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -95,40 +95,13 @@ import { getIsLoadingCart } from 'calypso/state/themes/selectors/get-is-loading-
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EligibilityWarningModal from '../themes/atomic-transfer-dialog';
+import { LivePreviewButton } from './live-preview-button';
 import ThemeDownloadCard from './theme-download-card';
 import ThemeFeaturesCard from './theme-features-card';
 import ThemeNotFoundError from './theme-not-found-error';
 import ThemeStyleVariations from './theme-style-variations';
 
 import './style.scss';
-
-const LivePreviewButton = ( {
-	isActive,
-	isAtomic,
-	isExternallyManagedTheme,
-	isWporg,
-	showTryAndCustomize,
-	siteSlug,
-	stylesheet,
-} ) => {
-	if ( isActive ) {
-		return null;
-	}
-	if ( showTryAndCustomize ) {
-		return null;
-	}
-	if ( isAtomic ) {
-		return null;
-	}
-	if ( isExternallyManagedTheme || isWporg ) {
-		return null;
-	}
-	return (
-		<Button href={ `https://${ siteSlug }/wp-admin/site-editor.php?theme_preview=${ stylesheet }` }>
-			Live Preview (PoC)
-		</Button>
-	);
-};
 
 const noop = () => {};
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -73,6 +73,7 @@ import {
 	themeStartActivationSync as themeStartActivationSyncAction,
 } from 'calypso/state/themes/actions';
 import {
+	canUseTheme as getCanUseTheme,
 	doesThemeBundleSoftwareSet,
 	isThemeActive,
 	isThemePremium,
@@ -86,7 +87,6 @@ import {
 	getThemeDetailsUrl,
 	getThemeForumUrl,
 	getThemeRequestErrors,
-	getThemeType,
 	shouldShowTryAndCustomize,
 	isExternallyManagedTheme as getIsExternallyManagedTheme,
 	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
@@ -625,10 +625,10 @@ class ThemeSheet extends Component {
 			isExternallyManagedTheme,
 			isWporg,
 			isLoggedIn,
-			themeType,
+			canUseTheme,
+			isFullSiteEditingTheme,
 			isSimple,
 			isThemeInstalledOnAtomicSite,
-			isFullSiteEditingTheme,
 			themeId,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
@@ -659,6 +659,7 @@ class ThemeSheet extends Component {
 								: this.renderButton() ) }
 						{ config.isEnabled( 'themes/block-theme-previews' ) && (
 							<LivePreviewButton
+								canUseTheme={ canUseTheme }
 								isActive={ isActive }
 								isAtomic={ isAtomic }
 								isExternallyManagedTheme={ isExternallyManagedTheme }
@@ -670,7 +671,6 @@ class ThemeSheet extends Component {
 								siteSlug={ siteSlug }
 								stylesheet={ stylesheet }
 								themeId={ themeId }
-								themeType={ themeType }
 								translate={ translate }
 							></LivePreviewButton>
 						) }
@@ -1564,10 +1564,6 @@ export default connect(
 		const isMarketplaceThemeSubscribed =
 			isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, theme?.id, siteId );
 
-		const themeType = config.isEnabled( 'themes/block-theme-previews' )
-			? getThemeType( state, themeId )
-			: undefined;
-
 		const isThemeInstalledOnAtomicSite = isAtomic && !! getTheme( state, siteId, themeId );
 
 		const isFullSiteEditingTheme = config.isEnabled( 'themes/block-theme-previews' )
@@ -1577,7 +1573,6 @@ export default connect(
 		return {
 			...theme,
 			themeId,
-			themeType,
 			price: getPremiumThemePrice( state, themeId, siteId ),
 			error,
 			siteId,
@@ -1604,6 +1599,7 @@ export default connect(
 			forumUrl: getThemeForumUrl( state, themeId, siteId ),
 			hasUnlimitedPremiumThemes: siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),
 			showTryAndCustomize: shouldShowTryAndCustomize( state, themeId, siteId ),
+			canUseTheme: getCanUseTheme( state, themeId, siteId ),
 			canUserUploadThemes: siteHasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
 			// Remove the trailing slash because the page URL doesn't have one either.
 			canonicalUrl: localizeUrl( englishUrl, getLocaleSlug(), false ).replace( /\/$/, '' ),

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -197,7 +197,7 @@ $theme-sheet-content-max-width: 1462px;
 			width: 100%;
 		}
 
-		button {
+		.button {
 			border-radius: 4px;
 
 			@include breakpoint-deprecated( "<960px" ) {

--- a/client/state/themes/selectors/is-full-site-editing-theme.ts
+++ b/client/state/themes/selectors/is-full-site-editing-theme.ts
@@ -11,7 +11,7 @@ export function isFullSiteEditingTheme(
 	if ( ! themeId ) {
 		return false;
 	}
-	const theme = getTheme( state, 'wpcom', themeId );
+	const theme = getTheme( state, 'wpcom', themeId ) || getTheme( state, 'wporg', themeId );
 	if ( ! theme ) {
 		return false;
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -197,7 +197,6 @@
 		"subscription-management/comments-list-controls": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews-poc": true,
 		"themes/block-theme-previews": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -134,7 +134,6 @@
 		"subscription-management/comments-list-controls": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews-poc": true,
 		"themes/block-theme-previews": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,

--- a/config/production.json
+++ b/config/production.json
@@ -161,7 +161,6 @@
 		"subscription-management/comments-list-controls": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews-poc": false,
 		"themes/block-theme-previews": false,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -154,7 +154,6 @@
 		"subscription-management/comments-list-controls": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews-poc": false,
 		"themes/block-theme-previews": false,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -166,7 +166,6 @@
 		"subscription-management/comments-list-controls": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews-poc": true,
 		"themes/block-theme-previews": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79218, https://github.com/Automattic/wp-calypso/pull/78456
## Proposed Changes

This PR adds the “Live Preview” button on the Theme Detail page.

- This PR focuses on adding the new button. I'll take care of other UI changes, such as hiding the "Open live demo" into three-dot and changing the copy of the "Open live demo".
- This PR is part of https://github.com/Automattic/wp-calypso/issues/79218. After finishing #79218, I'll address https://github.com/Automattic/wp-calypso/issues/79219.

| before | after |
|--------|--------|
| <img width="1438" alt="Screen Shot 2023-07-27 at 11 30 20" src="https://github.com/Automattic/wp-calypso/assets/5287479/e8754924-3a4f-4c33-8ff7-2bb1eeb369ce"> | <img width="1438" alt="Screen Shot 2023-07-27 at 11 30 12" src="https://github.com/Automattic/wp-calypso/assets/5287479/b6e4b923-433e-4082-b668-861648531c08"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Simple sites

- Patch D117384-code into your sandbox.
- Go to the Theme Showcase page.
- Click any theme and go to the Theme Detail page.
- See if clicking the "Live Preview" button redirects you to the Site Editor (Block Theme Previews).
	- You will not see the button when a theme is;
		- your active theme
		- is not FullSiteEditing compatible
		- a theme with a static page as a homepage 
		- a 3rd party theme
		- a premium theme
		- a woocommerce theme

Atomic sites

- Go to the Theme Showcase page.
- Click any theme and go to the Theme Detail page. 
- You must install a theme before using the Live Preview on Atomic sites. pbxlJb-3Uv-p2#known-issues
	- When you're using Calypso, activate it once and then reactivate the original theme. 
	- When you're using the classic view, just install it.
- See if clicking the "Live Preview" button redirects you to the Site Editor (Block Theme Previews).
	- You will not see the button when a theme is;
		- your active theme
		- is not FullSiteEditing compatible
		- a theme with a static page as a homepage 
		- not installed (not listed in "My Themes")

Please see pbxlJb-3Uv-p2#known-issues about unsupported themes. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?