### PR TITLE
Add custom Facebook event to the thank you page for bulk domain transfers

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -111,6 +111,12 @@ import type { DomainThankYouType } from 'calypso/my-sites/checkout/checkout-than
 import type { ReceiptState, ReceiptPurchase } from 'calypso/state/receipts/types';
 import type { LocalizeProps } from 'i18n-calypso';
 
+declare global {
+	interface Window {
+		fbq?: ( ...args: unknown[] ) => void;
+	}
+}
+
 type ComponentAndPrimaryPurchaseAndDomain =
 	| []
 	| [ string | false ]
@@ -256,6 +262,14 @@ export class CheckoutThankYou extends Component<
 				];
 				debug( 'recordOrderInGoogleAds: WPCom Domain Transfer Purchase', params );
 				window.gtag( ...params );
+			}
+
+			// Custom conversion for Facebook Ads/audiences
+			if ( mayWeTrackByTracker( 'facebook' ) ) {
+				const params = [ 'trackCustom', 'BulkDomainTransfer', {} ];
+
+				debug( 'recordOrderInFacebookAds: WPCom Bulk Domain Transfer Purchase', params );
+				window.fbq && window.fbq( ...params );
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1970

## Proposed Changes

* This adds a custom Facebook event `BulkDomainTransfer` that can be used for creating a custom conversion
* It's added to the thank you page, similar to how the Google Ads conversion tag is implemented in #79702

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Enable the `ad-tracking` and `cookie-banner` flag in development.json
* `yarn && yarn start`
* Ensure that correct Privacy settings are disabled
  * Make sure that browser `doNotTrack` setting is disabled. For example, in chrome, [follow these instructions to disable](https://support.google.com/chrome/answer/2790761?hl=en&co=GENIE.Platform%3DDesktop).
  * Enable the "Share information with our analytics tool about your use of services while logged in to your WordPress.com account" toggle in `/me` under the `Privacy` tab
  * If you're in GDPR, accept the GDPR banner.
  * That should be enough to address all potential privacy blocks, but I might have missed something. There may be other settings that need to be disabled in your environment. The logic is outlined in [this file](https://github.com/Automattic/wp-calypso/blob/7b73d26cb9e233370224799b1e40cf359142f6c1/client/lib/analytics/tracker-buckets.ts#L131-L132) under the `mayWeTrackByTracker` method
* Navigate to http://calypso.localhost:3000/setup/domain-transfer/domains
  * There are two ways to handle testing the actual domain transfer:
    1. Transfer the domain and cancel the transfer with your original domain registrar afterwards ( p1689366128054469-slack-C05CT832K2T ) 
    2. Change backend logic to permit an incorrect auth transfer code. Submit incorrect code, wait for system retries to complete, and then delete the transfer request in wordpress.com/domains/manage p1689594886918239-slack-C0BNMNMNG
  * Enter domain to transfer
  * Enter auth code ( you can enter fake auth codes by following these instructions p1689366128054469-slack-C05CT832K2T)
  * Click on transfer button
* Click on Pay $0 now
* Verify that the custom Facebook event was fired by checking the dev network tab for the facebook fetch request (you can filter the log on `BulkDomainTransfer`)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
