### PR TITLE
Stats: Updating notice CSS for Calypso

### DIFF
--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -67,7 +67,7 @@ const DoYouLoveJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
 	return (
 		<div
 			className={ `inner-notice-container has-odyssey-stats-bg-color ${
-				! isOdysseyStats && 'inner-notice-container--emerald'
+				! isOdysseyStats && 'inner-notice-container--calypso'
 			}` }
 		>
 			<NoticeBanner

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -65,7 +65,11 @@ const DoYouLoveJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
 	}
 
 	return (
-		<div className="inner-notice-container has-odyssey-stats-bg-color">
+		<div
+			className={ `inner-notice-container has-odyssey-stats-bg-color ${
+				! isOdysseyStats && 'inner-notice-container--emerald'
+			}` }
+		>
 			<NoticeBanner
 				level="info"
 				title={ translate( 'Do you love Jetpack Stats?' ) }

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -15,6 +15,7 @@ const getStatsPurchaseURL = ( siteId: number | null ) => {
 
 const FreePlanPurchaseSuccessJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
 	const translate = useTranslate();
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 
 	const dismissNotice = () => {
@@ -27,7 +28,11 @@ const FreePlanPurchaseSuccessJetpackStatsNotice = ( { siteId }: StatsNoticeProps
 	}
 
 	return (
-		<div className="inner-notice-container has-odyssey-stats-bg-color">
+		<div
+			className={ `inner-notice-container has-odyssey-stats-bg-color ${
+				! isOdysseyStats && 'inner-notice-container--calypso'
+			}` }
+		>
 			<NoticeBanner
 				level="success"
 				title={ translate( 'Thank you for using Jetpack Stats!' ) }

--- a/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
@@ -1,10 +1,11 @@
-/* eslint-disable no-console */
+import config from '@automattic/calypso-config';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 
 const PaidPlanPurchaseSuccessJetpackStatsNotice = () => {
 	const translate = useTranslate();
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 
 	const dismissNotice = () => {
@@ -17,7 +18,11 @@ const PaidPlanPurchaseSuccessJetpackStatsNotice = () => {
 	}
 
 	return (
-		<div className="inner-notice-container has-odyssey-stats-bg-color">
+		<div
+			className={ `inner-notice-container has-odyssey-stats-bg-color ${
+				! isOdysseyStats && 'inner-notice-container--calypso'
+			}` }
+		>
 			<NoticeBanner
 				level="success"
 				title={ translate( 'Thank you for supporting Jetpack Stats!' ) }

--- a/client/my-sites/stats/stats-notices/style.scss
+++ b/client/my-sites/stats/stats-notices/style.scss
@@ -10,22 +10,26 @@
 		display: inline-block;
 	}
 
-	&.inner-notice-container--emerald {
+	&.inner-notice-container--calypso {
 		p,
 		button,
 		a {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 
 		.notice-banner__action-button {
 			background-color: var(--color-accent);
 			border-color: var(--color-accent);
 			color: var(--color-text-inverted);
+			border-radius: 2px;
 		}
 
 		.notice-banner.is-info {
 			border-left-color: var(--color-accent);
+		}
+
+		.notice-banner__action-link > span {
+			border-bottom: 0;
 		}
 	}
 }

--- a/client/my-sites/stats/stats-notices/style.scss
+++ b/client/my-sites/stats/stats-notices/style.scss
@@ -9,4 +9,23 @@
 		vertical-align: middle;
 		display: inline-block;
 	}
+
+	&.inner-notice-container--emerald {
+		p,
+		button,
+		a {
+			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+			font-size: 14px;
+		}
+
+		.notice-banner__action-button {
+			background-color: var(--color-accent);
+			border-color: var(--color-accent);
+			color: var(--color-text-inverted);
+		}
+
+		.notice-banner.is-info {
+			border-left-color: var(--color-accent);
+		}
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79865

## Proposed Changes

* Updating notice style visible on Calypso to match Calypso CSS

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live branch for this PR
* Navigate to `/stats/purchase/:siteSlug?flags=stats/paid-wpcom-stats` and verify that the notice visible at the top has calypso colours applied to the button and the border on the left side
* Navigate to the same page on Odyssey and verify that the colours are black


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
