### PR TITLE
Domain Transfers: Redirect to default step using location.assign

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -205,10 +205,10 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	}
 
 	const RedirectToFirstStep = () => {
-		window.location.assign(
+		window.location.replace(
 			`/setup/${ flow.variantSlug ?? flow.name }/${ stepPaths[ 0 ] }${ search }`
 		);
-		return;
+		return null;
 	};
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -8,7 +8,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState, useCallback, Suspense, lazy } from 'react';
 import Modal from 'react-modal';
-import { Navigate, Route, Routes, generatePath, useNavigate, useLocation } from 'react-router-dom';
+import { Route, Routes, generatePath, useNavigate, useLocation } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
@@ -204,6 +204,13 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		} as React.CSSProperties;
 	}
 
+	const RedirectToFirstStep = () => {
+		window.location.assign(
+			`/setup/${ flow.variantSlug ?? flow.name }/${ stepPaths[ 0 ] }${ search }`
+		);
+		return;
+	};
+
 	return (
 		<Suspense fallback={ <StepperLoader /> }>
 			<DocumentHead title={ getDocumentHeadTitle() } />
@@ -224,12 +231,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 						}
 					/>
 				) ) }
-				<Route
-					path="*"
-					element={
-						<Navigate to={ `/${ flow.variantSlug ?? flow.name }/${ stepPaths[ 0 ] }${ search }` } />
-					}
-				/>
+				<Route path="*" element={ <RedirectToFirstStep /> } />
 			</Routes>
 			<AsyncCheckoutModal siteId={ site?.ID } />
 		</Suspense>


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3236

## Proposed Changes

Instead of using the `Navigate` component on default `Routes`, we redirect using `window.location.replace` to avoid leaving the `redirection stage` to browser history.

Slack conversation: p1690314087610609-slack-C057AH42XQD

## Testing Instructions

* Go to [/domains](https://wordpress.com/domains)
* Go to [/setup/domain-transfer/](http://calypso.localhost:3000/setup/domain-transfer/)
* Click on some place or on Get Started
* Return to the `/domains` by using the browser back button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?