### PR TITLE
Fix issue hiding blogging prompts card when on the site checklist view on my home

### DIFF
--- a/client/data/home/use-skip-current-view-mutation.ts
+++ b/client/data/home/use-skip-current-view-mutation.ts
@@ -39,9 +39,9 @@ function useSkipCurrentViewMutation< TData, TError >( siteId: number ): Result< 
 				},
 				{ query },
 				{
-					// Single card views are skipped by skipping the "view". These two endpoints allow skipping individual cards.
+					// Single card views are skipped by skipping the "view".
 					view: isSingleCardView ? view_name : undefined,
-					// temporarily prevent single card views from returning themself after skipping
+					// Prevents single card views from returning themself after skipping
 					card: isSingleCardView ? undefined : card,
 					...( reminder && { reminder } ),
 				}

--- a/client/data/home/use-skip-current-view-mutation.ts
+++ b/client/data/home/use-skip-current-view-mutation.ts
@@ -29,7 +29,7 @@ function useSkipCurrentViewMutation< TData, TError >( siteId: number ): Result< 
 			);
 
 			const view_name = ( data as any ).view_name;
-			const multipleCardViews = [ 'VIEW_POST_PUBLISH', 'VIEW_SITE_SETUP' ];
+			const multipleCardViews = [ 'VIEW_POST_LAUNCH', 'VIEW_SITE_SETUP' ];
 			const isSingleCardView = multipleCardViews.indexOf( view_name ) === -1;
 
 			return await wp.req.post(

--- a/client/data/home/use-skip-current-view-mutation.ts
+++ b/client/data/home/use-skip-current-view-mutation.ts
@@ -28,6 +28,10 @@ function useSkipCurrentViewMutation< TData, TError >( siteId: number ): Result< 
 				{ staleTime: Infinity }
 			);
 
+			const view_name = ( data as any ).view_name;
+			const multipleCardViews = [ 'VIEW_POST_PUBLISH', 'VIEW_SITE_SETUP' ];
+			const isSingleCardView = multipleCardViews.indexOf( view_name ) === -1;
+
 			return await wp.req.post(
 				{
 					path: `/sites/${ siteId }/home/layout/skip`,
@@ -35,9 +39,10 @@ function useSkipCurrentViewMutation< TData, TError >( siteId: number ): Result< 
 				},
 				{ query },
 				{
-					view: ( data as any ).view_name,
+					// Single card views are skipped by skipping the "view". These two endpoints allow skipping individual cards.
+					view: isSingleCardView ? view_name : undefined,
 					// temporarily prevent single card views from returning themself after skipping
-					card: ( data as any ).view_name === 'VIEW_POST_LAUNCH' ? card : undefined,
+					card: isSingleCardView ? undefined : card,
 					...( reminder && { reminder } ),
 				}
 			);


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/79380

This allows you to dismiss the blogging prompt card without also dismissing the onboarding checklist from my-home

### Code details
The code here is a little interesting basically as I understand it, there are three types of view.

* The `VIEW_SITE_SETUP` view which shows the site setup checklist
* Single card views such as the `VIEW_CELEBRATE_SITE_LAUNCH` view. They have one primary card
* The VIEW_POST_LAUNCH view which has the slider of advertisement style cards. This view cannot be skipped.

When dismissing a card, the `layout/skip` endpoint can be used in two ways:

Pass in a `card` and that `card` will be hidden.
Pass in a `view` and that `view` will be hidden.

We skipped single card views by passing the `view` to the API. So in effect, skipping a card and skipping a view were the same thing!

Prior to adding the blogging prompts card to the `VIEW_SITE_SETUP` view, that view had no skippable cards. The checklist items used a different endpoint to be dismissed.

So the bug appears when a skippable card (blogging prompts) was added to the `VIEW_SITE_SETUP` view. Dismissing this card would dismiss the whole view.

I was tempted to attempt to change the way that skipping cards and views works to make it more generic, but I think this is a simpler fix.

### Testing instructions

Reset calypso preferences to unhide all cards:
`wp user attribute delete <user_id> calypso_preferences`

Restore the site onboarding checklist:
`wp option delete --url=<site_slug> onboarding_checklist_completed`

With those commands you should be able to manually test this, different view types:
* Single card view. e.g. the post launch view which appears after launching a site.
* `VIEW_SITE_SETUP`
* `VIEW_POST_LAUNCH`