### PR TITLE
Theme showcase: show site assembler CTA on empty search on Desktop

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
-import { PatternAssemblerCta } from '@automattic/design-picker';
+import { PatternAssemblerCta, usePatternAssemblerCtaData } from '@automattic/design-picker';
 import { WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { Icon, addTemplate, brush, cloudUpload } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
@@ -38,6 +38,26 @@ const getGridColumns = ( gridContainerRef, minColumnWidth, margin ) => {
 	// in a division by zero. In that case, we just assume that there's only one column.
 	const columnsPerRow = Math.floor( availableWidth / ( minColumnWidth + margin ) ) || 1;
 	return columnsPerRow;
+};
+
+const getSiteAssemblerUrl = ( {
+	isLoggedIn,
+	selectedSite,
+	shouldGoToAssemblerStep,
+	siteEditorUrl,
+} ) => {
+	if ( ! shouldGoToAssemblerStep ) {
+		return siteEditorUrl;
+	}
+
+	const basePathname = isLoggedIn ? '/setup' : '/start';
+	const params = new URLSearchParams( { ref: 'calypshowcase' } );
+
+	if ( selectedSite?.slug ) {
+		params.set( 'siteSlug', selectedSite.slug );
+	}
+
+	return `${ basePathname }/${ WITH_THEME_ASSEMBLER_FLOW }?${ params }`;
 };
 
 export const ThemesList = ( { tabFilter, ...props } ) => {
@@ -83,23 +103,12 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 			goes_to_assembler_step: shouldGoToAssemblerStep,
 		} );
 
-		let destinationUrl;
-
-		// We have to redirect the user to the site editor directly if the user has logged in but
-		// they're on the small screen because the Assembler doesn't support the small screen yet.
-		if ( ! isLoggedIn || shouldGoToAssemblerStep ) {
-			const basePathname = isLoggedIn ? '/setup' : '/start';
-			const params = new URLSearchParams( { ref: 'calypshowcase' } );
-
-			if ( selectedSite?.slug ) {
-				params.set( 'siteSlug', selectedSite.slug );
-			}
-
-			destinationUrl = `${ basePathname }/${ WITH_THEME_ASSEMBLER_FLOW }?${ params }`;
-		} else {
-			destinationUrl = siteEditorUrl;
-		}
-
+		const destinationUrl = getSiteAssemblerUrl( {
+			isLoggedIn,
+			selectedSite,
+			shouldGoToAssemblerStep,
+			siteEditorUrl,
+		} );
 		window.location.assign( destinationUrl );
 	};
 
@@ -222,14 +231,20 @@ function ThemeBlock( props ) {
 }
 
 function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsellCardDisplayed } ) {
-	const isLoggedInShowcase = useSelector( isUserLoggedIn );
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	const selectedSite = useSelector( getSelectedSite );
 	const canInstallTheme = useSelector( ( state ) =>
 		siteHasFeature( state, selectedSite?.ID, FEATURE_INSTALL_THEMES )
 	);
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, selectedSite?.ID ) );
 	const sitePlan = selectedSite?.plan?.product_slug;
-	const siteEditorUrl = useSelector( ( state ) => getSiteEditorUrl( state, selectedSite?.ID ) );
+	const siteEditorUrl = useSelector( ( state ) =>
+		getSiteEditorUrl( state, selectedSite?.ID, {
+			canvas: 'edit',
+			assembler: '1',
+		} )
+	);
+	const assemblerCtaData = usePatternAssemblerCtaData();
 
 	const options = [];
 
@@ -241,27 +256,30 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 	}, [ upsellCardDisplayed ] );
 
 	// Design your own theme / homepage.
-	if ( isLoggedInShowcase ) {
-		// This should start the Pattern Assembler ideally, but it's not ready yet for the
-		// logged-in showcase, so we use the site editor as a fallback.
-		if ( isFSEActive ) {
+	if ( assemblerCtaData.shouldGoToAssemblerStep ) {
+		if ( ! isLoggedIn || isFSEActive ) {
 			options.push( {
-				title: translate( 'Design your own' ),
+				title: assemblerCtaData.title,
 				icon: addTemplate,
-				description: translate( 'Jump right into the editor to design your homepage.' ),
+				description: assemblerCtaData.subtitleLineTwo,
 				onClick: () =>
 					recordTracksEvent( 'calypso_themeshowcase_more_options_design_homepage_click', {
 						site_plan: sitePlan,
 						search_term: searchTerm,
-						destination: 'site-editor',
+						destination: assemblerCtaData.shouldGoToAssemblerStep ? 'assembler' : 'site-editor',
 					} ),
-				url: siteEditorUrl,
-				buttonText: translate( 'Open the editor' ),
+				url: getSiteAssemblerUrl( {
+					isLoggedIn,
+					selectedSite,
+					shouldGoToAssemblerStep: assemblerCtaData.shouldGoToAssemblerStep,
+					siteEditorUrl,
+				} ),
+				buttonText: assemblerCtaData.buttonText,
 			} );
 		}
 	} else {
 		// This should also start the Pattern Assembler, which is currently in development for
-		// the logged-out showcase. Since there isn't any proper fallback for the meantime, we
+		// the mobile viewport. Since there isn't any proper fallback for the meantime, we
 		// just don't include this option.
 	}
 
@@ -287,7 +305,7 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 	} );
 
 	// Upload a theme.
