### PR TITLE
GF Signup: Funnel the last searched domain across the signup flow as a dependency

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -81,8 +81,19 @@ export function generateSteps( {
 			stepName: 'domains-launch',
 			apiRequestFunction: addDomainToCart,
 			fulfilledStepCallback: isDomainFulfilled,
-			providesDependencies: [ 'domainItem', 'shouldHideFreePlan', 'signupDomainOrigin', 'siteUrl' ],
-			optionalDependencies: [ 'shouldHideFreePlan', 'signupDomainOrigin', 'siteUrl' ],
+			providesDependencies: [
+				'domainItem',
+				'shouldHideFreePlan',
+				'signupDomainOrigin',
+				'siteUrl',
+				'lastDomainSearched',
+			],
+			optionalDependencies: [
+				'shouldHideFreePlan',
+				'signupDomainOrigin',
+				'siteUrl',
+				'lastDomainSearched',
+			],
 			props: {
 				isDomainOnly: false,
 				showExampleSuggestions: false,
@@ -373,12 +384,14 @@ export function generateSteps( {
 				'isManageSiteFlow',
 				'signupDomainOrigin',
 				'siteUrl',
+				'lastDomainSearched',
 			],
 			optionalDependencies: [
 				'shouldHideFreePlan',
 				'isManageSiteFlow',
 				'signupDomainOrigin',
 				'siteUrl',
+				'lastDomainSearched',
 			],
 			props: {
 				isDomainOnly: false,
@@ -405,8 +418,15 @@ export function generateSteps( {
 		},
 		'domain-only': {
 			stepName: 'domain-only',
-			providesDependencies: [ 'siteId', 'siteSlug', 'siteUrl', 'domainItem', 'signupDomainOrigin' ], // note: siteId, siteSlug are not provided when used in domain flow
-			optionalDependencies: [ 'signupDomainOrigin', 'siteUrl' ],
+			providesDependencies: [
+				'siteId',
+				'siteSlug',
+				'siteUrl',
+				'domainItem',
+				'signupDomainOrigin',
+				'lastDomainSearched',
+			], // note: siteId, siteSlug are not provided when used in domain flow
+			optionalDependencies: [ 'signupDomainOrigin', 'siteUrl', 'lastDomainSearched' ],
 			props: {
 				isDomainOnly: true,
 				forceHideFreeDomainExplainerAndStrikeoutUi: true,
@@ -416,8 +436,15 @@ export function generateSteps( {
 		'domains-store': {
 			stepName: 'domains',
 			apiRequestFunction: createSiteWithCart,
-			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem', 'siteUrl' ],
-			optionalDependencies: [ 'siteUrl' ],
+			providesDependencies: [
+				'siteId',
+				'siteSlug',
+				'domainItem',
+				'themeItem',
+				'siteUrl',
+				'lastDomainSearched',
+			],
+			optionalDependencies: [ 'siteUrl', 'lastDomainSearched' ],
 			props: {
 				isDomainOnly: false,
 				forceDesignType: 'store',
@@ -437,12 +464,14 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'signupDomainOrigin',
 				'siteUrl',
+				'lastDomainSearched',
 			],
 			optionalDependencies: [
 				'shouldHideFreePlan',
 				'useThemeHeadstart',
 				'signupDomainOrigin',
 				'siteUrl',
+				'lastDomainSearched',
 			],
 			props: {
 				isDomainOnly: false,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -262,8 +262,9 @@ class DomainsStep extends Component {
 			? { useThemeHeadstart: shouldUseThemeAnnotation }
 			: {};
 
-		const suggestion = this.props.step.suggestion;
-
+		const { step } = this.props;
+		const { suggestion } = step;
+		const { lastDomainSearched } = step.domainForm;
 		const isPurchasingItem = suggestion && Boolean( suggestion.product_slug );
 
 		const siteUrl =
@@ -306,7 +307,8 @@ class DomainsStep extends Component {
 				this.isDependencyShouldHideFreePlanProvided() ? { shouldHideFreePlan } : {},
 				useThemeHeadstartItem,
 				signupDomainOrigin ? { signupDomainOrigin } : {},
-				suggestion?.domain_name ? { siteUrl: suggestion?.domain_name } : {}
+				suggestion?.domain_name ? { siteUrl: suggestion?.domain_name } : {},
+				lastDomainSearched ? { lastDomainSearched } : {}
 			)
 		);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

### Related to 
- Automattic/growth-foundations#139
- https://github.com/Automattic/wp-calypso/pull/79937

## Proposed Changes

* The subsequent steps of the domain search may utilize the domain search input for upsells and other optimizations
* This PR adds the dependency as an upsell 

## Testing Instructions
A new optional dependency is added to all domains steps which are shown below. 

https://github.com/Automattic/wp-calypso/blob/de3b5dd66ab0f1cc2e689e4d6e1f43c9c9a88cb8/client/signup/config/step-components.js#L14-L19

No visible changes, Make sure any flows that utilise a domain step from above works correctly. 

* `/start`
*  `/start/domain` (Domain only flow)
* `/start/launch-site`
* `/start/with-theme-assembler`
* `/start/with-theme (Go incognito to WordPress.com/themes)

- Locally it would be nice to debug and check that a siteUrl is provided.
