### PR TITLE
Stats: Release Paid Stats for All Env

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -120,7 +120,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
-		"stats/paid-stats": false,
+		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/production.json
+++ b/config/production.json
@@ -147,7 +147,7 @@
 		"ssr/sample-log-cache-misses": true,
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
-		"stats/paid-stats": false,
+		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -140,7 +140,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
-		"stats/paid-stats": false,
+		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/test.json
+++ b/config/test.json
@@ -97,7 +97,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
-		"stats/paid-stats": false,
+		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -152,7 +152,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
-		"stats/paid-stats": false,
+		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,


### PR DESCRIPTION
CfT: pejTkB-Ih-p2

## Proposed Changes

* Set feature flag `stats/paid-stats` to `true` for all env

## Testing Instructions

* Open Calypso Live Branch
* Open a self hosted Jetpack site without any paid stats products and upgrade notice never dismissed
* Ensure you can see the Upgrade notice
* Ensure you can purchase Stats products
* Ensure you are redirected back with a purchase success notice
* Ensure the notice doesn't show for WPCOM sites
* Ensure entry points <strike>4 &</strike> 5 are still behind feature flag

**Repeat for Odyssey Stats locally**

![image](https://github.com/Automattic/wp-calypso/assets/1425433/413944cf-6767-4837-bcf8-778e0bf8a8fe)

![image](https://github.com/Automattic/wp-calypso/assets/1425433/d3f936ed-3ae2-4f8e-8895-6d54ce509d3c)





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?