### PR TITLE
i18n: Translate ThemeShowcase page title and description

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
-import { localize, translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -529,12 +529,12 @@ class ThemeShowcase extends Component {
 				<ThemesHeader
 					title={
 						isLoggedIn
-							? translate( 'Themes' )
-							: translate( 'Find the perfect theme for your website' )
+							? this.props.translate( 'Themes' )
+							: this.props.translate( 'Find the perfect theme for your website' )
 					}
 					description={
 						isLoggedIn
-							? translate(
+							? this.props.translate(
 									'Select or update the visual design for your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 									{
 										components: {
@@ -544,7 +544,7 @@ class ThemeShowcase extends Component {
 										},
 									}
 							  )
-							: translate(
+							: this.props.translate(
 									'Beautiful and responsive WordPress.com themes. Choose from free and premium options for all types of websites. Then, activate the one that is right for you.'
 							  )
 					}
@@ -610,7 +610,7 @@ class ThemeShowcase extends Component {
 	}
 }
 
-const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
+const mapStateToProps = ( state, { siteId, filter, tier, vertical, translate } ) => {
 	return {
 		isLoggedIn: isUserLoggedIn( state ),
 		isAtomicSite: isAtomicSite( state, siteId ),
@@ -618,8 +618,8 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
 		areSiteFeaturesLoaded: !! getSiteFeaturesById( state, siteId ),
 		siteCanInstallThemes: siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES ),
 		siteSlug: getSiteSlug( state, siteId ),
-		description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),
-		title: getThemeShowcaseTitle( state, { filter, tier, vertical } ),
+		description: getThemeShowcaseDescription( state, { filter, tier, vertical }, translate ),
+		title: getThemeShowcaseTitle( state, { filter, tier, vertical }, translate ),
 		subjects: getThemeFilterTerms( state, 'subject' ) || {},
 		premiumThemesEnabled: arePremiumThemesEnabled( state, siteId ),
 		filterString: prependThemeFilterKeys( state, filter ),

--- a/client/state/themes/selectors/get-theme-showcase-description.js
+++ b/client/state/themes/selectors/get-theme-showcase-description.js
@@ -1,19 +1,31 @@
+import { translate as translateFallback } from 'i18n-calypso';
 import { get, includes } from 'lodash';
 import { findThemeFilterTerm } from 'calypso/state/themes/selectors/find-theme-filter-term';
 import { getThemeFilterTerm } from 'calypso/state/themes/selectors/get-theme-filter-term';
 
 import 'calypso/state/themes/init';
 
-export function getThemeShowcaseDescription( state, { filter, tier, vertical } = {} ) {
+export function getThemeShowcaseDescription(
+	state,
+	{ filter, tier, vertical } = {},
+	translate = translateFallback
+) {
 	if ( vertical ) {
 		const description = get( getThemeFilterTerm( state, 'subject', vertical ), 'description' );
 		if ( description ) {
 			return description;
 		}
-		return (
-			`Discover ${ vertical } WordPress Themes on the WordPress.com Showcase. ` +
-			'Here you can browse and find the best WordPress designs available on ' +
-			'WordPress.com to discover the one that is just right for you.'
+
+		/* translators: %(vertical)s will be replaced by a vertical name */
+		return translate(
+			'Discover %(vertical)s WordPress Themes on the WordPress.com Showcase. ' +
+				'Here you can browse and find the best WordPress designs available on ' +
+				'WordPress.com to discover the one that is just right for you.',
+			{
+				args: {
+					vertical,
+				},
+			}
 		);
 	}
 
@@ -23,21 +35,28 @@ export function getThemeShowcaseDescription( state, { filter, tier, vertical } =
 		if ( filterDescription ) {
 			return filterDescription;
 		}
-		return (
-			`Discover WordPress Themes supporting ${ filter } on the WordPress.com Showcase. ` +
-			'Here you can browse and find the best WordPress designs available on WordPress.com ' +
-			'to discover the one that is just right for you.'
+
+		/* translators: %(filter)s will be replaced by a filter name, e.g. "Store", "Blog" */
+		return translate(
+			'Discover WordPress Themes supporting %(filter)s on the WordPress.com Showcase. ' +
+				'Here you can browse and find the best WordPress designs available on ' +
+				'WordPress.com to discover the one that is just right for you.',
+			{
+				args: {
+					filter,
+				},
+			}
 		);
 	}
 
 	if ( tier === 'free' ) {
-		return 'Discover Free WordPress Themes on the WordPress.com Theme Showcase.';
+		return translate( 'Discover Free WordPress Themes on the WordPress.com Theme Showcase.' );
 	} else if ( tier === 'premium' ) {
-		return 'Discover Premium WordPress Themes on the WordPress.com Theme Showcase.';
+		return translate( 'Discover Premium WordPress Themes on the WordPress.com Theme Showcase.' );
 	}
 
-	return (
+	return translate(
 		'Beautiful, responsive, free and premium WordPress themes ' +
-		'for your photography site, portfolio, magazine, business website, or blog.'
+			'for your photography site, portfolio, magazine, business website, or blog.'
 	);
 }

--- a/client/state/themes/selectors/get-theme-showcase-description.js
+++ b/client/state/themes/selectors/get-theme-showcase-description.js
@@ -16,7 +16,7 @@ export function getThemeShowcaseDescription(
 			return description;
 		}
 
-		/* translators: %(vertical)s will be replaced by a vertical name */
+		/* translators: %(vertical)s will be replaced by a vertical name, e.g. "Business", "Portfolio" */
 		return translate(
 			'Discover %(vertical)s WordPress Themes on the WordPress.com Showcase. ' +
 				'Here you can browse and find the best WordPress designs available on ' +

--- a/client/state/themes/selectors/get-theme-showcase-title.js
+++ b/client/state/themes/selectors/get-theme-showcase-title.js
@@ -13,7 +13,7 @@ export function getThemeShowcaseTitle(
 	if ( vertical ) {
 		const verticalName = get( getThemeFilterTerm( state, 'subject', vertical ), 'name' );
 		if ( verticalName ) {
-			/* translators: %(verticalName)s will be replaced by a vertical name */
+			/* translators: %(verticalName)s will be replaced by a vertical name, e.g. "Business", "Portfolio" */
 			return translate( '%(verticalName)s WordPress Themes', {
 				args: {
 					verticalName,

--- a/client/state/themes/selectors/get-theme-showcase-title.js
+++ b/client/state/themes/selectors/get-theme-showcase-title.js
@@ -1,14 +1,24 @@
+import { translate as translateFallback } from 'i18n-calypso';
 import { get, includes } from 'lodash';
 import { findThemeFilterTerm } from 'calypso/state/themes/selectors/find-theme-filter-term';
 import { getThemeFilterTerm } from 'calypso/state/themes/selectors/get-theme-filter-term';
 
 import 'calypso/state/themes/init';
 
-export function getThemeShowcaseTitle( state, { filter, tier, vertical } = {} ) {
+export function getThemeShowcaseTitle(
+	state,
+	{ filter, tier, vertical } = {},
+	translate = translateFallback
+) {
 	if ( vertical ) {
-		const name = get( getThemeFilterTerm( state, 'subject', vertical ), 'name' );
-		if ( name ) {
-			return `${ name } WordPress Themes`;
+		const verticalName = get( getThemeFilterTerm( state, 'subject', vertical ), 'name' );
+		if ( verticalName ) {
+			/* translators: %(verticalName)s will be replaced by a vertical name */
+			return translate( '%(verticalName)s WordPress Themes', {
+				args: {
+					verticalName,
+				},
+			} );
 		}
 	}
 
@@ -16,15 +26,20 @@ export function getThemeShowcaseTitle( state, { filter, tier, vertical } = {} ) 
 	if ( filter && ! includes( filter, '+' ) ) {
 		const filterName = get( findThemeFilterTerm( state, filter ), 'name' );
 		if ( filterName ) {
-			return `${ filterName } WordPress Themes`;
+			/* translators: %(filterName)s will be replaced by a filter name, e.g. "Store", "Blog" */
+			return translate( '%(filterName)s WordPress Themes', {
+				args: {
+					filterName,
+				},
+			} );
 		}
 	}
 
 	if ( tier === 'free' ) {
-		return 'Free WordPress Themes';
+		return translate( 'Free WordPress Themes' );
 	} else if ( tier === 'premium' ) {
-		return 'Premium WordPress Themes';
+		return translate( 'Premium WordPress Themes' );
 	}
 
-	return 'WordPress Themes';
+	return translate( 'WordPress Themes' );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 478-gh-Automattic/i18n-issues

## Proposed Changes

* Wrap the theme showcase titles and descriptions texts in `translate()` calls.

The translate function is being provided as an additional parameter to the selector. Ideally, the selectors would've been converted into custom hooks and use the `useTranslate()`. However, since the component is currently implemented as a class component, it would've require a major refactoring, which is out of the scope of the issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use calypso.live build or checkout locally.
* Go to `/:locale/themes` logged out.
* Inspect the source and confirm the title and description meta tags are translated. Note that at the moment of creating this PR, most of the translations are still unavailable (either not yet translated, or not deployed).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
