### PR TITLE
Marketplace: Remove usage of Plugin Announcement Modal

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -24,7 +24,6 @@ import Primary from 'calypso/my-sites/customer-home/locations/primary';
 import Secondary from 'calypso/my-sites/customer-home/locations/secondary';
 import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
 import WooCommerceHomePlaceholder from 'calypso/my-sites/customer-home/wc-home-placeholder';
-import PluginsAnnouncementModal from 'calypso/my-sites/plugins/plugins-announcement-modal';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
 import {
@@ -176,7 +175,6 @@ const Home = ( {
 			) : (
 				<>
 					<Primary cards={ layout.primary } />
-					<PluginsAnnouncementModal />
 					<div className="customer-home__layout">
 						<div className="customer-home__layout-col customer-home__layout-col-left">
 							<Secondary cards={ layout.secondary } siteId={ siteId } />

--- a/client/my-sites/plugins/plugins-announcement-modal/index.jsx
+++ b/client/my-sites/plugins/plugins-announcement-modal/index.jsx
@@ -1,10 +1,9 @@
-import { isStarter } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import announcementImage from 'calypso/assets/images/marketplace/plugins-browser.svg';
 import AnnouncementModal from 'calypso/blocks/announcement-modal';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import { isJetpackSite, getSitePlan } from 'calypso/state/sites/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const PluginsAnnouncementModal = () => {
@@ -14,14 +13,13 @@ const PluginsAnnouncementModal = () => {
 	const jetpackNonAtomic = useSelector(
 		( state ) => isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId )
 	);
-	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 
 	if ( jetpackNonAtomic ) {
 		// Buying plugins is not yet available to self hosted sites.
 		return null;
 	}
 
-	if ( ! siteId || ! isStarter( sitePlan ) ) {
+	if ( ! siteId ) {
 		return null;
 	}
 

--- a/client/my-sites/plugins/plugins-announcement-modal/index.jsx
+++ b/client/my-sites/plugins/plugins-announcement-modal/index.jsx
@@ -19,7 +19,7 @@ const PluginsAnnouncementModal = () => {
 		return null;
 	}
 
-	if ( ! siteId ) {
+	if ( ! selectedSiteUrl ) {
 		return null;
 	}
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -14,7 +14,6 @@ import Categories from 'calypso/my-sites/plugins/categories';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
 import { MarketplaceFooter } from 'calypso/my-sites/plugins/education-footer';
 import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
-import PluginsAnnouncementModal from 'calypso/my-sites/plugins/plugins-announcement-modal';
 import SearchBoxHeader from 'calypso/my-sites/plugins/search-box-header';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -149,7 +148,6 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 				}
 			/>
 
-			<PluginsAnnouncementModal />
 			{ ! hideHeader && (
 				<PluginsNavigationHeader
 					navigationHeaderRef={ navigationHeaderRef }


### PR DESCRIPTION
The original usage was only for Starter plans that are now deprecated,
so the usage of that modal has been removed.

Additionally, the condition that displayed the modal only for Starter plans has been removed
as it does not apply anymore.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Solves https://github.com/Automattic/dotcom-forge/issues/3252

## Proposed Changes

* Removes usage of `<PluginsAnnouncementModal />` as it is not required anymore
* Deletes the condition `isStarter` in the modal as it no longer applies.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### On a Starter site
- Navigate to `/plugins/:siteId`
- Check that there are not unexpected errors in the console. 

#### On a non Starter site, e.g. Business or Free
- Navigate to `/plugins/:siteId`
- Check that there are not unexpected errors in the console. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
~- [] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
~- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
