### PR TITLE
Launchpad: Allow manage subscribers task to be clicked and completed

### DIFF
--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,6 +1,8 @@
+import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import page from 'page';
+import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { Item } from 'calypso/components/breadcrumb';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -39,6 +41,15 @@ const SubscribersPage = ( {
 	sortTermChanged,
 }: SubscribersProps ) => {
 	const selectedSite = useSelector( getSelectedSite );
+
+	useEffect( () => {
+		if ( selectedSite ) {
+			// Mark the `manage_subscribers` task as done when we visit this page.
+			updateLaunchpadSettings( selectedSite.slug, {
+				checklist_statuses: { manage_subscribers: true },
+			} );
+		}
+	}, [] );
 
 	const pageArgs = {
 		currentPage: pageNumber,

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -77,6 +77,11 @@ export const setUpActionsForTasks = ( {
 					window.location.assign( `/settings/reading/${ siteSlug }#newsletter-settings` );
 				};
 				break;
+			case 'manage_subscribers':
+				action = () => {
+					window.location.assign( `/subscribers/${ siteSlug }` );
+				};
+				break;
 		}
 
 		const actionDispatch = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79793

## Proposed Changes

* Alongside backend PR at https://github.com/Automattic/jetpack/pull/32064, this PR adds the front-end action for the "Manage subscribers" task, and the completion event when the user visits the `/subscribers/siteSlug` page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the back-end patch to your sandbox and sandbox public-api: https://github.com/Automattic/jetpack/pull/32064
* Create a new site from `/setup/newsletter` and select the import subscribers intent during onboarding.
* Complete onboarding by writing a test post.
* You'll be brought to My Home, where you should see the Newsletters task list:
<img width="718" alt="Screenshot 2023-07-25 at 3 12 11 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/061ea919-85ad-4cbf-b1b0-b92776cb6b19">

* You should see the "Manage your subscribers" task in the list.
* You should be brought to the `/subscribers/siteSlug` screen when you click on the task:

<img width="1075" alt="Screenshot 2023-07-25 at 3 35 29 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/826b0824-2bf0-48e4-8c1d-0da1e8676bae">

* Go back to `/home/siteSlug` and the task should be marked complete:

<img width="707" alt="Screenshot 2023-07-25 at 3 36 46 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/aa0dcbd3-e46d-4824-8a6b-3333f853febb">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
