### PR TITLE
Migration Trial: Create verify email step

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -271,6 +271,9 @@ const importFlow: Flow = {
 						return navigate( `sitePicker?from=${ fromParam }` );
 					}
 					return navigate( `import?siteSlug=${ siteSlugParam }` );
+
+				case 'verifyEmail':
+					return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
 			}
 		};
 

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -198,6 +198,10 @@ const importFlow: Flow = {
 				case 'error':
 					return navigate( providedDependencies?.url as string );
 
+				case 'verifyEmail':
+					// TODO: handle verify email submission, navigate to the next step
+					return;
+
 				case 'sitePicker': {
 					switch ( providedDependencies?.action ) {
 						case 'update-query': {

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -18,6 +18,7 @@ import ImportReady from './internals/steps-repository/import-ready';
 import ImportReadyNot from './internals/steps-repository/import-ready-not';
 import ImportReadyPreview from './internals/steps-repository/import-ready-preview';
 import ImportReadyWpcom from './internals/steps-repository/import-ready-wpcom';
+import ImportVerifyEmail from './internals/steps-repository/import-verify-email';
 import ImporterBlogger from './internals/steps-repository/importer-blogger';
 import ImporterMedium from './internals/steps-repository/importer-medium';
 import ImporterSquarespace from './internals/steps-repository/importer-squarespace';
@@ -55,6 +56,7 @@ const importFlow: Flow = {
 			{ slug: 'migrationHandler', component: MigrationHandler },
 			{ slug: 'sitePicker', component: SitePickerStep },
 			{ slug: 'error', component: MigrationError },
+			{ slug: 'verifyEmail', component: ImportVerifyEmail },
 		];
 	},
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/index.tsx
@@ -1,6 +1,7 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
 import { useSelector } from 'calypso/state';
@@ -15,11 +16,16 @@ const ImportVerifyEmail: Step = function ImportVerifyEmail( { navigation } ) {
 	const dispatch = useDispatch();
 	const { goBack, submit } = navigation;
 	const user = useSelector( getCurrentUser ) as UserData;
+	const site = useSite();
 
 	// Check if the email is verified and submit it for the next step
 	useEffect( () => {
 		user.email_verified && submit?.();
 	}, [ user ] );
+
+	if ( ! site ) {
+		return null;
+	}
 
 	return (
 		<>
@@ -35,7 +41,7 @@ const ImportVerifyEmail: Step = function ImportVerifyEmail( { navigation } ) {
 				skipButtonAlign="top"
 				goBack={ goBack }
 				isHorizontalLayout={ false }
-				stepContent={ <VerifyEmail user={ user } /> }
+				stepContent={ <VerifyEmail user={ user } site={ site } /> }
 				recordTracksEvent={ recordTracksEvent }
 			/>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/index.tsx
@@ -1,22 +1,44 @@
 import { StepContainer } from '@automattic/onboarding';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
+import { useSelector } from 'calypso/state';
+import { fetchCurrentUser } from 'calypso/state/current-user/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import VerifyEmail from './verify-email';
 import type { Step } from '../../types';
+import type { UserData } from 'calypso/lib/user/user';
 import './style.scss';
 
 const ImportVerifyEmail: Step = function ImportVerifyEmail( { navigation } ) {
-	const { goBack } = navigation;
+	const dispatch = useDispatch();
+	const { goBack, submit } = navigation;
+	const user = useSelector( getCurrentUser ) as UserData;
+
+	// Check if the email is verified and submit it for the next step
+	useEffect( () => {
+		user.email_verified && submit?.();
+	}, [ user ] );
 
 	return (
-		<StepContainer
-			className="import-layout__center"
-			stepName="email-verification"
-			skipButtonAlign="top"
-			goBack={ goBack }
-			isHorizontalLayout={ false }
-			stepContent={ <VerifyEmail /> }
-			recordTracksEvent={ recordTracksEvent }
-		/>
+		<>
+			{ ! user.email_verified && (
+				<Interval
+					onTick={ () => dispatch( fetchCurrentUser() as any ) }
+					period={ EVERY_FIVE_SECONDS }
+				/>
+			) }
+			<StepContainer
+				className="import-layout__center"
+				stepName="email-verification"
+				skipButtonAlign="top"
+				goBack={ goBack }
+				isHorizontalLayout={ false }
+				stepContent={ <VerifyEmail user={ user } /> }
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/index.tsx
@@ -21,7 +21,7 @@ const ImportVerifyEmail: Step = function ImportVerifyEmail( { navigation } ) {
 	// Check if the email is verified and submit it for the next step
 	useEffect( () => {
 		user.email_verified && submit?.();
-	}, [ user ] );
+	}, [ user, submit ] );
 
 	if ( ! site ) {
 		return null;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/index.tsx
@@ -1,0 +1,23 @@
+import { StepContainer } from '@automattic/onboarding';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import VerifyEmail from './verify-email';
+import type { Step } from '../../types';
+import './style.scss';
+
+const ImportVerifyEmail: Step = function ImportVerifyEmail( { navigation } ) {
+	const { goBack } = navigation;
+
+	return (
+		<StepContainer
+			className="import-layout__center"
+			stepName="email-verification"
+			skipButtonAlign="top"
+			goBack={ goBack }
+			isHorizontalLayout={ false }
+			stepContent={ <VerifyEmail /> }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default ImportVerifyEmail;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/style.scss
@@ -1,0 +1,19 @@
+.verify-email--container {
+	max-width: 672px;
+	margin: auto;
+	text-align: center;
+
+	.onboarding-title {
+		margin-bottom: 2rem;
+	}
+
+	.onboarding-subtitle {
+		margin-bottom: 3.5rem;
+		color: var(--studio-gray-100);
+	}
+
+	.action-buttons__next {
+		padding-left: 1.5rem;
+		padding-right: 1.5rem;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/verify-email.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/verify-email.tsx
@@ -1,0 +1,25 @@
+import { NextButton, SubTitle, Title } from '@automattic/onboarding';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+
+const VerifyEmail = function SitePicker() {
+	const { __ } = useI18n();
+
+	return (
+		<div className="verify-email--container">
+			<Title>{ __( 'Verify your email address' ) }</Title>
+			<SubTitle>
+				{ sprintf(
+					// translators: %s is the email address of current user
+					__(
+						'To start your Business plan 7-day trial, verify your email address by clicking the link we sent you to %(email)s.'
+					),
+					{ email: 'username@email.com' }
+				) }
+			</SubTitle>
+			<NextButton>{ __( 'Resend verification email' ) }</NextButton>
+		</div>
+	);
+};
+
+export default VerifyEmail;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/verify-email.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/verify-email.tsx
@@ -1,9 +1,13 @@
 import { NextButton, SubTitle, Title } from '@automattic/onboarding';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import { useSelector } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import type { UserData } from 'calypso/lib/user/user';
 
 const VerifyEmail = function SitePicker() {
 	const { __ } = useI18n();
+	const user = useSelector( getCurrentUser ) as UserData;
 
 	return (
 		<div className="verify-email--container">
@@ -14,7 +18,7 @@ const VerifyEmail = function SitePicker() {
 					__(
 						'To start your Business plan 7-day trial, verify your email address by clicking the link we sent you to %(email)s.'
 					),
-					{ email: 'username@email.com' }
+					{ email: user.email }
 				) }
 			</SubTitle>
 			<NextButton>{ __( 'Resend verification email' ) }</NextButton>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/verify-email.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/verify-email.tsx
@@ -1,20 +1,29 @@
+import { getPlan, PLAN_BUSINESS, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
+import { SiteDetails } from '@automattic/data-stores';
 import { NextButton, SubTitle, Title } from '@automattic/onboarding';
 import { useState } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSendEmailVerification } from 'calypso/landing/stepper/hooks/use-send-email-verification';
-import { useDispatch } from 'calypso/state';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+import { useSelector, useDispatch } from 'calypso/state';
 import { warningNotice } from 'calypso/state/notices/actions';
 import type { UserData } from 'calypso/lib/user/user';
 
 interface Props {
 	user: UserData;
+	site: SiteDetails;
 }
 const VerifyEmail = function VerifyEmail( props: Props ) {
 	const dispatch = useDispatch();
 	const { __ } = useI18n();
-	const { user } = props;
+	const { user, site } = props;
 	const sendEmail = useSendEmailVerification();
+	const targetSiteEligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, site?.ID )
+	);
+	const planType = targetSiteEligibleForProPlan ? PLAN_WPCOM_PRO : PLAN_BUSINESS;
+	const plan = getPlan( planType );
 
 	const defaultButtonState = {
 		status: 'default',
@@ -40,11 +49,14 @@ const VerifyEmail = function VerifyEmail( props: Props ) {
 			<Title>{ __( 'Verify your email address' ) }</Title>
 			<SubTitle>
 				{ sprintf(
-					// translators: %s is the email address of current user
+					// translators: planName could be "Pro" or "Business; email is the email address of current user
 					__(
-						'To start your Business plan 7-day trial, verify your email address by clicking the link we sent you to %(email)s.'
+						'To start your %(planName)s plan 7-day trial, verify your email address by clicking the link we sent you to %(email)s.'
 					),
-					{ email: user.email }
+					{
+						email: user.email,
+						planName: plan?.getTitle(),
+					}
 				) }
 			</SubTitle>
 			<NextButton isBusy={ buttonState.status === 'processing' } onClick={ onResendEmail }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/verify-email.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/verify-email.tsx
@@ -3,15 +3,17 @@ import { useState } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSendEmailVerification } from 'calypso/landing/stepper/hooks/use-send-email-verification';
-import { useSelector, useDispatch } from 'calypso/state';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { useDispatch } from 'calypso/state';
 import { warningNotice } from 'calypso/state/notices/actions';
 import type { UserData } from 'calypso/lib/user/user';
 
-const VerifyEmail = function SitePicker() {
+interface Props {
+	user: UserData;
+}
+const VerifyEmail = function VerifyEmail( props: Props ) {
 	const dispatch = useDispatch();
 	const { __ } = useI18n();
-	const user = useSelector( getCurrentUser ) as UserData;
+	const { user } = props;
 	const sendEmail = useSendEmailVerification();
 
 	const defaultButtonState = {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/79914

## Proposed Changes

- Created the Verify Email step.
- Updated and registered import-focused flow with a new step.

## Testing Instructions

**Test 1:**

* Login with a non-verified account
* Go to `/setup/import-focused/verifyEmail?siteSlug={SITE_SLUG}&from={JN_SITE}&option=everything`
* Press the "Resend verification email" button
* Open the developer tool, and check if there is a `/me` endpoint ping each 5 seconds
* Check your email box and click on verify CTA
* Once the email address is verified, [the flow submit handler](https://github.com/Automattic/wp-calypso/pull/79928/files#diff-fce80dd6e6117b25bd509bc804a326c4c59f543c203e0312aa834ab77ab26a94R202) will be invoked (currently missing implementation; will be implemented in the next iterations)

<img width="831" alt="Screenshot 2023-07-28 at 14 20 57" src="https://github.com/Automattic/wp-calypso/assets/1241413/11dfdd8b-1ba9-4b64-ae5e-4994c059c39b">


**Test 2:**
* Login with a verified account
* Go to `/setup/import-focused/verifyEmail?siteSlug={SITE_SLUG}&from={JN_SITE}&option=everything`
* The [submit handler](https://github.com/Automattic/wp-calypso/pull/79928/files#diff-fce80dd6e6117b25bd509bc804a326c4c59f543c203e0312aa834ab77ab26a94R202) will be called (currently missing implementation; will be implemented in the next iterations)
* Press the "Resend verification email"; Even in this scenario, when this screen will not be rendered because of the future redirection (since the user is verified), we handled the error
* Check if the global notification is there with the message "The email address associated with this account is already verified

<img width="667" alt="Screenshot 2023-07-28 at 14 20 34" src="https://github.com/Automattic/wp-calypso/assets/1241413/4f5725c0-c33d-4af8-84cf-0823b8e7ff4e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
