### PR TITLE
Domains: When a domain is registered prompt user to transfer

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -164,11 +164,15 @@ class DomainSearchResults extends Component {
 
 			if ( isDomainOnly && ! [ TLD_NOT_SUPPORTED, UNKNOWN ].includes( lastDomainStatus ) ) {
 				domainUnavailableMessage = translate(
-					'{{strong}}%(domain)s{{/strong}} is already registered. Please try another search.',
+					'{{strong}}%(domain)s{{/strong}} is already registered. Do you own this domain? {{a}}Transfer it to WordPress.com{{/a}} now, or try another search.',
 					{
 						args: { domain },
 						components: {
 							strong: <strong />,
+							a: (
+								// eslint-disable-next-line jsx-a11y/anchor-is-valid
+								<a href="/setup/domain-transfer" />
+							),
 						},
 					}
 				);

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -171,7 +171,7 @@ class DomainSearchResults extends Component {
 							strong: <strong />,
 							a: (
 								// eslint-disable-next-line jsx-a11y/anchor-is-valid
-								<a href="/setup/domain-transfer" />
+								<a href={ `/setup/domain-transfer?new=${ domain ?? '' }` } />
 							),
 						},
 					}


### PR DESCRIPTION
## Proposed Changes

* When a domain is registered, let's nudge users to go through the new transfer flow instead of leaving them at a dead end.

<img width="1291" alt="Screenshot 2023-07-24 at 2 42 03 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/cbb85933-6abe-43c5-8889-85ec1cd644f1">

See p1690226228866559-slack-C05CT832K2T

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout patch
* Go to http://calypso.localhost:3000/start/domain/domain-only?new=loachlaer.com&search=yes
* Ensure that you get a notice that mentions that you can transfer the domain
* Click the link
* Ensure that you land in the transfer flow
* Change your language, repeat, ensure that your language is reflected. Note: There will be some strings that aren't translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?