### PR TITLE
eCommerce features: Mention paid plugins

### DIFF
--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -2339,7 +2339,7 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate(
 				'Create, assign and list brands for products, and allow customers to view by brand.'
 			),
-		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getConditionalTitle: () => i18n.translate( 'Available with paid plugins' ),
 		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	[ FEATURE_PRODUCT_ADD_ONS ]: {
@@ -2350,7 +2350,7 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate(
 				'Increase your revenue with add-ons like gift wrapping or personalizations like engraving.'
 			),
-		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getConditionalTitle: () => i18n.translate( 'Available with paid plugins' ),
 		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	[ FEATURE_ASSEMBLED_KITS ]: {
@@ -2361,7 +2361,7 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate(
 				'Give customers the freedom to build their own products utilizing your existing items.'
 			),
-		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getConditionalTitle: () => i18n.translate( 'Available with paid plugins' ),
 		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	[ FEATURE_MIN_MAX_QTY ]: {
@@ -2370,7 +2370,7 @@ export const FEATURES_LIST: FeatureList = {
 
 		getDescription: () =>
 			i18n.translate( 'Specify the minimum and maximum allowed product quantities for orders.' ),
-		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getConditionalTitle: () => i18n.translate( 'Available with paid plugins' ),
 		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	[ FEATURE_STOCK_NOTIFS ]: {
@@ -2379,7 +2379,7 @@ export const FEATURES_LIST: FeatureList = {
 
 		getDescription: () =>
 			i18n.translate( 'Automatically notify customers when your products are restocked.' ),
-		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getConditionalTitle: () => i18n.translate( 'Available with paid plugins' ),
 		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	[ FEATURE_DYNAMIC_UPSELLS ]: {
@@ -2390,7 +2390,7 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate(
 				'Earn more revenue with automated upsell and cross-sell product recommendations.'
 			),
-		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getConditionalTitle: () => i18n.translate( 'Available with paid plugins' ),
 		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	[ FEATURE_LOYALTY_PROG ]: {
@@ -2401,7 +2401,7 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate(
 				'Boost organic sales with a customer referral program and offer free gifts or coupons as a reward.'
 			),
-		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getConditionalTitle: () => i18n.translate( 'Available with paid plugins' ),
 		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	[ FEATURE_CUSTOM_MARKETING_AUTOMATION ]: {
@@ -2412,7 +2412,7 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate(
 				'Advanced email marketing functionality, including subscriber segmentation, advanced analytics, and automation.'
 			),
-		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getConditionalTitle: () => i18n.translate( 'Available with paid plugins' ),
 		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	[ FEATURE_BULK_DISCOUNTS ]: {
@@ -2420,7 +2420,7 @@ export const FEATURES_LIST: FeatureList = {
 		getTitle: () => i18n.translate( 'Offer bulk discounts' ),
 
 		getDescription: () => i18n.translate( 'Offer personalized packages and bulk discounts.' ),
-		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getConditionalTitle: () => i18n.translate( 'Available with paid plugins' ),
 		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	[ FEATURE_INVENTORY_MGMT ]: {
@@ -2459,7 +2459,7 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate(
 				'Get real-time shipping prices, print labels and give your customers tracking codes.'
 			),
-		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getConditionalTitle: () => i18n.translate( 'Available with paid plugins' ),
 		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	/* END: 2023 Pricing Grid Features */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Some of the Business plan features are only available via paid plugins. These features will now be mentioned as "Available with paid plugins". 
* The list of features available via paid plugins is mentioned in pau2Xa-4W0#comment-13597.
* The corresponding landing page changes are in D117255-PR.

<img width="1337" alt="Screenshot 2023-07-27 at 4 16 52 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/664e1af0-c6d0-4acc-a184-83185d6f6259">


<img width="369" alt="Screenshot 2023-07-27 at 4 23 37 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/7f0b081f-28fb-4a45-bfb0-3885b42168c2">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enter the signup flow plans step, at `/start/plans`. 
* Verify that those features mentioned in pau2Xa-4W0#comment-13597 as available with paid plugins are mentioned in the plans grid.
* Verify on both desktop and mobile viewports.

