### PR TITLE
Subscription management: Fix confirming/deleting pending subscriptions

### DIFF
--- a/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
@@ -12,7 +12,7 @@ type PendingPostConfirmResponse = {
 };
 
 const usePendingPostConfirmMutation = () => {
-	const isLoggedIn = useIsLoggedIn();
+	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
 	const countCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
 	return useMutation( {

--- a/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
@@ -12,7 +12,7 @@ type PendingPostDeleteResponse = {
 };
 
 const usePendingPostDeleteMutation = () => {
-	const isLoggedIn = useIsLoggedIn();
+	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
 	const countCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
 	return useMutation( {

--- a/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
@@ -13,7 +13,7 @@ type PendingSiteConfirmResponse = {
 };
 
 const usePendingSiteConfirmMutation = () => {
-	const isLoggedIn = useIsLoggedIn();
+	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
 	const countCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
 	return useMutation( {

--- a/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
@@ -12,7 +12,7 @@ type PendingSiteDeleteResponse = {
 };
 
 const usePendingSiteDeleteMutation = () => {
-	const isLoggedIn = useIsLoggedIn();
+	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
 	const countCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
 	return useMutation( {


### PR DESCRIPTION
The isLoggedIn value was incorrectly extracted from the useIsLoggedIn hook in various queries/mutations. The previous instances of `const isLoggedIn = useIsLoggedIn();` have now been corrected to `const { isLoggedIn } = useIsLoggedIn();`, ensuring that the mutations behave as expected when handling pending site and post confirmations or deletions.

Discussion: p1689273487017629-slack-C02TCEHP3HA 

## Proposed Changes

- Pending sites were not removed from the pending list after confirming/deleting them 
- Investigation revealed that the cache key used to optimistically update the cache was not consistent with the key from the query
- The useIsLoggedIn hook was changed recently to return an object instead of a boolean
- This patch corrects the invocation of this hook from `const isLoggedIn = useIsLoggedIn();` to `const { isLoggedIn } = useIsLoggedIn();

## Testing Instructions

1. Apply this PR
2. Subscribe to a post and comments using a non-logged in user
3. Do the subkey cookie dance (extract the subkey cookie from `wordpress.com/subscriptions` and set it for `calypso.localhost:3000` by using `document.cookie="subkey="`) 
4. Visit `http://calypso.localhost:3000` and view the pending subscriptions
5. Clicking confirm/delete should remove the pending subscription from the list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?