### PR TITLE
Fix plan tooltip not showing in mobile viewports

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -111,7 +111,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 									) : (
 										<Plans2023Tooltip
 											text={ currentFeature.getDescription?.() }
-											handleMobileTooltipTouch={ handleMobileTooltipTouch }
+											handleMobileTooltipTouch={ ( value ) => handleMobileTooltipTouch( value ) }
 											mobileOpenTooltipText={ mobileOpenTooltipText }
 										>
 											{ currentFeature.getTitle( paidDomainName ) }

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -44,7 +44,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	hideUnavailableFeatures?: boolean;
 	selectedFeature?: string;
 	handleMobileTooltipTouch: ( value: TranslateResult ) => void;
-	mobileOpenTooltipText: TranslateResult;
+	// mobileOpenTooltipText: TranslateResult;
 } > = ( {
 	features,
 	planName,
@@ -53,7 +53,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	hideUnavailableFeatures,
 	selectedFeature,
 	handleMobileTooltipTouch,
-	mobileOpenTooltipText,
+	// mobileOpenTooltipText,
 } ) => {
 	const translate = useTranslate();
 
@@ -111,8 +111,8 @@ const PlanFeatures2023GridFeatures: React.FC< {
 									) : (
 										<Plans2023Tooltip
 											text={ currentFeature.getDescription?.() }
-											handleMobileTooltipTouch={ ( value ) => handleMobileTooltipTouch( value ) }
-											mobileOpenTooltipText={ mobileOpenTooltipText }
+											handleMobileTooltipTouch={ handleMobileTooltipTouch }
+											// mobileOpenTooltipText={ mobileOpenTooltipText }
 										>
 											{ currentFeature.getTitle( paidDomainName ) }
 										</Plans2023Tooltip>

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -1,7 +1,7 @@
 import { getPlanClass, FEATURE_CUSTOM_DOMAIN, isFreePlan } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { LoadingPlaceHolder } from '../../plans-features-main/components/loading-placeholder';
 import { PlanFeaturesItem } from './item';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
@@ -43,6 +43,8 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	wpcomFreeDomainSuggestion: SingleFreeDomainSuggestion;
 	hideUnavailableFeatures?: boolean;
 	selectedFeature?: string;
+	handleMobileTooltipTouch: ( value: TranslateResult ) => void;
+	mobileOpenTooltipText: TranslateResult;
 } > = ( {
 	features,
 	planName,
@@ -50,8 +52,11 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	wpcomFreeDomainSuggestion,
 	hideUnavailableFeatures,
 	selectedFeature,
+	handleMobileTooltipTouch,
+	mobileOpenTooltipText,
 } ) => {
 	const translate = useTranslate();
+
 	return (
 		<>
 			{ features.map( ( currentFeature, featureIndex ) => {
@@ -104,7 +109,11 @@ const PlanFeatures2023GridFeatures: React.FC< {
 											/>
 										</Plans2023Tooltip>
 									) : (
-										<Plans2023Tooltip text={ currentFeature.getDescription?.() }>
+										<Plans2023Tooltip
+											text={ currentFeature.getDescription?.() }
+											handleMobileTooltipTouch={ handleMobileTooltipTouch }
+											mobileOpenTooltipText={ mobileOpenTooltipText }
+										>
 											{ currentFeature.getTitle( paidDomainName ) }
 										</Plans2023Tooltip>
 									) }

--- a/client/my-sites/plan-features-2023-grid/components/plans-2023-tooltip.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plans-2023-tooltip.tsx
@@ -43,10 +43,15 @@ export const Plans2023Tooltip = (
 		}
 		props.mobileOpenTooltipText !== props.text && setIsVisible( false );
 	}, [ props.mobileOpenTooltipText, props.text, isMobile ] );
-	const handleTouchStart = () => {
+
+	const handleTouchStart = ( e ) => {
+		e.stopPropagation();
+		e.preventDefault();
 		setIsVisible( ( prevState ) => ! prevState );
 		props.text && props.handleMobileTooltipTouch( props.text );
 	};
+
+	const stopPropagation = ( event ) => event.stopPropagation();
 
 	if ( ! props.text ) {
 		return <>{ props.children }</>;
@@ -60,6 +65,7 @@ export const Plans2023Tooltip = (
 				onMouseEnter={ () => setIsVisible( true ) }
 				onMouseLeave={ () => setIsVisible( false ) }
 				onTouchStart={ handleTouchStart }
+				onClick={ stopPropagation }
 			>
 				{ props.children }
 			</HoverAreaContainer>

--- a/client/my-sites/plan-features-2023-grid/components/plans-2023-tooltip.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plans-2023-tooltip.tsx
@@ -3,10 +3,10 @@ import styled from '@emotion/styled';
 import { TranslateResult } from 'i18n-calypso';
 import { PropsWithChildren, useEffect, useRef, useState } from 'react';
 import Tooltip from 'calypso/components/tooltip';
+import { usePlansGridContext } from '../grid-context';
 
 const HoverAreaContainer = styled.span`
 	max-width: 220px;
-	cursor: default;
 `;
 
 const StyledTooltip = styled( Tooltip )`
@@ -30,28 +30,30 @@ export const Plans2023Tooltip = (
 	props: PropsWithChildren< {
 		text?: TranslateResult;
 		handleMobileTooltipTouch: ( value: TranslateResult ) => void;
-		mobileOpenTooltipText: TranslateResult;
+		// mobileOpenTooltipText: TranslateResult;
 	} >
 ) => {
 	const [ isVisible, setIsVisible ] = useState( false );
 	const tooltipRef = useRef< HTMLDivElement >( null );
 	const isMobile = useMobileBreakpoint();
+	const { mobileOpenTooltipText } = usePlansGridContext();
 
 	useEffect( () => {
 		if ( ! isMobile ) {
 			return;
 		}
-		props.mobileOpenTooltipText !== props.text && setIsVisible( false );
-	}, [ props.mobileOpenTooltipText, props.text, isMobile ] );
+		// console.log(mobileOpenTooltipText);
+		mobileOpenTooltipText === props.text ? setIsVisible( true ) : setIsVisible( false );
+		// props.mobileOpenTooltipText !== props.text && setIsVisible( false );
+	}, [ mobileOpenTooltipText, props.text, isMobile ] );
 
-	const handleTouchStart = ( e ) => {
-		e.stopPropagation();
-		e.preventDefault();
-		setIsVisible( ( prevState ) => ! prevState );
+	const handleTouchStart = () => {
+		// e.stopPropagation();
+		// e.preventDefault();
+		// setIsVisible( ( prevState ) => ! prevState );
+
 		props.text && props.handleMobileTooltipTouch( props.text );
 	};
-
-	const stopPropagation = ( event ) => event.stopPropagation();
 
 	if ( ! props.text ) {
 		return <>{ props.children }</>;
@@ -62,10 +64,10 @@ export const Plans2023Tooltip = (
 			<HoverAreaContainer
 				className="plans-2023-tooltip__hover-area-container"
 				ref={ tooltipRef }
-				onMouseEnter={ () => setIsVisible( true ) }
-				onMouseLeave={ () => setIsVisible( false ) }
+				// onMouseEnter={ () => setIsVisible( true ) }
+				// onMouseLeave={ () => setIsVisible( false ) }
 				onTouchStart={ handleTouchStart }
-				onClick={ stopPropagation }
+				// onClick={ handleTouchStart }
 			>
 				{ props.children }
 			</HoverAreaContainer>

--- a/client/my-sites/plan-features-2023-grid/components/plans-2023-tooltip.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plans-2023-tooltip.tsx
@@ -1,10 +1,12 @@
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import styled from '@emotion/styled';
 import { TranslateResult } from 'i18n-calypso';
-import { PropsWithChildren, useRef, useState } from 'react';
+import { PropsWithChildren, useEffect, useRef, useState } from 'react';
 import Tooltip from 'calypso/components/tooltip';
 
 const HoverAreaContainer = styled.span`
 	max-width: 220px;
+	cursor: default;
 `;
 
 const StyledTooltip = styled( Tooltip )`
@@ -24,9 +26,27 @@ const StyledTooltip = styled( Tooltip )`
 	}
 `;
 
-export const Plans2023Tooltip = ( props: PropsWithChildren< { text?: TranslateResult } > ) => {
+export const Plans2023Tooltip = (
+	props: PropsWithChildren< {
+		text?: TranslateResult;
+		handleMobileTooltipTouch: ( value: TranslateResult ) => void;
+		mobileOpenTooltipText: TranslateResult;
+	} >
+) => {
 	const [ isVisible, setIsVisible ] = useState( false );
 	const tooltipRef = useRef< HTMLDivElement >( null );
+	const isMobile = useMobileBreakpoint();
+
+	useEffect( () => {
+		if ( ! isMobile ) {
+			return;
+		}
+		props.mobileOpenTooltipText !== props.text && setIsVisible( false );
+	}, [ props.mobileOpenTooltipText, props.text, isMobile ] );
+	const handleTouchStart = () => {
+		setIsVisible( ( prevState ) => ! prevState );
+		props.text && props.handleMobileTooltipTouch( props.text );
+	};
 
 	if ( ! props.text ) {
 		return <>{ props.children }</>;
@@ -39,6 +59,7 @@ export const Plans2023Tooltip = ( props: PropsWithChildren< { text?: TranslateRe
 				ref={ tooltipRef }
 				onMouseEnter={ () => setIsVisible( true ) }
 				onMouseLeave={ () => setIsVisible( false ) }
+				onTouchStart={ handleTouchStart }
 			>
 				{ props.children }
 			</HoverAreaContainer>
@@ -47,6 +68,7 @@ export const Plans2023Tooltip = ( props: PropsWithChildren< { text?: TranslateRe
 				position="top"
 				context={ tooltipRef.current }
 				hideArrow
+				showOnMobile
 			>
 				{ props.text }
 			</StyledTooltip>

--- a/client/my-sites/plan-features-2023-grid/grid-context.tsx
+++ b/client/my-sites/plan-features-2023-grid/grid-context.tsx
@@ -9,15 +9,18 @@ interface PlansGridContext {
 	intent?: PlansIntent;
 	planRecords: Record< PlanSlug, GridPlan >;
 	visiblePlans: PlanSlug[];
+	mobileOpenTooltipText: string;
 }
 
 const PlansGridContext = createContext< PlansGridContext >( {} as PlansGridContext );
 
 const PlansGridContextProvider: React.FunctionComponent<
 	PlansGridContext & { children: React.ReactNode }
-> = ( { intent, planRecords, visiblePlans, children } ) => {
+> = ( { intent, planRecords, visiblePlans, mobileOpenTooltipText, children } ) => {
 	return (
-		<PlansGridContext.Provider value={ { intent, planRecords, visiblePlans } }>
+		<PlansGridContext.Provider
+			value={ { intent, planRecords, visiblePlans, mobileOpenTooltipText } }
+		>
 			{ children }
 		</PlansGridContext.Provider>
 	);

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -232,6 +232,17 @@ export class PlanFeatures2023Grid extends Component<
 		retargetViewPlans();
 	}
 
+	// shouldComponentUpdate( nextProps, nextState ) {
+	// 	console.log('prev: ');
+	// 	console.log(this.state.mobileOpenTooltipText);
+	// 	console.log('next: ' +nextState.mobileOpenTooltipText );
+	// 	if ( this.state.mobileOpenTooltipText !== nextState.mobileOpenTooltipText ) {
+	// 		return false;
+	// 	}
+
+	// 	return true;
+	// }
+
 	toggleShowPlansComparisonGrid = () => {
 		this.setState( ( { showPlansComparisonGrid } ) => ( {
 			showPlansComparisonGrid: ! showPlansComparisonGrid,
@@ -256,6 +267,9 @@ export class PlanFeatures2023Grid extends Component<
 
 	handleMobileTooltipTouch = ( value: TranslateResult ): void => {
 		this.setState( { mobileOpenTooltipText: value } );
+
+		// this.mobileOpenTooltipText = value;
+		// console.log(this.state.mobileOpenTooltipText);
 	};
 
 	render() {
@@ -286,6 +300,7 @@ export class PlanFeatures2023Grid extends Component<
 				intent={ intent }
 				planRecords={ planRecords }
 				visiblePlans={ visiblePlans }
+				mobileOpenTooltipText={ this.state.mobileOpenTooltipText }
 			>
 				<div className="plans-wrapper">
 					<QueryActivePromotions />
@@ -827,8 +842,8 @@ export class PlanFeatures2023Grid extends Component<
 							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
 							hideUnavailableFeatures={ hideUnavailableFeatures }
 							selectedFeature={ selectedFeature }
-							handleMobileTooltipTouch={ ( value ) => this.handleMobileTooltipTouch( value ) }
-							mobileOpenTooltipText={ this.state.mobileOpenTooltipText }
+							handleMobileTooltipTouch={ this.handleMobileTooltipTouch }
+							// mobileOpenTooltipText={ this.state.mobileOpenTooltipText }
 						/>
 						{ jpFeatures.length !== 0 && (
 							<div className="plan-features-2023-grid__jp-logo" key="jp-logo">
@@ -847,8 +862,8 @@ export class PlanFeatures2023Grid extends Component<
 							paidDomainName={ paidDomainName }
 							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
 							hideUnavailableFeatures={ hideUnavailableFeatures }
-							handleMobileTooltipTouch={ ( value ) => this.handleMobileTooltipTouch( value ) }
-							mobileOpenTooltipText={ this.state.mobileOpenTooltipText }
+							handleMobileTooltipTouch={ this.handleMobileTooltipTouch }
+							// mobileOpenTooltipText={ this.state.mobileOpenTooltipText }
 						/>
 					</Container>
 				);

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -33,7 +33,13 @@ import { isAnyHostingFlow } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
-import { localize, LocalizedComponent, LocalizeProps, useTranslate } from 'i18n-calypso';
+import {
+	localize,
+	LocalizedComponent,
+	LocalizeProps,
+	useTranslate,
+	TranslateResult,
+} from 'i18n-calypso';
 import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
@@ -135,6 +141,7 @@ type PlanFeatures2023GridType = PlanFeatures2023GridProps &
 
 type PlanFeatures2023GridState = {
 	showPlansComparisonGrid: boolean;
+	mobileOpenTooltipText: TranslateResult;
 };
 
 const PlanLogo: React.FunctionComponent< {
@@ -214,6 +221,7 @@ export class PlanFeatures2023Grid extends Component<
 > {
 	state = {
 		showPlansComparisonGrid: false,
+		mobileOpenTooltipText: '',
 	};
 
 	plansComparisonGridContainerRef = createRef< HTMLDivElement >();
@@ -245,6 +253,10 @@ export class PlanFeatures2023Grid extends Component<
 			} );
 		}
 	}
+
+	handleMobileTooltipTouch = ( value: TranslateResult ): void => {
+		this.setState( { mobileOpenTooltipText: value } );
+	};
 
 	render() {
 		const {
@@ -815,6 +827,8 @@ export class PlanFeatures2023Grid extends Component<
 							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
 							hideUnavailableFeatures={ hideUnavailableFeatures }
 							selectedFeature={ selectedFeature }
+							handleMobileTooltipTouch={ this.handleMobileTooltipTouch }
+							mobileOpenTooltipText={ this.state.mobileOpenTooltipText }
 						/>
 						{ jpFeatures.length !== 0 && (
 							<div className="plan-features-2023-grid__jp-logo" key="jp-logo">
@@ -833,6 +847,8 @@ export class PlanFeatures2023Grid extends Component<
 							paidDomainName={ paidDomainName }
 							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
 							hideUnavailableFeatures={ hideUnavailableFeatures }
+							handleMobileTooltipTouch={ this.handleMobileTooltipTouch }
+							mobileOpenTooltipText={ this.state.mobileOpenTooltipText }
 						/>
 					</Container>
 				);

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -827,7 +827,7 @@ export class PlanFeatures2023Grid extends Component<
 							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
 							hideUnavailableFeatures={ hideUnavailableFeatures }
 							selectedFeature={ selectedFeature }
-							handleMobileTooltipTouch={ this.handleMobileTooltipTouch }
+							handleMobileTooltipTouch={ ( value ) => this.handleMobileTooltipTouch( value ) }
 							mobileOpenTooltipText={ this.state.mobileOpenTooltipText }
 						/>
 						{ jpFeatures.length !== 0 && (
@@ -847,7 +847,7 @@ export class PlanFeatures2023Grid extends Component<
 							paidDomainName={ paidDomainName }
 							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
 							hideUnavailableFeatures={ hideUnavailableFeatures }
-							handleMobileTooltipTouch={ this.handleMobileTooltipTouch }
+							handleMobileTooltipTouch={ ( value ) => this.handleMobileTooltipTouch( value ) }
 							mobileOpenTooltipText={ this.state.mobileOpenTooltipText }
 						/>
 					</Container>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
