### PR TITLE
BackupBrowser: Fix base64 encoding to support UTF-8 characters

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
@@ -12,7 +12,7 @@ import { onPreparingDownloadError, onProcessingDownloadError } from './notices';
 import { FileBrowserItem } from './types';
 import { useBackupPathInfoQuery } from './use-backup-path-info-query';
 import { usePrepareDownload } from './use-prepare-download';
-import { convertBytes } from './util';
+import { encodeToBase64, convertBytes } from './util';
 
 interface FileInfoCardProps {
 	siteId: number;
@@ -77,7 +77,7 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 		setIsProcessingDownload( true );
 
 		if ( item.type !== 'archive' ) {
-			const manifestPath = window.btoa( item.manifestPath ?? '' );
+			const manifestPath = encodeToBase64( ( item.manifestPath as string ) ?? '' );
 			wp.req
 				.get( {
 					path: `/sites/${ siteId }/rewind/backup/${ item.period }/file/${ manifestPath }/url`,

--- a/client/my-sites/backup/backup-contents-page/file-browser/test/util.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/test/util.ts
@@ -1,5 +1,9 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { BackupPathInfoResponse, FileBrowserItemInfo } from '../types';
-import { convertBytes, parseBackupPathInfo } from '../util';
+import { convertBytes, encodeToBase64, parseBackupPathInfo } from '../util';
 
 describe( 'convertBytes', () => {
 	it( 'should correctly convert bytes to KB', () => {
@@ -81,5 +85,37 @@ describe( 'parseBackupPathInfo', () => {
 
 		const result = parseBackupPathInfo( payload );
 		expect( result ).toEqual( expected );
+	} );
+} );
+
+describe( 'encodeToBase64', () => {
+	it( 'should return Base64 encoded string for English text', () => {
+		const text = 'Hello, World!';
+		const encoded = encodeToBase64( text );
+		expect( encoded ).toBe( 'SGVsbG8sIFdvcmxkIQ==' );
+	} );
+
+	it( 'should return Base64 encoded string for Spanish text', () => {
+		const text = '¡Hola, Piña!';
+		const encoded = encodeToBase64( text );
+		expect( encoded ).toBe( 'wqFIb2xhLCBQacOxYSE=' );
+	} );
+
+	it( 'should return Base64 encoded string for Japanese text', () => {
+		const text = 'こんにちは、世界!';
+		const encoded = encodeToBase64( text );
+		expect( encoded ).toBe( '44GT44KT44Gr44Gh44Gv44CB5LiW55WMIQ==' );
+	} );
+
+	it( 'should return Base64 encoded string for Chinese text', () => {
+		const text = '你好，世界！';
+		const encoded = encodeToBase64( text );
+		expect( encoded ).toBe( '5L2g5aW977yM5LiW55WM77yB' );
+	} );
+
+	it( 'should return Base64 encoded string for Arabic text', () => {
+		const text = 'مرحبا، العالم!';
+		const encoded = encodeToBase64( text );
+		expect( encoded ).toBe( '2YXYsdit2KjYp9iMINin2YTYudin2YTZhSE=' );
 	} );
 } );

--- a/client/my-sites/backup/backup-contents-page/file-browser/use-backup-file-query.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/use-backup-file-query.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
+import { encodeToBase64 } from './util';
 
 export const useBackupFileQuery = (
 	siteId: number,
@@ -7,7 +8,7 @@ export const useBackupFileQuery = (
 	manifestPath: string | undefined,
 	shouldFetch = true
 ) => {
-	const encodedManifestPath = window.btoa( manifestPath ?? '' );
+	const encodedManifestPath = encodeToBase64( ( manifestPath as string ) ?? '' );
 
 	return useQuery( {
 		queryKey: [ 'jetpack-backup-file-url', siteId, rewindId, encodedManifestPath ],

--- a/client/my-sites/backup/backup-contents-page/file-browser/util.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/util.ts
@@ -199,3 +199,21 @@ export const convertBytes = (
 
 	return { unitAmount: size.toFixed( decimals ), unit: units[ i ] };
 };
+
+/**
+ * Encodes a given text string to Base64 format.
+ *
+ * The function employs the TextEncoder to convert the input text into a UTF-8 byte sequence. This step ensures
+ * accurate encoding of multibyte characters, which are prevalent in scripts like Japanese and Chinese. Directly
+ * using window.btoa on such characters without UTF-8 encoding can lead to incorrect results, as btoa is designed
+ * for ASCII strings. By first encoding to UTF-8, we ensure a consistent and accurate Base64 representation for
+ * a wide range of texts.
+ *
+ * @param {string} text - The text string to be encoded, potentially including non-ASCII characters.
+ * @returns {string} The Base64 encoded representation of the input text.
+ */
+export const encodeToBase64 = ( text: string ): string => {
+	const encoder = new TextEncoder();
+	const charCodes = encoder.encode( text );
+	return window.btoa( String.fromCharCode( ...charCodes ) );
+};


### PR DESCRIPTION
Currently, the backup browser is throwing an error when trying to fetch a file info if the filename has characters outside the Latin1 range (ISO-8859-1). This is a limitation of using `window.btoa` directly. So the idea of this PR is to encode the manifest paths into UTF-8.

<img width="1006" alt="CleanShot 2023-07-28 at 15 23 19@2x" src="https://github.com/Automattic/wp-calypso/assets/1488641/41817275-838a-4e1b-9ab7-b065413335cb">


## Proposed Changes
* Fix base64 encoding to support UTF-8 characters
* Added some test cases supporting some possible filenames in UTF-8.

## Testing Instructions
* Ensure your test site has files with Unicode characters.
* Take a look at your file through the backup browser and validate it loads the file info card, and you can download as well.
  <img width="549" alt="CleanShot 2023-07-28 at 15 06 18@2x" src="https://github.com/Automattic/wp-calypso/assets/1488641/3ececdb2-94c3-4f88-bb16-55c83f183020">

### Unit testing
Ensure unit testings still passing by running:
```
yarn run test-client client/my-sites/backup/backup-contents-page/file-browser/test
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