-	if ( ! isLoggedInShowcase ) {
+	if ( ! isLoggedIn ) {
 		options.push( {
 			title: translate( 'Upload a theme' ),
 			icon: cloudUpload,

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -46,7 +46,7 @@ const getSiteAssemblerUrl = ( {
 	shouldGoToAssemblerStep,
 	siteEditorUrl,
 } ) => {
-	if ( ! shouldGoToAssemblerStep ) {
+	if ( isLoggedIn && ! shouldGoToAssemblerStep ) {
 		return siteEditorUrl;
 	}
 

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -256,30 +256,31 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 	}, [ upsellCardDisplayed ] );
 
 	// Design your own theme / homepage.
-	if ( assemblerCtaData.shouldGoToAssemblerStep ) {
-		if ( ! isLoggedIn || isFSEActive ) {
-			options.push( {
-				title: assemblerCtaData.title,
-				icon: addTemplate,
-				description: assemblerCtaData.subtitleLineTwo,
-				onClick: () =>
-					recordTracksEvent( 'calypso_themeshowcase_more_options_design_homepage_click', {
-						site_plan: sitePlan,
-						search_term: searchTerm,
-						destination: assemblerCtaData.shouldGoToAssemblerStep ? 'assembler' : 'site-editor',
-					} ),
-				url: getSiteAssemblerUrl( {
-					isLoggedIn,
-					selectedSite,
-					shouldGoToAssemblerStep: assemblerCtaData.shouldGoToAssemblerStep,
-					siteEditorUrl,
+	if (
+		( isLoggedIn && isFSEActive ) ||
+		( ! isLoggedIn && assemblerCtaData.shouldGoToAssemblerStep )
+	) {
+		options.push( {
+			title: assemblerCtaData.title,
+			icon: addTemplate,
+			description: assemblerCtaData.subtitleLineTwo,
+			onClick: () =>
+				recordTracksEvent( 'calypso_themeshowcase_more_options_design_homepage_click', {
+					site_plan: sitePlan,
+					search_term: searchTerm,
+					destination: assemblerCtaData.shouldGoToAssemblerStep ? 'assembler' : 'site-editor',
 				} ),
-				buttonText: assemblerCtaData.buttonText,
-			} );
-		}
+			url: getSiteAssemblerUrl( {
+				isLoggedIn,
+				selectedSite,
+				shouldGoToAssemblerStep: assemblerCtaData.shouldGoToAssemblerStep,
+				siteEditorUrl,
+			} ),
+			buttonText: assemblerCtaData.buttonText,
+		} );
 	} else {
 		// This should also start the Pattern Assembler, which is currently in development for
-		// the mobile viewport. Since there isn't any proper fallback for the meantime, we
+		// the logged-out showcase on mobile viewport. Since there isn't any proper fallback for the meantime, we
 		// just don't include this option.
 	}
 

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -1,70 +1,60 @@
 import { Button } from '@automattic/components';
 import { useViewportMatch } from '@wordpress/compose';
-import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import blankCanvasImage from '../assets/images/blank-canvas-cta.svg';
 import './style.scss';
 
-type PatternAssemblerCtaProps = {
-	compact?: boolean;
-	hasPrimaryButton?: boolean;
-	onButtonClick: ( shouldGoToAssemblerStep: boolean ) => void;
-	showEditorFallback?: boolean;
-	showHeading?: boolean;
-	text?: string | JSX.Element;
+type PatternAssemblerCtaData = {
+	shouldGoToAssemblerStep: boolean;
+	title: string;
+	subtitleLineOne: string;
+	subtitleLineTwo: string;
+	buttonText: string;
 };
 
-const PatternAssemblerCta = ( {
-	compact = false,
-	hasPrimaryButton = true,
-	onButtonClick,
-	showEditorFallback = true,
-	showHeading = true,
-	text: customText,
-}: PatternAssemblerCtaProps ) => {
+type PatternAssemblerCtaProps = {
+	onButtonClick: ( shouldGoToAssemblerStep: boolean ) => void;
+};
+
+export function usePatternAssemblerCtaData(): PatternAssemblerCtaData {
 	const translate = useTranslate();
 	const isDesktop = useViewportMatch( 'large' );
 
 	const shouldGoToAssemblerStep = isDesktop;
 
+	return {
+		shouldGoToAssemblerStep,
+		title: translate( 'Design your own' ),
+		subtitleLineOne: translate( 'Can’t find something you like?' ),
+		subtitleLineTwo: shouldGoToAssemblerStep
+			? translate( 'Use our library of styles and patterns to build a homepage.' )
+			: translate( 'Jump right into the editor to design your homepage from scratch.' ),
+		buttonText: shouldGoToAssemblerStep
+			? translate( 'Start designing' )
+			: translate( 'Open the editor' ),
+	};
+}
+
+const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
+	const data = usePatternAssemblerCtaData();
+
 	const handleButtonClick = () => {
-		onButtonClick( shouldGoToAssemblerStep );
+		onButtonClick( data.shouldGoToAssemblerStep );
 	};
 
-	if ( ! shouldGoToAssemblerStep && ! showEditorFallback ) {
-		return null;
-	}
-
-	let text = customText;
-	if ( ! text ) {
-		text = (
-			<>
-				{ translate( 'Can’t find something you like?' ) }
-				<br />
-				{ shouldGoToAssemblerStep
-					? translate( 'Use our library of styles and patterns to build a homepage.' )
-					: translate( 'Jump right into the editor to design your homepage from scratch.' ) }
-			</>
-		);
-	}
-
 	return (
-		<div className={ classnames( 'pattern-assembler-cta-wrapper', { 'is-compact': compact } ) }>
+		<div className="pattern-assembler-cta-wrapper">
 			<div className="pattern-assembler-cta__image-wrapper">
 				<img className="pattern-assembler-cta__image" src={ blankCanvasImage } alt="Blank Canvas" />
 			</div>
-			{ showHeading && (
-				<h3 className="pattern-assembler-cta__title">{ translate( 'Design your own' ) }</h3>
-			) }
-			<p className="pattern-assembler-cta__subtitle">{ text }</p>
-			<Button
-				className="pattern-assembler-cta__button"
-				onClick={ handleButtonClick }
-				primary={ hasPrimaryButton }
-			>
-				{ shouldGoToAssemblerStep
-					? translate( 'Start designing' )
-					: translate( 'Open the editor' ) }
+			<h3 className="pattern-assembler-cta__title">{ data.title }</h3>
+			<p className="pattern-assembler-cta__subtitle">
+				{ data.subtitleLineOne }
+				<br />
+				{ data.subtitleLineTwo }
+			</p>
+			<Button className="pattern-assembler-cta__button" onClick={ handleButtonClick } primary>
+				{ data.buttonText }
 			</Button>
 		</div>
 	);

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -8,7 +8,10 @@ export {
 	default as UnifiedDesignPicker,
 	DesignPreviewImage,
 } from './components/unified-design-picker';
-export { default as PatternAssemblerCta } from './components/pattern-assembler-cta';
+export {
+	default as PatternAssemblerCta,
+	usePatternAssemblerCtaData,
+} from './components/pattern-assembler-cta';
 export {
 	availableDesignsConfig,
 	getAvailableDesigns,


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/79729

## Proposed Changes

This PR adds a CTA to the Site Assembler flow on empty theme showcase search as follows.

|Scenario|Before|After|
|-|-|-|
|Logged-in, Desktop|<img width="657" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/d770b023-264d-430e-b1e0-d4db56d1605d">|<img width="656" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/70fdf5ec-0c82-4218-bf3b-f79f279d0aaf">|
|Logged-in, Mobile|<img width="657" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/d770b023-264d-430e-b1e0-d4db56d1605d">|(no change)|
|Logged-out, Desktop|<img width="892" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/2935ff26-95c7-4a88-a314-9fd76a3c292e">|<img width="892" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/550f82d1-8021-4cdd-8182-9ad9d09416ca">|
|Logged-out, Mobile|<img width="892" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/2935ff26-95c7-4a88-a314-9fd76a3c292e">|(no change)|

### Implementation details

This PR extracts the copies into a separate hook so that it is reusable in Theme Showcase empty search options. Also, this PR removes all unused props from `PatternAssemblerCta`.

### Out of scope

- Refactor / rename the components from "PatternAssembler" to "SiteAssembler", as it will make this PR unnecessarily bigger.
- Handling of logged-out theme showcase on mobile viewport, as (I think) it is weird to have CTA on mobile that goes through the signup process just to land in a site editor. 

## Testing Instructions

1. Check out this PR / use the Live Preview URL.
1. Check ALL the cases in the above Before/After table:

|Case|URL|
|-|-|
|Logged-in|`/themes/<siteSlug>?s=boba+shop`|
|Logged-out|`/themes?s=boba+shop`|

3. For each case, make sure that the CTA text are correct, and the CTA button lands us to:
    - when on Desktop viewport: to the Site Assembler flow (`/with-theme-assembler`)
    - when on Mobile viewport: to the Site Editor.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
