### PR TITLE
Whitelist benefits step in cancellation flow

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-benefits-step.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-benefits-step.tsx
@@ -3,6 +3,10 @@ import {
 	isJetpackPlanSlug,
 	isJetpackBackupSlug,
 	isJetpackScanSlug,
+	isJetpackAntiSpamSlug,
+	isJetpackSearchSlug,
+	isJetpackBoostSlug,
+	isJetpackVideoPressSlug,
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
@@ -117,6 +121,18 @@ const JetpackBenefitsStep: React.FC< Props > = ( props ) => {
 		);
 	};
 
+	const hasBenefitsToShow = ( productSlug: string ) => {
+		return (
+			isJetpackScanSlug( productSlug ) ||
+			isJetpackBackupSlug( productSlug ) ||
+			isJetpackAntiSpamSlug( productSlug ) ||
+			isJetpackSearchSlug( productSlug ) ||
+			isJetpackBoostSlug( productSlug ) ||
+			isJetpackVideoPressSlug( productSlug ) ||
+			isJetpackPlanSlug( productSlug )
+		);
+	};
+
 	const getCancelConsequenceByProduct = ( productSlug: string ) => {
 		if ( isJetpackScanSlug( productSlug ) ) {
 			return translate(
@@ -130,9 +146,13 @@ const JetpackBenefitsStep: React.FC< Props > = ( props ) => {
 			return translate(
 				"Once you remove your subscription, you will no longer have Jetpack's enhanced search experience."
 			);
+		} else if ( hasBenefitsToShow( productSlug ) ) {
+			return translate(
+				'Once you remove your subscription, you will lose access to the following:'
+			);
 		}
 
-		return translate( 'Once you remove your subscription, you will lose access to the following:' );
+		return '';
 	};
 
 	return (
@@ -149,7 +169,9 @@ const JetpackBenefitsStep: React.FC< Props > = ( props ) => {
 				isSecondary={ true }
 			/>
 
-			<JetpackBenefits siteId={ siteId } productSlug={ productSlug } />
+			{ hasBenefitsToShow( productSlug ) && (
+				<JetpackBenefits siteId={ siteId } productSlug={ productSlug } />
+			) }
 
 			{ isJetpackPlanSlug( productSlug ) && ( // show general benefits for plans
 				<div className="cancel-jetpack-form__jetpack-general-benefits">


### PR DESCRIPTION
## Proposed Changes

* This PR whitelists the benefit step in the cancellation flow for Jetpack products so that if a product does not have any benefits to list, that section is omitted

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR
* Test the cancellation & removal process for different Jetpack products in Calypso
* Confirm that for products in the new whitelist check that you still see the product/ plan specific benefits listed when going to remove the plan (see screenshot). Note that you won't see the benefit list unless the product will be removed.
![Screenshot 2023-07-25 at 4 39 49 PM](https://github.com/Automattic/wp-calypso/assets/18016357/d0b83b91-b926-463a-b5c5-ab0b7f315b98)
* Confirm that products that are not in the whitelist (ex: AI, Stats) only show the time remaining on the plan
![Screenshot 2023-07-25 at 4 42 52 PM](https://github.com/Automattic/wp-calypso/assets/18016357/03d19dce-26dd-4f39-917f-2f1e59afdfb7)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
