### PR TITLE
Domain Transfer: Updated copy on domain congrats page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/DomainsTransferredList.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/DomainsTransferredList.tsx
@@ -1,9 +1,11 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import formatCurrency from '@automattic/format-currency';
+import { englishLocales } from '@automattic/i18n-utils';
 import { joinClasses } from '@automattic/wpcom-checkout';
 import { Button } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import i18n, { getLocaleSlug } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { domainManagementRoot, domainManagementTransferIn } from 'calypso/my-sites/domains/paths';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -26,8 +28,12 @@ const DomainsTransferredList = ( { purchases, manageDomainUrl, currency = 'USD' 
 	};
 
 	const purchaseLabel = ( priceInteger: number ) => {
+		const hasTranslation =
+			englishLocales.includes( String( getLocaleSlug() ) ) ||
+			i18n.hasTranslation( 'We pay the first year' );
+
 		if ( priceInteger === 0 ) {
-			return __( 'Free for one year' );
+			return hasTranslation ? __( 'We pay the first year' ) : __( 'Free for one year' );
 		}
 
 		const priceFormatted = formatCurrency( priceInteger, currency, {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 3269-gh-Automattic/dotcom-forge

## Proposed Changes

* Updated copy on domain congrats page to `We pay the first year` when it's a Google domain

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure we use the copy `We pay the first year` for domain congrats page:

<img width="797" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/2876e9b8-06dd-410d-ab10-0fc59b759606">


* Ensure the old copy still works as expected with the `Free for one year` text in non-EN languages:

<img width="782" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/70a2189b-87ab-48c1-8e16-9a94b92d43be">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?