### PR TITLE
Migration Trial: Update plans page upgrade button

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -1,6 +1,7 @@
 import {
 	getPlanClass,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_MIGRATION_TRIAL_MONTHLY,
 	PLAN_P2_FREE,
 	TERM_BIENNIALLY,
 	TERM_TRIENNIALLY,
@@ -185,12 +186,16 @@ const LoggedInPlansFeatureActionButton = ( {
 		);
 	}
 
+	const isTrialPlan =
+		currentSitePlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY ||
+		currentSitePlanSlug === PLAN_MIGRATION_TRIAL_MONTHLY;
+
 	// If the current plan is on a higher-term but lower-tier, then show a "Contact support" button.
 	if (
 		availableForPurchase &&
 		currentSitePlanSlug &&
 		! current &&
-		currentSitePlanSlug !== PLAN_ECOMMERCE_TRIAL_MONTHLY &&
+		! isTrialPlan &&
 		currentPlanBillPeriod &&
 		gridPlanBillPeriod &&
 		currentPlanBillPeriod > gridPlanBillPeriod
@@ -208,7 +213,7 @@ const LoggedInPlansFeatureActionButton = ( {
 		currentSitePlanSlug &&
 		! current &&
 		getPlanClass( planType ) === getPlanClass( currentSitePlanSlug ) &&
-		currentSitePlanSlug !== PLAN_ECOMMERCE_TRIAL_MONTHLY
+		! isTrialPlan
 	) {
 		if ( planMatches( planType, { term: TERM_TRIENNIALLY } ) ) {
 			return (


### PR DESCRIPTION
For an explanation of the issue, see https://github.com/Automattic/wp-calypso/pull/72836

Related to https://github.com/Automattic/wp-calypso/pull/72836
Fixes https://github.com/Automattic/wp-calypso/issues/79527

## Proposed Changes

* Add a Migration Trial button case

## Testing Instructions

1. Create a JN site
2. Connect Jetpack
3. Start the usual migration workflow but choose the "free" button (see https://github.com/Automattic/wp-calypso/pull/79731 for info)
4. Navigate to `/plans/__SLUG__`
5. Select "Pay annually"
6. You should see the "Upgrade button" in the "Business" and "Commerce" columns
7. This should be repeated for a WooCommerce Trial site too

**Important**: an `isTrialPlan` function should be created in the `client/state/sites/plans/selectors/trials` path. So this can be used in all the parts of codes where a generic check must be performed.

## Before
![before](https://github.com/Automattic/wp-calypso/assets/167611/0f3c4e88-3743-4b4e-8ac7-aa414a3f11e0)

## After
![after](https://github.com/Automattic/wp-calypso/assets/167611/469b2a0a-f91e-4a8a-a4df-fed943280054)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
