### PR TITLE
Domain Transfer: Checkout Thank You: Always send the user to /domains/manage

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/DomainsTransferredList.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/DomainsTransferredList.tsx
@@ -6,9 +6,6 @@ import { Button } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import i18n, { getLocaleSlug } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import { domainManagementRoot, domainManagementTransferIn } from 'calypso/my-sites/domains/paths';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 import './style.scss';
 
@@ -18,7 +15,7 @@ type Props = {
 	currency?: string;
 };
 
-const DomainsTransferredList = ( { purchases, manageDomainUrl, currency = 'USD' }: Props ) => {
+const DomainsTransferredList = ( { purchases, currency = 'USD' }: Props ) => {
 	const { __, _n } = useI18n();
 
 	const handleUserClick = ( destination: string ) => {
@@ -58,7 +55,7 @@ const DomainsTransferredList = ( { purchases, manageDomainUrl, currency = 'USD' 
 				</Button>
 
 				<Button
-					href={ manageDomainUrl }
+					href="/domains/manage"
 					className="manage-all-domains"
 					onClick={ () => handleUserClick( '/domains/manage' ) }
 					variant="primary"
@@ -88,15 +85,4 @@ const DomainsTransferredList = ( { purchases, manageDomainUrl, currency = 'USD' 
 	);
 };
 
-export default connect( ( state, ownProps: { purchases: ReceiptPurchase[] } ) => {
-	let manageDomainUrl = '/domains/manage';
-	if ( ownProps.purchases?.length === 1 ) {
-		const { blogId, meta } = ownProps.purchases[ 0 ];
-		const siteSlug = getSiteSlug( state, blogId );
-		manageDomainUrl = domainManagementTransferIn( siteSlug ?? '', meta, domainManagementRoot() );
-	}
-
-	return {
-		manageDomainUrl,
-	};
-} )( DomainsTransferredList );
+export default DomainsTransferredList;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/DomainsTransferredList.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/DomainsTransferredList.tsx
@@ -11,7 +11,6 @@ import './style.scss';
 
 type Props = {
 	purchases: ReceiptPurchase[] | undefined;
-	manageDomainUrl: string;
 	currency?: string;
 };
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3290

## Proposed Changes

* Fixes an issues where the manage domain button is broken shortly after checkout.

This doesn't directly fix the issue which occurs right after checkout. But, does work around it by always sending the user to `/domains/manage` which seems like a reasonable approach. The `/domains/manage` URL is shorter and simpler to understand and remember as well.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR
* Go to `/setup/domain-transfer`
* Work through flow
* Directly after checkout, ensure that you can click the manage domain button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
