### PR TITLE
Hide the go to campaign button if android version >= 22.9

### DIFF
--- a/client/lib/mobile-app/index.js
+++ b/client/lib/mobile-app/index.js
@@ -21,3 +21,27 @@ export function isWcMobileApp() {
 	}
 	return navigator.userAgent && /wc-(android|ios)/.test( navigator.userAgent );
 }
+
+const deviceUnknown = {
+	device: 'unknown',
+	version: 'unknown',
+};
+
+export function getMobileDeviceInfo() {
+	try {
+		const userAgent = navigator.userAgent.toLowerCase();
+		const regex = /wp-(android|iphone)\/(\d+.\d+)/;
+		const match = userAgent.match( regex );
+
+		if ( ! match ) {
+			return deviceUnknown;
+		}
+
+		return {
+			device: match[ 1 ],
+			version: match[ 2 ],
+		};
+	} catch ( e ) {
+		return deviceUnknown;
+	}
+}

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -48,6 +48,7 @@ declare global {
 				};
 				isV2?: boolean;
 				hotjarSiteSettings?: object;
+				options?: object;
 			} ) => void;
 			strings: any;
 		};
@@ -70,6 +71,34 @@ export async function loadDSPWidgetJS(): Promise< void > {
 	// in order to ensure that translate calls are not removed from the production build.
 	await import( './string' );
 }
+
+const ANDROID_VERSION_HIDE_CAMPAIGNS_BUTTON = 22.9;
+
+const shouldHideGoToCampaignButton = () => {
+	// Android versions higher or equal than 22.9 should hide the button
+	// Trycatching it since user-agents can be changed to send custom data
+	try {
+		const userAgent = navigator.userAgent.toLowerCase();
+
+		// check if it's a wp-android device
+		if ( ! userAgent.includes( 'wp-android' ) ) {
+			return false;
+		}
+
+		// check if it's a version higher or equal than 22.9
+		const version = userAgent.split( '/' )[ 1 ];
+		const versionNumber = parseFloat( version );
+		return versionNumber >= ANDROID_VERSION_HIDE_CAMPAIGNS_BUTTON;
+	} catch ( e ) {
+		return false;
+	}
+};
+
+const getWidgetOptions = () => {
+	return {
+		hideGoToCampaignsButton: shouldHideGoToCampaignButton(),
+	};
+};
 
 export async function showDSP(
 	siteSlug: string | null,
@@ -121,6 +150,7 @@ export async function showDSP(
 					: undefined,
 				isV2,
 				hotjarSiteSettings: { ...getHotjarSiteSettings(), isEnabled: mayWeLoadHotJarScript() },
+				options: getWidgetOptions(),
 			} );
 		} else {
 			reject( false );

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -3,7 +3,7 @@ import { loadScript } from '@automattic/load-script';
 import { __ } from '@wordpress/i18n';
 import { translate } from 'i18n-calypso/types';
 import { getHotjarSiteSettings, mayWeLoadHotJarScript } from 'calypso/lib/analytics/hotjar';
-import { isWpMobileApp } from 'calypso/lib/mobile-app';
+import { getMobileDeviceInfo, isWpMobileApp } from 'calypso/lib/mobile-app';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -74,24 +74,18 @@ export async function loadDSPWidgetJS(): Promise< void > {
 
 const ANDROID_VERSION_HIDE_CAMPAIGNS_BUTTON = 22.9;
 
+type DeviceInfo = {
+	device: string;
+	version: string;
+};
+
 const shouldHideGoToCampaignButton = () => {
 	// Android versions higher or equal than 22.9 should hide the button
-	// Trycatching it since user-agents can be changed to send custom data
-	try {
-		const userAgent = navigator.userAgent.toLowerCase();
-
-		// check if it's a wp-android device
-		if ( ! userAgent.includes( 'wp-android' ) ) {
-			return false;
-		}
-
-		// check if it's a version higher or equal than 22.9
-		const version = userAgent.split( '/' )[ 1 ];
-		const versionNumber = parseFloat( version );
-		return versionNumber >= ANDROID_VERSION_HIDE_CAMPAIGNS_BUTTON;
-	} catch ( e ) {
-		return false;
-	}
+	const deviceInfo = getMobileDeviceInfo() as DeviceInfo;
+	return (
+		deviceInfo.device.includes( 'android' ) &&
+		parseFloat( deviceInfo?.version ) >= ANDROID_VERSION_HIDE_CAMPAIGNS_BUTTON
+	);
 };
 
 const getWidgetOptions = () => {


### PR DESCRIPTION
Related to #

Jetpack app loads calypso to display the blazePress widget. Jetpack team needs that android version 22.9 and higher should not display the "Go to campaigns" button when creating a campaign. This PR adds the logic in calypso to detect the version and send a proper flag to BlazePress

## Proposed Changes
- Add a new "options" flag in showDsp() method to display or not the "Go to campaigns" button.
- Detect useragent version and get the android  version to send the proper flag "hideGoToCampaignsButton"

## Testing Instructions

* You need to be running Widget with pull number `288` (ask me in Slack if needed more info)
* You can spoof the user agent in devtoools:  
<img width="742" alt="image" src="https://github.com/Automattic/wp-calypso/assets/43957544/e45f9027-02e1-4f30-8649-dfe8809ba2d0">

* The Go To campaigns button should be hidden if it is detecting `wp-android/22.9" or superior (22.9.1 will be next)

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
