### PR TITLE
CI: add retry to Desktop App E2E as well as filter based on changed file path criteria.

### DIFF
--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -101,20 +101,11 @@ object E2ETests : BuildType({
 				Xvfb ${'$'}{DISPLAY} -screen 0 1280x1024x24 &
 
 				echo "Base URL is '${'$'}WP_DESKTOP_BASE_URL'"
-				# Run tests
-				cd desktop
 
-				# Disable exit on error to support retries.
-				set +o errexit
+				cd desktop
 
 				# Run tests
 				yarn run test:e2e --reporters=jest-teamcity --reporters=default
-
-				# Restore exit on error.
-				set -o errexit
-
-				# Retry failed tests only.
-				yarn run test:e2e --reporters=jest-teamcity --reporters=default --onlyFailures
 			"""
 			dockerImage = "%docker_image_desktop%"
 			// See https://stackoverflow.com/a/53975412 and https://blog.jessfraz.com/post/how-to-use-new-docker-seccomp-profiles/

--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -13,6 +13,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.notifications
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.retryBuild
 
 object DesktopApp : Project({
 	id("WpDesktop")


### PR DESCRIPTION
## Proposed Changes

This PR makes a couple of changes to the Desktop App E2E configuration:
- add retry to Desktop App E2E.
- add exclude trigger to filter out unnecessary builds.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Unit Test
  - [x] Desktop App E2E

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
