### PR TITLE
Jetpack Pro Dashboard: visually hide the label of the toggle control in the monitor notification settings popup.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/email-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/email-notification.tsx
@@ -44,6 +44,7 @@ export default function EmailNotification( {
 							setEnableEmailNotification( isEnabled );
 						} }
 						checked={ enableEmailNotification }
+						className="notification-settings__toggle-control"
 					/>
 				</div>
 				<div className="notification-settings__toggle-content">

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/mobile-push-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/mobile-push-notification.tsx
@@ -29,6 +29,7 @@ export default function MobilePushNotification( {
 						setEnableMobileNotification( isEnabled );
 					} }
 					checked={ enableMobileNotification }
+					className="notification-settings__toggle-control"
 				/>
 			</div>
 			<div className="notification-settings__toggle-content">

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
@@ -39,6 +39,7 @@ export default function SMSNotification( {
 						}
 						onChange={ handleToggleClick }
 						checked={ enableSMSNotification }
+						className="notification-settings__toggle-control"
 					/>
 				</div>
 				<div className="notification-settings__toggle-content">

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
@@ -151,3 +151,14 @@
 		margin-right: 7px;
 	}
 }
+
+// Visually hide the toggle control label by positioning
+// it far off-screen, making it effectively invisible.
+// It will be used by screen readers
+.notification-settings__toggle-control label {
+	position: absolute;
+	left: -9999px;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+}


### PR DESCRIPTION
Related to 1202619025189113-as-1205119881383168

## Proposed Changes

This [PR](https://github.com/Automattic/wp-calypso/pull/78711) added a label to the ToggleControl component, which broke the UI in the Jetpack Pro Dashboard(Downtime Monitor Notification Settings popup). So we have made some changes to visually hide the toggle control label by positioning it far off-screen, making it effectively invisible so that it will still be used by screen readers.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/url-support-open-license-info-popup` and `yarn start-jetpack-cloud` or open the Jetpack Cloud live link. 
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Verify the label for the mobile, push, and email notification toggle is no more visible.
6. Turn on the voiceover and verify that the toggle still reads the correct aria label.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="469" alt="Screenshot 2023-07-24 at 11 29 39 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/01c0edad-3536-4e3a-9858-1503f47251c0">
</td>
<td>
<img width="461" alt="Screenshot 2023-07-24 at 12 39 02 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e44daa2f-e480-427e-b58c-44c68f6318e3">
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?