### PR TITLE
GF Signup: Funnel the generated subdomain url across the flow

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -81,8 +81,8 @@ export function generateSteps( {
 			stepName: 'domains-launch',
 			apiRequestFunction: addDomainToCart,
 			fulfilledStepCallback: isDomainFulfilled,
-			providesDependencies: [ 'domainItem', 'shouldHideFreePlan', 'signupDomainOrigin' ],
-			optionalDependencies: [ 'shouldHideFreePlan', 'signupDomainOrigin' ],
+			providesDependencies: [ 'domainItem', 'shouldHideFreePlan', 'signupDomainOrigin', 'siteUrl' ],
+			optionalDependencies: [ 'shouldHideFreePlan', 'signupDomainOrigin', 'siteUrl' ],
 			props: {
 				isDomainOnly: false,
 				showExampleSuggestions: false,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -372,8 +372,14 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'isManageSiteFlow',
 				'signupDomainOrigin',
+				'siteUrl',
 			],
-			optionalDependencies: [ 'signupDomainOrigin', 'shouldHideFreePlan', 'isManageSiteFlow' ],
+			optionalDependencies: [
+				'shouldHideFreePlan',
+				'isManageSiteFlow',
+				'signupDomainOrigin',
+				'siteUrl',
+			],
 			props: {
 				isDomainOnly: false,
 			},
@@ -400,7 +406,7 @@ export function generateSteps( {
 		'domain-only': {
 			stepName: 'domain-only',
 			providesDependencies: [ 'siteId', 'siteSlug', 'siteUrl', 'domainItem', 'signupDomainOrigin' ], // note: siteId, siteSlug are not provided when used in domain flow
-			optionalDependencies: [ 'signupDomainOrigin' ],
+			optionalDependencies: [ 'signupDomainOrigin', 'siteUrl' ],
 			props: {
 				isDomainOnly: true,
 				forceHideFreeDomainExplainerAndStrikeoutUi: true,
@@ -410,7 +416,8 @@ export function generateSteps( {
 		'domains-store': {
 			stepName: 'domains',
 			apiRequestFunction: createSiteWithCart,
-			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
+			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem', 'siteUrl' ],
+			optionalDependencies: [ 'siteUrl' ],
 			props: {
 				isDomainOnly: false,
 				forceDesignType: 'store',
@@ -429,8 +436,14 @@ export function generateSteps( {
 				'useThemeHeadstart',
 				'shouldHideFreePlan',
 				'signupDomainOrigin',
+				'siteUrl',
 			],
-			optionalDependencies: [ 'shouldHideFreePlan', 'useThemeHeadstart', 'signupDomainOrigin' ],
+			optionalDependencies: [
+				'shouldHideFreePlan',
+				'useThemeHeadstart',
+				'signupDomainOrigin',
+				'siteUrl',
+			],
 			props: {
 				isDomainOnly: false,
 			},

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -305,7 +305,8 @@ class DomainsStep extends Component {
 				{ domainItem },
 				this.isDependencyShouldHideFreePlanProvided() ? { shouldHideFreePlan } : {},
 				useThemeHeadstartItem,
-				signupDomainOrigin ? { signupDomainOrigin } : {}
+				signupDomainOrigin ? { signupDomainOrigin } : {},
+				{ siteUrl: suggestion.domain_name }
 			)
 		);
 
@@ -338,9 +339,14 @@ class DomainsStep extends Component {
 				},
 				this.getThemeArgs()
 			),
-			Object.assign( { domainItem }, useThemeHeadstartItem, {
-				signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN,
-			} )
+			Object.assign(
+				{ domainItem },
+				useThemeHeadstartItem,
+				{
+					signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN,
+				},
+				{ siteUrl: domain }
+			)
 		);
 
 		this.props.goToNextStep();
@@ -374,7 +380,7 @@ class DomainsStep extends Component {
 				},
 				this.getThemeArgs()
 			),
-			Object.assign( { domainItem }, useThemeHeadstartItem )
+			Object.assign( { domainItem }, useThemeHeadstartItem, { siteUrl: domain } )
 		);
 
 		this.props.goToNextStep();

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -306,7 +306,7 @@ class DomainsStep extends Component {
 				this.isDependencyShouldHideFreePlanProvided() ? { shouldHideFreePlan } : {},
 				useThemeHeadstartItem,
 				signupDomainOrigin ? { signupDomainOrigin } : {},
-				{ siteUrl: suggestion.domain_name }
+				suggestion?.domain_name ? { siteUrl: suggestion?.domain_name } : {}
 			)
 		);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Related to 

- https://github.com/Automattic/growth-foundations/issues/139
- https://github.com/Automattic/wp-calypso/pull/79937

## Proposed Changes

The siteUrl (specially when a domain is not purchased) is required in the subsequent steps to communicate upsells for plans.
So the site url needs to be funnelled across as a dependency to the domains step.

## Testing Instructions
A new optional dependency is added to all domains steps which are shown below. 

https://github.com/Automattic/wp-calypso/blob/de3b5dd66ab0f1cc2e689e4d6e1f43c9c9a88cb8/client/signup/config/step-components.js#L14-L19

No visible changes, Make sure any flows that utilise a domain step from above works correctly. 

* `/start`
*  `/start/domain` (Domain only flow)
* `/start/launch-site`
* `/start/with-theme-assembler`
* `/start/with-theme (Go incognito to WordPress.com/themes)

- Locally it would be nice to debug and check that a siteUrl is provided.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
