### PR TITLE
Checkout: Update "absorb the cost" copy

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -393,7 +393,7 @@ function CheckoutSummaryFeaturesList( props: {
 					<CheckoutSummaryFeaturesListItem>
 						<WPCheckoutCheckIcon id="features-list-support-another-year" />
 						{ hasFreeCouponTransfersOnly( responseCart )
-							? translate( 'We pay the cost of your domain for one year.' )
+							? translate( "We'll pay the cost of your domain for one year" )
 							: translate( '1-year extension on your domain' ) }
 					</CheckoutSummaryFeaturesListItem>
 					<CheckoutSummaryFeaturesListItem>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -393,7 +393,7 @@ function CheckoutSummaryFeaturesList( props: {
 					<CheckoutSummaryFeaturesListItem>
 						<WPCheckoutCheckIcon id="features-list-support-another-year" />
 						{ hasFreeCouponTransfersOnly( responseCart )
-							? translate( "We'll pay the cost of your domain for one year" )
+							? translate( 'We pay for the first year' )
 							: translate( '1-year extension on your domain' ) }
 					</CheckoutSummaryFeaturesListItem>
 					<CheckoutSummaryFeaturesListItem>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -393,7 +393,7 @@ function CheckoutSummaryFeaturesList( props: {
 					<CheckoutSummaryFeaturesListItem>
 						<WPCheckoutCheckIcon id="features-list-support-another-year" />
 						{ hasFreeCouponTransfersOnly( responseCart )
-							? translate( 'We absorb the cost and give you an extra year of free registration' )
+							? translate( 'We pay the cost of your domain for one year.' )
 							: translate( '1-year extension on your domain' ) }
 					</CheckoutSummaryFeaturesListItem>
 					<CheckoutSummaryFeaturesListItem>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3289

## Proposed Changes

* Update absorb the cost copy at checkout.

Before | After
------ | -----
<img width="346" alt="Screen Shot 2023-07-28 at 4 06 25 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/76dd6c39-89b4-4802-a597-d99b2608a14d"> | <img width="335" alt="Screen Shot 2023-07-28 at 5 44 43 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/505b0088-287a-444d-9de8-7cf81cee0041">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to checkout for a Google domain.
* Verify that there's no "first year on us” or “absorb the cost” copy. Our message should be: "we’ll pay for one year."

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
