### PR TITLE
Adding optional free badge to domain transfers intro page

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
@@ -46,6 +46,7 @@ const Intro: React.FC< Props > = ( { onSubmit } ) => {
 					{
 						key: 'finalize',
 						title: __( 'Checkout' ),
+						badge: 'Free',
 						description: (
 							<p>
 								{ __(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
@@ -46,7 +46,7 @@ const Intro: React.FC< Props > = ( { onSubmit } ) => {
 					{
 						key: 'finalize',
 						title: __( 'Checkout' ),
-						badge: 'Free',
+						badge: __( 'Google Domains: Free' ),
 						description: (
 							<p>
 								{ __(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -107,6 +107,11 @@ $heading-font-family: "SF Pro Display", $sans;
 
 					}
 
+					.free-domain__primary-badge {
+						border-radius: 4px;
+						margin-left: 12px;
+					}
+
 					.select-items__item-icon {
 						margin-right: 8px;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -112,6 +112,18 @@ $heading-font-family: "SF Pro Display", $sans;
 						margin-left: 12px;
 					}
 
+
+					@media ( max-width: $break-mobile ) {
+						.select-items__item-title-badge {
+							display: block;
+						}
+
+						.free-domain__primary-badge {
+							margin-left: 0;
+							margin-top: 8px;
+						}
+					}
+
 					.select-items__item-icon {
 						margin-right: 8px;
 

--- a/packages/onboarding/src/select-items/index.tsx
+++ b/packages/onboarding/src/select-items/index.tsx
@@ -7,7 +7,7 @@ import { TranslateResult } from 'i18n-calypso';
 export interface SelectItem< T > {
 	key: string;
 	title: TranslateResult;
-	badge: TranslateResult;
+	badge?: TranslateResult;
 	description: TranslateResult;
 	icon: React.ReactElement;
 	value: T;
@@ -32,11 +32,13 @@ function SelectItems< T >( { className, items, onSelect, preventWidows }: Props<
 					<div className="select-items__item-info-wrapper">
 						<div className="select-items__item-info">
 							<h2 className="select-items__item-title">
-								{ preventWidows( title ) }
+								<span className="select-items__item-title-text">{ preventWidows( title ) }</span>
 								{ badge && (
-									<Badge className="free-domain__primary-badge" type="info-green">
-										{ preventWidows( badge ) }
-									</Badge>
+									<span className="select-items__item-title-badge">
+										<Badge className="free-domain__primary-badge" type="info-green">
+											{ preventWidows( badge ) }
+										</Badge>
+									</span>
 								) }
 							</h2>
 							<div className="select-items__item-description">{ preventWidows( description ) }</div>

--- a/packages/onboarding/src/select-items/index.tsx
+++ b/packages/onboarding/src/select-items/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Badge, Button } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import classnames from 'classnames';
 import './style.scss';
@@ -7,6 +7,7 @@ import { TranslateResult } from 'i18n-calypso';
 export interface SelectItem< T > {
 	key: string;
 	title: TranslateResult;
+	badge: TranslateResult;
 	description: TranslateResult;
 	icon: React.ReactElement;
 	value: T;
@@ -25,12 +26,19 @@ interface Props< T > {
 function SelectItems< T >( { className, items, onSelect, preventWidows }: Props< T > ) {
 	return (
 		<div className={ classnames( 'select-items', className ) }>
-			{ items.map( ( { key, title, description, icon, actionText, value, isPrimary } ) => (
+			{ items.map( ( { key, title, badge, description, icon, actionText, value, isPrimary } ) => (
 				<div key={ key } className="select-items__item">
 					<Icon className="select-items__item-icon" icon={ icon } size={ 24 } />
 					<div className="select-items__item-info-wrapper">
 						<div className="select-items__item-info">
-							<h2 className="select-items__item-title">{ preventWidows( title ) }</h2>
+							<h2 className="select-items__item-title">
+								{ preventWidows( title ) }
+								{ badge && (
+									<Badge className="free-domain__primary-badge" type="info-green">
+										{ preventWidows( badge ) }
+									</Badge>
+								) }
+							</h2>
 							<div className="select-items__item-description">{ preventWidows( description ) }</div>
 						</div>
 						{ actionText && (


### PR DESCRIPTION
## Description

We're adding a "Free" badge next to the "Checkout" section on the domain transfers intro page.

### Before

![before](https://github.com/Automattic/wp-calypso/assets/5634774/7d839b45-7dab-4087-acc9-2222231bbc63)

### After

<img width="430" alt="Screenshot 2023-07-26 at 5 55 56 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/79de0850-c38d-4f44-be16-8db929e1a1d9">
<img width="458" alt="Screenshot 2023-07-26 at 5 56 16 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/3943569e-3a8e-4299-84ff-0679fee24d61">
<img width="639" alt="Screenshot 2023-07-26 at 5 56 24 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/becfb5dd-3536-4381-a6b4-1fed43fab283">


In case you're curious, the font baselines are aligned:

<img width="743" alt="CleanShot 2023-07-26 at 15 38 16@2x" src="https://github.com/Automattic/wp-calypso/assets/5634774/bd18e6e9-e579-45d9-9b8e-7f4d3ae4e20c">

## Testing

- Load this PR locally.
- Head to: http://calypso.localhost:3000/setup/domain-transfer/intro

## Related to

https://github.com/Automattic/dotcom-forge/issues/3212

