### PR TITLE
Send Tracks events on Logged-out Navbar link clicks

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import page from 'page';
 import { ClickableItemProps, MenuItemProps } from '../types';
 
 export const NonClickableItem = ( { content, className }: MenuItemProps ) => {
@@ -43,9 +42,11 @@ const clickNavLinkEvent = ( target: HTMLElement ) => {
 	props.target = target.getAttribute( 'target' ) || '';
 	props.text = target.innerText || '';
 
-	const currentPage = page.current || '';
-	props.path = currentPage || '';
-	props.lp_name = currentPage.replace( /^\//, '' );
+	if ( typeof window !== 'undefined' && window.location ) {
+		const currentPage = window.location.pathname || '';
+		props.lp_name = currentPage.replace( /^\//, '' );
+		props.path = props.lp_name;
+	}
 
 	recordTracksEvent( 'calypso_link_click', props );
 };

--- a/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
@@ -1,3 +1,5 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import page from 'page';
 import { ClickableItemProps, MenuItemProps } from '../types';
 
 export const NonClickableItem = ( { content, className }: MenuItemProps ) => {
@@ -6,6 +8,46 @@ export const NonClickableItem = ( { content, className }: MenuItemProps ) => {
 			{ content } <span className="x-nav-link-chevron" aria-hidden="true"></span>
 		</button>
 	);
+};
+
+const getParentElement = ( node: HTMLElement | null, pattern: RegExp ) => {
+	let parent = node;
+	while ( parent && ! parent.className.match( pattern ) ) {
+		if ( parent === document.body ) {
+			return null;
+		}
+		parent = parent.parentElement;
+	}
+
+	return parent;
+};
+
+const clickNavLinkEvent = ( target: HTMLElement ) => {
+	const props: { [ key: string ]: string | number } = {};
+
+	const container = getParentElement( target, /container/ );
+	const section = getParentElement( target, /section/ );
+
+	props.container_id = container?.id || '';
+	props.container_class = container?.className || '';
+	props.container = props.container_id || props.container_class || '';
+
+	props.section_id = section?.id || '';
+	props.section_class = section?.className || '';
+	props.section = props.section_id || props.section_class || '';
+
+	props.id = target.id || '';
+	props.class = target.className || '';
+
+	props.href = target.getAttribute( 'href' ) || '';
+	props.target = target.getAttribute( 'target' ) || '';
+	props.text = target.innerText || '';
+
+	const currentPage = page.current || '';
+	props.path = currentPage || '';
+	props.lp_name = currentPage.replace( /^\//, '' );
+
+	recordTracksEvent( 'calypso_link_click', props );
 };
 
 export const ClickableItem = ( {
@@ -24,6 +66,11 @@ export const ClickableItem = ( {
 	if ( className ) {
 		liClassName = liClassName + ' ' + className;
 	}
+
+	const onClick = ( event: React.MouseEvent< HTMLElement > ) => {
+		const target = event.currentTarget;
+		clickNavLinkEvent( target );
+	};
 	return (
 		<li className={ liClassName }>
 			<a
@@ -33,6 +80,7 @@ export const ClickableItem = ( {
 				title={ titleValue }
 				tabIndex={ -1 }
 				target={ target }
+				onClick={ onClick }
 			>
 				{ content }
 			</a>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
More info: pduY5I-wJ-p2#comment-326

## Proposed Changes

This triggers a `calypso_link_click` Tracks event for the links in the Logged Out Navigation bar.
The event contains a few common properties that the equivalent `wpcom_link_click` has. More props can be added as follow-ups.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you're logged out
* Visit /plugins and /themes
* Click on any of the Navigation Links
<img width="340" alt="Screenshot 2023-07-24 at 14 25 21" src="https://github.com/Automattic/wp-calypso/assets/2749938/4cc6801e-24cc-4c11-b7ec-53a54679ae75">
<img width="340" alt="Screenshot 2023-07-24 at 14 25 11" src="https://github.com/Automattic/wp-calypso/assets/2749938/886f9825-84e9-4ce7-93ee-9b9d9283e260">

* Ensure `calypso_link_click` events are sent for each click
<img width="340" alt="Screenshot 2023-07-24 at 14 15 57" src="https://github.com/Automattic/wp-calypso/assets/2749938/f33a140c-325f-4f7f-90d3-f5e2a5611b99">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
