### PR TITLE
Reader sharing button - separate social and reblog sharing to their own buttons.

### DIFF
--- a/apps/notifications/src/panel/templates/gridicons.jsx
+++ b/apps/notifications/src/panel/templates/gridicons.jsx
@@ -149,7 +149,7 @@ export default class extends Component {
 
 			case 'gridicons-reblog':
 				return (
-					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
 						<title>Reblog</title>
 						<g>
 							<path d="M22.086 9.914L20 7.828V18c0 1.105-.895 2-2 2h-7v-2h7V7.828l-2.086 2.086L14.5 8.5 19 4l4.5 4.5-1.414 1.414zM6 16.172V6h7V4H6c-1.105 0-2 .895-2 2v10.172l-2.086-2.086L.5 15.5 5 20l4.5-4.5-1.414-1.414L6 16.172z" />

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -40,7 +40,3 @@
 	font-size: 13px;
 	font-weight: 500;
 }
-
-.comment-button__icon {
-	margin-right: 4px;
-}

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -422,10 +422,6 @@
 		top: 9px;
 	}
 
-	.comment-button__icon {
-		margin-right: 0;
-	}
-
 	.comment-button__label-status {
 		display: none;
 	}

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -6,7 +6,7 @@ import CommentButton from 'calypso/blocks/comment-button';
 import { shouldShowComments } from 'calypso/blocks/comments/helper';
 import PostEditButton from 'calypso/blocks/post-edit-button';
 import ShareButton from 'calypso/blocks/reader-share';
-import { shouldShowShare } from 'calypso/blocks/reader-share/helper';
+import { shouldShowShare, shouldShowReblog } from 'calypso/blocks/reader-share/helper';
 import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
 import ReaderViews from 'calypso/blocks/reader-views';
 import ReaderVisitLink from 'calypso/blocks/reader-visit-link';
@@ -15,7 +15,9 @@ import ReaderFollowButton from 'calypso/reader/follow-button';
 import LikeButton from 'calypso/reader/like-button';
 import { shouldShowLikes } from 'calypso/reader/like-helper';
 import * as stats from 'calypso/reader/stats';
+import { useSelector } from 'calypso/state';
 import { userCan } from 'calypso/state/posts/utils';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 
 import './style.scss';
 
@@ -37,6 +39,8 @@ const ReaderPostActions = ( props ) => {
 	} = props;
 
 	const [ isSuggestedFollowsModalOpen, setIsSuggestedFollowsModalOpen ] = useState( false );
