### PR TITLE
`useSiteLogsQuery`: rework to remove `on*` handlers

### DIFF
--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -1,5 +1,5 @@
 import { UseQueryOptions, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 
 interface SiteLogsAPIResponse {
@@ -15,6 +15,7 @@ export type SiteLogsData = {
 	total_results: number;
 	logs: Record< string, unknown >[];
 	scroll_id: string | null;
+	has_more: boolean;
 };
 
 export type SiteLogsTab = 'php' | 'web';
@@ -35,7 +36,6 @@ export function useSiteLogsQuery(
 ) {
 	const queryClient = useQueryClient();
 	const [ scrollId, setScrollId ] = useState< string | undefined >();
-	const [ isFinishedPaging, setIsFinishedPaging ] = useState< boolean >( false );
 
 	// The scroll ID represents the state of a particular set of filtering arguments. If any of
 	// those filter arguments change we throw out the scroll ID so we can start over.
@@ -69,25 +69,16 @@ export function useSiteLogsQuery(
 				}
 			);
 		},
+		keepPreviousData: true,
 		enabled: !! siteId && params.start <= params.end,
 		staleTime: Infinity, // The logs within a specified time range never change.
 		select( { data } ) {
 			return {
 				...data,
+				has_more: !! data.scroll_id,
 				total_results:
 					typeof data.total_results === 'number' ? data.total_results : data.total_results.value,
 			};
-		},
-		onSuccess( data ) {
-			if ( data.scroll_id ) {
-				setScrollId( data.scroll_id );
-			} else {
-				setIsFinishedPaging( true );
-			}
-
-			if ( queryOptions.onSuccess ) {
-				return queryOptions.onSuccess( data );
-			}
 		},
 		meta: {
 			persist: false,
@@ -95,13 +86,20 @@ export function useSiteLogsQuery(
 		...queryOptions,
 	} );
 
+	const { data } = queryResult;
+
+	useEffect( () => {
+		if ( data?.has_more && scrollId !== data.scroll_id ) {
+			setScrollId( data.scroll_id ?? undefined );
+		}
+	}, [ data, scrollId ] );
+
 	// The state represented by scroll ID will have already advanced to the next page, so we
 	// can't allow `refetch` to be used. Remember, the logs are fetched with a POST and the
 	// requests are not idempotent.
 	const { refetch, ...remainingQueryResults } = queryResult;
 
 	return {
-		isFinishedPaging,
 		...remainingQueryResults,
 	};
 }

--- a/client/my-sites/site-logs/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/index.tsx
@@ -1,3 +1,4 @@
+import { usePrevious } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { memo, useMemo } from 'react';
@@ -12,22 +13,25 @@ type SiteLogs = SiteLogsData[ 'logs' ];
 
 interface SiteLogsTableProps {
 	logs?: SiteLogs;
+	logType?: string;
 	isLoading?: boolean;
 }
 
 export const SiteLogsTable = memo( function SiteLogsTable( {
 	logs,
+	logType,
 	isLoading,
 }: SiteLogsTableProps ) {
 	const { __ } = useI18n();
 	const columns = useSiteColumns( logs );
 	const siteGmtOffset = useCurrentSiteGmtOffset();
+	const previousLogType = usePrevious( logType );
 
 	const logsWithKeys = useMemo( () => {
 		return generateRowKeys( logs );
 	}, [ logs ] );
 
-	if ( isLoading && ! logsWithKeys.length ) {
+	if ( isLoading && logType !== previousLogType ) {
 		return <Skeleton />;
 	}
 

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -2,18 +2,14 @@ import { ToggleControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import Pagination from 'calypso/components/pagination';
-import {
-	SiteLogsData,
-	SiteLogsTab,
-	useSiteLogsQuery,
-} from 'calypso/data/hosting/use-site-logs-query';
+import { SiteLogsTab, useSiteLogsQuery } from 'calypso/data/hosting/use-site-logs-query';
 import { useInterval } from 'calypso/lib/interval';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -55,7 +51,7 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 
 	const [ logType, setLogType ] = useState< SiteLogsTab >( () => getLogTypeQueryParam() || 'php' );
 
-	const { data: latestPageData, isLoading } = useSiteLogsQuery( siteId, {
+	const { data, isInitialLoading, isFetching } = useSiteLogsQuery( siteId, {
 		logType,
 		start: dateRange.startTime.unix(),
 		end: dateRange.endTime.unix(),
@@ -75,18 +71,9 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 	}, [ getLatestDateRange ] );
 	useInterval( autoRefreshCallback, autoRefresh && 10 * 1000 );
 
-	// We keep a copy of the most recently shown page so that we can use it as part of the loading state while switching pages.
-	const [ data, setCachedPageData ] = useState< SiteLogsData | undefined >();
-	useEffect( () => {
-		if ( ! isLoading ) {
-			setCachedPageData( latestPageData );
-		}
-	}, [ latestPageData, isLoading ] );
-
 	const handleTabSelected = ( tabName: SiteLogsTab ) => {
 		setLogType( tabName );
 		setCurrentPageIndex( 0 );
-		setCachedPageData( undefined );
 	};
 
 	const handleAutoRefreshClick = ( isChecked: boolean ) => {
@@ -102,7 +89,7 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 	};
 
 	const handlePageClick = ( nextPageNumber: number ) => {
-		if ( isLoading ) {
+		if ( isInitialLoading ) {
 			return;
 		}
 
@@ -145,7 +132,7 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 	};
 
 	return (
-		<Main fullWidthLayout className={ classnames( 'site-logs', { 'is-loading': isLoading } ) }>
+		<Main fullWidthLayout className={ classnames( 'site-logs', { 'is-loading': isFetching } ) }>
 			<DocumentHead title={ titleHeader } />
 			{ siteId && <QuerySiteSettings siteId={ siteId } /> }
 			<FormattedHeader
@@ -172,7 +159,7 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 							endDateTime={ dateRange.endTime }
 							onDateTimeChange={ handleDateTimeChange }
 						/>
-						<SiteLogsTable logs={ data?.logs } isLoading={ isLoading } />
+						<SiteLogsTable logs={ data?.logs } logType={ logType } isLoading={ isFetching } />
 						{ paginationText && (
 							<div className="site-logs__pagination-text">{ paginationText }</div>
 						) }


### PR DESCRIPTION
## Proposed Changes

With the upcoming v5 of RQ `onSuccess`, `onError`, `onSettled` are removed from `useQuery` hooks. This PR removes those handlers from `useSiteLogsQuery` in preparation for the upgrade.

After removing the handlers I did a few more optimizations, mainly adding `keepPreviousData` to let RQ handle the pagination instead of doing our own version of it. All other refactors are a direct consequence of this change.

## Testing Instructions

* Go to `/site-logs/:site-slug` (I think this is only for sites which have hosting features or are AT)
* Verify the site logs feature works exactly as it does on prod (pagination buttons appear on the bottom of the page as soon as more than 50 entries are shown, you may need to tweak the time range settings).
