### PR TITLE
Domain Transfer - Remove auth page from browser history if redirecting to domain transfer flow

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -52,7 +52,7 @@ function ContinueAsUser( {
 	const isLoading = validatingQueryURL || validatingPath;
 
 	const userName = currentUser.display_name || currentUser.username;
-
+	const domainTransferFlowURL = '/setup/domain-transfer/';
 	// Render ContinueAsUser straight away, even before validation.
 	// This helps avoid jarring layout shifts. It's not ideal that the link URL changes transparently
 	// like that, but it is better than the alternative, and in practice it should happen quicker than
@@ -99,6 +99,17 @@ function ContinueAsUser( {
 		</a>
 	);
 
+	const handleRedirection = () => {
+		// If the redirect URL is for the domain transfer flow, we need to replace the current URL
+		if ( validatedRedirectUrlFromQuery.startsWith( domainTransferFlowURL ) ) {
+			return window.location.replace( validatedRedirectUrlFromQuery );
+		} else if ( validatedRedirectPath.startsWith( domainTransferFlowURL ) ) {
+			return window.location.replace( validatedRedirectPath );
+		}
+		// Otherwise, we can just assign the URL
+		window.location.assign( validatedRedirectUrlFromQuery || validatedRedirectPath || '/' );
+	};
+
 	if ( isWooOAuth2Client ) {
 		return (
 			<div className="continue-as-user">
@@ -114,11 +125,7 @@ function ContinueAsUser( {
 							{ translate( 'Log in with a different WordPress.com account' ) }
 						</button>
 					</div>
-					<Button
-						busy={ isLoading }
-						primary
-						href={ validatedRedirectUrlFromQuery || validatedRedirectPath || '/' }
-					>
+					<Button busy={ isLoading } primary onClick={ handleRedirection }>
 						{ `${ translate( 'Continue as', {
 							context: 'Continue as an existing WordPress.com user',
 						} ) } ${ userName }` }
@@ -132,11 +139,7 @@ function ContinueAsUser( {
 		<div className="continue-as-user">
 			<div className="continue-as-user__user-info">
 				{ gravatarLink }
-				<Button
-					busy={ isLoading }
-					primary
-					href={ validatedRedirectUrlFromQuery || validatedRedirectPath || '/' }
-				>
+				<Button busy={ isLoading } primary onClick={ handleRedirection }>
 					{ translate( 'Continue' ) }
 				</Button>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3264

## Proposed Changes

* Remove auth page from the browser when navigating to domain transfers flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and run it
* Log out, navigate to `/setup/domain-transfer`, click "Get Started", create a new user, until you reach the authentication screen. Click "continue" and you should be navigated to `/setup/domain-transfer/domains`
* Click the browser back button and verify you are navigated to `/setup/domain-transfer/intro`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
