### PR TITLE
Checkout: Add extra handlers to CheckoutErrorBoundary for impossible situations

### DIFF
--- a/packages/composite-checkout/src/components/checkout-error-boundary.tsx
+++ b/packages/composite-checkout/src/components/checkout-error-boundary.tsx
@@ -20,11 +20,31 @@ export default class CheckoutErrorBoundary extends Component< CheckoutErrorBound
 
 	componentDidCatch( error: Error ): void {
 		if ( this.props.onError ) {
-			const errorContext =
-				typeof this.props.errorMessage === 'string' && this.props.errorMessage.length > 0
-					? this.props.errorMessage
-					: `${ error }`;
+			if ( error.message.length === 0 ) {
+				// I don't know how it happens but sometimes there's no error
+				// message so let's not log an empty string.
+				const errorWithCause = new Error( 'No error message found!', { cause: error } );
+				this.props.onError( errorWithCause );
+				return;
+			}
+
+			// If there is no custom error message, just report the error.
+			if ( typeof this.props.errorMessage !== 'string' || this.props.errorMessage.length === 0 ) {
+				this.props.onError( error );
+				return;
+			}
+
+			// Use the custom error message as the error and include the
+			// original error as the cause.
+			const errorContext = this.props.errorMessage;
 			const errorWithCause = new Error( errorContext, { cause: error } );
+			if ( ! errorWithCause.cause ) {
+				// It's standard but it's possible that some browsers might not
+				// support the second argument to the Error constructor so we
+				// provide a fallback here.
+				this.props.onError( error );
+				return;
+			}
 			this.props.onError( errorWithCause );
 		}
 	}


### PR DESCRIPTION
Checkout and other parts of calypso that have to do with payments use the `CheckoutErrorBoundary` as a React error boundary to catch fatal errors, log them, and prevent the user from seeing a blank page. However, recently we've been seeing a lot of errors reported that have no error message.

## Proposed Changes

To try to track down these mystery errors, this PR modifies `CheckoutErrorBoundary` so that it supports two fallbacks:

1. If the caught error has an empty `message` property, it will be replaced by a new error that explicitly reads `No error message found!`.
2. We add the caught error as the `cause` to a new error which is reported. If for some reason the `cause` does not get added (old browsers?) then we log the original error instead.

## Testing Instructions

None should be needed.