### PR TITLE
Theme showcase: Add theme type to Track events

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -26,6 +26,7 @@ import {
 	isThemeActive,
 	isInstallingTheme,
 	prependThemeFilterKeys,
+	getThemeType,
 } from 'calypso/state/themes/selectors';
 import { getThemeHiddenFilters } from 'calypso/state/themes/selectors/get-theme-hidden-filters';
 import { addStyleVariation, trackClick, interlaceThemes } from './helpers';
@@ -49,6 +50,7 @@ class ThemesSelection extends Component {
 		] ),
 		getPremiumThemePrice: PropTypes.func,
 		getThemeDetailsUrl: PropTypes.func,
+		getThemeType: PropTypes.func,
 		isInstallingTheme: PropTypes.func,
 		isLastPage: PropTypes.bool,
 		isRequesting: PropTypes.bool,
@@ -88,6 +90,7 @@ class ThemesSelection extends Component {
 			page_number: query.page,
 			theme_on_page: parseInt( ( resultsRank + 1 ) / query.number ),
 			action: snakeCase( action ),
+			theme_type: this.props.getThemeType( themeId ),
 		} );
 	};
 
@@ -124,6 +127,7 @@ class ThemesSelection extends Component {
 			results_rank: resultsRank + 1,
 			page_number: query.page,
 			theme_on_page: parseInt( ( resultsRank + 1 ) / query.number ),
+			theme_type: this.props.getThemeType( themeId ),
 		};
 
 		if ( variation ) {
@@ -307,6 +311,10 @@ function bindGetThemeDetailsUrl( state, siteId ) {
 	return ( themeId ) => getThemeDetailsUrl( state, themeId, siteId );
 }
 
+function bindGetThemeType( state ) {
+	return ( themeId ) => getThemeType( state, themeId );
+}
+
 // Exporting this for use in customized themes lists (recommended-themes.jsx, etc.)
 // We do not want pagination triggered in that use of the component.
 export const ConnectedThemesSelection = connect(
@@ -407,6 +415,7 @@ export const ConnectedThemesSelection = connect(
 			// redundant AJAX requests, we're not rendering these query components locally.
 			getPremiumThemePrice: bindGetPremiumThemePrice( state, siteId ),
 			getThemeDetailsUrl: bindGetThemeDetailsUrl( state, siteId ),
+			getThemeType: bindGetThemeType( state ),
 			filterString: prependThemeFilterKeys( state, query.filter ),
 			shouldFetchWpOrgThemes,
 			wpOrgQuery,

--- a/client/state/themes/actions/theme-activated.js
+++ b/client/state/themes/actions/theme-activated.js
@@ -6,6 +6,7 @@ import { THEME_ACTIVATE_SUCCESS } from 'calypso/state/themes/action-types';
 import {
 	getActiveTheme,
 	getLastThemeQuery,
+	getThemeType,
 	prependThemeFilterKeys,
 } from 'calypso/state/themes/selectors';
 import { getThemeIdFromStylesheet } from 'calypso/state/themes/utils';
@@ -43,18 +44,20 @@ export function themeActivated(
 
 	// it is named function just for testing purposes
 	return function themeActivatedThunk( dispatch, getState ) {
+		const themeId = getThemeIdFromStylesheet( themeStylesheet );
 		const previousThemeId = getActiveTheme( getState(), siteId );
 		const query = getLastThemeQuery( getState(), siteId );
 		const search_taxonomies = prependThemeFilterKeys( getState(), query.filter );
 		const search_term = search_taxonomies + ( query.search || '' );
 		const trackThemeActivation = recordTracksEvent( 'calypso_themeshowcase_theme_activate', {
-			theme: getThemeIdFromStylesheet( themeStylesheet ),
+			theme: themeId,
 			previous_theme: previousThemeId,
 			source: source,
 			purchased: purchased,
 			search_term: search_term || null,
 			search_taxonomies,
 			style_variation_slug: styleVariationSlug || '',
+			theme_type: getThemeType( getState(), themeId ),
 		} );
 		dispatch( withAnalytics( trackThemeActivation, action ) );
 

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -540,6 +540,7 @@ describe( 'actions', () => {
 									source: 'unknown',
 									style_variation_slug: '',
 									theme: 'twentysixteen',
+									theme_type: 'free',
 								},
 								service: 'tracks',
 							},


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3123

## Proposed Changes

Adds a new `theme_type` prop that indicates the "pricing" category of a theme (e.g. free, premium, dot-org, etc) to the following Track events of the theme showcase:
- `calypso_themeshowcase_theme_click`: when there is a click on a theme item.
- `calypso_themeshowcase_theme_style_variation_click`: when a variation is selected via the style variations discs.
- `calypso_themeshowcase_theme_style_variation_more_click`:  when the "+X" button of the style variations discs is clicked. 
- `calypso_themeshowcase_theme_activate`: when a theme is activated.

## Testing Instructions

- Use the Calypso live link below.
- Go to Appearance > Themes.
- Observe the `t.gif` requests in the Networks tab of your browser devtools.
- Try to trigger the events listed above.
- Make sure they all have a new `theme_type` property with the expected value.