### PR TITLE
Make the domain tip dismissible

### DIFF
--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -9,7 +9,15 @@ import { isCardDismissed } from './selectors';
 
 import './style.scss';
 
-function DismissibleCard( { className, highlight, temporary, onClick, preferenceName, children } ) {
+function DismissibleCard( {
+	className,
+	highlight,
+	temporary,
+	onClick,
+	preferenceName,
+	href,
+	children,
+} ) {
 	const isDismissed = useSelector( isCardDismissed( preferenceName ) );
 	const hasReceivedPreferences = useSelector( hasReceivedRemotePreferences );
 	const dispatch = useDispatch();
@@ -25,7 +33,7 @@ function DismissibleCard( { className, highlight, temporary, onClick, preference
 	}
 
 	return (
-		<Card className={ className } highlight={ highlight }>
+		<Card className={ className } highlight={ highlight } href={ href } showLinkIcon={ false }>
 			<QueryPreferences />
 			<button
 				className="dismissible-card__close-button"
@@ -45,6 +53,7 @@ DismissibleCard.propTypes = {
 	temporary: PropTypes.bool,
 	onClick: PropTypes.func,
 	preferenceName: PropTypes.string.isRequired,
+	href: PropTypes.string,
 };
 
 export default DismissibleCard;

--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -30,6 +30,7 @@ function DismissibleCard( {
 	function handleClick( event ) {
 		onClick?.( event );
 		dispatch( dismissCard( preferenceName, temporary ) );
+		event.preventDefault();
 	}
 
 	return (

--- a/client/blocks/domain-tip/index.jsx
+++ b/client/blocks/domain-tip/index.jsx
@@ -78,6 +78,8 @@ class DomainTip extends Component {
 				<QueryDomainsSuggestions { ...this.props.queryObject } />
 				<UpsellNudge
 					event={ `domain_tip_${ this.props.event }` }
+					dismissPreferenceName="calypso_domain_tip_dismiss"
+					dismissWithoutSavingPreference={ true }
 					tracksImpressionName="calypso_upgrade_nudge_impression"
 					tracksClickName="calypso_upgrade_nudge_cta_click"
 					feature={ FEATURE_CUSTOM_DOMAIN }

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -306,7 +306,7 @@ export class Banner extends Component {
 			{ 'is-jetpack': jetpack },
 			{ 'is-atomic': isAtomic }
 		);
-
+		const href = ( disableHref || callToAction ) && ! forceHref ? null : this.getHref();
 		if ( dismissPreferenceName ) {
 			return (
 				<DismissibleCard
@@ -314,6 +314,7 @@ export class Banner extends Component {
 					preferenceName={ dismissPreferenceName }
 					temporary={ dismissTemporary }
 					onClick={ this.handleDismiss }
+					href={ href }
 				>
 					{ this.getIcon() }
 					{ this.getContent() }
@@ -324,7 +325,7 @@ export class Banner extends Component {
 		return (
 			<Card
 				className={ classes }
-				href={ ( disableHref || callToAction ) && ! forceHref ? null : this.getHref() }
+				href={ href }
 				onClick={ callToAction && ! forceHref ? null : this.handleClick }
 				displayAsLink={ displayAsLink }
 				showLinkIcon={ showLinkIcon }


### PR DESCRIPTION
Per @simison's request. There's no particular reason why this particular tip should not be dismissible other than maybe looking uglier with the x.

In case a person doesn't want to use a custom domain, they should be able to dismiss the ad to never see it again.

Note that this tip might be a good fit to be a JITM

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Before:
<img width="1175" alt="Screenshot 2023-07-24 at 16 06 13" src="https://github.com/Automattic/wp-calypso/assets/82778/c922e0ba-034b-4c49-b859-746bc79b26ae">

After:
<img width="1175" alt="Screenshot 2023-07-24 at 16 05 48" src="https://github.com/Automattic/wp-calypso/assets/82778/9b20a89a-8ff4-42ad-87b8-e7fffa6ca023">

## Testing Instructions

1. With the store sandbox enabled, purchase a plan but not a domain
2. Go to /stats/insights/

The upsell should be dismissible

Once the setting is persisted, it can be reset with wpsh, details in 31588-pb

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
