### PR TITLE
Purchases by Ownership: Add new route

### DIFF
--- a/client/lib/purchases/assembler.ts
+++ b/client/lib/purchases/assembler.ts
@@ -63,6 +63,7 @@ function createPurchaseObject( purchase: RawPurchase | RawPurchaseCreditCard ): 
 		isRenewable: Boolean( purchase.is_renewable ),
 		isRenewal: Boolean( purchase.is_renewal ),
 		meta: purchase.meta,
+		ownershipId: Number( purchase.ownership_id ),
 		priceText: purchase.price_text,
 		priceTierList: purchase.price_tier_list?.map(
 			( rawTier ): PurchasePriceTier => ( {

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -38,6 +38,7 @@ export interface Purchase {
 	isRenewal: boolean;
 	meta?: string;
 	mostRecentRenewDate?: string;
+	ownershipId?: number;
 	partnerName: string | undefined;
 	partnerSlug: string | undefined;
 	payment: PurchasePayment | PurchasePaymentWithCreditCard | PurchasePaymentWithPayPal;
@@ -200,6 +201,7 @@ export interface RawPurchase {
 	is_renewable: boolean;
 	is_renewal: boolean;
 	meta: string | undefined;
+	ownership_id: number | undefined;
 	partner_name: string | undefined;
 	partner_slug: string | undefined;
 	partner_key_id: number | undefined;

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -27,6 +27,7 @@ import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import CancelPurchase from './cancel-purchase';
 import ConfirmCancelDomain from './confirm-cancel-domain';
 import ManagePurchase from './manage-purchase';
+import { ManagePurchaseByOwnership } from './manage-purchase/manage-purchase-by-ownership';
 import PurchasesList from './purchases-list';
 import titles from './titles';
 import VatInfoPage from './vat-info';
@@ -203,6 +204,28 @@ export function managePurchase( context, next ) {
 	} );
 
 	context.primary = <ManagePurchasesWrapper />;
+	next();
+}
+
+export function managePurchaseByOwnership( context, next ) {
+	const ManagePurchasesByOwnershipWrapper = localize( () => {
+		const classes = 'manage-purchase';
+
+		return (
+			<PurchasesWrapper title={ titles.managePurchase }>
+				<Main wideLayout className={ classes }>
+					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+					<PageViewTracker
+						path="/me/purchases/:ownershipId"
+						title="Purchases > Manage Purchase by Ownership"
+					/>
+					<ManagePurchaseByOwnership ownershipId={ parseInt( context.params.ownershipId, 10 ) } />
+				</Main>
+			</PurchasesWrapper>
+		);
+	} );
+
+	context.primary = <ManagePurchasesByOwnershipWrapper />;
 	next();
 }
 

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -89,6 +89,14 @@ export default ( router ) => {
 		clientRender
 	);
 
+	router(
+		paths.managePurchaseByOwnership( ':ownershipId' ),
+		sidebar,
+		controller.managePurchaseByOwnership,
+		makeLayout,
+		clientRender
+	);
+
 	/**
 	 * The siteSelection middleware has been removed from this route.
 	 * No selected site!

--- a/client/me/purchases/manage-purchase/manage-purchase-by-ownership.jsx
+++ b/client/me/purchases/manage-purchase/manage-purchase-by-ownership.jsx
@@ -1,0 +1,23 @@
+import { useSelector } from 'react-redux';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import { getPurchases, hasLoadedUserPurchasesFromServer } from 'calypso/state/purchases/selectors';
+import ManagePurchase from '.';
+
+export function ManagePurchaseByOwnership( { ownershipId } ) {
+	const purchases = useSelector( getPurchases );
+	const purchaseByOwnership = purchases.find(
+		( purchase ) => purchase.ownershipId === ownershipId
+	);
+	const hasRequestedPurchases = useSelector( hasLoadedUserPurchasesFromServer );
+
+	if ( ! hasRequestedPurchases ) {
+		return <QueryUserPurchases />;
+	}
+
+	return (
+		<ManagePurchase
+			purchaseId={ purchaseByOwnership?.id }
+			siteSlug={ purchaseByOwnership?.domain }
+		/>
+	);
+}

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -28,6 +28,16 @@ export function managePurchase( siteName, purchaseId ) {
 	return purchasesRoot + `/${ siteName }/${ purchaseId }`;
 }
 
+export function managePurchaseByOwnership( ownershipId ) {
+	if ( process.env.NODE_ENV !== 'production' ) {
+		if ( 'undefined' === typeof ownershipId ) {
+			throw new Error( 'ownershipId must be provided' );
+		}
+	}
+
+	return '/me/purchases-by-owner/' + ownershipId;
+}
+
 export function cancelPurchase( siteName, purchaseId ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {

--- a/client/sections.js
+++ b/client/sections.js
@@ -50,7 +50,12 @@ const sections = [
 	},
 	{
 		name: 'purchases',
-		paths: [ '/me/purchases', '/me/billing', '/payment-methods/add-credit-card' ],
+		paths: [
+			'/me/purchases',
+			'/me/purchases-by-owner',
+			'/me/billing',
+			'/payment-methods/add-credit-card',
+		],
 		module: 'calypso/me/purchases',
 		group: 'me',
 	},

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -110,6 +110,7 @@ describe( 'selectors', () => {
 				isRenewal: false,
 				meta: undefined,
 				mostRecentRenewDate: undefined,
+				ownershipId: NaN,
 				partnerKeyId: undefined,
 				partnerName: undefined,
 				partnerSlug: undefined,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/68704

## Proposed Changes

* Add a new route to access purchase from the ownership number: `/me/purchases-by-owner/:ownershipId`
* Create a component to find the purchase from the ownership id and render the ManagePurchase component
* Add the ownershipId field to the purchase object

## Testing Instructions

* From the store manager and get an ownership id from there
* Go to the new route created and append the ownership id: `/me/purchases-by-owner/{ownership_id_here}`
* Check if the page render properly
* Add an inexistent ownership id to the route
* You should be redirected back to `/me/purchases`

![CleanShot 2023-07-26 at 10 56 28@2x](https://github.com/Automattic/wp-calypso/assets/5039531/914a108b-4586-4b52-b8da-89e6cad5b41b)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
