### PR TITLE
Domain Transfers: Updated first and second input placeholder text and colors

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -177,7 +177,7 @@ export function DomainCodePair( {
 							id={ id }
 							value={ domain }
 							className="domains__domain-name-input-field"
-							placeholder={ __( 'Please enter the domain name and authorization code.' ) }
+							placeholder={ __( 'example.com' ) }
 							onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
 								onChange( id, {
 									domain: event.target.value.trim().toLowerCase(),
@@ -228,6 +228,7 @@ export function DomainCodePair( {
 							id={ id + '-auth' }
 							disabled={ valid || hasDuplicates }
 							value={ auth }
+							placeholder="123"
 							onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
 								onChange( id, {
 									domain,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -209,15 +209,6 @@
 
 	.domains__domain-domain {
 		flex: 0 0 420px;
-
-		.form-text-input::placeholder {
-			color: var(--gray-gray-20, #a7aaad);
-			font-size: 0.875rem;
-		}
-
-		@media (max-width: $break-medium ) {
-			flex: 1;
-		}
 	}
 
 	.domains__domain-key {
@@ -231,9 +222,17 @@
 		.info-popover:focus {
 			outline: 1px solid var(--studio-blue-50);
 		}
+	}
 
+	.domains__domain-domain,
+	.domains__domain-key {
 		@media (max-width: $break-medium ) {
 			flex: 1;
+		}
+
+		.form-text-input::placeholder {
+			color: var(--gray-gray-20, #a7aaad) !important;
+			font-size: 0.875rem;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 3173-gh-Automattic/dotcom-forge

## Proposed Changes

* Updated placeholder text
* Updated placeholder colors

<img width="935" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/9265ea65-64c7-4cb2-89f0-a1576c6ec214">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open [the domain transfer](http://calypso.localhost:3000/setup/domain-transfer/domains) and ensure it matches Figma (available at related card)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?