### PR TITLE
Domain Transfer - Add new domain name input from 'new' query parameter

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -213,7 +213,6 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 		Object.keys( newDomainsState ).forEach( ( domainData ) => {
 			if ( newDomainsState[ domainData ].domain === newDomainTransferQueryArg ) {
 				duplicateDomain = true;
-				return;
 			}
 		} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -208,19 +208,6 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 	const setNewDomainFromQueryArg = () => {
 		let duplicateDomain = false;
 		const newDomainsState = { ...domainsState };
-		const singleDomainState = Object.keys( newDomainsState ).length === 1;
-
-		// Update the existing domain name if there is only one domain in the state and it is empty
-		if ( singleDomainState ) {
-			const domainData = Object.values( newDomainsState )[ 0 ];
-
-			if ( domainData.domain === '' ) {
-				domainData.domain = String( newDomainTransferQueryArg );
-				const updatedDomainData = { domainData };
-				setDomainsTransferData( updatedDomainData );
-				return;
-			}
-		}
 
 		// Check if the domain already exists in the state
 		Object.keys( newDomainsState ).forEach( ( domainData ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -8,7 +8,8 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback, useState } from 'react';
+import { getQueryArg } from '@wordpress/url';
+import { useCallback, useEffect, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 import QueryPlans from 'calypso/components/data/query-plans';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
@@ -67,6 +68,7 @@ const getFormattedTotalPrice = ( state: DomainTransferData ) => {
 
 const Domains: React.FC< Props > = ( { onSubmit } ) => {
 	const [ enabledDataLossWarning, setEnabledDataLossWarning ] = useState( true );
+	const newDomainTransferQueryArg = getQueryArg( window.location.search, 'new' );
 
 	const storedDomainsState = useSelect( ( select ) => {
 		const onboardSelect = select( ONBOARD_STORE ) as OnboardSelect;
@@ -202,6 +204,51 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 
 		return __( 'Transfer for free' );
 	}
+
+	const setNewDomainFromQueryArg = () => {
+		let duplicateDomain = false;
+		const newDomainsState = { ...domainsState };
+		const singleDomainState = Object.keys( newDomainsState ).length === 1;
+
+		// Update the existing domain name if there is only one domain in the state and it is empty
+		if ( singleDomainState ) {
+			const domainData = Object.values( newDomainsState )[ 0 ];
+
+			if ( domainData.domain === '' ) {
+				domainData.domain = String( newDomainTransferQueryArg );
+				const updatedDomainData = { domainData };
+				setDomainsTransferData( updatedDomainData );
+				return;
+			}
+		}
+
+		// Check if the domain already exists in the state
+		Object.keys( newDomainsState ).forEach( ( domainData ) => {
+			if ( newDomainsState[ domainData ].domain === newDomainTransferQueryArg ) {
+				duplicateDomain = true;
+				return;
+			}
+		} );
+
+		newDomainsState[ uuid() ] = {
+			domain: String( newDomainTransferQueryArg ),
+			auth: '',
+			valid: false,
+			rawPrice: 0,
+			saleCost: undefined,
+			currencyCode: undefined,
+		};
+
+		if ( ! duplicateDomain ) {
+			setDomainsTransferData( newDomainsState );
+		}
+	};
+
+	useEffect( () => {
+		if ( newDomainTransferQueryArg ) {
+			setNewDomainFromQueryArg();
+		}
+	}, [] );
 
 	return (
 		<div className="bulk-domain-transfer__container">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3214

## Proposed Changes

* Add logic to retrieve a new domain name from the `new` query parameter. This will populate the domain name/auth list on the `/setup/domain-transfer/domains` screen.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR
* Navigate to `/setup/domain-transfer/domains`. Clear all the domains if you have any existing domains.
* Navigate to `/setup/domain-transfer/domains?new=helloworld.com` and verify the domain appears in the domain name/auth list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
