### PR TITLE
Domains Transfers: Match back button & browser back on /domains

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -104,7 +104,11 @@ const domainTransfer: Flow = {
 		const goBack = () => {
 			switch ( _currentStepSlug ) {
 				case 'domains':
-					return navigate( 'intro' );
+					if ( window.history.length === 0 ) {
+						return navigate( 'intro' );
+					}
+					window.history.back();
+					return;
 				default:
 					return;
 			}

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -104,7 +104,7 @@ const domainTransfer: Flow = {
 		const goBack = () => {
 			switch ( _currentStepSlug ) {
 				case 'domains':
-					if ( window.history.length === 0 ) {
+					if ( window.history.length < 3 ) {
 						return navigate( 'intro' );
 					}
 					window.history.back();


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3040

Uses `window.history.back` on the `< Back` button on the `/domains` page, because if the user uses the page back button and then the browser back button, it returns to the `/domains` page instead of get out of the flow.
 
## Testing Instructions

* With a logged in user
* Go to `/setup/domain-transfer/`
* Click on `Get started`
* Click on the `< Back` button of the page
* Now you can click on Browser `forward` button to go back to `/domains`
* You can't get out of the flow because of a bug mentioned here (p1690314087610609-slack-C057AH42XQD)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?