### PR TITLE
Checkout: Add min-height to main content area to fix 'empty' sidebar space on smaller devices

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -840,6 +840,7 @@ const WPCheckoutWrapper = styled.div`
 const WPCheckoutMainContent = styled.div`
 	grid-area: main-content;
 	margin-top: 50px;
+	min-height: 100vh;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		padding: 0 24px;


### PR DESCRIPTION
The checkout comprised of a main content area and a sidebar area, where the sidebar stacks on top of the main content on tablet and smaller devices.

The wrapper component `WPCheckoutWrapper` uses `min-height: 100vh` to force the checkout to fill the screen vertically. Its children `WPCheckoutMainContent` and `WPCheckoutSidebarContent` then take their respective grid areas within `WPCheckoutMainContent`. On tablets, this means the sidebar, followed by the main content, are aligned vertically one after the other. 

But, and I'm not entirely certain of why the grid css spec does this, the sidebar section seems to anchor to the start/top while the main content section seems to anchor to the end/bottom, thus leaving an empty space that the sidebar's short button cannot fill. Note, the space seems to only show on very long screens when in tablet mode:

![image](https://github.com/Automattic/wp-calypso/assets/16580129/374b9358-bda5-436b-828e-7ffa56396f27)



Related to #79737 

## Proposed Changes

If we add a `min-height: 100vh` to the `WPCheckoutMainContent` section we force the section to fill the space until it runs into the sidebar's button element: 

|**With sidebar closed**|**With sidebar open**|
|-------|-------|
|![image](https://github.com/Automattic/wp-calypso/assets/16580129/82876f96-aa61-48aa-8d4e-df07093493e4)|![image](https://github.com/Automattic/wp-calypso/assets/16580129/1fe35454-5e31-4f5b-97f1-7a5cef3756e8)|

## Testing Instructions

* Open checkout and in the developer tools toggle between different screen widths (or click and drag the window size manually).
* Ensure that all parts of the checkout are visible and accessible
* Ensure that desktop sized screens aren't affected by these changes (they shouldn't be)
* Also check different screen heights for smaller devices