+
+	const hasSites = !! useSelector( getPrimarySiteId );
 
 	const openSuggestedFollowsModal = ( followClicked ) => {
 		setIsSuggestedFollowsModalOpen( followClicked );
@@ -110,6 +114,17 @@ const ReaderPostActions = ( props ) => {
 			{ shouldShowShare( post ) && (
 				<li className="reader-post-actions__item">
 					<ShareButton post={ post } position="bottom" tagName="div" iconSize={ iconSize } />
+				</li>
+			) }
+			{ shouldShowReblog( post, hasSites ) && (
+				<li className="reader-post-actions__item">
+					<ShareButton
+						post={ post }
+						position="bottom"
+						tagName="div"
+						iconSize={ iconSize }
+						isReblogSelection
+					/>
 				</li>
 			) }
 			{ shouldShowComments( post ) && (

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -55,4 +55,8 @@
 	.follow-button__label {
 		display: none;
 	}
+
+	@include breakpoint-deprecated( "<660px" ) {
+		margin-right: 12px;
+	}
 }

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -57,6 +57,6 @@
 	}
 
 	@include breakpoint-deprecated( "<660px" ) {
-		margin-right: 12px;
+		margin-right: 18px;
 	}
 }

--- a/client/blocks/reader-share/helper.jsx
+++ b/client/blocks/reader-share/helper.jsx
@@ -1,3 +1,7 @@
 export function shouldShowShare( post ) {
 	return ! post.site_is_private;
 }
+
+export function shouldShowReblog( post, hasSites ) {
+	return hasSites && ! post.site_is_private;
+}

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -10,6 +10,7 @@ import ReaderShareIcon from 'calypso/reader/components/icons/share-icon';
 import * as stats from 'calypso/reader/stats';
 import { preloadEditor } from 'calypso/sections-preloaders';
 import { infoNotice } from 'calypso/state/notices/actions';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import ReaderReblogSelection from './reblog';
 import ReaderSocialShareSelection from './social';
@@ -91,9 +92,14 @@ class ReaderShare extends Component {
 
 	toggle = () => {
 		if ( ! this.state.showingMenu ) {
-			stats.recordAction( 'open_share' );
-			stats.recordGaEvent( 'Opened Share' );
-			stats.recordTrack( 'calypso_reader_share_opened', {
+			const actionName = this.props.isReblogSelection ? 'open_reader_reblog' : 'open_share';
+			const eventName = this.props.isReblogSelection ? 'Opened Reader Reblog' : 'Opened Share';
+			const trackName = this.props.isReblogSelection
+				? 'calypso_reader_reblog_opened'
+				: 'calypso_reader_share_opened';
+			stats.recordAction( actionName );
+			stats.recordGaEvent( eventName );
+			this.props.recordReaderTracksEvent( trackName, {
 				has_sites: this.props.hasSites,
 			} );
 		}
@@ -115,7 +121,7 @@ class ReaderShare extends Component {
 		if ( actionFunc ) {
 			stats.recordAction( 'share_' + action );
 			stats.recordGaEvent( 'Clicked on Share to ' + action );
-			stats.recordTrack( 'calypso_reader_share_action_picked', {
+			this.props.recordReaderTracksEvent( 'calypso_reader_share_action_picked', {
 				action: action,
 			} );
 			actionFunc( this.props.post );
@@ -187,7 +193,7 @@ const mapStateToProps = ( state ) => {
 	};
 };
 
-const mapDispatchToProps = { infoNotice };
+const mapDispatchToProps = { infoNotice, recordReaderTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const onCopyLinkClick = () => {

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -170,7 +170,11 @@ class ReaderShare extends Component {
 							popoverProps={ popoverProps }
 						/>
 					) : (
-						<ReaderReblogSelection post={ this.props.post } popoverProps={ popoverProps } />
+						<ReaderReblogSelection
+							post={ this.props.post }
+							popoverProps={ popoverProps }
+							closeMenu={ this.closeMenu }
+						/>
 					) ) }
 			</div>
 		);

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -6,17 +6,13 @@ import { defer } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
-import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import PopoverMenuItemClipboard from 'calypso/components/popover-menu/item-clipboard';
-import ReaderFacebookIcon from 'calypso/reader/components/icons/facebook-icon';
 import ReaderShareIcon from 'calypso/reader/components/icons/share-icon';
-import ReaderTwitterIcon from 'calypso/reader/components/icons/twitter-icon';
-import ReaderPopoverMenu from 'calypso/reader/components/reader-popover/menu';
 import * as stats from 'calypso/reader/stats';
 import { preloadEditor } from 'calypso/sections-preloaders';
 import { infoNotice } from 'calypso/state/notices/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import ReaderReblogSelection from './reblog';
+import ReaderSocialShareSelection from './social';
 import './style.scss';
 
 /**
@@ -134,6 +130,15 @@ class ReaderShare extends Component {
 			'is-active': this.state.showingMenu,
 		} );
 
+		const popoverProps = {
+			key: 'menu',
+			context: this.shareButton.current,
+			isVisible: this.state.showingMenu,
+			onClose: this.closeExternalShareMenu,
+			position: this.props.position,
+			className: 'popover reader-share__popover',
+		};
+
 		// The event.preventDefault() on the wrapping div is needed to prevent the
 		// full post opening when a share method is selected in the popover
 		return (
@@ -153,45 +158,16 @@ class ReaderShare extends Component {
 						iconSize: this.props.iconSize,
 					} ) }
 				</Button>
-				{ this.state.showingMenu && (
-					<ReaderPopoverMenu
-						key="menu"
-						context={ this.shareButton.current }
-						isVisible={ this.state.showingMenu }
-						onClose={ this.closeExternalShareMenu }
-						position={ this.props.position }
-						className="popover reader-share__popover"
-						popoverTitle={ translate( 'Share on' ) }
-					>
-						<PopoverMenuItem
-							action="facebook"
-							className="reader-share__popover-item"
-							title={ translate( 'Share on Facebook' ) }
-							focusOnHover={ false }
-						>
-							<ReaderFacebookIcon iconSize={ 20 } />
-							<span>Facebook</span>
-						</PopoverMenuItem>
-						<PopoverMenuItem
-							action="twitter"
-							className="reader-share__popover-item"
-							title={ translate( 'Share on Twitter' ) }
-							focusOnHover={ false }
-						>
-							<ReaderTwitterIcon iconSize={ 20 } />
-							<span>Twitter</span>
-						</PopoverMenuItem>
-						<PopoverMenuItemClipboard
-							action="copy_link"
-							text={ this.props.post.URL }
-							onCopy={ onCopyLinkClick }
-							icon="link"
-						>
-							{ translate( 'Copy link' ) }
-						</PopoverMenuItemClipboard>
-						<ReaderReblogSelection post={ this.props.post } />
-					</ReaderPopoverMenu>
-				) }
+				{ this.state.showingMenu &&
+					( ! this.props.isReblogSelection ? (
+						<ReaderSocialShareSelection
+							post={ this.props.post }
+							onCopyLinkClick={ onCopyLinkClick }
+							popoverProps={ popoverProps }
+						/>
+					) : (
+						<ReaderReblogSelection post={ this.props.post } popoverProps={ popoverProps } />
+					) ) }
 			</div>
 		);
 	}

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -3,13 +3,11 @@ import { Button } from '@automattic/components';
 import classnames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
 import { defer } from 'lodash';
-import page from 'page';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import PopoverMenuItemClipboard from 'calypso/components/popover-menu/item-clipboard';
-import SiteSelector from 'calypso/components/site-selector';
 import ReaderFacebookIcon from 'calypso/reader/components/icons/facebook-icon';
 import ReaderShareIcon from 'calypso/reader/components/icons/share-icon';
 import ReaderTwitterIcon from 'calypso/reader/components/icons/twitter-icon';
@@ -18,7 +16,7 @@ import * as stats from 'calypso/reader/stats';
 import { preloadEditor } from 'calypso/sections-preloaders';
 import { infoNotice } from 'calypso/state/notices/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
-
+import ReaderReblogSelection from './reblog';
 import './style.scss';
 
 /**
@@ -51,22 +49,6 @@ const actionMap = {
 	},
 	copy_link() {},
 };
-
-function buildQuerystringForPost( post ) {
-	const args = {};
-
-	if ( post.content_embeds && post.content_embeds.length ) {
-		args.embed = post.content_embeds[ 0 ].embedUrl || post.content_embeds[ 0 ].src;
-	}
-
-	args.title = `${ post.title } — ${ post.site_name }`;
-	args.text = post.excerpt;
-	args.url = post.URL;
-	args.is_post_share = true; // There is a dependency on this here https://github.com/Automattic/wp-calypso/blob/a69ded693a99fa6a957b590b1a538f32a581eb8a/client/gutenberg/editor/controller.js#L209
-
-	const params = new URLSearchParams( args );
-	return params.toString();
-}
 
 class ReaderShare extends Component {
 	static propTypes = {
@@ -129,14 +111,6 @@ class ReaderShare extends Component {
 		if ( this.mounted ) {
 			this.deferMenuChange( false );
 		}
-	};
-
-	pickSiteToShareTo = ( slug ) => {
-		stats.recordAction( 'share_wordpress' );
-		stats.recordGaEvent( 'Clicked on Share to WordPress' );
-		stats.recordTrack( 'calypso_reader_share_to_site' );
-		page( `/post/${ slug }?` + buildQuerystringForPost( this.props.post ) );
-		return true;
 	};
 
 	closeExternalShareMenu = ( action ) => {
@@ -215,13 +189,7 @@ class ReaderShare extends Component {
 						>
 							{ translate( 'Copy link' ) }
 						</PopoverMenuItemClipboard>
-						{ this.props.hasSites && (
-							<SiteSelector
-								className="reader-share__site-selector"
-								onSiteSelect={ this.pickSiteToShareTo }
-								groups
-							/>
-						) }
+						<ReaderReblogSelection post={ this.props.post } />
 					</ReaderPopoverMenu>
 				) }
 			</div>

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
 import { defer } from 'lodash';
@@ -154,9 +154,13 @@ class ReaderShare extends Component {
 					onTouchStart={ preloadEditor }
 					ref={ this.shareButton }
 				>
-					{ ReaderShareIcon( {
-						iconSize: this.props.iconSize,
-					} ) }
+					{ ! this.props.isReblogSelection ? (
+						ReaderShareIcon( {
+							iconSize: this.props.iconSize,
+						} )
+					) : (
+						<Gridicon icon="reblog" size={ this.props.iconSize } />
+					) }
 				</Button>
 				{ this.state.showingMenu &&
 					( ! this.props.isReblogSelection ? (

--- a/client/blocks/reader-share/reblog.jsx
+++ b/client/blocks/reader-share/reblog.jsx
@@ -31,6 +31,7 @@ const ReaderReblogSelection = ( props ) => {
 			'reblog post',
 			'width=550,height=420,resizeable,scrollbars'
 		);
+		props.closeMenu();
 		return true;
 	};
 

--- a/client/blocks/reader-share/reblog.jsx
+++ b/client/blocks/reader-share/reblog.jsx
@@ -1,0 +1,45 @@
+import page from 'page';
+import SiteSelector from 'calypso/components/site-selector';
+import * as stats from 'calypso/reader/stats';
+import { useSelector } from 'calypso/state';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+
+const ReaderReblogSelection = ( props ) => {
+	const hasSites = !! useSelector( getPrimarySiteId );
+
+	const buildQuerystringForPost = ( post ) => {
+		const args = {};
+
+		if ( post.content_embeds && post.content_embeds.length ) {
+			args.embed = post.content_embeds[ 0 ].embedUrl || post.content_embeds[ 0 ].src;
+		}
+
+		args.title = `${ post.title } — ${ post.site_name }`;
+		args.text = post.excerpt;
+		args.url = post.URL;
+		args.is_post_share = true; // There is a dependency on this here https://github.com/Automattic/wp-calypso/blob/a69ded693a99fa6a957b590b1a538f32a581eb8a/client/gutenberg/editor/controller.js#L209
+
+		const params = new URLSearchParams( args );
+		return params.toString();
+	};
+
+	const pickSiteToShareTo = ( slug ) => {
+		stats.recordAction( 'share_wordpress' );
+		stats.recordGaEvent( 'Clicked on Share to WordPress' );
+		stats.recordTrack( 'calypso_reader_share_to_site' );
+		page( `/post/${ slug }?` + buildQuerystringForPost( props.post ) );
+		return true;
+	};
+
+	return (
+		hasSites && (
+			<SiteSelector
+				className="reader-share__site-selector"
+				onSiteSelect={ pickSiteToShareTo }
+				groups
+			/>
+		)
+	);
+};
+
+export default ReaderReblogSelection;

--- a/client/blocks/reader-share/reblog.jsx
+++ b/client/blocks/reader-share/reblog.jsx
@@ -1,11 +1,14 @@
+import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import SiteSelector from 'calypso/components/site-selector';
+import ReaderPopoverMenu from 'calypso/reader/components/reader-popover/menu';
 import * as stats from 'calypso/reader/stats';
 import { useSelector } from 'calypso/state';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 
 const ReaderReblogSelection = ( props ) => {
 	const hasSites = !! useSelector( getPrimarySiteId );
+	const translate = useTranslate();
 
 	const buildQuerystringForPost = ( post ) => {
 		const args = {};
@@ -33,11 +36,13 @@ const ReaderReblogSelection = ( props ) => {
 
 	return (
 		hasSites && (
-			<SiteSelector
-				className="reader-share__site-selector"
-				onSiteSelect={ pickSiteToShareTo }
-				groups
-			/>
+			<ReaderPopoverMenu { ...props.popoverProps } popoverTitle={ translate( 'Reblog on' ) }>
+				<SiteSelector
+					className="reader-share__site-selector"
+					onSiteSelect={ pickSiteToShareTo }
+					groups
+				/>
+			</ReaderPopoverMenu>
 		)
 	);
 };

--- a/client/blocks/reader-share/reblog.jsx
+++ b/client/blocks/reader-share/reblog.jsx
@@ -1,13 +1,9 @@
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import SiteSelector from 'calypso/components/site-selector';
 import ReaderPopoverMenu from 'calypso/reader/components/reader-popover/menu';
 import * as stats from 'calypso/reader/stats';
-import { useSelector } from 'calypso/state';
-import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 
 const ReaderReblogSelection = ( props ) => {
-	const hasSites = !! useSelector( getPrimarySiteId );
 	const translate = useTranslate();
 
 	const buildQuerystringForPost = ( post ) => {
@@ -30,20 +26,22 @@ const ReaderReblogSelection = ( props ) => {
 		stats.recordAction( 'share_wordpress' );
 		stats.recordGaEvent( 'Clicked on Share to WordPress' );
 		stats.recordTrack( 'calypso_reader_share_to_site' );
-		page( `/post/${ slug }?` + buildQuerystringForPost( props.post ) );
+		window.open(
+			`/post/${ slug }?${ buildQuerystringForPost( props.post ) }`,
+			'reblog post',
+			'width=550,height=420,resizeable,scrollbars'
+		);
 		return true;
 	};
 
 	return (
-		hasSites && (
-			<ReaderPopoverMenu { ...props.popoverProps } popoverTitle={ translate( 'Reblog on' ) }>
-				<SiteSelector
-					className="reader-share__site-selector"
-					onSiteSelect={ pickSiteToShareTo }
-					groups
-				/>
-			</ReaderPopoverMenu>
-		)
+		<ReaderPopoverMenu { ...props.popoverProps } popoverTitle={ translate( 'Reblog on' ) }>
+			<SiteSelector
+				className="reader-share__site-selector"
+				onSiteSelect={ pickSiteToShareTo }
+				groups
+			/>
+		</ReaderPopoverMenu>
 	);
 };
 

--- a/client/blocks/reader-share/social.jsx
+++ b/client/blocks/reader-share/social.jsx
@@ -1,0 +1,43 @@
+import { useTranslate } from 'i18n-calypso';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import PopoverMenuItemClipboard from 'calypso/components/popover-menu/item-clipboard';
+import ReaderFacebookIcon from 'calypso/reader/components/icons/facebook-icon';
+import ReaderTwitterIcon from 'calypso/reader/components/icons/twitter-icon';
+import ReaderPopoverMenu from 'calypso/reader/components/reader-popover/menu';
+
+const ReaderSocialShareSelection = ( props ) => {
+	const translate = useTranslate();
+
+	return (
+		<ReaderPopoverMenu { ...props.popoverProps } popoverTitle={ translate( 'Share on' ) }>
+			<PopoverMenuItem
+				action="facebook"
+				className="reader-share__popover-item"
+				title={ translate( 'Share on Facebook' ) }
+				focusOnHover={ false }
+			>
+				<ReaderFacebookIcon iconSize={ 20 } />
+				<span>Facebook</span>
+			</PopoverMenuItem>
+			<PopoverMenuItem
+				action="twitter"
+				className="reader-share__popover-item"
+				title={ translate( 'Share on Twitter' ) }
+				focusOnHover={ false }
+			>
+				<ReaderTwitterIcon iconSize={ 20 } />
+				<span>Twitter</span>
+			</PopoverMenuItem>
+			<PopoverMenuItemClipboard
+				action="copy_link"
+				text={ props.post.URL }
+				onCopy={ props.onCopyLinkClick }
+				icon="link"
+			>
+				{ translate( 'Copy link' ) }
+			</PopoverMenuItemClipboard>
+		</ReaderPopoverMenu>
+	);
+};
+
+export default ReaderSocialShareSelection;

--- a/client/blocks/reader-share/social.jsx
+++ b/client/blocks/reader-share/social.jsx
@@ -1,15 +1,75 @@
+import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import PopoverMenuItemClipboard from 'calypso/components/popover-menu/item-clipboard';
 import ReaderFacebookIcon from 'calypso/reader/components/icons/facebook-icon';
 import ReaderTwitterIcon from 'calypso/reader/components/icons/twitter-icon';
 import ReaderPopoverMenu from 'calypso/reader/components/reader-popover/menu';
+import * as stats from 'calypso/reader/stats';
+import { useDispatch } from 'calypso/state';
+import { infoNotice } from 'calypso/state/notices/actions';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+
+/**
+ * Local variables
+ */
+const actionMap = {
+	twitter( post ) {
+		const baseUrl = new URL( 'https://twitter.com/intent/tweet' );
+		const params = new URLSearchParams( {
+			text: post.title,
+			url: post.URL,
+		} );
+		baseUrl.search = params.toString();
+
+		const twitterUrl = baseUrl.href;
+
+		window.open( twitterUrl, 'twitter', 'width=550,height=420,resizeable,scrollbars' );
+	},
+	facebook( post ) {
+		const baseUrl = new URL( 'https://www.facebook.com/sharer.php' );
+		const params = new URLSearchParams( {
+			u: post.URL,
+			app_id: config( 'facebook_api_key' ),
+		} );
+		baseUrl.search = params.toString();
+
+		const facebookUrl = baseUrl.href;
+
+		window.open( facebookUrl, 'facebook', 'width=626,height=436,resizeable,scrollbars' );
+	},
+	copy_link() {},
+};
 
 const ReaderSocialShareSelection = ( props ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const onCopyLinkClick = () => {
+		dispatch( infoNotice( translate( 'Link copied to clipboard.' ), { duration: 3000 } ) );
+	};
+
+	const closeExternalShareMenu = ( action ) => {
+		props.closeMenu();
+		const actionFunc = actionMap[ action ];
+		if ( actionFunc ) {
+			stats.recordAction( 'share_' + action );
+			stats.recordGaEvent( 'Clicked on Share to ' + action );
+			dispatch(
+				recordReaderTracksEvent( 'calypso_reader_share_action_picked', {
+					action: action,
+				} )
+			);
+			actionFunc( props.post );
+		}
+	};
 
 	return (
-		<ReaderPopoverMenu { ...props.popoverProps } popoverTitle={ translate( 'Share on' ) }>
+		<ReaderPopoverMenu
+			{ ...props.popoverProps }
+			popoverTitle={ translate( 'Share on' ) }
+			onClose={ closeExternalShareMenu }
+		>
 			<PopoverMenuItem
 				action="facebook"
 				className="reader-share__popover-item"
@@ -31,7 +91,7 @@ const ReaderSocialShareSelection = ( props ) => {
 			<PopoverMenuItemClipboard
 				action="copy_link"
 				text={ props.post.URL }
-				onCopy={ props.onCopyLinkClick }
+				onCopy={ onCopyLinkClick }
 				icon="link"
 			>
 				{ translate( 'Copy link' ) }

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -25,7 +25,9 @@
 	}
 
 	.gridicons-reblog {
+		height: 20px;
 		top: 0;
+		width: 20px;
 	}
 
 	&.is-active {
@@ -117,6 +119,7 @@
 		fill: var(--color-facebook);
 	}
 
+	&:focus,
 	&:hover {
 		.gridicon,
 		.reader-twitter,

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -24,6 +24,10 @@
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 	}
 
+	.gridicons-reblog {
+		top: 0;
+	}
+
 	&.is-active {
 		color: var(--color-primary);
 

--- a/client/blocks/reader-views/index.jsx
+++ b/client/blocks/reader-views/index.jsx
@@ -5,7 +5,7 @@ import './style.scss';
 const ReaderViews = ( { viewCount } ) => {
 	return (
 		<div className="reader-views">
-			<SVGIcon classes="reader-views__icon" name="bar-chart" size="24" icon={ BarChart } />
+			<SVGIcon classes="reader-views__icon" name="bar-chart" size="20" icon={ BarChart } />
 			<span className="reader-views__view-count">{ viewCount }</span>
 		</div>
 	);

--- a/client/blocks/reader-visit-link/style.scss
+++ b/client/blocks/reader-visit-link/style.scss
@@ -7,6 +7,10 @@
 	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 13px;
 	font-weight: 500;
+
+	@include breakpoint-deprecated( "<660px" ) {
+		display: none;
+	}
 }
 
 .reader-visit-link:hover,

--- a/client/components/svg-icon/index.tsx
+++ b/client/components/svg-icon/index.tsx
@@ -19,7 +19,7 @@ const SVGIcon = React.forwardRef< SVGSVGElement, AllProps >( ( props: AllProps, 
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
-			viewBox="0 0 24 24"
+			viewBox={ `0 0 ${ size } ${ size }` }
 			className={ iconClass }
 			height={ size }
 			width={ size }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-13E-p2

## Proposed Changes

* This separates the social sharing and reblogging/press-this options from the readers sharing button. Instead we show two buttons, one for each. Here we have refactored the reader-share component to be able to handle either option (social vs. reblog) via a prop `isReblogSelection`.

* This also updates reader reblog/press-this to open the editor in a new window as opposed to forcing navigation in the current page.

Before:
<img width="180" alt="Screenshot 2023-07-27 at 1 20 35 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/21cb47de-170f-4ebf-9b9a-e1045805e417">

After:
<img width="261" alt="Screenshot 2023-07-27 at 1 20 13 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/f5facc46-2bfc-40c3-859c-68467f3f1543">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Smoke test reader social sharing options (facebook, twitter, copy-link).
* Verify the reader reblogging works as expected from the new popover and opens in a new window.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?