### PR TITLE
Domain Transfer: Address copy feedback from round 2

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -109,11 +109,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 							purchases?.length
 						) }
 					</div>
-					<div>
-						{ translate( '{{strong}}It may take up to 5-10 days.{{/strong}}', {
-							components: { strong: <strong /> },
-						} ) }
-					</div>
 				</>
 			);
 		}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/BulkDomainTransferFooter.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/BulkDomainTransferFooter.tsx
@@ -13,7 +13,7 @@ const BulkDomainTransferFooter = () => {
 				description={ __(
 					'Check your inbox for an email from your current domain provider for instructions on how to speed up the transfer process.'
 				) }
-				buttonText={ __( 'Learn more expediting domain transfers' ) }
+				buttonText={ __( 'Learn about expediting domain transfers' ) }
 				href={ localizeUrl( 'https://wordpress.com/support/domains/incoming-domain-transfer/' ) }
 				onClick={ () =>
 					recordTracksEvent( 'calypso_domain_transfer_complete_click', {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/BulkDomainTransferFooter.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/BulkDomainTransferFooter.tsx
@@ -9,6 +9,19 @@ const BulkDomainTransferFooter = () => {
 	return (
 		<div>
 			<PurchaseDetail
+				title={ __( 'Want to speed this up?' ) }
+				description={ __(
+					'Check your inbox for an email from your current domain provider for instructions on how to speed up the transfer process.'
+				) }
+				buttonText={ __( 'Learn more expediting domain transfers' ) }
+				href={ localizeUrl( 'https://wordpress.com/support/domains/incoming-domain-transfer/' ) }
+				onClick={ () =>
+					recordTracksEvent( 'calypso_domain_transfer_complete_click', {
+						destination: '/support/domains/incoming-domain-transfer/',
+					} )
+				}
+			/>
+			<PurchaseDetail
 				title={ __( 'Dive into domain essentials' ) }
 				description={ __(
 					"Unlock the domain world's secrets. Dive into our comprehensive resource to learn the basics of domains, from registration to management."
@@ -18,20 +31,6 @@ const BulkDomainTransferFooter = () => {
 				onClick={ () =>
 					recordTracksEvent( 'calypso_domain_transfer_complete_click', {
 						destination: '/support/domains',
-					} )
-				}
-			/>
-
-			<PurchaseDetail
-				title={ __( 'Consider moving your sites too?' ) }
-				description={ __(
-					'You can find step-by-step guides below that will help you move your site to WordPress.com'
-				) }
-				buttonText={ __( 'Learn more about site transfers' ) }
-				href={ localizeUrl( 'https://wordpress.com/support/moving-a-blog/' ) }
-				onClick={ () =>
-					recordTracksEvent( 'calypso_domain_transfer_complete_click', {
-						destination: '/support/moving-a-blog',
 					} )
 				}
 			/>

--- a/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
@@ -141,13 +141,11 @@ const TransferredDomainDetails = ( {
 
 		return hasTranslation(
 			'Your transfer has been started and is waiting for authorization from your current ' +
-				'domain provider. This process can take up to 5-10 days. If you need to cancel or expedite the ' +
-				'transfer please contact them for assistance.'
+				"domain provider. Your current domain provider should allow you to speed this process up, either through their website or an email they've already sent you."
 		) || isEnglishLocale
 			? translate(
 					'Your transfer has been started and is waiting for authorization from your current ' +
-						'domain provider. This process can take up to 5-10 days. If you need to cancel or expedite the ' +
-						'transfer please contact them for assistance.'
+						"domain provider. Your current domain provider should allow you to speed this process up, either through their website or an email they've already sent you."
 			  )
 			: translate(
 					'Your transfer has been started and is waiting for authorization from your current ' +


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3287
Fixes https://github.com/Automattic/dotcom-forge/issues/3265
Fixes https://github.com/Automattic/dotcom-forge/issues/3288

## Proposed Changes

Address 5-10 day language and nudge user towards speeding up the transfer on checkout thank you and in single domains management views.

**Note:** This is pending documentation updates as discussed here: p1690565115628209-slack-C05CT832K2T

<img width="783" alt="Screenshot 2023-07-28 at 12 22 13 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/5c7b3db1-74c0-4e40-b5a7-ec13e7d85d09">

<img width="839" alt="Screenshot 2023-07-28 at 4 11 48 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/7b2048ae-d29d-4bca-8778-ff9c8e5cc64d">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit /setup/domain-transfer and work through flow
* Verify copy above for checkout thank you
* Verify copy on single domain management page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?