### PR TITLE
Checkout: Prevent reporting stored payment methods error for undefined data

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
@@ -117,7 +117,7 @@ export function useStoredPaymentMethods( {
 		if ( error ) {
 			return error.message;
 		}
-		if ( ! isDataValid ) {
+		if ( data !== undefined && ! isDataValid ) {
 			return translate( 'There was a problem loading your stored payment methods.', {
 				textOnly: true,
 			} );


### PR DESCRIPTION
## Proposed Changes

I noticed that there is a case where the `useStoredPaymentMethods()` hook could return the error `There was a problem loading your stored payment methods` while the stored payment methods are still loading. That error should only ever happen if the endpoint misbehaves. This could happen if `useQuery()` returned `undefined` for the data before the query completes.

In this PR we prevent returning the error message unless the data exists AND is invalid.

## Testing Instructions

No testing should be required. 