### PR TITLE
Jetpack Pro Dashboard: show SMS counter to downtime monitor notification settings popup

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/index.tsx
@@ -10,6 +10,7 @@ import {
 	StateMonitorSettingsSMS,
 } from '../../sites-overview/types';
 import FeatureRestrictionBadge from '../feature-restriction-badge';
+import SMSCounter from '../notification-settings/form-content/sms-counter';
 import { RestrictionType } from '../types';
 import ContactListItem from './item';
 import { getContactActionEventName, getContactItemValue } from './utils';
@@ -64,6 +65,8 @@ export default function ContactList( {
 		}
 	}, [ items.length, type ] );
 
+	const showSMSCounter = false;
+
 	return (
 		<>
 			{ type === 'sms' && ! items.length && (
@@ -107,6 +110,7 @@ export default function ContactList( {
 						{ translate( 'Multiple email recipients is part of the Basic plan.' ) }
 					</div>
 				) }
+				{ showSMSCounter && type === 'sms' && <SMSCounter /> }
 			</div>
 		</>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-counter.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-counter.tsx
@@ -1,0 +1,26 @@
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+
+export default function SMSCounter() {
+	const translate = useTranslate();
+
+	// TODO: Replace with real data
+	const monthlyUsedCount = 5;
+	const montlyLimit = 20;
+
+	const limitReached = monthlyUsedCount >= montlyLimit;
+
+	return (
+		<div
+			className={ classNames( 'notification-settings__sms-counter', {
+				'notification-settings__sms-counter-limit-reached': limitReached,
+			} ) }
+		>
+			{ translate( '%(monthlyUsedCount)d/%(montlyLimit)d SMS used this month on this site', {
+				args: { monthlyUsedCount, montlyLimit },
+				comment:
+					'monthlyUsedCount is the number of SMS used in a month, montlyLimit is the maximum number of SMS allowed in a month',
+			} ) }
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
@@ -177,3 +177,13 @@
 	height: 1px;
 	overflow: hidden;
 }
+
+.notification-settings__sms-counter {
+	color: var(--studio-gray-50);
+	font-size: 0.75rem;
+	margin-block-start: 8px;
+
+	&.notification-settings__sms-counter-limit-reached {
+		color: var(--color-scary-40);
+	}
+}


### PR DESCRIPTION
Related to 1204992567518369-as-1205068508514269

## Proposed Changes

This PR adds an SMS counter to the downtime monitor notification settings popup.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/url-support-open-license-info-popup` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already > Click on the clock icon next to the monitor toggle.
4. Click on the Mobile notification toggle, and click the "+ Add phone number" button -> Enter all the fields and click "Verify"
5. Set the `showSMSCounter` constant to `true` manually in the file: `client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/index.tsx`.
6. Verify that the counter is as shown below

<img width="476" alt="Screenshot 2023-07-27 at 3 41 14 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/49e75df5-25a0-4a04-a8cb-bfec77c32321">

7. Set the `monthlyUsedCount` to `20` in the file: `client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-counter.tsx`.
8. Verify that the counter is as shown below

<img width="479" alt="Screenshot 2023-07-27 at 3 41 36 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c509416d-aed3-4eb3-880b-6f4316baae03">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?