### PR TITLE
Remove blaze credits eligibility flag

### DIFF
--- a/client/lib/user/shared-utils/filter-user-object.js
+++ b/client/lib/user/shared-utils/filter-user-object.js
@@ -16,7 +16,6 @@ const allowedKeys = [
 	'phone_account',
 	'email',
 	'email_verified',
-	'blaze_credits_enabled',
 	'is_valid_google_apps_country',
 	'user_ip_country_code',
 	'logout_URL',

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -19,7 +19,6 @@ export type OptionalUserData = {
 	display_name: string;
 	email: string;
 	email_verified: boolean;
-	blaze_credits_enabled: boolean;
 	has_unseen_notes: boolean;
 	is_new_reader: boolean;
 	is_valid_google_apps_country: boolean;


### PR DESCRIPTION
## Proposed Changes

This feature flag is being retired, the feature is now launched and not gated to any subset of users.

There is also a WPCOM revision that is related to this:
`D117141`

There isn't really much to test here, as the feature gating got removed some time ago, this is just cleaning up some bits that were missed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
