### PR TITLE
Add and update the interval param when changing the billing switcher

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -11,6 +11,7 @@ import { Fragment, useState, useCallback, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { getPluginPurchased, getSoftwareSlug, getSaasRedirectUrl } from 'calypso/lib/plugins/utils';
+import { setQueryArgs } from 'calypso/lib/query-args';
 import { addQueryArgs } from 'calypso/lib/route';
 import { userCan } from 'calypso/lib/site/utils';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
@@ -146,7 +147,10 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	}, [ displayManageSitePluginsModal ] );
 
 	const onIntervalSwitcherChange = useCallback(
-		( interval ) => dispatch( setBillingInterval( interval ) ),
+		( interval ) => {
+			setQueryArgs( { interval: interval?.toLowerCase() } );
+			dispatch( setBillingInterval( interval ) );
+		},
 		[ dispatch ]
 	);
 


### PR DESCRIPTION
Related to #79552

## Proposed Changes

Add and update the interval param when changing the billing switcher

## Testing Instructions
* Go to a paid plugin page. Ex: `/plugins/woocommerce-subscriptions/:site`
* Click on the Billing Switcher and check if the `interval` parameter is added to the URL
* Copy the URL with both options (`monthly`/`annually`) and past in a new tab
* The new tab should start with the selected option

![CleanShot 2023-07-28 at 10 03 18@2x](https://github.com/Automattic/wp-calypso/assets/5039531/199d03c8-cb6a-47e3-ac47-8f16b1857655)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
