### PR TITLE
Add progress bar to server bundler

### DIFF
--- a/client/server/bundler/index.js
+++ b/client/server/bundler/index.js
@@ -35,6 +35,20 @@ function middleware( app ) {
 		} );
 	}
 
+	// Add a progress logging function to the ProgressPlugin
+	new compiler.webpack.ProgressPlugin( ( percentage, message ) => {
+		const width = 40; // width of progress bar
+		const pos = Math.floor( percentage * width );
+
+		// create progress bar
+		const progressBar = '[' + '#'.repeat( pos ) + ' '.repeat( width - pos ) + ']';
+
+		// print progress bar
+		process.stderr.write(
+			`\rProgress: ${ ( percentage * 100 ).toFixed( 2 ) }% ${ progressBar } ${ message }`
+		);
+	} ).apply( compiler );
+
 	compiler.hooks.done.tap( 'Calypso', function () {
 		built = true;
 


### PR DESCRIPTION
The commit introduces a progress logging function to the webpack.compiler (ProgressPlugin) in the server bundler. This function creates and displays a progress bar in the console, providing a visual insight into the bundling process progress. This feature can aid in identifying issues during the process or simply provide a better UX during development.

Discussion: [p1690291026042139-slack-C02DQP0F ](p1690291026042139-slack-C02DQP0FP)

@Automattic/team-calypso 

## Proposed Changes

This adds a simple progress bar to the bundling process. This PR is mainly to get some discussion going whether it is feasible to bring some progress tracking to Calypso. 

![CleanShot 2023-07-25 at 15 11 25](https://github.com/Automattic/wp-calypso/assets/528287/8ce7fd97-f555-42cc-826f-c6ab5cf08c12)

Some things to note:

- It abuses `stderr`. If writing to `stdout`, it only works as long as no other `console.log ` statements happen afterwards.
- There isn't a newline at the end (otherwise `\r` wouldn't work). Subsequent console.log statements aren't wrapped to a new line because of this.
- For some reason I didn't really look into too deeply, the number sometimes goes down a bit, before going back up 🫠 

An alternative approach, that doesn't mess up other console messages, could be to show some progress inside the Terminal's title bar: 

```
process.stdout.write(String.fromCharCode(27) + "]0;" + `${(percentage * 100).toFixed(2)}%` + String.fromCharCode(7));
```

## Testing Instructions

- Apply PR
- `yarn start`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?