### PR TITLE
Revert "Revert "Plans 2023: add sticky behaviour to the CTA bar""

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -7,8 +7,10 @@ import {
 	TERM_TRIENNIALLY,
 	planMatches,
 	TERM_ANNUALLY,
+	PlanSlug,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import { formatCurrency } from '@automattic/format-currency';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
@@ -18,6 +20,7 @@ import ExternalLinkWithTracking from 'calypso/components/external-link/with-trac
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getPlanBillPeriod } from 'calypso/state/plans/selectors';
+import { usePlanPricesDisplay } from '../hooks/use-plan-prices-display';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import type { PlanActionOverrides } from '../types';
 
@@ -34,13 +37,18 @@ type PlanFeaturesActionsButtonProps = {
 	isLaunchPage?: boolean | null;
 	onUpgradeClick: () => void;
 	planName: TranslateResult;
-	planType: string;
+	planSlug: string;
 	flowName?: string | null;
 	buttonText?: string;
 	isWpcomEnterpriseGridPlan: boolean;
 	isWooExpressPlusPlan?: boolean;
 	selectedSiteSlug: string | null;
 	planActionOverrides?: PlanActionOverrides;
+	showMonthlyPrice: boolean;
+	siteId?: number | null;
+	isStuck: boolean;
+	isLargeCurrency?: boolean;
+	currencyCode: string;
 };
 
 const DummyDisabledButton = styled.div`
@@ -59,11 +67,17 @@ const SignupFlowPlanFeatureActionButton = ( {
 	freePlan,
 	planName,
 	classes,
+	priceString,
+	isStuck,
+	isLargeCurrency,
 	handleUpgradeButtonClick,
 }: {
 	freePlan: boolean;
 	planName: TranslateResult;
 	classes: string;
+	priceString: string | null;
+	isStuck: boolean;
+	isLargeCurrency: boolean;
 	handleUpgradeButtonClick: () => void;
 } ) => {
 	const translate = useTranslate();
@@ -71,6 +85,15 @@ const SignupFlowPlanFeatureActionButton = ( {
 
 	if ( freePlan ) {
 		btnText = translate( 'Start with Free' );
+	} else if ( isStuck && ! isLargeCurrency ) {
+		btnText = translate( 'Get %(plan)s – %(priceString)s', {
+			args: {
+				plan: planName,
+				priceString: priceString ?? '',
+			},
+			comment:
+				'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Get Premium - $10',
+		} );
 	} else {
 		btnText = translate( 'Get %(plan)s', {
 			args: {
@@ -90,11 +113,17 @@ const LaunchPagePlanFeatureActionButton = ( {
 	freePlan,
 	planName,
 	classes,
+	priceString,
+	isStuck,
+	isLargeCurrency,
 	handleUpgradeButtonClick,
 }: {
 	freePlan: boolean;
 	planName: TranslateResult;
 	classes: string;
+	priceString: string | null;
+	isStuck: boolean;
+	isLargeCurrency: boolean;
 	handleUpgradeButtonClick: () => void;
 } ) => {
 	const translate = useTranslate();
@@ -110,16 +139,31 @@ const LaunchPagePlanFeatureActionButton = ( {
 		);
 	}
 
+	let buttonText;
+
+	if ( isStuck && ! isLargeCurrency ) {
+		buttonText = translate( 'Select %(plan)s – %(priceString)s', {
+			args: {
+				plan: planName,
+				priceString: priceString ?? '',
+			},
+			comment:
+				'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Select Premium - $10',
+		} );
+	} else {
+		buttonText = translate( 'Select %(plan)s', {
+			args: {
+				plan: planName,
+			},
+			context: 'Button to select a paid plan by plan name, e.g., "Select Personal"',
+			comment:
+				'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
+		} );
+	}
+
 	return (
 		<Button className={ classes } onClick={ handleUpgradeButtonClick }>
-			{ translate( 'Select %(plan)s', {
-				args: {
-					plan: planName,
-				},
-				context: 'Button to select a paid plan by plan name, e.g., "Select Personal"',
-				comment:
-					'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
-			} ) }
+			{ buttonText }
 		</Button>
 	);
 };
@@ -128,8 +172,12 @@ const LoggedInPlansFeatureActionButton = ( {
 	freePlan,
 	availableForPurchase,
 	classes,
+	priceString,
+	isStuck,
+	isLargeCurrency,
+	planName,
 	handleUpgradeButtonClick,
-	planType,
+	planSlug,
 	current,
 	manageHref,
 	canUserPurchasePlan,
@@ -140,8 +188,12 @@ const LoggedInPlansFeatureActionButton = ( {
 	freePlan: boolean;
 	availableForPurchase?: boolean;
 	classes: string;
+	priceString: string | null;
+	isStuck: boolean;
+	isLargeCurrency: boolean;
+	planName: TranslateResult;
 	handleUpgradeButtonClick: () => void;
-	planType: string;
+	planSlug: string;
 	current?: boolean;
 	manageHref?: string;
 	canUserPurchasePlan?: boolean | null;
@@ -155,7 +207,7 @@ const LoggedInPlansFeatureActionButton = ( {
 		return currentSitePlanSlug ? getPlanBillPeriod( state, currentSitePlanSlug ) : null;
 	} );
 	const gridPlanBillPeriod = useSelector( ( state ) => {
-		return planType ? getPlanBillPeriod( state, planType ) : null;
+		return planSlug ? getPlanBillPeriod( state, planSlug ) : null;
 	} );
 
 	if ( freePlan ) {
@@ -178,7 +230,7 @@ const LoggedInPlansFeatureActionButton = ( {
 		);
 	}
 
-	if ( current && planType !== PLAN_P2_FREE ) {
+	if ( current && planSlug !== PLAN_P2_FREE ) {
 		return (
 			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
 				{ canUserPurchasePlan ? translate( 'Manage plan' ) : translate( 'View plan' ) }
@@ -212,10 +264,10 @@ const LoggedInPlansFeatureActionButton = ( {
 		availableForPurchase &&
 		currentSitePlanSlug &&
 		! current &&
-		getPlanClass( planType ) === getPlanClass( currentSitePlanSlug ) &&
+		getPlanClass( planSlug ) === getPlanClass( currentSitePlanSlug ) &&
 		! isTrialPlan
 	) {
-		if ( planMatches( planType, { term: TERM_TRIENNIALLY } ) ) {
+		if ( planMatches( planSlug, { term: TERM_TRIENNIALLY } ) ) {
 			return (
 				<Button className={ classes } onClick={ handleUpgradeButtonClick }>
 					{ buttonText || translate( 'Upgrade to Triennial' ) }
@@ -223,7 +275,7 @@ const LoggedInPlansFeatureActionButton = ( {
 			);
 		}
 
-		if ( planMatches( planType, { term: TERM_BIENNIALLY } ) ) {
+		if ( planMatches( planSlug, { term: TERM_BIENNIALLY } ) ) {
 			return (
 				<Button className={ classes } onClick={ handleUpgradeButtonClick }>
 					{ buttonText || translate( 'Upgrade to Biennial' ) }
@@ -231,7 +283,7 @@ const LoggedInPlansFeatureActionButton = ( {
 			);
 		}
 
-		if ( planMatches( planType, { term: TERM_ANNUALLY } ) ) {
+		if ( planMatches( planSlug, { term: TERM_ANNUALLY } ) ) {
 			return (
 				<Button className={ classes } onClick={ handleUpgradeButtonClick }>
 					{ buttonText || translate( 'Upgrade to Yearly' ) }
@@ -240,7 +292,25 @@ const LoggedInPlansFeatureActionButton = ( {
 		}
 	}
 
-	const buttonTextFallback = buttonText ?? translate( 'Upgrade', { context: 'verb' } );
+	let buttonTextFallback;
+
+	if ( buttonText ) {
+		buttonTextFallback = buttonText;
+	} else if ( isStuck && ! isLargeCurrency ) {
+		buttonTextFallback = translate( 'Upgrade – %(priceString)s', {
+			context: 'verb',
+			args: { priceString: priceString ?? '' },
+			comment: '%(priceString)s is the full price including the currency. Eg: Get Upgrade - $10',
+		} );
+	} else if ( isStuck && isLargeCurrency ) {
+		buttonTextFallback = translate( 'Upgrade – %(plan)s', {
+			context: 'verb',
+			args: { plan: planName ?? '' },
+			comment: '%(plan)s is the name of the plan ',
+		} );
+	} else {
+		buttonTextFallback = translate( 'Upgrade', { context: 'verb' } );
+	}
 
 	if ( availableForPurchase ) {
 		return (
@@ -278,13 +348,18 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	isLaunchPage,
 	onUpgradeClick,
 	planName,
-	planType,
+	planSlug,
 	flowName,
 	buttonText,
 	isWpcomEnterpriseGridPlan = false,
 	isWooExpressPlusPlan = false,
 	selectedSiteSlug,
 	planActionOverrides,
+	showMonthlyPrice,
+	siteId,
+	currencyCode,
+	isStuck,
+	isLargeCurrency,
 } ) => {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
@@ -293,11 +368,18 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 		'is-current-plan': current,
 	} );
 
+	const planPrices = usePlanPricesDisplay( {
+		planSlug: planSlug as PlanSlug,
+		returnMonthly: showMonthlyPrice,
+		currentSitePlanSlug,
+		siteId,
+	} );
+
 	const handleUpgradeButtonClick = () => {
 		if ( ! freePlan ) {
 			recordTracksEvent( 'calypso_plan_features_upgrade_click', {
 				current_plan: currentSitePlanSlug,
-				upgrading_to: planType,
+				upgrading_to: planSlug,
 			} );
 		}
 
@@ -333,7 +415,9 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 					  } ) }
 			</Button>
 		);
-	} else if ( isWooExpressPlusPlan ) {
+	}
+
+	if ( isWooExpressPlusPlan ) {
 		return (
 			<ExternalLinkWithTracking
 				className={ classNames( classes ) }
@@ -345,21 +429,38 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 				{ translate( 'Get in touch' ) }
 			</ExternalLinkWithTracking>
 		);
-	} else if ( isLaunchPage ) {
+	}
+
+	const priceString = formatCurrency(
+		planPrices.discountedPrice || planPrices.originalPrice,
+		currencyCode || 'USD',
+		{
+			stripZeros: true,
+		}
+	);
+
+	if ( isLaunchPage ) {
 		return (
 			<LaunchPagePlanFeatureActionButton
 				freePlan={ freePlan }
 				planName={ planName }
 				classes={ classes }
+				priceString={ priceString }
+				isStuck={ isStuck }
+				isLargeCurrency={ !! isLargeCurrency }
 				handleUpgradeButtonClick={ handleUpgradeButtonClick }
 			/>
 		);
-	} else if ( isInSignup ) {
+	}
+	if ( isInSignup ) {
 		return (
 			<SignupFlowPlanFeatureActionButton
 				freePlan={ freePlan }
 				planName={ planName }
 				classes={ classes }
+				priceString={ priceString }
+				isStuck={ isStuck }
+				isLargeCurrency={ !! isLargeCurrency }
 				handleUpgradeButtonClick={ handleUpgradeButtonClick }
 			/>
 		);
@@ -371,7 +472,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			availableForPurchase={ availableForPurchase }
 			classes={ classes }
 			handleUpgradeButtonClick={ handleUpgradeButtonClick }
-			planType={ planType }
+			planSlug={ planSlug }
 			current={ current }
 			manageHref={ manageHref }
 			canUserPurchasePlan={ canUserPurchasePlan }
@@ -379,6 +480,10 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			buttonText={ buttonText }
 			selectedSiteSlug={ selectedSiteSlug }
 			planActionOverrides={ planActionOverrides }
+			priceString={ priceString }
+			isStuck={ isStuck }
+			isLargeCurrency={ !! isLargeCurrency }
+			planName={ planName }
 		/>
 	);
 };

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -467,11 +467,14 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 				isInSignup={ isInSignup }
 				isLaunchPage={ isLaunchPage }
 				planName={ planConstantObj.getTitle() }
-				planType={ planName }
+				planSlug={ planName }
 				flowName={ flowName }
 				selectedSiteSlug={ selectedSiteSlug }
 				onUpgradeClick={ () => onUpgradeClick( planProperties ) }
 				planActionOverrides={ planActionOverrides }
+				currencyCode=""
+				showMonthlyPrice={ false }
+				isStuck={ false }
 			/>
 		</Cell>
 	);

--- a/client/my-sites/plan-features-2023-grid/components/sticky-container.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/sticky-container.tsx
@@ -1,0 +1,84 @@
+import { Global, css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { useRef, type ElementType, useState, useLayoutEffect, ReactNode } from 'react';
+
+type Props = {
+	children: ( isStuck: boolean ) => ReactNode;
+	stickyClass?: string;
+	element?: ElementType;
+	stickyOffset?: number; // offset from the top of the scrolling container to control when the element should start sticking, default 0
+	topOffset?: number; // offset from the top of the scrolling container to control the position of the sticky element, default 0
+};
+
+const Container = styled.div< { topOffset: number } >`
+	position: sticky;
+	top: ${ ( props ) => props.topOffset + 'px' };
+	z-index: 1;
+`;
+
+export function StickyContainer( props: Props ) {
+	const { stickyOffset = 0, topOffset = 0, stickyClass = '', element = 'div', children } = props;
+
+	const stickyRef = useRef( null );
+	const [ isStuck, setIsStuck ] = useState( false );
+
+	/**
+	 * This effect sets the value of `isStuck` state when it detects that
+	 * the element is sticky.
+	 * The top property of the root margin is set at -1px (plus optional offset).
+	 * So when position:sticky takes effect, the intersection ratio will always be ~99%
+	 */
+	useLayoutEffect( () => {
+		const observer = new IntersectionObserver(
+			( [ entry ] ) => {
+				if ( entry.intersectionRatio === 0 ) {
+					// The element is out of view
+					setIsStuck( false );
+				} else if ( entry.intersectionRect.bottom === entry.rootBounds?.bottom ) {
+					// The element is intersecting, but it is at the bottom of the screen
+					setIsStuck( false );
+				} else {
+					// The element is in the "stuck" state
+					setIsStuck( entry.intersectionRatio < 1 );
+				}
+			},
+			{
+				rootMargin: `-${ stickyOffset + 1 }px 0px 0px 0px`,
+				threshold: [ 0, 1 ],
+			}
+		);
+
+		if ( stickyRef.current ) {
+			observer.observe( stickyRef.current );
+		}
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [ stickyOffset ] );
+
+	return (
+		<>
+			<Global
+				styles={ css`
+					/**
+				 * .layout__content has overflow set to hidden, which prevents position: sticky from working.
+				 * Instead of removing it globally, this CSS only unsets the property when this component is rendered.
+				 */
+					.layout__content {
+						overflow: unset;
+					}
+				` }
+			/>
+			<Container
+				{ ...props }
+				as={ element }
+				ref={ stickyRef }
+				topOffset={ topOffset }
+				className={ isStuck ? stickyClass : '' }
+			>
+				{ children( isStuck ) }
+			</Container>
+		</>
+	);
+}

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -61,6 +61,7 @@ import { PlanFeaturesItem } from './components/item';
 import { PlanComparisonGrid } from './components/plan-comparison-grid';
 import { Plans2023Tooltip } from './components/plans-2023-tooltip';
 import PopularBadge from './components/popular-badge';
+import { StickyContainer } from './components/sticky-container';
 import { StorageAddOnDropdown } from './components/storage-add-on-dropdown';
 import PlansGridContextProvider, { usePlansGridContext } from './grid-context';
 import useHighlightAdjacencyMatrix from './hooks/npm-ready/use-highlight-adjacency-matrix';
@@ -76,6 +77,7 @@ import './style.scss';
 
 type PlanRowOptions = {
 	isTableCell?: boolean;
+	isStuck?: boolean;
 };
 
 export type PlanSelectedStorage = { [ key: string ]: WPComStorageAddOnSlug | null };
@@ -120,6 +122,7 @@ export type PlanFeatures2023GridProps = {
 	showLegacyStorageFeature?: boolean;
 	spotlightPlanSlug?: PlanSlug;
 	showUpgradeableStorage: boolean; // feature flag used to show the storage add-on dropdown
+	stickyRowOffset: number;
 };
 
 type PlanFeatures2023GridConnectedProps = {
@@ -356,7 +359,7 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderTable( planProperties: PlanProperties[] ) {
-		const { translate, spotlightPlanSlug } = this.props;
+		const { translate, spotlightPlanSlug, stickyRowOffset, isInSignup } = this.props;
 
 		// Do not render the spotlight plan if it exists
 		const planPropertiesToRender = planProperties.filter(
@@ -379,7 +382,16 @@ export class PlanFeatures2023Grid extends Component<
 					<tr>{ this.renderPlanTagline( planPropertiesToRender, { isTableCell: true } ) }</tr>
 					<tr>{ this.renderPlanPrice( planPropertiesToRender, { isTableCell: true } ) }</tr>
 					<tr>{ this.renderBillingTimeframe( planPropertiesToRender, { isTableCell: true } ) }</tr>
-					<tr>{ this.renderTopButtons( planPropertiesToRender, { isTableCell: true } ) }</tr>
+					<StickyContainer
+						stickyClass="is-sticky-top-buttons-row"
+						element="tr"
+						stickyOffset={ stickyRowOffset }
+						topOffset={ stickyRowOffset + ( isInSignup ? 0 : 20 ) }
+					>
+						{ ( isStuck: boolean ) =>
+							this.renderTopButtons( planPropertiesToRender, { isTableCell: true, isStuck } )
+						}
+					</StickyContainer>
 					<tr>{ this.maybeRenderRefundNotice( planPropertiesToRender, { isTableCell: true } ) }</tr>
 					<tr>
 						{ this.renderPreviousFeaturesIncludedTitle( planPropertiesToRender, {
@@ -701,12 +713,14 @@ export class PlanFeatures2023Grid extends Component<
 			selectedSiteSlug,
 			translate,
 			planActionOverrides,
+			siteId,
+			isLargeCurrency,
 		} = this.props;
 
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( properties: PlanProperties ) => {
-				const { planName, planConstantObj, current } = properties;
+				const { planName, planConstantObj, current, currencyCode } = properties;
 				const classes = classNames(
 					'plan-features-2023-grid__table-item',
 					'is-top-buttons',
@@ -742,13 +756,18 @@ export class PlanFeatures2023Grid extends Component<
 							isLaunchPage={ isLaunchPage }
 							onUpgradeClick={ () => this.handleUpgradeClick( properties ) }
 							planName={ planConstantObj.getTitle() }
-							planType={ planName }
+							planSlug={ planName }
 							flowName={ flowName }
 							current={ current ?? false }
 							currentSitePlanSlug={ currentSitePlanSlug }
 							selectedSiteSlug={ selectedSiteSlug }
 							buttonText={ buttonText }
 							planActionOverrides={ planActionOverrides }
+							showMonthlyPrice={ true }
+							siteId={ siteId }
+							isStuck={ options?.isStuck || false }
+							isLargeCurrency={ isLargeCurrency }
+							currencyCode={ currencyCode || 'USD' }
 						/>
 					</Container>
 				);

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -406,6 +406,10 @@ $mobile-card-max-width: 440px;
 		&.is-top-buttons {
 			padding: 0 20px;
 			vertical-align: bottom;
+			@include plans-2023-break-small {
+				padding-top: 16px;
+				padding-bottom: 16px;
+			}
 		}
 
 		@include plans-2023-break-small {
@@ -584,7 +588,7 @@ body.is-section-signup.is-white-signup,
 			padding: 0 19px 24px 20px;
 
 			@include plans-2023-break-small {
-				padding-bottom: 16px;
+				padding-bottom: 0;
 			}
 
 			.plan-features-2023-grid__vip-price {
@@ -720,7 +724,7 @@ body.is-section-signup.is-white-signup,
 			margin-bottom: 12px;
 
 			@include plans-2023-break-small {
-				margin-top: 36px;
+				margin-top: 20px;
 				font-size: $font-body-extra-small;
 			}
 
@@ -738,6 +742,17 @@ body.is-section-signup.is-white-signup,
 
 			&.is-ecommerce-plan {
 				color: #55347d;
+			}
+		}
+	}
+
+	.is-sticky-top-buttons-row {
+		.is-top-buttons.plan-features-2023-grid__table-item {
+			border: none;
+			background-color: #f9f9f9;
+			box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.04);
+			.plan-features-2023-grid__actions-button {
+				font-size: rem(12px);
 			}
 		}
 	}

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -12,7 +12,7 @@ import {
 import { Button } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useLayoutEffect, useState } from '@wordpress/element';
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -190,6 +190,44 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		) as PlanSlug | undefined;
 	}
 
+	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
+
+	/**
+	 * Calculates the height of the masterbar if it exists, and passes it to the component as an offset
+	 * for the sticky CTA bar.
+	 */
+	useLayoutEffect( () => {
+		const masterbarElement = document.querySelector< HTMLDivElement >( 'header.masterbar' );
+
+		if ( ! masterbarElement ) {
+			return;
+		}
+
+		if ( ! window.ResizeObserver ) {
+			setMasterbarHeight( masterbarElement.offsetHeight );
+			return;
+		}
+
+		let lastHeight = masterbarElement.offsetHeight;
+
+		const observer = new ResizeObserver(
+			( [ masterbar ]: Parameters< ResizeObserverCallback >[ 0 ] ) => {
+				const currentHeight = masterbar.contentRect.height;
+
+				if ( currentHeight !== lastHeight ) {
+					setMasterbarHeight( currentHeight );
+					lastHeight = currentHeight;
+				}
+			}
+		);
+
+		observer.observe( masterbarElement );
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [] );
+
 	const asyncProps: PlanFeatures2023GridProps = {
 		paidDomainName,
 		wpcomFreeDomainSuggestion,
@@ -214,6 +252,7 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		showLegacyStorageFeature,
 		spotlightPlanSlug,
 		showUpgradeableStorage,
+		stickyRowOffset: masterbarHeight,
 	};
 
 	const asyncPlanFeatures2023Grid = (


### PR DESCRIPTION
Reverts Automattic/wp-calypso#79905

* The original PR was #78940
* Reverted it via https://github.com/Automattic/wp-calypso/pull/79905 since strings were not translated.
* This PR is a "revert of a revert", and will be shipped once strings have been translated.

**Screenshots**
<img width="1907" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/639a1ac6-d259-421b-915c-4263e0772773">

<img width="1603" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/1e6580d6-2a3f-493a-a143-4a65ccba4cc5">

<img width="1904" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/b073b6ef-3c13-41b5-86be-65b5f1ae6b6f">

