### PR TITLE
Stepper: fix navigation

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -104,11 +104,7 @@ const domainTransfer: Flow = {
 		const goBack = () => {
 			switch ( _currentStepSlug ) {
 				case 'domains':
-					if ( window.history.length < 3 ) {
-						return navigate( 'intro' );
-					}
-					window.history.back();
-					return;
+					return navigate( 'intro' );
 				default:
 					return;
 			}

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -227,7 +227,10 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 				<Route
 					path="*"
 					element={
-						<Navigate to={ `/${ flow.variantSlug ?? flow.name }/${ stepPaths[ 0 ] }${ search }` } />
+						<Navigate
+							to={ `/${ flow.variantSlug ?? flow.name }/${ stepPaths[ 0 ] }${ search }` }
+							replace
+						/>
 					}
 				/>
 			</Routes>


### PR DESCRIPTION
Fixes 3236-gh-Automattic/dotcom-forge and reverts https://github.com/Automattic/wp-calypso/pull/79841.

### Changes
1. When you land at a Stepper flow's root /flow, it automatically takes you to the first step, /flow/intro.
2. Before this PR, it did that by pushing a new state down the history stack.
3. This means you click "Back", you go back to /flow, which injects another state /flow/intro.
4. This makes clicking back seem like nothing happened and creates an infinite loop.
5. This PR resolves the issue by replacing the state instead of pushing new one.

### Testing
#### First issue - the infinite loop

1. Click this link: https://container-optimistic-tesla.calypso.live/setup/domain-transfer
2. Click the browser's back, you should be taken back to this PR.

#### Second issue - going back after logging in
1. While logged out from WP.com go to /setup/domain-transfer.
2. Click "Get started" and log in.
3. After logging in, click Back button in the flow, you should be taken to the intro step.