### PR TITLE
Fixing duplicate override and using global overrides on Button for Domain Transfer and Link in Bio

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -22,10 +22,6 @@
 	background-color: var(--color-accent);
 	border-color: var(--color-accent);
 	color: var(--color-text-inverted);
-	border-radius: 2px;
-	font-size: 0.875rem;
-	font-weight: 500;
-	justify-content: center;
 
 	&:active:not(:disabled),
 	&:hover:not(:disabled),

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -108,3 +108,9 @@
 		}
 	}
 }
+
+:root {
+	--wp-components-color-accent: var(--studio-blue-50);
+	--wp-components-color-accent-darker-20: var(--studio-blue-60);
+	--wp-components-color-accent-darker-10: var(--studio-blue-60);
+}

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -37,7 +37,6 @@
 		color: var(--color-neutral-20);
 		background-color: var(--color-neutral-5);
 		border-color: var(--color-neutral-5);
-		opacity: 1;
 	}
 }
 

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -22,6 +22,10 @@
 	background-color: var(--color-accent);
 	border-color: var(--color-accent);
 	color: var(--color-text-inverted);
+	border-radius: 4px;
+	font-size: 0.875rem;
+	font-weight: 500;
+	justify-content: center;
 
 	&:active:not(:disabled),
 	&:hover:not(:disabled),
@@ -35,8 +39,9 @@
 	&:disabled,
 	&.disabled {
 		color: var(--color-neutral-20);
-		background-color: var(--color-surface);
+		background-color: var(--gray-gray-5, #dcdcde);
 		border-color: var(--color-neutral-5);
+		opacity: 1;
 	}
 }
 

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -35,7 +35,7 @@
 	&:disabled,
 	&.disabled {
 		color: var(--color-neutral-20);
-		background-color: var(--gray-gray-5, #dcdcde);
+		background-color: var(--color-neutral-5);
 		border-color: var(--color-neutral-5);
 		opacity: 1;
 	}

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -22,7 +22,7 @@
 	background-color: var(--color-accent);
 	border-color: var(--color-accent);
 	color: var(--color-text-inverted);
-	border-radius: 4px;
+	border-radius: 2px;
 	font-size: 0.875rem;
 	font-weight: 500;
 	justify-content: center;
@@ -107,11 +107,4 @@
 			background-color: var(--color-accent);
 		}
 	}
-}
-
-// WordPress.org components no longer use blue-50 as the primary color.
-// This changes the primary color to blue-50 to conform to the WordPress.com colors.
-body {
-	--color-accent: var(--studio-blue-50);
-	--color-accent-60: var(--studio-blue-60);
 }

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -109,8 +109,9 @@
 	}
 }
 
-:root {
-	--wp-components-color-accent: var(--studio-blue-50);
-	--wp-components-color-accent-darker-20: var(--studio-blue-60);
-	--wp-components-color-accent-darker-10: var(--studio-blue-60);
+// WordPress.org components no longer use blue-50 as the primary color.
+// This changes the primary color to blue-50 to conform to the WordPress.com colors.
+body {
+	--color-accent: var(--studio-blue-50);
+	--color-accent-60: var(--studio-blue-60);
 }

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -168,6 +168,17 @@ button {
 			}
 		}
 	}
