### PR TITLE
Fix transfer copy issues

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -486,7 +486,7 @@ export function resolveDomainStatus(
 					status: translate( 'Active' ),
 					icon: 'info',
 					noticeText: translate(
-						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com name servers.{{/a}}',
+						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need {{a}}point it to WordPress.com name servers.{{/a}}',
 						{
 							components: {
 								strong: <strong />,

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -486,7 +486,7 @@ export function resolveDomainStatus(
 					status: translate( 'Active' ),
 					icon: 'info',
 					noticeText: translate(
-						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need {{a}}point it to WordPress.com name servers.{{/a}}',
+						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com name servers.{{/a}}',
 						{
 							components: {
 								strong: <strong />,

--- a/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
@@ -103,7 +103,7 @@ const TransferredDomainDetails = ( {
 
 		return translate(
 			'Your transfer has been started and is waiting for authorization from your current ' +
-				'domain provider. This process can take up to 7 days. If you need to cancel or expedite the ' +
+				'domain provider. This process can take up to 5-10 days. If you need to cancel or expedite the ' +
 				'transfer please contact them for assistance.'
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { Button } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import { transferStatus } from 'calypso/lib/domains/constants';
@@ -17,6 +18,7 @@ const TransferredDomainDetails = ( {
 	selectedSite,
 }: DetailsCardProps ) => {
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const renderStartTransferButton = () => {
 		if ( ! domain.currentUserIsOwner || transferStatus.PENDING_START !== domain.transferStatus ) {
@@ -101,11 +103,21 @@ const TransferredDomainDetails = ( {
 				  );
 		}
 
-		return translate(
+		return hasTranslation(
 			'Your transfer has been started and is waiting for authorization from your current ' +
 				'domain provider. This process can take up to 5-10 days. If you need to cancel or expedite the ' +
 				'transfer please contact them for assistance.'
-		);
+		) || isEnglishLocale
+			? translate(
+					'Your transfer has been started and is waiting for authorization from your current ' +
+						'domain provider. This process can take up to 5-10 days. If you need to cancel or expedite the ' +
+						'transfer please contact them for assistance.'
+			  )
+			: translate(
+					'Your transfer has been started and is waiting for authorization from your current ' +
+						'domain provider. This process can take up to 7 days. If you need to cancel or expedite the ' +
+						'transfer please contact them for assistance.'
+			  );
 	};
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3210
Fixes https://github.com/Automattic/dotcom-forge/issues/3209

## Proposed Changes

* Change 7 days to 5-10 days to be consistent.
* Add "to" where it's missing in transfer success notification.

<img width="701" alt="Screen Shot 2023-07-26 at 2 51 26 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/992dbbac-f51d-4375-9e09-cc74e9674b69">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the transfer page for a pending domain. /domains/manage/all/{domain}/transfer/in/{domain}
* Check that the copy says 5-10 days, not 7.
* For a completed transfer, check that the success notification includes "to" (currently there's a typo where "to" is missing).

![Screenshot 2023-07-26 at 18 41 52](https://github.com/Automattic/wp-calypso/assets/1689238/95bc7cf4-8f71-4c80-888c-cf215a08db5b)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
