### PR TITLE
Reader reblog popover - ensure close on external click

### DIFF
--- a/client/blocks/reader-share/reblog.jsx
+++ b/client/blocks/reader-share/reblog.jsx
@@ -36,7 +36,11 @@ const ReaderReblogSelection = ( props ) => {
 	};
 
 	return (
-		<ReaderPopoverMenu { ...props.popoverProps } popoverTitle={ translate( 'Reblog on' ) }>
+		<ReaderPopoverMenu
+			{ ...props.popoverProps }
+			popoverTitle={ translate( 'Reblog on' ) }
+			onClose={ props.closeMenu }
+		>
 			<SiteSelector
 				className="reader-share__site-selector"
 				onSiteSelect={ pickSiteToShareTo }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/79932


## Proposed Changes

* a small bug introduced in https://github.com/Automattic/wp-calypso/pull/79932 - the reader reblog popover does not close if the user clicks outside of the popover.

Before / on production:
![popover-no-close](https://github.com/Automattic/wp-calypso/assets/28742426/ec896daa-a8fa-412f-8c70-ca3af13babbc)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch of calypso.
* visit the reader and click on the reblog button to open the popover.
* click outside the popover, such as clicking on the social sharing button, and verify the reblog popover closes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
