### PR TITLE
Fixes the view button/ promote button in mobile views

### DIFF
--- a/apps/blaze-dashboard/src/app.scss
+++ b/apps/blaze-dashboard/src/app.scss
@@ -158,11 +158,17 @@
 $break-medium-expanded-menu: $break-medium + 272px;
 @media screen and (max-width: $break-medium-expanded-menu) {
 	body #wpcontent .jp-blaze-dashboard .promote-post-i2 {
-		.post-item__post-data .post-item__post-data-row-mobile .post-item__actions-mobile button.post-item__post-promote-button {
-			padding: 12px;
-			line-height: 16px;
-			font-weight: 600;
-			font-size: 0.75rem;
+		.post-item__post-data .post-item__post-data-row-mobile .post-item__actions-mobile {
+			.button.post-item__view-link {
+				border: 1px solid var(--studio-gray-50);
+				line-height: 38px;
+			}
+			button.post-item__post-promote-button {
+				font-size: 0.75rem;
+				font-weight: 600;
+				line-height: 16px;
+				padding: 12px;
+			}
 		}
 	}
 }

--- a/client/my-sites/promote-post-i2/components/post-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/post-item/index.tsx
@@ -110,7 +110,7 @@ export default function PostItem( { post }: { post: BlazablePost } ) {
 					<div className="post-item__actions-mobile">
 						<a
 							href={ post.post_url }
-							className="post-item__view-link"
+							className="button post-item__view-link"
 							target="_blank"
 							rel="noreferrer"
 						>

--- a/client/my-sites/promote-post-i2/components/post-item/style.scss
+++ b/client/my-sites/promote-post-i2/components/post-item/style.scss
@@ -181,6 +181,7 @@ body.is-section-promote-post-i2 {
 						&-mobile {
 							display: flex;
 							justify-content: space-between;
+							flex-direction: column;
 						}
 
 						.post-item__post-title {
@@ -210,14 +211,21 @@ body.is-section-promote-post-i2 {
 		.post-item__post-data .post-item__post-data-row-mobile .post-item__actions-mobile a.post-item__view-link,
 		.post-item__post-data .post-item__post-data-row-mobile .post-item__actions-mobile a.post-item__view-link:visited {
 			@include blazepress-data-row-font-mobile;
-
-			margin-right: 4px;
+			border-radius: 4px;
+			display: inline-block;
+			flex-grow: 1;
+			height: 40px;
+			line-height: 22px;
+			margin-right: 8px;
+			text-decoration: none;
 		}
 
 		// Promote link
 		.post-item__post-data .post-item__post-data-row-mobile .post-item__actions-mobile button.post-item__post-promote-button {
-			height: 26px;
-			margin-left: 5px;
+			display: inline-block;
+			flex-grow: 1;
+			height: 40px;
+			margin-left: 8px;
 		}
 	}
 }

--- a/client/my-sites/promote-post-i2/style.scss
+++ b/client/my-sites/promote-post-i2/style.scss
@@ -29,8 +29,16 @@
 			display: none;
 			margin-top: 20px;
 
+			.post-item__actions-mobile {
+				display: flex;
+				justify-content: space-between;
+				margin-top: 20px;
+				width: 100%;
+			}
+
 			.post-item__stats-mobile,
 			.campaign-item__stats-mobile {
+				align-self: start;
 				@include blazepress-data-row-font-mobile;
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

SELFSERVE-683

## Proposed Changes

fix mobile version in advertising page (posts list) action buttons 

before version 
![Screenshot 2023-07-27 at 19 02 19](https://github.com/Automattic/wp-calypso/assets/1416426/b1fa705f-b3ea-4a51-9ccb-445b2d6526e6)

after version 

![Screenshot 2023-07-27 at 19 01 54](https://github.com/Automattic/wp-calypso/assets/1416426/eaacda47-000e-4619-b911-3e208723e164)


code review

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
