### PR TITLE
Launchpad: Add action for "Customize welcome message" task

### DIFF
--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
+import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { useSiteOption } from 'calypso/state/sites/hooks';
 import { SubscriptionOptions } from '../settings-reading/main';
@@ -50,12 +51,16 @@ export const NewsletterSettingsSection = ( {
 	// This makes sure the form fields hold the current value after saving.
 	useEffect( () => {
 		updateFields( { subscription_options: savedSubscriptionOptions } );
+
+		// If the URL has a hash, scroll to it.
+		scrollToAnchor( { offset: 15 } );
 	}, [ savedSubscriptionOptions ] );
 
 	return (
 		<>
 			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
 			<SettingsSectionHeader
+				id="newsletter-settings"
 				title={ translate( 'Newsletter settings' ) }
 				showButton
 				onButtonClick={ handleSubmitForm }

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -72,6 +72,11 @@ export const setUpActionsForTasks = ( {
 					window.location.assign( `/page/${ siteSlug }/${ task?.extra_data?.about_page_id }` );
 				};
 				break;
+			case 'customize_welcome_message':
+				action = () => {
+					window.location.assign( `/settings/reading/${ siteSlug }#newsletter-settings` );
+				};
+				break;
 		}
 
 		const actionDispatch = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79563

## Proposed Changes

* Combined with https://github.com/Automattic/jetpack/pull/32034, this adds the action/handler for the "Customize welcome message" task for the Newsletter paid and free post-launch task lists.
* Link to an in-page anchor `newsletter-settings` under `/settings/reading` and scroll directly to it when a user clicks on the task.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Apply the Jetpack patch to your sandbox: https://github.com/Automattic/jetpack/pull/32034
* Sandbox `public-api.wordpress.com`
* Since we don't yet have a frontend component for the newsletter task lists, you can add this task to the `keep-building` task list on your sandbox in `launchpad.php` to test it:
```
                        'task_ids'            => array(
				'site_title',
				'domain_claim',
				'verify_email',
				'domain_customize',
				'add_new_page',
				'drive_traffic',
				'edit_page',
				'share_site',
				'customize_welcome_message',
			),
```
* Create a new site from `/start` with the "Promote myself or business" intent
* Launch the site
* The last task in the list should be "Customize welcome message":

<img width="728" alt="Screenshot 2023-07-24 at 12 13 03 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/e34f1c5e-21a5-460e-ad8c-4625d28f6ba7">

* Click on the task to go to the Settings -> Reading screen; you should be brought right to the Newsletter settings:

<img width="740" alt="Screenshot 2023-07-24 at 12 07 02 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/23ddf9db-8955-41b7-8c28-d3cdbb715791">

* Change the value of the "Confirmation email message" textarea and save settings.
* Return to `/home`; you should see the task at the top of the list, marked completed:

<img width="696" alt="Screenshot 2023-07-24 at 12 07 36 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/e64f3c6c-fe3e-4138-af22-3dc18d13c41a">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
