### PR TITLE
Subscriptions Management: Add search term url support.

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscriptions-list-actions-bar.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscriptions-list-actions-bar.tsx
@@ -5,7 +5,7 @@ import { useMemo } from 'react';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { SearchIcon } from 'calypso/landing/subscriptions/components/icons';
 import { SortControls, Option } from 'calypso/landing/subscriptions/components/sort-controls';
-import { getOptionLabel } from 'calypso/landing/subscriptions/helpers';
+import { getOptionLabel, getUrlQuerySearchTerm } from 'calypso/landing/subscriptions/helpers';
 import { useSiteSubscriptionsFilterOptions } from 'calypso/landing/subscriptions/hooks/';
 import './styles/site-subscriptions-list-actions-bar.scss';
 
@@ -16,6 +16,8 @@ const getSortOptions = ( translate: ReturnType< typeof useTranslate > ) => [
 	{ value: SortBy.DateSubscribed, label: translate( 'Recently subscribed' ) },
 	{ value: SortBy.SiteName, label: translate( 'Site name' ) },
 ];
+
+const initialUrlQuerySearchTerm = getUrlQuerySearchTerm();
 
 const ListActionsBar = () => {
 	const translate = useTranslate();
@@ -31,6 +33,7 @@ const ListActionsBar = () => {
 				placeholder={ translate( 'Search by site name or address…' ) }
 				searchIcon={ <SearchIcon size={ 18 } /> }
 				onSearch={ setSearchTerm }
+				defaultValue={ initialUrlQuerySearchTerm }
 			/>
 
 			<SelectDropdown

--- a/client/landing/subscriptions/helpers/index.ts
+++ b/client/landing/subscriptions/helpers/index.ts
@@ -1,4 +1,10 @@
+import { getQueryArgs } from '@wordpress/url';
 import type { Option } from 'calypso/landing/subscriptions/components/sort-controls';
 
 export const getOptionLabel = < T >( options: Option< T >[], value: T ) =>
 	options.find( ( option ) => option.value === value )?.label;
+
+export const getUrlQuerySearchTerm = () => {
+	const { s: urlQuerySearchTerm } = getQueryArgs( window.location.href );
+	return urlQuerySearchTerm as string;
+};

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { getQueryString } from '@wordpress/url';
 import i18n from 'i18n-calypso';
 import page from 'page';
 import AsyncLoad from 'calypso/components/async-load';
@@ -10,7 +11,8 @@ const analyticsPageTitle = 'Reader';
 const exported = {
 	followingManage( context, next ) {
 		if ( isEnabled( 'subscription-management-redirect-following' ) ) {
-			return page.redirect( '/read/subscriptions' );
+			const queryString = getQueryString( window.location.href );
+			return page.redirect( '/read/subscriptions' + ( queryString ? '?' + queryString : '' ) );
 		}
 
 		const basePath = sectionify( context.path );

--- a/client/reader/site-subscriptions-manager/reader-site-subscriptions.tsx
+++ b/client/reader/site-subscriptions-manager/reader-site-subscriptions.tsx
@@ -57,9 +57,7 @@ const ReaderSiteSubscriptions = () => {
 
 	// Update url query when search term changes
 	useEffect( () => {
-		if ( debouncedSearchTerm ) {
-			setUrlQuery( SEARCH_KEY, debouncedSearchTerm );
-		}
+		setUrlQuery( SEARCH_KEY, debouncedSearchTerm );
 	}, [ debouncedSearchTerm ] );
 
 	useEffect( () => {

--- a/client/reader/site-subscriptions-manager/reader-site-subscriptions.tsx
+++ b/client/reader/site-subscriptions-manager/reader-site-subscriptions.tsx
@@ -1,5 +1,7 @@
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
+import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useEffect } from 'react';
 import { useDebounce } from 'use-debounce';
 import { UnsubscribedFeedsSearchList } from 'calypso/blocks/reader-unsubscribed-feeds-search-list';
@@ -7,6 +9,7 @@ import {
 	SiteSubscriptionsList,
 	SiteSubscriptionsListActionsBar,
 } from 'calypso/landing/subscriptions/components/site-subscriptions-list';
+import { getUrlQuerySearchTerm } from 'calypso/landing/subscriptions/helpers';
 import {
 	useRecordSearchPerformed,
 	useRecordSearchByUrlPerformed,
@@ -15,9 +18,23 @@ import { resemblesUrl } from 'calypso/lib/url';
 import { RecommendedSites } from '../recommended-sites';
 import NotFoundSiteSubscriptions from './not-found-site-subscriptions';
 
+const SEARCH_KEY = 's';
+
+const setUrlQuery = ( key: string, value: string ) => {
+	const path = window.location.pathname + window.location.search;
+
+	if ( ! value ) {
+		return page.show( removeQueryArgs( path, key ) );
+	}
+
+	return page.show( addQueryArgs( path, { [ key ]: value } ) );
+};
+
+const initialUrlQuerySearchTerm = getUrlQuerySearchTerm();
+
 const ReaderSiteSubscriptions = () => {
 	const translate = useTranslate();
-	const { searchTerm } = SubscriptionManager.useSiteSubscriptionsQueryProps();
+	const { searchTerm, setSearchTerm } = SubscriptionManager.useSiteSubscriptionsQueryProps();
 	const siteSubscriptionsQuery = SubscriptionManager.useSiteSubscriptionsQuery();
 	const unsubscribedFeedsSearch = Reader.useUnsubscribedFeedsSearch();
 
@@ -28,6 +45,22 @@ const ReaderSiteSubscriptions = () => {
 	const recordSearchByUrlPerformed = useRecordSearchByUrlPerformed();
 
 	const [ debouncedSearchTerm ] = useDebounce( searchTerm, 600 );
+
+	// Takes the ?s= url query search term and set it to the subscriptions query.
+	useEffect( () => {
+		if ( initialUrlQuerySearchTerm ) {
+			setSearchTerm( initialUrlQuerySearchTerm as string );
+		}
+		// This should only run once
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	// Update url query when search term changes
+	useEffect( () => {
+		if ( debouncedSearchTerm ) {
+			setUrlQuery( SEARCH_KEY, debouncedSearchTerm );
+		}
+	}, [ debouncedSearchTerm ] );
 
 	useEffect( () => {
 		if ( debouncedSearchTerm ) {


### PR DESCRIPTION
## Proposed Changes

This PR adds url query support for search term`?s=`.

* When user enters `/following/manage?s=mysite.wordpress.com`:
  * redirect user to `/read/subscriptions?s=mysite.wordpress.com`.
* When user enters `/read/subscriptions?s=foobar`:
  * set `foobar` as initial value on search input.
  * automatically start searching for subscriptions using the `foobar` keyword.
* When user enters a keyword in the search input:
  * update the url query `?s=` with the new keyword.

## Testing Instructions

**Test redirection:**
1. Enter`/following/manage?s=mysite.wordpress.com`.
2. You should be redirected to `/read/subscriptions?s=mysite.wordpress.com`.
3. The subscription list should show the site that you're subscribed to.

**Test initial search term from url:**
1. Enter`/read/subscriptions?s=your_keyword_here`.
2. The search input should contain `your_keyword_here`.
3. The subscription list should automatically search and show results matching `your_keyword_here`.

**Test url param update:**
1. Enter any keyword in the search input.
2. The url param `?s=` on the address bar should update to reflect the latest keyword.

**Test url param clearing:**
1. Clear the search input by backspace or pressing the X button.
2. The url param `?s=` on the address bar should now disappear.

## Known issues

Pressing the Back button doesn't update the search input or the search results. This bug also exists in the existing Posts page and Subscribers page that's why I did not work on this here.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
