### PR TITLE
`blocks/user-mentions`: fix ref and other warnings

### DIFF
--- a/client/blocks/user-mentions/connect.jsx
+++ b/client/blocks/user-mentions/connect.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
-import { PureComponent, Fragment } from 'react';
-import { connect } from 'react-redux';
+import { forwardRef } from 'react';
+import { useSelector } from 'react-redux';
 import QueryUsersSuggestions from 'calypso/components/data/query-users-suggestions';
 import { getUserSuggestions } from 'calypso/state/user-suggestions/selectors';
 
@@ -13,27 +13,23 @@ import { getUserSuggestions } from 'calypso/state/user-suggestions/selectors';
  * @returns {Object} the enhanced component
  */
 const connectUserMentions = ( WrappedComponent ) => {
-	class connectUserMentionsFetcher extends PureComponent {
-		static propTypes = {
-			siteId: PropTypes.number,
-		};
-
-		render() {
-			return (
-				<Fragment>
-					<QueryUsersSuggestions siteId={ this.props.siteId } />
-					<WrappedComponent { ...this.props } />
-				</Fragment>
-			);
-		}
+	function ConnectUserMentionsFetcher( { siteId, forwardedRef, ...rest } ) {
+		const suggestions = useSelector( ( state ) => getUserSuggestions( state, siteId ) );
+		return (
+			<>
+				<QueryUsersSuggestions siteId={ siteId } />
+				<WrappedComponent suggestions={ suggestions } ref={ forwardedRef } { ...rest } />
+			</>
+		);
 	}
 
-	return connect( ( state, ownProps ) => {
-		return {
-			siteId: ownProps.siteId,
-			suggestions: getUserSuggestions( state, ownProps.siteId ),
-		};
-	} )( connectUserMentionsFetcher );
+	ConnectUserMentionsFetcher.propTypes = {
+		siteId: PropTypes.number,
+	};
+
+	return forwardRef( ( props, ref ) => (
+		<ConnectUserMentionsFetcher { ...props } forwardedRef={ ref } />
+	) );
 };
 
 export default connectUserMentions;

--- a/client/blocks/user-mentions/index.jsx
+++ b/client/blocks/user-mentions/index.jsx
@@ -1,5 +1,4 @@
-import PropTypes from 'prop-types';
-import { PureComponent, forwardRef } from 'react';
+import { forwardRef } from 'react';
 import addUserMentions from './add';
 import connectUserMentions from './connect';
 
@@ -11,14 +10,8 @@ import connectUserMentions from './connect';
  * @returns {Object} the enhanced component
  */
 const withUserMentions = ( WrappedComponent ) => {
-	class TextInputWrapper extends PureComponent {
-		static propTypes = {
-			siteId: PropTypes.number,
-		};
-
-		render() {
-			return <WrappedComponent { ...this.props } ref={ this.props.forwardedRef } />;
-		}
+	function TextInputWrapper( { siteId, forwardedRef, ...rest } ) {
+		return <WrappedComponent { ...rest } ref={ forwardedRef } />;
 	}
 
 	return connectUserMentions(


### PR DESCRIPTION
fixes #79726

## Proposed Changes

* Properly forward refs, don't forward just any props and migrate class components to functional components

## Testing Instructions

* Verify all 3 warnings described in #79726 are gone

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
