### PR TITLE
Hosting: cross-link flows at the top bar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -25,14 +25,32 @@ export const ImportWrapper: Step = function ( props ) {
 	const currentRoute = useCurrentRoute();
 	const [ , setMigrationConfirmed ] = useMigrationConfirmation();
 	const shouldHideBackBtn = currentRoute === `${ IMPORT_FOCUSED_FLOW }/${ BASE_ROUTE }`;
-	const skipLabelText =
-		flow === IMPORT_FOCUSED_FLOW ? __( 'Skip to dashboard' ) : __( "I don't have a site address" );
+	const getSkipLabelText = () => {
+		if ( flow === IMPORT_HOSTED_SITE_FLOW ) {
+			return __( 'Create a site' );
+		}
+
+		return flow === IMPORT_FOCUSED_FLOW
+			? __( 'Skip to dashboard' )
+			: __( "I don't have a site address" );
+	};
+
+	const getGoNext = () => {
+		if ( flow === IMPORT_HOSTED_SITE_FLOW ) {
+			return () => window.location.assign( '/setup/new-hosted-site' );
+		}
+
+		return navigation.goNext;
+	};
 
 	useEffect( () => setMigrationConfirmed( false ), [] );
 
 	const shouldHideSkipBtn = () => {
 		switch ( flow ) {
 			case IMPORT_FOCUSED_FLOW:
+				return currentRoute !== `${ flow }/${ BASE_ROUTE }`;
+
+			case IMPORT_HOSTED_SITE_FLOW:
 				return currentRoute !== `${ flow }/${ BASE_ROUTE }`;
 
 			default:
@@ -52,8 +70,8 @@ export const ImportWrapper: Step = function ( props ) {
 				hideBack={ shouldHideBackBtn }
 				hideFormattedHeader={ true }
 				goBack={ navigation.goBack }
-				goNext={ navigation.goNext }
-				skipLabelText={ skipLabelText }
+				goNext={ getGoNext() }
+				skipLabelText={ getSkipLabelText() }
 				isFullLayout={ true }
 				stepContent={ children as ReactElement }
 				recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
@@ -167,7 +167,8 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 				stepName="site-options"
 				backLabelText={ __( 'Back' ) }
 				goBack={ goBack }
-				hideSkip={ true }
+				skipLabelText={ __( 'Import a site' ) }
+				goNext={ () => window.location.assign( '/setup/import-hosted-site' ) }
 				isHorizontalLayout
 				formattedHeader={
 					<FormattedHeader id="site-options-header" headerText={ headerText } align="left" />


### PR DESCRIPTION
Closes Automattic/dotcom-forge#3283

## Proposed Changes

The only place that the user has the opportunity to kickoff a migration is by clicking the CTAs on the landing page. That's because we removed the bifurcation: that's the right move because the volume of new site creations is much higher, but we're removing the opportunity for the user to move their site to our infra.

Let's add a button to the top-right corner of both hosted flows referencing each other:

| New hosted site | Import hosted site |
| ---------------- | ------------------- |
| ![Image](https://github.com/Automattic/dotcom-forge/assets/26530524/d8ec3b7a-c442-4362-a12e-aab2dbac9896) | ![Image](https://github.com/Automattic/dotcom-forge/assets/26530524/326ae6bb-4abf-4740-b2e8-b6d6ad530bc8) |

## Testing Instructions

1. Enter `/setup/new-hosted-site` and verify that a link to "Import a site" shows up at the top-right corner. Clicking it should redirect you to `/setup/import-hosted-site`
2. Enter `/setup/import-hosted-site` and verify that a link to "Create a site" shows up at the top-right corner. Clicking it should redirect you to `/setup/new-hosted-site`
