### PR TITLE
E2E: run Likes: Post spec for branch and release.

### DIFF
--- a/test/e2e/specs/published-content/likes__post.ts
+++ b/test/e2e/specs/published-content/likes__post.ts
@@ -1,5 +1,7 @@
 /**
  * @group gutenberg
+ * @group calypso-pr
+ * @group calypso-release
  */
 
 import {
@@ -51,7 +53,7 @@ describe( 'Likes: Post', function () {
 		);
 	} );
 
-	describe( 'As the posting user', function () {
+	describe( 'While authenticated', function () {
 		let publishedPostPage: PublishedPostPage;
 
 		it( 'View post', async function () {
@@ -75,7 +77,7 @@ describe( 'Likes: Post', function () {
 		} );
 	} );
 
-	describe( 'As an unrelated user', function () {
+	describe( 'While unauthenticated', function () {
 		let newPage: Page;
 		let publishedPostPage: PublishedPostPage;
 
@@ -94,10 +96,8 @@ describe( 'Likes: Post', function () {
 				await otherUser.logInViaPopupPage( popup );
 			} );
 
-			await ElementHelper.reloadAndRetry( newPage, async () => {
-				publishedPostPage = new PublishedPostPage( newPage );
-				await publishedPostPage.likePost();
-			} );
+			publishedPostPage = new PublishedPostPage( newPage );
+			await publishedPostPage.likePost();
 		} );
 	} );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/32083.

## Proposed Changes

This PR tries to prevent regression in the Likes: Post spec that occurred in https://github.com/Automattic/jetpack/issues/32083. 

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
