### PR TITLE
Plans: Adjust the styling and layout for the free product cards

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -3,7 +3,7 @@
 .display-price {
 	&.is-free {
 		margin-block-start: -4px;
-		padding-block-start: 24px;
+		padding-block-start: 12px;
 
 		@include break-medium {
 			min-height: 80px;
@@ -32,7 +32,7 @@
 
 		.display-price__price-free {
 			display: block;
-			line-height: $font-headline-medium;
+			font-size: $font-headline-small;
 			letter-spacing: -2px;
 		}
 	}
@@ -107,7 +107,7 @@
 	&__get-started,
 	&__no-savings {
 		display: inline-block;
-		margin-block-start: 24px;
+		margin-inline-start: 12px;
 		border-radius: 4px;
 		padding: 4px 8px;
 

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -89,6 +89,10 @@
 		align-items: center;
 		margin: 0;
 	}
+
+	&.is-free .display-price__billing-time-frame {
+		margin-left: 4px;
+	}
 }
 
 .item-price .display-price.is-placeholder {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79867 

## Proposed Changes

* Decrease the font size of the `Free` text on the plan card.
* Increase the gap between elements in the card.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the Calypso Live link.
* Navigate to the plans page for a Jetpack site with the feature flag: `/plans/{jetpack-site-slug}?flags=stats/paid-stats`.
* Ensure the styling of the Stats Free product card looks more reasonable.

|Before|After|
|-|-|
|<img width="623" alt="截圖 2023-07-26 下午11 01 02" src="https://github.com/Automattic/wp-calypso/assets/6869813/72fdaf4f-ba2c-423f-95d7-727bdb9dd9d0">|<img width="620" alt="截圖 2023-07-26 下午4 53 03" src="https://github.com/Automattic/wp-calypso/assets/6869813/32e3d65c-8bf7-4c0d-9db5-d78c333621ba">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
