### PR TITLE
Theme Showcase: Rename Paid themes to Partner themes

### DIFF
--- a/client/components/theme-type-badge/index.tsx
+++ b/client/components/theme-type-badge/index.tsx
@@ -83,8 +83,8 @@ const ThemeTypeBadge = ( {
 			<PremiumBadge
 				{ ...badgeContentProps }
 				className={ classNames( badgeContentProps.className, 'is-marketplace' ) }
-				labelText={ translate( 'Paid', {
-					context: 'Refers to paid service, such as paid theme',
+				labelText={ translate( 'Partner', {
+					context: 'This theme is developed and supported by a theme partner',
 					textOnly: true,
 				} ) }
 			/>

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -111,7 +111,10 @@ const ThemeTypeBadgeTooltip = ( {
 				textOnly: true,
 			} ),
 			[ WOOCOMMERCE_THEME ]: translate( 'WooCommerce theme' ),
-			[ MARKETPLACE_THEME ]: translate( 'Paid theme' ),
+			[ MARKETPLACE_THEME ]: translate( 'Partner theme', {
+				context: 'This theme is developed and supported by a theme partner',
+				textOnly: true,
+			} ),
 		} as { [ key: string ]: string };
 
 		if ( ! ( type in headers ) ) {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -642,8 +642,8 @@ class ThemeSheet extends Component {
 				disableHref={ url === '' }
 				icon="notice"
 				href={ url }
-				title={ translate( 'Paid themes cannot be purchased on staging sites' ) }
-				description={ translate( 'Subscribe to this premium theme on your production site.' ) }
+				title={ translate( 'Partner themes cannot be purchased on staging sites' ) }
+				description={ translate( 'Subscribe to this theme on your production site.' ) }
 			/>
 		);
 	};

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -195,8 +195,8 @@ class ThemeShowcase extends Component {
 
 		tiers.push( {
 			value: 'marketplace',
-			label: this.props.translate( 'Paid', {
-				context: 'Refers to paid service, such as paid theme',
+			label: this.props.translate( 'Partner', {
+				context: 'This theme is developed and supported by a theme partner',
 			} ),
 		} );
 


### PR DESCRIPTION
## Proposed Changes

As discussed in paYJgx-3AU-p2#comment-3740, we are interested in finding a better term for third-party developed themes. Currently, we use "Paid themes", which can be confusing and hard to translate. As replacement, the following terms were suggested:

- Marketplace themes (https://github.com/Automattic/wp-calypso/pull/79351)
- Third Party themes
- Vendor themes
- Partner themes
- Third Party Premium themes
- Premium Party themes

There are many comments in favor of "Partner themes", so [let's go with that](pekYwv-2tC-p2) as the next best thing:

- paYJgx-3AU-p2#comment-3754
- paYJgx-3AU-p2#comment-3793
- paYJgx-3AU-p2#comment-3800
- p1689262800233069/1689200222.553109-slack-C048CUFRGFQ

Theme Showcase:
| Before | After |
| --- | --- |
 | ![Screenshot 2023-07-26 at 2 44 28 PM](https://github.com/Automattic/wp-calypso/assets/797888/bb2f06cb-5dda-4deb-9de7-bb977072f0ce) |![Screenshot 2023-07-26 at 2 43 55 PM](https://github.com/Automattic/wp-calypso/assets/797888/932a0b2d-09be-49df-9048-f9730bba7499)|

Theme Detail page (Atomic staging): 
| Before | After |
| --- | --- |
| ![Screenshot 2023-07-26 at 2 50 37 PM](https://github.com/Automattic/wp-calypso/assets/797888/411cceda-4407-4192-9cff-166e6550941e) | ![Screenshot 2023-07-26 at 2 51 05 PM](https://github.com/Automattic/wp-calypso/assets/797888/5d5c6118-937d-46b9-86e0-dfa942e30688) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Ensure that the pricing filter option Paid is now Partner.
* Ensure that the theme type badge Paid is now Partner.
* Ensure that the theme type badge's tooltip no longer shows Paid theme, but Partner theme.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?