### PR TITLE
Load odie widget on eligible pages

### DIFF
--- a/client/components/odie-widget/index.tsx
+++ b/client/components/odie-widget/index.tsx
@@ -1,16 +1,19 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
 import { showOdie } from 'calypso/lib/odie';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const OdieWidget = () => {
 	const widgetContainer = useRef< HTMLDivElement >( null );
 	const localeSlug = useLocale();
+	const siteId = useSelector( getSelectedSiteId );
 
 	useEffect( () => {
 		( async () => {
-			await showOdie( widgetContainer.current, localeSlug );
+			await showOdie( siteId, widgetContainer.current, localeSlug );
 		} )();
-	}, [ localeSlug ] );
+	}, [ siteId, localeSlug ] );
 
 	return <div className="odie-widget__widget-container" ref={ widgetContainer }></div>;
 };

--- a/client/components/odie-widget/index.tsx
+++ b/client/components/odie-widget/index.tsx
@@ -1,0 +1,18 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useEffect, useRef } from 'react';
+import { showOdie } from 'calypso/lib/odie';
+
+const OdieWidget = () => {
+	const widgetContainer = useRef< HTMLDivElement >( null );
+	const localeSlug = useLocale();
+
+	useEffect( () => {
+		( async () => {
+			await showOdie( widgetContainer.current, localeSlug );
+		} )();
+	}, [ localeSlug ] );
+
+	return <div className="odie-widget__widget-container" ref={ widgetContainer }></div>;
+};
+
+export default OdieWidget;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -15,6 +15,7 @@ import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySiteSelectedEditor from 'calypso/components/data/query-site-selected-editor';
 import QuerySites from 'calypso/components/data/query-sites';
 import JetpackCloudMasterbar from 'calypso/components/jetpack/masterbar';
+import OdieWidget from 'calypso/components/odie-widget';
 import { withCurrentRoute } from 'calypso/components/route';
 import SympathyDevWarning from 'calypso/components/sympathy-dev-warning';
 import { retrieveMobileRedirect } from 'calypso/jetpack-connect/persistence-utils';
