### PR TITLE
Enable videopress-tv flows on horizon

### DIFF
--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	LINK_IN_BIO_DOMAIN_FLOW,
 	START_WRITING_FLOW,
@@ -31,14 +32,6 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	videopress: () =>
 		import( /* webpackChunkName: "videopress-flow" */ '../declarative-flow/videopress' ),
-
-	[ VIDEOPRESS_TV_FLOW ]: () =>
-		import( /* webpackChunkName: "videopress-tv-flow" */ `../declarative-flow/videopress-tv` ),
-
-	[ VIDEOPRESS_TV_PURCHASE_FLOW ]: () =>
-		import(
-			/* webpackChunkName: "videopress-tv-flow" */ `../declarative-flow/videopress-tv-purchase`
-		),
 
 	'link-in-bio': () =>
 		import( /* webpackChunkName: "link-in-bio-flow" */ '../declarative-flow/link-in-bio' ),
@@ -123,4 +116,19 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 		import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' ),
 };
 
-export default availableFlows;
+const videoPressTvFlows: Record< string, () => Promise< { default: Flow } > > = config.isEnabled(
+	'videopress-tv'
+)
+	? {
+			[ VIDEOPRESS_TV_FLOW ]: () =>
+				import( /* webpackChunkName: "videopress-tv-flow" */ `../declarative-flow/videopress-tv` ),
+
+			[ VIDEOPRESS_TV_PURCHASE_FLOW ]: () =>
+				import(
+					/* webpackChunkName: "videopress-tv-flow" */
+					`../declarative-flow/videopress-tv-purchase`
+				),
+	  }
+	: {};
+
+export default { ...availableFlows, ...videoPressTvFlows };

--- a/config/development.json
+++ b/config/development.json
@@ -209,6 +209,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"user-management-revamp": true,
+		"videopress-tv": false,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -145,6 +145,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"use-translation-chunks": true,
 		"user-management-revamp": true,
+		"videopress-tv": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true

--- a/config/production.json
+++ b/config/production.json
@@ -173,6 +173,7 @@
 		"upsell/concierge-session": true,
 		"use-translation-chunks": true,
 		"user-management-revamp": true,
+		"videopress-tv": false,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/greenhouse/issues/1803

## Proposed Changes

* Enable videopress-tv flows on horizon

## Testing Instructions

* run `yarn start` locally. Navigating to calypso.localhost:3000/setup/videopress-tv or calypso.localhost:3000/setup/videopress-tv-purchase will redirect to calypso.localhost:3000
* run `ENABLE_FEATURES=videopress-tv yarn start` locally. You can now visit the urls and see the flow.

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
