### PR TITLE
Happy blocks: Remove temporary happy blocks code

### DIFF
--- a/apps/happy-blocks/block-library/universal-header/includes.php
+++ b/apps/happy-blocks/block-library/universal-header/includes.php
@@ -26,6 +26,3 @@ $wpcom_nav_bar_css = wpcom_navbar_get_assets( is_rtl() ? 'view.rtl.css' : 'view.
 
 wp_enqueue_style( 'wpsupport3-wpcom-navbar-search-style', $wpcom_nav_bar_css['path'], array(), $wpcom_nav_bar_css['version'] );
 wp_enqueue_script( 'wpsupport3-wpcom-navbar-search-script', $wpcom_nav_bar_js['path'], array(), $wpcom_nav_bar_js['version'], true );
-
-// Temporary load styles from education header.
-require_once WP_CONTENT_DIR . '/a8c-plugins/happy-blocks/block-library/education-header/includes.php';

--- a/apps/happy-blocks/block-library/universal-header/index.php
+++ b/apps/happy-blocks/block-library/universal-header/index.php
@@ -15,8 +15,8 @@ require_once WP_CONTENT_DIR . '/themes/h4/landing/marketing/pages/_common/lib/fu
 if ( ! isset( $args ) ) {
 	$args = array();
 }
-$happy_blocks_is_english   = ( 0 === stripos( get_locale(), 'en' ) );
-$happy_blocks_current_page = $args['active_page'];
+$happy_blocks_is_english = ( 0 === stripos( get_locale(), 'en' ) );
+
 ?>
 <div id="lpc-header-nav" class="lpc lpc-header-nav">
 	<div class="x-root lpc-header-nav-wrapper">
@@ -536,25 +536,6 @@ $happy_blocks_current_page = $args['active_page'];
 				</div>
 			</div>
 			<!-- Mobile menu ends here. -->
-		</div>
-	</div>
-</div>
-<!-- temporary -->
-<div class="universal-header-temporary-wpcom-nav-bar happy-blocks-mini-search happy-blocks-header is-<?php echo esc_html( $happy_blocks_current_page ); ?>">
-	<div class="happy-blocks-search-container">
-		<div class="happy-blocks-global-header-site__title">
-			<?php if ( $args['include_site_title'] ) : ?>
-			<div class="happy-blocks-global-header-site__title__wrapper">
-				<h1><?php echo esc_html( $args['site_title'] ); ?></h1>
-				<p><?php echo esc_html( $args['site_tagline'] ); ?></p>
-			</div>
-			<?php endif; ?>
-			<form class="<?php echo ! $args['include_site_title'] ? 'happy-blocks_inner_search' : ''; ?>" role="search"
-				method="get" action=""><label for="wp-block-search__input-1"
-					class="screen-reader-text"><?php echo esc_html( $args['search_placeholder'] ); ?></label>
-				<div class="happy-blocks-search__inside-wrapper"><input type="search" id="wp-block-search__input-1"
-						name="s" value="" placeholder="<?php echo esc_html( $args['search_placeholder'] ); ?>"></div>
-			</form>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
## Proposed Changes

To be able to deploy this [PR](https://github.com/Automattic/wp-calypso/pull/79842) without any breakage for the users, we had to add temporary code to keep it working fine, this PR removes this temporary code.

## Testing Instructions

- Pull this branch
- Navigate to `apps/happy-blocks` and run `yarn dev --sync`
- Go to wpsupport3 repo and run it normally.
- Inspect element and you should see only one `div` element with these classes `happy-blocks-mini-search happy-blocks-header is-support` element.



Before:

<img width="759" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/d9677d19-1217-45df-bf3d-0357f2a00790">


After:

<img width="755" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/2906a3ef-c19c-471e-87db-086313b5c80b">
