### PR TITLE
Stats: Fix PWYW Starting price when switching from Commercial

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -11,6 +11,7 @@ import { COMPONENT_CLASS_NAME, MIN_STEP_SPLITS } from './stats-purchase-wizard';
 interface PersonalPurchaseProps {
 	subscriptionValue: number;
 	setSubscriptionValue: ( value: number ) => number;
+	defaultStartingValue: number;
 	handlePlanSwap: ( e: React.MouseEvent< HTMLAnchorElement, MouseEvent > ) => void;
 	currencyCode: string;
 	siteSlug: string;
@@ -28,6 +29,7 @@ interface PersonalPurchaseProps {
 const PersonalPurchase = ( {
 	subscriptionValue,
 	setSubscriptionValue,
+	defaultStartingValue,
 	handlePlanSwap,
 	currencyCode,
 	siteSlug,
@@ -42,8 +44,6 @@ const PersonalPurchase = ( {
 	const [ isBusinessChecked, setBusinessChecked ] = useState( false );
 	const { sliderStepPrice, maxSliderPrice, uiEmojiHeartTier, uiImageCelebrationTier } =
 		sliderSettings;
-
-	const [ defaultStartingValue ] = useState( subscriptionValue );
 
 	const sliderLabel = ( ( props, state ) => {
 		let emoji;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -40,7 +40,6 @@ const TitleNode = ( { label, indicatorNumber, active } ) => {
 };
 
 const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redirectUri, from } ) => {
-	const commercialPlanPrice = commercialProduct?.cost;
 	const maxSliderPrice = commercialProduct.cost;
 	const sliderStepPrice = pwywProduct.cost / MIN_STEP_SPLITS;
 
@@ -66,7 +65,6 @@ const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redire
 	};
 
 	const setCommercialSite = () => {
-		setSubscriptionValue( commercialPlanPrice );
 		setSiteType( TYPE_COMMERCIAL );
 		setWizardStep( SCREEN_PURCHASE );
 	};
@@ -193,9 +191,13 @@ const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redire
 					</div>
 					<div className={ `${ COMPONENT_CLASS_NAME }__card-inner--right` }>
 						<StatsPurchaseSVG
-							isFree={ subscriptionValue === 0 }
-							hasHighlight={ subscriptionValue >= uiImageCelebrationTier }
-							extraMessage={ subscriptionValue >= uiImageCelebrationTier }
+							isFree={ siteType === TYPE_PERSONAL && ! subscriptionValue === 0 }
+							hasHighlight={
+								siteType === TYPE_COMMERCIAL || subscriptionValue >= uiImageCelebrationTier
+							}
+							extraMessage={
+								siteType === TYPE_COMMERCIAL || subscriptionValue >= uiImageCelebrationTier
+							}
 						/>
 						<div className={ `${ COMPONENT_CLASS_NAME }__card-inner--right-background` }>
 							<img src={ statsPurchaseBackgroundSVG } alt="Blurred background" />

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -161,6 +161,7 @@ const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redire
 										<PersonalPurchase
 											subscriptionValue={ subscriptionValue }
 											setSubscriptionValue={ setSubscriptionValue }
+											defaultStartingValue={ defaultStartingValue }
 											handlePlanSwap={ ( e ) => handlePlanSwap( e ) }
 											currencyCode={ pwywProduct?.currency_code }
 											siteSlug={ siteSlug }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -192,7 +192,7 @@ const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redire
 					</div>
 					<div className={ `${ COMPONENT_CLASS_NAME }__card-inner--right` }>
 						<StatsPurchaseSVG
-							isFree={ siteType === TYPE_PERSONAL && ! subscriptionValue === 0 }
+							isFree={ siteType === TYPE_PERSONAL && subscriptionValue === 0 }
 							hasHighlight={
 								siteType === TYPE_COMMERCIAL || subscriptionValue >= uiImageCelebrationTier
 							}


### PR DESCRIPTION
Related: pejTkB-Ih-p2#comment-650

## Proposed Changes

* Fixes average paid value changing between rendering
* Fixes when switching from commercial, the PWYW gets set to the max price

## Testing Instructions

* Open Calypso Live Branch
* Open `/stats/purchase/:siteSlug`
* Choose `Personal site`
* Slide to a certain position other than the default value
* Switch to `Commercial site`
* Switch back to `Personal site`
* Ensure the slider retains the prices it did
* Ensure the value of `Our users pay $xxx per month on average` retains its value too

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?