### PR TITLE
Domain Transfer: Fork transfer flow to allow Google Domains customizations

### DIFF
--- a/client/landing/stepper/declarative-flow/google-domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/google-domain-transfer.ts
@@ -1,0 +1,9 @@
+import { GOOGLE_DOMAIN_TRANSFER } from '@automattic/onboarding';
+import domainTransfer from './domain-transfer';
+
+const googleDomainTransfer = {
+	...domainTransfer,
+	name: GOOGLE_DOMAIN_TRANSFER,
+};
+
+export default googleDomainTransfer;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -92,6 +92,7 @@ button {
 .celebration-step,
 .use-my-domain,
 .domain-transfer,
+.google-domain-transfer,
 .update-design {
 	padding: 60px 0 0;
 	box-sizing: border-box;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -1,7 +1,8 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/onboarding/styles/mixins";
 
-.domain-transfer {
+.domain-transfer,
+.google-domain-transfer {
 	height: 100%;
 	padding: 60px 0 0;
 	margin: 0 auto;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
@@ -1,9 +1,9 @@
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { usePresalesChat } from 'calypso/lib/presales-chat';
+import { isGoogleDomainsTransferFlow } from '../../../../utils/domain-transfer-flow';
 import IntroStep from './intro';
 import type { Step } from '../../types';
 
@@ -12,7 +12,6 @@ import './styles.scss';
 const Intro: Step = function Intro( { navigation } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
-	const isEnglishLocale = useIsEnglishLocale();
 
 	usePresalesChat( 'wpcom' );
 
@@ -28,11 +27,17 @@ const Intro: Step = function Intro( { navigation } ) {
 				<FormattedHeader
 					id="domain-transfer-header"
 					headerText={
-						isEnglishLocale ? __( 'Transfer your domains' ) : __( 'Transfer Your Domains' )
+						isGoogleDomainsTransferFlow()
+							? __( 'Transfer your Google domains' )
+							: __( 'Transfer Your Domains' )
 					}
-					subHeaderText={ __(
-						'Follow these three simple steps to transfer your domains to WordPress.com.'
-					) }
+					subHeaderText={
+						isGoogleDomainsTransferFlow()
+							? __(
+									'Follow these three simple steps to transfer your Google domains to WordPress.com.'
+							  )
+							: __( 'Follow these three simple steps to transfer your domains to WordPress.com.' )
+					}
 				/>
 			}
 			stepContent={ <IntroStep onSubmit={ handleSubmit } /> }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
@@ -4,6 +4,7 @@ import { Button } from '@wordpress/components';
 import { Icon, unlock, plus, payment } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { preventWidows } from 'calypso/lib/formatting';
+import { isGoogleDomainsTransferFlow } from '../../../../utils/domain-transfer-flow';
 
 interface Props {
 	onSubmit: () => void;
@@ -48,7 +49,9 @@ const Intro: React.FC< Props > = ( { onSubmit } ) => {
 					{
 						key: 'finalize',
 						title: __( 'Checkout' ),
-						badge: __( 'Free for Google Domains' ),
+						badge: isGoogleDomainsTransferFlow()
+							? __( 'We pay the first year' )
+							: __( 'Free for Google Domains' ),
 						description: (
 							<p>
 								{ isEnglishLocale ||

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -4,7 +4,8 @@
 $font-family: "SF Pro Text", $sans;
 $heading-font-family: "SF Pro Display", $sans;
 
-.domain-transfer {
+.domain-transfer,
+.google-domain-transfer {
 	height: 100%;
 	padding: 60px 0 0;
 	margin: 0 auto;
@@ -98,6 +99,7 @@ $heading-font-family: "SF Pro Display", $sans;
 					padding-right: 0;
 
 					.select-items__item {
+						margin: 0 auto;
 						padding: 24px;
 
 						@media (max-width: $break-medium ) {

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -7,6 +7,7 @@ import {
 	TRANSFERRING_HOSTED_SITE_FLOW,
 	IMPORT_HOSTED_SITE_FLOW,
 	DOMAIN_TRANSFER,
+	GOOGLE_DOMAIN_TRANSFER,
 	ONBOARDING_PM_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
@@ -105,6 +106,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	[ DOMAIN_TRANSFER ]: () =>
 		import( /* webpackChunkName: "domain-transfer" */ './domain-transfer' ),
+
+	[ GOOGLE_DOMAIN_TRANSFER ]: () =>
+		import( /* webpackChunkName: "domain-transfer" */ './google-domain-transfer' ),
 
 	[ 'plugin-bundle' ]: () =>
 		import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' ),

--- a/client/landing/stepper/utils/domain-transfer-flow.ts
+++ b/client/landing/stepper/utils/domain-transfer-flow.ts
@@ -1,0 +1,5 @@
+import { GOOGLE_DOMAIN_TRANSFER } from '@automattic/onboarding';
+
+export const isGoogleDomainsTransferFlow = () => {
+	return GOOGLE_DOMAIN_TRANSFER === window.location.pathname.split( '/' )[ 2 ];
+};

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -28,6 +28,7 @@ export const WITH_THEME_ASSEMBLER_FLOW = 'with-theme-assembler';
 export const UPDATE_DESIGN_FLOW = 'update-design';
 export const DOMAIN_UPSELL_FLOW = 'domain-upsell';
 export const DOMAIN_TRANSFER = 'domain-transfer';
+export const GOOGLE_DOMAIN_TRANSFER = 'google-domain-transfer';
 export const ONBOARDING_PM_FLOW = 'onboarding-media';
 
 export const isOnboardingPMFlow = ( flowName: string | null | undefined ) => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3279

## Proposed Changes

* Forks the domain transfer flow to allow Google Domains specific customizations.

I explored this option as well as adding a `google` step to the original `domain-transfer` flow. I like this approach more because it allows us to extend later steps. Such as modifying the information icon on the `domains` step to be specific to Google Domains with transfer steps modal.

## Testing Instructions

<img width="1284" alt="Screenshot 2023-07-29 at 12 08 28 AM" src="https://github.com/Automattic/wp-calypso/assets/1126811/5b27f69c-a8c1-4de4-a9d4-a8c43a738837">
<img width="1284" alt="Screenshot 2023-07-29 at 12 08 25 AM" src="https://github.com/Automattic/wp-calypso/assets/1126811/88d8e066-8422-4f7f-a990-0b22e03a171b">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
