### PR TITLE
Checkout: Convert recordOrder/recordPurchase to TypeScript

### DIFF
--- a/client/lib/analytics/ad-tracking/criteo.js
+++ b/client/lib/analytics/ad-tracking/criteo.js
@@ -11,7 +11,7 @@ import './setup';
  * Records an event in Criteo
  *
  * @param {string} eventName - The name of the 'event' property such as 'viewItem' or 'viewBasket'
- * @param {Object} eventProps - Additional details about the event such as `{ item: '1' }`
+ * @param {Record<string, any>} eventProps - Additional details about the event such as `{ item: '1' }`
  * @returns {void}
  */
 export async function recordInCriteo( eventName, eventProps ) {

--- a/client/lib/analytics/record-purchase.ts
+++ b/client/lib/analytics/record-purchase.ts
@@ -1,8 +1,17 @@
 import { recordOrder } from 'calypso/lib/analytics/ad-tracking';
 import { costToUSD } from 'calypso/lib/analytics/utils';
 import { gaRecordEvent } from './ga';
+import type { ResponseCart } from '@automattic/shopping-cart';
 
-export async function recordPurchase( { cart, orderId, sitePlanSlug } ) {
+export async function recordPurchase( {
+	cart,
+	orderId,
+	sitePlanSlug,
+}: {
+	cart: ResponseCart;
+	orderId: number | null | undefined;
+	sitePlanSlug: string | null | undefined;
+} ) {
 	if ( cart.total_cost >= 0.01 ) {
 		const usdValue = costToUSD( cart.total_cost, cart.currency );
 

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -32,6 +32,7 @@ export function getEmptyResponseCartProduct(): ResponseCartProduct {
 	return {
 		time_added_to_cart: Date.now(),
 		product_name: 'Replace me',
+		product_name_en: 'Replace me',
 		product_slug: 'replace-me',
 		currency: 'USD',
 		extra: {},

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -353,6 +353,8 @@ export interface ResponseCartProduct {
 	product_id: number;
 	currency: string;
 
+	product_name_en: string;
+
 	/**
 	 * The cart item's original price in the currency's smallest unit.
 	 *


### PR DESCRIPTION
## Proposed Changes

This PR converts the `recordOrder` and `recordPurchase` functions to TypeScript, fixing some subtle bugs as part of the process. These bugs occasionally result in errors which we can see in Sentry reports (these do not crash calypso because [we catch them](https://github.com/Automattic/wp-calypso/blob/c0a866becc2969e8b533624f3892de18493fdffc/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx#L309-L318)). For example, sometimes we get `undefined is not an object (evaluating 'orderId.toString')` [on this line](https://github.com/Automattic/wp-calypso/blob/14461a79df2bc0ff33579a2e192e61b2f218c770/client/lib/analytics/ad-tracking/record-order.js#L525) since `orderId` is [sometimes undefined](https://github.com/Automattic/wp-calypso/blob/14461a79df2bc0ff33579a2e192e61b2f218c770/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx#L303-L306).

If you look closely you'll notice that this actually removes some of the parameters being recorded, but that's only because they never have existed and by removing them we make this explicit rather than me trying to guess what would be a better replacement. For example, the code used to [try to record a billing_term](https://github.com/Automattic/wp-calypso/blob/14461a79df2bc0ff33579a2e192e61b2f218c770/client/lib/analytics/ad-tracking/record-order.js#L732) for each purchase, but there has never been a `cart.billing` property. Similarly, we used to [try to send each product's price to Pintrest](https://github.com/Automattic/wp-calypso/blob/14461a79df2bc0ff33579a2e192e61b2f218c770/client/lib/analytics/ad-tracking/record-order.js#L123) but `product.price` has never existed.

## Testing Instructions

None should be needed as this does not change any functionality other than what is noted above.