### PR TITLE
Domains Transfer: update badge styles.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
@@ -46,7 +46,7 @@ const Intro: React.FC< Props > = ( { onSubmit } ) => {
 					{
 						key: 'finalize',
 						title: __( 'Checkout' ),
-						badge: __( 'Google Domains: Free' ),
+						badge: __( 'Free for Google Domains' ),
 						description: (
 							<p>
 								{ __(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -109,7 +109,9 @@ $heading-font-family: "SF Pro Display", $sans;
 
 					.free-domain__primary-badge {
 						border-radius: 4px;
-						margin-left: 12px;
+						margin-left: 16px;
+						vertical-align: middle;
+						font-size: rem(12px);
 					}
 
 


### PR DESCRIPTION
Small tweaks to badge styles:

<img width="661" alt="image" src="https://github.com/Automattic/wp-calypso/assets/548849/67eb4775-fd23-4271-979e-86a415edda29">
