### PR TITLE
Add core-profiler specific events on Jetpack connection page

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -452,7 +452,7 @@ export class JetpackAuthorize extends Component {
 				window.location.href = e.target.href;
 				break;
 			case this.isWooCoreProfiler():
-				recordTracksEvent( 'calypso_jpc_different_user_click' );
+				recordTracksEvent( 'calypso_jpc_wc_coreprofiler_different_user_click' );
 				window.location.href = e.target.href;
 				break;
 			default:

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -532,6 +532,10 @@ export class JetpackAuthorize extends Component {
 			recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { use_account: true } );
 		}
 
+		if ( 'woocommerce-core-profiler' === from ) {
+			recordTracksEvent( 'calypso_jpc_wc_coreprofiler_connect', { use_account: true } );
+		}
+
 		return this.authorize();
 	};
 

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -198,6 +198,9 @@ export class JetpackSignup extends Component {
 	 * @param {string} _.bearerToken Bearer token
 	 */
 	handleUserCreationSuccess = ( { username, bearerToken } ) => {
+		if ( this.isWooCoreProfiler() ) {
+			this.props.recordTracksEvent( 'calypso_jpc_wc_coreprofiler_create_account_success' );
+		}
 		this.setState( {
 			newUsername: username,
 			bearerToken,

--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -16,33 +16,36 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 // Masterbar for WooCommerce Core Profiler Jetpack step
 const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) => string } ) => {
-	const { redirectTo, shouldShowProgressBar, shouldShowNoThanks } = useSelector( ( state ) => {
-		const currentRoute = getCurrentRoute( state );
-		let redirectTo = null;
-		let shouldShowProgressBar = true;
-		let shouldShowNoThanks = true;
-		switch ( currentRoute ) {
-			case '/jetpack/connect/authorize':
-				redirectTo = getCurrentQueryArguments( state )?.redirect_after_auth;
-			case '/log-in/jetpack':
-				redirectTo = getQueryArg( getRedirectToOriginal( state ) || '', 'redirect_after_auth' );
-			default:
-		}
+	const { redirectTo, shouldShowProgressBar, shouldShowNoThanks, currentRoute } = useSelector(
+		( state ) => {
+			const currentRoute = getCurrentRoute( state );
+			let redirectTo = null;
+			let shouldShowProgressBar = true;
+			let shouldShowNoThanks = true;
+			switch ( currentRoute ) {
+				case '/jetpack/connect/authorize':
+					redirectTo = getCurrentQueryArguments( state )?.redirect_after_auth;
+				case '/log-in/jetpack':
+					redirectTo = getQueryArg( getRedirectToOriginal( state ) || '', 'redirect_after_auth' );
+				default:
+			}
 
-		if (
-			currentRoute === '/log-in/jetpack/lostpassword' ||
-			getCurrentQueryArguments( state )?.lostpassword_flow
-		) {
-			shouldShowProgressBar = false;
-			shouldShowNoThanks = false;
-		}
+			if (
+				currentRoute === '/log-in/jetpack/lostpassword' ||
+				getCurrentQueryArguments( state )?.lostpassword_flow
+			) {
+				shouldShowProgressBar = false;
+				shouldShowNoThanks = false;
+			}
 
-		return {
-			redirectTo,
-			shouldShowProgressBar,
-			shouldShowNoThanks,
-		};
-	} );
+			return {
+				redirectTo,
+				shouldShowProgressBar,
+				shouldShowNoThanks,
+				currentRoute,
+			};
+		}
+	);
 
 	return (
 		<Fragment>
@@ -66,7 +69,9 @@ const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) 
 							{ shouldShowNoThanks && typeof redirectTo === 'string' && isWebUri( redirectTo ) && (
 								<Button
 									onClick={ () => {
-										recordTracksEvent( 'calypso_jpc_wc_coreprofiler_skip' );
+										recordTracksEvent( 'calypso_jpc_wc_coreprofiler_skip', {
+											page: currentRoute,
+										} );
 									} }
 									href={ redirectTo }
 									className="masterbar__no-thanks-button"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79868

## Proposed Changes

* Added `calypso_jpc_wc_coreprofiler_connect` track that fires when the connect button is clicked and the flow is from the core profiler
* Added `calypso_jpc_wc_coreprofiler_create_account_success` after successful account creation when the flow is from the core profiler.
* Added `page` event property for `calypso_jpc_wc_coreprofiler_skip` event

The issue requires the following events.

| When      | Event | Note|
| ----------- | ----------- |----|
| % of users that click "No Thanks"      | calypso_jpc_wc_coreprofiler_skip       | Added `page`|
| % of users that sign in as different users   | calypso_jpc_different_user_click        | pre-existing |
| % of users that connect their account| calypso_jpc_wc_coreprofiler_connect | pre-existing|
| % of users that create an account| calypso_jpc_wc_coreprofiler_create_account_success| new|

## Testing Instructions


Step 1: Let's get Jetpack connect page parameters.

1. Check out this branch and start the server.
2. Create a new JN site with WooCommerce
3. Start the core profiler and proceed to the plugins page. Make sure to select Jetpack.
4. Click continue and you'll be redirected to Jetpack connection. 
5. Copy the URL.
6. Replace https://wordpress.com part with your local wp-calypso URL. 
7. Your new URL should look like `http://calypso.localhost:3000/jetpack/connect/authorize...`
8. Enter the new URL.

Step 2: Testing `calypso_jpc_wc_coreprofiler_connect` (continued)

1. Open your browser console.
2. Enter `window.localStorage.setItem( 'debug', '*' )` ane make sure log level is verbose.

![Screen Shot 2023-07-26 at 4 25 30 PM](https://github.com/Automattic/wp-calypso/assets/4723145/9a8fd28e-3fa5-436d-95fc-c1833d17377f)
3. Follow https://stackoverflow.com/questions/5327955/how-to-make-google-chrome-javascript-console-persistent to preserve console log.
4. Click the connect button and confirm `calypso_jpc_wc_coreprofiler_connect` event has been fired.

Step 3: Testing `calypso_jpc_wc_coreprofiler_create_account_success`

1. Create a new JN site by performing step 1. 
2. Open the new URL in an incognito session.
3. Open your browser console and enter `window.localStorage.setItem( 'debug', '*' )` 
4. Click `Create an account` and confirm `calypso_jpc_wc_coreprofiler_create_account_success` event has been fired.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
