### PR TITLE
Domain Transfer: Allow wrapping price non-EN; Disable wrapping domain code pair

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -12,6 +12,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormInput from 'calypso/components/forms/form-text-input';
 import InfoPopover from 'calypso/components/info-popover';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { useValidationMessage } from './use-validation-message';
 
@@ -160,7 +161,7 @@ export function DomainCodePair( {
 		</>
 	);
 	return (
-		<div className="domains__domain-info-and-validation">
+		<div className={ `domains__domain-info-and-validation ${ getLocaleSlug() }` }>
 			<div className="domains__domain-info">
 				<div className="domains__domain-domain">
 					<FormFieldset>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -138,11 +138,12 @@
 		display: flex;
 		gap: 20px;
 		align-items: flex-end;
-		flex-wrap: wrap;
+		flex-wrap: nowrap;
 
 		@media (max-width: $break-medium ) {
 			align-items: normal;
 			flex-direction: column;
+			flex-wrap: wrap;
 		}
 
 		.form-fieldset {
@@ -208,7 +209,7 @@
 	}
 
 	.domains__domain-domain {
-		flex: 0 0 390px;
+		flex: 0 0 420px;
 	}
 
 	.domains__domain-key {
@@ -272,7 +273,6 @@
 				font-size: 0.75rem;
 				font-weight: 500;
 				line-height: 16px;
-				white-space: nowrap;
 			}
 		}
 	}
@@ -451,6 +451,13 @@
 			// Remove left-padding for first button to minimize padding when line wraps on mobile.
 			button:first-of-type {
 				padding-left: 0;
+			}
+		}
+
+		&.en,
+		&.en-gb {
+			.domains__domain-price-text {
+				white-space: nowrap;
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed Changes

- Fixes some issues with wrapping when the free price text was displayed. 
<img width="1168" alt="Screenshot 2023-07-27 at 1 07 34 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/34fefcad-5d70-49e9-bd5e-b35eb1bc4dac">
<img width="520" alt="Screenshot 2023-07-27 at 1 07 41 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/c5f38301-efd1-425f-bd5f-8561770ebd45">
<img width="1105" alt="Screenshot 2023-07-27 at 1 09 53 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/d090253d-25ae-4e24-9356-0b687d9fab9c">
<img width="522" alt="Screenshot 2023-07-27 at 1 08 14 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/0513b4db-cd2e-4e25-811d-38e65e1a5d86">


## Testing Instructions

* Go to `/setup/domain-transfer`
* Use Google Domain
* Verify you get free pricing
* Verify no wrapping for en or en-gb
* Change language
* Verify likely wrapping

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
