### PR TITLE
Jetpack Pro Dashboard: Fix product slug matching by limiting it to 38 characters

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/hooks/use-assign-licenses-to-site.ts
+++ b/client/jetpack-cloud/sections/partner-portal/hooks/use-assign-licenses-to-site.ts
@@ -46,7 +46,10 @@ const useAssignLicensesToSite = (
 			const keysWithProductNames = licenseKeys
 				.map( ( key ) => {
 					const productSlug = getProductSlugFromLicenseKey( key );
-					const selectedProduct = products?.data?.find?.( ( p ) => p.slug === productSlug );
+					const selectedProduct = products?.data?.find?.(
+						// Product slugs are limited to 38 characters in license keys.
+						( p ) => p.slug.substring( 0, 38 ) === productSlug
+					);
 
 					return {
 						key,


### PR DESCRIPTION
1204137270272763-as-1205159280216587

## Proposed Changes

* Jetpack Pro Dashboard: Fix product slug matching by limiting it to 38 characters

## Testing Instructions

* Make sure you have a license for a product with a slug that exceeds 38 characters such as Jetpack VaultPress Backup 10GB Add-on (`jetpack-backup-addon-storage-10gb-mont_RANDOMCHARSGOHERE`).
* Try to assign the license to any site - the license won't be assigned and you will be redirected to the license list.
* Checkout this PR and repeat the steps - the license should now be assigned.

This happens because product slugs are limited to 38 characters in the license key which is used to compare against product slugs. This fix is obviously far from ideal but is necessary in order to remove the blocker asap.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?