### PR TITLE
Fix/blazepress mobile posts view

### DIFF
--- a/apps/blaze-dashboard/src/app.scss
+++ b/apps/blaze-dashboard/src/app.scss
@@ -158,17 +158,11 @@
 $break-medium-expanded-menu: $break-medium + 272px;
 @media screen and (max-width: $break-medium-expanded-menu) {
 	body #wpcontent .jp-blaze-dashboard .promote-post-i2 {
-		.post-item__post-data .post-item__post-data-row-mobile .post-item__actions-mobile {
-			.button.post-item__view-link {
-				border: 1px solid var(--studio-gray-50);
-				line-height: 38px;
-			}
-			button.post-item__post-promote-button {
-				font-size: 0.75rem;
-				font-weight: 600;
-				line-height: 16px;
-				padding: 12px;
-			}
+		.post-item__post-data .post-item__post-data-row-mobile .post-item__actions-mobile button.post-item__post-promote-button {
+			padding: 12px;
+			line-height: 16px;
+			font-weight: 600;
+			font-size: 0.75rem;
 		}
 	}
 }

--- a/apps/blaze-dashboard/src/app.scss
+++ b/apps/blaze-dashboard/src/app.scss
@@ -158,11 +158,17 @@
 $break-medium-expanded-menu: $break-medium + 272px;
 @media screen and (max-width: $break-medium-expanded-menu) {
 	body #wpcontent .jp-blaze-dashboard .promote-post-i2 {
-		.post-item__post-data .post-item__post-data-row-mobile .post-item__actions-mobile button.post-item__post-promote-button {
-			padding: 12px;
-			line-height: 16px;
-			font-weight: 600;
-			font-size: 0.75rem;
+		.post-item__post-data .post-item__post-data-row-mobile .post-item__actions-mobile {
+			.button.post-item__view-link {
+				border: 1px solid var(--studio-gray-50);
+				line-height: 38px;
+			}
+			button.post-item__post-promote-button {
+				font-size: 0.75rem;
+				font-weight: 600;
+				line-height: 16px;
+				padding: 12px;
+			}
 		}
 	}
 }

--- a/client/my-sites/promote-post-i2/components/post-item/style.scss
+++ b/client/my-sites/promote-post-i2/components/post-item/style.scss
@@ -191,12 +191,13 @@ body.is-section-promote-post-i2 {
 								@include blazepress-data-row-font-mobile;
 
 								display: block;
+								margin-bottom: 8px;
 							}
 
 							.post-item__post-title-content {
 								font-size: 0.875rem;
 								font-weight: 600;
-								line-height: 1.47;
+								line-height: 1.4285;
 							}
 						}
 					}

--- a/client/my-sites/promote-post-i2/components/relative-time/style.scss
+++ b/client/my-sites/promote-post-i2/components/relative-time/style.scss
@@ -8,6 +8,7 @@
 
 		&,
 		svg.gridicons-info-outline {
+			fill: var(--studio-gray-40);
 			height: 16px;
 			width: 16px;
 		}

--- a/client/my-sites/promote-post-i2/style.scss
+++ b/client/my-sites/promote-post-i2/style.scss
@@ -16,7 +16,7 @@
 	color: var(--studio-gray-40);
 	font-size: 0.75rem;
 	font-weight: 400;
-	line-height: 1.125;
+	line-height: 1.5;
 }
 
 @mixin blazepress-data-row {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* We want to introduce several small tweaks related to mobile view for "Ready to Promote" posts
* Changes include:
  * increasing the space between row with post date and post title,
  * changing the color of a tooltip icon (to be the same as post date).

## Testing Instructions

- Build this branch locally or use a live preview link below
- See design changes from Bart [mentioned](https://www.figma.com/file/uvh2KtY65b7hGBHI9exbJ1/BlazePress?type=design&node-id=9038%3A73706&mode=design&t=Nnlf5XUeGTAaKqfK-1) in Figma (excluding proposed button changes)
- Open "Ready to Promote" tab in mobile view
- Compare it with Figma

<img width="771" alt="image" src="https://github.com/Automattic/wp-calypso/assets/115007291/6063889c-3462-4b21-811e-ecfbf90f4c2f">


**Note** : the font size for post title should be `15px` according to design but to accomplish it the unit for the size is `rem` and `0.9375rem` is not allowed by linter rules. That's why the font-size for post title is `14px` instead.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
