### PR TITLE
Update the display names for stats products

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -156,7 +156,7 @@ export const getJetpackProductsDisplayNames = (): Record< string, TranslateResul
 	);
 	const backup = translate( 'VaultPress Backup' );
 	const search = translate( 'Site Search' );
-	const stats = translate( 'Stats' );
+	const stats = translate( 'Stats (Personal)' );
 	const statsFree = translate( 'Stats (Free)' );
 	const statsCommercial = translate( 'Stats (Commercial)' );
 	const scan = translate( 'Scan' );

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -157,6 +157,8 @@ export const getJetpackProductsDisplayNames = (): Record< string, TranslateResul
 	const backup = translate( 'VaultPress Backup' );
 	const search = translate( 'Site Search' );
 	const stats = translate( 'Stats' );
+	const statsFree = translate( 'Stats (Free)' );
+	const statsCommercial = translate( 'Stats (Commercial)' );
 	const scan = translate( 'Scan' );
 	const scanRealtime = (
 		<>
@@ -246,9 +248,9 @@ export const getJetpackProductsDisplayNames = (): Record< string, TranslateResul
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: search,
 		[ PRODUCT_WPCOM_SEARCH ]: search,
 		[ PRODUCT_WPCOM_SEARCH_MONTHLY ]: search,
-		[ PRODUCT_JETPACK_STATS_MONTHLY ]: stats,
+		[ PRODUCT_JETPACK_STATS_MONTHLY ]: statsCommercial,
 		[ PRODUCT_JETPACK_STATS_PWYW_YEARLY ]: stats,
-		[ PRODUCT_JETPACK_STATS_FREE ]: stats,
+		[ PRODUCT_JETPACK_STATS_FREE ]: statsFree,
 		[ PRODUCT_JETPACK_SCAN ]: scan,
 		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: scan,
 		[ PRODUCT_JETPACK_SCAN_REALTIME ]: scanRealtime,


### PR DESCRIPTION
## Proposed Changes

* This diff updates display names for stats products to make it clear which products are free/ commercial

## Testing Instructions

* Apply this diff on your local testing environment
* If you do not already, obtain some test stats purchases
* Confirm that in the purchases list on `me/purchases` and on the purchase management page that the Free and Commercial plans contain a descriptor in parenthesis next to the name stats
![Screenshot 2023-07-25 at 3 45 23 PM](https://github.com/Automattic/wp-calypso/assets/18016357/e62893d2-1a39-40c5-bf9b-a15cde026678)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
