### PR TITLE
Paid Stats: Remove mentions of removing ads

### DIFF
--- a/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
@@ -24,7 +24,7 @@ const PaidPlanPurchaseSuccessJetpackStatsNotice = () => {
 				onClose={ dismissNotice }
 			>
 				{ translate(
-					"{{p}}You'll now get instant access to upcoming features, get priority support, and no ads in Jetpack Stats.{{/p}}",
+					"{{p}}You'll now get instant access to upcoming features and priority support.{{/p}}",
 					{
 						components: {
 							p: <p />,

--- a/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
@@ -64,7 +64,6 @@ const CommercialPurchase = ( {
 				<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--included` }>
 					<li>{ translate( 'Instant access to upcoming features' ) }</li>
 					<li>{ translate( 'Priority support' ) }</li>
-					<li>{ translate( 'Ad-free experience' ) }</li>
 				</ul>
 			</div>
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -108,7 +108,6 @@ const PersonalPurchase = ( {
 					<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--not-included` }>
 						<li>{ translate( 'No access to upcoming features' ) }</li>
 						<li>{ translate( 'No priority support' ) }</li>
-						<li>{ translate( "You'll see upsells and ads in the Stats page" ) }</li>
 					</ul>
 				) : (
 					<>
@@ -116,7 +115,6 @@ const PersonalPurchase = ( {
 						<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--included` }>
 							<li>{ translate( 'Instant access to upcoming features' ) }</li>
 							<li>{ translate( 'Priority support' ) }</li>
-							<li>{ translate( 'Ad-free experience' ) }</li>
 						</ul>
 					</>
 				) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79810

## Proposed Changes

Personal|Commercial
-|-
<img width="622" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/86c14e49-944d-4c3d-a273-131f4b9a3094">|<img width="603" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/d7a30f50-a75c-4696-80b7-2422a12f21ee">

* Update the benefits copy for both personal and commercial site types in the stats purchase page.

<img width="1255" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/04b3221b-bc9b-4e13-906e-fbac850d3404">

* Update the post-purchase copy.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Purchase flow copy:

* Navigate to `/stats/purchase/:siteSlug?flags=stats/paid-stats`.
* Ensure that the new copy is in effect for both personal and commercial site types.

Post-purchase copy:

* Navigate to `/stats/day/:siteSlug?statsPurchaseSuccess=paid`
* Ensure that the new copy is in effect.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
