### PR TITLE
Domain Transfer: Add nbsp to minimize widow in screen 2 subheading

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -1,5 +1,5 @@
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import { hasTranslation } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -22,16 +22,14 @@ const Intro: Step = function Intro( { navigation, flow } ) {
 		submit?.();
 	};
 
-	const getTranslatedSubHeaderText =
-		hasTranslation(
-			'Enter your domain names and authorization codes below. You can transfer up to fifty domains at a time.'
-		) || isEnglishLocale
-			? __(
-					'Enter your domain names and authorization codes below. You can transfer up to fifty domains at a time.'
-			  )
-			: __(
-					'Enter your domain names and authorization codes below. You can transfer up to 50 domains at a time.'
-			  );
+	const getTranslatedSubHeaderText = isEnglishLocale
+		? createInterpolateElement(
+				'Enter your domain names and authorization codes below. You<nbsp/>can transfer up to fifty domains at a time.',
+				{ nbsp: <>&nbsp;</> }
+		  )
+		: __(
+				'Enter your domain names and authorization codes below. You can transfer up to fifty domains at a time.'
+		  );
 
 	return (
 		<StepContainer


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3217 

## Proposed Changes

* Adds nbsp to minimize widow in subheading of screen 2

English:

<img width="1052" alt="Screenshot 2023-07-26 at 3 11 00 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/f4383221-50fd-41d5-8b0e-986a1445b560">

Non-English:

<img width="915" alt="Screenshot 2023-07-26 at 3 10 51 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/efed918a-c118-4457-a3da-f574df874223">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Go to `/setup/domain-transfer`
* Click CTA to go to send step
* In English, verify that "you" doesn't end up dangling on the top line.
* Switch to another language. Note that the nbsp isn't applied for now. We'll need to come back to this later.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
