### PR TITLE
Domain Transfer: Change case of intro step of flow to sentence case

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
@@ -1,3 +1,4 @@
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -11,6 +12,7 @@ import './styles.scss';
 const Intro: Step = function Intro( { navigation } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	usePresalesChat( 'wpcom' );
 
@@ -25,7 +27,9 @@ const Intro: Step = function Intro( { navigation } ) {
 			formattedHeader={
 				<FormattedHeader
 					id="domain-transfer-header"
-					headerText={ __( 'Transfer your domains' ) }
+					headerText={
+						isEnglishLocale ? __( 'Transfer your domains' ) : __( 'Transfer Your Domains' )
+					}
 					subHeaderText={ __(
 						'Follow these three simple steps to transfer your domains to WordPress.com.'
 					) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
@@ -25,7 +25,7 @@ const Intro: Step = function Intro( { navigation } ) {
 			formattedHeader={
 				<FormattedHeader
 					id="domain-transfer-header"
-					headerText={ __( 'Transfer Your Domains' ) }
+					headerText={ __( 'Transfer your domains' ) }
 					subHeaderText={ __(
 						'Follow these three simple steps to transfer your domains to WordPress.com.'
 					) }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3216

## Proposed Changes

* Change title case on intro step to be sentence case.

<img width="727" alt="Screenshot 2023-07-26 at 2 27 39 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/6453f779-12c8-4726-928e-a8c05e05deca">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR
* Go to `/setup/domain-transfer`
* Verify sentence case

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
