### PR TITLE
Revert "Transfer success message: Fix missing "to" typo."

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@automattic/components';
-import { localizeUrl, englishLocales } from '@automattic/i18n-utils';
-import i18n, { getLocaleSlug } from 'i18n-calypso';
+import { localizeUrl } from '@automattic/i18n-utils';
 import moment from 'moment';
 import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import { isExpiringSoon } from 'calypso/lib/domains/utils/is-expiring-soon';
@@ -481,46 +480,24 @@ export function resolveDomainStatus(
 			}
 
 			if ( domain.transferStatus === transferStatus.COMPLETED && ! domain.pointsToWpcom ) {
-				const hasTranslation =
-					englishLocales.includes( String( getLocaleSlug() ) ) ||
-					i18n.hasTranslation(
-						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com name servers.{{/a}}'
-					);
-
-				const oldCopy = translate(
-					'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need {{a}}point it to WordPress.com name servers.{{/a}}',
-					{
-						components: {
-							strong: <strong />,
-							a: (
-								<a
-									href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute ) }
-								/>
-							),
-						},
-					}
-				);
-
-				const newCopy = translate(
-					'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com name servers.{{/a}}',
-					{
-						components: {
-							strong: <strong />,
-							a: (
-								<a
-									href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute ) }
-								/>
-							),
-						},
-					}
-				);
-
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-success',
 					status: translate( 'Active' ),
 					icon: 'info',
-					noticeText: hasTranslation ? newCopy : oldCopy,
+					noticeText: translate(
+						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need {{a}}point it to WordPress.com name servers.{{/a}}',
+						{
+							components: {
+								strong: <strong />,
+								a: (
+									<a
+										href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute ) }
+									/>
+								),
+							},
+						}
+					),
 					listStatusWeight: 600,
 				};
 			}


### PR DESCRIPTION
Reverts Automattic/wp-calypso#79935