### PR TITLE
Reader: Follow error should not be displayed on a successful site follow request

### DIFF
--- a/client/state/data-layer/wpcom/read/following/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/index.js
@@ -33,6 +33,10 @@ export function requestFollow( action ) {
 }
 
 function handleRecommendedSiteFollowSuccess( recommendedSiteInfo ) {
+	if ( ! recommendedSiteInfo ) {
+		return [];
+	}
+
 	const { siteId, seed, siteTitle } = recommendedSiteInfo;
 	return [
 		followedRecommendedSite( { siteId, seed } ),

--- a/client/state/data-layer/wpcom/read/following/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/index.js
@@ -32,12 +32,13 @@ export function requestFollow( action ) {
 	);
 }
 
-function handleRecommendedSiteFollowSuccess( recommendedSiteInfo ) {
+function getRecommendedSiteFollowSuccessActions( recommendedSiteInfo ) {
 	if ( ! recommendedSiteInfo ) {
 		return [];
 	}
 
 	const { siteId, seed, siteTitle } = recommendedSiteInfo;
+
 	return [
 		followedRecommendedSite( { siteId, seed } ),
 		successNotice( translate( "Success! You're now subscribed to %s.", { args: siteTitle } ), {
@@ -55,7 +56,11 @@ export function receiveFollow( action, response ) {
 			requestFollowCompleted( action?.payload?.feedUrl ),
 		];
 
-		return [ ...actions, ...handleRecommendedSiteFollowSuccess( recommendedSiteInfo ) ];
+		if ( recommendedSiteInfo ) {
+			actions.push( ...getRecommendedSiteFollowSuccessActions( recommendedSiteInfo ) );
+		}
+
+		return actions;
 	}
 	return followError( action, response );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Related Conversations 
- p1690198703267199-slack-C02TCEHP3HA

## Proposed Changes

* Always check if the `recommendedSiteInfo` argument is passed along with the `READER_FOLLOW` action before getting and appending the actions related with a success of following a recommended site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/discover
* Try to follow any of the "Popular Sites" on the right-hand side. You should not be displayed with an error message, and the subscription should be successful. You can verify whether the subscription was successful on the https://wordpress.com/read/susbcriptions, by looking for the site you just followed.
* Go to http://calypso.localhost:3000/read/subscriptions
* Try to "Subscribe" to any of the displayed "Recommended Sites".
* You should be displayed with a success notice message, once the subscription request has completed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?