### PR TITLE
Fix setting dates in Site Logs view

### DIFF
--- a/client/my-sites/site-logs/components/site-logs-toolbar/date-time-picker.tsx
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/date-time-picker.tsx
@@ -6,10 +6,14 @@ interface Props
 	value: Moment;
 	max?: Moment;
 	min?: Moment;
+
+	// The value returned by onChange ignores the `gmtOffset` prop. It will be in the same
+	// timezone as the time passed to the `value` prop. This makes round-tripping values through
+	// the `<DateTimePicker>` easier.
 	onChange: ( value: Moment ) => void;
 
 	// datetime-local inputs don't understand timezones, but this prop will cause the component
-	// to display values, and return values with onChange, in this timezone.
+	// to display values in this timezone.
 	// gmtOffset is in hours.
 	gmtOffset?: number;
 }
@@ -21,7 +25,9 @@ export function DateTimePicker( { value, onChange, gmtOffset = 0, max, min, ...r
 	const moment = useLocalizedMoment();
 
 	const onDateChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
-		const newDate = moment( event.currentTarget.value, INPUT_DATE_FORMAT );
+		const newDate = moment( event.currentTarget.value, INPUT_DATE_FORMAT )
+			.utcOffset( gmtOffset * 60, true )
+			.utcOffset( value.utcOffset() );
 		onChange( newDate );
 	};
 
@@ -29,12 +35,21 @@ export function DateTimePicker( { value, onChange, gmtOffset = 0, max, min, ...r
 		<input
 			className="button"
 			type="datetime-local"
-			value={ value.utcOffset( gmtOffset * 60 ).format( INPUT_DATE_FORMAT ) }
+			value={ value
+				.clone()
+				.utcOffset( gmtOffset * 60 )
+				.format( INPUT_DATE_FORMAT ) }
 			{ ...( min && {
-				min: min.utcOffset( gmtOffset * 60 ).format( INPUT_DATE_FORMAT ),
+				min: min
+					.clone()
+					.utcOffset( gmtOffset * 60 )
+					.format( INPUT_DATE_FORMAT ),
 			} ) }
 			{ ...( max && {
-				max: max.utcOffset( gmtOffset * 60 ).format( INPUT_DATE_FORMAT ),
+				max: max
+					.clone()
+					.utcOffset( gmtOffset * 60 )
+					.format( INPUT_DATE_FORMAT ),
 			} ) }
 			step={ 1 } // support 1 second granularity
 			onChange={ onDateChange }

--- a/client/my-sites/site-logs/test/date-time-picker.tsx
+++ b/client/my-sites/site-logs/test/date-time-picker.tsx
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import moment from 'moment';
+import { DateTimePicker } from '../components/site-logs-toolbar/date-time-picker';
+
+test( `display values in the specified timezone`, () => {
+	const { rerender } = render(
+		<DateTimePicker
+			data-testid="input"
+			value={ moment( '2023-07-28T03:13:13Z' ) }
+			gmtOffset={ +12 }
+			onChange={ () => undefined }
+		/>
+	);
+
+	expect( screen.getByTestId( 'input' ) ).toHaveAttribute( 'value', '2023-07-28T15:13:13' );
+
+	rerender(
+		<DateTimePicker
+			data-testid="input"
+			value={ moment( '2023-07-28T03:13:13+05' ) }
+			gmtOffset={ +4 }
+			onChange={ () => undefined }
+		/>
+	);
+
+	expect( screen.getByTestId( 'input' ) ).toHaveAttribute( 'value', '2023-07-28T02:13:13' );
+} );
+
+test( `values returned by onChange use the same timezone used by the value prop`, () => {
+	const handleChange = jest.fn();
+
+	const { rerender } = render(
+		<DateTimePicker
+			data-testid="input"
+			value={ moment( '2023-07-28T03:00:00Z' ).utcOffset( 0 ) }
+			gmtOffset={ +10 }
+			onChange={ handleChange }
+		/>
+	);
+
+	fireEvent.change( screen.getByTestId( 'input' ), {
+		target: { value: '2023-07-28T14:00:00' },
+	} );
+
+	expect( handleChange ).toHaveBeenCalledTimes( 1 );
+	expect( handleChange.mock.lastCall[ 0 ].unix() ).toBe( moment( '2023-07-28T04:00:00Z' ).unix() );
+	expect( handleChange.mock.lastCall[ 0 ].utcOffset() ).toBe( 0 );
+
+	rerender(
+		<DateTimePicker
+			data-testid="input"
+			value={ moment( '2023-07-28T03:00:00+05' ).utcOffset( 5 * 60 ) } // utcOffset uses minutes
+			gmtOffset={ +4 }
+			onChange={ handleChange }
+		/>
+	);
+
+	fireEvent.change( screen.getByTestId( 'input' ), {
+		target: { value: '2023-07-28T03:00:00' },
+	} );
+
+	expect( handleChange ).toHaveBeenCalledTimes( 2 );
+	expect( handleChange.mock.lastCall[ 0 ].unix() ).toBe(
+		moment( '2023-07-28T04:00:00+05' ).unix()
+	);
+	expect( handleChange.mock.lastCall[ 0 ].utcOffset() ).toBe( 5 * 60 );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/79923

## Proposed Changes

* Moment objects are annoyingly mutable. Calling moment methods to display dates correctly was unintentionally modifying the components props.
* We ensured dates were displayed in the site's timezone, but we failed to recognise that the new dates supplied by the user would also be in the site's timezone.
* I didn't think it made a lot of sense to set the `value` prop in one timezone and then have the `onChange` callback return a different timezone. So now timestamps round-trip using the same timezone, and that timezone can be independent of the display timezone.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow reproduction steps in https://github.com/Automattic/wp-calypso/issues/79923

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
