### PR TITLE
Launchpad: Fix launchpad WSOD when the site has an unrecognised plan

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -60,7 +60,7 @@ export function getEnhancedTasks(
 		( isBlogOnboardingFlow( flow ) ? planCartItem?.product_slug : null ) ??
 		site?.plan?.product_slug;
 
-	const translatedPlanName = productSlug ? PLANS_LIST[ productSlug ].getTitle() : '';
+	const translatedPlanName = ( productSlug && PLANS_LIST[ productSlug ]?.getTitle() ) || '';
 
 	const firstPostPublished = Boolean(
 		tasks?.find( ( task ) => task.id === 'first_post_published' )?.completed


### PR DESCRIPTION
This situation would occur when the site has a plan that's not in the `@automattic/calypso-products` package for whatever reason.

The situation happened to me when I had a site with the `wp_bundle_migration_trial_monthly` plan (currently a WIP) open in the launchpad. The launchpad tries to get the site's plan title from `@automattic/calypso-products` but wasn't handling the case where a plan which is known about on the backend is not yet available on the front end.

So not something that would happen to users, but making the change in the name of resiliency.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* The plan badge—which appears in the `design-first` and `start-writing` flows—falls back to being hidden when the site has an unrecognised plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test launchpad with a migration trial
   * Create a new free site using `/start`
   * Go through the flow until you land on the launchpad
   * Visit your users Store Admin and manually add the Migration Trial plan to your new site
   * Refresh the launchpad
   * It should not crash
* Test the badge still works correctly with the `start-writing` flow
   * Log out
   * Start at `/setup/start-writing`
   * Signup and go through flow
   * Once in the editor publish your post
   * You will land in the launchpad
   * Choose a plan
   * Once back on the launchpad, confirm the selected plan name appears in the badge

The `start-writing` flow looks like this:

https://github.com/Automattic/wp-calypso/assets/1500769/d09abf23-6619-4b33-b8e4-9b4a9ac88333



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), ~Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
