### PR TITLE
Stats: Add stats purchase learn more link

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
@@ -40,7 +40,7 @@ const CommercialPurchase = ( {
 				) }
 				<Button
 					variant="link"
-					href="https://jetpack.com/redirect/?source=learn-more-about-new-pricing"
+					href="https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing"
 					target="_blank"
 					rel="noopener noreferrer"
 				>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
@@ -41,6 +41,8 @@ const CommercialPurchase = ( {
 				<Button
 					variant="link"
 					href="https://jetpack.com/redirect/?source=learn-more-about-new-pricing"
+					target="_blank"
+					rel="noopener noreferrer"
 				>
 					{ translate( 'Learn more' ) }
 				</Button>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
@@ -38,7 +38,10 @@ const CommercialPurchase = ( {
 				{ translate(
 					'Upgrade now to take advantage of the introductory flat rate. Starting in 2024, we will introduce metered billing. '
 				) }
-				<Button variant="link" href="#">
+				<Button
+					variant="link"
+					href="https://jetpack.com/redirect/?source=learn-more-about-new-pricing"
+				>
 					{ translate( 'Learn more' ) }
 				</Button>
 			</div>


### PR DESCRIPTION
## Proposed Changes

* Add a Jetpack redirect link to learn more

Note: we do not have a proper page to link to. We should change the target in Jetpack Redirect when we do.

## Testing Instructions

* Open Calypso Live Branch
* Open `/stats/purchase/:siteSlug`
* Click 'Commercial'
* Ensure `learn more` links to `https://jetpack.com/stats` via Jetpack Redirect

![image](https://github.com/Automattic/wp-calypso/assets/1425433/22e91b89-32b9-4fad-ae56-e0fa48e7ec23)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
