### PR TITLE
Adds filtering by post type in the Advertising - Posts page

### DIFF
--- a/client/data/promote-post/use-promote-post-posts-query-paged.ts
+++ b/client/data/promote-post/use-promote-post-posts-query-paged.ts
@@ -17,6 +17,9 @@ export const getSearchOptionsQueryParams = ( searchOptions: SearchOptions ) => {
 		if ( searchOptions.filter.status && searchOptions.filter.status !== 'all' ) {
 			searchQueryParams += `&status=${ searchOptions.filter.status }`;
 		}
+		if ( searchOptions.filter.postType && searchOptions.filter.postType !== 'all' ) {
+			searchQueryParams += `&filter_post_type=${ searchOptions.filter.postType }`;
+		}
 	}
 	if ( searchOptions.order ) {
 		searchQueryParams += `&order_by=${ searchOptions.order.orderBy }`;

--- a/client/my-sites/promote-post-i2/components/campaigns-filter/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-filter/index.tsx
@@ -2,7 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useRef } from 'react';
 import SegmentedControl from 'calypso/components/segmented-control';
 
-export type CampaignsFilterType = 'all' | 'active' | 'created' | 'finished' | 'rejected';
+export type CampaignsFilterType = '' | 'active' | 'created' | 'finished' | 'rejected';
 
 interface Props {
 	campaignsFilter: CampaignsFilterType;
@@ -31,9 +31,8 @@ export default function CampaignsFilter( props: Props ) {
 
 	const options = [
 		{
-			value: 'all',
+			value: '',
 			label: translate( 'All' ),
-			selectedCondition: campaignsFilter === 'all' || ! campaignsFilter,
 		},
 		{
 			value: 'active',
@@ -58,9 +57,7 @@ export default function CampaignsFilter( props: Props ) {
 			{ options.map( ( option ) => (
 				<SegmentedControl.Item
 					key={ option.value }
-					selected={
-						option.selectedCondition ? option.selectedCondition : campaignsFilter === option.value
-					}
+					selected={ campaignsFilter === option.value }
 					onClick={ () => handleChange( option.value as CampaignsFilterType ) }
 				>
 					<span ref={ ( el ) => ( tabsRef.current[ option.value ] = el ) }>{ option.label }</span>

--- a/client/my-sites/promote-post-i2/components/post-item/style.scss
+++ b/client/my-sites/promote-post-i2/components/post-item/style.scss
@@ -163,6 +163,10 @@ body.is-section-promote-post-i2 {
 			width: calc(100% - 32px);
 		}
 
+		th.posts-list__header-column {
+			display: none;
+		}
+
 		.post-item__post {
 			// Do not show the rest of columns on mobiles
 			&-type,

--- a/client/my-sites/promote-post-i2/components/search-bar/style.scss
+++ b/client/my-sites/promote-post-i2/components/search-bar/style.scss
@@ -15,24 +15,21 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 	margin-bottom: 20px;
 	flex-wrap: wrap;
 	display: grid;
-	grid-template-columns: 1fr 480px;
+	grid-template-columns: 1fr auto;
 
-	&.wide {
-		grid-template-columns: 1fr 220px;
-	}
+	.promote-post-i2__search-bar-options {
+		display: flex;
 
-	.promote-post-i2__search-bar-dropdown {
-		&.select-dropdown {
-			height: 50px;
-		}
+		.promote-post-i2__search-bar-dropdown {
 
-		.select-dropdown__container {
-			max-width: 220px;
-			width: 100%;
-		}
-
-		.select-dropdown__header {
-			height: 50px;
+			&.select-dropdown {
+				&.order-by .select-dropdown__container {
+					min-width: 200px;
+				}
+				&.post-type .select-dropdown__container {
+					min-width: 160px;
+				}
+			}
 		}
 	}
 
@@ -105,15 +102,21 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 }
 
 @mixin blazepress-search-bar-mobile {
-	.promote-post-i2__search-bar-wrapper {
+	.main.promote-post-i2 .promote-post-i2__search-bar-wrapper {
 		display: flex;
 		position: relative;
 
+		.promote-post-i2__search-bar-search.search-component {
+			margin-bottom: 12px;
+		}
+
+		.promote-post-i2__search-bar-options {
+			width: 100%;
+			justify-content: space-between;
+		}
+
 		.promote-post-i2__search-bar-dropdown {
-			position: absolute;
-			right: 0;
-			top: 3rem;
-			z-index: 100; // Search dropdown should be above the post list.
+			margin: 0;
 
 			.select-dropdown__header {
 				background: transparent;


### PR DESCRIPTION
We are adding the possibility to filter by post type on the Advertising page. 

![Screenshot 2023-07-27 at 14 35 17](https://github.com/Automattic/wp-calypso/assets/1258162/e5665c7a-eee0-4bb2-9021-3f0723a52324)

![Screenshot 2023-07-27 at 14 35 37](https://github.com/Automattic/wp-calypso/assets/1258162/73b7da79-cfb0-4077-912d-9307213d7fe6)


## Proposed Changes

I added a new filter in the Ready to Promote page for the Advertising section. The options of the new filter are: All, Posts and pages.

## Testing Instructions

* Open the live preview and navigate to Tools->Advertising
* Check that the new filter is shown on the Posts page
* Change its value and verify that the resulting table is correctly filtered
* Change the screen to mobile, and verify that the mobile view for the change is correct
* Go to the campaign list page, and verify that the status filter continue to work correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
