### PR TITLE
Checkout: Only create setup intent ID just before using it

### DIFF
--- a/client/me/purchases/add-new-payment-method/index.tsx
+++ b/client/me/purchases/add-new-payment-method/index.tsx
@@ -1,8 +1,4 @@
-import {
-	StripeHookProvider,
-	StripeSetupIntentIdProvider,
-	useStripe,
-} from '@automattic/calypso-stripe';
+import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -85,11 +81,7 @@ export default function AccountLevelAddNewPaymentMethodWrapper() {
 	const locale = useSelector( getCurrentUserLocale );
 	return (
 		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
-			<StripeSetupIntentIdProvider
-				fetchStripeSetupIntentId={ () => getStripeConfiguration( { needs_intent: true } ) }
-			>
-				<AddNewPaymentMethod />
-			</StripeSetupIntentIdProvider>
+			<AddNewPaymentMethod />
 		</StripeHookProvider>
 	);
 }

--- a/client/me/purchases/manage-purchase/change-payment-method/index.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.tsx
@@ -1,8 +1,4 @@
-import {
-	StripeHookProvider,
-	StripeSetupIntentIdProvider,
-	useStripe,
-} from '@automattic/calypso-stripe';
+import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
 import page from 'page';
 import { Fragment, useEffect } from 'react';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
@@ -121,11 +117,7 @@ export default function ChangePaymentMethodWrapper( props: ChangePaymentMethodPr
 	const locale = useSelector( getCurrentUserLocale );
 	return (
 		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
-			<StripeSetupIntentIdProvider
-				fetchStripeSetupIntentId={ () => getStripeConfiguration( { needs_intent: true } ) }
-			>
-				<ChangePaymentMethod { ...props } />
-			</StripeSetupIntentIdProvider>
+			<ChangePaymentMethod { ...props } />
 		</StripeHookProvider>
 	);
 }

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -21,6 +21,23 @@ import type { Purchase } from 'calypso/lib/purchases/types';
 import type { CalypsoDispatch } from 'calypso/state/types';
 import type { LocalizeProps } from 'i18n-calypso';
 
