### PR TITLE
Use inline support link on domain authorization learn more button to load the article on page

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -47,6 +47,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/domains/',
 		post_id: 1988,
 	},
+	'domain-transfer-authorization-codes': {
+		link: 'https://wordpress.com/support/domains/incoming-domain-transfer/#step-2-obtain-your-domain-transfer-authorization-code',
+		post_id: 137759,
+	},
 	earn: {
 		link: 'https://wordpress.com/support/monetize-your-site/',
 		post_id: 120172,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -1,7 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FormInputValidation } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { Button, Icon } from '@wordpress/components';
 import { check, closeSmall } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -12,6 +11,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormInput from 'calypso/components/forms/form-text-input';
 import InfoPopover from 'calypso/components/info-popover';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { useValidationMessage } from './use-validation-message';
@@ -212,15 +212,12 @@ export function DomainCodePair( {
 									'Unique code proving ownership, needed for secure domain transfer between registrars.'
 								) }
 								<div>
-									<Button
-										href={ localizeUrl(
-											'https://wordpress.com/support/domains/incoming-domain-transfer/#step-2-obtain-your-domain-transfer-authorization-code'
-										) }
-										target="_blank"
-										variant="link"
+									<InlineSupportLink
+										supportContext="domain-transfer-authorization-codes"
+										showIcon={ false }
 									>
-										<span className="learn-more-label">{ __( 'Learn more' ) }</span>
-									</Button>
+										{ __( 'Learn more' ) }
+									</InlineSupportLink>
 								</div>
 							</InfoPopover>
 						</FormLabel>

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -130,6 +130,7 @@ window.AppBoot = async () => {
 							placeholder={ null }
 							id="notices"
 						/>
+						<AsyncLoad require="calypso/blocks/support-article-dialog" placeholder={ null } />
 					</BrowserRouter>
 					{ 'development' === process.env.NODE_ENV && (
 						<AsyncLoad require="calypso/components/webpack-build-monitor" placeholder={ null } />

--- a/client/lib/route-modal/use-route-modal.tsx
+++ b/client/lib/route-modal/use-route-modal.tsx
@@ -36,12 +36,23 @@ const useRouteModal = ( queryKey: string, targetValue = '' ): RouteModalData => 
 			[ queryKey ]: currentValue,
 		};
 
+		// NOTE: /setup/domain-transfer/domains is inside the stepper framework which doesn't use page
+		// for routing.
+		if ( url.includes( '/setup/domain-transfer/domains' ) ) {
+			window.location.replace( addQueryArgs( queryParams, url ) );
+		}
+
 		// Note: addQueryArgs in wordpress/url has a bug which means we cannot use
 		// it. See https://github.com/Automattic/wp-calypso/issues/63185
 		page( addQueryArgs( queryParams, url ) );
 	};
 
 	const closeModal = () => {
+		// NOTE: /setup/domain-transfer/domains is inside the stepper framework which doesn't use page
+		// for routing.
+		if ( window.location.pathname.includes( '/setup/domain-transfer/domains' ) ) {
+			window.location.replace( '/setup/domain-transfer/domains' );
+		}
 		page( removeQueryArgs( previousRoute, queryKey ) );
 	};
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3249

## Proposed Changes

* Replaces learn more link with inline support link

Todo:

* [ ] Make it work :confused: 

## Testing Instructions

* http://calypso.localhost:3000/setup/domain-transfer/domains
* Click here:
![Screenshot(91)](https://github.com/Automattic/wp-calypso/assets/811776/63959453-32f2-41ce-ba2c-6581be282022)
