### PR TITLE
Logged-Out Theme Showcase: Update SEO Content

### DIFF
--- a/client/my-sites/themes/get-theme-showcase-logged-out-seo-content.js
+++ b/client/my-sites/themes/get-theme-showcase-logged-out-seo-content.js
@@ -86,7 +86,7 @@ const THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT = {
 			title: translate( 'Premium Business WordPress Themes' ),
 			header: translate( 'Choose premium themes for your business website.' ),
 			description: translate(
-				"Enhance your business website with the perfect premium paid theme. Available on all Premium, Business, and Ecommerce plans. Activate the one that's right for you."
+				"Enhance your business website with the perfect premium theme. Available on all Premium, Business, and Ecommerce plans. Activate the one that's right for you."
 			),
 		},
 		marketplace: {

--- a/client/my-sites/themes/get-theme-showcase-logged-out-seo-content.js
+++ b/client/my-sites/themes/get-theme-showcase-logged-out-seo-content.js
@@ -159,31 +159,31 @@ const THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT = {
 	},
 	about: {
 		all: {
-			title: translate( 'About WordPress Themes' ),
-			header: translate( 'Find the perfect theme for your about website.' ),
+			title: translate( 'About Me WordPress Themes' ),
+			header: translate( 'Find the perfect theme for your About Me website.' ),
 			description: translate(
-				"Start your about website with the perfect theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
+				"Start your About Me website with the perfect theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
 			),
 		},
 		free: {
-			title: translate( 'Free About WordPress Themes' ),
-			header: translate( 'Discover the perfect free theme for your about website.' ),
+			title: translate( 'Free About Me WordPress Themes' ),
+			header: translate( 'Discover the perfect free theme for your About Me website.' ),
 			description: translate(
-				"Launch your about website with the perfect free theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
+				"Launch your About Me website with the perfect free theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
 			),
 		},
 		premium: {
-			title: translate( 'Premium About WordPress Themes' ),
-			header: translate( 'Choose premium themes for your about website.' ),
+			title: translate( 'Premium About Me WordPress Themes' ),
+			header: translate( 'Choose premium themes for your About Me website.' ),
 			description: translate(
-				"Enhance your about website with the perfect premium theme. Available on all Premium, Business, and Ecommerce plans. Activate the one that's right for you."
+				"Enhance your About Me website with the perfect premium theme. Available on all Premium, Business, and Ecommerce plans. Activate the one that's right for you."
 			),
 		},
 		marketplace: {
-			title: translate( 'Paid About WordPress Themes' ),
-			header: translate( 'Select paid themes for your about website.' ),
+			title: translate( 'Paid About Me WordPress Themes' ),
+			header: translate( 'Select paid themes for your About Me website.' ),
 			description: translate(
-				"Improve your about website with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
+				"Improve your About Me website with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
 			),
 		},
 	},

--- a/client/my-sites/themes/get-theme-showcase-logged-out-seo-content.js
+++ b/client/my-sites/themes/get-theme-showcase-logged-out-seo-content.js
@@ -1,0 +1,263 @@
+import { translate } from 'i18n-calypso';
+
+/**
+ * SEO content:
+ * - title: the page's <title> tag.
+ * - header: the page's main heading.
+ * - description: the page's sub-heading and <meta> description.
+ */
+const THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT = {
+	recommended: {
+		all: {
+			title: translate( 'WordPress Themes' ),
+			header: translate( 'Find the perfect theme for your website.' ),
+			description: translate(
+				'Beautiful and responsive WordPress themes. Choose from free and premium options for all types of websites. Then, activate the one that’s best for you.'
+			),
+		},
+		free: {
+			title: translate( 'Free WordPress Themes' ),
+			header: translate( 'Find the perfect free WordPress theme for your blog or website.' ),
+			description: translate(
+				'Browse all free themes for WordPress.com. Try one or try them all. Risk-free.'
+			),
+		},
+		premium: {
+			title: translate( 'Premium WordPress Themes' ),
+			header: translate( 'Find the perfect premium WordPress theme for your blog or website.' ),
+			description: translate(
+				"Browse all premium themes for WordPress.com. Available on all Premium, Business, and Ecommerce plans. Activate the one that's right for you."
+			),
+		},
+		marketplace: {
+			title: translate( 'Paid WordPress Themes' ),
+			header: translate( 'Find the perfect paid WordPress theme for your blog or website.' ),
+			description: translate(
+				"Browse all paid themes for WordPress.com. Activate the one that's right for you, risk-free for 14 days."
+			),
+		},
+	},
+	blog: {
+		all: {
+			title: translate( 'Blog WordPress Themes' ),
+			header: translate( 'Find the perfect theme for your blog.' ),
+			description: translate(
+				"Start your blog with the perfect theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
+			),
+		},
+		free: {
+			title: translate( 'Free Blog WordPress Themes' ),
+			header: translate( 'Discover the perfect free theme for your blog.' ),
+			description: translate(
+				"Launch your blog with the perfect free theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
+			),
+		},
+		premium: {
+			title: translate( 'Premium Blog WordPress Themes' ),
+			header: translate( 'Choose premium themes for your blog.' ),
+			description: translate(
+				"Enhance your blog with the perfect premium theme. Available on all Premium, Business, and Ecommerce plans. Activate the one that's right for you."
+			),
+		},
+		marketplace: {
+			title: translate( 'Paid Blog WordPress Themes' ),
+			header: translate( 'Select paid themes for your blog.' ),
+			description: translate(
+				"Improve your blog with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
+			),
+		},
+	},
+	business: {
+		all: {
+			title: translate( 'Business WordPress Themes' ),
+			header: translate( 'Find the perfect theme for your business website.' ),
+			description: translate(
+				"Start your business website with the perfect theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
+			),
+		},
+		free: {
+			title: translate( 'Free Business WordPress Themes' ),
+			header: translate( 'Discover the perfect free theme for your business website.' ),
+			description: translate(
+				"Launch your business website with the perfect free theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
+			),
+		},
+		premium: {
+			title: translate( 'Premium Business WordPress Themes' ),
+			header: translate( 'Choose premium themes for your business website.' ),
+			description: translate(
+				"Enhance your business website with the premium paid theme. Available on all Premium, Business, and Ecommerce plans. Activate the one that's right for you."
+			),
+		},
+		marketplace: {
+			title: translate( 'Paid Business WordPress Themes' ),
+			header: translate( 'Select paid themes for your business website.' ),
+			description: translate(
+				"Improve your business website with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
+			),
+		},
+	},
+	portfolio: {
+		all: {
+			title: translate( 'Portfolio WordPress Themes' ),
+			header: translate( 'Find the perfect theme for your portfolio.' ),
+			description: translate(
+				"Start your portfolio with the perfect theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
+			),
+		},
+		free: {
+			title: translate( 'Free Portfolio WordPress Themes' ),
+			header: translate( 'Discover the perfect free theme for your portfolio.' ),
+			description: translate(
+				"Launch your portfolio website with the perfect free theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
+			),
+		},
+		premium: {
+			title: translate( 'Premium Portfolio WordPress Themes' ),
+			header: translate( 'Choose premium themes for your portfolio.' ),
+			description: translate(
+				"Enhance your portfolio website with the perfect premium theme. Available on all Premium, Business, and Ecommerce plans. Activate the one that's right for you."
+			),
+		},
+		marketplace: {
+			title: translate( 'Paid Portfolio WordPress Themes' ),
+			header: translate( 'Select paid themes for your portfolio.' ),
+			description: translate(
+				"Improve your portfolio website with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
+			),
+		},
+	},
+	store: {
+		all: {
+			title: translate( 'Store WordPress Themes' ),
+			header: translate( 'Find the perfect theme for your online store.' ),
+			description: translate(
+				"Start your online store with the perfect theme. Choose from options for WordPress and WooCommerce sites. Then, activate the one that's right for you."
+			),
+		},
+		free: {
+			title: translate( 'Free Store WordPress Themes' ),
+			header: translate( 'Discover the perfect free theme for your online store.' ),
+			description: translate(
+				"Launch your online store with the perfect free theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
+			),
+		},
+		premium: {
+			title: translate( 'Premium Store WordPress Themes' ),
+			header: translate( 'Choose premium themes for your online store.' ),
+			description: translate(
+				"Enhance your online store with the perfect premium theme. Available on all Premium, Business, and Ecommerce plans. Activate the one that's right for you."
+			),
+		},
+		marketplace: {
+			title: translate( 'Paid Store WordPress Themes' ),
+			header: translate( 'Select paid themes for your online store.' ),
+			description: translate(
+				"Improve your online store with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
+			),
+		},
+	},
+	about: {
+		all: {
+			title: translate( 'About WordPress Themes' ),
+			header: translate( 'Find the perfect theme for your about website.' ),
+			description: translate(
+				"Start your about website with the perfect theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
+			),
+		},
+		free: {
+			title: translate( 'Free About WordPress Themes' ),
+			header: translate( 'Discover the perfect free theme for your about website.' ),
+			description: translate(
+				"Launch your about website with the perfect free theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
+			),
+		},
+		premium: {
+			title: translate( 'Premium About WordPress Themes' ),
+			header: translate( 'Choose premium themes for your about website.' ),
+			description: translate(
+				"Enhance your about website with the perfect premium theme. Available on all Premium, Business, and Ecommerce plans. Activate the one that's right for you."
+			),
+		},
+		marketplace: {
+			title: translate( 'Paid About WordPress Themes' ),
+			header: translate( 'Select paid themes for your about website.' ),
+			description: translate(
+				"Improve your about website with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
+			),
+		},
+	},
+	'link-in-bio': {
+		all: {
+			title: translate( 'Link in Bio WordPress Themes' ),
+			header: translate( 'Find the perfect theme for your about website.' ),
+			description: translate(
+				"Start your link in bio website with the perfect theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
+			),
+		},
+		free: {
+			title: translate( 'Free Link in Bio WordPress Themes' ),
+			header: translate( 'Discover the perfect free theme for your link in bio website.' ),
+			description: translate(
+				"Launch your link in bio website with the perfect free theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
+			),
+		},
+		premium: {
+			title: translate( 'Premium Link in Bio WordPress Themes' ),
+			header: translate( 'Choose premium themes for your link in bio website.' ),
+			description: translate(
+				"Enhance your link in bio website with the perfect premium theme. Available on all Premium, Business, and Ecommerce plans. Activate the one that's right for you."
+			),
+		},
+		marketplace: {
+			title: translate( 'Paid Link in Bio WordPress Themes' ),
+			header: translate( 'Select paid themes for your link in bio website.' ),
+			description: translate(
+				"Improve your link in bio website with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
+			),
+		},
+	},
+	newsletter: {
+		all: {
+			title: translate( 'Newsletter WordPress Themes' ),
+			header: translate( 'Find the perfect theme for your site-hosted newsletter.' ),
+			description: translate(
+				"Start your newsletter with the perfect theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
+			),
+		},
+		free: {
+			title: translate( 'Free Newsletter WordPress Themes' ),
+			header: translate( 'Discover the perfect free theme for your site-hosted newsletter.' ),
+			description: translate(
+				"Launch your newsletter with the perfect free theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
+			),
+		},
+		premium: {
+			title: translate( 'Premium Newsletter WordPress Themes' ),
+			header: translate( 'Choose premium themes for your site-hosted newsletter.' ),
+			description: translate(
+				"Enhance your newsletter with the perfect premium theme. Available on all Premium, Business, and Ecommerce plans. Activate the one that's right for you."
+			),
+		},
+		marketplace: {
+			title: translate( 'Paid Newsletter WordPress Themes' ),
+			header: translate( 'Select paid themes for your site-hosted newsletter.' ),
+			description: translate(
+				"Improve your newsletter with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
+			),
+		},
+	},
+};
+
+export default function getThemeShowcaseLoggedOutSeoContent( filter, tier ) {
+	const parsedFilter = filter?.replace( 'subject:', '' ) || 'recommended';
+	const parsedTier = tier || 'all';
+
+	const seoContent = THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT?.[ parsedFilter ]?.[ parsedTier ];
+
+	if ( ! seoContent ) {
+		return THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT.recommended.all;
+	}
+
+	return seoContent;
+}

--- a/client/my-sites/themes/get-theme-showcase-logged-out-seo-content.js
+++ b/client/my-sites/themes/get-theme-showcase-logged-out-seo-content.js
@@ -12,7 +12,7 @@ const THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT = {
 			title: translate( 'WordPress Themes' ),
 			header: translate( 'Find the perfect theme for your website.' ),
 			description: translate(
-				'Beautiful and responsive WordPress themes. Choose from free and premium options for all types of websites. Then, activate the one that’s best for you.'
+				"Beautiful and responsive WordPress themes. Choose from free and premium options for all types of websites. Then, activate the one that's best for you."
 			),
 		},
 		free: {

--- a/client/my-sites/themes/get-theme-showcase-logged-out-seo-content.js
+++ b/client/my-sites/themes/get-theme-showcase-logged-out-seo-content.js
@@ -30,10 +30,10 @@ const THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT = {
 			),
 		},
 		marketplace: {
-			title: translate( 'Paid WordPress Themes' ),
-			header: translate( 'Find the perfect paid WordPress theme for your blog or website.' ),
+			title: translate( 'Partner WordPress Themes' ),
+			header: translate( 'Find the perfect partner WordPress theme for your blog or website.' ),
 			description: translate(
-				"Browse all paid themes for WordPress.com. Activate the one that's right for you, risk-free for 14 days."
+				"Browse all partner themes for WordPress.com. Activate the one that's right for you, risk-free for 14 days."
 			),
 		},
 	},
