### PR TITLE
Plugin Browse: Update e2e test to check URL with selected site

### DIFF
--- a/test/e2e/specs/plugins/plugins__browse.ts
+++ b/test/e2e/specs/plugins/plugins__browse.ts
@@ -103,6 +103,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			'Search Engine Optimization',
 			envVariables.VIEWPORT_NAME !== 'mobile' ? true : false
 		);
+		await page.waitForURL( new RegExp( `/plugins/browse/seo/${ siteUrl }$`, 'g' ) );
 	} );
 
 	it.each( [ 'Yoast SEO' ] )(

--- a/test/e2e/specs/plugins/plugins__browse.ts
+++ b/test/e2e/specs/plugins/plugins__browse.ts
@@ -103,7 +103,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			'Search Engine Optimization',
 			envVariables.VIEWPORT_NAME !== 'mobile' ? true : false
 		);
-		await page.waitForURL( new RegExp( `/plugins/browse/seo/${ siteUrl }$`, 'g' ) );
+		await page.waitForURL( new RegExp( `/plugins/browse/seo/${ siteUrl }$` ) );
 	} );
 
 	it.each( [ 'Yoast SEO' ] )(


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/66637
Related to https://github.com/Automattic/wp-calypso/pull/66636

## Proposed Changes

Add URL check at the end of the Category selection e2e test.
This guarantees the site URL will always be present on this action.

## Testing Instructions
Check if all checks are passing. Including e2e tests.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
