### PR TITLE
Hosting: remove 'I am a developer' checkbox on signup

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { Button, FormInputValidation } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { SelectCardCheckbox } from '@automattic/onboarding';
 import classNames from 'classnames';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
@@ -41,7 +40,6 @@ import TextControl from 'calypso/components/text-control';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
-import { preventWidows } from 'calypso/lib/formatting';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import {
 	isCrowdsignalOAuth2Client,
@@ -51,7 +49,6 @@ import {
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
-import { getIAmDeveloperCopy } from 'calypso/me/profile/get-i-am-a-developer-copy';
 import { isP2Flow } from 'calypso/signup/utils';
 import { recordTracksEventWithClientId } from 'calypso/state/analytics/actions';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
@@ -99,7 +96,6 @@ class SignupForm extends Component {
 		handleLogin: PropTypes.func,
 		handleSocialResponse: PropTypes.func,
 		isPasswordless: PropTypes.bool,
-		showIsDevAccountCheckbox: PropTypes.bool,
 		isSocialSignupEnabled: PropTypes.bool,
 		locale: PropTypes.string,
 		positionInFlow: PropTypes.number,
@@ -124,7 +120,6 @@ class SignupForm extends Component {
 		displayUsernameInput: true,
 		flowName: '',
 		isPasswordless: false,
-		showIsDevAccountCheckbox: false,
 		isSocialSignupEnabled: false,
 		horizontal: false,
 		shouldDisplayUserExistsError: false,
@@ -156,7 +151,6 @@ class SignupForm extends Component {
 
 		this.state = {
 			submitting: false,
-			isDevAccount: false,
 			isFieldDirty: {
 				email: false,
 				username: false,
@@ -535,7 +529,6 @@ class SignupForm extends Component {
 		const userData = {
 			password: formState.getFieldValue( this.state.form, 'password' ),
 			email: formState.getFieldValue( this.state.form, 'email' ),
-			is_dev_account: this.state.isDevAccount,
 		};
 
 		if ( this.props.displayNameInput ) {
@@ -934,28 +927,6 @@ class SignupForm extends Component {
 		return false;
 	}
 
-	isDevAccountCheckbox() {
-		if ( ! this.props.showIsDevAccountCheckbox ) {
-			return null;
-		}
-
-		const { translate } = this.props;
-		return (
-			<SelectCardCheckbox
-				className="signup-form__is-dev-account-checkbox signup-form__span-columns"
-				checked={ this.state.isDevAccount }
-				onChange={ ( isDevAccount ) => {
-					recordTracksEvent( 'calypso_signup_dev_account_toggle', {
-						is_dev_account: isDevAccount,
-					} );
-					this.setState( { isDevAccount } );
-				} }
-			>
-				{ preventWidows( getIAmDeveloperCopy( translate ) ) }
-			</SelectCardCheckbox>
-		);
-	}
-
 	emailDisableExplanation() {
 		if ( this.props.disableEmailInput && this.props.disableEmailExplanation ) {
 			return (
@@ -1196,7 +1167,6 @@ class SignupForm extends Component {
 					} ) }
 				>
 					{ this.getNotice() }
-					{ this.isDevAccountCheckbox() }
 					<PasswordlessSignupForm
 						step={ this.props.step }
 						stepName={ this.props.stepName }
@@ -1207,7 +1177,6 @@ class SignupForm extends Component {
 						disabled={ this.props.disabled }
 						disableSubmitButton={ this.props.disableSubmitButton }
 						queryArgs={ this.props.queryArgs }
-						isDevAccount={ this.state.isDevAccount }
 					/>
 
 					{ showSeparator && (
@@ -1223,7 +1192,6 @@ class SignupForm extends Component {
 							socialServiceResponse={ this.props.socialServiceResponse }
 							isReskinned={ this.props.isReskinned }
 							redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
-							isDevAccount={ this.state.isDevAccount }
 						/>
 					) }
 					{ this.props.footerLink || this.footerLink() }
@@ -1267,7 +1235,6 @@ class SignupForm extends Component {
 							compact={ this.props.isWoo || isGravatarOAuth2Client( this.props.oauth2Client ) }
 							redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
 							loginUrl={ this.props.loginUrl }
-							isDevAccount={ this.state.isDevAccount }
 						/>
 					</Fragment>
 				) }

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -20,12 +20,10 @@ import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/
 class PasswordlessSignupForm extends Component {
 	static propTypes = {
 		locale: PropTypes.string,
-		isDevAccount: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		locale: 'en',
-		isDevAccount: false,
 	};
 
 	state = {
@@ -82,7 +80,6 @@ class PasswordlessSignupForm extends Component {
 				locale: getLocaleSlug(),
 				client_id: config( 'wpcom_signup_id' ),
 				client_secret: config( 'wpcom_signup_key' ),
-				is_dev_account: this.props.isDevAccount,
 			} );
 			this.createAccountCallback( null, response );
 		} catch ( err ) {

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -27,12 +27,10 @@ class SocialSignupForm extends Component {
 		flowName: PropTypes.string,
 		redirectToAfterLoginUrl: PropTypes.string,
 		loginUrl: PropTypes.string,
-		isDevAccount: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		compact: false,
-		isDevAccount: false,
 	};
 
 	handleAppleResponse = ( response ) => {
@@ -40,13 +38,14 @@ class SocialSignupForm extends Component {
 			return;
 		}
 
-		const extraUserData = {
-			is_dev_account: this.props.isDevAccount,
-			...( response.user && {
+		let extraUserData = {};
+
+		if ( response.user ) {
+			extraUserData = {
 				user_name: response.user.name,
 				user_email: response.user.email,
-			} ),
-		};
+			};
+		}
 
 		this.props.handleResponse( 'apple', null, response.id_token, extraUserData );
 	};
@@ -60,9 +59,7 @@ class SocialSignupForm extends Component {
 			social_account_type: 'google',
 		} );
 
-		this.props.handleResponse( 'google', tokens.access_token, tokens.id_token, {
-			is_dev_account: this.props.isDevAccount,
-		} );
+		this.props.handleResponse( 'google', tokens.access_token, tokens.id_token );
 	};
 
 	trackSocialSignup = ( service ) => {

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -116,21 +116,6 @@
 	}
 }
 
-.signup-form__is-dev-account-checkbox {
-	margin-bottom: 48px;
-
-	@include break-large {
-		width: fit-content;
-	}
-
-	// The SelectCardCheckbox label is flex by default, which is good for badges, but makes
-	// the <strong> section of the label it's own block and not wrap nicely with the rest
-	// of the label.
-	&.select-card-checkbox__container .select-card-checkbox__label {
-		display: inline;
-	}
-}
-
 // Replace recaptcha badge with ToS text and space
 // everything out a little more.
 @media ( max-width: 660px ) {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -142,7 +142,6 @@ export function generateSteps( {
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 				isPasswordless: true,
-				showIsDevAccountCheckbox: true,
 			},
 		},
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -116,12 +116,10 @@ export class UserStep extends Component {
 		subHeaderText: PropTypes.string,
 		isSocialSignupEnabled: PropTypes.bool,
 		initialContext: PropTypes.object,
-		showIsDevAccountCheckbox: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		isSocialSignupEnabled: false,
-		showIsDevAccountCheckbox: false,
 	};
 
 	state = {
@@ -323,10 +321,7 @@ export class UserStep extends Component {
 				oauth2Signup,
 				...data,
 			},
-			dependencies,
-			{
-				is_dev_account: data.userData.is_dev_account ?? false,
-			}
+			dependencies
 		);
 	};
 
@@ -496,7 +491,7 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const { oauth2Client, isReskinned, isPasswordless, showIsDevAccountCheckbox } = this.props;
+		const { oauth2Client, isReskinned, isPasswordless } = this.props;
 		let socialService;
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
@@ -528,7 +523,6 @@ export class UserStep extends Component {
 					suggestedUsername={ this.props.suggestedUsername }
 					handleSocialResponse={ this.handleSocialResponse }
 					isPasswordless={ isMobile() || isPasswordless }
-					showIsDevAccountCheckbox={ showIsDevAccountCheckbox }
 					queryArgs={ this.props.initialContext?.query || {} }
 					isSocialSignupEnabled={ isSocialSignupEnabled }
 					socialService={ socialService }


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3281.

## Proposed Changes

Let's remove the "I am a developer" checkbox from /start/hosting to make this part of the flow as frictionless as possible.

It's not clear what it does, and it doesn't affect the flow in any way. If we're really keen about it, let's add it to other places (e.g., in the home view.)

## Testing Instructions

Open `/start/hosting` and verify that you can signup as normal, and that `is_dev_account` is not passed as a property to related Tracks events.