### PR TITLE
Checkout: Domain Transfer: Copy updates for thank you page

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -12,8 +12,6 @@ import { getQueryArg } from '@wordpress/url';
 import { useCallback, useEffect, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 import QueryPlans from 'calypso/components/data/query-plans';
-import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
-import FormLabel from 'calypso/components/forms/form-label';
 import { domainTransfer } from 'calypso/lib/cart-values/cart-items';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
 import { ONBOARD_STORE } from '../../../../stores';
@@ -27,7 +25,6 @@ export interface Props {
 }
 
 const defaultState: DomainTransferForm = {
-	shouldImportDnsRecords: true,
 	domains: {
 		[ uuid() ]: {
 			domain: '',
@@ -72,7 +69,6 @@ const Domains: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 	const storedDomainsState = useSelect( ( select ) => {
 		const onboardSelect = select( ONBOARD_STORE ) as OnboardSelect;
 		return {
-			shouldImportDnsRecords: onboardSelect.getBulkDomainsImportDnsRecords(),
 			domains: onboardSelect.getBulkDomainsData(),
 		};
 	}, [] );
@@ -84,10 +80,9 @@ const Domains: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 		( { valid } ) => valid
 	).length;
 
-	const { setPendingAction, setDomainsTransferData, setShouldImportDomainTransferDnsRecords } =
-		useDispatch( ONBOARD_STORE );
+	const { setPendingAction, setDomainsTransferData } = useDispatch( ONBOARD_STORE );
 
-	const { __, _n } = useI18n();
+	const { __ } = useI18n();
 
 	const filledDomainValues = Object.values( domainsState ).filter( ( x ) => x.domain && x.auth );
 	const allGood = filledDomainValues.every( ( { valid } ) => valid );
@@ -114,7 +109,7 @@ const Domains: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 					extra: {
 						auth_code: auth,
 						signup: false,
-						import_dns_records: storedDomainsState.shouldImportDnsRecords,
+						import_dns_records: true,
 					},
 				} )
 			);
@@ -269,29 +264,6 @@ const Domains: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 					{ getTransferButtonText() }
 				</Button>
 			</div>
