### PR TITLE
Design Picker: add assembler CTA after category filter

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -546,6 +546,14 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		}
 	}
 
+	function clickDesignYourOwnTopButton( design: Design ) {
+		recordTracksEvent(
+			'calypso_signup_design_your_own_top_button_click',
+			getDesignEventProps( { flow, intent, design } )
+		);
+		designYourOwn( design, true );
+	}
+
 	function handleSubmit( providedDependencies?: ProvidedDependencies, optionalProps?: object ) {
 		const _selectedDesign = providedDependencies?.selectedDesign as Design;
 		if ( ! isAssemblerDesign( _selectedDesign ) ) {
@@ -735,6 +743,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			designs={ designs }
 			locale={ locale }
 			onDesignYourOwn={ designYourOwn }
+			onClickDesignYourOwnTopButton={ clickDesignYourOwnTopButton }
 			onPreview={ previewDesign }
 			onChangeVariation={ onChangeVariation }
 			onViewAllDesigns={ trackAllDesignsView }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -548,7 +548,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	function clickDesignYourOwnTopButton( design: Design ) {
 		recordTracksEvent(
-			'calypso_signup_design_your_own_top_button_click',
+			'calypso_signup_design_picker_design_your_own_top_button_click',
 			getDesignEventProps( { flow, intent, design } )
 		);
 		designYourOwn( design, true );

--- a/packages/design-picker/src/components/design-picker-category-filter/unified-design-picker-category-filter.tsx
+++ b/packages/design-picker/src/components/design-picker-category-filter/unified-design-picker-category-filter.tsx
@@ -4,12 +4,18 @@ import type { Category } from '../../types';
 import './style.scss';
 
 interface Props {
+	className: string;
 	categories: Category[];
 	selectedSlug: string | null;
 	onSelect: ( selectedSlug: string | null ) => void;
 }
 
-export function UnifiedDesignPickerCategoryFilter( { categories, onSelect, selectedSlug }: Props ) {
+export function UnifiedDesignPickerCategoryFilter( {
+	className,
+	categories,
+	onSelect,
+	selectedSlug,
+}: Props ) {
 	const onClick = ( index: number ) => {
 		const category = categories[ index ];
 
@@ -21,15 +27,14 @@ export function UnifiedDesignPickerCategoryFilter( { categories, onSelect, selec
 	};
 	const initialActiveIndex = categories.findIndex( ( { slug } ) => slug === selectedSlug );
 	return (
-		<div className="unified-design-picker-category-filter">
-			<ResponsiveToolbarGroup
-				initialActiveIndex={ initialActiveIndex !== -1 ? initialActiveIndex : 0 }
-				onClick={ onClick }
-			>
-				{ categories.map( ( category ) => (
-					<span key={ `category-${ category.slug }` }>{ category.name }</span>
-				) ) }
-			</ResponsiveToolbarGroup>
-		</div>
+		<ResponsiveToolbarGroup
+			className={ className }
+			initialActiveIndex={ initialActiveIndex !== -1 ? initialActiveIndex : 0 }
+			onClick={ onClick }
+		>
+			{ categories.map( ( category ) => (
+				<span key={ `category-${ category.slug }` }>{ category.name }</span>
+			) ) }
+		</ResponsiveToolbarGroup>
 	);
 }

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -22,6 +22,18 @@
 		flex-grow: 1;
 	}
 
+	.design-picker__filters {
+		display: flex;
+
+		.design-picker__category-filter {
+			flex: 1;
+		}
+
+		button {
+			height: 100%;
+		}
+	}
+
 	.design-picker__grid,
 	.design-picker__grid-minimal {
 		flex: 5;

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -189,6 +189,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 interface DesignPickerProps {
 	locale: string;
 	onDesignYourOwn: ( design: Design, shouldGoToAssemblerStep: boolean ) => void;
+	onClickDesignYourOwnTopButton: ( design: Design ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	designs: Design[];
@@ -201,6 +202,7 @@ interface DesignPickerProps {
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
 	onDesignYourOwn,
+	onClickDesignYourOwnTopButton,
 	onPreview,
 	onChangeVariation,
 	designs,
@@ -232,7 +234,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 					/>
 				) }
 				{ assemblerCtaData.shouldGoToAssemblerStep && (
-					<Button onClick={ () => onDesignYourOwn( DEFAULT_ASSEMBLER_DESIGN, true ) }>
+					<Button onClick={ () => onClickDesignYourOwnTopButton( DEFAULT_ASSEMBLER_DESIGN ) }>
 						{ assemblerCtaData.title }
 					</Button>
 				) }
@@ -271,6 +273,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 export interface UnifiedDesignPickerProps {
 	locale: string;
 	onDesignYourOwn: ( design: Design, shouldGoToAssemblerStep: boolean ) => void;
+	onClickDesignYourOwnTopButton: ( design: Design ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	onViewAllDesigns: () => void;
@@ -285,6 +288,7 @@ export interface UnifiedDesignPickerProps {
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	locale,
 	onDesignYourOwn,
+	onClickDesignYourOwnTopButton,
 	onPreview,
 	onChangeVariation,
 	onViewAllDesigns,
@@ -323,6 +327,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 				<DesignPicker
 					locale={ locale }
 					onDesignYourOwn={ onDesignYourOwn }
+					onClickDesignYourOwnTopButton={ onClickDesignYourOwnTopButton }
 					onPreview={ onPreview }
 					onChangeVariation={ onChangeVariation }
 					designs={ designs }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button } from '@automattic/components';
 import { MShotsImage } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
 import classnames from 'classnames';
@@ -13,7 +14,7 @@ import {
 	filterDesignsByCategory,
 } from '../utils';
 import { UnifiedDesignPickerCategoryFilter } from './design-picker-category-filter/unified-design-picker-category-filter';
-import PatternAssemblerCta from './pattern-assembler-cta';
+import PatternAssemblerCta, { usePatternAssemblerCtaData } from './pattern-assembler-cta';
 import ThemeCard from './theme-card';
 import type { Categorization } from '../hooks/use-categorization';
 import type { Design, StyleVariation } from '../types';
@@ -217,15 +218,26 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 		return designs;
 	}, [ designs, categorization?.selection ] );
 
+	const assemblerCtaData = usePatternAssemblerCtaData();
+
 	return (
 		<div>
-			{ categorization && hasCategories && (
-				<UnifiedDesignPickerCategoryFilter
-					categories={ categorization.categories }
-					onSelect={ categorization.onSelect }
-					selectedSlug={ categorization.selection }
-				/>
-			) }
+			<div className="design-picker__filters">
+				{ categorization && hasCategories && (
+					<UnifiedDesignPickerCategoryFilter
+						className="design-picker__category-filter"
+						categories={ categorization.categories }
+						onSelect={ categorization.onSelect }
+						selectedSlug={ categorization.selection }
+					/>
+				) }
+				{ assemblerCtaData.shouldGoToAssemblerStep && (
+					<Button onClick={ () => onDesignYourOwn( DEFAULT_ASSEMBLER_DESIGN, true ) }>
+						{ assemblerCtaData.title }
+					</Button>
+				) }
+			</div>
+
 			<div className="design-picker__grid">
 				{ filteredDesigns.map( ( design, index ) => {
 					if ( isBlankCanvasDesign( design ) ) {


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/79655

## Proposed Changes

This PR adds a "Design your own" button on the right of the categories filter in the Design Picker.

This button is only visible on viewports that the Site Assembler supports.

P.S.: I hope the design is good enough!

|Before|After|
|-|-|
|<img width="1240" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/47b6f245-e7e7-41e4-b602-48aeb90ecaba">|<img width="1239" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/19698ecf-129b-4bc6-9d85-560a1177478f">|

## Testing Instructions

1. Check out this PR or use the Calypso Live link.
2. Go to `/setup/site-setup/designSetup?siteSlug=<siteSlug>`
3. Verify that you see the new button on desktop viewport.
3. Verify that you DO NOT see the new button on mobile viewport.
4. Verify that the button indeed takes us to the Site Assembler flow.
5. Verify that the flow can be completed successfully.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