@@ -60,10 +60,10 @@ const THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT = {
 			),
 		},
 		marketplace: {
-			title: translate( 'Paid Blog WordPress Themes' ),
-			header: translate( 'Select paid themes for your blog.' ),
+			title: translate( 'Partner Blog WordPress Themes' ),
+			header: translate( 'Select partner themes for your blog.' ),
 			description: translate(
-				"Improve your blog with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
+				"Improve your blog with the perfect partner theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
 			),
 		},
 	},
@@ -90,10 +90,10 @@ const THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT = {
 			),
 		},
 		marketplace: {
-			title: translate( 'Paid Business WordPress Themes' ),
-			header: translate( 'Select paid themes for your business website.' ),
+			title: translate( 'Partner Business WordPress Themes' ),
+			header: translate( 'Select partner themes for your business website.' ),
 			description: translate(
-				"Improve your business website with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
+				"Improve your business website with the perfect partner theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
 			),
 		},
 	},
@@ -120,10 +120,10 @@ const THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT = {
 			),
 		},
 		marketplace: {
-			title: translate( 'Paid Portfolio WordPress Themes' ),
-			header: translate( 'Select paid themes for your portfolio.' ),
+			title: translate( 'Partner Portfolio WordPress Themes' ),
+			header: translate( 'Select partner themes for your portfolio.' ),
 			description: translate(
-				"Improve your portfolio website with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
+				"Improve your portfolio website with the perfect partner theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
 			),
 		},
 	},
