### PR TITLE
Domain Transfer: Removes limit of 50 domains

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -21,8 +21,6 @@ import { DomainCodePair } from './domain-code-pair';
 import DomainTransferFAQ from './faqs';
 import type { OnboardSelect } from '@automattic/data-stores';
 
-const MAX_DOMAINS = 50;
-
 export interface Props {
 	onSubmit: () => void;
 }
@@ -256,11 +254,9 @@ const Domains: React.FC< Props > = ( { onSubmit } ) => {
 					) }
 				/>
 			) ) }
-			{ domainCount < MAX_DOMAINS && (
-				<Button className="bulk-domain-transfer__add-domain" icon={ plus } onClick={ addDomain }>
-					{ __( 'Add more' ) }
-				</Button>
-			) }
+			<Button className="bulk-domain-transfer__add-domain" icon={ plus } onClick={ addDomain }>
+				{ __( 'Add more' ) }
+			</Button>
 			<div className="bulk-domain-transfer__cta-container">
 				<Button
 					disabled={ numberOfValidDomains === 0 || ! allGood }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -1,5 +1,3 @@
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -14,22 +12,12 @@ import './styles.scss';
 const Intro: Step = function Intro( { navigation, flow } ) {
 	const { submit, goBack } = navigation;
 	const { __ } = useI18n();
-	const isEnglishLocale = useIsEnglishLocale();
 
 	usePresalesChat( 'wpcom' );
 
 	const handleSubmit = () => {
 		submit?.();
 	};
-
-	const getTranslatedSubHeaderText = isEnglishLocale
-		? createInterpolateElement(
-				'Enter your domain names and authorization codes below. You<nbsp/>can transfer up to fifty domains at a time.',
-				{ nbsp: <>&nbsp;</> }
-		  )
-		: __(
-				'Enter your domain names and authorization codes below. You can transfer up to fifty domains at a time.'
-		  );
 
 	return (
 		<StepContainer
@@ -44,7 +32,7 @@ const Intro: Step = function Intro( { navigation, flow } ) {
 					headerText={ __( 'Add your domains' ) }
 					subHeaderText={
 						<>
-							<span>{ getTranslatedSubHeaderText }</span>
+							<span>{ __( 'Enter your domain names and authorization codes below.' ) }</span>
 						</>
 					}
 					align="center"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -51,13 +51,6 @@
 				justify-content: center;
 				margin-top: 16px;
 				line-height: 20px;
-
-				span {
-					display: block;
-					@media (min-width: $break-medium ) {
-						width: 60%;
-					}
-				}
 			}
 		}
 


### PR DESCRIPTION
## Proposed Changes

* Removes limit of 50 domains allowed in bulk transfer.

We'll follow-up on the backend to improve performance.

<img width="921" alt="Screenshot 2023-07-28 at 8 33 54 AM" src="https://github.com/Automattic/wp-calypso/assets/1126811/56697173-245e-4ccc-a307-1e9adc131ec2">


## Testing Instructions

* Go to `/setup/domain-transfer`
* Ensure copy is updated
* Ensure that you can add more than 50 domains

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