+
+	// While we don't standardize all Calypso interfaces, we need to override this for onboarding flows #79851
+	.components-button.is-primary {
+		&[disabled],
+		&:disabled,
+		&.disabled {
+			color: #fff;
+			background-color: var(--studio-blue-20);
+			border-color: var(--studio-blue-20);
+		}
+	}
 }
 
 .import-focused .step-container.site-picker {

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -1,7 +1,6 @@
 /*
     Global styles for Stepper framework
 */
-@import "@wordpress/components/build-style/style";
 @import "@automattic/calypso-color-schemes";
 @import "@automattic/typography/styles/fonts";
 @import "@automattic/onboarding/styles/mixins";

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -161,8 +161,6 @@ button {
  	 * Step Container
  	 */
 	.step-container {
-		--color-accent: #117ac9;
-		--color-accent-60: #0e64a5;
 
 		.form-fieldset {
 			label {

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -172,6 +172,9 @@ button {
 	// While we don't standardize all Calypso interfaces, we need to override this for onboarding flows #79851
 	.components-button.is-primary {
 		border-radius: 4px;
+		font-size: 0.875rem;
+		font-weight: 500;
+		justify-content: center;
 
 		&[disabled],
 		&:disabled,

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -171,6 +171,8 @@ button {
 
 	// While we don't standardize all Calypso interfaces, we need to override this for onboarding flows #79851
 	.components-button.is-primary {
+		border-radius: 4px;
+
 		&[disabled],
 		&:disabled,
 		&.disabled {
@@ -179,6 +181,11 @@ button {
 			border-color: var(--studio-blue-20);
 		}
 	}
+
+	// WordPress.org components no longer use blue-50 as the primary color.
+	// This changes the primary color to blue-50 to conform to the WordPress.com colors.
+	--color-accent: var(--studio-blue-50);
+	--color-accent-60: var(--studio-blue-60);
 }
 
 .import-focused .step-container.site-picker {
@@ -254,12 +261,6 @@ button {
 .link-in-bio-tld,
 .setup-form__form {
 	button {
-		&[type="submit"] {
-			font-size: $font-body-small;
-			background-color: var(--studio-blue-50);
-			font-weight: 500;
-		}
-
 		&.site-icon-with-picker__upload-button {
 			border-radius: 4px;
 			border: 1px solid rgba($color: #000, $alpha: 0.2);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-import { Button, FormInputValidation } from '@automattic/components';
-import { TextControl } from '@wordpress/components';
+import { FormInputValidation } from '@automattic/components';
+import { TextControl, Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { Dispatch, FormEvent, ReactNode, SetStateAction, useEffect } from 'react';
@@ -128,6 +128,7 @@ const SetupForm = ( {
 			<Button
 				className={ `setup-form__submit ${ isTitleEmpty && 'disabled' }` }
 				disabled={ isLoading }
+				variant="primary"
 				type="submit"
 			>
 				{ isLoading ? __( 'Loading' ) : translatedText?.buttonText ?? __( 'Continue' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
@@ -84,13 +84,9 @@
 
 	.setup-form__submit {
 		border: none;
-		background-color: var(--studio-blue-50);
-		border-radius: 4px;
-		color: var(--color-surface);
-		font-weight: 500;
 		width: 100%;
 		// adds +2 px of padding to the button to match the input field height
-		padding: 10px 14px;
+		height: 40px;
 		margin-top: 16px;
 		&.disabled,
 		&.disabled:focus,
@@ -104,9 +100,6 @@
 			outline: 2px solid var(--studio-blue-60);
 			outline-offset: 1px;
 			background: var(--studio-blue-60);
-		}
-		&:hover {
-			background-color: var(--wp-admin-theme-color-darker-10);
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -232,6 +232,7 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 				<Button
 					disabled={ numberOfValidDomains === 0 || ! allGood }
 					className="bulk-domain-transfer__cta"
+					variant="primary"
 					onClick={ handleAddTransfer }
 				>
 					{ getTransferButtonText() }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
@@ -63,7 +63,7 @@ const Intro: React.FC< Props > = ( { onSubmit } ) => {
 				onSelect={ onSubmit }
 			/>
 			<div className="bulk-domain-transfer__cta-container">
-				<Button className="bulk-domain-transfer__cta" onClick={ onSubmit }>
+				<Button variant="primary" className="bulk-domain-transfer__cta" onClick={ onSubmit }>
 					{ __( 'Get Started' ) }
 				</Button>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -22,6 +22,12 @@ $heading-font-family: "SF Pro Display", $sans;
 			height: 48px;
 			width: 240px;
 
+			// While we don't standardize all Calypso interfaces, we need to override this for domain transfer flow #79851
+			&:disabled {
+				background: var(--gray-gray-5, #dcdcde);
+				opacity: 1;
+			}
+
 			@media (max-width: $break-medium ) {
 				width: 100%;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -22,12 +22,6 @@ $heading-font-family: "SF Pro Display", $sans;
 			height: 48px;
 			width: 240px;
 
-			// While we don't standardize all Calypso interfaces, we need to override this for domain transfer flow #79851
-			&:disabled {
-				background: var(--gray-gray-5, #dcdcde);
-				opacity: 1;
-			}
-
 			@media (max-width: $break-medium ) {
 				width: 100%;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -19,26 +19,8 @@ $heading-font-family: "SF Pro Display", $sans;
 		margin-bottom: 32px;
 
 		.bulk-domain-transfer__cta {
-			justify-content: center;
-			color: var(--black-white-white, #fff);
 			height: 48px;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-			border-radius: 0.25rem;
-			background: var(--blue-blue-50, #0675c4);
-			font-size: 0.875rem;
 			width: 240px;
-			font-weight: 500;
-
-			&:hover {
-				background: var(--studio-blue-60);
-			}
-
-			&:disabled {
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-				border-radius: 0.25rem;
-				background: var(--gray-gray-5, #dcdcde);
-				opacity: 1;
-			}
 
 			@media (max-width: $break-medium ) {
 				width: 100%;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up to https://github.com/Automattic/wp-calypso/pull/79692 and https://github.com/Automattic/wp-calypso/pull/79708

Implementing [Louis' suggestion](https://github.com/Automattic/wp-calypso/pull/79708#discussion_r1271701088) that deal with the root cause: avoids an override of an override by removing `@wordpress/components/build-style/style` from `client/landing/stepper/declarative-flow/internals/global.scss`

More context: p1689919222911329-slack-C05CT832K2T

https://github.com/Automattic/wp-calypso/assets/1044309/bab7cf90-7fd7-4526-ba43-627d5fb8143d


## Proposed Changes

* Removes unnecessary override at `@wordpress/components/build-style/style` from `client/landing/stepper/declarative-flow/internals/global.scss`
* Link in bio is using global overrides instead of local
* Domain transfer is using global overrides instead of local

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to /setup/domain-transfer.
* Check the first two steps (the second one, we need to remove the `disabled` attribute to see it)
* Check the second step disable button state has the correct style
* The buttons should have blue-50 and should have Calypso hover state.

Go to /setup/link-in-bio.
* Check the first and second steps
* The buttons should have blue-50 and should have Calypso hover state.

Go to /setup/newsletter/newsletterSetup.
* Check the steps
* The buttons should have blue-50 and should have Calypso hover state.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?