### PR TITLE
Stats Revert: revert auto remove statsPurchaseSucess

### DIFF
--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -13,7 +13,6 @@ import DoYouLoveJetpackStatsNotice from './do-you-love-jetpack-stats-notice';
 import FeedbackNotice from './feedback-notice';
 import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-success-notice';
 import LegacyStatsNotices from './legacy-notices';
-import removeStatsPurchaseSuccessParam from './lib/remove-stats-purchase-success-param';
 import OptOutNotice from './opt-out-notice';
 import PaidPlanPurchaseSuccessJetpackStatsNotice from './paid-plan-purchase-success-notice';
 import { StatsNoticesProps } from './types';
@@ -72,26 +71,12 @@ const PostPurchaseNotices = ( { siteId, statsPurchaseSuccess }: StatsNoticesProp
 	const showFreePlanPurchaseSuccessNotice = statsPurchaseSuccess === 'free';
 	const showPaidPlanPurchaseSuccessNotice = statsPurchaseSuccess === 'paid';
 
-	const removeParam = () => {
-		if ( ! statsPurchaseSuccess ) {
-			return;
-		}
-		const newUrl = removeStatsPurchaseSuccessParam( window.location.href );
-		// Odyssey would try to hack the URL on load to remove duplicate params. We need to wait for that to finish.
-		setTimeout( () => window.history.replaceState( null, '', newUrl ), 300 );
-	};
-
 	return (
 		<>
 			{ /* TODO: Consider combining/refactoring these components into a single component */ }
-			{ showPaidPlanPurchaseSuccessNotice && (
-				<PaidPlanPurchaseSuccessJetpackStatsNotice onNoticeViewed={ removeParam } />
-			) }
+			{ showPaidPlanPurchaseSuccessNotice && <PaidPlanPurchaseSuccessJetpackStatsNotice /> }
 			{ showFreePlanPurchaseSuccessNotice && (
-				<FreePlanPurchaseSuccessJetpackStatsNotice
-					siteId={ siteId }
-					onNoticeViewed={ removeParam }
-				/>
+				<FreePlanPurchaseSuccessJetpackStatsNotice siteId={ siteId } />
 			) }
 		</>
 	);


### PR DESCRIPTION
## Proposed Changes

There's a bug stopping Odyssey from selecting other tabs, so we are reverting the behaviour first.

## Testing Instructions


* Open Odyssey Stats
* Purchase a Stats product
* When it returns to Odyssey Stats
* Ensure you could select Insights tab and other tabs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
