### PR TITLE
Domain Transfers: Hide Connect to a site when is_domain_only sites

### DIFF
--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -25,6 +25,7 @@ import {
 	domainUseMyDomain,
 	isUnderDomainManagementAll,
 } from 'calypso/my-sites/domains/paths';
+import { useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getDomainDns } from 'calypso/state/domains/dns/selectors';
@@ -35,8 +36,8 @@ import {
 	isFetchingSitePurchases,
 	hasLoadedSitePurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
+import { canAnySiteConnectDomains } from 'calypso/state/selectors/can-any-site-connect-domains';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
-import getSites from 'calypso/state/selectors/get-sites';
 import { IAppState } from 'calypso/state/types';
 import ConnectedDomainDetails from './cards/connected-domain-details';
 import ContactsPrivacyInfo from './cards/contact-information/contacts-privacy-info';
@@ -68,7 +69,6 @@ const Settings = ( {
 	selectedSite,
 	updateNameservers,
 	whoisData,
-	sites,
 }: SettingsPageProps ) => {
 	const translate = useTranslate();
 	const contactInformation = findRegistrantWhois( whoisData );
@@ -78,6 +78,8 @@ const Settings = ( {
 			requestWhois( selectedDomainName );
 		}
 	}, [ contactInformation, selectedDomainName ] );
+
+	const hasConnectableSites = useSelector( ( state ) => canAnySiteConnectDomains( state ) );
 
 	const renderBreadcrumbs = () => {
 		const previousPath = domainManagementList(
@@ -139,7 +141,7 @@ const Settings = ( {
 	const renderStatusSection = () => {
 		if (
 			! ( domain && selectedSite?.options?.is_domain_only ) ||
-			sites.length === sites.filter( ( site ) => site?.options?.is_domain_only ).length ||
+			! hasConnectableSites ||
 			domain.type === domainTypes.TRANSFER
 		) {
 			return null;
@@ -510,7 +512,6 @@ export default connect(
 				isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
 			purchase: purchase && purchase.userId === currentUserId ? purchase : null,
 			dns: getDomainDns( state, ownProps.selectedDomainName ),
-			sites: getSites( state ),
 		};
 	},
 	{

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -36,6 +36,7 @@ import {
 	hasLoadedSitePurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
+import getSites from 'calypso/state/selectors/get-sites';
 import { IAppState } from 'calypso/state/types';
 import ConnectedDomainDetails from './cards/connected-domain-details';
 import ContactsPrivacyInfo from './cards/contact-information/contacts-privacy-info';
@@ -67,6 +68,7 @@ const Settings = ( {
 	selectedSite,
 	updateNameservers,
 	whoisData,
+	sites,
 }: SettingsPageProps ) => {
 	const translate = useTranslate();
 	const contactInformation = findRegistrantWhois( whoisData );
@@ -137,6 +139,7 @@ const Settings = ( {
 	const renderStatusSection = () => {
 		if (
 			! ( domain && selectedSite?.options?.is_domain_only ) ||
+			sites.length === sites.filter( ( site ) => site?.options?.is_domain_only ).length ||
 			domain.type === domainTypes.TRANSFER
 		) {
 			return null;
@@ -507,6 +510,7 @@ export default connect(
 				isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
 			purchase: purchase && purchase.userId === currentUserId ? purchase : null,
 			dns: getDomainDns( state, ownProps.selectedDomainName ),
+			sites: getSites( state ),
 		};
 	},
 	{

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -35,7 +35,6 @@ export type SettingsPageConnectedProps = {
 	purchase: Purchase | null;
 	whoisData: WhoisData[];
 	dns: DnsRequest;
-	sites: ( SiteDetails | null | undefined )[];
 };
 
 export type SettingsPageNameServerHocProps = {

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -35,6 +35,7 @@ export type SettingsPageConnectedProps = {
 	purchase: Purchase | null;
 	whoisData: WhoisData[];
 	dns: DnsRequest;
+	sites: ( SiteDetails | null | undefined )[];
 };
 
 export type SettingsPageNameServerHocProps = {

--- a/client/state/selectors/can-any-site-connect-domains.ts
+++ b/client/state/selectors/can-any-site-connect-domains.ts
@@ -1,0 +1,25 @@
+import { createSelector } from '@automattic/state-utils';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import getSites from 'calypso/state/selectors/get-sites';
+import type { AppState } from 'calypso/types';
+
+import 'calypso/state/ui/init';
+
+/**
+ * Return true if is user is able to use plugins on any of their sites.
+ *
+ * @param state Global state tree
+ */
+
+export const canAnySiteConnectDomains = createSelector(
+	( state: AppState ): boolean =>
+		getSites( state ).some(
+			( site ) =>
+				site &&
+				canCurrentUser( state, site.ID, 'manage_options' ) &&
+				! ( site.jetpack && ! ( site?.options?.is_automated_transfer ?? false ) ) && // Simple and Atomic sites. Not Jetpack sites.
+				! ( site?.is_wpcom_staging_site ?? false ) &&
+				! ( site?.options?.is_domain_only ?? false )
+		),
+	( state ) => [ state.sites.items, state.currentUser.capabilities ]
+);

--- a/client/state/selectors/can-any-site-connect-domains.ts
+++ b/client/state/selectors/can-any-site-connect-domains.ts
@@ -6,7 +6,8 @@ import type { AppState } from 'calypso/types';
 import 'calypso/state/ui/init';
 
 /**
- * Return true if is user is able to use plugins on any of their sites.
+ * Return true if a user has sites that are able to be connected to domains.
+ * Returns false when a user has no sites or only self hosted Jetpack sites.
  *
  * @param state Global state tree
  */


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3175

## Proposed Changes

Remove `connect to an existing site` if the user doesn't have any existing sites that match the same conditions as [here](https://github.com/Automattic/wp-calypso/blob/544283df5cb36b94de74767011dc4e5f91ed5845/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx#L52)

| Before | After |
| --- | --- |
| <img width="1099" alt="image" src="https://github.com/Automattic/wp-calypso/assets/402286/47ddc837-543f-4a3b-98fa-c03f8e9bda15"> | <img width="1091" alt="image" src="https://github.com/Automattic/wp-calypso/assets/402286/afd9d2a3-f396-4bba-bcd2-bd28d26aa1cb"> |

## Testing Instructions

* With a non-sites user with domains
* Go to`/domains/manage/all/`
* Choose a domain
* You should not see the `Connect a WordPress.com site` section

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
