### PR TITLE
Stats: Gate stats notices for WPCOM sites

### DIFF
--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -84,9 +84,8 @@ export default function StatsNotices( {
 		getJetpackStatsAdminVersion( state, siteId )
 	);
 
-	// Only show notice on Odyssey stats for now as the styles don't match WPCOM.
 	const supportNewStatsNotices =
-		isOdysseyStats &&
+		( ! isOdysseyStats && config.isEnabled( 'stats/paid-wpcom-stats' ) ) ||
 		!! ( statsAdminVersion && version_compare( statsAdminVersion, '0.10.0-alpha', '>=' ) );
 
 	return supportNewStatsNotices ? (

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { useSelector } from 'react-redux';
 import version_compare from 'calypso/lib/version-compare';
+import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
@@ -35,6 +36,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => 
 	const isOwnedByTeam51 = useSelector(
 		( state ) => getSelectedSite( state )?.site_owner === TEAM51_OWNER_ID
 	);
+	const isWpcom = useSelector( isSiteWpcom );
 
 	// TODO: Display error messages on the notice.
 	const { hasLoadedPurchases } = usePurchasesToUpdateSiteProducts( isOdysseyStats, siteId );
@@ -45,7 +47,8 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => 
 		! isP2 &&
 		! isOwnedByTeam51 &&
 		! hasPaidStats &&
-		hasLoadedPurchases;
+		! isWpcom; // TODO: remove this when we are ready to roll out to WPCOM sites.
+	hasLoadedPurchases;
 
 	return (
 		<>

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -35,7 +35,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => 
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
-	const isWpcom = useSelector( isSiteWpcom );
+	const isWpcom = useSelector( ( state ) => isSiteWpcom( state, siteId ) );
 	const isP2 = useSelector( ( state ) => !! isSiteWPForTeams( state as object, siteId as number ) );
 	const isOwnedByTeam51 = useSelector(
 		( state ) => getSelectedSite( state )?.site_owner === TEAM51_OWNER_ID

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { useSelector } from 'react-redux';
 import version_compare from 'calypso/lib/version-compare';
-import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
@@ -36,7 +35,6 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => 
 	const isOwnedByTeam51 = useSelector(
 		( state ) => getSelectedSite( state )?.site_owner === TEAM51_OWNER_ID
 	);
-	const isWpcom = useSelector( isSiteWpcom );
 
 	// TODO: Display error messages on the notice.
 	const { hasLoadedPurchases } = usePurchasesToUpdateSiteProducts( isOdysseyStats, siteId );
@@ -47,8 +45,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => 
 		! isP2 &&
 		! isOwnedByTeam51 &&
 		! hasPaidStats &&
-		! isWpcom; // TODO: remove this when we are ready to roll out to WPCOM sites.
-	hasLoadedPurchases;
+		hasLoadedPurchases;
 
 	return (
 		<>
@@ -87,8 +84,9 @@ export default function StatsNotices( {
 		getJetpackStatsAdminVersion( state, siteId )
 	);
 
+	// Only show notice on Odyssey stats for now as the styles don't match WPCOM.
 	const supportNewStatsNotices =
-		! isOdysseyStats ||
+		isOdysseyStats &&
 		!! ( statsAdminVersion && version_compare( statsAdminVersion, '0.10.0-alpha', '>=' ) );
 
 	return supportNewStatsNotices ? (

--- a/config/client.json
+++ b/config/client.json
@@ -28,6 +28,7 @@
 	"stats/new-video-summary",
 	"stats/subscribers-chart-section",
 	"stats/paid-stats",
+	"stats/paid-wpcom-stats",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",
 	"wpcom_signup_key",

--- a/config/development.json
+++ b/config/development.json
@@ -185,6 +185,7 @@
 		"stats/new-video-summary": true,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": true,
+		"stats/paid-wpcom-stats": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -121,6 +121,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": false,
+		"stats/paid-wpcom-stats": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/production.json
+++ b/config/production.json
@@ -148,6 +148,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": false,
+		"stats/paid-wpcom-stats": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -141,6 +141,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": false,
+		"stats/paid-wpcom-stats": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/test.json
+++ b/config/test.json
@@ -98,6 +98,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": false,
+		"stats/paid-wpcom-stats": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -153,6 +153,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": false,
+		"stats/paid-wpcom-stats": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,


### PR DESCRIPTION
Related: p1690221869686939-slack-C0438NHCLSY

## Proposed Changes

* Gate Stats Notices for the WPCOM sites
* Show Stats Notices on Odyssey Stats (still behind feature flag)
* Show Stats Notices for Jetpack sites on both platforms (still behind feature flag)
* Purchase notices are not gated as they require GET params

## Testing Instructions

* Open Calypso Live
* Open a Jetpack site `/stats/day/:siteSlug?flags=stats/paid-stats`
* Ensure you see the upgrade notice
* Open a WoA site `/stats/day/:siteSlug?flags=stats/paid-stats`
* Ensure you do NOT see the upgrade notice
* Open a Simple site `/stats/day/:siteSlug?flags=stats/paid-stats`
* Ensure you do NOT see the upgrade notice
* Replace feature flag to `flags=stats/paid-wpcom-stats` for WoA and Simple sites
* Ensure you see the upgrade notice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?