### PR TITLE
Stats: Restore Jetpack upsell section to all

### DIFF
--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -10,7 +10,6 @@ import {
 import { JetpackUpsellCard } from '@automattic/components';
 import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { useSelector } from 'calypso/state';
-import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-paid';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import usePurchasedProducts from './use-purchased-products';
 
@@ -26,14 +25,13 @@ const QUERY_VALUES = {
 
 export default function JetpackUpsellSection() {
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
-	const hasPaidStats = useSelector( hasSiteProductJetpackStatsPaid );
 
 	// NOTE: This will only work within Odyssey Stats.
 	const { purchasedProducts } = usePurchasedProducts();
 
 	// Exit early if we don't have and can't get the site purchase data.
 	// Also exit early if we're not in the Odyssey Stats environment.
-	if ( ! isOdysseyStats || hasPaidStats ) {
+	if ( ! isOdysseyStats ) {
 		return null;
 	}
 

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -72,7 +72,7 @@ const DoYouLoveJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
 				onClose={ dismissNotice }
 			>
 				{ translate(
-					'{{p}}Upgrade Jetpack Stats to unlock upcoming features, priority support, and an ad-free experience.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{learnMoreLink}}{{learnMoreLinkText}}Learn more{{/learnMoreLinkText}}{{externalIcon /}}{{/learnMoreLink}}{{/p}}',
+					'{{p}}Upgrade Jetpack Stats to unlock upcoming features and priority support.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{learnMoreLink}}{{learnMoreLinkText}}Learn more{{/learnMoreLinkText}}{{externalIcon /}}{{/learnMoreLink}}{{/p}}',
 					{
 						components: {
 							p: <p />,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79810

## Proposed Changes

<img width="1252" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/4ccbd7e2-b877-4f9c-97c0-89c6bb3ce563">

* Updates upgrade notice to omit mentions of "ads"

<img width="1245" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/b5b551b1-5d06-4f31-a926-1821b58d3645">

* Restores the Jetpack upsell section to Odyssey Stats, even if you have a paid stats plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Optional steps to take if you've dismissed the paid stats notice previously for the site:

1. Remove any existing Stats purchase from your test site via `https://wordpress.com/purchases/subscriptions/${siteSlug}`.
2. Purge notice status if previously dismissed:
    * Run `wpsh` in sandbox
    * Run `switch_to_blog($blog_id);`
    * Run `delete_option('stats_dashboard_options');`

### Setting up Odyssey Stats:

1. Build Jetpack if necessary `jetpack build plugins/jetpack`
2. Build Odyssey Stats locally `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev`
3. Navigate to the Odyssey Stats dashboard `/stats/day/${siteSlug}flags=stats/paid-stats`

### Verifying changes
1. Ensure that the upsell section renders at the bottom of the stats dashboard.
2. Ensure you see an updated upgrade notice (with no mention of an ads-free benefit).
3. Click `Upgrade my Stats` and purchase a paid stats plan for the site.
4. Return to the bottom of the Odyssey Stats dashboard and ensure that the upsell section continues to render.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