@@ -150,10 +150,10 @@ const THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT = {
 			),
 		},
 		marketplace: {
-			title: translate( 'Paid Store WordPress Themes' ),
-			header: translate( 'Select paid themes for your online store.' ),
+			title: translate( 'Partner Store WordPress Themes' ),
+			header: translate( 'Select partner themes for your online store.' ),
 			description: translate(
-				"Improve your online store with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
+				"Improve your online store with the perfect partner theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
 			),
 		},
 	},
@@ -180,10 +180,10 @@ const THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT = {
 			),
 		},
 		marketplace: {
-			title: translate( 'Paid About Me WordPress Themes' ),
-			header: translate( 'Select paid themes for your About Me website.' ),
+			title: translate( 'Partner About Me WordPress Themes' ),
+			header: translate( 'Select partner themes for your About Me website.' ),
 			description: translate(
-				"Improve your About Me website with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
+				"Improve your About Me website with the perfect partner theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
 			),
 		},
 	},
@@ -210,10 +210,10 @@ const THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT = {
 			),
 		},
 		marketplace: {
-			title: translate( 'Paid Link in Bio WordPress Themes' ),
-			header: translate( 'Select paid themes for your link in bio website.' ),
+			title: translate( 'Partner Link in Bio WordPress Themes' ),
+			header: translate( 'Select partner themes for your link in bio website.' ),
 			description: translate(
-				"Improve your link in bio website with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
+				"Improve your link in bio website with the perfect partner theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
 			),
 		},
 	},
