### PR TITLE
Stats: Adding upgrade link tracking

### DIFF
--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
@@ -11,6 +12,20 @@ const getStatsPurchaseURL = ( siteId: number | null ) => {
 		return purchasePath;
 	}
 	return `https://wordpress.com${ purchasePath }`;
+};
+
+const handleUpgradeClick = (
+	event: React.MouseEvent< HTMLAnchorElement, MouseEvent >,
+	siteUrl: string,
+	isOdysseyStats: boolean
+) => {
+	event.preventDefault();
+
+	isOdysseyStats
+		? recordTracksEvent( 'jetpack_odyssey_stats_purchase_success_banner_upgrade_clicked' )
+		: recordTracksEvent( 'calypso_stats_purchase_success_banner_upgrade_clicked' );
+
+	setTimeout( () => ( window.location.href = siteUrl ), 250 );
 };
 
 const FreePlanPurchaseSuccessJetpackStatsNotice = ( {
@@ -49,6 +64,9 @@ const FreePlanPurchaseSuccessJetpackStatsNotice = ( {
 							p: <p />,
 							jetpackStatsProductLink: (
 								<a
+									onClick={ ( e ) =>
+										handleUpgradeClick( e, getStatsPurchaseURL( siteId ), isOdysseyStats )
+									}
 									className="notice-banner__action-link"
 									href={ getStatsPurchaseURL( siteId ) }
 									target="_blank"

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -8,7 +8,7 @@ import { StatsNoticeProps } from './types';
 const getStatsPurchaseURL = ( siteId: number | null ) => {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const from = isOdysseyStats ? 'jetpack' : 'calypso';
-	const purchasePath = `/stats/purchase/${ siteId }?from=${ from }-free-stats-purchase-success-upgrade-notice`;
+	const purchasePath = `/stats/purchase/${ siteId }?from=${ from }-free-stats-purchase-success-notice`;
 
 	if ( ! isOdysseyStats ) {
 		return purchasePath;

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -6,8 +6,10 @@ import { useEffect, useState } from 'react';
 import { StatsNoticeProps } from './types';
 
 const getStatsPurchaseURL = ( siteId: number | null ) => {
-	const purchasePath = `/stats/purchase/${ siteId }`;
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const from = isOdysseyStats ? 'jetpack' : 'calypso';
+	const purchasePath = `/stats/purchase/${ siteId }?from=${ from }-free-stats-purchase-success-upgrade-notice`;
+
 	if ( ! isOdysseyStats ) {
 		return purchasePath;
 	}

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -18,7 +18,7 @@ const getStatsPurchaseURL = ( siteId: number | null ) => {
 
 const handleUpgradeClick = (
 	event: React.MouseEvent< HTMLAnchorElement, MouseEvent >,
-	siteUrl: string,
+	upgradeUrl: string,
 	isOdysseyStats: boolean
 ) => {
 	event.preventDefault();
@@ -27,7 +27,7 @@ const handleUpgradeClick = (
 		? recordTracksEvent( 'jetpack_odyssey_stats_purchase_success_banner_upgrade_clicked' )
 		: recordTracksEvent( 'calypso_stats_purchase_success_banner_upgrade_clicked' );
 
-	setTimeout( () => ( window.location.href = siteUrl ), 250 );
+	setTimeout( () => ( window.location.href = upgradeUrl ), 250 );
 };
 
 const FreePlanPurchaseSuccessJetpackStatsNotice = ( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79339

## Proposed Changes

* adding a tracking event to an upgrade link in purchase free plan success banner

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch
* purchase a free plan and click on a link in the success banner (or show it manually on a local branch)
* verify that the new event is visible in the internal tools

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
