### PR TITLE
Checkout: Show tax fields in new card form if no contact step shown

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -346,6 +346,7 @@ function CheckoutMain( {
 	} );
 
 	const paymentMethodObjects = useCreatePaymentMethods( {
+		contactDetailsType,
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -38,6 +38,7 @@ import useCreateExistingCards from './use-create-existing-cards';
 import type { StripeConfiguration, StripeLoadingError } from '@automattic/calypso-stripe';
 import type { PaymentMethod } from '@automattic/composite-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
+import type { ContactDetailsType } from '@automattic/wpcom-checkout';
 import type { Stripe } from '@stripe/stripe-js';
 import type { ReactNode } from 'react';
 
@@ -338,6 +339,7 @@ function useCreateGooglePay( {
 }
 
 export default function useCreatePaymentMethods( {
+	contactDetailsType,
 	isStripeLoading,
 	stripeLoadingError,
 	stripeConfiguration,
@@ -345,6 +347,7 @@ export default function useCreatePaymentMethods( {
 	storedCards,
 	siteSlug,
 }: {
+	contactDetailsType: ContactDetailsType;
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
 	stripeConfiguration: StripeConfiguration | null;
@@ -404,7 +407,12 @@ export default function useCreatePaymentMethods( {
 		translateCheckoutPaymentMethodToWpcomPaymentMethod( 'ebanx' ) ?? ''
 	);
 	const allowUseForAllSubscriptions = true;
+	// Normally checkout will get the tax contact information from the contact
+	// step. However, if the contact step is not shown, we need to collect it
+	// in the credit card form instead.
+	const shouldShowTaxFields = contactDetailsType === 'none';
 	const stripeMethod = useCreateCreditCard( {
+		shouldShowTaxFields,
 		isStripeLoading,
 		stripeLoadingError,
 		shouldUseEbanx,

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -11,6 +11,7 @@ import { assignNewCardProcessor } from 'calypso/me/purchases/manage-purchase/pay
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { recordTransactionBeginAnalytics } from '../lib/analytics';
 import existingCardProcessor from './existing-card-processor';
+import getContactDetailsType from './get-contact-details-type';
 import getDomainDetails from './get-domain-details';
 import getPostalCode from './get-postal-code';
 import submitWpcomTransaction from './submit-wpcom-transaction';
@@ -266,6 +267,28 @@ export default async function multiPartnerCardProcessor(
 		if ( ! freePurchaseData?.translate ) {
 			throw new Error( 'Required free purchase data is missing' );
 		}
+
+		const contactDetailsType = getContactDetailsType( dataForProcessor.responseCart );
+		const submitDataWithContactInfo =
+			contactDetailsType === 'none'
+				? submitData
+				: {
+						...submitData,
+						// In `PaymentMethodSelector` which is used for adding new cards, the
+						// stripe payment method is passed `shouldShowTaxFields` which causes
+						// it to show required tax location fields in the payment method
+						// itself; that data is then submitted to the `assignNewCardProcessor`
+						// to send to Stripe as part of saving the card. However, in checkout
+						// we normally do not display those fields since they are already included in
+						// the billing details step. Therefore we must pass in the tax location
+						// data explicitly here so we can use `assignNewCardProcessor`.
+						countryCode: dataForProcessor.contactDetails?.countryCode?.value,
+						postalCode: getPostalCode( dataForProcessor.contactDetails ),
+						state: dataForProcessor.contactDetails?.state?.value,
+						city: dataForProcessor.contactDetails?.city?.value,
+						organization: dataForProcessor.contactDetails?.organization?.value,
+						address: dataForProcessor.contactDetails?.address1?.value,
+				  };
 		const newCardResponse = await assignNewCardProcessor(
 			{
 				purchase: undefined,
@@ -277,23 +300,7 @@ export default async function multiPartnerCardProcessor(
 				reduxDispatch: dataForProcessor.reduxDispatch,
 				eventSource: '/checkout',
 			},
-			{
-				...submitData,
-				// In `PaymentMethodSelector` which is used for adding new cards, the
-				// stripe payment method is passed `shouldShowTaxFields` which causes
-				// it to show required tax location fields in the payment method
-				// itself; that data is then submitted to the `assignNewCardProcessor`
-				// to send to Stripe as part of saving the card. However, in checkout
-				// we do not display those fields since they are already included in
-				// the billing details step. Therefore we must pass in the tax location
-				// data explicitly here so we can use `assignNewCardProcessor`.
-				countryCode: dataForProcessor.contactDetails?.countryCode?.value,
-				postalCode: getPostalCode( dataForProcessor.contactDetails ),
-				state: dataForProcessor.contactDetails?.state?.value,
-				city: dataForProcessor.contactDetails?.city?.value,
-				organization: dataForProcessor.contactDetails?.organization?.value,
-				address: dataForProcessor.contactDetails?.address1?.value,
-			}
+			submitDataWithContactInfo
 		);
 		if ( newCardResponse.type === PaymentProcessorResponseType.ERROR ) {
 			return newCardResponse;


### PR DESCRIPTION
## Proposed Changes

Paying with a new (not previously-saved) credit card in checkout requires tax location information (usually postal code and country). Normally, checkout gets this information from the contact step in the checkout form. However, some purchases do not display the contact step (free purchases which are not Akismet, not domain products, not GSuite, and not full credits – see `getContactDetailsType`). This was not a problem before https://github.com/Automattic/wp-calypso/pull/79083 because free purchases did not display the new credit card option. However, now this situation can occur.

The new credit card form has the ability to show its own tax fields. This PR enables those fields for checkout if the contact step is not shown.

Before:

<img width="584" alt="Screenshot 2023-07-26 at 10 48 43 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/6bbe32d3-2a15-45dd-b0f0-48624b4375a9">


After:

<img width="576" alt="Screenshot 2023-07-26 at 10 31 34 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/0e337c1f-a0c3-4cbf-97e5-7b9920d33fcf">


Fixes https://github.com/Automattic/wp-calypso/issues/79875

## Testing Instructions

- Visit `/checkout/example.com/jetpack_stats_free_yearly`, replacing `example.com` with your site.
- Make sure the purchase is free.
- Select "Credit or debit card" as the payment method.
- Fill in the form (you can use a [Stripe test card](https://stripe.com/docs/testing) if you have sandboxed the API).
- Submit checkout.
- Verify the purchase completes with no errors.