-			{ numberOfValidDomains > 0 && (
-				<div className="bulk-domain-transfer__import-dns-records">
-					<FormLabel
-						htmlFor="import-dns-records"
-						className="bulk-domain-transfer__import-dns-records-label"
-					>
-						<FormInputCheckbox
-							id="import-dns-records"
-							onChange={ ( event ) => {
-								setShouldImportDomainTransferDnsRecords( event.target.checked );
-							} }
-							checked={ storedDomainsState.shouldImportDnsRecords }
-						/>
-						<span>
-							{ _n(
-								'Import DNS records from this domain',
-								'Import DNS records from these domains',
-								domainCount
-							) }
-						</span>
-					</FormLabel>
-				</div>
-			) }
 			{ isEnabled( 'domain-transfer/faq' ) && (
 				<div className="bulk-domain-transfer__faqs">
 					<DomainTransferFAQ />

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -104,8 +104,15 @@ export class CheckoutThankYouHeader extends PureComponent {
 				<>
 					<div>
 						{ _n(
-							"We got it from here! We'll send an email when your domain is ready to use.",
-							"We got it from here! We'll send an email when your domains are ready to use.",
+							'We got it from here. Your domain is being transferred with no downtime.',
+							'We got it from here! Your domain is being transferred with no downtime.',
+							purchases?.length
+						) }
+					</div>
+					<div>
+						{ _n(
+							"We'll send an email when your domain is ready to use.",
+							"We'll send an email when your domains are ready to use.",
 							purchases?.length
 						) }
 					</div>

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -105,8 +105,8 @@ export class CheckoutThankYouHeader extends PureComponent {
 					<div>
 						{ preventWidows(
 							_n(
-								'We got it from here. Your domain is being transferred with no downtime.',
-								'We got it from here! Your domain is being transferred with no downtime.',
+								"We've got it from here. Your domain is being transferred with no downtime.",
+								"We've got it from here! Your domain is being transferred with no downtime.",
 								purchases?.length
 							)
 						) }

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -103,17 +103,21 @@ export class CheckoutThankYouHeader extends PureComponent {
 			return (
 				<>
 					<div>
-						{ _n(
-							'We got it from here. Your domain is being transferred with no downtime.',
-							'We got it from here! Your domain is being transferred with no downtime.',
-							purchases?.length
+						{ preventWidows(
+							_n(
+								'We got it from here. Your domain is being transferred with no downtime.',
+								'We got it from here! Your domain is being transferred with no downtime.',
+								purchases?.length
+							)
 						) }
 					</div>
 					<div>
-						{ _n(
-							"We'll send an email when your domain is ready to use.",
-							"We'll send an email when your domains are ready to use.",
-							purchases?.length
+						{ preventWidows(
+							_n(
+								"We'll send an email when your domain is ready to use.",
+								"We'll send an email when your domains are ready to use.",
+								purchases?.length
+							)
 						) }
 					</div>
 				</>

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/BulkDomainTransferFooter.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/BulkDomainTransferFooter.tsx
@@ -22,17 +22,13 @@ const BulkDomainTransferFooter = () => {
 				}
 			/>
 			<PurchaseDetail
-				title={ __( 'Dive into domain essentials' ) }
+				title={ __( 'Will my email continue to work?' ) }
 				description={ __(
-					"Unlock the domain world's secrets. Dive into our comprehensive resource to learn the basics of domains, from registration to management."
+					"We'll automatically import any MX, TXT, and A records for your domain, so your email will transfer seamlessly."
 				) }
-				buttonText={ __( 'Master the domain basics' ) }
-				href={ localizeUrl( 'https://wordpress.com/support/domains/' ) }
-				onClick={ () =>
-					recordTracksEvent( 'calypso_domain_transfer_complete_click', {
-						destination: '/support/domains',
-					} )
-				}
+				buttonText={ null }
+				href={ null }
+				onClick={ null }
 			/>
 		</div>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/BulkDomainTransferFooter.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/BulkDomainTransferFooter.tsx
@@ -1,5 +1,3 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useI18n } from '@wordpress/react-i18n';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 
@@ -13,13 +11,9 @@ const BulkDomainTransferFooter = () => {
 				description={ __(
 					'Check your inbox for an email from your current domain provider for instructions on how to speed up the transfer process.'
 				) }
-				buttonText={ __( 'Learn about expediting domain transfers' ) }
-				href={ localizeUrl( 'https://wordpress.com/support/domains/incoming-domain-transfer/' ) }
-				onClick={ () =>
-					recordTracksEvent( 'calypso_domain_transfer_complete_click', {
-						destination: '/support/domains/incoming-domain-transfer/',
-					} )
-				}
+				buttonText={ null }
+				href={ null }
+				onClick={ null }
 			/>
 			<PurchaseDetail
 				title={ __( 'Will my email continue to work?' ) }

--- a/packages/data-stores/src/onboard/types.ts
+++ b/packages/data-stores/src/onboard/types.ts
@@ -38,6 +38,5 @@ export type DomainTransferData = Record<
 >;
 
 export type DomainTransferForm = {
-	shouldImportDnsRecords: boolean;
 	domains: DomainTransferData;
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3296

## Proposed Changes

* Updates copy for domain transfer checkout thank you page to attempt to ease potential concerns around the transfer. 
* Import DNS records by default to simplify experience.

<img width="1019" alt="Screenshot 2023-07-31 at 10 33 29 AM" src="https://github.com/Automattic/wp-calypso/assets/1126811/78797e0b-b2ef-45f2-ba34-9d4abfb56217">


Known issues that should be addressed:

There are no support doc or other links on the thank you page. We could consider implementing a modal for speeding up transfer. I'm not sure it's necessary as we're just prompting users to check their email.

## Testing Instructions


* Complete a successful transfer
* Make note of the receipt ID
* Go to `/checkout/thank-you/no-site/RECEIPT_ID`
*  Verify changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
