### PR TITLE
Design Picker: refine assembler CTA button styles

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -30,9 +30,9 @@
 		}
 
 		.design-picker__design-your-own-button {
-			height: 36px;
-			line-height: 18px;
-			margin-top: 6px;
+			height: 32px;
+			line-height: 14px;
+			margin-top: 9px;
 		}
 	}
 

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -29,8 +29,10 @@
 			flex: 1;
 		}
 
-		button {
-			height: 100%;
+		.design-picker__design-your-own-button {
+			height: 36px;
+			line-height: 18px;
+			margin-top: 6px;
 		}
 	}
 

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -234,7 +234,10 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 					/>
 				) }
 				{ assemblerCtaData.shouldGoToAssemblerStep && (
-					<Button onClick={ () => onClickDesignYourOwnTopButton( DEFAULT_ASSEMBLER_DESIGN ) }>
+					<Button
+						className="design-picker__design-your-own-button"
+						onClick={ () => onClickDesignYourOwnTopButton( DEFAULT_ASSEMBLER_DESIGN ) }
+					>
 						{ assemblerCtaData.title }
 					</Button>
 				) }


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/79655#issuecomment-1654008825

## Proposed Changes

This PR reduces the "Design Your Own" button **height** and align it with the category filters on the left.

|Before|After|
|-|-|
|<img width="943" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/d6a514b4-f47a-4677-abf5-6e67092f73c3">|<img width="943" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/ee975aa0-1bb8-4355-8524-00bcd6e8993f">|

## Testing Instructions

1. Go to `/setup/site-setup/designSetup?siteSlug=<site slug>`
2. Verify that the button looks like the above screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
