### PR TITLE
Make sure "Renew now" button appears disabled

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -43,7 +43,7 @@
 			@include placeholder();
 		}
 
-		& .button:not(.is-primary) {
+		& .button:not(.is-primary):not(:disabled) {
 			color: var(--studio-gray-80);
 		}
 		& .button:not(:first-child) {


### PR DESCRIPTION
## Description

When the "Renew now" button is disabled, the text should look disabled. This PR fixes that.

### Before

![CleanShot 2023-07-26 at 16 10 59](https://github.com/Automattic/wp-calypso/assets/5634774/cffe2505-c9cf-4274-afa3-e881bdddb0b3)

### After

![CleanShot 2023-07-26 at 16 10 23](https://github.com/Automattic/wp-calypso/assets/5634774/3a8f25e1-1cb4-413f-9e21-80f1c4dbe50a)

## Testing
- Load this PR locally
- Head to a domain that you've transferred in