### PR TITLE
Jetpack Cloud: Add site's posts management

### DIFF
--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryScanState from 'calypso/components/data/query-jetpack-scan';
@@ -60,7 +61,7 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 			{ isAdmin && (
 				<SidebarItem
 					tipTarget="posts"
-					customIcon={ showIcons && <JetpackIcons icon="activity-log" /> }
+					customIcon={ showIcons && <Gridicon className="sidebar__menu-icon" icon="pin" /> }
 					label={ translate( 'Posts', {
 						comment: 'Jetpack sidebar menu item',
 					} ) }

--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -57,6 +57,19 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 					expandSection={ expandSection }
 				/>
 			) }
+			{ isAdmin && (
+				<SidebarItem
+					tipTarget="posts"
+					customIcon={ showIcons && <JetpackIcons icon="activity-log" /> }
+					label={ translate( 'Posts', {
+						comment: 'Jetpack sidebar menu item',
+					} ) }
+					link={ `/posts/${ siteSlug }` }
+					onNavigate={ onNavigate( tracksEventNames.postsClicked ) }
+					selected={ currentPathMatches( `/posts/${ siteSlug }` ) }
+					expandSection={ expandSection }
+				></SidebarItem>
+			) }
 			{ isAdmin && ! isWPForTeamsSite && (
 				<SidebarItem
 					customIcon={ showIcons && <JetpackIcons icon="backup" /> }

--- a/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
+++ b/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
@@ -58,6 +58,7 @@ export default ( { path } ) => {
 				showIcons={ true }
 				tracksEventNames={ {
 					activityClicked: 'calypso_jetpack_sidebar_activity_clicked',
+					postsClicked: 'calypso_jetpack_sidebar_posts_clicked',
 					backupClicked: 'calypso_jetpack_sidebar_backup_clicked',
 					scanClicked: 'calypso_jetpack_sidebar_scan_clicked',
 					searchClicked: 'calypso_jetpack_sidebar_search_clicked',

--- a/client/jetpack-cloud/sections/posts/controller.tsx
+++ b/client/jetpack-cloud/sections/posts/controller.tsx
@@ -1,0 +1,26 @@
+import Posts from 'calypso/my-sites/posts/main';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export function posts( context, next ) {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	const author = context.params.author === 'my' ? getCurrentUserId( state ) : null;
+	let search = context.query.s || '';
+	const category = context.query.category;
+	const tag = context.query.tag;
+
+	if ( ! siteId ) {
+		search = '';
+	}
+
+	context.primary = createElement( Posts, {
+		context,
+		author,
+		statusSlug: context.params.status,
+		search,
+		category,
+		tag,
+	} );
+
+	next();
+}

--- a/client/jetpack-cloud/sections/posts/controller.tsx
+++ b/client/jetpack-cloud/sections/posts/controller.tsx
@@ -1,4 +1,6 @@
 import Posts from 'calypso/my-sites/posts/main';
+import areAllSitesSingleUser from 'calypso/state/selectors/are-all-sites-single-user';
+import { isJetpackSite, isSingleUserSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export function posts( context, next ) {
@@ -9,8 +11,25 @@ export function posts( context, next ) {
 	const category = context.query.category;
 	const tag = context.query.tag;
 
+	function shouldRedirectMyPosts() {
+		if ( ! author ) {
+			return false;
+		}
+		if ( areAllSitesSingleUser( state ) ) {
+			return true;
+		}
+		if ( isSingleUserSite( state, siteId ) || isJetpackSite( state, siteId ) ) {
+			return true;
+		}
+	}
+
 	if ( ! siteId ) {
 		search = '';
+	}
+
+	if ( shouldRedirectMyPosts() ) {
+		page.redirect( context.path.replace( /\/my\b/, '' ) );
+		return;
 	}
 
 	context.primary = createElement( Posts, {

--- a/client/jetpack-cloud/sections/posts/controller.tsx
+++ b/client/jetpack-cloud/sections/posts/controller.tsx
@@ -1,7 +1,9 @@
-import Posts from 'calypso/my-sites/posts/main';
+import { createElement } from 'react';
+/* import Posts from 'calypso/my-sites/posts/main'; */
 import areAllSitesSingleUser from 'calypso/state/selectors/are-all-sites-single-user';
 import { isJetpackSite, isSingleUserSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import Posts from './main';
 
 export function posts( context, next ) {
 	const state = context.store.getState();

--- a/client/jetpack-cloud/sections/posts/index.ts
+++ b/client/jetpack-cloud/sections/posts/index.ts
@@ -2,14 +2,14 @@ import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
 import { getSiteFragment } from 'calypso/lib/route';
 import { navigation, siteSelection } from 'calypso/my-sites/controller';
-import postsController from 'calypso/my-sites/posts/controller';
+import * as controller from './controller';
 
 export default function () {
 	page(
 		'/posts/:author(my)?/:status(published|drafts|scheduled|trashed)?/:domain?',
 		siteSelection,
 		navigation,
-		postsController.posts,
+		controller.posts,
 		makeLayout,
 		clientRender
 	);

--- a/client/jetpack-cloud/sections/posts/index.ts
+++ b/client/jetpack-cloud/sections/posts/index.ts
@@ -1,0 +1,24 @@
+import page from 'page';
+import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
+import { getSiteFragment } from 'calypso/lib/route';
+import { navigation, siteSelection } from 'calypso/my-sites/controller';
+import postsController from 'calypso/my-sites/posts/controller';
+
+export default function () {
+	page(
+		'/posts/:author(my)?/:status(published|drafts|scheduled|trashed)?/:domain?',
+		siteSelection,
+		navigation,
+		postsController.posts,
+		makeLayout,
+		clientRender
+	);
+
+	page( '/posts/*', ( { path } ) => {
+		const siteFragment = getSiteFragment( path );
+		if ( siteFragment ) {
+			return page.redirect( `/posts/my/${ siteFragment }` );
+		}
+		return page.redirect( '/posts/my' );
+	} );
+}

--- a/client/jetpack-cloud/sections/posts/main.tsx
+++ b/client/jetpack-cloud/sections/posts/main.tsx
@@ -1,0 +1,59 @@
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import Main from 'calypso/components/main';
+import ScreenOptionsTab from 'calypso/components/screen-options-tab';
+import PostTypeFilter from 'calypso/my-sites/post-type-filter';
+import PostTypeList from 'calypso/my-sites/post-type-list';
+
+const PostsMain = ( { author, category, search, siteId, statusSlug, tag } ) => {
+	const translate = useTranslate();
+	const isAllSites = siteId ? 1 : 0;
+	const query = {
+		author,
+		category,
+		number: 20, // max supported by /me/posts endpoint for all-sites mode
+		order: status === 'future' ? 'ASC' : 'DESC',
+		search,
+		site_visibility: ! siteId ? 'visible' : undefined,
+		// When searching, search across all statuses so the user can
+		// always find what they are looking for, regardless of what tab
+		// the search was initiated from. Use POST_STATUSES rather than
+		// "any" to do this, since the latter excludes trashed posts.
+		status: search ? POST_STATUSES.join( ',' ) : status,
+		tag,
+		type: 'post',
+	};
+	const showPublishedStatus = Boolean( query.search );
+
+	return (
+		<Main wideLayout className="posts">
+			<DocumentHead title={ translate( 'Posts' ) } />
+			<FormattedHeader
+				className="posts__page-heading"
+				headerText={ translate( 'Posts' ) }
+				subHeaderText={ translate(
+					'Create, edit, and manage the posts on your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					'Create, edit, and manage the posts on your sites. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						count: isAllSites,
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="posts" showIcon={ false } />,
+						},
+					}
+				) }
+				align="left"
+				hasScreenOptions
+			/>
+			<ScreenOptionsTab wpAdminPath="edit.php" />
+			<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ statusSlug } />
+			<PostTypeList
+				query={ query }
+				showPublishedStatus={ showPublishedStatus }
+				scrollContainer={ document.body }
+			/>
+		</Main>
+	);
+};
+export default PostsMain;

--- a/client/sections.js
+++ b/client/sections.js
@@ -500,6 +500,13 @@ const sections = [
 		enableLoggedOut: true,
 	},
 	{
+		name: 'jetpack-cloud-post',
+		paths: [ '/post', '/page', '/edit' ],
+		module: 'calypso/gutenberg/editor',
+		group: 'jetpack-cloud',
+		enableLoggedOut: true,
+	},
+	{
 		name: 'jetpack-cloud-posts',
 		paths: [ '/posts' ],
 		module: 'calypso/jetpack-cloud/sections/posts',

--- a/client/sections.js
+++ b/client/sections.js
@@ -500,6 +500,12 @@ const sections = [
 		enableLoggedOut: true,
 	},
 	{
+		name: 'jetpack-cloud-posts',
+		paths: [ '/posts' ],
+		module: 'calypso/jetpack-cloud/sections/posts',
+		group: 'jetpack-cloud',
+	},
+	{
 		name: 'jetpack-cloud-agency-dashboard',
 		paths: [ '/dashboard' ],
 		module: 'calypso/jetpack-cloud/sections/agency-dashboard',

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -85,6 +85,7 @@
 		"jetpack-cloud-pricing": true,
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-golden-token": true,
+		"jetpack-cloud-posts": true,
 		"jetpack-search": true,
 		"jetpack-social": true,
 		"scan": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -85,6 +85,7 @@
 		"jetpack-cloud-pricing": true,
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-golden-token": true,
+		"jetpack-cloud-post": true,
 		"jetpack-cloud-posts": true,
 		"jetpack-search": true,
 		"jetpack-social": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
* The overall goal is to lower the contrast between the capabilities of the Jetpack Mobile App and Jetpack Cloud
* Adds the ability to manage Jetpack sites' posts from Jetpack Cloud

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* http://jetpack.cloud.localhost:3000/posts

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
