### PR TITLE
Checkout: Remove useViewportMatch from checkout line items

### DIFF
--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -632,7 +632,8 @@ describe( 'CheckoutMain', () => {
 			expect( navigate ).not.toHaveBeenCalled();
 		} );
 		expect( await screen.findByText( /WordPress.com Personal/ ) ).toBeInTheDocument();
-		expect( await screen.findByText( 'Gift' ) ).toBeInTheDocument();
+		// There are two versions of the "Gift" label: one shown at small width and one at wide width.
+		expect( ( await screen.findAllByText( 'Gift' ) ).length ).toBeGreaterThan( 0 );
 		expect( errorNotice ).not.toHaveBeenCalled();
 	} );
 

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -42,7 +42,6 @@
 		"@automattic/shopping-cart": "workspace:^",
 		"@emotion/styled": "^11.3.0",
 		"@stripe/stripe-js": "^1.53.0",
-		"@wordpress/compose": "^6.15.0",
 		"@wordpress/data": "^9.8.0",
 		"@wordpress/i18n": "^4.38.0",
 		"@wordpress/react-i18n": "^3.36.0",

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -27,7 +27,6 @@ import {
 } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import styled from '@emotion/styled';
-import { useViewportMatch } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
 import { useState, PropsWithChildren } from 'react';
 import { getLabel, getSublabel } from './checkout-labels';
@@ -935,6 +934,28 @@ function GSuiteDiscountCallout( { product }: { product: ResponseCartProduct } ) 
 	return null;
 }
 
+function GiftBadgeWithWrapper() {
+	const translate = useTranslate();
+	return (
+		<GiftBadgeWrapper>
+			<GiftBadge>{ translate( 'Gift' ) }</GiftBadge>
+		</GiftBadgeWrapper>
+	);
+}
+
+const OnlyMobileContainer = styled.div`
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		display: none;
+	}
+`;
+
+const OnlyNotMobileContainer = styled.div`
+	display: none;
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		display: block;
+	}
+`;
+
 function WPLineItem( {
 	children,
 	product,
@@ -963,7 +984,6 @@ function WPLineItem( {
 } > ) {
 	const id = product.uuid;
 	const translate = useTranslate();
-	const isMobile = useViewportMatch( 'small', '<' );
 	const hasBundledDomainsInCart = responseCart.products.some(
 		( product ) =>
 			( product.is_domain_registration || product.product_slug === 'domain_transfer' ) &&
@@ -1018,12 +1038,6 @@ function WPLineItem( {
 		products: [ product ],
 	} );
 
-	const giftBadgeElement = (
-		<GiftBadgeWrapper>
-			<GiftBadge>{ translate( 'Gift' ) }</GiftBadge>
-		</GiftBadgeWrapper>
-	);
-
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div
@@ -1031,10 +1045,14 @@ function WPLineItem( {
 			data-e2e-product-slug={ productSlug }
 			data-product-type={ isPlan( product ) ? 'plan' : product.product_slug }
 		>
-			{ isMobile && responseCart.is_gift_purchase && giftBadgeElement }
+			<OnlyMobileContainer>
+				{ responseCart.is_gift_purchase && <GiftBadgeWithWrapper /> }
+			</OnlyMobileContainer>
 			<LineItemTitle id={ itemSpanId } isSummary={ isSummary }>
 				{ label }
-				{ ! isMobile && responseCart.is_gift_purchase && giftBadgeElement }
+				<OnlyNotMobileContainer>
+					{ responseCart.is_gift_purchase && <GiftBadgeWithWrapper /> }
+				</OnlyNotMobileContainer>
 			</LineItemTitle>
 			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
 				<LineItemPrice

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -97,12 +97,6 @@ export const CouponLineItem = styled( WPCouponLineItem )< {
 	}
 `;
 
-const GiftBadgeWrapper = styled.span`
-	@media ( max-width: 660px ) {
-		width: 100%;
-	}
-`;
-
 const GiftBadge = styled.span`
 	color: #234929;
 	background-color: #b8e6bf;
@@ -934,22 +928,20 @@ function GSuiteDiscountCallout( { product }: { product: ResponseCartProduct } ) 
 	return null;
 }
 
-function GiftBadgeWithWrapper() {
+function GiftBadgeWithText() {
 	const translate = useTranslate();
-	return (
-		<GiftBadgeWrapper>
-			<GiftBadge>{ translate( 'Gift' ) }</GiftBadge>
-		</GiftBadgeWrapper>
-	);
+	return <GiftBadge>{ translate( 'Gift' ) }</GiftBadge>;
 }
 
-const OnlyMobileContainer = styled.div`
+const MobileGiftWrapper = styled.div`
+	display: block;
+	width: 100%;
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		display: none;
 	}
 `;
 
-const OnlyNotMobileContainer = styled.div`
+const DesktopGiftWrapper = styled.div`
 	display: none;
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		display: block;
@@ -1045,14 +1037,18 @@ function WPLineItem( {
 			data-e2e-product-slug={ productSlug }
 			data-product-type={ isPlan( product ) ? 'plan' : product.product_slug }
 		>
-			<OnlyMobileContainer>
-				{ responseCart.is_gift_purchase && <GiftBadgeWithWrapper /> }
-			</OnlyMobileContainer>
+			{ responseCart.is_gift_purchase && (
+				<MobileGiftWrapper>
+					<GiftBadgeWithText />
+				</MobileGiftWrapper>
+			) }
 			<LineItemTitle id={ itemSpanId } isSummary={ isSummary }>
 				{ label }
-				<OnlyNotMobileContainer>
-					{ responseCart.is_gift_purchase && <GiftBadgeWithWrapper /> }
-				</OnlyNotMobileContainer>
+				{ responseCart.is_gift_purchase && (
+					<DesktopGiftWrapper>
+						<GiftBadgeWithText />
+					</DesktopGiftWrapper>
+				) }
 			</LineItemTitle>
 			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
 				<LineItemPrice

--- a/yarn.lock
+++ b/yarn.lock
@@ -1762,7 +1762,6 @@ __metadata:
     "@stripe/stripe-js": ^1.53.0
     "@testing-library/jest-dom": ^5.16.5
     "@testing-library/react": ^14.0.0
-    "@wordpress/compose": ^6.15.0
     "@wordpress/data": ^9.8.0
     "@wordpress/i18n": ^4.38.0
     "@wordpress/react-i18n": ^3.36.0


### PR DESCRIPTION
## Proposed Changes

Checkout's line items use the Gutenberg hook `useViewportMatch` to determine where to show the "Gift" badge for a gift purchase since https://github.com/Automattic/wp-calypso/pull/70309. However, that hook uses `useMediaQuery` and there is a bug in that hook (https://github.com/Automattic/wp-calypso/issues/79948) which causes fatal errors in some cases.

In this PR we remove `useViewportMatch` from the checkout line items and instead rely on media queries to hide and show the Gift badge.

| Desktop | Mobile |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/402286/203439065-debb1dc7-303a-454e-994b-4eebc0c99721.png) | ![image](https://user-images.githubusercontent.com/402286/203439080-d7530a62-0471-4b61-9dbd-8ed08219e2a5.png) |


## Testing Instructions

- Add a gift to your cart (eg: /checkout/value_bundle/gift/1011844) and visit checkout. Full instructions for gift purchases can be found in D92011-code.
- Verify that the gift badge appears only once at mobile width (where it should appear above the line item title) and at desktop width (where it should appear after the line item title).