### PR TITLE
Theme Detail page: Fix hydration mismatch for the theme detail page iframe token

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1,3 +1,4 @@
+import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import {
 	FEATURE_PREMIUM_THEMES_V2,
@@ -523,7 +524,7 @@ class ThemeSheet extends Component {
 	}
 
 	renderWebPreview = () => {
-		const { locale, stylesheet, styleVariations, themeId } = this.props;
+		const { locale, siteSlug, stylesheet, styleVariations, themeId } = this.props;
 		const baseStyleVariation = styleVariations.find( ( style ) =>
 			isDefaultGlobalStylesVariationSlug( style.slug )
 		);
@@ -534,12 +535,21 @@ class ThemeSheet extends Component {
 			{ language: locale, viewport_unit_to_px: true }
 		);
 
+		// Normally, the ThemeWebPreview component will generate the iframe token via uuid.
+		// Given that this page supports SSR, using uuid will cause hydration mismatch.
+		// To avoid this, we pass a custom token that consists of the theme ID and user/anon ID.
+		const iframeToken = themeId;
+		if ( typeof document !== 'undefined' ) {
+			iframeToken.concat( '-', getTracksAnonymousUserId() ?? siteSlug );
+		}
+
 		return (
 			<div className="theme__sheet-web-preview">
 				<ThemeWebPreview
 					url={ url }
 					inlineCss={ baseStyleVariationInlineCss + selectedStyleVariationInlineCss }
 					iframeScaleRatio={ 0.5 }
+					iframeToken={ iframeToken }
 					isShowFrameBorder={ false }
 					isShowDeviceSwitcher={ false }
 					isFitHeight

--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -18,6 +18,7 @@ interface ThemePreviewProps {
 	inlineCss?: string;
 	viewportWidth?: number;
 	iframeScaleRatio?: number;
+	iframeToken?: string;
 	isFitHeight?: boolean;
 	isShowFrameBorder?: boolean;
 	isShowDeviceSwitcher?: boolean;
@@ -35,6 +36,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	inlineCss,
 	viewportWidth,
 	iframeScaleRatio = 1,
+	iframeToken,
 	isFitHeight,
 	isShowFrameBorder,
 	isShowDeviceSwitcher,
@@ -47,7 +49,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	const [ isFullyLoaded, setIsFullyLoaded ] = useState( ! isUrlWpcomApi( url ) );
 	const [ viewport, setViewport ] = useState< Viewport >();
 	const [ containerResizeListener, { width: containerWidth } ] = useResizeObserver();
-	const calypso_token = useMemo( () => uuid(), [] );
+	const calypso_token = useMemo( () => iframeToken || uuid(), [ iframeToken ] );
 	const scale = containerWidth && viewportWidth ? containerWidth / viewportWidth : iframeScaleRatio;
 
 	const wrapperHeight = useMemo( () => {


### PR DESCRIPTION
## Proposed Changes

This PR fixes the issue where the logged-out Theme Detail page's large preview doesn't work properly upon refresh. This is reproducible by directly going to the Theme Detail page via URL (e.g.: https://wordpress.com/theme/luminance), where you'd see the large preview stuck in a loading state:

![Screen Capture on 2023-07-28 at 08-49-39](https://github.com/Automattic/wp-calypso/assets/797888/f0c7475f-a858-4ad3-a143-39258638c8e6)

This bug is caused by hydration mismatch, where the SSR iframe URL does not match with the client-side's iframe URL. Thus, this PR proposes a solution that ensures the consistency of the iframe URL.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head directly to a Theme Detail page, such as https://wordpress.com/theme/luminance, while logged-out.
* Ensure that the large preview is not stuck in a loading state as shown above.
* Refresh the page, and ensure that the large preview is still working as intended.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?