+async function fetchStripeSetupIntentId( source: string ): Promise< StripeSetupIntentId > {
+	const configuration = await wp.req.get( '/me/stripe-configuration', {
+		needs_intent: true,
+		source,
+	} );
+	const intentId: string | undefined =
+		configuration?.setup_intent_id && typeof configuration.setup_intent_id === 'string'
+			? configuration.setup_intent_id
+			: undefined;
+	if ( ! intentId ) {
+		throw new Error(
+			'Error loading new payment method intent. Received invalid data from the server.'
+		);
+	}
+	return intentId;
+}
+
 const wpcomAssignPaymentMethod = (
 	subscriptionId: string,
 	stored_details_id: string
@@ -64,19 +81,19 @@ export async function assignNewCardProcessor(
 		translate,
 		stripe,
 		stripeConfiguration,
-		stripeSetupIntentId,
 		cardNumberElement,
 		reduxDispatch,
 		eventSource,
+		isCheckout,
 	}: {
 		purchase: Purchase | undefined;
 		translate: LocalizeProps[ 'translate' ];
 		stripe: Stripe | null;
 		stripeConfiguration: StripeConfiguration | null;
-		stripeSetupIntentId: StripeSetupIntentId | undefined;
 		cardNumberElement: StripeCardNumberElement | undefined;
 		reduxDispatch: CalypsoDispatch;
 		eventSource?: string;
+		isCheckout?: boolean;
 	},
 	submitData: unknown
 ): Promise< PaymentProcessorResponse > {
@@ -84,7 +101,7 @@ export async function assignNewCardProcessor(
 		if ( ! isNewCardDataValid( submitData ) ) {
 			throw new Error( 'Credit Card data is invalid' );
 		}
-		if ( ! stripe || ! stripeConfiguration || ! stripeSetupIntentId ) {
+		if ( ! stripe || ! stripeConfiguration ) {
 			throw new Error( 'Cannot assign payment method if Stripe is not loaded' );
 		}
 		if ( ! cardNumberElement ) {
@@ -153,6 +170,9 @@ export async function assignNewCardProcessor(
 
 		reduxDispatch( recordFormSubmitEvent( { purchase, useForAllSubscriptions } ) );
 
+		const stripeSetupIntentId = await fetchStripeSetupIntentId(
+			isCheckout ? 'checkout' : 'not-checkout'
+		);
 		const formFieldValues = {
 			country: countryCode,
 			postal_code: postalCode ?? '',
@@ -168,11 +188,6 @@ export async function assignNewCardProcessor(
 		if ( ! token ) {
 			throw new Error( String( translate( 'Failed to add card.' ) ) );
 		}
-
-		// If we've reached this point in the code and anything after this fails,
-		// we must regenerate the payment intent, which is done by calling `reload`
-		// as returned by `useStripeSetupIntentId` from
-		// `@automattic/calypso-stripe`.
 
 		if ( purchase ) {
 			const result = await updateCreditCard( {

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { isAkismetProduct } from '@automattic/calypso-products';
-import { useStripe, useStripeSetupIntentId } from '@automattic/calypso-stripe';
+import { useStripe } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
 import { Card, Gridicon } from '@automattic/components';
 import {
@@ -33,7 +33,6 @@ import {
 	useHandleRedirectChangeError,
 	useHandleRedirectChangeComplete,
 } from './url-event-handlers';
-import type { ReloadSetupIntentId } from '@automattic/calypso-stripe';
 import type { CheckoutPageErrorCallback, PaymentMethod } from '@automattic/composite-checkout';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { TranslateResult } from 'i18n-calypso';
@@ -84,11 +83,6 @@ export default function PaymentMethodSelector( {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 	const { isStripeLoading, stripe, stripeConfiguration, stripeLoadingError } = useStripe();
-	const {
-		reload: reloadSetupIntentId,
-		setupIntentId: stripeSetupIntentId,
-		error: setupIntentError,
-	} = useStripeSetupIntentId();
 	const currentlyAssignedPaymentMethodId = getPaymentMethodIdFromPayment( purchase?.payment );
 
 	const isAkismetPurchase = purchase ? isAkismetProduct( purchase ) : false;
@@ -105,10 +99,8 @@ export default function PaymentMethodSelector( {
 						translate( 'There was a problem assigning that payment method. Please try again.' )
 				)
 			);
-			// We need to regenerate the setup intent if the form was submitted.
-			reloadSetupIntentId();
 		},
-		[ reduxDispatch, translate, reloadSetupIntentId ]
+		[ reduxDispatch, translate ]
 	);
 
 	const showSuccessMessage = useCallback(
@@ -129,8 +121,6 @@ export default function PaymentMethodSelector( {
 			'There was a problem assigning that payment method. Please try again.'
 		);
 		reduxDispatch( errorNotice( message ) );
-		// We need to regenerate the setup intent if the form was submitted.
-		reloadSetupIntentId();
 	} );
 	useHandleRedirectChangeComplete( () => {
 		onPaymentSelectComplete( {
@@ -138,7 +128,6 @@ export default function PaymentMethodSelector( {
 			translate,
 			showSuccessMessage,
 			purchase,
-			reloadSetupIntentId,
 		} );
 	} );
 
@@ -147,12 +136,6 @@ export default function PaymentMethodSelector( {
 			reduxDispatch( errorNotice( stripeLoadingError.message ) );
 		}
 	}, [ stripeLoadingError, reduxDispatch ] );
-
-	useEffect( () => {
-		if ( setupIntentError ) {
-			reduxDispatch( errorNotice( setupIntentError.message ) );
-		}
-	}, [ setupIntentError, reduxDispatch ] );
 
 	const elements = useElements();
 
@@ -164,7 +147,6 @@ export default function PaymentMethodSelector( {
 					translate,
 					showSuccessMessage,
 					purchase,
-					reloadSetupIntentId,
 				} );
 			} }
 			onPaymentRedirect={ showRedirectMessage }
@@ -184,7 +166,6 @@ export default function PaymentMethodSelector( {
 							translate,
 							stripe,
 							stripeConfiguration,
-							stripeSetupIntentId,
 							cardNumberElement: elements?.getElement( CardNumberElement ) ?? undefined,
 							reduxDispatch,
 							eventSource: eventContext,
@@ -243,21 +224,17 @@ function onPaymentSelectComplete( {
 	translate,
 	showSuccessMessage,
 	purchase,
-	reloadSetupIntentId,
 }: {
 	successCallback: () => void;
 	translate: ReturnType< typeof useTranslate >;
 	showSuccessMessage: ( message: string | TranslateResult ) => void;
 	purchase?: Purchase | undefined;
-	reloadSetupIntentId: ReloadSetupIntentId;
 } ) {
 	if ( purchase ) {
 		showSuccessMessage( translate( 'Your payment method has been set.' ) );
 	} else {
 		showSuccessMessage( translate( 'Your payment method has been added successfully.' ) );
 	}
-	// We need to regenerate the setup intent if the form was submitted.
-	reloadSetupIntentId();
 	successCallback();
 }
 

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -20,7 +20,7 @@ import {
 	createTransactionEndpointCartFromResponseCart,
 } from './translate-cart';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
-import type { StripeSetupIntentId, StripeConfiguration } from '@automattic/calypso-stripe';
+import type { StripeConfiguration } from '@automattic/calypso-stripe';
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type { Stripe, StripeCardNumberElement } from '@stripe/stripe-js';
 import type { LocalizeProps } from 'i18n-calypso';
@@ -238,7 +238,6 @@ async function ebanxCardProcessor(
 }
 
 export interface FreePurchaseData {
-	stripeSetupIntentId: StripeSetupIntentId | undefined;
 	translate: LocalizeProps[ 'translate' ];
 }
 
@@ -295,9 +294,9 @@ export default async function multiPartnerCardProcessor(
 				translate: freePurchaseData.translate,
 				stripe: dataForProcessor.stripe,
 				stripeConfiguration: dataForProcessor.stripeConfiguration,
-				stripeSetupIntentId: freePurchaseData?.stripeSetupIntentId,
 				cardNumberElement: submitData.cardNumberElement,
 				reduxDispatch: dataForProcessor.reduxDispatch,
+				isCheckout: true,
 				eventSource: '/checkout',
 			},
 			submitDataWithContactInfo

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -1,9 +1,5 @@
 import config from '@automattic/calypso-config';
-import {
-	StripeHookProvider,
-	StripeSetupIntentIdProvider,
-	useStripe,
-} from '@automattic/calypso-stripe';
+import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
@@ -170,11 +166,7 @@ export function SiteLevelAddNewPaymentMethod( props: { siteSlug: string } ) {
 	const locale = useSelector( getCurrentUserLocale );
 	return (
 		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
-			<StripeSetupIntentIdProvider
-				fetchStripeSetupIntentId={ () => getStripeConfiguration( { needs_intent: true } ) }
-			>
-				<SiteLevelAddNewPaymentMethodForm { ...props } />
-			</StripeSetupIntentIdProvider>
+			<SiteLevelAddNewPaymentMethodForm { ...props } />
 		</StripeHookProvider>
 	);
 }


### PR DESCRIPTION
In order to add a new credit card without a (paid) purchase, we must create a Stripe Setup Intent. To do this requires first fetching an intent ID from our endpoint. Because of the implementation details when this was originally implemented, we fetched this ID when the "Add new payment method" form (originally the only place that used a Setup Intent) loaded. This was fine because it was very likely that the user would add a new card on that form. However, now that we accept new credit cards for free purchases in checkout, this means we are creating far more setup intent IDs than we need.

## Proposed Changes

In this PR we modify checkout and the "Add new payment method" form to instead fetch the intent ID just before it needs to be used, inside the payment method processor. In this way we remove a lot of the machinery around setup intent IDs.

NOTE: this PR does not remove `StripeSetupIntentIdProvider` or `useStripeSetupIntentId` because they appear to still be in use by the Jetpack partner-portal code. Since that's maintained by a different team I don't want to make any changes there until we can come up with a test plan. It should continue to work as it has before.

## Testing Instructions

We'll need to test both checkout and the "Add new payment method" form.

### To test checkout

- Add a new product (not a renewal) to your cart and visit checkout.
- Add a coupon or credits to make the purchase free.
- Select "Credit or debit card" and enter credit card information for a new card.
- Submit checkout and verify that the new card was created and attached to the subscription.

### To test the "add new payment method" form

- Visit `/me/purchases/add-payment-method`.
- Fill out and submit the form.
- Verify that the new card is created successfully.