### PR TITLE
Launchpad: Add action for enable_subscribers_modal task

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/intent-newsletter.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-newsletter.tsx
@@ -2,6 +2,7 @@ import { useLaunchpad } from '@automattic/data-stores';
 import { setUpActionsForTasks } from '@automattic/launchpad';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
+import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CustomerHomeLaunchpad from '.';
@@ -12,6 +13,9 @@ const LaunchpadIntentNewsletter = ( { checklistSlug }: { checklistSlug: string }
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
 	const launchpadContext = 'customer-home';
+	const isAtomicSite = useSelector( ( state: AppState ) => {
+		return ( siteId && isSiteAtomic( state, siteId ) ) as boolean;
+	} );
 
 	const {
 		data: { checklist },
@@ -23,7 +27,7 @@ const LaunchpadIntentNewsletter = ( { checklistSlug }: { checklistSlug: string }
 	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext };
 
 	const sortedTasksWithActions = ( tasks: Task[] ) => {
-		return setUpActionsForTasks( { tasks, siteSlug, tracksData } );
+		return setUpActionsForTasks( { tasks, siteSlug, tracksData, isAtomicSite } );
 	};
 
 	return (

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -87,9 +87,7 @@ export const setUpActionsForTasks = ( {
 			case 'enable_subscribers_modal':
 				action = () => {
 					const redirect = isAtomicSite
-						? addQueryArgs( `https://${ siteSlug }/wp-admin/admin.php`, {
-								page: 'jetpack#/discussion#jp-settings-subscriptions',
-						  } )
+						? `https://${ siteSlug }/wp-admin/admin.php?page=jetpack#/discussion`
 						: `/settings/reading/${ siteSlug }#newsletter-settings`;
 					window.location.assign( redirect );
 				};

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -1,4 +1,5 @@
 import { isMobile } from '@automattic/viewport';
+import { addQueryArgs } from '@wordpress/url';
 import type { LaunchpadTaskActionsProps, Task } from './types';
 
 export const setUpActionsForTasks = ( {
@@ -86,7 +87,9 @@ export const setUpActionsForTasks = ( {
 			case 'enable_subscribers_modal':
 				action = () => {
 					const redirect = isAtomicSite
-						? `https://${ siteSlug }/wp-admin/admin.php?page=jetpack#/discussion`
+						? addQueryArgs( `https://${ siteSlug }/wp-admin/admin.php`, {
+								page: 'jetpack#/discussion#jp-settings-subscriptions',
+						  } )
 						: `/settings/reading/${ siteSlug }#newsletter-settings`;
 					window.location.assign( redirect );
 				};

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -4,6 +4,7 @@ import type { LaunchpadTaskActionsProps, Task } from './types';
 export const setUpActionsForTasks = ( {
 	siteSlug,
 	tasks,
+	isAtomicSite,
 	tracksData,
 	extraActions,
 }: LaunchpadTaskActionsProps ): Task[] => {
@@ -84,7 +85,10 @@ export const setUpActionsForTasks = ( {
 				break;
 			case 'enable_subscribers_modal':
 				action = () => {
-					window.location.assign( `/settings/reading/${ siteSlug }#newsletter-settings` );
+					const redirect = isAtomicSite
+						? `https://${ siteSlug }/wp-admin/admin.php?page=jetpack#/discussion`
+						: `/settings/reading/${ siteSlug }#newsletter-settings`;
+					window.location.assign( redirect );
 				};
 				break;
 		}

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -1,5 +1,4 @@
 import { isMobile } from '@automattic/viewport';
-import { addQueryArgs } from '@wordpress/url';
 import type { LaunchpadTaskActionsProps, Task } from './types';
 
 export const setUpActionsForTasks = ( {

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -5,9 +5,9 @@ import type { LaunchpadTaskActionsProps, Task } from './types';
 export const setUpActionsForTasks = ( {
 	siteSlug,
 	tasks,
-	isAtomicSite,
 	tracksData,
 	extraActions,
+	isAtomicSite,
 }: LaunchpadTaskActionsProps ): Task[] => {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
 	const { setShareSiteModalIsOpen } = extraActions || {};

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -82,6 +82,11 @@ export const setUpActionsForTasks = ( {
 					window.location.assign( `/subscribers/${ siteSlug }` );
 				};
 				break;
+			case 'enable_subscribers_modal':
+				action = () => {
+					window.location.assign( `/settings/reading/${ siteSlug }#newsletter-settings` );
+				};
+				break;
 		}
 
 		const actionDispatch = () => {

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -54,9 +54,9 @@ export interface LaunchpadResponse {
 export interface LaunchpadTaskActionsProps {
 	siteSlug: string | null;
 	tasks: Task[];
-	isAtomicSite?: boolean;
 	tracksData: LaunchpadTracksData;
 	extraActions?: {
 		setShareSiteModalIsOpen?: ( isOpen: boolean ) => void;
 	};
+	isAtomicSite?: boolean;
 }

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -54,6 +54,7 @@ export interface LaunchpadResponse {
 export interface LaunchpadTaskActionsProps {
 	siteSlug: string | null;
 	tasks: Task[];
+	isAtomicSite?: boolean;
 	tracksData: LaunchpadTracksData;
 	extraActions?: {
 		setShareSiteModalIsOpen?: ( isOpen: boolean ) => void;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79560

## Proposed Changes

* Add an action for the `enable_subscriber_modal` task introduced in https://github.com/Automattic/jetpack/pull/32042

## Testing Instructions

**Test on Simple:**

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Switch to this PR
* Apply the Jetpack patch to your sandbox: https://github.com/Automattic/jetpack/pull/32042
* Add the following filter to your `0-sandbox.php` file to enable the modal on your test site: `add_filter( 'jetpack_subscriptions_modal_enabled', '__return_true', 20 );`
* Sandbox `public-api.wordpress.com`
* Create a new site from `/setup/newsletter/intro`:
* As part of the "launch" process, you need to publish at least one post.
* Visit `/home/siteSlug`.
* The last task in the list should be "Enable subscribers modal":

<img width="707" alt="Screenshot 2023-07-25 at 4 14 47 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/e7d1bb13-9b76-4d6b-8f37-4a0742c7d64a">

* Click on the task to go to the Settings -> Reading screen; you should be brought right to the Newsletter settings:

<img width="740" alt="Screenshot 2023-07-25 at 4 14 22 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/683b0f05-acf4-49e9-8aae-7c69bcb821ca">

* If you're on Calypso.live, enable the feature flag via query param by adding `?flags=newsletter/subscribe-modal` to the URL, then reload the screen.
* Toggle the `Enable subscriber modal` setting to `on` and save settings.
* Return to `/home`; you should see the task at the top of the list, marked completed:

<img width="710" alt="Screenshot 2023-07-26 at 9 35 24 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/1c908ac1-bf9a-464d-931e-8277f166dc01">

**Test on Atomic:**

We can't fully test this on Atomic until the `site_goal` and `sm_enabled` site options are synced with Jetpack Sync, which should be handled by these PRs: D117113-code, https://github.com/Automattic/jetpack/pull/32068, https://github.com/Automattic/jetpack/pull/32042, and D117188-code

* Switch to this PR
* Create a newsletter site from `/setup/newsletter/intro`; you'll need to publish at least one test post to "launch" the site.
* Upgrade the site to a Business plan
* Install and activate the Jetpack Beta plugin (this should move the site to the Atomic infrastructure)
* Go to Manage under the WordPress.com Features part of the beta plugin
* Activate the `add/enable-subscriber-modal-task` feature branch
* SSH into your Atomic site and add the `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );` constant to your wp-config.php
* While you're in there, add the filter to enable the subscriptions modal: `add_filter( 'jetpack_subscriptions_modal_enabled', '__return_true', 20 );` I put it in `wp-content/mu-plugins/index.php`
* Go to `/home/siteSlug` to see the Newsletter task list.
* You should see the "Enable subscribers modal" task:

* Click on the task to go to the Jetpack -> Settings -> Discussion screen in wp-admin; you'll be brought to the Subscriptions settings:

<img width="1058" alt="Screenshot 2023-07-24 at 2 29 22 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/a70cc97f-ede8-4aa4-8a59-d5e73edeb912">

* Toggle the "Enable subscriber modal" setting on.
* Return to `/home/siteSlug` and the task should be marked completed:




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?