### PR TITLE
Paid Stats: Hide addon card behind a new feature flag

### DIFF
--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -120,8 +120,7 @@ const useModifiedActionPrimary = (
 			text: translate( 'Upgrade Stats' ),
 			handler: () => {
 				// Navigate to the stats purchase page, scrolled to the top.
-				// TODO: Remove "?flags=stats/paid-stats" once the new stats purchase page is live.
-				page.show( `/stats/purchase/${ siteSlug }?flags=stats/paid-stats` );
+				page.show( `/stats/purchase/${ siteSlug }` );
 				window.scrollTo( 0, 0 );
 			},
 		};

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -156,11 +156,11 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 					return false;
 				}
 
-				// TODO: Remove this check once paid stats is live.
+				// TODO: Remove this check once paid WPCOM stats is live.
 				// gate the Jetpack Stats add-on on a feature flag
 				if (
 					addOn.productSlug === PRODUCT_JETPACK_STATS_PWYW_YEARLY &&
-					! config.isEnabled( 'stats/paid-stats' )
+					! config.isEnabled( 'stats/paid-wpcom-stats' )
 				) {
 					return false;
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #79817.

## Proposed Changes

<img width="547" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/aa7d8f02-ba45-4d97-8dae-27b9775240ff">

* Gates the new paid stats addon card behind a `stats/paid-wpcom-stats` feature flag.

## Testing Instructions

* For a Simple or Atomic site, navigate to the Addons page via Upgrades -> Addons.
* Add `?flags=stats/paid-wpcom-stats` to your address bar.
* Ensure that you can see the new Jetpack Stats addon.
* Click on Upgrade Stats. 
* Ensure that you're taken to the new Stats Purchase page at `/stats/purchase/:siteSlug`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
