### PR TITLE
Migration Trial: Users should not be able to launch sites on Migration Trial plan

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -50,7 +50,10 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { launchSite } from 'calypso/state/sites/launch/actions';
-import { isSiteOnECommerceTrial as getIsSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
+import {
+	isSiteOnECommerceTrial as getIsSiteOnECommerceTrial,
+	isSiteOnMigrationTrial as getIsSiteOnMigrationTrial,
+} from 'calypso/state/sites/plans/selectors';
 import {
 	getSiteOption,
 	isJetpackSite,
@@ -64,6 +67,7 @@ import {
 } from 'calypso/state/ui/selectors';
 import Masterbar from './masterbar';
 import SiteIconSetting from './site-icon-setting';
+import TrialUpsellNotice from './trial-upsell-notice';
 import wrapSettingsForm from './wrap-settings-form';
 
 export class SiteSettingsFormGeneral extends Component {
@@ -577,6 +581,58 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
+	isLaunchable() {
+		const { isSiteOnECommerceTrial, isSiteOnMigrationTrial } = this.props;
+		return ! isSiteOnECommerceTrial && ! isSiteOnMigrationTrial;
+	}
+
+	recordTracksEventForTrialNoticeClick = () => {
+		const { recordTracksEvent, isSiteOnECommerceTrial } = this.props;
+		const eventName = isSiteOnECommerceTrial
+			? `calypso_ecommerce_trial_launch_banner_click`
+			: `calypso_migration_trial_launch_banner_click`;
+		recordTracksEvent( eventName );
+	};
+
+	getTrialUpsellNotice() {
+		const { translate, siteSlug, isSiteOnECommerceTrial, isSiteOnMigrationTrial } = this.props;
+		if ( this.isLaunchable() ) {
+			return null;
+		}
+		let noticeText;
+		if ( isSiteOnECommerceTrial ) {
+			noticeText = translate(
+				'Before you can share your store with the world, you need to {{a}}pick a plan{{/a}}.',
+				{
+					components: {
+						a: (
+							<a
+								href={ `/plans/${ siteSlug }` }
+								onClick={ this.recordTracksEventForTrialNoticeClick }
+							/>
+						),
+					},
+				}
+			);
+		} else if ( isSiteOnMigrationTrial ) {
+			noticeText = translate(
+				'Before you can share your stories with the world, you need to {{a}}pick a plan{{/a}}.',
+				{
+					components: {
+						a: (
+							<a
+								href={ `/plans/${ siteSlug }` }
+								onClick={ this.recordTracksEventForTrialNoticeClick }
+							/>
+						),
+					},
+				}
+			);
+		}
+
+		return noticeText && <TrialUpsellNotice text={ noticeText } />;
+	}
+
 	renderLaunchSite() {
 		const {
 			translate,
@@ -588,8 +644,6 @@ export class SiteSettingsFormGeneral extends Component {
 			fields,
 			hasSitePreviewLink,
 			site,
-			isSiteOnECommerceTrial,
-			recordTracksEvent,
 		} = this.props;
 
 		const launchSiteClasses = classNames( 'site-settings__general-settings-launch-site-button', {
@@ -598,15 +652,13 @@ export class SiteSettingsFormGeneral extends Component {
 		const btnText = translate( 'Launch site' );
 		let querySiteDomainsComponent;
 		let btnComponent;
-		let eCommerceTrialUpsell;
-		const isLaunchable = ! isSiteOnECommerceTrial;
 
 		if ( 0 === siteDomains.length ) {
 			querySiteDomainsComponent = <QuerySiteDomains siteId={ siteId } />;
 			btnComponent = <Button>{ btnText }</Button>;
 		} else if ( isPaidPlan && siteDomains.length > 1 ) {
 			btnComponent = (
-				<Button onClick={ this.props.launchSite } disabled={ ! isLaunchable }>
+				<Button onClick={ this.props.launchSite } disabled={ ! this.isLaunchable() }>
 					{ btnText }
 				</Button>
 			);
@@ -630,33 +682,11 @@ export class SiteSettingsFormGeneral extends Component {
 
 		const LaunchCard = showPreviewLink ? CompactCard : Card;
 
-		if ( isSiteOnECommerceTrial ) {
-			const recordTracksEventForClick = () =>
-				recordTracksEvent( 'calypso_ecommerce_trial_launch_banner_click' );
-			const eCommerceTrialUpsellText = translate(
-				'Before you can share your store with the world, you need to {{a}}pick a plan{{/a}}.',
-				{
-					components: {
-						a: <a href={ `/plans/${ siteSlug }` } onClick={ recordTracksEventForClick } />,
-					},
-				}
-			);
-			eCommerceTrialUpsell = (
-				<Notice
-					className="site-settings__ecommerce-trial-notice"
-					icon="info"
-					showDismiss={ false }
-					text={ eCommerceTrialUpsellText }
-					isCompact={ false }
-				/>
-			);
-		}
-
 		return (
 			<>
 				<SettingsSectionHeader title={ translate( 'Launch site' ) } />
 				<LaunchCard>
-					{ eCommerceTrialUpsell }
+					{ this.getTrialUpsellNotice() }
 					<div className="site-settings__general-settings-launch-site">
 						<div className="site-settings__general-settings-launch-site-text">
 							<p>
@@ -963,6 +993,7 @@ const connectComponent = connect( ( state ) => {
 		hasSubscriptionGifting: siteHasFeature( state, siteId, WPCOM_FEATURES_SUBSCRIPTION_GIFTING ),
 		hasSitePreviewLink: siteHasFeature( state, siteId, WPCOM_FEATURES_SITE_PREVIEW_LINKS ),
 		isSiteOnECommerceTrial: getIsSiteOnECommerceTrial( state, siteId ),
+		isSiteOnMigrationTrial: getIsSiteOnMigrationTrial( state, siteId ),
 	};
 }, mapDispatchToProps );
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -53,6 +53,7 @@ import { launchSite } from 'calypso/state/sites/launch/actions';
 import {
 	isSiteOnECommerceTrial as getIsSiteOnECommerceTrial,
 	isSiteOnMigrationTrial as getIsSiteOnMigrationTrial,
+	isTrialSite,
 } from 'calypso/state/sites/plans/selectors';
 import {
 	getSiteOption,
@@ -581,11 +582,6 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
-	isLaunchable() {
-		const { isSiteOnECommerceTrial, isSiteOnMigrationTrial } = this.props;
-		return ! isSiteOnECommerceTrial && ! isSiteOnMigrationTrial;
-	}
-
 	recordTracksEventForTrialNoticeClick = () => {
 		const { recordTracksEvent, isSiteOnECommerceTrial } = this.props;
 		const eventName = isSiteOnECommerceTrial
@@ -595,8 +591,9 @@ export class SiteSettingsFormGeneral extends Component {
 	};
 
 	getTrialUpsellNotice() {
-		const { translate, siteSlug, isSiteOnECommerceTrial, isSiteOnMigrationTrial } = this.props;
-		if ( this.isLaunchable() ) {
+		const { translate, siteSlug, isSiteOnECommerceTrial, isSiteOnMigrationTrial, isLaunchable } =
+			this.props;
+		if ( isLaunchable ) {
 			return null;
 		}
 		let noticeText;
@@ -641,6 +638,7 @@ export class SiteSettingsFormGeneral extends Component {
 			fields,
 			hasSitePreviewLink,
 			site,
+			isLaunchable,
 		} = this.props;
 
 		const launchSiteClasses = classNames( 'site-settings__general-settings-launch-site-button', {
@@ -655,7 +653,7 @@ export class SiteSettingsFormGeneral extends Component {
 			btnComponent = <Button>{ btnText }</Button>;
 		} else if ( isPaidPlan && siteDomains.length > 1 ) {
 			btnComponent = (
-				<Button onClick={ this.props.launchSite } disabled={ ! this.isLaunchable() }>
+				<Button onClick={ this.props.launchSite } disabled={ ! isLaunchable }>
 					{ btnText }
 				</Button>
 			);
@@ -991,6 +989,7 @@ const connectComponent = connect( ( state ) => {
 		hasSitePreviewLink: siteHasFeature( state, siteId, WPCOM_FEATURES_SITE_PREVIEW_LINKS ),
 		isSiteOnECommerceTrial: getIsSiteOnECommerceTrial( state, siteId ),
 		isSiteOnMigrationTrial: getIsSiteOnMigrationTrial( state, siteId ),
+		isLaunchable: ! isTrialSite( state, siteId ),
 	};
 }, mapDispatchToProps );
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -615,19 +615,16 @@ export class SiteSettingsFormGeneral extends Component {
 				}
 			);
 		} else if ( isSiteOnMigrationTrial ) {
-			noticeText = translate(
-				'Before you can share your stories with the world, you need to {{a}}pick a plan{{/a}}.',
-				{
-					components: {
-						a: (
-							<a
-								href={ `/plans/${ siteSlug }` }
-								onClick={ this.recordTracksEventForTrialNoticeClick }
-							/>
-						),
-					},
-				}
-			);
+			noticeText = translate( 'Ready to launch your site? {{a}}Upgrade to a paid plan{{/a}}.', {
+				components: {
+					a: (
+						<a
+							href={ `/plans/${ siteSlug }` }
+							onClick={ this.recordTracksEventForTrialNoticeClick }
+						/>
+					),
+				},
+			} );
 		}
 
 		return noticeText && <TrialUpsellNotice text={ noticeText } />;

--- a/client/my-sites/site-settings/trial-upsell-notice.jsx
+++ b/client/my-sites/site-settings/trial-upsell-notice.jsx
@@ -9,6 +9,7 @@ const TrialUpsellNotice = ( { text } ) => {
 			showDismiss={ false }
 			text={ text }
 			isCompact={ false }
+			status="is-warning"
 		/>
 	);
 };

--- a/client/my-sites/site-settings/trial-upsell-notice.jsx
+++ b/client/my-sites/site-settings/trial-upsell-notice.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Notice from 'calypso/components/notice';
+
+const TrialUpsellNotice = ( { text } ) => {
+	return (
+		<Notice
+			className="site-settings__trial-upsell-notice"
+			icon="info"
+			showDismiss={ false }
+			text={ text }
+			isCompact={ false }
+		/>
+	);
+};
+
+export default TrialUpsellNotice;

--- a/client/state/sites/plans/selectors/index.js
+++ b/client/state/sites/plans/selectors/index.js
@@ -23,3 +23,4 @@ export { default as isMigrationTrialExpired } from './trials/is-migration-trial-
 export { default as isSiteOnEcommerce } from './trials/is-site-on-ecommerce';
 export { default as isSiteOnECommerceTrial } from './trials/is-site-on-ecommerce-trial';
 export { default as isSiteOnWooExpressEcommerceTrial } from './is-site-on-woo-express-ecommerce-trial';
+export { default as isTrialSite } from './trials/is-trial-site';

--- a/client/state/sites/plans/selectors/trials/is-trial-site.ts
+++ b/client/state/sites/plans/selectors/trials/is-trial-site.ts
@@ -1,0 +1,13 @@
+import { isSiteOnMigrationTrial, isSiteOnECommerceTrial } from '..';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Checks whether the current site is on migration or eCommerce trial.
+ *
+ * @param {AppState} state Global state tree
+ * @param {number} siteId - Site ID
+ * @returns {boolean} Returns true if the site is on a trial
+ */
+export default function isTrialSite( state: AppState, siteId: number ): boolean {
+	return isSiteOnECommerceTrial( state, siteId ) || isSiteOnMigrationTrial( state, siteId );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79901

## Proposed Changes

* This PR is attempting to add the same behavior that Woo Trial has implemented on the launch site. The original PR can be found at: #72237
* Adds a nudge on the "Launch site" card to let the users know that to launch the site, they need to upgrade to an paid plan.
* This PR also refactor a bit so we can reuse the notice section that's use in Woo Trial. 
![Screen Shot 2023-07-28 at 10 20 05 AM](https://github.com/Automattic/wp-calypso/assets/4074459/949238b6-4e42-42f6-90bc-b733a0047b40)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On your site with the Migration trial plan, navigate to `/settings/general/{SITE}`
* Scroll down to the "Launch site" card.
* You should see the nudge inviting the user to upgrade to a paid plan.
* You can also click on the nudge, it should take you to the plans page.
* See if the track event `calypso_migration_trial_launch_banner_click` gets recorded correctly. 
* Do the same test for a WooExpress trial plan site and make sure nothing is broken.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
