### PR TITLE
Presales Chat: Add Login Check Override Option

### DIFF
--- a/client/components/jetpack/portal-nav/index.tsx
+++ b/client/components/jetpack/portal-nav/index.tsx
@@ -6,7 +6,7 @@ import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { dashboardPath } from 'calypso/lib/jetpack/paths';
-import { usePresalesChat } from 'calypso/lib/presales-chat';
+import { usePresalesChatWithOptions } from 'calypso/lib/presales-chat';
 import { isSectionNameEnabled } from 'calypso/sections-filter';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -54,11 +54,10 @@ export default function PortalNav( { className = '' }: Props ) {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const manageSiteLink = useManageSiteLink();
 
-	usePresalesChat(
-		'jpAgency',
-		hasJetpackPartnerAccess && isSectionNameEnabled( 'jetpack-cloud-partner-portal' ),
-		true
-	);
+	usePresalesChatWithOptions( 'jpAgency', {
+		enabled: hasJetpackPartnerAccess && isSectionNameEnabled( 'jetpack-cloud-partner-portal' ),
+		skipAvailabilityCheck: true,
+	} );
 
 	// Route belongs dashboard when it starts with /dashboard or /plugins and no site is selected(multi-site view).
 	const isDashboardRoute =

--- a/client/lib/presales-chat/README.md
+++ b/client/lib/presales-chat/README.md
@@ -45,6 +45,8 @@ This hook internally calls `usePresalesChat`, passing it the properties from the
 
 Here is an example of how to use the `usePresalesChatWithOptions` hook:
 
+<!-- eslint-disable -->
+
 ```javascript
 usePresalesChatWithOptions( 'jpGeneral', {
 	enabled: true,

--- a/client/lib/presales-chat/README.md
+++ b/client/lib/presales-chat/README.md
@@ -40,17 +40,3 @@ The `usePresalesChatWithOptions` hook provides a more readable and maintainable 
   - `skipEligibilityCheck: boolean` - If `true`, the hook will skip the check for chat eligibility. Defaults to `false`.
 
 This hook internally calls `usePresalesChat`, passing it the properties from the `options` object.
-
-## Example Usage
-
-Here is an example of how to use the `usePresalesChatWithOptions` hook:
-
-<!-- eslint-disable -->
-
-```javascript
-usePresalesChatWithOptions( 'jpGeneral', {
-	enabled: true,
-	skipAvailabilityCheck: false,
-	skipEligibilityCheck: true,
-} );
-```

--- a/client/lib/presales-chat/README.md
+++ b/client/lib/presales-chat/README.md
@@ -1,0 +1,54 @@
+# Presales Chat Hook
+
+This package provides a set of hooks to manage the status and availability of a presales chat.
+
+## Overview
+
+The main hook exported by this package is `usePresalesChat`. This hook manages the chat's availability and status based on the user's locale, their connection to Zendesk, and other criteria.
+
+The package also exports a `KeyType` type, which represents the possible chat configurations.
+
+## KeyType
+
+The `KeyType` is a string union type, which can be one of the following: `'akismet'`, `'jpAgency'`, `'jpCheckout'`, `'jpGeneral'`, or `'wpcom'`.
+
+## Hooks
+
+### usePresalesChat
+
+The `usePresalesChat` hook is called with the following arguments:
+
+- `keyType: KeyType` - This is the configuration type for the chat.
+- `enabled: boolean` - This is a flag that indicates whether the chat is enabled. Defaults to `true`.
+- `skipAvailabilityCheck: boolean` - If `true`, the hook will skip the check for chat availability. Defaults to `false`.
+- `skipEligibilityCheck: boolean` - If `true`, the hook will skip the check for chat eligibility. Defaults to `false`.
+
+The hook returns an object with the following properties:
+
+- `isChatActive: boolean` - This indicates whether the chat is currently active.
+- `isLoading: boolean` - This indicates whether the chat availability is currently being checked.
+- `isPresalesChatAvailable: boolean` - This indicates whether the presales chat is available.
+
+### usePresalesChatWithOptions
+
+The `usePresalesChatWithOptions` hook provides a more readable and maintainable way to call `usePresalesChat`, while allowing backward compatibility with the original usePresalesChat hook. It takes the following arguments:
+
+- `keyType: KeyType` - This is the configuration type for the chat.
+- `options: object` - An optional object that can contain the following properties:
+  - `enabled: boolean` - This is a flag that indicates whether the chat is enabled. Defaults to `true`.
+  - `skipAvailabilityCheck: boolean` - If `true`, the hook will skip the check for chat availability. Defaults to `false`.
+  - `skipEligibilityCheck: boolean` - If `true`, the hook will skip the check for chat eligibility. Defaults to `false`.
+
+This hook internally calls `usePresalesChat`, passing it the properties from the `options` object.
+
+## Example Usage
+
+Here is an example of how to use the `usePresalesChatWithOptions` hook:
+
+```javascript
+usePresalesChatWithOptions( 'jpGeneral', {
+	enabled: true,
+	skipAvailabilityCheck: false,
+	skipEligibilityCheck: true,
+} );
+```

--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -38,10 +38,16 @@ function getGroupName( keyType: KeyType ) {
 	}
 }
 
-export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabilityCheck = false ) {
+export function usePresalesChat(
+	keyType: KeyType,
+	enabled = true,
+	skipAvailabilityCheck = false,
+	skipEligibilityCheck = false
+) {
 	const isEnglishLocale = useIsEnglishLocale();
 	const { canConnectToZendesk } = useChatStatus();
-	const isEligibleForPresalesChat = enabled && isEnglishLocale && canConnectToZendesk;
+	const isEligibleForPresalesChat =
+		( enabled && isEnglishLocale && canConnectToZendesk ) || skipEligibilityCheck;
 
 	const group = getGroupName( keyType );
 
@@ -64,4 +70,18 @@ export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabil
 		isLoading: isLoadingAvailability,
 		isPresalesChatAvailable,
 	};
+}
+
+// This function consolidates the options that are passed to usePresalesChat for better readability and backward compatibility.
+export function usePresalesChatWithOptions(
+	keyType: KeyType,
+	options: {
+		enabled?: boolean;
+		skipAvailabilityCheck?: boolean;
+		skipEligibilityCheck?: boolean;
+	} = {}
+) {
+	const { enabled = true, skipAvailabilityCheck = false, skipEligibilityCheck = false } = options;
+
+	return usePresalesChat( keyType, enabled, skipAvailabilityCheck, skipEligibilityCheck );
 }

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from '@wordpress/element';
 import StoreFooter from 'calypso/jetpack-connect/store-footer';
-import { usePresalesChat } from 'calypso/lib/presales-chat';
+import { usePresalesChatWithOptions } from 'calypso/lib/presales-chat';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import OpenSourceSection from '../open-source';
@@ -40,7 +40,11 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 
 	const showJetpackFree = useShowJetpackFree();
 
-	usePresalesChat( 'jpGeneral' );
+	usePresalesChatWithOptions( 'jpGeneral', {
+		enabled: true,
+		skipAvailabilityCheck: false,
+		skipEligibilityCheck: true,
+	} );
 
 	useEffect( () => {
 		if ( ! didMount.current ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p8wKgj-4vv-p2#comment-21126

## Proposed Changes

* It was recently discovered that the chat widget does not appear to users on the Jetpack pricing page, which should show
* The cause is that the presales chat hook sends all chats through an eligibility check, and logged out users are ineligible.
* This PR adds another parameter to `usePresalesChat`  that bypasses that check if true
* Because of this added to the existing option to skip availability check, things started getting a little cumbersome, resulting in code that looks like `usePresalesChat( 'jpGeneral', true, false, true );`  IMHO this has become cumbersome, so...
* I added a second hook to usePresalesChat, `usePresalesChatWithOptions` which works as a wrapper and takes the options as an object, so everything can be labelled and only the needed options be added when calling the hook.  It was done this way as a separate hook to keep backward compatibility with all the other places we're calling usePresalesChat
* As an extra bonus, I added a readme file to further reduce future confusion.
* I also refactored the chat call from #79475 to use the new hook.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* We'll need to test the 2 areas where we're using the new hook, the logged out pricing page and the agency dashboard
* First, use the jetpack cloud live link below, or build this PR locally

Jetpack Cloud page:

- This assumes chat is staffed (see below for a tip on how to force staffing if you don't want to bug the JPOP HEs)
- Copy the jetpack cloud live link.  In an incognito browser window, paste the link and add /pricing
- You should see the chat bubble
- If you do the same thing in production, you will not see the chat bubble

![Screenshot 2023-07-28 at 10 03 59 AM](https://github.com/Automattic/wp-calypso/assets/12895386/14530099-98ac-4037-ada3-2d3ad4f9b82a)


Agency Dashboard:

- This assumes chat is UNSTAFFED and you are an agency partner
- Once again visit the live link or your localhost link and go to /dashboard
- You should see the chat bubble regardless of chat being staffed or not
- This is the same behavior as production, we're just making sure I didn't break it.

Forcing staffing status:

- You'll need sandbox access for this
- Sandbox public-api.wordpress.com
- Edit wp-content/plugins/zendesk-chat-api.php 
- Around line 58, you'll find the staffing function:
`	public function get_agents_status( string $group ) {
		$department_id = $this->map_group_to_department( $group );
		if ( is_null( $department_id ) ) {
			return null;
		}

		$this->log_usage( 'agents_status' );
		return $this->http_get( self::REAL_TIME_API_URL, 'agents/?department_id=' . $department_id )->content->data ?? null;
	}`
- Modify the function to return null (for unstaffed) or a value greater than 0 (for staffed).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205145991068646