### PR TITLE
Revert 69331: ETK deactivation message on unlaunched site

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -418,39 +418,3 @@ function load_wpcom_domain_upsell_callout() {
 	require_once __DIR__ . '/wpcom-domain-upsell-callout/class-wpcom-domain-upsell-callout.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_domain_upsell_callout' );
-/**
- * Shows a confirm prompt when the plugin is about to be deactivated on a unlaunched site.
- *
- * This will filter the FSE actions on the plugin manager list to add the confirm
- * prompt on the click event of the action=deactivate.
- *
- * The option launch-status exists only on wpcom sites.
- *
- * @TODO: Remove after coming-soon is migrated to the new jetpack-mu-wpcom plugin
- */
-if ( has_action( 'plugins_loaded', 'Jetpack\Mu_Wpcom\load_coming_soon' ) === false ) {
-	add_filter(
-		'plugin_action_links_' . plugin_basename( __FILE__ ),
-		function ( $actions ) {
-			$unlaunched = get_option( 'launch-status' ) === 'unlaunched';
-
-			if ( $unlaunched ) {
-				$actions = array_map(
-					function ( $action ) {
-						$message = __( 'Disabling this plugin will make your site public.', 'full-site-editing' );
-						$confirm = "confirm('$message') ? null : event.preventDefault()";
-
-						return str_replace(
-							'<a href="plugins.php?action=deactivate',
-							"<a onclick=\"$confirm\" href=\"plugins.php?action=deactivate",
-							$action
-						);
-					},
-					$actions
-				);
-			}
-
-			return $actions;
-		}
-	);
-}


### PR DESCRIPTION
## Proposed Changes

Follow-up to #69331
Closes #79804 

This reverts commit e67ae553e005e8570f16a8370c665e86fe572c5d.

As the coming-soon functionality has now been moved to the `jetpack-mu-wpcom` package which is utilized in wpcomsh for WoA sites. 

## Testing Instructions

* When deactivating the updated ETK plugin, there should no longer be the "Disabling this plugin will make your site public" message displayed.
* Coming Soon functionality should otherwise remain unchanged.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
