### PR TITLE
Consolidate help center toggles between checkout and thank you pages

### DIFF
--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -1,27 +1,19 @@
 import { WordPressWordmark } from '@automattic/components';
 import { checkoutTheme, CheckoutModal } from '@automattic/composite-checkout';
-import { HelpCenter } from '@automattic/data-stores';
-import { HelpIcon } from '@automattic/help-center';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { ThemeProvider } from '@emotion/react';
-import {
-	useSelect as useDataStoreSelect,
-	useDispatch as useDataStoreDispatch,
-} from '@wordpress/data';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import AkismetLogo from 'calypso/components/akismet-logo';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import { DefaultMasterbarContact } from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url';
 import { leaveCheckout } from 'calypso/my-sites/checkout/composite-checkout/lib/leave-checkout';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import Item from './item';
 import Masterbar from './masterbar';
-import type { HelpCenterSelect } from '@automattic/data-stores';
-
-const HELP_CENTER_STORE = HelpCenter.register();
 
 interface Props {
 	title: string;
@@ -59,12 +51,6 @@ const CheckoutMasterbar = ( {
 	const cartKey = useCartKey();
 	const { responseCart, replaceProductsInCart } = useShoppingCart( cartKey );
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
-	const { setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
-
-	const isShowingHelpCenter = useDataStoreSelect(
-		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
-		[]
-	);
 
 	const closeAndLeave = () =>
 		leaveCheckout( {
@@ -122,17 +108,7 @@ const CheckoutMasterbar = ( {
 				<span className="masterbar__secure-checkout-text">{ translate( 'Secure checkout' ) }</span>
 			</div>
 			{ title && <Item className="masterbar__item-title">{ title }</Item> }
-			{ loadHelpCenterIcon && (
-				<Item
-					onClick={ () => setShowHelpCenter( ! isShowingHelpCenter ) }
-					className={ classnames( 'masterbar__item-help', {
-						'is-active': isShowingHelpCenter,
-					} ) }
-					icon={ <HelpIcon /> }
-				>
-					{ translate( 'Help' ) }
-				</Item>
-			) }
+			{ loadHelpCenterIcon && <DefaultMasterbarContact /> }
 			<CheckoutModal
 				title={ modalTitleText }
 				copy={ modalBodyText }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -74,8 +74,12 @@ $masterbar-color-secondary: #101517;
 		background-color: var(--studio-white);
 		border-bottom: none 0;
 		color: var(--color-checkout-masterbar-text);
-		height: var(--masterbar-checkout-height);
+		height: var(--masterbar-height);
 		position: absolute;
+
+		@include break-mobile {
+			height: var(--masterbar-checkout-height);
+		}
 
 		@include breakpoint-deprecated( ">960px" ) {
 			background-color: var(--color-checkout-masterbar-background);
@@ -232,8 +236,12 @@ $masterbar-color-secondary: #101517;
 	justify-content: center;
 
 	.masterbar--is-checkout & {
-		height: var(--masterbar-checkout-height);
-		line-height: var(--masterbar-checkout-height);
+		height: var(--masterbar-height);
+		line-height: var(--masterbar-height);
+		@include break-mobile {
+			height: var(--masterbar-checkout-height);
+			line-height: var(--masterbar-checkout-height);
+		}
 	}
 
 	&:visited {
@@ -870,7 +878,11 @@ a.masterbar__quick-language-switcher {
 .masterbar__secure-checkout {
 	display: flex;
 	align-items: center;
-	margin-left: 24px;
+	margin-left: 12px;
+
+	@include break-mobile {
+		margin-left: 24px;
+	}
 
 	.masterbar__wpcom-wordmark {
 		color: var(--color-checkout-masterbar-text);

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -913,29 +913,8 @@ a.masterbar__quick-language-switcher {
 .masterbar__item-help {
 	padding: 0 11px;
 
-	.masterbar--is-checkout & {
-		padding: 0 24px;
-
-		@include breakpoint-deprecated( "<480px" ) {
-			display: none;
-		}
-
-		&.is-active {
-			background: var(--color-checkout-masterbar-item-hover-background);
-		}
-
-		&:focus {
-			box-shadow: none;
-		}
-	}
-
 	svg {
 		fill: var(--color-masterbar-text);
-
-		.masterbar--is-checkout & {
-			fill: var(--color-checkout-masterbar-text);
-			margin-right: 6px;
-		}
 	}
 }
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -878,11 +878,7 @@ a.masterbar__quick-language-switcher {
 .masterbar__secure-checkout {
 	display: flex;
 	align-items: center;
-	margin-left: 12px;
-
-	@include break-mobile {
-		margin-left: 24px;
-	}
+	margin-left: 24px;
 
 	.masterbar__wpcom-wordmark {
 		color: var(--color-checkout-masterbar-text);
@@ -897,6 +893,11 @@ a.masterbar__quick-language-switcher {
 
 	.masterbar__akismet-wordmark {
 		margin: 0 5px;
+	}
+
+	.masterbar__close-button {
+		flex: initial;
+		width: initial;
 	}
 
 	.masterbar__secure-checkout-text {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -898,6 +898,11 @@ a.masterbar__quick-language-switcher {
 	.masterbar__close-button {
 		flex: initial;
 		width: initial;
+		margin-right: 10px;
+
+		@include break-mobile {
+			margin-right: 0;
+		}
 	}
 
 	.masterbar__secure-checkout-text {

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -861,7 +861,11 @@ const WPCheckoutMainContent = styled.div`
 const WPCheckoutSidebarContent = styled.div`
 	background: ${ ( props ) => props.theme.colors.background };
 	grid-area: sidebar-content;
-	margin-top: var( --masterbar-checkout-height );
+	margin-top: var( --masterbar-height );
+
+	@media ( ${ ( props ) => props.theme.breakpoints.bigPhoneUp } ) {
+		margin-top: var( --masterbar-checkout-height );
+	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		margin-top: 0;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3233

## Proposed Changes

* Consolidates help center toggle for checkout and thank you page.
* Replaces "? Help" toggle with the "Need Extra Help" link from the thank you page redesign.

## Testing Instructions

* Checkout should show the new help center toggle found in the redesigned thank you pages
* Enter the checkout from anywhere e.g. plans page http://calypso.localhost:3000/checkout/premium
* Check mobile styling
* Check other flows like [jetpack](http://calypso.localhost:3000/checkout/jetpack/jetpack_security_t1_yearly?source=jetpack-plans) / [akismet](http://calypso.localhost:3000/checkout/akismet/ak_plus_yearly_1).

WP before / after

![Screenshot 2023-07-27 at 16-32-20 Checkout — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/b05dfea9-b7b2-45cc-bf6a-d6c2a790c882)
![Screenshot 2023-07-27 at 16-32-07 Checkout — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/78965d41-6d98-4c69-a136-5edccd977788)

## Mobile
### WP

| Before  | After | After (help center) |
| :-------------: | :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/3dea613f-0c44-48c7-8af1-82a34373546f">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/45c150b8-9093-42ea-92e5-043fceb053af"> | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/12f1fcf7-42fc-4f88-be13-baa05e5bc15c"> |

### Jetpack

| Before  | After | After (help center) |
| :-------------: | :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/09f20c75-d92d-4984-8130-e820792471c6">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/93a8a1a3-4307-40a8-b764-ae6c488cfff7"> | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/60799242-52de-42ec-b386-bea192427442"> |

### Akismet

| Before  | After | After (help center) |
| :-------------: | :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/0062b615-a529-4338-acf3-763a7c97b1c5">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/b22221c1-dfc2-4518-9497-08afcd723159"> | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/eca25c96-d6ea-4fe8-8470-183adb77a0eb"> |

