### PR TITLE
Checkout: Move 3DS challenge code to own functions

### DIFF
--- a/client/lib/logstash/index.ts
+++ b/client/lib/logstash/index.ts
@@ -15,6 +15,7 @@ interface LogToLogstashParams {
 	message: string;
 	extra?: any;
 	site_id?: number;
+	tags?: string[];
 	[ key: string ]: any;
 }
 

--- a/client/lib/logstash/index.ts
+++ b/client/lib/logstash/index.ts
@@ -15,7 +15,7 @@ interface LogToLogstashParams {
 	message: string;
 	extra?: any;
 	site_id?: number;
-	tags?: string;
+	tags?: string[];
 	[ key: string ]: any;
 }
 

--- a/client/lib/logstash/index.ts
+++ b/client/lib/logstash/index.ts
@@ -15,7 +15,7 @@ interface LogToLogstashParams {
 	message: string;
 	extra?: any;
 	site_id?: number;
-	tags?: string[];
+	tags?: string;
 	[ key: string ]: any;
 }
 

--- a/client/my-sites/checkout/composite-checkout/lib/analytics.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/analytics.ts
@@ -29,9 +29,11 @@ export function logStashLoadErrorEvent(
 	} );
 }
 
+export type DataForLog = Record< string, string > & { tags?: string[] };
+
 export function logStashEvent(
 	message: string,
-	dataForLog: Record< string, string > = {},
+	dataForLog: DataForLog,
 	severity: 'error' | 'warning' | 'info' = 'error'
 ): Promise< void > {
 	return logToLogstash( {
@@ -42,6 +44,7 @@ export function logStashEvent(
 			env: config( 'env_id' ),
 			...dataForLog,
 		},
+		tags: dataForLog.tags ?? [],
 	} );
 }
 

--- a/client/my-sites/checkout/composite-checkout/lib/analytics.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/analytics.ts
@@ -29,7 +29,7 @@ export function logStashLoadErrorEvent(
 	} );
 }
 
-export type DataForLog = Record< string, string > & { tags?: string[] };
+export type DataForLog = Record< string, string >;
 
 export function logStashEvent(
 	message: string,

--- a/client/my-sites/checkout/composite-checkout/lib/analytics.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/analytics.ts
@@ -29,7 +29,7 @@ export function logStashLoadErrorEvent(
 	} );
 }
 
