### PR TITLE
Update role name in pre-release test

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/free-signup-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/free-signup-flow.ts
@@ -38,7 +38,7 @@ export class FreeSignupFlow {
 	 * @param {string} name Name of the site.
 	 */
 	async enterSiteName( name: string ): Promise< void > {
-		await this.page.getByRole( 'textbox', { name: 'My WebSite' } ).fill( name );
+		await this.page.getByRole( 'textbox', { name: 'Site name' } ).fill( name );
 	}
 
 	/**


### PR DESCRIPTION
After merging #79647, the pre release tests broke. It looks like for WordPress text inputs, the accessible name has changed from the placeholder to the label, so this text needs to change from "My Website" to "Site name" 

<img width="1804" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6265975/f5922cd9-e6eb-49a9-ae2d-f70dc6a3d53f">
