### PR TITLE
Stats: remove `statsPurchaseSuccess` param on notice viewed

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -369,7 +369,6 @@ export function site( context, next ) {
 			chartTab={ chartTab }
 			context={ context }
 			period={ rangeOfPeriod( activeFilter.period, date ) }
-			statsPurchaseSuccess={ queryOptions.statsPurchaseSuccess }
 		/>
 	);
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -172,7 +172,6 @@ class StatsSite extends Component {
 			isOdysseyStats,
 			context,
 			moduleSettings,
-			statsPurchaseSuccess,
 		} = this.props;
 
 		let defaultPeriod = PAST_SEVEN_DAYS;
@@ -242,7 +241,7 @@ class StatsSite extends Component {
 				<StatsNotices
 					siteId={ siteId }
 					isOdysseyStats={ isOdysseyStats }
-					statsPurchaseSuccess={ statsPurchaseSuccess }
+					statsPurchaseSuccess={ context.query.statsPurchaseSuccess }
 				/>
 				<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
 				<div id="my-stats-content" className={ wrapperClass }>

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { StatsNoticeProps } from './types';
 
 const getStatsPurchaseURL = ( siteId: number | null ) => {
@@ -13,15 +13,17 @@ const getStatsPurchaseURL = ( siteId: number | null ) => {
 	return `https://wordpress.com${ purchasePath }`;
 };
 
-const FreePlanPurchaseSuccessJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
+const FreePlanPurchaseSuccessJetpackStatsNotice = ( {
+	siteId,
+	onNoticeViewed,
+}: StatsNoticeProps ) => {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 
-	const dismissNotice = () => {
-		// TODO: Remove the query string from the window URL without a refresh.
-		setNoticeDismissed( true );
-	};
+	useEffect( () => onNoticeViewed && onNoticeViewed() );
+
+	const dismissNotice = () => setNoticeDismissed( true );
 
 	if ( noticeDismissed ) {
 		return null;

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -21,7 +21,9 @@ const FreePlanPurchaseSuccessJetpackStatsNotice = ( {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 
-	useEffect( () => onNoticeViewed && onNoticeViewed() );
+	useEffect( () => {
+		onNoticeViewed && onNoticeViewed();
+	} );
 
 	const dismissNotice = () => setNoticeDismissed( true );
 

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -13,6 +13,7 @@ import DoYouLoveJetpackStatsNotice from './do-you-love-jetpack-stats-notice';
 import FeedbackNotice from './feedback-notice';
 import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-success-notice';
 import LegacyStatsNotices from './legacy-notices';
+import removeStatsPurchaseSuccessParam from './lib/remove-stats-purchase-success-param';
 import OptOutNotice from './opt-out-notice';
 import PaidPlanPurchaseSuccessJetpackStatsNotice from './paid-plan-purchase-success-notice';
 import { NewStatsNoticesProps, StatsNoticesProps, PurchaseNoticesProps } from './types';
@@ -20,29 +21,6 @@ import usePurchasesToUpdateSiteProducts from './use-purchases-to-update-site-pro
 import './style.scss';
 
 const TEAM51_OWNER_ID = 70055110;
-
-const removeStatsPurchaseSuccessParamCalypso = () => {
-	const newUrl = new URL( window.location.href );
-	newUrl.searchParams.delete( 'statsPurchaseSuccess' );
-
-	return window.history.replaceState( null, '', newUrl.toString() );
-};
-
-const removeStatsPurchaseSuccessParamOdyssey = () => {
-	// For Odyssey Stats, we simply update the hash which is equavalent to updating the URL.
-	const currentUrl = new URL( window.location.href );
-	const hashUrl = new URL( window.location.hash.substring( 2 ), window.location.origin );
-	hashUrl.searchParams.delete( 'statsPurchaseSuccess' );
-	currentUrl.hash = `#!${ hashUrl.toString() }`;
-	window.history.replaceState( null, '', currentUrl.toString() );
-};
-
-const removeStatsPurchaseSuccessParam = ( isOdysseyStats: boolean ) => {
-	if ( ! isOdysseyStats ) {
-		return removeStatsPurchaseSuccessParamCalypso();
-	}
-	removeStatsPurchaseSuccessParamOdyssey();
-};
 
 /**
  * New notices aim to support Calypso and Odyssey stats.
@@ -89,17 +67,18 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => 
 	);
 };
 
-const PostPurchaseNotices = ( {
-	siteId,
-	statsPurchaseSuccess,
-	isOdysseyStats,
-}: PurchaseNoticesProps ) => {
+const PostPurchaseNotices = ( { siteId, statsPurchaseSuccess }: PurchaseNoticesProps ) => {
 	// Check if the GET param is passed to show the Free or Paid plan purchase notices
 	const showFreePlanPurchaseSuccessNotice = statsPurchaseSuccess === 'free';
 	const showPaidPlanPurchaseSuccessNotice = statsPurchaseSuccess === 'paid';
 
-	const removeParam = () =>
-		statsPurchaseSuccess && removeStatsPurchaseSuccessParam( isOdysseyStats );
+	const removeParam = () => {
+		if ( ! statsPurchaseSuccess ) {
+			return;
+		}
+		const newUrl = removeStatsPurchaseSuccessParam( window.location.href );
+		setTimeout( () => window.history.replaceState( null, '', newUrl ), 300 );
+	};
 
 	return (
 		<>

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -16,7 +16,7 @@ import LegacyStatsNotices from './legacy-notices';
 import removeStatsPurchaseSuccessParam from './lib/remove-stats-purchase-success-param';
 import OptOutNotice from './opt-out-notice';
 import PaidPlanPurchaseSuccessJetpackStatsNotice from './paid-plan-purchase-success-notice';
-import { NewStatsNoticesProps, StatsNoticesProps, PurchaseNoticesProps } from './types';
+import { StatsNoticesProps } from './types';
 import usePurchasesToUpdateSiteProducts from './use-purchases-to-update-site-products';
 import './style.scss';
 
@@ -26,7 +26,7 @@ const TEAM51_OWNER_ID = 70055110;
  * New notices aim to support Calypso and Odyssey stats.
  * New notices are based on async API call and hence is faster than the old notices.
  */
-const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => {
+const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 	const hasPaidStats = useSelector( ( state ) => hasSiteProductJetpackStatsPaid( state, siteId ) );
 	// `is_vip` is not correctly placed in Odyssey, so we need to check `options.is_vip` as well.
 	const isVip = useSelector(
@@ -67,7 +67,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => 
 	);
 };
 
-const PostPurchaseNotices = ( { siteId, statsPurchaseSuccess }: PurchaseNoticesProps ) => {
+const PostPurchaseNotices = ( { siteId, statsPurchaseSuccess }: StatsNoticesProps ) => {
 	// Check if the GET param is passed to show the Free or Paid plan purchase notices
 	const showFreePlanPurchaseSuccessNotice = statsPurchaseSuccess === 'free';
 	const showPaidPlanPurchaseSuccessNotice = statsPurchaseSuccess === 'paid';

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -77,6 +77,7 @@ const PostPurchaseNotices = ( { siteId, statsPurchaseSuccess }: PurchaseNoticesP
 			return;
 		}
 		const newUrl = removeStatsPurchaseSuccessParam( window.location.href );
+		// Odyssey would try to hack the URL on load to remove duplicate params. We need to wait for that to finish.
 		setTimeout( () => window.history.replaceState( null, '', newUrl ), 300 );
 	};
 

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -21,6 +21,29 @@ import './style.scss';
 
 const TEAM51_OWNER_ID = 70055110;
 
+const removeStatsPurchaseSuccessParamCalypso = () => {
+	const newUrl = new URL( window.location.href );
+	newUrl.searchParams.delete( 'statsPurchaseSuccess' );
+
+	return window.history.replaceState( null, '', newUrl.toString() );
+};
+
+const removeStatsPurchaseSuccessParamOdyssey = () => {
+	// For Odyssey Stats, we simply update the hash which is equavalent to updating the URL.
+	const currentUrl = new URL( window.location.href );
+	const hashUrl = new URL( window.location.hash.substring( 2 ), window.location.origin );
+	hashUrl.searchParams.delete( 'statsPurchaseSuccess' );
+	currentUrl.hash = `#!${ hashUrl.toString() }`;
+	window.history.replaceState( null, '', currentUrl.toString() );
+};
+
+const removeStatsPurchaseSuccessParam = ( isOdysseyStats: boolean ) => {
+	if ( ! isOdysseyStats ) {
+		return removeStatsPurchaseSuccessParamCalypso();
+	}
+	removeStatsPurchaseSuccessParamOdyssey();
+};
+
 /**
  * New notices aim to support Calypso and Odyssey stats.
  * New notices are based on async API call and hence is faster than the old notices.
@@ -66,17 +89,29 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: NewStatsNoticesProps ) => 
 	);
 };
 
-const PostPurchaseNotices = ( { siteId, statsPurchaseSuccess }: PurchaseNoticesProps ) => {
+const PostPurchaseNotices = ( {
+	siteId,
+	statsPurchaseSuccess,
+	isOdysseyStats,
+}: PurchaseNoticesProps ) => {
 	// Check if the GET param is passed to show the Free or Paid plan purchase notices
 	const showFreePlanPurchaseSuccessNotice = statsPurchaseSuccess === 'free';
 	const showPaidPlanPurchaseSuccessNotice = statsPurchaseSuccess === 'paid';
 
+	const removeParam = () =>
+		statsPurchaseSuccess && removeStatsPurchaseSuccessParam( isOdysseyStats );
+
 	return (
 		<>
 			{ /* TODO: Consider combining/refactoring these components into a single component */ }
-			{ showPaidPlanPurchaseSuccessNotice && <PaidPlanPurchaseSuccessJetpackStatsNotice /> }
+			{ showPaidPlanPurchaseSuccessNotice && (
+				<PaidPlanPurchaseSuccessJetpackStatsNotice onNoticeViewed={ removeParam } />
+			) }
 			{ showFreePlanPurchaseSuccessNotice && (
-				<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
+				<FreePlanPurchaseSuccessJetpackStatsNotice
+					siteId={ siteId }
+					onNoticeViewed={ removeParam }
+				/>
 			) }
 		</>
 	);
@@ -100,7 +135,11 @@ export default function StatsNotices( {
 
 	return supportNewStatsNotices ? (
 		<>
-			<PostPurchaseNotices siteId={ siteId } statsPurchaseSuccess={ statsPurchaseSuccess } />
+			<PostPurchaseNotices
+				siteId={ siteId }
+				statsPurchaseSuccess={ statsPurchaseSuccess }
+				isOdysseyStats={ isOdysseyStats }
+			/>
 			<NewStatsNotices siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
 		</>
 	) : (

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -115,11 +115,7 @@ export default function StatsNotices( {
 
 	return supportNewStatsNotices ? (
 		<>
-			<PostPurchaseNotices
-				siteId={ siteId }
-				statsPurchaseSuccess={ statsPurchaseSuccess }
-				isOdysseyStats={ isOdysseyStats }
-			/>
+			<PostPurchaseNotices siteId={ siteId } statsPurchaseSuccess={ statsPurchaseSuccess } />
 			<NewStatsNotices siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
 		</>
 	) : (

--- a/client/my-sites/stats/stats-notices/lib/remove-stats-purchase-success-param.ts
+++ b/client/my-sites/stats/stats-notices/lib/remove-stats-purchase-success-param.ts
@@ -5,7 +5,7 @@ const removeStatsPurchaseSuccessParam = ( url: string ) => {
 
 	// Delete param in hash URL if any.
 	if ( currentUrl.hash ) {
-		const hashUrl = new URL( currentUrl.hash.substring( 2 ), window.location.origin );
+		const hashUrl = new URL( currentUrl.hash.substring( 2 ), currentUrl.origin );
 		hashUrl.searchParams.delete( 'statsPurchaseSuccess' );
 		currentUrl.hash = `#!${ hashUrl.pathname }${ hashUrl.search }`;
 	}

--- a/client/my-sites/stats/stats-notices/lib/remove-stats-purchase-success-param.ts
+++ b/client/my-sites/stats/stats-notices/lib/remove-stats-purchase-success-param.ts
@@ -3,13 +3,12 @@ const removeStatsPurchaseSuccessParam = ( url: string ) => {
 	const currentUrl = new URL( url );
 	currentUrl.searchParams.delete( 'statsPurchaseSuccess' );
 
-	// Delete param in hash URL.
-	const hashUrl = new URL( currentUrl.hash.substring( 2 ), window.location.origin );
-	hashUrl.searchParams.delete( 'statsPurchaseSuccess' );
-	if ( hashUrl.search ) {
+	// Delete param in hash URL if any.
+	if ( currentUrl.hash ) {
+		const hashUrl = new URL( currentUrl.hash.substring( 2 ), window.location.origin );
+		hashUrl.searchParams.delete( 'statsPurchaseSuccess' );
 		currentUrl.hash = `#!${ hashUrl.pathname }${ hashUrl.search }`;
 	}
-
 	return currentUrl.toString();
 };
 

--- a/client/my-sites/stats/stats-notices/lib/remove-stats-purchase-success-param.ts
+++ b/client/my-sites/stats/stats-notices/lib/remove-stats-purchase-success-param.ts
@@ -1,0 +1,18 @@
+const removeStatsPurchaseSuccessParam = ( url: string ) => {
+	// For Odyssey Stats, we simply update the hash which is equavalent to updating the URL.
+	const currentUrl = new URL( url );
+
+	// Delete param in GET params.
+	currentUrl.searchParams.delete( 'statsPurchaseSuccess' );
+
+	const hashUrl = new URL( currentUrl.hash.substring( 2 ), window.location.origin );
+	// Delete param in hash URL.
+	hashUrl.searchParams.delete( 'statsPurchaseSuccess' );
+	if ( hashUrl.search ) {
+		currentUrl.hash = `#!${ hashUrl.pathname }${ hashUrl.search }`;
+	}
+
+	return currentUrl.toString();
+};
+
+export { removeStatsPurchaseSuccessParam as default };

--- a/client/my-sites/stats/stats-notices/lib/remove-stats-purchase-success-param.ts
+++ b/client/my-sites/stats/stats-notices/lib/remove-stats-purchase-success-param.ts
@@ -1,12 +1,10 @@
 const removeStatsPurchaseSuccessParam = ( url: string ) => {
-	// For Odyssey Stats, we simply update the hash which is equavalent to updating the URL.
-	const currentUrl = new URL( url );
-
 	// Delete param in GET params.
+	const currentUrl = new URL( url );
 	currentUrl.searchParams.delete( 'statsPurchaseSuccess' );
 
-	const hashUrl = new URL( currentUrl.hash.substring( 2 ), window.location.origin );
 	// Delete param in hash URL.
+	const hashUrl = new URL( currentUrl.hash.substring( 2 ), window.location.origin );
 	hashUrl.searchParams.delete( 'statsPurchaseSuccess' );
 	if ( hashUrl.search ) {
 		currentUrl.hash = `#!${ hashUrl.pathname }${ hashUrl.search }`;

--- a/client/my-sites/stats/stats-notices/lib/test/remove-stats-purchase-success-param.js
+++ b/client/my-sites/stats/stats-notices/lib/test/remove-stats-purchase-success-param.js
@@ -1,6 +1,3 @@
-/**
- * @jest-environment jsdom
- */
 import removeStatsPurchaseSuccessParam from '../remove-stats-purchase-success-param';
 
 describe( 'removeStatsPurchaseSuccessParam', () => {

--- a/client/my-sites/stats/stats-notices/lib/test/remove-stats-purchase-success-param.js
+++ b/client/my-sites/stats/stats-notices/lib/test/remove-stats-purchase-success-param.js
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+import removeStatsPurchaseSuccessParam from '../remove-stats-purchase-success-param';
+
+describe( 'removeStatsPurchaseSuccessParam', () => {
+	it( 'should return the original path if nothing removed', () => {
+		expect(
+			removeStatsPurchaseSuccessParam(
+				'https://wp.com/statsPurchaseSuccess=1/?page=page1&c=d#!/ab/c?e=f'
+			)
+		).toEqual( 'https://wp.com/statsPurchaseSuccess=1/?page=page1&c=d#!/ab/c?e=f' );
+		expect( removeStatsPurchaseSuccessParam( 'https://wp.com/statsPurchaseSuccess=1' ) ).toEqual(
+			'https://wp.com/statsPurchaseSuccess=1'
+		);
+	} );
+
+	it( 'should return the path with the statsPurchaseSuccess in GET params removed', () => {
+		expect(
+			removeStatsPurchaseSuccessParam( 'https://wp.com/?statsPurchaseSuccess=1&page=page1' )
+		).toEqual( 'https://wp.com/?page=page1' );
+		expect(
+			removeStatsPurchaseSuccessParam( 'https://wp.com/?page=page1&statsPurchaseSuccess=1' )
+		).toEqual( 'https://wp.com/?page=page1' );
+		expect(
+			removeStatsPurchaseSuccessParam( 'https://wp.com/?page=page1&statsPurchaseSuccess=1&c=d' )
+		).toEqual( 'https://wp.com/?page=page1&c=d' );
+		expect( removeStatsPurchaseSuccessParam( 'https://wp.com/?statsPurchaseSuccess=1' ) ).toEqual(
+			'https://wp.com/'
+		);
+	} );
+
+	it( 'should return the path with the statsPurchaseSuccess in hash removed', () => {
+		expect(
+			removeStatsPurchaseSuccessParam( 'https://wp.com/?page=page1#!/ab/c?statsPurchaseSuccess=1' )
+		).toEqual( 'https://wp.com/?page=page1#!/ab/c' );
+		expect(
+			removeStatsPurchaseSuccessParam(
+				'https://wp.com/?page=page1#!/ab/c?statsPurchaseSuccess=1&d=e'
+			)
+		).toEqual( 'https://wp.com/?page=page1#!/ab/c?d=e' );
+		expect(
+			removeStatsPurchaseSuccessParam(
+				'https://wp.com/?page=page1#!/ab/c?d=e&statsPurchaseSuccess=1&f=g'
+			)
+		).toEqual( 'https://wp.com/?page=page1#!/ab/c?d=e&f=g' );
+	} );
+
+	it( 'should return the path with the statsPurchaseSuccess in hash and query removed', () => {
+		expect(
+			removeStatsPurchaseSuccessParam(
+				'https://wp.com/?page=page1&statsPurchaseSuccess=1&c=d#!/ab/c?statsPurchaseSuccess=1&e=f'
+			)
+		).toEqual( 'https://wp.com/?page=page1&c=d#!/ab/c?e=f' );
+	} );
+} );

--- a/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
@@ -11,7 +11,9 @@ const PaidPlanPurchaseSuccessJetpackStatsNotice = ( {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 
-	useEffect( () => onNoticeViewed && onNoticeViewed() );
+	useEffect( () => {
+		onNoticeViewed && onNoticeViewed();
+	} );
 
 	const dismissNotice = () => {
 		setNoticeDismissed( true );

--- a/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
@@ -2,9 +2,11 @@ import config from '@automattic/calypso-config';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
-import { StatsNoticeProps } from './types';
+import { PaidPlanPurchaseSuccessJetpackStatsNoticeProps } from './types';
 
-const PaidPlanPurchaseSuccessJetpackStatsNotice = ( { onNoticeViewed }: StatsNoticeProps ) => {
+const PaidPlanPurchaseSuccessJetpackStatsNotice = ( {
+	onNoticeViewed,
+}: PaidPlanPurchaseSuccessJetpackStatsNoticeProps ) => {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );

--- a/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
@@ -2,9 +2,11 @@ import config from '@automattic/calypso-config';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
-import { StatsNoticeProps } from './types';
+import { PaidPlanPurchaseNoticeProps } from './types';
 
-const PaidPlanPurchaseSuccessJetpackStatsNotice = ( { onNoticeViewed }: StatsNoticeProps ) => {
+const PaidPlanPurchaseSuccessJetpackStatsNotice = ( {
+	onNoticeViewed,
+}: PaidPlanPurchaseNoticeProps ) => {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );

--- a/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
@@ -1,15 +1,17 @@
 import config from '@automattic/calypso-config';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { StatsNoticeProps } from './types';
 
-const PaidPlanPurchaseSuccessJetpackStatsNotice = () => {
+const PaidPlanPurchaseSuccessJetpackStatsNotice = ( { onNoticeViewed }: StatsNoticeProps ) => {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 
+	useEffect( () => onNoticeViewed && onNoticeViewed() );
+
 	const dismissNotice = () => {
-		// TODO: Remove the query string from the window URL without a refresh.
 		setNoticeDismissed( true );
 	};
 

--- a/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
@@ -2,11 +2,9 @@ import config from '@automattic/calypso-config';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
-import { PaidPlanPurchaseNoticeProps } from './types';
+import { StatsNoticeProps } from './types';
 
-const PaidPlanPurchaseSuccessJetpackStatsNotice = ( {
-	onNoticeViewed,
-}: PaidPlanPurchaseNoticeProps ) => {
+const PaidPlanPurchaseSuccessJetpackStatsNotice = ( { onNoticeViewed }: StatsNoticeProps ) => {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -24,7 +24,7 @@ export interface StatsNoticesProps {
 
 export interface NewStatsNoticesProps {
 	siteId: number | null;
-	isOdysseyStats: boolean;
+	isOdysseyStats?: boolean;
 }
 
 export interface PurchaseNoticesProps extends NewStatsNoticesProps {

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -14,15 +14,6 @@ export interface FeedbackNoticeBodyProps extends NoticeBodyProps {
 
 export interface StatsNoticesProps {
 	siteId: number | null;
-	isOdysseyStats: boolean;
-	statsPurchaseSuccess?: string;
-}
-
-export interface NewStatsNoticesProps {
-	siteId: number | null;
 	isOdysseyStats?: boolean;
-}
-
-export interface PurchaseNoticesProps extends NewStatsNoticesProps {
-	statsPurchaseSuccess: string | undefined;
+	statsPurchaseSuccess?: string;
 }

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -1,9 +1,5 @@
-export interface PaidPlanPurchaseNoticeProps {
-	onNoticeViewed?: () => void;
-}
-
 export interface StatsNoticeProps {
-	siteId: number | null;
+	siteId?: number | null;
 	onNoticeViewed?: () => void;
 }
 

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -1,5 +1,9 @@
+export interface PaidPlanPurchaseNoticeProps {
+	onNoticeViewed?: () => void;
+}
+
 export interface StatsNoticeProps {
-	siteId?: number | null;
+	siteId: number | null;
 	onNoticeViewed?: () => void;
 }
 
@@ -14,7 +18,7 @@ export interface FeedbackNoticeBodyProps extends NoticeBodyProps {
 
 export interface StatsNoticesProps {
 	siteId: number | null;
-	isOdysseyStats?: boolean;
+	isOdysseyStats: boolean;
 	statsPurchaseSuccess?: string;
 }
 

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -1,5 +1,9 @@
+export interface PaidPlanPurchaseSuccessJetpackStatsNoticeProps {
+	onNoticeViewed?: () => void;
+}
+
 export interface StatsNoticeProps {
-	siteId?: number | null;
+	siteId: number | null;
 	onNoticeViewed?: () => void;
 }
 

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -1,5 +1,6 @@
 export interface StatsNoticeProps {
-	siteId: number | null;
+	siteId?: number | null;
+	onNoticeViewed?: () => void;
 }
 
 export interface NoticeBodyProps {
@@ -19,10 +20,9 @@ export interface StatsNoticesProps {
 
 export interface NewStatsNoticesProps {
 	siteId: number | null;
-	isOdysseyStats?: boolean;
+	isOdysseyStats: boolean;
 }
 
-export interface PurchaseNoticesProps {
-	siteId: number | null;
+export interface PurchaseNoticesProps extends NewStatsNoticesProps {
 	statsPurchaseSuccess: string | undefined;
 }


### PR DESCRIPTION
Related to #79652 

## Proposed Changes

The PR proposes to remove `statsPurchaseSuccess` on purchase success notices rendering, so that the purchase notices would show only once and the notices wouldn't show up again by sharing links of the page or by refreshing.

## Testing Instructions

* Open Calypso Live Branch `/stats/day/:siteSlug?statsPurchaseSuccess=paid`
* Ensure `statsPurchaseSuccess` is removed after loading finished
* Refresh the page, the purchase success notice does not show up again

Repeat the above steps for Odyssey Stats.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