@@ -240,10 +240,10 @@ const THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT = {
 			),
 		},
 		marketplace: {
-			title: translate( 'Paid Newsletter WordPress Themes' ),
-			header: translate( 'Select paid themes for your site-hosted newsletter.' ),
+			title: translate( 'Partner Newsletter WordPress Themes' ),
+			header: translate( 'Select partner themes for your site-hosted newsletter.' ),
 			description: translate(
-				"Improve your newsletter with the perfect paid theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
+				"Improve your newsletter with the perfect partner theme. Browse high-quality, professionally-designed options. Then, purchase the one that's right for you."
 			),
 		},
 	},

--- a/client/my-sites/themes/get-theme-showcase-logged-out-seo-content.js
+++ b/client/my-sites/themes/get-theme-showcase-logged-out-seo-content.js
@@ -249,8 +249,15 @@ const THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT = {
 	},
 };
 
+function findParsedFilter( filter ) {
+	const splitFilters = filter?.replace( 'subject:', '' )?.split( '+' ) || [];
+	const categories = Object.keys( THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT );
+	const parsedFilter = splitFilters.find( ( f ) => categories.includes( f ) );
+	return parsedFilter;
+}
+
 export default function getThemeShowcaseLoggedOutSeoContent( filter, tier ) {
-	const parsedFilter = filter?.replace( 'subject:', '' ) || 'recommended';
+	const parsedFilter = findParsedFilter( filter ) || 'recommended';
 	const parsedTier = tier || 'all';
 
 	const seoContent = THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT?.[ parsedFilter ]?.[ parsedTier ];

--- a/client/my-sites/themes/get-theme-showcase-logged-out-seo-content.js
+++ b/client/my-sites/themes/get-theme-showcase-logged-out-seo-content.js
@@ -86,7 +86,7 @@ const THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT = {
 			title: translate( 'Premium Business WordPress Themes' ),
 			header: translate( 'Choose premium themes for your business website.' ),
 			description: translate(
-				"Enhance your business website with the premium paid theme. Available on all Premium, Business, and Ecommerce plans. Activate the one that's right for you."
+				"Enhance your business website with the perfect premium paid theme. Available on all Premium, Business, and Ecommerce plans. Activate the one that's right for you."
 			),
 		},
 		marketplace: {
@@ -190,7 +190,7 @@ const THEME_SHOWCASE_LOGGED_OUT_SEO_CONTENT = {
 	'link-in-bio': {
 		all: {
 			title: translate( 'Link in Bio WordPress Themes' ),
-			header: translate( 'Find the perfect theme for your about website.' ),
+			header: translate( 'Find the perfect theme for your link in bio website.' ),
 			description: translate(
 				"Start your link in bio website with the perfect theme. Browse high-quality, professionally-designed options. Then, activate the one that's right for you."
 			),

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -39,6 +39,7 @@ import {
 } from 'calypso/state/themes/selectors';
 import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
 import EligibilityWarningModal from './atomic-transfer-dialog';
+import getThemeShowcaseLoggedOutSeoContent from './get-theme-showcase-logged-out-seo-content';
 import {
 	addTracking,
 	appendStyleVariationToThemesPath,
@@ -451,7 +452,6 @@ class ThemeShowcase extends Component {
 			filter,
 			isLoggedIn,
 			pathName,
-			title,
 			filterString,
 			isMultisite,
 			locale,
@@ -462,9 +462,34 @@ class ThemeShowcase extends Component {
 
 		const canonicalUrl = 'https://wordpress.com' + pathName;
 
+		const {
+			title: documentHeadTitle,
+			metaDescription: metaDescription,
+			header: themesHeaderTitle,
+			description: themesHeaderDescription,
+		} = isLoggedIn
+			? {
+					title: this.props.title,
+					metaDescription: this.props.description,
+					header: translate( 'Themes' ),
+					description: translate(
+						'Select or update the visual design for your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="themes" showIcon={ false } />,
+							},
+						}
+					),
+			  }
+			: getThemeShowcaseLoggedOutSeoContent( filter, tier );
+
 		const metas = [
-			{ name: 'description', property: 'og:description', content: this.props.description },
-			{ property: 'og:title', content: title },
+			{
+				name: 'description',
+				property: 'og:description',
+				content: metaDescription || themesHeaderDescription,
+			},
+			{ property: 'og:title', content: documentHeadTitle },
 			{ property: 'og:url', content: canonicalUrl },
 			{ property: 'og:type', content: 'website' },
 			{ property: 'og:site_name', content: 'WordPress.com' },
@@ -520,35 +545,13 @@ class ThemeShowcase extends Component {
 
 		return (
 			<div className="theme-showcase">
-				<DocumentHead title={ title } meta={ metas } />
+				<DocumentHead title={ documentHeadTitle } meta={ metas } />
 				<PageViewTracker
 					path={ this.props.analyticsPath }
 					title={ this.props.analyticsPageTitle }
 					properties={ { is_logged_in: isLoggedIn } }
 				/>
-				<ThemesHeader
-					title={
-						isLoggedIn
-							? translate( 'Themes' )
-							: translate( 'Find the perfect theme for your website' )
-					}
-					description={
-						isLoggedIn
-							? translate(
-									'Select or update the visual design for your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-									{
-										components: {
-											learnMoreLink: (
-												<InlineSupportLink supportContext="themes" showIcon={ false } />
-											),
-										},
-									}
-							  )
-							: translate(
-									'Beautiful and responsive WordPress.com themes. Choose from free and premium options for all types of websites. Then, activate the one that is right for you.'
-							  )
-					}
-				>
+				<ThemesHeader title={ themesHeaderTitle } description={ themesHeaderDescription }>
 					{ isLoggedIn && (
 						<>
 							<div className="themes__install-theme-button-container">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/78225

## Proposed Changes

* Update title, meta description, header and sub-header of the Logged-Out Theme Showcase so that different filters will result in different copy.

See the [source spreadsheet](https://docs.google.com/spreadsheets/d/10uoJqOZLTne3565nbbR6ggR09vrPhUpK_ztwbuvau14/edit#gid=0) for the proposed copy.

| Before | After |
|--------|--------|
| <img width="1109" alt="Screenshot 2023-07-25 at 18 41 08" src="https://github.com/Automattic/wp-calypso/assets/2070010/b52111db-75bd-409c-a374-8ba22625f6b8"> | <img width="1109" alt="Screenshot 2023-07-25 at 18 41 13" src="https://github.com/Automattic/wp-calypso/assets/2070010/632a6ef4-d9e0-401b-9761-94c7ea02b0cc"> | 

## Testing Instructions

* While logged-out, visit `/themes`.
  * If you are running Calypso locally, ensure [the SSR is in debug mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/server-side-rendering.md#debugging).
* Change subjects and pricing filters.
* Check the page's heading and sub-heading, and ensure the copy matches the hardcoded list provided in this PR.
* Inspect the page source, and ensure the `<title>` and `<meta name="description">` tags too match the hardcoded list.
* Open `/themes` while logged-in.
* Ensure the header looks like this and does not changes depending on the filters.
  * <img width="416" alt="Screenshot 2023-07-25 at 18 48 45" src="https://github.com/Automattic/wp-calypso/assets/2070010/44ec70c1-8f14-4064-a4d4-3da116e28bac">
