### PR TITLE
Ensure that "first year free" doesn't wrap

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -208,7 +208,7 @@
 	}
 
 	.domains__domain-domain {
-		flex: 0 0 420px;
+		flex: 0 0 390px;
 	}
 
 	.domains__domain-key {
@@ -272,6 +272,7 @@
 				font-size: 0.75rem;
 				font-weight: 500;
 				line-height: 16px;
+				white-space: nowrap;
 			}
 		}
 	}


### PR DESCRIPTION
## Description

In this PR we made sure that "first year free" doesn't wrap on the domain transfer selection page.

### Before

![before](https://github.com/Automattic/wp-calypso/assets/5634774/3c512c0d-dbdd-41b5-b789-83ad73465d5d)

### After

![CleanShot 2023-07-26 at 16 18 24](https://github.com/Automattic/wp-calypso/assets/5634774/71effa07-90d7-405c-a563-69d0952e2df7)

### Note

I had to adjust the width of the domain field as well, else the row would wrap:

![CleanShot 2023-07-26 at 16 18 32](https://github.com/Automattic/wp-calypso/assets/5634774/68d61847-8dff-4230-81f5-764bf5f9eb89)

## Testing

- Load this PR locally
- Head to: http://calypso.localhost:3000/setup/domain-transfer/domains
- Enter a valid domain and transfer code