### PR TITLE
Launchpad: Add task counter

### DIFF
--- a/packages/launchpad/src/checklist-item/index.tsx
+++ b/packages/launchpad/src/checklist-item/index.tsx
@@ -17,6 +17,10 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 		actionDispatch && actionDispatch();
 	};
 
+	// Display task counter if task is incomplete and has the count properties;
+	const shouldDisplayTaskCounter =
+		! completed && task.target_repetitions && null !== task.repetition_count;
+
 	return (
 		<li
 			className={ classnames( 'checklist-item__task', {
@@ -55,6 +59,11 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 					) }
 					<span className="checklist-item__text">{ title }</span>
 					{ task.badge_text ? <Badge type="info-blue">{ task.badge_text }</Badge> : null }
+					{ shouldDisplayTaskCounter && (
+						<span className="checklist-item__counter">
+							{ task.repetition_count }/{ task.target_repetitions }
+						</span>
+					) }
 					{ shouldDisplayChevron && (
 						<Gridicon
 							aria-label={ translate( 'Task enabled' ) }

--- a/packages/launchpad/src/checklist-item/index.tsx
+++ b/packages/launchpad/src/checklist-item/index.tsx
@@ -19,7 +19,9 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 
 	// Display task counter if task is incomplete and has the count properties;
 	const shouldDisplayTaskCounter =
-		! completed && task.target_repetitions && null !== task.repetition_count;
+		task.target_repetitions &&
+		null !== task.repetition_count &&
+		undefined !== task.repetition_count;
 
 	return (
 		<li

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -75,6 +75,8 @@
 // general styles
 .checklist-item__text {
 	font-weight: 600;
+	flex-grow: 1;
+	text-align: left;
 }
 
 .checklist-item__subtext {
@@ -163,14 +165,17 @@
 .checklist-item__chevron {
 	display: flex;
 	line-height: 20px;
-	text-align: left;
 	width: 30px;
-	margin-left: auto;
 }
 
 .gridicon.checklist-item__chevron {
-	top: 0;
+	top: 2px;
 	margin-top: 0;
+}
+
+.checklist-item__counter {
+	margin-right: 5px;
+	font-weight: 600;
 }
 
 .checklist-item__checklist-primary-button {

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -133,6 +133,11 @@
 	.checklist-item__checkmark {
 		fill: var(--studio-gray-50);
 	}
+	.checklist-item__counter {
+		color: var(--studio-gray-50);
+		font-weight: 400;
+		margin-right: 0;
+	}
 }
 
 // pending tasks and completed enabled

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -174,7 +174,7 @@
 }
 
 .checklist-item__counter {
-	margin-right: 5px;
+	margin-right: 1em;
 	font-weight: 600;
 }
 

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -11,6 +11,8 @@ export interface Task {
 	actionDispatch?: () => void;
 	isLaunchTask?: boolean;
 	extra_data?: TaskExtraData;
+	target_repetitions?: number;
+	repetition_count?: number;
 }
 
 export type LaunchpadChecklist = Task[];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79611

## Proposed Changes

Some of the new tasks for the Newsletter task lists require the same action to be repeated several times, for example, the "Write 3 posts" task, which requires the user to write three posts to mark it as complete. We decided then to add the counter props(link below). This PR simply displays these options on the front end.

I also changed the styles of the task list. I removed the margin from the caret and made the title `grow:1`. This will automatically push everything to the right side of the component screen.

Before: 

https://github.com/Automattic/wp-calypso/assets/1234758/3d7aafd2-aef6-4f27-b218-e2774e6b1870

After:

https://github.com/Automattic/wp-calypso/assets/1234758/5bef1ab1-0581-44bc-9fa7-b1db336ae6e9

Related to:
* https://github.com/Automattic/jetpack/pull/31970
* 
![Screen Shot 2023-07-26 at 14 17 24](https://github.com/Automattic/wp-calypso/assets/1234758/357cb825-d1ef-4544-9632-02b17e84b423)

![Screen Shot 2023-07-31 at 15 17 06](https://github.com/Automattic/wp-calypso/assets/1234758/ba6ab575-6a10-4a8f-9f66-18701ab1ec05)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On your sandbox, edit your `launchpad-task-definitions.php` production file to add the `repetition_count_callback` and `target_repetitions` props to one of the build intent tasks:
```
                'share_site'                      => array(
                        'get_title'            => function () {
                                return __( 'Share your site', 'jetpack-mu-wpcom' );
                        },
                        'is_complete_callback' => 'wpcom_is_task_option_completed',

                        'repetition_count_callback' => function() {
                                return 2;
                        },
                        'target_repetitions'        => 3,
                ),
```
* Then, create a site with the build intent.
* Go through the flow until you reach the Customer Home.
* You should see the counter on the Share site task.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
