### PR TITLE
CI: Update TeamCity setting version

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -42,7 +42,7 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 'Debug' option is available in the context menu for the task.
 */
 
-version = "2022.04"
+version = "2023.05"
 
 project {
 


### PR DESCRIPTION
## Proposed Changes

This PR updates the TeamCity setting version to the newest available version, which also matches the TC server version we're currently running (`2023.05.1`). This effectively updates the Kotlin DSL API, so that scripts can access new features that are only available in the new version (for example: p1689871665470589/1689036910.937589-slack-CBTN58FTJ)

This is a follow-up to: https://github.com/Automattic/wp-calypso/pull/69269

Related to: pMz3w-i1O-p2

## Testing Instructions

* All checks should pass
