### PR TITLE
wpcom-proxy-request: trigger request error when iframe is not loaded

### DIFF
--- a/packages/wpcom-proxy-request/History.md
+++ b/packages/wpcom-proxy-request/History.md
@@ -3,6 +3,7 @@
 ## Next / TBD
 
 - Don't modify a falsy boolean JSON response body by defaulting it.
+- Trigger request error when proxy iframe is not present and loaded.
 
 ## 7.0.4 / 2023-07-11
 

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -220,6 +220,22 @@ export function requestAllBlogsAccess() {
  */
 
 function submitRequest( params ) {
+	// Sometimes the `iframe.contentWindow` is `null` even though the `iframe` has been correctly
+	// loaded. Can happen when some other buggy script removes it from the document.
+	if ( ! iframe.contentWindow ) {
+		debug( 'proxy iframe is not present in the document' );
+		// Look up the issuing XHR request and make it fail
+		const id = params.callback;
+		const xhr = requests[ id ];
+		delete requests[ id ];
+		reject(
+			xhr,
+			new WPError( { status_code: 500, error_description: 'proxy iframe element is not loaded' } ),
+			{}
+		);
+		return;
+	}
+
 	debug( 'sending API request to proxy <iframe> %o', params );
 
 	// `formData` needs to be patched if it contains `File` objects to work around

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -230,7 +230,7 @@ function submitRequest( params ) {
 		delete requests[ id ];
 		reject(
 			xhr,
-			new WPError( { status_code: 500, error_description: 'proxy iframe element is not loaded' } ),
+			WPError( { status_code: 500, error_description: 'proxy iframe element is not loaded' } ),
 			{}
 		);
 		return;


### PR DESCRIPTION
Fixes an error frequently reported in Sentry where the `iframe.contentWindow` is `null` although the `wpcom-proxy-request` made sure that the `iframe` is created and loaded before it submits any requests to it.

The most likely cause is that some 3rd party script or extension is removing the `iframe`, effectively "stealing" it from the `wpcom-proxy-request` library.

Discussed also in this thread: https://github.com/Automattic/wp-calypso/pull/75138#issuecomment-1633819827

This is how the Sentry error looks like:

<img width="870" alt="Screenshot 2023-07-25 at 10 40 51" src="https://github.com/Automattic/wp-calypso/assets/664258/6f740255-b383-40f7-a7ae-751b653b644a">

**How to test:**
Load Calypso in dev mode, and after it's loaded, then in devtools find the proxy `iframe` element and delete it. Since that moment, you should be seeing errors in console every time the app wants to do a REST request:

<img width="691" alt="Screenshot 2023-07-25 at 10 29 54" src="https://github.com/Automattic/wp-calypso/assets/664258/38a09f73-1ca1-4a94-a79e-be76cd1501eb">
