### PR TITLE
Theme Detail page: Use iframe for large preview except for WP.org and 3PD themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1217,6 +1217,7 @@ class ThemeSheet extends Component {
 			isMarketplaceThemeSubscribed,
 			isExternallyManagedTheme,
 			isThemeActivationSyncStarted,
+			isWpcomTheme,
 		} = this.props;
 
 		const analyticsPath = `/theme/${ themeId }${ section ? '/' + section : '' }${
@@ -1420,7 +1421,9 @@ class ThemeSheet extends Component {
 					</div>
 					{ ! isRemoved && (
 						<div className="theme__sheet-column-right">
-							{ ! isExternallyManagedTheme ? this.renderWebPreview() : this.renderScreenshot() }
+							{ isWpcomTheme && ! isExternallyManagedTheme
+								? this.renderWebPreview()
+								: this.renderScreenshot() }
 						</div>
 					) }
 				</div>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1207,7 +1207,6 @@ class ThemeSheet extends Component {
 			siteId,
 			siteSlug,
 			retired,
-			styleVariations,
 			isBundledSoftwareSet,
 			translate,
 			isLoggedIn,
@@ -1421,7 +1420,7 @@ class ThemeSheet extends Component {
 					</div>
 					{ ! isRemoved && (
 						<div className="theme__sheet-column-right">
-							{ styleVariations.length ? this.renderWebPreview() : this.renderScreenshot() }
+							{ ! isExternallyManagedTheme ? this.renderWebPreview() : this.renderScreenshot() }
 						</div>
 					) }
 				</div>

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -16,15 +16,16 @@ $theme-sheet-content-max-width: 1462px;
 			padding-right: 0;
 		}
 
+		.theme__sheet-screenshot,
 		.theme__sheet-web-preview {
 			@include breakpoint-deprecated( ">960px" ) {
 				top: calc(var(--masterbar-height) + 16px);
 			}
+		}
 
-			.theme-preview__frame-wrapper {
-				@include breakpoint-deprecated( ">960px" ) {
-					max-height: calc(100vh - 32px - var(--masterbar-height));
-				}
+		.theme__sheet-web-preview .theme-preview__frame-wrapper {
+			@include breakpoint-deprecated( ">960px" ) {
+				max-height: calc(100vh - 32px - var(--masterbar-height));
 			}
 		}
 	}
@@ -337,6 +338,37 @@ $theme-sheet-content-max-width: 1462px;
 	font-size: 90%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 }
 
+.theme__sheet-web-preview {
+	$iframe-viewport-height: 1040px;
+	$iframe-viewport-height-scaled: calc($iframe-viewport-height / 2);
+
+	min-height: $iframe-viewport-height-scaled;
+	pointer-events: none;
+
+	.theme-preview__frame-wrapper {
+		@include breakpoint-deprecated( ">960px" ) {
+			max-height: calc(100vh - var(--masterbar-height));
+
+			.theme-preview__frame {
+				height: 200%;
+				max-height: 200vh;
+				max-width: 200%;
+				min-height: $iframe-viewport-height-scaled;
+				transform: scale(0.5) !important;
+				width: 200%;
+			}
+		}
+	}
+
+	.theme-preview__container {
+		position: relative;
+	}
+
+	.theme-preview__frame {
+		transform: none !important;
+	}
+}
+
 .theme__sheet-web-preview,
 .theme__sheet-screenshot {
 	background-color: transparentize(rgb(255, 255, 255), 0.5);
@@ -374,47 +406,16 @@ $theme-sheet-content-max-width: 1462px;
 	}
 
 	@include breakpoint-deprecated( ">960px" ) {
+		pointer-events: all;
+		position: sticky;
+		top: 16px;
+
 		&.is-active:hover {
 			cursor: pointer;
 			box-shadow:
 				0 0 0 1px var(--color-neutral-light),
 				0 2px 10px 0 rgba(var(--color-neutral-dark-rgb), 0.5);
 		}
-	}
-}
-
-.theme__sheet-web-preview {
-	$iframe-viewport-height: 1040px;
-	$iframe-viewport-height-scaled: calc($iframe-viewport-height / 2);
-
-	min-height: $iframe-viewport-height-scaled;
-	pointer-events: none;
-
-	@include breakpoint-deprecated( ">960px" ) {
-		pointer-events: all;
-		position: sticky;
-		top: 16px;
-
-		.theme-preview__frame-wrapper {
-			max-height: calc(100vh - var(--masterbar-height));
-
-			.theme-preview__frame {
-				height: 200%;
-				max-height: 200vh;
-				max-width: 200%;
-				min-height: $iframe-viewport-height-scaled;
-				transform: scale(0.5) !important;
-				width: 200%;
-			}
-		}
-	}
-
-	.theme-preview__container {
-		position: relative;
-	}
-
-	.theme-preview__frame {
-		transform: none !important;
 	}
 }
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -255,7 +255,7 @@ $theme-sheet-content-max-width: 1462px;
 	box-shadow: 0 1px var(--color-border-subtle);
 }
 
-.theme__sheet-action-bar.card {
+.header-cake.card.theme__sheet-action-bar {
 	box-shadow: none;
 	box-sizing: content-box;
 	margin: 0 auto;
@@ -270,7 +270,7 @@ $theme-sheet-content-max-width: 1462px;
 	}
 }
 
-.is-mobile-app-view .theme__sheet-action-bar.card {
+.is-mobile-app-view .header-cake.card.theme__sheet-action-bar {
 	display: none;
 }
 

--- a/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
@@ -3,7 +3,7 @@ import { PreviewComponent } from '../components';
 
 const selectors = {
 	// Preview
-	demoPane: '.theme__sheet-screenshot',
+	demoButton: 'button:text("Open live demo")',
 
 	// Main body
 	activateDesignButton: 'button:text("Activate this design")',
@@ -38,7 +38,7 @@ export class ThemesDetailPage {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async preview(): Promise< void > {
-		await this.page.click( selectors.demoPane );
+		await this.page.click( selectors.demoButton );
 		const previewComponent = new PreviewComponent( this.page );
 		await previewComponent.previewReady();
 	}


### PR DESCRIPTION
## Proposed Changes

As suggested in p1690364207288989-slack-CRWCHQGUB, we want to use iframe in the large preview of the Theme Detail page, instead of the theme's screenshot. In production, we only use the iframe when the theme has style variations, since we inject global styles into the iframe.

@alaczek suggested to use iframe for all themes, since users can interact with the preview, and see things like link or button hover states, which is not possible via image. Unfortunately, due to technical aspects, currently we cannot use iframe as large preview for WP.org or 3PD themes.

Note for KitKat team: Previously, clicking the large preview as an image opens up the live demo modal. By changing the large preview to iframe, this behavior is changed, so we updated the selector to be the "Open Live Demo" button of the Theme Detail page.

![Screenshot 2023-07-27 at 3 08 00 PM](https://github.com/Automattic/wp-calypso/assets/797888/172f671a-3e5b-4205-accf-2a7a6fc0edc4)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase `/themes`.
* Select a theme with style variations, and ensure that the large preview in the Theme Detail page is an iframe.
* Select a theme without style variations, and ensure that the large preview in the Theme Detail page is an iframe.
* Select a 3PD theme, and ensure that the large preview in the Theme Detail page is an image.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?