@@ -325,9 +326,12 @@ class Layout extends Component {
 					</div>
 					<div id="primary" className="layout__primary">
 						{ this.shouldShowOdieAssistant() ? (
-							<OdieAssistantProvider sectionName={ this.props.sectionName }>
-								{ this.props.primary }
-							</OdieAssistantProvider>
+							<>
+								<OdieAssistantProvider sectionName={ this.props.sectionName }>
+									{ this.props.primary }
+								</OdieAssistantProvider>
+								{ config.isEnabled( 'odie/widget' ) && <OdieWidget /> }
+							</>
 						) : (
 							this.props.primary
 						) }

--- a/client/lib/odie/README.md
+++ b/client/lib/odie/README.md
@@ -1,0 +1,9 @@
+# Odie Chatbot
+
+Allow users to chat with a bot.
+This is implemented by invoking our chat client widget.
+
+In order to translate:
+
+- Execute `yarn translate` in odie-client project
+- copy `odie-client/build/strings.ts` in this folder

--- a/client/lib/odie/index.ts
+++ b/client/lib/odie/index.ts
@@ -7,10 +7,12 @@ declare global {
 		Odie?: {
 			render: ( params: {
 				authToken: string;
+				siteId: number | null;
 				domNode?: HTMLElement | null;
 				locale?: string;
 				hotjarSiteSettings?: object;
 				onLoaded?: () => void;
+				botJids?: string[];
 			} ) => void;
 			strings: any; // would be used for translations
 		};
@@ -35,7 +37,11 @@ export async function loadOdieWidgetJS(): Promise< void > {
 	// await import( './string' );
 }
 
-export async function showOdie( domNodeOrId?: HTMLElement | string | null, locale?: string ) {
+export async function showOdie(
+	siteId: number | null,
+	domNodeOrId?: HTMLElement | string | null,
+	locale?: string
+) {
 	await loadOdieWidgetJS();
 	return new Promise( ( resolve, reject ) => {
 		if ( window.Odie ) {
@@ -45,6 +51,8 @@ export async function showOdie( domNodeOrId?: HTMLElement | string | null, local
 				locale,
 				hotjarSiteSettings: { ...getHotjarSiteSettings(), isEnabled: mayWeLoadHotJarScript() },
 				onLoaded: () => resolve( true ),
+				siteId,
+				botJids: [ 'wapuu-bot@xmpp.jetpacksandbox.com' ],
 			} );
 		} else {
 			reject( false );

--- a/client/lib/odie/index.ts
+++ b/client/lib/odie/index.ts
@@ -1,0 +1,51 @@
+import config from '@automattic/calypso-config';
+import { loadScript } from '@automattic/load-script';
+import { getHotjarSiteSettings, mayWeLoadHotJarScript } from 'calypso/lib/analytics/hotjar';
+
+declare global {
+	interface Window {
+		Odie?: {
+			render: ( params: {
+				domNode?: HTMLElement | null;
+				locale?: string;
+				hotjarSiteSettings?: object;
+				onLoaded?: () => void;
+			} ) => void;
+			strings: any; // would be used for translations
+		};
+	}
+}
+
+export async function loadOdieWidgetJS(): Promise< void > {
+	// check if already loaded
+	if ( window.Odie ) {
+		return;
+	}
+
+	// To test the widget locally:
+	// Run `yarn widget:dev:wpcom` in odie-client
+	// Change `odie_widget_js_src` in development.json to `http://localhost:3004/widget.js`
+	const odieWidgetJS: string = config( 'odie_widget_js_src' );
+	const src = odieWidgetJS + '?ver=' + Math.round( Date.now() / ( 1000 * 60 * 60 ) );
+	await loadScript( src );
+	// Load the strings so that translations get associated with the module and loaded properly.
+	// The module will assign the placeholder component to `window.Odie.strings` as a side-effect,
+	// in order to ensure that translate calls are not removed from the production build.
+	// await import( './string' );
+}
+
+export async function showOdie( domNodeOrId?: HTMLElement | string | null, locale?: string ) {
+	await loadOdieWidgetJS();
+	return new Promise( ( resolve, reject ) => {
+		if ( window.Odie ) {
+			window.Odie.render( {
+				domNode: typeof domNodeOrId !== 'string' ? domNodeOrId : undefined,
+				locale,
+				hotjarSiteSettings: { ...getHotjarSiteSettings(), isEnabled: mayWeLoadHotJarScript() },
+				onLoaded: () => resolve( true ),
+			} );
+		} else {
+			reject( false );
+		}
+	} );
+}

--- a/client/lib/odie/index.ts
+++ b/client/lib/odie/index.ts
@@ -6,6 +6,7 @@ declare global {
 	interface Window {
 		Odie?: {
 			render: ( params: {
+				authToken: string;
 				domNode?: HTMLElement | null;
 				locale?: string;
 				hotjarSiteSettings?: object;
@@ -39,6 +40,7 @@ export async function showOdie( domNodeOrId?: HTMLElement | string | null, local
 	return new Promise( ( resolve, reject ) => {
 		if ( window.Odie ) {
 			window.Odie.render( {
+				authToken: 'wpcom-proxy-request',
 				domNode: typeof domNodeOrId !== 'string' ? domNodeOrId : undefined,
 				locale,
 				hotjarSiteSettings: { ...getHotjarSiteSettings(), isEnabled: mayWeLoadHotJarScript() },

--- a/client/lib/odie/package.json
+++ b/client/lib/odie/package.json
@@ -1,0 +1,3 @@
+{
+	"sideEffects": true
+}

--- a/client/lib/odie/string.ts
+++ b/client/lib/odie/string.ts
@@ -1,0 +1,10 @@
+import { useTranslate } from 'i18n-calypso';
+
+const OdieStrings = () => {
+	const translate = useTranslate();
+	translate( 'Chat' );
+};
+
+if ( window.Odie ) {
+	window.Odie.strings = OdieStrings;
+}

--- a/client/lib/odie/test/index.jsx
+++ b/client/lib/odie/test/index.jsx
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { showOdie } from '../';
+import { getHotjarSiteSettings, mayWeLoadHotJarScript } from '../../analytics/hotjar';
+
+jest.mock( 'calypso/lib/jetpack/is-jetpack-cloud' );
+
+describe( 'index', () => {
+	test( 'Should call showOdie with hotjarSiteSettings', async () => {
+		global.window.Odie = {};
+		let mockOdieMockCall = null;
+
+		global.window.Odie.render = jest.fn( ( args ) => {
+			mockOdieMockCall = args;
+			args.onLoaded();
+		} );
+
+		isJetpackCloud.mockReturnValue( true );
+		const jetpackCloudEnableReturn = {
+			...getHotjarSiteSettings(),
+			isEnabled: mayWeLoadHotJarScript(),
+		};
+
+		await showOdie( 'foo' );
+		expect( mockOdieMockCall.hotjarSiteSettings ).toEqual( jetpackCloudEnableReturn );
+
+		isJetpackCloud.mockReturnValue( false );
+		const jetpackCloudDisableReturn = {
+			...getHotjarSiteSettings(),
+			isEnabled: mayWeLoadHotJarScript(),
+		};
+
+		await showOdie( 'foo' );
+		expect( mockOdieMockCall.hotjarSiteSettings ).toEqual( jetpackCloudDisableReturn );
+
+		expect( jetpackCloudEnableReturn ).not.toEqual( jetpackCloudDisableReturn );
+	} );
+} );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -226,5 +226,6 @@
 		"onboarding-2023-pricing-grid",
 		"domain-transfer"
 	],
-	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js"
+	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",
+	"odie_widget_js_src": "https://widgets.wp.com/odie/widget.js"
 }

--- a/config/development.json
+++ b/config/development.json
@@ -28,6 +28,7 @@
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
+	"odie_widget_js_src": "http://localhost:3004/widget.js",
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,


### PR DESCRIPTION
Related to 196-gh-Automattic/ai-services

## Proposed Changes

* Load the Odie widget for local development on the same eligible pages as Odie, behind the feature flag `odie/widget`

## Testing Instructions

To run locally
1. Setup reverse tunnel for WPCOM API proxy
2. Start Odie serve app
3. Start Odie client with `yarn widget:dev:wpcom`
4. Start Calypso
5. Go to http://calypso.localhost:3000/plans/<site>?flags=odie/widget

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
