### PR TITLE
Add a paid plan upsell when a free domain and free plan are selected

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -33,6 +33,7 @@ const FreePlanCustomDomainFeature: React.FC< { domainName: string } > = ( { doma
 	const [ isLoadingAssignment, isCustomDomainAllowedOnFreePlan ] =
 		useIsCustomDomainAllowedOnFreePlan( domainName );
 	const wpcomFreeDomain = ! isError && wordPressSubdomainSuggestions?.[ 0 ]?.domain_name;
+	const isLoading = isInitialLoading || isLoadingAssignment;
 
 	return (
 		<Plans2023Tooltip
@@ -42,20 +43,22 @@ const FreePlanCustomDomainFeature: React.FC< { domainName: string } > = ( { doma
 			} ) }
 		>
 			<SubdomainSuggestion>
-				{ ( isInitialLoading || isLoadingAssignment ) && <LoadingPlaceHolder /> }
-				{ ! isError && isCustomDomainAllowedOnFreePlan ? (
-					<div>
-						{ translate( '%s will be a redirect', {
-							args: [ domainName ],
-							comment: '%s is a domain name.',
-						} ) }
-					</div>
-				) : (
-					<>
-						<div className="is-domain-name">{ domainName }</div>
-						<div>{ wpcomFreeDomain }</div>
-					</>
-				) }
+				{ isLoading && <LoadingPlaceHolder /> }
+				{ ! isError &&
+					! isLoading &&
+					( isCustomDomainAllowedOnFreePlan ? (
+						<div>
+							{ translate( '%s will be a redirect', {
+								args: [ domainName ],
+								comment: '%s is a domain name.',
+							} ) }
+						</div>
+					) : (
+						<>
+							<div className="is-domain-name">{ domainName }</div>
+							<div>{ wpcomFreeDomain }</div>
+						</>
+					) ) }
 			</SubdomainSuggestion>
 		</Plans2023Tooltip>
 	);

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { LoadingPlaceHolder } from '../../plans-features-main/components/loading-placeholder';
+import useIsCustomDomainAllowedOnFreePlan from '../../plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan';
 import { PlanFeaturesItem } from './item';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import type { TransformedFeatureObject } from '../types';
@@ -28,12 +29,32 @@ const FreePlanCustomDomainFeature: React.FC< { domainName: string } > = ( { doma
 		isError,
 	} = DomainSuggestions.useGetWordPressSubdomain( domainName );
 
+	const translate = useTranslate();
+	const isCustomDomainAllowedOnFreePlan = useIsCustomDomainAllowedOnFreePlan( domainName );
+
+	const getFreeDomainSuggestion = ( suggestions?: DomainSuggestions.DomainSuggestion[] ) => {
+		return suggestions?.[ 0 ]?.domain_name;
+	};
+
 	return (
-		<SubdomainSuggestion>
-			<div className="is-domain-name">{ domainName }</div>
-			{ isInitialLoading && <LoadingPlaceHolder /> }
-			{ ! isError && <div>{ wordPressSubdomainSuggestions?.[ 0 ]?.domain_name }</div> }
-		</SubdomainSuggestion>
+		<Plans2023Tooltip
+			text={ translate( '%s is not included', {
+				args: [ domainName ],
+				comment: '%s is a domain name.',
+			} ) }
+		>
+			<SubdomainSuggestion>
+				<div className="is-domain-name">{ domainName }</div>
+				{ isInitialLoading && <LoadingPlaceHolder /> }
+				{ ! isError && isCustomDomainAllowedOnFreePlan ? (
+					<div>{ `${ domainName } redirects to ${ getFreeDomainSuggestion(
+						wordPressSubdomainSuggestions
+					) }` }</div>
+				) : (
+					<div>{ getFreeDomainSuggestion( wordPressSubdomainSuggestions ) }</div>
+				) }
+			</SubdomainSuggestion>
+		</Plans2023Tooltip>
 	);
 };
 
@@ -44,7 +65,6 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	hideUnavailableFeatures?: boolean;
 	selectedFeature?: string;
 } > = ( { features, planName, domainName, hideUnavailableFeatures, selectedFeature } ) => {
-	const translate = useTranslate();
 	return (
 		<>
 			{ features.map( ( currentFeature, featureIndex ) => {
@@ -84,17 +104,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 							<span className={ spanClasses } key={ key }>
 								<span className={ itemTitleClasses }>
 									{ isFreePlanAndCustomDomainFeature ? (
-										<Plans2023Tooltip
-											text={ translate( '%s is not included', {
-												args: [ domainName as string ],
-												comment: '%s is a domain name.',
-											} ) }
-										>
-											<FreePlanCustomDomainFeature
-												key={ key }
-												domainName={ domainName as string }
-											/>
-										</Plans2023Tooltip>
+										<FreePlanCustomDomainFeature key={ key } domainName={ domainName as string } />
 									) : (
 										<Plans2023Tooltip text={ currentFeature.getDescription?.() }>
 											{ currentFeature.getTitle( domainName ) }

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -31,10 +31,7 @@ const FreePlanCustomDomainFeature: React.FC< { domainName: string } > = ( { doma
 
 	const translate = useTranslate();
 	const isCustomDomainAllowedOnFreePlan = useIsCustomDomainAllowedOnFreePlan( domainName );
-
-	const getFreeDomainSuggestion = ( suggestions?: DomainSuggestions.DomainSuggestion[] ) => {
-		return suggestions?.[ 0 ]?.domain_name;
-	};
+	const wpcomFreeDomain = ! isError && wordPressSubdomainSuggestions?.[ 0 ]?.domain_name;
 
 	return (
 		<Plans2023Tooltip
@@ -44,14 +41,19 @@ const FreePlanCustomDomainFeature: React.FC< { domainName: string } > = ( { doma
 			} ) }
 		>
 			<SubdomainSuggestion>
-				<div className="is-domain-name">{ domainName }</div>
 				{ isInitialLoading && <LoadingPlaceHolder /> }
 				{ ! isError && isCustomDomainAllowedOnFreePlan ? (
-					<div>{ `${ domainName } redirects to ${ getFreeDomainSuggestion(
-						wordPressSubdomainSuggestions
-					) }` }</div>
+					<div>
+						{ translate( '%s will be a redirect', {
+							args: [ domainName ],
+							comment: '%s is a domain name.',
+						} ) }
+					</div>
 				) : (
-					<div>{ getFreeDomainSuggestion( wordPressSubdomainSuggestions ) }</div>
+					<>
+						<div className="is-domain-name">{ domainName }</div>
+						<div>{ wpcomFreeDomain }</div>
+					</>
 				) }
 			</SubdomainSuggestion>
 		</Plans2023Tooltip>

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -30,7 +30,8 @@ const FreePlanCustomDomainFeature: React.FC< { domainName: string } > = ( { doma
 	} = DomainSuggestions.useGetWordPressSubdomain( domainName );
 
 	const translate = useTranslate();
-	const isCustomDomainAllowedOnFreePlan = useIsCustomDomainAllowedOnFreePlan( domainName );
+	const [ isLoadingAssignment, isCustomDomainAllowedOnFreePlan ] =
+		useIsCustomDomainAllowedOnFreePlan( domainName );
 	const wpcomFreeDomain = ! isError && wordPressSubdomainSuggestions?.[ 0 ]?.domain_name;
 
 	return (
@@ -41,7 +42,7 @@ const FreePlanCustomDomainFeature: React.FC< { domainName: string } > = ( { doma
 			} ) }
 		>
 			<SubdomainSuggestion>
-				{ isInitialLoading && <LoadingPlaceHolder /> }
+				{ ( isInitialLoading || isLoadingAssignment ) && <LoadingPlaceHolder /> }
 				{ ! isError && isCustomDomainAllowedOnFreePlan ? (
 					<div>
 						{ translate( '%s will be a redirect', {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -101,7 +101,8 @@ export type PlanFeatures2023GridProps = {
 	isReskinned?: boolean;
 	onUpgradeClick?: ( cartItem?: MinimalRequestCartProduct | null ) => void;
 	flowName?: string | null;
-	domainName?: string;
+	paidDomainName?: string;
+	freeSubdomain?: string;
 	placeholder?: string;
 	intervalType?: string;
 	currentSitePlanSlug?: string | null;
@@ -471,11 +472,11 @@ export class PlanFeatures2023Grid extends Component<
 		if ( isMonthlyPlan || isWpComFreePlan( planName ) || isWpcomEnterpriseGridPlan( planName ) ) {
 			return null;
 		}
-		const { domainName } = this.props;
+		const { paidDomainName } = this.props;
 
-		const displayText = domainName
+		const displayText = paidDomainName
 			? translate( '%(domainName)s is included', {
-					args: { domainName },
+					args: { paidDomainName },
 			  } )
 			: translate( 'Free domain for one year' );
 
@@ -802,7 +803,7 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderPlanFeaturesList( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
-		const { domainName, translate, hideUnavailableFeatures, selectedFeature } = this.props;
+		const { paidDomainName, translate, hideUnavailableFeatures, selectedFeature } = this.props;
 		const planProperties = planPropertiesObj.filter(
 			( properties ) =>
 				! isWpcomEnterpriseGridPlan( properties.planName ) &&
@@ -822,7 +823,7 @@ export class PlanFeatures2023Grid extends Component<
 						<PlanFeatures2023GridFeatures
 							features={ features }
 							planName={ planName }
-							domainName={ domainName }
+							domainName={ paidDomainName }
 							hideUnavailableFeatures={ hideUnavailableFeatures }
 							selectedFeature={ selectedFeature }
 						/>
@@ -840,7 +841,7 @@ export class PlanFeatures2023Grid extends Component<
 						<PlanFeatures2023GridFeatures
 							features={ jpFeatures }
 							planName={ planName }
-							domainName={ domainName }
+							domainName={ paidDomainName }
 							hideUnavailableFeatures={ hideUnavailableFeatures }
 						/>
 					</Container>

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -120,6 +120,46 @@ const StyledButton = styled( Button )`
 	}
 `;
 
+function GetSuggestedPlanSection( {
+	domainName,
+	suggestedPlanSlug,
+	onButtonClick,
+	isBusy,
+}: {
+	domainName: string;
+	suggestedPlanSlug: PlanSlug;
+	onButtonClick: () => void;
+	isBusy: boolean;
+} ) {
+	const translate = useTranslate();
+	const planPrices = usePlanPrices( { planSlug: suggestedPlanSlug, returnMonthly: true } );
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const planTitle = getPlan( suggestedPlanSlug )?.getTitle();
+
+	return (
+		<>
+			<DomainName>
+				<div>{ domainName }</div>
+				<FreeDomainText>{ translate( 'Free for one year ' ) }</FreeDomainText>
+			</DomainName>
+			<StyledButton busy={ isBusy } primary onClick={ onButtonClick }>
+				{ currencyCode &&
+					translate( 'Get %(planTitle)s - %(planPrice)s/month', {
+						comment: 'Eg: Get Personal - $4/month',
+						args: {
+							planTitle: planTitle as string,
+							planPrice: formatCurrency(
+								planPrices.discountedRawPrice || planPrices.rawPrice,
+								currencyCode,
+								{ stripZeros: true }
+							),
+						},
+					} ) }
+			</StyledButton>
+		</>
+	);
+}
+
 type DomainPlanDialogProps = {
 	domainName: string;
 	suggestedPlanSlug: PlanSlug;
@@ -136,14 +176,11 @@ function DialogPaidPlanIsRequired( {
 	const translate = useTranslate();
 	const queryClient = useQueryClient();
 	const [ isBusy, setIsBusy ] = useState( false );
-	const planPrices = usePlanPrices( { planSlug: suggestedPlanSlug, returnMonthly: true } );
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const {
 		data: wordPressSubdomainSuggestions,
 		isInitialLoading,
 		isError,
 	} = DomainSuggestions.useGetWordPressSubdomain( domainName );
-	const planTitle = getPlan( suggestedPlanSlug )?.getTitle();
 
 	function handlePaidPlanClick() {
 		setIsBusy( true );
@@ -169,24 +206,12 @@ function DialogPaidPlanIsRequired( {
 			</SubHeading>
 			<ButtonContainer>
 				<RowWithBorder>
-					<DomainName>
-						<div>{ domainName }</div>
-						<FreeDomainText>{ translate( 'Free for one year ' ) }</FreeDomainText>
-					</DomainName>
-					<StyledButton busy={ isBusy } primary onClick={ handlePaidPlanClick }>
-						{ currencyCode &&
-							translate( 'Get %(planTitle)s - %(planPrice)s/month', {
-								comment: 'Eg: Get Personal - $4/month',
-								args: {
-									planTitle: planTitle as string,
-									planPrice: formatCurrency(
-										planPrices.discountedRawPrice || planPrices.rawPrice,
-										currencyCode,
-										{ stripZeros: true }
-									),
-								},
-							} ) }
-					</StyledButton>
+					<GetSuggestedPlanSection
+						domainName={ domainName }
+						suggestedPlanSlug={ suggestedPlanSlug }
+						isBusy={ isBusy }
+						onButtonClick={ handlePaidPlanClick }
+					/>
 				</RowWithBorder>
 				<Row>
 					<DomainName>
@@ -215,14 +240,11 @@ function DialogBlogDomainAndFreePlan( {
 	const translate = useTranslate();
 	const queryClient = useQueryClient();
 	const [ isBusy, setIsBusy ] = useState( false );
-	const planPrices = usePlanPrices( { planSlug: suggestedPlanSlug, returnMonthly: true } );
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const {
 		data: wordPressSubdomainSuggestions,
 		isInitialLoading,
 		isError,
 	} = DomainSuggestions.useGetWordPressSubdomain( domainName );
-	const planTitle = getPlan( suggestedPlanSlug )?.getTitle();
 
 	function handlePaidPlanClick() {
 		setIsBusy( true );
@@ -243,25 +265,17 @@ function DialogBlogDomainAndFreePlan( {
 			<Heading>{ translate( 'A paid plan is required for a custom primary domain.' ) }</Heading>
 			<SubHeading>
 				{ translate(
-					'Without a paid plan, your custom domain will automatically redirect to your free WordPress.com domain, xxx.wordpress.com.Custom. Please read {{a}}our support document{{/a}} for more details.'
+					'Without a paid plan, your custom domain will automatically redirect to your free WordPress.com domain, and they are free with an anuual paid plan. Please read {{a}}our support document{{/a}} for more details.'
 				) }
 			</SubHeading>
 			<ButtonContainer>
 				<RowWithBorder>
-					<StyledButton busy={ isBusy } primary onClick={ handlePaidPlanClick }>
-						{ currencyCode &&
-							translate( 'Get %(planTitle)s - %(planPrice)s/month', {
-								comment: 'Eg: Get Personal - $4/month',
-								args: {
-									planTitle: planTitle as string,
-									planPrice: formatCurrency(
-										planPrices.discountedRawPrice || planPrices.rawPrice,
-										currencyCode,
-										{ stripZeros: true }
-									),
-								},
-							} ) }
-					</StyledButton>
+					<GetSuggestedPlanSection
+						domainName={ domainName }
+						suggestedPlanSlug={ suggestedPlanSlug }
+						isBusy={ isBusy }
+						onButtonClick={ handlePaidPlanClick }
+					/>
 				</RowWithBorder>
 				<Row>
 					<DomainName>

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -120,17 +120,19 @@ const StyledButton = styled( Button )`
 	}
 `;
 
+type DomainPlanDialogProps = {
+	domainName: string;
+	suggestedPlanSlug: PlanSlug;
+	onFreePlanSelected: ( domainSuggestion: DomainSuggestion ) => void;
+	onPlanSelected: () => void;
+};
+
 function DialogPaidPlanIsRequired( {
 	domainName,
 	suggestedPlanSlug,
 	onFreePlanSelected,
 	onPlanSelected,
-}: {
-	domainName: string;
-	suggestedPlanSlug: PlanSlug;
-	onFreePlanSelected: ( domainSuggestion: DomainSuggestion ) => void;
-	onPlanSelected: () => void;
-} ) {
+}: DomainPlanDialogProps ) {
 	const translate = useTranslate();
 	const queryClient = useQueryClient();
 	const [ isBusy, setIsBusy ] = useState( false );
@@ -209,12 +211,7 @@ function DialogBlogDomainAndFreePlan( {
 	suggestedPlanSlug,
 	onFreePlanSelected,
 	onPlanSelected,
-}: {
-	domainName: string;
-	suggestedPlanSlug: PlanSlug;
-	onFreePlanSelected: ( domainSuggestion: DomainSuggestion ) => void;
-	onPlanSelected: () => void;
-} ) {
+}: DomainPlanDialogProps ) {
 	const translate = useTranslate();
 	const queryClient = useQueryClient();
 	const [ isBusy, setIsBusy ] = useState( false );
@@ -301,6 +298,12 @@ export function FreePlanPaidDomainDialog( {
 	// It means that this condition relies on the parent component to handle the implied "free plan is picked" condition, which is not a good practice.
 	// However, it's also not an immediate concern before we are sure about making this the default behavior.
 	const isBlogDomainAndFreePlan = getTld( domainName ) === 'blog';
+	const dialogCommonProps: DomainPlanDialogProps = {
+		domainName,
+		suggestedPlanSlug,
+		onFreePlanSelected,
+		onPlanSelected,
+	};
 
 	return (
 		<Dialog
@@ -321,19 +324,9 @@ export function FreePlanPaidDomainDialog( {
 				` }
 			/>
 			{ isBlogDomainAndFreePlan ? (
-				<DialogBlogDomainAndFreePlan
-					domainName={ domainName }
-					suggestedPlanSlug={ suggestedPlanSlug }
-					onFreePlanSelected={ onFreePlanSelected }
-					onPlanSelected={ onPlanSelected }
-				/>
+				<DialogBlogDomainAndFreePlan { ...dialogCommonProps } />
 			) : (
-				<DialogPaidPlanIsRequired
-					domainName={ domainName }
-					suggestedPlanSlug={ suggestedPlanSlug }
-					onFreePlanSelected={ onFreePlanSelected }
-					onPlanSelected={ onPlanSelected }
-				/>
+				<DialogPaidPlanIsRequired { ...dialogCommonProps } />
 			) }
 		</Dialog>
 	);

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -359,11 +359,12 @@ export function FreePlanPaidDomainDialog( {
 				` }
 			/>
 			{ isLoadingAssignment && <LoadingPlaceHolder /> }
-			{ ! isLoadingAssignment && isCustomDomainAllowedOnFreePlan ? (
-				<DialogCustomDomainAndFreePlan { ...dialogCommonProps } />
-			) : (
-				<DialogPaidPlanIsRequired { ...dialogCommonProps } />
-			) }
+			{ ! isLoadingAssignment &&
+				( isCustomDomainAllowedOnFreePlan ? (
+					<DialogCustomDomainAndFreePlan { ...dialogCommonProps } />
+				) : (
+					<DialogPaidPlanIsRequired { ...dialogCommonProps } />
+				) ) }
 		</Dialog>
 	);
 }

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -2,6 +2,7 @@ import { PlanSlug, getPlan } from '@automattic/calypso-products';
 import { Button, Dialog } from '@automattic/components';
 import { DomainSuggestions } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useQueryClient } from '@tanstack/react-query';
@@ -265,7 +266,20 @@ function DialogBlogDomainAndFreePlan( {
 			<Heading>{ translate( 'A paid plan is required for a custom primary domain.' ) }</Heading>
 			<SubHeading>
 				{ translate(
-					'Without a paid plan, your custom domain will automatically redirect to your free WordPress.com domain, and they are free with an anuual paid plan. Please read {{a}}our support document{{/a}} for more details.'
+					'Your custom domain can only be used as the primary domain with a paid plan and is free for the first year with an annual paid plan. For more details, please read {{a}}our support document{{/a}}.',
+					{
+						components: {
+							a: (
+								<a
+									href={ localizeUrl(
+										'https://wordpress.com/support/domains/set-a-primary-address/'
+									) }
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+						},
+					}
 				) }
 			</SubHeading>
 			<ButtonContainer>

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -330,7 +330,8 @@ export function FreePlanPaidDomainDialog( {
 	onPlanSelected,
 	onClose,
 }: DomainPlanDialogProps & { onClose: () => void } ) {
-	const isCustomDomainAllowedOnFreePlan = useIsCustomDomainAllowedOnFreePlan( domainName );
+	const [ isLoadingAssignment, isCustomDomainAllowedOnFreePlan ] =
+		useIsCustomDomainAllowedOnFreePlan( domainName );
 
 	const dialogCommonProps: DomainPlanDialogProps = {
 		domainName,
@@ -357,7 +358,8 @@ export function FreePlanPaidDomainDialog( {
 					}
 				` }
 			/>
-			{ isCustomDomainAllowedOnFreePlan ? (
+			{ isLoadingAssignment && <LoadingPlaceHolder /> }
+			{ ! isLoadingAssignment && isCustomDomainAllowedOnFreePlan ? (
 				<DialogCustomDomainAndFreePlan { ...dialogCommonProps } />
 			) : (
 				<DialogPaidPlanIsRequired { ...dialogCommonProps } />

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -8,10 +8,10 @@ import styled from '@emotion/styled';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import { getTld } from 'calypso/lib/domains';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import usePlanPrices from '../../plans/hooks/use-plan-prices';
+import useIsCustomDomainAllowedOnFreePlan from '../hooks/use-is-custom-domain-allowed-on-free-plan';
 import { LoadingPlaceHolder } from './loading-placeholder';
 import type { DomainSuggestion } from '@automattic/data-stores';
 
@@ -232,7 +232,7 @@ function DialogPaidPlanIsRequired( {
 	);
 }
 
-function DialogBlogDomainAndFreePlan( {
+function DialogCustomDomainAndFreePlan( {
 	domainName,
 	suggestedPlanSlug,
 	onFreePlanSelected,
@@ -322,10 +322,8 @@ export function FreePlanPaidDomainDialog( {
 	onFreePlanSelected: ( domainSuggestion: DomainSuggestion ) => void;
 	onPlanSelected: () => void;
 } ) {
-	// The complete condition here is actually a .blog domain + Free plan.
-	// It means that this condition relies on the parent component to handle the implied "free plan is picked" condition, which is not a good practice.
-	// However, it's also not an immediate concern before we are sure about making this the default behavior.
-	const isBlogDomainAndFreePlan = getTld( domainName ) === 'blog';
+	const isCustomDomainAllowedOnFreePlan = useIsCustomDomainAllowedOnFreePlan( domainName );
+
 	const dialogCommonProps: DomainPlanDialogProps = {
 		domainName,
 		suggestedPlanSlug,
@@ -351,8 +349,8 @@ export function FreePlanPaidDomainDialog( {
 					}
 				` }
 			/>
-			{ isBlogDomainAndFreePlan ? (
-				<DialogBlogDomainAndFreePlan { ...dialogCommonProps } />
+			{ isCustomDomainAllowedOnFreePlan ? (
+				<DialogCustomDomainAndFreePlan { ...dialogCommonProps } />
 			) : (
 				<DialogPaidPlanIsRequired { ...dialogCommonProps } />
 			) }

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -119,16 +119,14 @@ const StyledButton = styled( Button )`
 	}
 `;
 
-export function FreePlanPaidDomainDialog( {
+function DialogPaidPlanIsRequired( {
 	domainName,
 	suggestedPlanSlug,
 	onFreePlanSelected,
 	onPlanSelected,
-	onClose,
 }: {
 	domainName: string;
 	suggestedPlanSlug: PlanSlug;
-	onClose: () => void;
 	onFreePlanSelected: ( domainSuggestion: DomainSuggestion ) => void;
 	onPlanSelected: () => void;
 } ) {
@@ -159,6 +157,66 @@ export function FreePlanPaidDomainDialog( {
 	}
 
 	return (
+		<DialogContainer>
+			<Heading>{ translate( 'A paid plan is required for your domain.' ) }</Heading>
+			<SubHeading>
+				{ translate(
+					'Custom domains are only available with a paid plan. And they are free for the first year with an annual paid plan.'
+				) }
+			</SubHeading>
+			<ButtonContainer>
+				<RowWithBorder>
+					<DomainName>
+						<div>{ domainName }</div>
+						<FreeDomainText>{ translate( 'Free for one year ' ) }</FreeDomainText>
+					</DomainName>
+					<StyledButton busy={ isBusy } primary onClick={ handlePaidPlanClick }>
+						{ currencyCode &&
+							translate( 'Get %(planTitle)s - %(planPrice)s/month', {
+								comment: 'Eg: Get Personal - $4/month',
+								args: {
+									planTitle: planTitle as string,
+									planPrice: formatCurrency(
+										planPrices.discountedRawPrice || planPrices.rawPrice,
+										currencyCode,
+										{ stripZeros: true }
+									),
+								},
+							} ) }
+					</StyledButton>
+				</RowWithBorder>
+				<Row>
+					<DomainName>
+						{ isInitialLoading && <LoadingPlaceHolder /> }
+						{ ! isError && <div>{ wordPressSubdomainSuggestions?.[ 0 ]?.domain_name }</div> }
+					</DomainName>
+					<StyledButton
+						disabled={ isInitialLoading || ! wordPressSubdomainSuggestions?.[ 0 ]?.domain_name }
+						busy={ isBusy }
+						onClick={ handleFreeDomainClick }
+					>
+						{ translate( 'Continue with Free plan' ) }
+					</StyledButton>
+				</Row>
+			</ButtonContainer>
+		</DialogContainer>
+	);
+}
+
+export function FreePlanPaidDomainDialog( {
+	domainName,
+	suggestedPlanSlug,
+	onFreePlanSelected,
+	onPlanSelected,
+	onClose,
+}: {
+	domainName: string;
+	suggestedPlanSlug: PlanSlug;
+	onClose: () => void;
+	onFreePlanSelected: ( domainSuggestion: DomainSuggestion ) => void;
+	onPlanSelected: () => void;
+} ) {
+	return (
 		<Dialog
 			isBackdropVisible={ true }
 			isVisible={ true }
@@ -176,49 +234,12 @@ export function FreePlanPaidDomainDialog( {
 					}
 				` }
 			/>
-			<DialogContainer>
-				<Heading>{ translate( 'A paid plan is required for your domain.' ) }</Heading>
-				<SubHeading>
-					{ translate(
-						'Custom domains are only available with a paid plan. And they are free for the first year with an annual paid plan.'
-					) }
-				</SubHeading>
-				<ButtonContainer>
-					<RowWithBorder>
-						<DomainName>
-							<div>{ domainName }</div>
-							<FreeDomainText>{ translate( 'Free for one year ' ) }</FreeDomainText>
-						</DomainName>
-						<StyledButton busy={ isBusy } primary onClick={ handlePaidPlanClick }>
-							{ currencyCode &&
-								translate( 'Get %(planTitle)s - %(planPrice)s/month', {
-									comment: 'Eg: Get Personal - $4/month',
-									args: {
-										planTitle: planTitle as string,
-										planPrice: formatCurrency(
-											planPrices.discountedRawPrice || planPrices.rawPrice,
-											currencyCode,
-											{ stripZeros: true }
-										),
-									},
-								} ) }
-						</StyledButton>
-					</RowWithBorder>
-					<Row>
-						<DomainName>
-							{ isInitialLoading && <LoadingPlaceHolder /> }
-							{ ! isError && <div>{ wordPressSubdomainSuggestions?.[ 0 ]?.domain_name }</div> }
-						</DomainName>
-						<StyledButton
-							disabled={ isInitialLoading || ! wordPressSubdomainSuggestions?.[ 0 ]?.domain_name }
-							busy={ isBusy }
-							onClick={ handleFreeDomainClick }
-						>
-							{ translate( 'Continue with Free plan' ) }
-						</StyledButton>
-					</Row>
-				</ButtonContainer>
-			</DialogContainer>
+			<DialogPaidPlanIsRequired
+				domainName={ domainName }
+				suggestedPlanSlug={ suggestedPlanSlug }
+				onFreePlanSelected={ onFreePlanSelected }
+				onPlanSelected={ onPlanSelected }
+			/>
 		</Dialog>
 	);
 }

--- a/client/my-sites/plans-features-main/components/plan-select-dialogs/free-domain-free-plan-doalog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-select-dialogs/free-domain-free-plan-doalog.tsx
@@ -1,0 +1,89 @@
+import { Gridicon } from '@automattic/components';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import {
+	DialogContainer,
+	DomainPlanDialogProps,
+	Heading,
+	StyledButton,
+	SubHeading,
+} from '../free-plan-paid-domain-dialog';
+
+export const List = styled.ul`
+	list-style: none;
+	margin: 20px 0 20px;
+`;
+export const ListItem = styled.li`
+	display: flex;
+	& div:first-of-type {
+		margin: 0 10px 0 10px;
+	}
+`;
+
+export function DialogFreeDomainFreePlan( {
+	freeSubdomain,
+	onPlanSelected,
+	onFreePlanSelected,
+}: { freeSubdomain: string } & Omit< DomainPlanDialogProps, 'paidDomainName' > ) {
+	const translate = useTranslate();
+
+	return (
+		<DialogContainer>
+			<Heading>{ translate( "Don't miss out" ) }</Heading>
+			<SubHeading>
+				{ translate( 'With a Free plan, you miss out on a lot of great features:' ) }
+			</SubHeading>
+			<List>
+				<ListItem>
+					<div>
+						<Gridicon icon="cross" size={ 24 } />
+					</div>
+					<div>No free custom domain: Your site will be shown to visitors as { freeSubdomain }</div>
+				</ListItem>
+				<ListItem>
+					<div>
+						<Gridicon icon="cross" size={ 24 } />
+					</div>
+					<div>
+						{ translate(
+							'No ad-free experience: Your visitors will see external ads on your site.'
+						) }
+					</div>
+				</ListItem>
+				<ListItem>
+					<div>
+						<Gridicon icon="cross" size={ 24 } />
+					</div>
+					<div>
+						{ translate( 'No unlimited professional customer support (only community forums)' ) }
+					</div>
+				</ListItem>
+				<ListItem>
+					<div>
+						<Gridicon icon="cross" size={ 24 } />
+					</div>
+					<div>
+						{ translate(
+							'No extra storage. You only get 1GB for photos, videos, media, and documents.'
+						) }
+					</div>
+				</ListItem>
+
+				<div>
+					{ translate(
+						'Unlock these features with a Personal plan for $4/month. Risk-free with our 14-day money back guarantee.'
+					) }
+				</div>
+				<div>
+					<StyledButton onClick={ onFreePlanSelected }>
+						{ translate( 'Continue with Free plan' ) }
+					</StyledButton>
+					<StyledButton primary onClick={ onPlanSelected }>
+						{ translate( 'Get the Personal plan' ) }
+					</StyledButton>
+				</div>
+				<div>Personal plan: $4 per month, $48 billed annually. Excluding taxes.</div>
+			</List>
+		</DialogContainer>
+	);
+}

--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -1,14 +1,21 @@
-import config from '@automattic/calypso-config';
 import { getTld } from 'calypso/lib/domains';
+import { useExperiment } from 'calypso/lib/explat';
 
-// TODO
-// it's not really a hook now, but it eventually will contain a request fetching assigned variations from ExPlat endpoints
-const useIsCustomDomainAllowedOnFreePlan = ( domainName?: string ) => {
-	if ( ! domainName ) {
-		return false;
+const useIsCustomDomainAllowedOnFreePlan = ( domainName?: string ): [ boolean, boolean | null ] => {
+	const [ isLoadingAssignment, experimentAssignment ] = useExperiment(
+		'calypso_onboarding_plans_dotblog_on_free_plan_202307'
+	);
+
+	if ( isLoadingAssignment ) {
+		return [ true, null ];
 	}
 
-	return config.isEnabled( 'domains/blog-domain-free-plan' ) && getTld( domainName ) === 'blog';
+	return [
+		isLoadingAssignment,
+		experimentAssignment?.variationName === 'treatment'
+			? domainName != null && getTld( domainName ) === 'blog'
+			: false,
+	];
 };
 
 export default useIsCustomDomainAllowedOnFreePlan;

--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -1,0 +1,14 @@
+import config from '@automattic/calypso-config';
+import { getTld } from 'calypso/lib/domains';
+
+// TODO
+// it's not really a hook now, but it eventually will contain a request fetching assigned variations from ExPlat endpoints
+const useIsCustomDomainAllowedOnFreePlan = ( domainName?: string ) => {
+	if ( ! domainName ) {
+		return false;
+	}
+
+	return config.isEnabled( 'domains/blog-domain-free-plan' ) && getTld( domainName ) === 'blog';
+};
+
+export default useIsCustomDomainAllowedOnFreePlan;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -381,8 +381,8 @@ const PlansFeaturesMain = ( {
 					domainName={ domainName }
 					suggestedPlanSlug={ PLAN_PERSONAL }
 					onClose={ toggleIsFreePlanPaidDomainDialogOpen }
-					onFreePlanSelected={ ( freeDomainSuggestion ) => {
-						replacePaidDomainWithFreeDomain?.( freeDomainSuggestion );
+					onFreePlanSelected={ ( freeDomainSuggestion?: DomainSuggestion | null ) => {
+						freeDomainSuggestion && replacePaidDomainWithFreeDomain?.( freeDomainSuggestion );
 						onUpgradeClick?.( null );
 					} }
 					onPlanSelected={ () => {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -9,7 +9,6 @@ import {
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
-import { isOnboardingPMFlow } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import classNames from 'classnames';
@@ -61,7 +60,8 @@ export interface PlansFeaturesMainProps {
 	onUpgradeClick?: ( cartItemForPlan?: MinimalRequestCartProduct | null ) => void;
 	redirectToAddDomainFlow?: boolean;
 	hidePlanTypeSelector?: boolean;
-	domainName?: string;
+	paidDomainName?: string;
+	freeSubdomain?: string;
 	flowName?: string | null;
 	replacePaidDomainWithFreeDomain?: ( freeDomainSuggestion: DomainSuggestion ) => void;
 	intervalType?: IntervalType;
@@ -115,7 +115,8 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 	const {
 		plans,
 		visiblePlans,
-		domainName,
+		paidDomainName,
+		freeSubdomain,
 		isInSignup,
 		isLaunchPage,
 		flowName,
@@ -159,7 +160,8 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 	}
 
 	const asyncProps: PlanFeatures2023GridProps = {
-		domainName,
+		paidDomainName,
+		freeSubdomain,
 		isInSignup,
 		isLaunchPage,
 		onUpgradeClick,
@@ -200,7 +202,8 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 };
 
 const PlansFeaturesMain = ( {
-	domainName,
+	paidDomainName,
+	freeSubdomain,
 	flowName,
 	replacePaidDomainWithFreeDomain,
 	onUpgradeClick,
@@ -232,7 +235,7 @@ const PlansFeaturesMain = ( {
 	isStepperUpgradeFlow = false,
 	isLaunchPage = false,
 }: PlansFeaturesMainProps ) => {
-	const [ isFreePlanPaidDomainDialogOpen, setIsFreePlanPaidDomainDialogOpen ] = useState( false );
+	const [ isFreePlanPaidDomainDialogOpen, setIsFreePlanPaidDomainDialogOpen ] = useState( true );
 	const currentPlan = useSelector( ( state: IAppState ) => getCurrentPlan( state, siteId ) );
 	const eligibleForWpcomMonthlyPlans = useSelector( ( state: IAppState ) =>
 		isEligibleForWpComMonthlyPlan( state, siteId )
@@ -278,9 +281,9 @@ const PlansFeaturesMain = ( {
 		// in that case and exit. `FreePlanPaidDomainDialog` takes over from there.
 		// - only applicable to main onboarding flow (default `/start`)
 		if (
-			( 'onboarding' === flowName || isOnboardingPMFlow( flowName ) ) &&
-			domainName &&
-			! cartItemForPlan
+			( 'onboarding' === flowName || 'onboarding-pm' === flowName ) &&
+			! cartItemForPlan &&
+			( freeSubdomain || paidDomainName ) // During launch site flow neither freeSubdomain nor paidDomainName is available
 		) {
 			toggleIsFreePlanPaidDomainDialogOpen();
 			return;
@@ -376,9 +379,10 @@ const PlansFeaturesMain = ( {
 			<QueryPlans />
 			<QuerySites siteId={ siteId } />
 			<QuerySitePlans siteId={ siteId } />
-			{ domainName && isFreePlanPaidDomainDialogOpen && (
+			{ isFreePlanPaidDomainDialogOpen && (
 				<FreePlanPaidDomainDialog
-					domainName={ domainName }
+					freeSubdomain={ freeSubdomain }
+					paidDomainName={ paidDomainName }
 					suggestedPlanSlug={ PLAN_PERSONAL }
 					onClose={ toggleIsFreePlanPaidDomainDialogOpen }
 					onFreePlanSelected={ ( freeDomainSuggestion ) => {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -381,7 +381,7 @@ const PlansFeaturesMain = ( {
 					domainName={ domainName }
 					suggestedPlanSlug={ PLAN_PERSONAL }
 					onClose={ toggleIsFreePlanPaidDomainDialogOpen }
-					onFreePlanSelected={ ( freeDomainSuggestion?: DomainSuggestion | null ) => {
+					onFreePlanSelected={ ( freeDomainSuggestion ) => {
 						freeDomainSuggestion && replacePaidDomainWithFreeDomain?.( freeDomainSuggestion );
 						onUpgradeClick?.( null );
 					} }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -144,7 +144,13 @@ export class PlansStep extends Component {
 			);
 		}
 
-		const domainName = getDomainName( this.props.signupDependencies.domainItem );
+		const { signupDependencies } = this.props;
+		const isFreeSubDomainGenerated = ! signupDependencies.domainItem;
+		const paidDomainName = getDomainName( signupDependencies.domainItem );
+		const freeSubdomain =
+			isFreeSubDomainGenerated && signupDependencies.siteUrl
+				? `${ signupDependencies.siteUrl }.wordpress.com`
+				: null;
 
 		return (
 			<div>
@@ -155,7 +161,8 @@ export class PlansStep extends Component {
 					isLaunchPage={ isLaunchPage }
 					intervalType={ intervalType }
 					onUpgradeClick={ ( cartItem ) => this.onSelectPlan( cartItem ) }
-					domainName={ domainName }
+					paidDomainName={ paidDomainName }
+					freeSubdomain={ freeSubdomain }
 					customerType={ this.getCustomerType() }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain } // TODO clk investigate
 					plansWithScroll={ this.state.isDesktop }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions
From @isatuncman-auto 

### We want to implement free/free modal. There are two ways users could hit this banner in signup funnel:
 - User select a free domain (or skip domain selection) and choose a free plan --> **Show the free/free modal**
 - User chooses a paid domain + free plan hit the paid/free modal, downgrade to free domain --> **Do not show the free/free modal**

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
