### PR TITLE
Domain Transfer: Update checkout step copy to include copy used elsewhere

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
@@ -50,7 +50,8 @@ const Intro: React.FC< Props > = ( { onSubmit } ) => {
 						description: (
 							<p>
 								{ __(
-									'Review your payment and contact details. Google Domains transfers and the first year are free.'
+									'Review your payment and contact details. When you transfer a domain from Google Domains, ' +
+										"we'll absorb the cost and give you an extra year of free registration."
 								) }
 							</p>
 						),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
@@ -1,3 +1,4 @@
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { IntentScreen } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { Icon, unlock, plus, payment } from '@wordpress/icons';
@@ -9,7 +10,8 @@ interface Props {
 }
 
 const Intro: React.FC< Props > = ( { onSubmit } ) => {
-	const { __ } = useI18n();
+	const { __, hasTranslation } = useI18n();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	return (
 		<>
@@ -49,10 +51,16 @@ const Intro: React.FC< Props > = ( { onSubmit } ) => {
 						badge: __( 'Google Domains: Free' ),
 						description: (
 							<p>
-								{ __(
-									'Review your payment and contact details. When you transfer a domain from Google Domains, ' +
-										"we'll absorb the cost and give you an extra year of free registration."
-								) }
+								{ isEnglishLocale ||
+								hasTranslation(
+									"Review your payment and contact details. If you're transferring a domain from Google, we'll absorb the cost and give you an extra year of free registration."
+								)
+									? __(
+											"Review your payment and contact details. If you're transferring a domain from Google, we'll absorb the cost and give you an extra year of free registration."
+									  )
+									: __(
+											'Review your payment and contact details. Google Domains transfers and the first year are free.'
+									  ) }
 							</p>
 						),
 						icon: <Icon icon={ payment } />,


### PR DESCRIPTION
Fixed https://github.com/Automattic/dotcom-forge/issues/3211

## Proposed Changes

* On checkout step, use copy from elsewhere.

<img width="686" alt="Screenshot 2023-07-26 at 10 01 05 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/87760001-ae60-49f8-aad3-eb228394f155">

With Spanish enabled to demonstrate the fallback to previous string:

<img width="659" alt="Screenshot 2023-07-26 at 10 01 33 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/66a691bc-ae9a-4fd3-80bb-42c8fa9271dc">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout patch
* Go to `/setup/domain-transfer`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