-export type DataForLog = Record< string, string >;
+export type DataForLog = Record< string, string | string[] > & { tags?: string[] };
 
 export function logStashEvent(
 	message: string,

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -101,12 +101,7 @@ export default async function existingCardProcessor(
 			return stripeResponse;
 		} )
 		.then( ( stripeResponse ) => {
-			const hasPaymentIntent =
-				stripeResponse &&
-				'message' in stripeResponse &&
-				typeof stripeResponse.message !== 'string' &&
-				stripeResponse?.message?.payment_intent_client_secret;
-			if ( stripeResponse?.redirect_url && ! hasPaymentIntent ) {
+			if ( stripeResponse?.redirect_url && ! doesTransactionResponseRequire3DS( stripeResponse ) ) {
 				debug( 'transaction requires redirect' );
 				return makeRedirectResponse( stripeResponse.redirect_url );
 			}

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -89,7 +89,8 @@ export default async function existingCardProcessor(
 				await handle3DSChallenge(
 					reduxDispatch,
 					stripe,
-					stripeResponse.message.payment_intent_client_secret
+					stripeResponse.message.payment_intent_client_secret,
+					stripeResponse.message.payment_intent_id
 				);
 				// We must return the original authentication response in order
 				// to have access to the order_id so that we can display a

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -117,9 +117,13 @@ export default async function existingCardProcessor(
 					payment_intent_id: paymentIntentId ?? '',
 				} )
 			);
-			logStashEvent( 'calypso_checkout_card_transaction_failed', {
-				payment_intent_id: paymentIntentId ?? '',
-			} );
+			logStashEvent(
+				'calypso_checkout_card_transaction_failed',
+				{
+					payment_intent_id: paymentIntentId ?? '',
+				},
+				'info'
+			);
 
 			// Errors here are "expected" errors, meaning that they (hopefully) come
 			// from the endpoint and not from some bug in the frontend code.

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -121,7 +121,7 @@ export default async function existingCardProcessor(
 				'calypso_checkout_card_transaction_failed',
 				{
 					payment_intent_id: paymentIntentId ?? '',
-					tags: `payment_intent_id:${ paymentIntentId }`,
+					tags: [ `payment_intent_id:${ paymentIntentId }` ],
 				},
 				'info'
 			);

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -121,6 +121,7 @@ export default async function existingCardProcessor(
 				'calypso_checkout_card_transaction_failed',
 				{
 					payment_intent_id: paymentIntentId ?? '',
+					tags: [ `payment_intent_id:${ paymentIntentId }` ],
 				},
 				'info'
 			);

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -121,7 +121,7 @@ export default async function existingCardProcessor(
 				'calypso_checkout_card_transaction_failed',
 				{
 					payment_intent_id: paymentIntentId ?? '',
-					tags: [ `payment_intent_id:${ paymentIntentId }` ],
+					tags: `payment_intent_id:${ paymentIntentId }`,
 				},
 				'info'
 			);

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -170,7 +170,7 @@ async function stripeCardProcessor(
 			);
 			logStashEvent( 'calypso_checkout_card_transaction_failed', {
 				payment_intent_id: paymentIntentId ?? '',
-				tags: `payment_intent_id:${ paymentIntentId }`,
+				tags: [ `payment_intent_id:${ paymentIntentId }` ],
 			} );
 
 			// Errors here are "expected" errors, meaning that they (hopefully) come

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -154,12 +154,7 @@ async function stripeCardProcessor(
 			return stripeResponse;
 		} )
 		.then( ( stripeResponse ) => {
-			const hasPaymentIntent =
-				stripeResponse &&
-				'message' in stripeResponse &&
-				typeof stripeResponse.message !== 'string' &&
-				stripeResponse?.message?.payment_intent_client_secret;
-			if ( stripeResponse.redirect_url && ! hasPaymentIntent ) {
+			if ( stripeResponse.redirect_url && ! doesTransactionResponseRequire3DS( stripeResponse ) ) {
 				return makeRedirectResponse( stripeResponse.redirect_url );
 			}
 			return makeSuccessResponse( stripeResponse );

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -142,7 +142,8 @@ async function stripeCardProcessor(
 				await handle3DSChallenge(
 					reduxDispatch,
 					submitData.stripe,
-					stripeResponse.message.payment_intent_client_secret
+					stripeResponse.message.payment_intent_client_secret,
+					stripeResponse.message.payment_intent_id
 				);
 				// We must return the original authentication response in order
 				// to have access to the order_id so that we can display a

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -170,7 +170,7 @@ async function stripeCardProcessor(
 			);
 			logStashEvent( 'calypso_checkout_card_transaction_failed', {
 				payment_intent_id: paymentIntentId ?? '',
-				tags: [ `payment_intent_id:${ paymentIntentId }` ],
+				tags: `payment_intent_id:${ paymentIntentId }`,
 			} );
 
 			// Errors here are "expected" errors, meaning that they (hopefully) come

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -170,6 +170,7 @@ async function stripeCardProcessor(
 			);
 			logStashEvent( 'calypso_checkout_card_transaction_failed', {
 				payment_intent_id: paymentIntentId ?? '',
+				tags: [ `payment_intent_id:${ paymentIntentId }` ],
 			} );
 
 			// Errors here are "expected" errors, meaning that they (hopefully) come

--- a/client/my-sites/checkout/composite-checkout/lib/stripe-3ds.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/stripe-3ds.ts
@@ -20,6 +20,7 @@ export async function handle3DSChallenge(
 		'calypso_checkout_modal_authorization',
 		{
 			payment_intent_id: paymentIntentId,
+			tags: [ `payment_intent_id:${ paymentIntentId }` ],
 		},
 		'info'
 	);

--- a/client/my-sites/checkout/composite-checkout/lib/stripe-3ds.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/stripe-3ds.ts
@@ -16,9 +16,13 @@ export async function handle3DSChallenge(
 			payment_intent_id: paymentIntentId,
 		} )
 	);
-	logStashEvent( 'calypso_checkout_modal_authorization', {
-		payment_intent_id: paymentIntentId,
-	} );
+	logStashEvent(
+		'calypso_checkout_modal_authorization',
+		{
+			payment_intent_id: paymentIntentId,
+		},
+		'info'
+	);
 	// If this fails, it will reject (throw).
 	await confirmStripePaymentIntent( stripe, paymentIntentClientSecret );
 }

--- a/client/my-sites/checkout/composite-checkout/lib/stripe-3ds.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/stripe-3ds.ts
@@ -20,7 +20,7 @@ export async function handle3DSChallenge(
 		'calypso_checkout_modal_authorization',
 		{
 			payment_intent_id: paymentIntentId,
-			tags: `payment_intent_id:${ paymentIntentId }`,
+			tags: [ `payment_intent_id:${ paymentIntentId }` ],
 		},
 		'info'
 	);

--- a/client/my-sites/checkout/composite-checkout/lib/stripe-3ds.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/stripe-3ds.ts
@@ -26,7 +26,7 @@ export async function handle3DSChallenge(
 export function doesTransactionResponseRequire3DS(
 	response: unknown
 ): response is TransactionResponseRequiringAction {
-	if ( ! response || typeof response === 'object' ) {
+	if ( ! response || typeof response !== 'object' ) {
 		return false;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/lib/stripe-3ds.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/stripe-3ds.ts
@@ -1,15 +1,24 @@
 import { confirmStripePaymentIntent } from '@automattic/calypso-stripe';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { logStashEvent } from '../lib/analytics';
 import type { Stripe } from '@stripe/stripe-js';
 import type { CalypsoDispatch } from 'calypso/state/types';
 
 export async function handle3DSChallenge(
 	reduxDispatch: CalypsoDispatch,
 	stripe: Stripe,
-	paymentIntentClientSecret: string
+	paymentIntentClientSecret: string,
+	paymentIntentId: string
 ): Promise< void > {
 	// 3DS authentication required
-	reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
+	reduxDispatch(
+		recordTracksEvent( 'calypso_checkout_modal_authorization', {
+			payment_intent_id: paymentIntentId,
+		} )
+	);
+	logStashEvent( 'calypso_checkout_modal_authorization', {
+		payment_intent_id: paymentIntentId,
+	} );
 	// If this fails, it will reject (throw).
 	await confirmStripePaymentIntent( stripe, paymentIntentClientSecret );
 }
@@ -52,4 +61,5 @@ interface NoActionRequiredMessage {
 interface RequiresActionMessage {
 	requires_action: true;
 	payment_intent_client_secret: string;
+	payment_intent_id: string;
 }

--- a/client/my-sites/checkout/composite-checkout/lib/stripe-3ds.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/stripe-3ds.ts
@@ -20,7 +20,7 @@ export async function handle3DSChallenge(
 		'calypso_checkout_modal_authorization',
 		{
 			payment_intent_id: paymentIntentId,
-			tags: [ `payment_intent_id:${ paymentIntentId }` ],
+			tags: `payment_intent_id:${ paymentIntentId }`,
 		},
 		'info'
 	);

--- a/client/my-sites/checkout/composite-checkout/lib/stripe-3ds.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/stripe-3ds.ts
@@ -1,0 +1,55 @@
+import { confirmStripePaymentIntent } from '@automattic/calypso-stripe';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import type { Stripe } from '@stripe/stripe-js';
+import type { CalypsoDispatch } from 'calypso/state/types';
+
+export async function handle3DSChallenge(
+	reduxDispatch: CalypsoDispatch,
+	stripe: Stripe,
+	paymentIntentClientSecret: string
+): Promise< void > {
+	// 3DS authentication required
+	reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
+	// If this fails, it will reject (throw).
+	await confirmStripePaymentIntent( stripe, paymentIntentClientSecret );
+}
+
+export function doesTransactionResponseRequire3DS(
+	response: unknown
+): response is TransactionResponseRequiringAction {
+	if ( ! response || typeof response === 'object' ) {
+		return false;
+	}
+
+	const transactionResponse = response as TransactionResponse;
+	if ( ! transactionResponse.message ) {
+		return false;
+	}
+
+	if ( ! transactionResponse.message.requires_action ) {
+		return false;
+	}
+
+	if ( ! transactionResponse.message.payment_intent_client_secret ) {
+		return false;
+	}
+
+	return true;
+}
+
+interface TransactionResponse {
+	message?: NoActionRequiredMessage | RequiresActionMessage;
+}
+
+export interface TransactionResponseRequiringAction {
+	message: RequiresActionMessage;
+}
+
+interface NoActionRequiredMessage {
+	requires_action: false;
+}
+
+interface RequiresActionMessage {
+	requires_action: true;
+	payment_intent_client_secret: string;
+}

--- a/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
@@ -8,6 +8,7 @@ import {
 	countryCode,
 	postalCode,
 	contactDetailsForDomain,
+	mockLogStashEndpoint,
 } from './util';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type { Stripe } from '@stripe/stripe-js';
@@ -64,6 +65,10 @@ describe( 'existingCardProcessor', () => {
 			sensitive_pixel_options: '',
 		},
 	};
+
+	beforeEach( () => {
+		mockLogStashEndpoint();
+	} );
 
 	it( 'throws an error if there is no storedDetailsId passed', async () => {
 		const submitData = {};

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
@@ -16,6 +16,7 @@ import {
 	mockCreateAccountSiteNotCreatedResponse,
 	planWithoutDomain,
 	getBasicCart,
+	mockLogStashEndpoint,
 } from './util';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type {
@@ -189,6 +190,10 @@ describe( 'multiPartnerCardProcessor', () => {
 		stripeConfiguration,
 		responseCart: cart,
 	};
+
+	beforeEach( () => {
+		mockLogStashEndpoint();
+	} );
 
 	it( 'throws an error if there is no paymentPartner', async () => {
 		const submitData = {};


### PR DESCRIPTION
## Proposed Changes

This is a cleanup of the 3DS challenge code to DRY its use a bit across the payment methods that utilize it. It also adds logstash logging for events surrounding the 3DS challenge for better debugging (see https://github.com/Automattic/payments-shilling/issues/1851).

Requires D117605-code to tag the logstash messages.

## Testing Instructions

- Sandbox the API so we can use [Stripe test cards](https://stripe.com/docs/testing).
- Add a product to your cart and visit checkout.
- Enter a 3DS required Stripe test card and submit the purchase.
- Verify that the modal dialog appears.
- Confirm the dialog and verify that the purchase completes.