### PR TITLE
Replace renew with extend copy in domain transfer checkout message

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -166,7 +166,7 @@ export function hasTransferProduct( cart: ObjectWithProducts ): boolean {
 }
 
 export function hasFreeCouponTransfersOnly( cart: ObjectWithProducts ): boolean {
-	const temp = getAllCartItems( cart ).every( ( item ) => {
+	return getAllCartItems( cart ).every( ( item ) => {
 		return (
 			( isDomainTransfer( item ) &&
 				item.is_sale_coupon_applied &&
@@ -174,8 +174,6 @@ export function hasFreeCouponTransfersOnly( cart: ObjectWithProducts ): boolean 
 			isPartialCredits( item )
 		);
 	} );
-
-	return temp;
 }
 
 export function getDomainTransfers( cart: ObjectWithProducts ): ResponseCartProduct[] {

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -178,12 +178,6 @@ export function hasFreeCouponTransfersOnly( cart: ObjectWithProducts ): boolean 
 	return temp;
 }
 
-export function hasTransferProductOnly( cart: ObjectWithProducts ): boolean {
-	return getAllCartItems( cart ).every( ( item ) => {
-		return isDomainTransfer( item ) || isPartialCredits( item );
-	} );
-}
-
 export function getDomainTransfers( cart: ObjectWithProducts ): ResponseCartProduct[] {
 	return getAllCartItems( cart ).filter(
 		( product ) => product.product_slug === domainProductSlugs.TRANSFER_IN

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -165,6 +165,10 @@ export function hasTransferProduct( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isDomainTransfer );
 }
 
+export function hasTransferProductOnly( cart: ObjectWithProducts ): boolean {
+	return getAllCartItems( cart ).every( isDomainTransfer );
+}
+
 export function getDomainTransfers( cart: ObjectWithProducts ): ResponseCartProduct[] {
 	return getAllCartItems( cart ).filter(
 		( product ) => product.product_slug === domainProductSlugs.TRANSFER_IN

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -165,8 +165,23 @@ export function hasTransferProduct( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isDomainTransfer );
 }
 
+export function hasFreeCouponTransfersOnly( cart: ObjectWithProducts ): boolean {
+	const temp = getAllCartItems( cart ).every( ( item ) => {
+		return (
+			( isDomainTransfer( item ) &&
+				item.is_sale_coupon_applied &&
+				item.item_subtotal_integer === 0 ) ||
+			isPartialCredits( item )
+		);
+	} );
+
+	return temp;
+}
+
 export function hasTransferProductOnly( cart: ObjectWithProducts ): boolean {
-	return getAllCartItems( cart ).every( isDomainTransfer );
+	return getAllCartItems( cart ).every( ( item ) => {
+		return isDomainTransfer( item ) || isPartialCredits( item );
+	} );
 }
 
 export function getDomainTransfers( cart: ObjectWithProducts ): ResponseCartProduct[] {

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -35,6 +35,7 @@ import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
+import { hasTransferProductOnly } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
@@ -358,6 +359,9 @@ function CheckoutSummaryFeaturesList( props: {
 		isDomainTransfer( product )
 	);
 
+	const hasGoogleDomainsOnly =
+		hasTransferProductOnly( responseCart ) && responseCart?.sub_total_integer !== 0;
+
 	return (
 		<CheckoutSummaryFeaturesListWrapper>
 			{ hasDomainsInCart &&
@@ -391,7 +395,9 @@ function CheckoutSummaryFeaturesList( props: {
 				<>
 					<CheckoutSummaryFeaturesListItem>
 						<WPCheckoutCheckIcon id="features-list-support-another-year" />
-						{ translate( "We'll renew your domain for another year" ) }
+						{ hasGoogleDomainsOnly
+							? translate( '1-year extension on your domain for $0' )
+							: translate( "We'll renew your domain for another year" ) }
 					</CheckoutSummaryFeaturesListItem>
 					<CheckoutSummaryFeaturesListItem>
 						<WPCheckoutCheckIcon id="features-list-support-privacy" />

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -359,9 +359,7 @@ function CheckoutSummaryFeaturesList( props: {
 		isDomainTransfer( product )
 	);
 
-	// We don't currently pass down google domain detection in the cart
-	// we're relying on a subtotal of 0 to exclude carts with non-google products
-	const hasGoogleDomainsOnly = responseCart.products.every( ( product ) => {
+	const hasFreeCouponTransfersOnly = responseCart.products.every( ( product ) => {
 		return (
 			isDomainTransfer( product ) &&
 			product.is_sale_coupon_applied &&
@@ -402,7 +400,7 @@ function CheckoutSummaryFeaturesList( props: {
 				<>
 					<CheckoutSummaryFeaturesListItem>
 						<WPCheckoutCheckIcon id="features-list-support-another-year" />
-						{ hasGoogleDomainsOnly && hasTransferProductOnly( responseCart )
+						{ hasFreeCouponTransfersOnly && hasTransferProductOnly( responseCart )
 							? translate( 'We absorb the cost and give you an extra year of free registration' )
 							: translate( '1-year extension on your domain' ) }
 					</CheckoutSummaryFeaturesListItem>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -359,8 +359,10 @@ function CheckoutSummaryFeaturesList( props: {
 		isDomainTransfer( product )
 	);
 
+	// We don't currently pass down google domain detection in the cart
+	// we're relying on a subtotal of 0 to exclude carts with non-google products
 	const hasGoogleDomainsOnly =
-		hasTransferProductOnly( responseCart ) && responseCart?.sub_total_integer !== 0;
+		hasTransferProductOnly( responseCart ) && responseCart?.sub_total_integer === 0;
 
 	return (
 		<CheckoutSummaryFeaturesListWrapper>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -399,7 +399,7 @@ function CheckoutSummaryFeaturesList( props: {
 						<WPCheckoutCheckIcon id="features-list-support-another-year" />
 						{ hasGoogleDomainsOnly
 							? translate( '1-year extension on your domain for $0' )
-							: translate( "We'll renew your domain for another year" ) }
+							: translate( '1-year extension on your domain' ) }
 					</CheckoutSummaryFeaturesListItem>
 					<CheckoutSummaryFeaturesListItem>
 						<WPCheckoutCheckIcon id="features-list-support-privacy" />

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -35,7 +35,7 @@ import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
-import { hasTransferProductOnly } from 'calypso/lib/cart-values/cart-items';
+import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
@@ -359,14 +359,6 @@ function CheckoutSummaryFeaturesList( props: {
 		isDomainTransfer( product )
 	);
 
-	const hasFreeCouponTransfersOnly = responseCart.products.every( ( product ) => {
-		return (
-			isDomainTransfer( product ) &&
-			product.is_sale_coupon_applied &&
-			product.item_subtotal_integer === 0
-		);
-	} );
-
 	return (
 		<CheckoutSummaryFeaturesListWrapper>
 			{ hasDomainsInCart &&
@@ -400,7 +392,7 @@ function CheckoutSummaryFeaturesList( props: {
 				<>
 					<CheckoutSummaryFeaturesListItem>
 						<WPCheckoutCheckIcon id="features-list-support-another-year" />
-						{ hasFreeCouponTransfersOnly && hasTransferProductOnly( responseCart )
+						{ hasFreeCouponTransfersOnly( responseCart )
 							? translate( 'We absorb the cost and give you an extra year of free registration' )
 							: translate( '1-year extension on your domain' ) }
 					</CheckoutSummaryFeaturesListItem>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -361,8 +361,13 @@ function CheckoutSummaryFeaturesList( props: {
 
 	// We don't currently pass down google domain detection in the cart
 	// we're relying on a subtotal of 0 to exclude carts with non-google products
-	const hasGoogleDomainsOnly =
-		hasTransferProductOnly( responseCart ) && responseCart?.sub_total_integer === 0;
+	const hasGoogleDomainsOnly = responseCart.products.every( ( product ) => {
+		return (
+			isDomainTransfer( product ) &&
+			product.is_sale_coupon_applied &&
+			product.item_subtotal_integer === 0
+		);
+	} );
 
 	return (
 		<CheckoutSummaryFeaturesListWrapper>
@@ -397,8 +402,8 @@ function CheckoutSummaryFeaturesList( props: {
 				<>
 					<CheckoutSummaryFeaturesListItem>
 						<WPCheckoutCheckIcon id="features-list-support-another-year" />
-						{ hasGoogleDomainsOnly
-							? translate( '1-year extension on your domain for $0' )
+						{ hasGoogleDomainsOnly && hasTransferProductOnly( responseCart )
+							? translate( 'We absorb the cost and give you an extra year of free registration' )
 							: translate( '1-year extension on your domain' ) }
 					</CheckoutSummaryFeaturesListItem>
 					<CheckoutSummaryFeaturesListItem>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3229

## Proposed Changes

* Replace renew with extend language.

## Testing Instructions

* http://calypso.localhost:3000/setup/domain-transfer
* Get to checkout with non google registered domain
* And test again with google registered domain
* Should se text changed for google registered domain 

Before

![Screenshot 2023-07-27 at 22-11-45 Checkout — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/1c3b925e-a84a-47c2-bffe-1f175c53a502)

After


<img width="396" alt="Screenshot 2023-07-27 at 9 44 45 AM" src="https://github.com/Automattic/wp-calypso/assets/1126811/40dab97e-595a-4620-8a2a-750c2426d735">

