### PR TITLE
Checkout: Update features for domains products

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -176,6 +176,12 @@ export function hasFreeCouponTransfersOnly( cart: ObjectWithProducts ): boolean 
 	} );
 }
 
+export function hasDomainProductsOnly( cart: ObjectWithProducts ): boolean {
+	return getAllCartItems( cart ).every( ( item ) => {
+		return isDomainProduct( item ) || isDomainTransfer( item ) || isPartialCredits( item );
+	} );
+}
+
 export function getDomainTransfers( cart: ObjectWithProducts ): ResponseCartProduct[] {
 	return getAllCartItems( cart ).filter(
 		( product ) => product.product_slug === domainProductSlugs.TRANSFER_IN

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -35,7 +35,10 @@ import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
-import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
+import {
+	hasFreeCouponTransfersOnly,
+	hasDomainProductsOnly,
+} from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
@@ -396,9 +399,22 @@ function CheckoutSummaryFeaturesList( props: {
 							? translate( 'We absorb the cost and give you an extra year of free registration' )
 							: translate( '1-year extension on your domain' ) }
 					</CheckoutSummaryFeaturesListItem>
+				</>
+			) }
+
+			{ hasDomainProductsOnly( responseCart ) && (
+				<>
 					<CheckoutSummaryFeaturesListItem>
 						<WPCheckoutCheckIcon id="features-list-support-privacy" />
 						{ translate( 'Private domain registration and SSL certificate included for free' ) }
+					</CheckoutSummaryFeaturesListItem>
+					<CheckoutSummaryFeaturesListItem>
+						<WPCheckoutCheckIcon id="features-list-fast-dns" />
+						{ translate( 'Extremely fast DNS' ) }
+					</CheckoutSummaryFeaturesListItem>
+					<CheckoutSummaryFeaturesListItem>
+						<WPCheckoutCheckIcon id="features-list-fast-dns" />
+						{ translate( 'Manage everything you need in one place' ) }
 					</CheckoutSummaryFeaturesListItem>
 				</>
 			) }
@@ -593,12 +609,11 @@ function CheckoutSummaryChatIfAvailable( props: {
 	const currentPlanSlug = currentPlan?.productSlug;
 
 	const isChatAvailable =
-		props.hasDomainTransferInCart ||
-		( currentPlanSlug &&
-			( isWpComPremiumPlan( currentPlanSlug ) ||
-				isWpComBusinessPlan( currentPlanSlug ) ||
-				isWpComEcommercePlan( currentPlanSlug ) ) &&
-			! isMonthly( currentPlanSlug ) );
+		currentPlanSlug &&
+		( isWpComPremiumPlan( currentPlanSlug ) ||
+			isWpComBusinessPlan( currentPlanSlug ) ||
+			isWpComEcommercePlan( currentPlanSlug ) ) &&
+		! isMonthly( currentPlanSlug );
 
 	if ( ! isChatAvailable ) {
 		return null;


### PR DESCRIPTION
## Proposed Changes

* Update features for domains products in checkout.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout patch
* Add domain through `/setup/domain-transfer`
* Verify checkout shows new features and no live chat
* Add domain from `/domains`
* Verify checkout shows features and no live chat
* Add any other product
* Ensure no domains features

**Transfer**
<img width="383" alt="Screenshot 2023-07-27 at 2 31 47 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/da2c8fa2-2447-46c5-94bf-64599ca4ef5e">

**Domain only**

<img width="383" alt="Screenshot 2023-07-27 at 2 27 01 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/a4507d94-f5f4-4f08-af58-13e5b193c440">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
