### PR TITLE
Update styles for pricing page nav

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -125,6 +125,11 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 								tagline: translate( 'Advertise your best content' ),
 								href: `${ JETPACK_COM_BASE_URL }/blaze/`,
 							},
+							{
+								label: translate( 'Newsletter' ),
+								tagline: translate( 'Write once, reach all' ),
+								href: `${ JETPACK_COM_BASE_URL }/newsletter/`,
+							},
 						],
 					},
 				],

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -133,8 +133,8 @@
 	@media ( max-width: 900px ) {
 		.header {
 			position: relative;
-			padding: 0;
-			height: 80px;
+			padding: 1.5rem 0;
+			height: auto;
 			background-color: var(--studio-white);
 		}
 	}
@@ -155,7 +155,6 @@
 	}
 
 	.header__content-wrapper {
-		position: absolute;
 		width: 100%;
 	}
 

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -627,8 +627,25 @@
 		display: flex;
 		justify-content: space-between;
 		box-sizing: border-box;
-		gap: 3rem;
+		gap: 1.25rem;
 	}
+
+	.header__submenu-section-separator,
+	.header__submenu-bottom-section {
+		max-width: 1200px;
+		width: 85%;
+		margin-left: auto;
+		margin-right: auto;
+		box-sizing: border-box;
+	}
+
+	.header__submenu-bottom-section {
+		@media ( min-width: 900px ) {
+			display: flex;
+			gap: 3rem;
+		}
+	}
+
 	@media ( max-width: 1300px ) {
 		.header__submenu-bottom-section,
 		.header__submenu-categories-list {
@@ -669,7 +686,7 @@
 	}
 	@media ( max-width: 900px ) {
 		.header__submenu-categories-list > li {
-			margin-bottom: 3rem;
+			margin-bottom: 2.5rem;
 			animation: none;
 		}
 	}
@@ -749,12 +766,9 @@
 	.header__submenu-links-list > li:nth-of-type(5) > a {
 		animation-delay: calc(calc(0.055s * 9) + calc(0.1s / 1.5));
 	}
-
-	.header__submenu-bottom-section {
-		@media ( min-width: 900px ) {
-			display: flex;
-			gap: 6rem;
-		}
+	.header__submenu-categories-list > li:nth-of-type(3)
+	.header__submenu-links-list > li:nth-of-type(6) > a {
+		animation-delay: calc(calc(0.055s * 10) + calc(0.1s / 1.5));
 	}
 
 	.header__submenu-bundles {
@@ -771,28 +785,14 @@
 
 	.header__submenu-category-heading {
 		color: var(--studio-gray-50);
-		font-size: 1.25rem;
+		font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
 		margin-bottom: 0;
+		margin-top: 1em;
 	}
 
 	.header__submenu-section-separator {
 		background-color: var(--studio-gray-10);
-		margin-bottom: 1.125rem;
-
-		@media ( max-width: 782px ) {
-			margin-left: 2rem;
-			margin-right: 2rem;
-			width: auto;
-		}
-	}
-
-	.header__submenu-section-separator,
-	.header__submenu-bottom-section {
-		max-width: 1200px;
-		width: 85%;
-		margin-left: auto;
-		margin-right: auto;
-		box-sizing: border-box;
+		margin: 0 auto;
 
 		@media ( max-width: 1300px ) {
 			width: 90%;
@@ -800,20 +800,24 @@
 		@media ( max-width: 1100px ) {
 			width: 95%;
 		}
+		@media ( max-width: 782px ) {
+			margin-left: 2rem;
+			margin-right: 2rem;
+			width: auto;
+		}
 	}
 
 	.header__submenu-bundles .header__submenu-links-list {
 		display: flex;
 		justify-content: flex-start;
-		gap: 2rem;
+		gap: 4.875rem;
 
 		@media ( max-width: 900px ) {
 			display: block;
+			margin-bottom: 2.5rem;
 		}
 
 		> li {
-			flex: 0;
-			min-width: 200px;
 			animation-fill-mode: backwards;
 			animation-name: submenu-item;
 			animation-duration: 0.25s;
@@ -847,11 +851,11 @@
 		list-style-type: none;
 	}
 	.header__submenu-links-list > li {
-		margin: 1.75rem 0;
+		margin: 1.25rem 0;
 	}
 	@media ( max-width: 900px ) {
 		.header__submenu-links-list > li {
-			margin: 1.375rem 0;
+			margin: 1.1rem 0;
 		}
 	}
 
@@ -860,7 +864,7 @@
 		display: flex;
 		flex-direction: column;
 		width: fit-content;
-		font-size: 2rem;
+		font-size: 1rem;
 		font-weight: 700;
 	}
 	.header__submenu-link:focus-visible {
@@ -923,12 +927,12 @@
 	}
 
 	.header__submenu-category {
-		margin-bottom: 3rem;
-		font-size: 2.625rem; /* stylelint-disable-line scales/font-sizes */
+		margin-bottom: 1.5rem;
+		font-size: 2rem;
 	}
 	@media ( max-width: 900px ) {
 		.header__submenu-category {
-			margin-bottom: 1rem;
+			margin-bottom: 2rem;
 		}
 	}
 	.header__submenu-category .header__submenu-label {


### PR DESCRIPTION
## Proposed Changes

* This diff updates the nav on the Jetpack pricing page to match some changes on the main Jetpack.com

## Testing Instructions

* Apply this patch, make sure the nav matches D117317-code (see linked design)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?