### PR TITLE
Add migration trial product unit tests

### DIFF
--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	FEATURE_ACTIVITY_LOG,
 	FEATURE_ALL_PERSONAL_FEATURES,
@@ -72,6 +73,7 @@ import {
 	PLAN_WOOEXPRESS_PLUS,
 	PLAN_WPCOM_PRO_2_YEARS,
 	PLAN_JETPACK_SECURITY_T1_BI_YEARLY,
+	PLAN_MIGRATION_TRIAL_MONTHLY,
 } from '../src/constants';
 import {
 	getPlan,
@@ -114,7 +116,12 @@ import {
 	isWooExpressPlusPlan,
 } from '../src/index';
 
-const PLANS_LIST = getPlans();
+jest.mock( '@automattic/calypso-config', () => {
+	const mock = () => '';
+	mock.isEnabled = jest.fn( () => true );
+
+	return mock;
+} );
 
 describe( 'isFreePlan', () => {
 	test( 'should return true for free plans', () => {
@@ -768,11 +775,13 @@ describe( 'getPlanClass', () => {
 
 describe( 'getPlan', () => {
 	test( 'should return a proper plan - by key', () => {
-		expect( getPlan( PLAN_PERSONAL ) ).toEqual( PLANS_LIST[ PLAN_PERSONAL ] );
+		const plansList = getPlans();
+		expect( getPlan( PLAN_PERSONAL ) ).toEqual( plansList[ PLAN_PERSONAL ] );
 	} );
 
 	test( 'should return a proper plan - by value', () => {
-		expect( getPlan( PLANS_LIST[ PLAN_PERSONAL ] ) ).toEqual( PLANS_LIST[ PLAN_PERSONAL ] );
+		const plansList = getPlans();
+		expect( getPlan( plansList[ PLAN_PERSONAL ] ) ).toEqual( plansList[ PLAN_PERSONAL ] );
 	} );
 
 	test( 'should return undefined for invalid plan - by key', () => {
@@ -1021,11 +1030,20 @@ describe( 'findSimilarPlansKeys', () => {
 				type: TYPE_BUSINESS,
 				group: GROUP_WPCOM,
 			} )
-		).toEqual( [ PLAN_BUSINESS_MONTHLY ] );
+		).toEqual( [ PLAN_BUSINESS_MONTHLY, PLAN_MIGRATION_TRIAL_MONTHLY ] );
 	} );
 } );
 
 describe( 'findPlansKeys', () => {
+	beforeEach( () => {
+		// Enable migration trials mock
+		config.isEnabled.mockImplementation( ( key ) => key === 'plans/migration-trial' );
+	} );
+
+	afterEach( () => {
+		jest.resetAllMocks();
+	} );
+
 	test( 'all matching plans keys - by term', () => {
 		expect( findPlansKeys( { term: TERM_BIENNIALLY } ) ).toEqual( [
 			PLAN_BLOGGER_2_YEARS,
@@ -1069,7 +1087,8 @@ describe( 'findPlansKeys', () => {
 			PLAN_WPCOM_FLEXIBLE,
 			PLAN_WPCOM_PRO,
 		] );
-		expect( findPlansKeys( { term: TERM_MONTHLY } ) ).toEqual( [
+
+		const termMonthlyPaid = [
 			PLAN_PERSONAL_MONTHLY,
 			PLAN_PREMIUM_MONTHLY,
 			PLAN_BUSINESS_MONTHLY,
@@ -1088,7 +1107,10 @@ describe( 'findPlansKeys', () => {
 			PLAN_P2_PLUS,
 			PLAN_WPCOM_PRO_MONTHLY,
 			PLAN_ECOMMERCE_TRIAL_MONTHLY,
-		] );
+			PLAN_MIGRATION_TRIAL_MONTHLY,
+		];
+
+		expect( findPlansKeys( { term: TERM_MONTHLY } ) ).toEqual( termMonthlyPaid );
 	} );
 
 	test( 'all matching plans keys - by type', () => {
@@ -1124,6 +1146,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_BUSINESS_3_YEARS,
 			PLAN_JETPACK_BUSINESS,
 			PLAN_JETPACK_BUSINESS_MONTHLY,
+			PLAN_MIGRATION_TRIAL_MONTHLY,
 		] );
 	} );
 
@@ -1162,6 +1185,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_WPCOM_PRO_MONTHLY,
 			PLAN_WPCOM_PRO_2_YEARS,
 			PLAN_ECOMMERCE_TRIAL_MONTHLY,
+			PLAN_MIGRATION_TRIAL_MONTHLY,
 		] );
 		expect( findPlansKeys( { group: GROUP_JETPACK } ) ).toEqual( [
 			PLAN_JETPACK_FREE,
@@ -1209,6 +1233,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_BUSINESS,
 			PLAN_BUSINESS_2_YEARS,
 			PLAN_BUSINESS_3_YEARS,
+			PLAN_MIGRATION_TRIAL_MONTHLY,
 		] );
 		expect( findPlansKeys( { group: GROUP_JETPACK, type: TYPE_BLOGGER } ) ).toEqual( [] );
 		expect( findPlansKeys( { group: GROUP_JETPACK, type: TYPE_PERSONAL } ) ).toEqual( [


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Plan list unit tests will stop working after the Migration Trial feature flag is unlocked in production. This PR will add new tests that work with that flag enabled.

Fixes https://github.com/Automattic/wp-calypso/issues/79829

## Proposed Changes

* Add new unit tests.
* The tests call `getPlans()` each test and not a global `PLANS_LIST`. So it can be mocked.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn jest 'packages/calypso-products/test/plan-lookups.js' -c 'packages/calypso-products/jest.config.js' -- --silent=false`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
