### PR TITLE
Plans 2023: Migrate componentDidMount & componentDidUpdate logic to PlansFeaturesMain

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -33,16 +33,13 @@ import { isAnyHostingFlow } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
-import { localize, LocalizedComponent, LocalizeProps, useTranslate } from 'i18n-calypso';
-import { Component, createRef } from 'react';
-import { connect } from 'react-redux';
+import { LocalizeProps, useTranslate } from 'i18n-calypso';
+import { Component, ForwardedRef, forwardRef, createRef } from 'react';
+import { useSelector } from 'react-redux';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
 import FoldableCard from 'calypso/components/foldable-card';
-import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
-import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible';
 import { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
@@ -94,7 +91,7 @@ const Container = (
 	);
 };
 
-export type PlanFeatures2023GridProps = {
+export interface PlanFeatures2023GridProps {
 	gridPlansForFeaturesGrid: GridPlan[];
 	gridPlansForComparisonGrid: GridPlan[];
 	gridPlanForSpotlight?: GridPlan;
@@ -125,26 +122,25 @@ export type PlanFeatures2023GridProps = {
 	stickyRowOffset: number;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
 	showOdie?: () => void;
-};
-
-type PlanFeatures2023GridConnectedProps = {
-	translate: LocalizeProps[ 'translate' ];
-	recordTracksEvent: ( slug: string ) => void;
-	canUserPurchasePlan: boolean | null;
+	// temporary
+	showPlansComparisonGrid: boolean;
+	// temporary
+	toggleShowPlansComparisonGrid: () => void;
 	planTypeSelectorProps: PlanTypeSelectorProps;
+}
+
+interface PlanFeatures2023GridType extends PlanFeatures2023GridProps {
+	isLargeCurrency: boolean;
+	translate: LocalizeProps[ 'translate' ];
+	canUserPurchasePlan: boolean | null;
 	manageHref: string;
 	selectedSiteSlug: string | null;
 	isPlanUpgradeCreditEligible: boolean;
-	isGlobalStylesOnPersonal?: boolean;
-};
-
-type PlanFeatures2023GridType = PlanFeatures2023GridProps &
-	PlanFeatures2023GridConnectedProps & { children?: React.ReactNode } & {
-		isLargeCurrency: boolean;
-	};
+	// temporary: element ref to scroll comparison grid into view once "Compare plans" button is clicked
+	plansComparisonGridRef: ForwardedRef< HTMLDivElement >;
+}
 
 type PlanFeatures2023GridState = {
-	showPlansComparisonGrid: boolean;
 	selectedStorage: PlanSelectedStorage;
 };
 
@@ -229,17 +225,10 @@ export class PlanFeatures2023Grid extends Component<
 	buttonRef: React.RefObject< HTMLButtonElement > = createRef< HTMLButtonElement >();
 
 	state: PlanFeatures2023GridState = {
-		showPlansComparisonGrid: false,
 		selectedStorage: {},
 	};
 
-	plansComparisonGridContainerRef = createRef< HTMLDivElement >();
-
 	componentDidMount() {
-		// TODO clk: move these to PlansFeaturesMain (after Woo plans migrate)
-		this.props.recordTracksEvent( 'calypso_wp_plans_test_view' );
-		retargetViewPlans();
-
 		this.observer = new IntersectionObserver( ( entries ) => {
 			entries.forEach( ( entry ) => {
 				if ( entry.isIntersecting ) {
@@ -260,12 +249,6 @@ export class PlanFeatures2023Grid extends Component<
 		}
 	}
 
-	toggleShowPlansComparisonGrid = () => {
-		this.setState( ( { showPlansComparisonGrid } ) => ( {
-			showPlansComparisonGrid: ! showPlansComparisonGrid,
-		} ) );
-	};
-
 	setSelectedStorage = ( updatedSelectedStorage: PlanSelectedStorage ) => {
 		this.setState( ( { selectedStorage } ) => ( {
 			selectedStorage: {
@@ -274,22 +257,6 @@ export class PlanFeatures2023Grid extends Component<
 			},
 		} ) );
 	};
-
-	componentDidUpdate(
-		prevProps: Readonly< PlanFeatures2023GridType >,
-		prevState: Readonly< PlanFeatures2023GridState >
-	) {
-		// If the "Compare plans" button is clicked, scroll to the plans comparison grid.
-		if (
-			prevState.showPlansComparisonGrid === false &&
-			this.plansComparisonGridContainerRef.current
-		) {
-			scrollIntoViewport( this.plansComparisonGridContainerRef.current, {
-				behavior: 'smooth',
-				scrollMode: 'if-needed',
-			} );
-		}
-	}
 
 	renderTable( renderedGridPlans: GridPlan[] ) {
 		const { translate, gridPlanForSpotlight, stickyRowOffset, isInSignup } = this.props;
@@ -892,6 +859,9 @@ export class PlanFeatures2023Grid extends Component<
 			showLegacyStorageFeature,
 			usePricingMetaForGridPlans,
 			allFeaturesList,
+			plansComparisonGridRef,
+			toggleShowPlansComparisonGrid,
+			showPlansComparisonGrid,
 		} = this.props;
 
 		return (
@@ -929,16 +899,16 @@ export class PlanFeatures2023Grid extends Component<
 				</div>
 				{ ! hidePlansFeatureComparison && (
 					<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
-						<Button onClick={ this.toggleShowPlansComparisonGrid } ref={ this.buttonRef }>
-							{ this.state.showPlansComparisonGrid
+						<Button onClick={ toggleShowPlansComparisonGrid } ref={ this.buttonRef }>
+							{ showPlansComparisonGrid
 								? translate( 'Hide comparison' )
 								: translate( 'Compare plans' ) }
 						</Button>
 					</div>
 				) }
-				{ ! hidePlansFeatureComparison && this.state.showPlansComparisonGrid ? (
+				{ ! hidePlansFeatureComparison && showPlansComparisonGrid ? (
 					<div
-						ref={ this.plansComparisonGridContainerRef }
+						ref={ plansComparisonGridRef }
 						className="plan-features-2023-grid__plan-comparison-grid-container"
 					>
 						<PlansGridContextProvider
@@ -965,7 +935,7 @@ export class PlanFeatures2023Grid extends Component<
 								showLegacyStorageFeature={ showLegacyStorageFeature }
 							/>
 							<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
-								<Button onClick={ this.toggleShowPlansComparisonGrid }>
+								<Button onClick={ toggleShowPlansComparisonGrid }>
 									{ translate( 'Hide comparison' ) }
 								</Button>
 							</div>
@@ -977,67 +947,77 @@ export class PlanFeatures2023Grid extends Component<
 	}
 }
 
-const withIsLargeCurrency = ( Component: LocalizedComponent< typeof PlanFeatures2023Grid > ) => {
-	return function ( props: PlanFeatures2023GridType ) {
+const WrappedPlanFeatures2023Grid = forwardRef< HTMLDivElement, PlanFeatures2023GridProps >(
+	function WrappedPlanFeatures2023Grid( props, ref ) {
+		const { siteId } = props;
+		const translate = useTranslate();
+		const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible(
+			props.siteId,
+			props.gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug )
+		);
 		const isLargeCurrency = useIsLargeCurrency( {
 			gridPlans: props.gridPlansForFeaturesGrid,
 		} );
-		return <Component { ...props } isLargeCurrency={ isLargeCurrency } />;
-	};
-};
 
-/* eslint-disable wpcalypso/redux-no-bound-selectors */
-const ConnectedPlanFeatures2023Grid = connect(
-	( state: IAppState, ownProps: PlanFeatures2023GridType ) => {
-		const { siteId } = ownProps;
 		// TODO clk: canUserManagePlan should be passed through props instead of being calculated here
-		const canUserPurchasePlan = siteId
-			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
-			: null;
-		const purchaseId = siteId && getCurrentPlanPurchaseId( state, siteId );
+		const canUserPurchasePlan = useSelector( ( state: IAppState ) =>
+			siteId
+				? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
+				: null
+		);
+		const purchaseId = useSelector( ( state: IAppState ) =>
+			siteId ? getCurrentPlanPurchaseId( state, siteId ) : null
+		);
 		// TODO clk: selectedSiteSlug has no other use than computing manageRef below. stop propagating it through props
-		const selectedSiteSlug = getSiteSlug( state, siteId );
+		const selectedSiteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
 
 		const manageHref =
 			purchaseId && selectedSiteSlug
 				? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
 				: `/plans/my-plan/${ siteId }`;
 
-		return {
-			canUserPurchasePlan,
-			manageHref,
-			selectedSiteSlug,
-		};
-	},
-	{
-		recordTracksEvent,
-	}
-)( withIsLargeCurrency( localize( PlanFeatures2023Grid ) ) );
-/* eslint-enable wpcalypso/redux-no-bound-selectors */
+		if ( props.isInSignup ) {
+			return (
+				<PlanFeatures2023Grid
+					{ ...props }
+					plansComparisonGridRef={ ref }
+					isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
+					isLargeCurrency={ isLargeCurrency }
+					canUserPurchasePlan={ canUserPurchasePlan }
+					manageHref={ manageHref }
+					selectedSiteSlug={ selectedSiteSlug }
+					translate={ translate }
+				/>
+			);
+		}
 
-const WrappedPlanFeatures2023Grid = ( props: PlanFeatures2023GridType ) => {
-	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible(
-		props.siteId,
-		props.gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug )
-	);
-
-	if ( props.isInSignup ) {
 		return (
-			<ConnectedPlanFeatures2023Grid
-				{ ...props }
-				isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
-			/>
+			<CalypsoShoppingCartProvider>
+				<PlanFeatures2023Grid
+					{ ...props }
+					plansComparisonGridRef={ ref }
+					isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
+					isLargeCurrency={ isLargeCurrency }
+					canUserPurchasePlan={ canUserPurchasePlan }
+					manageHref={ manageHref }
+					selectedSiteSlug={ selectedSiteSlug }
+					translate={ translate }
+				/>
+			</CalypsoShoppingCartProvider>
 		);
 	}
-
-	return (
-		<CalypsoShoppingCartProvider>
-			<ConnectedPlanFeatures2023Grid
-				{ ...props }
-				isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
-			/>
-		</CalypsoShoppingCartProvider>
-	);
-};
+);
 
 export default WrappedPlanFeatures2023Grid;
+
+// const PlanFeatures2023GridWithRef = forwardRef< HTMLDivElement, PlanFeatures2023GridProps >(
+// 	function PlanFeatures2023GridWithRef( props, ref ) {
+// 		return <PlanFeatures2023Grid { ...props } ref={ ref } />;
+// 	}
+// );
+
+// export default forwardRef(
+// 	( props: PlanFeatures2023GridProps, ref: ForwardedRef< HTMLDivElement > ) => (
+// 		<WrappedPlanFeatures2023Grid { ...props } ref={ ref } />
+// 	)
+// );

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -864,6 +864,8 @@ export class PlanFeatures2023Grid extends Component<
 			showPlansComparisonGrid,
 		} = this.props;
 
+		console.log( 'render', showPlansComparisonGrid, plansComparisonGridRef );
+
 		return (
 			<div className="plans-wrapper">
 				<QueryActivePromotions />

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -864,8 +864,6 @@ export class PlanFeatures2023Grid extends Component<
 			showPlansComparisonGrid,
 		} = this.props;
 
-		console.log( 'render', showPlansComparisonGrid, plansComparisonGridRef );
-
 		return (
 			<div className="plans-wrapper">
 				<QueryActivePromotions />
@@ -949,7 +947,7 @@ export class PlanFeatures2023Grid extends Component<
 	}
 }
 
-const WrappedPlanFeatures2023Grid = forwardRef< HTMLDivElement, PlanFeatures2023GridProps >(
+export default forwardRef< HTMLDivElement, PlanFeatures2023GridProps >(
 	function WrappedPlanFeatures2023Grid( props, ref ) {
 		const { siteId } = props;
 		const translate = useTranslate();
@@ -1009,17 +1007,3 @@ const WrappedPlanFeatures2023Grid = forwardRef< HTMLDivElement, PlanFeatures2023
 		);
 	}
 );
-
-export default WrappedPlanFeatures2023Grid;
-
-// const PlanFeatures2023GridWithRef = forwardRef< HTMLDivElement, PlanFeatures2023GridProps >(
-// 	function PlanFeatures2023GridWithRef( props, ref ) {
-// 		return <PlanFeatures2023Grid { ...props } ref={ ref } />;
-// 	}
-// );
-
-// export default forwardRef(
-// 	( props: PlanFeatures2023GridProps, ref: ForwardedRef< HTMLDivElement > ) => (
-// 		<WrappedPlanFeatures2023Grid { ...props } ref={ ref } />
-// 	)
-// );

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -12,7 +12,7 @@ import {
 import { Button } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useLayoutEffect, useEffect, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from '@wordpress/element';
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -571,15 +571,20 @@ const PlansFeaturesMain = ( {
 		setShowPlansComparisonGrid( ! showPlansComparisonGrid );
 	};
 
-	useEffect( () => {
-		setTimeout( () => {
-			if ( showPlansComparisonGrid && plansComparisonGridRef.current ) {
-				scrollIntoViewport( plansComparisonGridRef.current, {
-					behavior: 'smooth',
-					scrollMode: 'if-needed',
-				} );
-			}
-		} );
+	useLayoutEffect( () => {
+		console.log( showPlansComparisonGrid, plansComparisonGridRef.current );
+		if ( showPlansComparisonGrid ) {
+			setTimeout( () => {
+				if ( plansComparisonGridRef.current ) {
+					scrollIntoViewport( plansComparisonGridRef.current, {
+						behavior: 'smooth',
+						scrollMode: 'if-needed',
+						block: 'nearest',
+						inline: 'nearest',
+					} );
+				}
+			}, 2000 );
+		}
 	}, [ showPlansComparisonGrid ] );
 
 	useEffect( () => {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -22,6 +22,7 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
 import { isValidFeatureKey, FEATURES_LIST } from 'calypso/lib/plans/features-list';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
@@ -32,7 +33,6 @@ import useRestructuredPlanFeaturesForComparisonGrid from 'calypso/my-sites/plan-
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
 import PlanTypeSelector from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import { useOdieAssistantContext } from 'calypso/odie/context';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -64,7 +64,6 @@ import type {
 	DataResponse,
 	PlanActionOverrides,
 } from 'calypso/my-sites/plan-features-2023-grid/types';
-import type { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import type { IAppState } from 'calypso/state/types';
 
 import './style.scss';
@@ -111,23 +110,6 @@ export interface PlansFeaturesMainProps {
 	isSpotlightOnCurrentPlan?: boolean;
 }
 
-type OnboardingPricingGrid2023Props = PlansFeaturesMainProps & {
-	showUpgradeableStorage: boolean;
-	gridPlansForComparisonGrid: GridPlan[];
-	gridPlansForFeaturesGrid: GridPlan[];
-	planTypeSelectorProps: PlanTypeSelectorProps;
-	sitePlanSlug?: PlanSlug | null;
-	siteSlug?: string | null;
-	intent?: PlansIntent;
-	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >;
-	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >;
-	isGlobalStylesOnPersonal?: boolean;
-	showOdie?: () => void;
-	plansComparisonGridRef: React.RefObject< HTMLDivElement >;
-	showPlansComparisonGrid: boolean;
-	toggleShowPlansComparisonGrid: () => void;
-};
-
 const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
 	const translate = useTranslate();
 	const headerText = translate( 'Upgrade your plan to access this feature and more' );
@@ -144,149 +126,6 @@ const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) 
 			compactOnMobile
 			isSecondary
 		/>
-	);
-};
-
-const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
-	const {
-		gridPlansForFeaturesGrid,
-		gridPlansForComparisonGrid,
-		paidDomainName,
-		wpcomFreeDomainSuggestion,
-		isInSignup,
-		isLaunchPage,
-		flowName,
-		onUpgradeClick,
-		selectedFeature,
-		selectedPlan,
-		siteId,
-		plansWithScroll,
-		isReskinned,
-		intervalType,
-		planTypeSelectorProps,
-		hidePlansFeatureComparison,
-		hideUnavailableFeatures,
-		sitePlanSlug,
-		siteSlug,
-		intent,
-		isCustomDomainAllowedOnFreePlan,
-		showLegacyStorageFeature,
-		isSpotlightOnCurrentPlan,
-		showUpgradeableStorage,
-		isGlobalStylesOnPersonal,
-		plansComparisonGridRef,
-		showPlansComparisonGrid,
-		toggleShowPlansComparisonGrid,
-	} = props;
-	const translate = useTranslate();
-	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
-	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
-	const showDomainUpsellDialog = useCallback( () => {
-		setShowDomainUpsellDialog( true );
-	}, [ setShowDomainUpsellDialog ] );
-
-	let planActionOverrides: PlanActionOverrides | undefined;
-	if ( sitePlanSlug && isFreePlan( sitePlanSlug ) ) {
-		planActionOverrides = {
-			loggedInFreePlan: domainFromHomeUpsellFlow
-				? {
-						callback: showDomainUpsellDialog,
-						text: translate( 'Keep my plan', { context: 'verb' } ),
-				  }
-				: {
-						callback: () => {
-							page.redirect( `/add-ons/${ siteSlug }` );
-						},
-						text: translate( 'Manage add-ons', { context: 'verb' } ),
-				  },
-		};
-	}
-
-	let gridPlanForSpotlight: GridPlan | undefined;
-	if ( sitePlanSlug && isSpotlightOnCurrentPlan ) {
-		gridPlanForSpotlight = gridPlansForFeaturesGrid.find(
-			( { planSlug } ) => getPlanClass( planSlug ) === getPlanClass( sitePlanSlug )
-		);
-	}
-
-	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
-
-	/**
-	 * Calculates the height of the masterbar if it exists, and passes it to the component as an offset
-	 * for the sticky CTA bar.
-	 */
-	useLayoutEffect( () => {
-		const masterbarElement = document.querySelector< HTMLDivElement >( 'header.masterbar' );
-
-		if ( ! masterbarElement ) {
-			return;
-		}
-
-		if ( ! window.ResizeObserver ) {
-			setMasterbarHeight( masterbarElement.offsetHeight );
-			return;
-		}
-
-		let lastHeight = masterbarElement.offsetHeight;
-
-		const observer = new ResizeObserver(
-			( [ masterbar ]: Parameters< ResizeObserverCallback >[ 0 ] ) => {
-				const currentHeight = masterbar.contentRect.height;
-
-				if ( currentHeight !== lastHeight ) {
-					setMasterbarHeight( currentHeight );
-					lastHeight = currentHeight;
-				}
-			}
-		);
-
-		observer.observe( masterbarElement );
-
-		return () => {
-			observer.disconnect();
-		};
-	}, [] );
-
-	return (
-		<div
-			className={ classNames( 'plans-features-main__group', 'is-wpcom', 'is-2023-pricing-grid', {
-				'is-scrollable': plansWithScroll,
-			} ) }
-			data-e2e-plans="wpcom"
-		>
-			<PlanFeatures2023Grid
-				paidDomainName={ paidDomainName }
-				wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
-				isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-				isInSignup={ isInSignup }
-				isLaunchPage={ isLaunchPage }
-				onUpgradeClick={ onUpgradeClick }
-				flowName={ flowName }
-				selectedFeature={ selectedFeature }
-				selectedPlan={ selectedPlan }
-				siteId={ siteId }
-				isReskinned={ isReskinned }
-				intervalType={ intervalType }
-				hidePlansFeatureComparison={ hidePlansFeatureComparison }
-				hideUnavailableFeatures={ hideUnavailableFeatures }
-				currentSitePlanSlug={ sitePlanSlug }
-				planActionOverrides={ planActionOverrides }
-				intent={ intent }
-				isGlobalStylesOnPersonal={ isGlobalStylesOnPersonal }
-				gridPlansForFeaturesGrid={ gridPlansForFeaturesGrid }
-				gridPlansForComparisonGrid={ gridPlansForComparisonGrid }
-				showLegacyStorageFeature={ showLegacyStorageFeature }
-				gridPlanForSpotlight={ gridPlanForSpotlight }
-				showUpgradeableStorage={ showUpgradeableStorage }
-				stickyRowOffset={ masterbarHeight }
-				usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
-				allFeaturesList={ FEATURES_LIST }
-				showPlansComparisonGrid={ showPlansComparisonGrid }
-				toggleShowPlansComparisonGrid={ toggleShowPlansComparisonGrid }
-				planTypeSelectorProps={ planTypeSelectorProps }
-				ref={ plansComparisonGridRef }
-			/>
-		</div>
 	);
 };
 
@@ -331,6 +170,10 @@ const PlansFeaturesMain = ( {
 }: PlansFeaturesMainProps ) => {
 	const [ isFreePlanPaidDomainDialogOpen, setIsFreePlanPaidDomainDialogOpen ] = useState( false );
 	const [ isFreeFreeUpsellOpen, setIsFreeFreeUpsellOpen ] = useState( false );
+	const [ showPlansComparisonGrid, setShowPlansComparisonGrid ] = useState( false );
+	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
+	const translate = useTranslate();
+	const plansComparisonGridRef = useRef< HTMLDivElement >( null );
 	const currentPlan = useSelector( ( state: IAppState ) => getCurrentPlan( state, siteId ) );
 	const eligibleForWpcomMonthlyPlans = useSelector( ( state: IAppState ) =>
 		isEligibleForWpComMonthlyPlan( state, siteId )
@@ -352,6 +195,17 @@ const PlansFeaturesMain = ( {
 		!! paidDomainName
 	);
 	const { globalStylesInPersonalPlan } = useSiteGlobalStylesStatus( siteId );
+	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
+	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
+	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
+
+	const toggleShowPlansComparisonGrid = () => {
+		setShowPlansComparisonGrid( ! showPlansComparisonGrid );
+	};
+
+	const showDomainUpsellDialog = useCallback( () => {
+		setShowDomainUpsellDialog( true );
+	}, [ setShowDomainUpsellDialog ] );
 
 	const { isVisible, setIsVisible, trackEvent } = useOdieAssistantContext();
 
@@ -550,7 +404,22 @@ const PlansFeaturesMain = ( {
 		plans: gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ),
 	};
 
-	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
+	const planActionOverrides: PlanActionOverrides | undefined =
+		sitePlanSlug && isFreePlan( sitePlanSlug )
+			? {
+					loggedInFreePlan: domainFromHomeUpsellFlow
+						? {
+								callback: showDomainUpsellDialog,
+								text: translate( 'Keep my plan', { context: 'verb' } ),
+						  }
+						: {
+								callback: () => {
+									page.redirect( `/add-ons/${ siteSlug }` );
+								},
+								text: translate( 'Manage add-ons', { context: 'verb' } ),
+						  },
+			  }
+			: undefined;
 
 	/**
 	 * The spotlight in smaller grids looks broken.
@@ -560,12 +429,48 @@ const PlansFeaturesMain = ( {
 	 * Eventually once the spotlight card is made responsive this flag can be removed.
 	 * Check : https://github.com/Automattic/wp-calypso/pull/80232 for more details.
 	 */
-	const isSpotlightOnCurrentPlanAllowed = SPOTLIGHT_ENABLED_INTENTS.includes( intent );
-	const plansComparisonGridRef = useRef< HTMLDivElement >( null );
-	const [ showPlansComparisonGrid, setShowPlansComparisonGrid ] = useState( false );
-	const toggleShowPlansComparisonGrid = () => {
-		setShowPlansComparisonGrid( ! showPlansComparisonGrid );
-	};
+	const gridPlanForSpotlight =
+		sitePlanSlug && isSpotlightOnCurrentPlan && SPOTLIGHT_ENABLED_INTENTS.includes( intent )
+			? gridPlansForFeaturesGrid.find(
+					( { planSlug } ) => getPlanClass( planSlug ) === getPlanClass( sitePlanSlug )
+			  )
+			: undefined;
+
+	/**
+	 * Calculates the height of the masterbar if it exists, and passes it to the component as an offset
+	 * for the sticky CTA bar.
+	 */
+	useLayoutEffect( () => {
+		const masterbarElement = document.querySelector< HTMLDivElement >( 'header.masterbar' );
+
+		if ( ! masterbarElement ) {
+			return;
+		}
+
+		if ( ! window.ResizeObserver ) {
+			setMasterbarHeight( masterbarElement.offsetHeight );
+			return;
+		}
+
+		let lastHeight = masterbarElement.offsetHeight;
+
+		const observer = new ResizeObserver(
+			( [ masterbar ]: Parameters< ResizeObserverCallback >[ 0 ] ) => {
+				const currentHeight = masterbar.contentRect.height;
+
+				if ( currentHeight !== lastHeight ) {
+					setMasterbarHeight( currentHeight );
+					lastHeight = currentHeight;
+				}
+			}
+		);
+
+		observer.observe( masterbarElement );
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [] );
 
 	useLayoutEffect( () => {
 		if ( showPlansComparisonGrid ) {
@@ -661,47 +566,59 @@ const PlansFeaturesMain = ( {
 			{ ! intentFromSiteMeta.processing && (
 				<>
 					{ ! hidePlanSelector && <PlanTypeSelector { ...planTypeSelectorProps } /> }
-					<OnboardingPricingGrid2023
-						gridPlansForFeaturesGrid={ gridPlansForFeaturesGrid }
-						gridPlansForComparisonGrid={ gridPlansForComparisonGrid }
-						paidDomainName={ paidDomainName }
-						wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
-						isInSignup={ isInSignup }
-						isLaunchPage={ isLaunchPage }
-						flowName={ flowName }
-						onUpgradeClick={ handleUpgradeClick }
-						selectedFeature={ selectedFeature }
-						selectedPlan={ selectedPlan }
-						withDiscount={ withDiscount }
-						discountEndDate={ discountEndDate }
-						siteId={ siteId }
-						plansWithScroll={ plansWithScroll }
-						isReskinned={ isReskinned }
-						intervalType={ intervalType }
-						planTypeSelectorProps={ planTypeSelectorProps }
-						hidePlansFeatureComparison={ hidePlansFeatureComparison }
-						hideUnavailableFeatures={ hideUnavailableFeatures }
-						sitePlanSlug={ sitePlanSlug }
-						siteSlug={ siteSlug }
-						intent={ intent }
-						isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-						showLegacyStorageFeature={ showLegacyStorageFeature }
-						isSpotlightOnCurrentPlan={ isSpotlightOnCurrentPlanAllowed && isSpotlightOnCurrentPlan }
-						showUpgradeableStorage={ showUpgradeableStorage }
-						isGlobalStylesOnPersonal={ globalStylesInPersonalPlan }
-						showOdie={ () => {
-							if ( ! isVisible ) {
-								trackEvent( 'calypso_odie_chat_toggle_visibility', {
-									visibility: true,
-									trigger: 'scroll',
-								} );
-								setIsVisible( true );
+					<div
+						className={ classNames(
+							'plans-features-main__group',
+							'is-wpcom',
+							'is-2023-pricing-grid',
+							{
+								'is-scrollable': plansWithScroll,
 							}
-						} }
-						plansComparisonGridRef={ plansComparisonGridRef }
-						showPlansComparisonGrid={ showPlansComparisonGrid }
-						toggleShowPlansComparisonGrid={ toggleShowPlansComparisonGrid }
-					/>
+						) }
+						data-e2e-plans="wpcom"
+					>
+						<PlanFeatures2023Grid
+							gridPlansForFeaturesGrid={ gridPlansForFeaturesGrid }
+							gridPlansForComparisonGrid={ gridPlansForComparisonGrid }
+							gridPlanForSpotlight={ gridPlanForSpotlight }
+							paidDomainName={ paidDomainName }
+							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+							isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
+							isInSignup={ isInSignup }
+							isLaunchPage={ isLaunchPage }
+							onUpgradeClick={ handleUpgradeClick }
+							flowName={ flowName }
+							selectedFeature={ selectedFeature }
+							selectedPlan={ selectedPlan }
+							siteId={ siteId }
+							isReskinned={ isReskinned }
+							intervalType={ intervalType }
+							hidePlansFeatureComparison={ hidePlansFeatureComparison }
+							hideUnavailableFeatures={ hideUnavailableFeatures }
+							currentSitePlanSlug={ sitePlanSlug }
+							planActionOverrides={ planActionOverrides }
+							intent={ intent }
+							isGlobalStylesOnPersonal={ globalStylesInPersonalPlan }
+							showLegacyStorageFeature={ showLegacyStorageFeature }
+							showUpgradeableStorage={ showUpgradeableStorage }
+							stickyRowOffset={ masterbarHeight }
+							usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+							allFeaturesList={ FEATURES_LIST }
+							showOdie={ () => {
+								if ( ! isVisible ) {
+									trackEvent( 'calypso_odie_chat_toggle_visibility', {
+										visibility: true,
+										trigger: 'scroll',
+									} );
+									setIsVisible( true );
+								}
+							} }
+							showPlansComparisonGrid={ showPlansComparisonGrid }
+							toggleShowPlansComparisonGrid={ toggleShowPlansComparisonGrid }
+							planTypeSelectorProps={ planTypeSelectorProps }
+							ref={ plansComparisonGridRef }
+						/>
+					</div>
 				</>
 			) }
 		</div>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -56,7 +56,6 @@ import useGetFreeSubdomainSuggestion from './hooks/use-suggested-free-domain-fro
 import type { IntervalType } from './types';
 import type { DomainSuggestion } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import type { PlanFeatures2023GridProps } from 'calypso/my-sites/plan-features-2023-grid';
 import type {
 	GridPlan,
 	PlansIntent,
@@ -175,7 +174,6 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		isSpotlightOnCurrentPlan,
 		showUpgradeableStorage,
 		isGlobalStylesOnPersonal,
-		showOdie,
 		plansComparisonGridRef,
 		showPlansComparisonGrid,
 		toggleShowPlansComparisonGrid,
@@ -249,39 +247,6 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		};
 	}, [] );
 
-	const asyncProps: PlanFeatures2023GridProps = {
-		paidDomainName,
-		wpcomFreeDomainSuggestion,
-		isInSignup,
-		isLaunchPage,
-		onUpgradeClick,
-		flowName,
-		selectedFeature,
-		selectedPlan,
-		siteId,
-		isReskinned,
-		intervalType,
-		hidePlansFeatureComparison,
-		hideUnavailableFeatures,
-		currentSitePlanSlug: sitePlanSlug,
-		planActionOverrides,
-		intent,
-		isCustomDomainAllowedOnFreePlan,
-		isGlobalStylesOnPersonal,
-		gridPlansForFeaturesGrid,
-		gridPlansForComparisonGrid,
-		showLegacyStorageFeature,
-		gridPlanForSpotlight,
-		showUpgradeableStorage,
-		stickyRowOffset: masterbarHeight,
-		usePricingMetaForGridPlans,
-		allFeaturesList: FEATURES_LIST,
-		showPlansComparisonGrid,
-		toggleShowPlansComparisonGrid,
-		planTypeSelectorProps,
-		showOdie,
-	};
-
 	return (
 		<div
 			className={ classNames( 'plans-features-main__group', 'is-wpcom', 'is-2023-pricing-grid', {
@@ -289,7 +254,38 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 			} ) }
 			data-e2e-plans="wpcom"
 		>
-			<PlanFeatures2023Grid { ...asyncProps } ref={ plansComparisonGridRef } />
+			<PlanFeatures2023Grid
+				paidDomainName={ paidDomainName }
+				wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+				isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
+				isInSignup={ isInSignup }
+				isLaunchPage={ isLaunchPage }
+				onUpgradeClick={ onUpgradeClick }
+				flowName={ flowName }
+				selectedFeature={ selectedFeature }
+				selectedPlan={ selectedPlan }
+				siteId={ siteId }
+				isReskinned={ isReskinned }
+				intervalType={ intervalType }
+				hidePlansFeatureComparison={ hidePlansFeatureComparison }
+				hideUnavailableFeatures={ hideUnavailableFeatures }
+				currentSitePlanSlug={ sitePlanSlug }
+				planActionOverrides={ planActionOverrides }
+				intent={ intent }
+				isGlobalStylesOnPersonal={ isGlobalStylesOnPersonal }
+				gridPlansForFeaturesGrid={ gridPlansForFeaturesGrid }
+				gridPlansForComparisonGrid={ gridPlansForComparisonGrid }
+				showLegacyStorageFeature={ showLegacyStorageFeature }
+				gridPlanForSpotlight={ gridPlanForSpotlight }
+				showUpgradeableStorage={ showUpgradeableStorage }
+				stickyRowOffset={ masterbarHeight }
+				usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+				allFeaturesList={ FEATURES_LIST }
+				showPlansComparisonGrid={ showPlansComparisonGrid }
+				toggleShowPlansComparisonGrid={ toggleShowPlansComparisonGrid }
+				planTypeSelectorProps={ planTypeSelectorProps }
+				ref={ plansComparisonGridRef }
+			/>
 		</div>
 	);
 };
@@ -572,7 +568,6 @@ const PlansFeaturesMain = ( {
 	};
 
 	useLayoutEffect( () => {
-		console.log( showPlansComparisonGrid, plansComparisonGridRef.current );
 		if ( showPlansComparisonGrid ) {
 			setTimeout( () => {
 				if ( plansComparisonGridRef.current ) {
@@ -583,7 +578,7 @@ const PlansFeaturesMain = ( {
 						inline: 'nearest',
 					} );
 				}
-			}, 2000 );
+			} );
 		}
 	}, [ showPlansComparisonGrid ] );
 

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -3,7 +3,7 @@
  */
 
 jest.mock( 'calypso/components/marketing-message', () => () => null );
-jest.mock( 'calypso/components/async-load', () => ( { gridPlansForFeaturesGrid } ) => (
+jest.mock( 'calypso/my-sites/plan-features-2023-grid', () => ( { gridPlansForFeaturesGrid } ) => (
 	<div data-testid="plan-features">
 		<div data-testid="visible-plans">
 			{ JSON.stringify( gridPlansForFeaturesGrid.map( ( { planSlug } ) => planSlug ) ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/78993

## Proposed Changes

* Moves the lifecycle methods from `plan-features-2023-grid` to `plans-features-main`, uncoupling a couple of local dependencies
* Cleans up `plans-features-main` a little, removing the so-far temporary `OnboardingPricingGrid2023` component (we had created this previously for moving some parts into a function component). It is no longer necessary, and for the most just adds complexity with needing to pass props around
* Also removes the `AsyncLoad` component. We can reintroduce this later if necessary, although it will have a different form with individual components imported from `plan-features-2023-grid` next (per https://github.com/Automattic/wp-calypso/issues/78266). This was also necessary for now to pass a ref for the comparison-grid from `plans-features-main` (another temporary thing).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure general sanity of `/plans[ paid | free ]`. That notices show properly, plan type selector works, etc. 
* Ensure general sanity on `/start` and any of the tailored flows under `/setup` (link-in-bio, newsletter)
* Ensure comparison grid scrolls smoothly into view when clicking on `compare plans`. Test this over the live image and double-check with production (or `trunk` in local) when in doubt
* Ensure the event `calypso_wp_plans_test_view` fires off once when visiting `/plans` or `/start`. It should be identical to production. 
    * from browser's dev tools: check Network tab for a `pixel.wp.com/t.gif` GET request with `_en: calypso_wp_plans_test_view` in payload/params

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
