### PR TITLE
WPCOM Proxy Request: Avoid window in module initialization

### DIFF
--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -12,11 +12,6 @@ const debug = debugFactory( 'wpcom-proxy-request' );
  */
 const proxyOrigin = 'https://public-api.wordpress.com';
 
-/**
- * "Origin" of the current HTML page.
- */
-const origin = window.location.protocol + '//' + window.location.host;
-
 let onStreamRecord = null;
 
 /**
@@ -82,14 +77,6 @@ let buffered;
 const requests = {};
 
 /**
- * Are HTML5 XMLHttpRequest2 "progress" events supported?
- * See: http://goo.gl/xxYf6D
- */
-const supportsProgress = !! window.ProgressEvent && !! window.FormData;
-
-debug( 'using "origin": %o', origin );
-
-/**
  * Performs a "proxied REST API request". This happens by calling
  * `iframe.postMessage()` on the proxy iframe instance, which from there
  * takes care of WordPress.com user authentication (via the currently
@@ -114,7 +101,7 @@ const makeRequest = ( originalParams, fn ) => {
 	params.callback = id;
 	params.supports_args = true; // supports receiving variable amount of arguments
 	params.supports_error_obj = true; // better Error object info
-	params.supports_progress = supportsProgress; // supports receiving XHR "progress" events
+	params.supports_progress = true; // supports receiving XHR "progress" events
 
 	// force uppercase "method" since that's what the <iframe> is expecting
 	params.method = String( params.method || 'GET' ).toUpperCase();
@@ -306,6 +293,9 @@ function install() {
 
 	// create the <iframe>
 	iframe = document.createElement( 'iframe' );
+
+	const origin = window.location.origin;
+	debug( 'using "origin": %o', origin );
 
 	// set `src` and hide the iframe
 	iframe.src = proxyOrigin + '/wp-admin/rest-proxy/?v=2.0#' + origin;


### PR DESCRIPTION
Extracted from https://github.com/Automattic/wp-calypso/pull/79741

This updates wpcom-proxy-request to not reference `window` in its module initialization code. Which in turns makes SSR happy.

Without it, if this code is referenced during SSR (like what happens in #79741, it seems), there's an error during startup:

```
/Users/klimeryk/work/workspace/calypso/build/webpack:/wp-calypso/packages/wpcom-proxy-request/src/index.js:18
const origin = window?.location?.protocol + '//' + window?.location?.host;
               ^
ReferenceError: window is not defined
    at Object../client/components/inline-support-link/index.jsx (/Users/klimeryk/work/workspace/calypso/build/webpack:/wp-calypso/packages/wpcom-proxy-request/src/index.js:18:16)
    at __webpack_require__ (/Users/klimeryk/work/workspace/calypso/build/webpack:/wp-calypso/webpack/bootstrap:19:1)
    at Object../client/my-sites/plugins/index.node.js (/Users/klimeryk/work/workspace/calypso/build/server.js:45587:27)
    at __webpack_require__ (/Users/klimeryk/work/workspace/calypso/build/webpack:/wp-calypso/webpack/bootstrap:19:1)
    at Object.load (/Users/klimeryk/work/workspace/calypso/build/webpack:/wp-calypso/client/sections.js:146:17)
    at forEach (/Users/klimeryk/work/workspace/calypso/build/webpack:/wp-calypso/client/server/pages/index.js:908:13)
    at Array.forEach (<anonymous>)
    at pages (/Users/klimeryk/work/workspace/calypso/build/webpack:/wp-calypso/client/server/pages/index.js:899:4)
    at boot (/Users/klimeryk/work/workspace/calypso/build/webpack:/wp-calypso/client/server/boot/index.js:96:11)
    at /Users/klimeryk/work/workspace/calypso/build/webpack:/wp-calypso/client/server/index.js:14:13

```

## Proposed Changes

* Inline references to `window` to place them next to their usage and remove from module initialization.

## Testing Instructions

I'm not sure - this code is the backbone of many things across Calypso. I'd hope that if something broke, it'd be painfully and immediately obvious 😬 