### PR TITLE
Update domain price text to 'We pay the first year'

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FormInputValidation } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, englishLocales, useLocale } from '@automattic/i18n-utils';
 import { Button, Icon } from '@wordpress/components';
 import { check, closeSmall } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -61,7 +61,8 @@ const domainInputFieldIcon = ( isValidDomain: boolean, shouldReportError: boolea
 };
 
 const DomainPrice = ( { rawPrice, saleCost, currencyCode = 'USD' }: DomainPriceProps ) => {
-	const { __ } = useI18n();
+	const { __, hasTranslation } = useI18n();
+	const locale = useLocale();
 
 	if ( ! rawPrice ) {
 		return <div className="domains__domain-price-number disabled"></div>;
@@ -75,6 +76,11 @@ const DomainPrice = ( { rawPrice, saleCost, currencyCode = 'USD' }: DomainPriceP
 		);
 	}
 
+	let pricetext = __( 'First year free' );
+	if ( englishLocales.includes( locale ) || hasTranslation( 'We pay the first year' ) ) {
+		pricetext = __( 'We pay the first year' );
+	}
+
 	return (
 		<div className="domains__domain-price-value">
 			<div>
@@ -85,7 +91,7 @@ const DomainPrice = ( { rawPrice, saleCost, currencyCode = 'USD' }: DomainPriceP
 					{ formatCurrency( rawPrice, currencyCode, { stripZeros: true } ) }
 				</span>
 			</div>
-			<div className="domains__domain-price-text">{ __( 'First year free' ) }</div>
+			<div className="domains__domain-price-text">{ pricetext }</div>
 		</div>
 	);
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3268

## Proposed Changes

* Replace "First year free" with "We pay the first year"

## Testing Instructions

* http://calypso.localhost:3000/setup/google-transfer/domains
* Check the first year free text has been replaced when entering in a google hosted domain
* If you don't have a google domain, sandbox pub-api and make `init_registered_with_google_domains` return true.
* Check non english locales still load old translation e.g:

![Screenshot 2023-07-31 at 10-40-17 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/e5b6e671-5f2c-4014-ba2d-e96497d5e529)

Before

![Screenshot 2023-07-31 at 10-37-17 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/a444da21-1caf-432f-8c36-859804fd4fb5)

After

![Screenshot 2023-07-31 at 10-36-56 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/4e26a2da-7ac8-4a27-ae03-1d28ba46a162)
