### PR TITLE
Create selectors for the Live Preview feature

### DIFF
--- a/client/my-sites/theme/live-preview-button/index.jsx
+++ b/client/my-sites/theme/live-preview-button/index.jsx
@@ -1,131 +1,20 @@
 import { Button } from '@automattic/components';
 
 /**
- * Hardcoded list of themes that are not compatible with Block Theme Previews.
- * This list should be removed once they are retired.
- *
- * @see pekYwv-284-p2
- */
-const NOT_COMPATIBLE_THEMES = [
-	'premium/alonso',
-	'premium/baxter',
-	'premium/byrne',
-	'premium/kerr',
-	'premium/munchies',
-	'premium/payton',
-	'premium/skivers',
-	'premium/thriving-artist',
-	'pub/ames',
-	'pub/antonia',
-	'pub/appleton',
-	'pub/arbutus',
-	'pub/attar',
-	'pub/barnett',
-	'pub/bennett',
-	'pub/calvin',
-	'pub/calyx',
-	'pub/course',
-	'pub/dorna',
-	'pub/farrow',
-	'pub/geologist-blue',
-	'pub/geologist-cream',
-	'pub/geologist-slate',
-	'pub/geologist-yellow',
-	'pub/hari',
-	'pub/heiwa',
-	'pub/jackson',
-	'pub/kingsley',
-	'pub/marl',
-	'pub/meraki',
-	'pub/quadrat-black',
-	'pub/quadrat-green',
-	'pub/quadrat-red',
-	'pub/quadrat-white',
-	'pub/quadrat-yellow',
-	'pub/quadrat',
-	'pub/russell',
-	'pub/seedlet-blocks',
-	'pub/winkel',
-];
-
-const isNotCompatibleThemes = ( stylesheet ) => {
-	return NOT_COMPATIBLE_THEMES.includes( stylesheet );
-};
-
-/**
  * Live Preview leveraging Gutenberg's Block Theme Previews
- *
- * The scenarios where the Live Preview does NOT support;
- * - On both Simple and Atomic sites;
- *   - If the theme is users' active theme.
- *   - If the theme is not FullSiteEditing compatible.
- *   - If the theme has a static page as a homepage.
- * - On Atomic sites;
- *   - If the theme is not installed on Atomic sites.
- * - On Simple sites;
- *   - If the theme is a 3rd party theme.
- *   - If the theme is not included in a plan.
  *
  * @see pbxlJb-3Uv-p2
  */
 export const LivePreviewButton = ( {
-	canUseTheme,
-	isActive,
 	isAtomic,
-	isExternallyManagedTheme,
-	isFullSiteEditingTheme,
-	isSimple,
-	isThemeInstalledOnAtomicSite,
-	isWporg,
+	isLivePreviewSupported,
 	siteSlug,
 	stylesheet,
 	themeId,
 	translate,
 } ) => {
-	// A user doesn't want to preview the active theme.
-	if ( isActive ) {
+	if ( ! isLivePreviewSupported ) {
 		return null;
-	}
-
-	// A theme should be FullSiteEditing compatible to use Block Theme Previews.
-	if ( ! isFullSiteEditingTheme ) {
-		return null;
-	}
-
-	/**
-	 * Block Theme Previews do not support themes with a static page as a homepage
-	 * as the Site Editor cannot control Reading Settings.
-	 *
-	 * @see pekYwv-284-p2#background
-	 */
-	if ( isNotCompatibleThemes( stylesheet ) ) {
-		return null;
-	}
-
-	// Block Theme Previews need the theme installed on Atomic sites.
-	if ( isAtomic && ! isThemeInstalledOnAtomicSite ) {
-		return null;
-	}
-
-	if ( isSimple ) {
-		/**
-		 * Disable Live Preview for 3rd party themes, as Block Theme Previews need a theme installed.
-		 * Note that BTP works on Atomic sites if a theme is installed.
-		 */
-		if ( isExternallyManagedTheme || isWporg ) {
-			return null;
-		}
-
-		/**
-		 * Disable Live Preview for themes that are not included in a plan.
-		 * This should be updated as we implement the flow for them.
-		 * Note that BTP works on Atomic sites if a theme is installed.
-		 *
-		 * @see https://github.com/Automattic/wp-calypso/issues/79223
-		 */
-		if ( ! canUseTheme ) {
-			return null;
-		}
 	}
 
 	const themePath = isAtomic ? themeId : stylesheet;

--- a/client/my-sites/theme/live-preview-button/index.jsx
+++ b/client/my-sites/theme/live-preview-button/index.jsx
@@ -1,13 +1,25 @@
 import { Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { getIsLivePreviewSupported, getLivePreviewUrl } from 'calypso/state/themes/selectors';
 
 /**
  * Live Preview leveraging Gutenberg's Block Theme Previews
  *
  * @see pbxlJb-3Uv-p2
  */
-export const LivePreviewButton = ( { isLivePreviewSupported, translate, livePreviewUrl } ) => {
+const _LivePreviewButton = ( { isLivePreviewSupported, translate, livePreviewUrl } ) => {
 	if ( ! isLivePreviewSupported ) {
 		return null;
 	}
 	return <Button href={ livePreviewUrl }>{ translate( 'Live Preview' ) }</Button>;
 };
+
+export const LivePreviewButton = connect( ( state, { themeId, siteId } ) => {
+	const isLivePreviewSupported = getIsLivePreviewSupported( state, themeId, siteId );
+	const livePreviewUrl = getLivePreviewUrl( state, themeId, siteId );
+	return {
+		isLivePreviewSupported,
+		livePreviewUrl,
+	};
+} )( localize( _LivePreviewButton ) );

--- a/client/my-sites/theme/live-preview-button/index.jsx
+++ b/client/my-sites/theme/live-preview-button/index.jsx
@@ -5,25 +5,9 @@ import { Button } from '@automattic/components';
  *
  * @see pbxlJb-3Uv-p2
  */
-export const LivePreviewButton = ( {
-	isAtomic,
-	isLivePreviewSupported,
-	siteSlug,
-	stylesheet,
-	themeId,
-	translate,
-} ) => {
+export const LivePreviewButton = ( { isLivePreviewSupported, translate, livePreviewUrl } ) => {
 	if ( ! isLivePreviewSupported ) {
 		return null;
 	}
-
-	const themePath = isAtomic ? themeId : stylesheet;
-
-	return (
-		<Button
-			href={ `https://${ siteSlug }/wp-admin/site-editor.php?wp_theme_preview=${ themePath }` }
-		>
-			{ translate( 'Live Preview' ) }
-		</Button>
-	);
+	return <Button href={ livePreviewUrl }>{ translate( 'Live Preview' ) }</Button>;
 };

--- a/client/my-sites/theme/live-preview-button/index.jsx
+++ b/client/my-sites/theme/live-preview-button/index.jsx
@@ -8,10 +8,10 @@ import { getIsLivePreviewSupported, getLivePreviewUrl } from 'calypso/state/them
  *
  * @see pbxlJb-3Uv-p2
  */
-export const LivePreviewButton = ( { themeId, siteId } ) => {
+export const LivePreviewButton = ( { themeId, siteId, sourceSiteId } ) => {
 	const translate = useTranslate();
 	const isLivePreviewSupported = useSelector( ( state ) =>
-		getIsLivePreviewSupported( state, themeId, siteId )
+		getIsLivePreviewSupported( state, themeId, siteId, sourceSiteId )
 	);
 	const livePreviewUrl = useSelector( ( state ) => getLivePreviewUrl( state, themeId, siteId ) );
 	if ( ! isLivePreviewSupported ) {

--- a/client/my-sites/theme/live-preview-button/index.jsx
+++ b/client/my-sites/theme/live-preview-button/index.jsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
 import { getIsLivePreviewSupported, getLivePreviewUrl } from 'calypso/state/themes/selectors';
 
 /**
@@ -8,18 +8,14 @@ import { getIsLivePreviewSupported, getLivePreviewUrl } from 'calypso/state/them
  *
  * @see pbxlJb-3Uv-p2
  */
-const _LivePreviewButton = ( { isLivePreviewSupported, translate, livePreviewUrl } ) => {
+export const LivePreviewButton = ( { themeId, siteId } ) => {
+	const translate = useTranslate();
+	const isLivePreviewSupported = useSelector( ( state ) =>
+		getIsLivePreviewSupported( state, themeId, siteId )
+	);
+	const livePreviewUrl = useSelector( ( state ) => getLivePreviewUrl( state, themeId, siteId ) );
 	if ( ! isLivePreviewSupported ) {
 		return null;
 	}
 	return <Button href={ livePreviewUrl }>{ translate( 'Live Preview' ) }</Button>;
 };
-
-export const LivePreviewButton = connect( ( state, { themeId, siteId } ) => {
-	const isLivePreviewSupported = getIsLivePreviewSupported( state, themeId, siteId );
-	const livePreviewUrl = getLivePreviewUrl( state, themeId, siteId );
-	return {
-		isLivePreviewSupported,
-		livePreviewUrl,
-	};
-} )( localize( _LivePreviewButton ) );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -81,7 +81,6 @@ import {
 	isWpcomTheme as isThemeWpcom,
 	isWporgTheme,
 	getCanonicalTheme,
-	getLivePreviewUrl,
 	getPremiumThemePrice,
 	getThemeDemoUrl,
 	getThemeDetailsUrl,
@@ -92,7 +91,6 @@ import {
 	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
 	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
 	isThemeActivationSyncStarted as getIsThemeActivationSyncStarted,
-	isLivePreviewSupported as getIsLivePreviewSupported,
 } from 'calypso/state/themes/selectors';
 import { getIsLoadingCart } from 'calypso/state/themes/selectors/get-is-loading-cart';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
@@ -617,8 +615,8 @@ class ThemeSheet extends Component {
 			softLaunched,
 			translate,
 			isLoggedIn,
-			isLivePreviewSupported,
-			livePreviewUrl,
+			themeId,
+			siteId,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
@@ -646,11 +644,8 @@ class ThemeSheet extends Component {
 							( this.shouldRenderUnlockStyleButton()
 								? this.renderUnlockStyleButton()
 								: this.renderButton() ) }
-						<LivePreviewButton
-							isLivePreviewSupported={ isLivePreviewSupported }
-							livePreviewUrl={ livePreviewUrl }
-							translate={ translate }
-						></LivePreviewButton>
+						{ /* WIP */ }
+						<LivePreviewButton themeId={ themeId } siteId={ siteId } />
 						{ this.shouldRenderPreviewButton() && (
 							<Button
 								onClick={ ( e ) => {
@@ -1541,9 +1536,6 @@ export default connect(
 		const isMarketplaceThemeSubscribed =
 			isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, theme?.id, siteId );
 
-		const isLivePreviewSupported = getIsLivePreviewSupported( state, themeId, siteId );
-		const livePreviewUrl = getLivePreviewUrl( state, themeId, siteId );
-
 		return {
 			...theme,
 			themeId,
@@ -1552,7 +1544,6 @@ export default connect(
 			siteId,
 			siteSlug,
 			backPath,
-			livePreviewUrl,
 			isCurrentUserPaid,
 			isWpcomTheme,
 			isWporg: isWporgTheme( state, themeId ),
@@ -1562,7 +1553,6 @@ export default connect(
 			isActive: isThemeActive( state, themeId, siteId ),
 			isJetpack,
 			isAtomic,
-			isLivePreviewSupported,
 			isStandaloneJetpack,
 			isVip: isVipSite( state, siteId ),
 			isPremium: isThemePremium( state, themeId ),

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -67,13 +67,12 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
-import { getSiteSlug, isJetpackSite, isSimpleSite } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	setThemePreviewOptions,
 	themeStartActivationSync as themeStartActivationSyncAction,
 } from 'calypso/state/themes/actions';
 import {
-	canUseTheme as getCanUseTheme,
 	doesThemeBundleSoftwareSet,
 	isThemeActive,
 	isThemePremium,
@@ -92,12 +91,11 @@ import {
 	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
 	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
 	isThemeActivationSyncStarted as getIsThemeActivationSyncStarted,
-	isFullSiteEditingTheme as getIsFullSiteEditingTheme,
+	isLivePreviewSupported as getIsLivePreviewSupported,
 } from 'calypso/state/themes/selectors';
 import { getIsLoadingCart } from 'calypso/state/themes/selectors/get-is-loading-cart';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { getTheme } from '../../state/themes/selectors';
 import EligibilityWarningModal from '../themes/atomic-transfer-dialog';
 import { LivePreviewButton } from './live-preview-button';
 import ThemeDownloadCard from './theme-download-card';
@@ -620,15 +618,8 @@ class ThemeSheet extends Component {
 			siteSlug,
 			stylesheet,
 			isAtomic,
-			isActive,
-			showTryAndCustomize,
-			isExternallyManagedTheme,
-			isWporg,
 			isLoggedIn,
-			canUseTheme,
-			isFullSiteEditingTheme,
-			isSimple,
-			isThemeInstalledOnAtomicSite,
+			isLivePreviewSupported,
 			themeId,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
@@ -657,23 +648,14 @@ class ThemeSheet extends Component {
 							( this.shouldRenderUnlockStyleButton()
 								? this.renderUnlockStyleButton()
 								: this.renderButton() ) }
-						{ config.isEnabled( 'themes/block-theme-previews' ) && (
-							<LivePreviewButton
-								canUseTheme={ canUseTheme }
-								isActive={ isActive }
-								isAtomic={ isAtomic }
-								isExternallyManagedTheme={ isExternallyManagedTheme }
-								isFullSiteEditingTheme={ isFullSiteEditingTheme }
-								isSimple={ isSimple }
-								isThemeInstalledOnAtomicSite={ isThemeInstalledOnAtomicSite }
-								isWporg={ isWporg }
-								showTryAndCustomize={ showTryAndCustomize }
-								siteSlug={ siteSlug }
-								stylesheet={ stylesheet }
-								themeId={ themeId }
-								translate={ translate }
-							></LivePreviewButton>
-						) }
+						<LivePreviewButton
+							isAtomic={ isAtomic }
+							isLivePreviewSupported={ isLivePreviewSupported }
+							siteSlug={ siteSlug }
+							stylesheet={ stylesheet }
+							themeId={ themeId }
+							translate={ translate }
+						></LivePreviewButton>
 						{ this.shouldRenderPreviewButton() && (
 							<Button
 								onClick={ ( e ) => {
@@ -1564,11 +1546,9 @@ export default connect(
 		const isMarketplaceThemeSubscribed =
 			isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, theme?.id, siteId );
 
-		const isThemeInstalledOnAtomicSite = isAtomic && !! getTheme( state, siteId, themeId );
-
-		const isFullSiteEditingTheme = config.isEnabled( 'themes/block-theme-previews' )
-			? getIsFullSiteEditingTheme( state, themeId )
-			: undefined;
+		const isLivePreviewSupported = config.isEnabled( 'themes/block-theme-previews' )
+			? getIsLivePreviewSupported( state, { themeId, siteId } )
+			: false;
 
 		return {
 			...theme,
@@ -1587,19 +1567,16 @@ export default connect(
 			isActive: isThemeActive( state, themeId, siteId ),
 			isJetpack,
 			isAtomic,
-			isFullSiteEditingTheme,
+			isLivePreviewSupported,
 			isStandaloneJetpack,
 			isVip: isVipSite( state, siteId ),
 			isPremium: isThemePremium( state, themeId ),
-			isThemeInstalledOnAtomicSite,
 			isThemePurchased: isPremiumThemeAvailable( state, themeId, siteId ),
 			isBundledSoftwareSet: doesThemeBundleSoftwareSet( state, themeId ),
-			isSimple: isSimpleSite( state, siteId ),
 			isSiteBundleEligible: isSiteEligibleForBundledSoftware( state, siteId ),
 			forumUrl: getThemeForumUrl( state, themeId, siteId ),
 			hasUnlimitedPremiumThemes: siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),
 			showTryAndCustomize: shouldShowTryAndCustomize( state, themeId, siteId ),
-			canUseTheme: getCanUseTheme( state, siteId, themeId ),
 			canUserUploadThemes: siteHasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
 			// Remove the trailing slash because the page URL doesn't have one either.
 			canonicalUrl: localizeUrl( englishUrl, getLocaleSlug(), false ).replace( /\/$/, '' ),

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -81,6 +81,7 @@ import {
 	isWpcomTheme as isThemeWpcom,
 	isWporgTheme,
 	getCanonicalTheme,
+	getLivePreviewUrl,
 	getPremiumThemePrice,
 	getThemeDemoUrl,
 	getThemeDetailsUrl,
@@ -615,12 +616,9 @@ class ThemeSheet extends Component {
 			retired,
 			softLaunched,
 			translate,
-			siteSlug,
-			stylesheet,
-			isAtomic,
 			isLoggedIn,
 			isLivePreviewSupported,
-			themeId,
+			livePreviewUrl,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
@@ -649,11 +647,8 @@ class ThemeSheet extends Component {
 								? this.renderUnlockStyleButton()
 								: this.renderButton() ) }
 						<LivePreviewButton
-							isAtomic={ isAtomic }
 							isLivePreviewSupported={ isLivePreviewSupported }
-							siteSlug={ siteSlug }
-							stylesheet={ stylesheet }
-							themeId={ themeId }
+							livePreviewUrl={ livePreviewUrl }
 							translate={ translate }
 						></LivePreviewButton>
 						{ this.shouldRenderPreviewButton() && (
@@ -1547,8 +1542,12 @@ export default connect(
 			isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, theme?.id, siteId );
 
 		const isLivePreviewSupported = config.isEnabled( 'themes/block-theme-previews' )
-			? getIsLivePreviewSupported( state, { themeId, siteId } )
+			? getIsLivePreviewSupported( state, themeId, siteId )
 			: false;
+
+		const livePreviewUrl = config.isEnabled( 'themes/block-theme-previews' )
+			? getLivePreviewUrl( state, themeId, siteId )
+			: undefined;
 
 		return {
 			...theme,
@@ -1558,6 +1557,7 @@ export default connect(
 			siteId,
 			siteSlug,
 			backPath,
+			livePreviewUrl,
 			isCurrentUserPaid,
 			isWpcomTheme,
 			isWporg: isWporgTheme( state, themeId ),

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -34,7 +34,6 @@ import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import QueryTheme from 'calypso/components/data/query-theme';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import SyncActiveTheme from 'calypso/components/data/sync-active-theme';
 import HeaderCake from 'calypso/components/header-cake';
@@ -644,7 +643,6 @@ class ThemeSheet extends Component {
 							( this.shouldRenderUnlockStyleButton()
 								? this.renderUnlockStyleButton()
 								: this.renderButton() ) }
-						{ /* WIP */ }
 						<LivePreviewButton themeId={ themeId } siteId={ siteId } />
 						{ this.shouldRenderPreviewButton() && (
 							<Button
@@ -1349,7 +1347,6 @@ class ThemeSheet extends Component {
 		return (
 			<Main className={ className }>
 				<QueryCanonicalTheme themeId={ this.props.themeId } siteId={ siteId } />
-				<QueryTheme themeId={ this.props.themeId } siteId={ siteId } />
 				<QueryProductsList />
 				<QueryUserPurchases />
 				{

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -646,11 +646,12 @@ class ThemeSheet extends Component {
 								? this.renderUnlockStyleButton()
 								: this.renderButton() ) }
 						<LivePreviewButton
+							siteId={ siteId }
 							/**
 							 * Pass the siteId that QueryCanonicalTheme component will use to fetch the theme.
 							 * This avoids LivePreviewButton appearing a moment later.
 							 */
-							siteId={ ( isWpcomTheme && 'wpcom' ) || ( isWporg && 'wporg' ) || siteId }
+							sourceSiteId={ ( isWpcomTheme && 'wpcom' ) || ( isWporg && 'wporg' ) || siteId }
 							themeId={ themeId }
 						/>
 						{ this.shouldRenderPreviewButton() && (

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -608,16 +608,16 @@ class ThemeSheet extends Component {
 	renderHeader = () => {
 		const {
 			author,
+			isLoggedIn,
+			isWpcomTheme,
 			isWPForTeamsSite,
+			isWporg,
 			name,
 			retired,
-			softLaunched,
-			translate,
-			isLoggedIn,
-			themeId,
 			siteId,
-			isWpcomTheme,
-			isWporg,
+			softLaunched,
+			themeId,
+			translate,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
@@ -646,12 +646,12 @@ class ThemeSheet extends Component {
 								? this.renderUnlockStyleButton()
 								: this.renderButton() ) }
 						<LivePreviewButton
-							themeId={ themeId }
 							/**
 							 * Pass the siteId that QueryCanonicalTheme component will use to fetch the theme.
 							 * This avoids LivePreviewButton appearing a moment later.
 							 */
 							siteId={ ( isWpcomTheme && 'wpcom' ) || ( isWporg && 'wporg' ) || siteId }
+							themeId={ themeId }
 						/>
 						{ this.shouldRenderPreviewButton() && (
 							<Button

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -616,6 +616,8 @@ class ThemeSheet extends Component {
 			isLoggedIn,
 			themeId,
 			siteId,
+			isWpcomTheme,
+			isWporg,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
@@ -643,7 +645,14 @@ class ThemeSheet extends Component {
 							( this.shouldRenderUnlockStyleButton()
 								? this.renderUnlockStyleButton()
 								: this.renderButton() ) }
-						<LivePreviewButton themeId={ themeId } siteId={ siteId } />
+						<LivePreviewButton
+							themeId={ themeId }
+							/**
+							 * Pass the siteId that QueryCanonicalTheme component will use to fetch the theme.
+							 * This avoids LivePreviewButton appearing a moment later.
+							 */
+							siteId={ ( isWpcomTheme && 'wpcom' ) || ( isWporg && 'wporg' ) || siteId }
+						/>
 						{ this.shouldRenderPreviewButton() && (
 							<Button
 								onClick={ ( e ) => {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1541,13 +1541,8 @@ export default connect(
 		const isMarketplaceThemeSubscribed =
 			isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, theme?.id, siteId );
 
-		const isLivePreviewSupported = config.isEnabled( 'themes/block-theme-previews' )
-			? getIsLivePreviewSupported( state, themeId, siteId )
-			: false;
-
-		const livePreviewUrl = config.isEnabled( 'themes/block-theme-previews' )
-			? getLivePreviewUrl( state, themeId, siteId )
-			: undefined;
+		const isLivePreviewSupported = getIsLivePreviewSupported( state, themeId, siteId );
+		const livePreviewUrl = getLivePreviewUrl( state, themeId, siteId );
 
 		return {
 			...theme,

--- a/client/state/themes/selectors/get-is-live-preview-supported.js
+++ b/client/state/themes/selectors/get-is-live-preview-supported.js
@@ -9,7 +9,7 @@ import {
 	getTheme,
 	isExternallyManagedTheme,
 	canUseTheme,
-} from '../selectors';
+} from '.';
 
 /**
  * Hardcoded list of themes that are not compatible with Block Theme Previews.

--- a/client/state/themes/selectors/get-is-live-preview-supported.js
+++ b/client/state/themes/selectors/get-is-live-preview-supported.js
@@ -82,7 +82,7 @@ const isNotCompatibleThemes = ( themeId ) => {
  *
  * @see pbxlJb-3Uv-p2
  */
-export const getIsLivePreviewSupported = ( state, themeId, siteId ) => {
+export const getIsLivePreviewSupported = ( state, themeId, siteId, sourceSiteId ) => {
 	if ( ! config.isEnabled( 'themes/block-theme-previews' ) ) {
 		return false;
 	}
@@ -98,7 +98,7 @@ export const getIsLivePreviewSupported = ( state, themeId, siteId ) => {
 	}
 
 	// A theme should be FullSiteEditing compatible to use Block Theme Previews.
-	if ( ! isFullSiteEditingTheme( state, themeId, siteId ) ) {
+	if ( ! isFullSiteEditingTheme( state, themeId, sourceSiteId ) ) {
 		return false;
 	}
 
@@ -114,7 +114,7 @@ export const getIsLivePreviewSupported = ( state, themeId, siteId ) => {
 
 	// Block Theme Previews need the theme installed on Atomic sites.
 	const isAtomic = isSiteAutomatedTransfer( state, siteId );
-	const isThemeInstalledOnAtomicSite = isAtomic && !! getTheme( state, siteId, themeId );
+	const isThemeInstalledOnAtomicSite = isAtomic && !! getTheme( state, sourceSiteId, themeId );
 	if ( isAtomic && ! isThemeInstalledOnAtomicSite ) {
 		return false;
 	}

--- a/client/state/themes/selectors/get-live-preview-url.js
+++ b/client/state/themes/selectors/get-live-preview-url.js
@@ -1,0 +1,20 @@
+import { addQueryArgs } from 'calypso/lib/route';
+import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { getTheme } from './';
+
+const QUERY_NAME = 'wp_theme_preview';
+
+export const getLivePreviewUrl = ( state, themeId, siteId ) => {
+	const siteEditorUrl = getSiteEditorUrl( state, siteId );
+
+	if ( isSiteAutomatedTransfer( state, siteId ) ) {
+		return addQueryArgs( { [ QUERY_NAME ]: themeId }, `${ siteEditorUrl }` );
+	}
+
+	const theme = getTheme( state, 'wpcom', themeId );
+	if ( ! theme ) {
+		return siteEditorUrl;
+	}
+	return addQueryArgs( { [ QUERY_NAME ]: theme.stylesheet }, `${ siteEditorUrl }` );
+};

--- a/client/state/themes/selectors/get-live-preview-url.js
+++ b/client/state/themes/selectors/get-live-preview-url.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { addQueryArgs } from 'calypso/lib/route';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -6,6 +7,10 @@ import { getTheme } from './';
 const QUERY_NAME = 'wp_theme_preview';
 
 export const getLivePreviewUrl = ( state, themeId, siteId ) => {
+	if ( ! config.isEnabled( 'themes/block-theme-previews' ) ) {
+		return undefined;
+	}
+
 	const siteEditorUrl = getSiteEditorUrl( state, siteId );
 
 	if ( isSiteAutomatedTransfer( state, siteId ) ) {

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -52,6 +52,7 @@ export { isExternallyManagedTheme } from 'calypso/state/themes/selectors/is-exte
 export { isFulfilledThemesForQuery } from 'calypso/state/themes/selectors/is-fulfilled-request-themes-for-query';
 export { isFullSiteEditingTheme } from 'calypso/state/themes/selectors/is-full-site-editing-theme';
 export { isInstallingTheme } from 'calypso/state/themes/selectors/is-installing-theme';
+export { isLivePreviewSupported } from 'calypso/state/themes/selectors/is-live-preview-supported';
 export { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed';
 export { isPremiumThemeAvailable } from 'calypso/state/themes/selectors/is-premium-theme-available';
 export { isRequestingActiveTheme } from 'calypso/state/themes/selectors/is-requesting-active-theme';

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -53,7 +53,7 @@ export { isExternallyManagedTheme } from 'calypso/state/themes/selectors/is-exte
 export { isFulfilledThemesForQuery } from 'calypso/state/themes/selectors/is-fulfilled-request-themes-for-query';
 export { isFullSiteEditingTheme } from 'calypso/state/themes/selectors/is-full-site-editing-theme';
 export { isInstallingTheme } from 'calypso/state/themes/selectors/is-installing-theme';
-export { getIsLivePreviewSupported } from 'calypso/state/themes/selectors/is-live-preview-supported';
+export { getIsLivePreviewSupported } from 'calypso/state/themes/selectors/get-is-live-preview-supported';
 export { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed';
 export { isPremiumThemeAvailable } from 'calypso/state/themes/selectors/is-premium-theme-available';
 export { isRequestingActiveTheme } from 'calypso/state/themes/selectors/is-requesting-active-theme';

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -53,7 +53,7 @@ export { isExternallyManagedTheme } from 'calypso/state/themes/selectors/is-exte
 export { isFulfilledThemesForQuery } from 'calypso/state/themes/selectors/is-fulfilled-request-themes-for-query';
 export { isFullSiteEditingTheme } from 'calypso/state/themes/selectors/is-full-site-editing-theme';
 export { isInstallingTheme } from 'calypso/state/themes/selectors/is-installing-theme';
-export { isLivePreviewSupported } from 'calypso/state/themes/selectors/is-live-preview-supported';
+export { getIsLivePreviewSupported } from 'calypso/state/themes/selectors/is-live-preview-supported';
 export { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed';
 export { isPremiumThemeAvailable } from 'calypso/state/themes/selectors/is-premium-theme-available';
 export { isRequestingActiveTheme } from 'calypso/state/themes/selectors/is-requesting-active-theme';

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -9,6 +9,7 @@ export { getActiveTheme } from 'calypso/state/themes/selectors/get-active-theme'
 export { getCanonicalTheme } from 'calypso/state/themes/selectors/get-canonical-theme';
 export { getJetpackUpgradeUrlIfPremiumTheme } from 'calypso/state/themes/selectors/get-jetpack-upgrade-url-if-premium-theme';
 export { getLastThemeQuery } from 'calypso/state/themes/selectors/get-last-theme-query';
+export { getLivePreviewUrl } from 'calypso/state/themes/selectors/get-live-preview-url';
 export { getMarketplaceThemeSubscriptionPrices } from 'calypso/state/themes/selectors/get-marketplace-theme-subscription-prices';
 export { getPremiumThemePrice } from 'calypso/state/themes/selectors/get-premium-theme-price';
 export { getPurchasedThemes } from 'calypso/state/themes/selectors/get-purchased-themes';

--- a/client/state/themes/selectors/is-full-site-editing-theme.ts
+++ b/client/state/themes/selectors/is-full-site-editing-theme.ts
@@ -6,12 +6,16 @@ import 'calypso/state/themes/init';
 
 export function isFullSiteEditingTheme(
 	state: AppState,
-	themeId: string | null | undefined
+	themeId: string | null | undefined,
+	siteId: number | null | undefined
 ): boolean {
 	if ( ! themeId ) {
 		return false;
 	}
-	const theme = getTheme( state, 'wpcom', themeId ) || getTheme( state, 'wporg', themeId );
+	const theme =
+		getTheme( state, 'wpcom', themeId ) ||
+		getTheme( state, 'wporg', themeId ) ||
+		( siteId && getTheme( state, siteId, themeId ) );
 	if ( ! theme ) {
 		return false;
 	}

--- a/client/state/themes/selectors/is-live-preview-supported.js
+++ b/client/state/themes/selectors/is-live-preview-supported.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isSimpleSite } from 'calypso/state/sites/selectors';
 import {
@@ -81,6 +82,10 @@ const isNotCompatibleThemes = ( themeId ) => {
  * @see pbxlJb-3Uv-p2
  */
 export const isLivePreviewSupported = ( state, themeId, siteId ) => {
+	if ( ! config.isEnabled( 'themes/block-theme-previews' ) ) {
+		return false;
+	}
+
 	// A user doesn't want to preview the active theme.
 	if ( isThemeActive( state, themeId, siteId ) ) {
 		return false;

--- a/client/state/themes/selectors/is-live-preview-supported.js
+++ b/client/state/themes/selectors/is-live-preview-supported.js
@@ -1,0 +1,134 @@
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isSimpleSite } from 'calypso/state/sites/selectors';
+import {
+	isWporgTheme,
+	isThemeActive,
+	isFullSiteEditingTheme,
+	getTheme,
+	isExternallyManagedTheme,
+	canUseTheme,
+} from '../selectors';
+
+/**
+ * Hardcoded list of themes that are not compatible with Block Theme Previews.
+ * This list should be removed once they are retired.
+ *
+ * @see pekYwv-284-p2
+ */
+const NOT_COMPATIBLE_THEMES = [
+	// premium themes (premium/*)
+	'alonso',
+	'baxter',
+	'byrne',
+	'kerr',
+	'munchies',
+	'payton',
+	'skivers',
+	'thriving-artist',
+
+	// free themes (pub/*)
+	'ames',
+	'antonia',
+	'appleton',
+	'arbutus',
+	'attar',
+	'barnett',
+	'bennett',
+	'calvin',
+	'calyx',
+	'course',
+	'dorna',
+	'farrow',
+	'geologist-blue',
+	'geologist-cream',
+	'geologist-slate',
+	'geologist-yellow',
+	'hari',
+	'heiwa',
+	'jackson',
+	'kingsley',
+	'marl',
+	'meraki',
+	'quadrat-black',
+	'quadrat-green',
+	'quadrat-red',
+	'quadrat-white',
+	'quadrat-yellow',
+	'quadrat',
+	'russell',
+	'seedlet-blocks',
+	'winkel',
+];
+
+const isNotCompatibleThemes = ( themeId ) => {
+	return NOT_COMPATIBLE_THEMES.includes( themeId );
+};
+
+/**
+ * Live Preview leveraging Gutenberg's Block Theme Previews
+ *
+ * The scenarios where the Live Preview does NOT support;
+ * - On both Simple and Atomic sites;
+ *   - If the theme is users' active theme.
+ *   - If the theme is not FullSiteEditing compatible.
+ *   - If the theme has a static page as a homepage.
+ * - On Atomic sites;
+ *   - If the theme is not installed on Atomic sites.
+ * - On Simple sites;
+ *   - If the theme is a 3rd party theme.
+ *   - If the theme is not included in a plan.
+ *
+ * @see pbxlJb-3Uv-p2
+ */
+export const isLivePreviewSupported = ( state, { themeId, siteId } ) => {
+	// A user doesn't want to preview the active theme.
+	if ( isThemeActive( state, themeId, siteId ) ) {
+		return false;
+	}
+
+	// A theme should be FullSiteEditing compatible to use Block Theme Previews.
+	if ( ! isFullSiteEditingTheme( state, themeId, siteId ) ) {
+		return false;
+	}
+
+	/**
+	 * Block Theme Previews do not support themes with a static page as a homepage
+	 * as the Site Editor cannot control Reading Settings.
+	 *
+	 * @see pekYwv-284-p2#background
+	 */
+	if ( isNotCompatibleThemes( themeId ) ) {
+		return null;
+	}
+
+	// Block Theme Previews need the theme installed on Atomic sites.
+	const isAtomic = isSiteAutomatedTransfer( state, siteId );
+	const isThemeInstalledOnAtomicSite = isAtomic && !! getTheme( state, siteId, themeId );
+	if ( isAtomic && ! isThemeInstalledOnAtomicSite ) {
+		return false;
+	}
+
+	const isSimple = isSimpleSite( state, siteId );
+	if ( isSimple ) {
+		/**
+		 * Disable Live Preview for 3rd party themes, as Block Theme Previews need a theme installed.
+		 * Note that BTP works on Atomic sites if a theme is installed.
+		 */
+		if ( isExternallyManagedTheme( state, themeId ) || isWporgTheme( state, themeId ) ) {
+			return false;
+		}
+
+		/**
+		 * Disable Live Preview for themes that are not included in a plan.
+		 * This should be updated as we implement the flow for them.
+		 * Note that BTP works on Atomic sites if a theme is installed.
+		 *
+		 * @see https://github.com/Automattic/wp-calypso/issues/79223
+		 */
+		if ( ! canUseTheme( state, siteId, themeId ) ) {
+			return false;
+		}
+	}
+
+	return true;
+};

--- a/client/state/themes/selectors/is-live-preview-supported.js
+++ b/client/state/themes/selectors/is-live-preview-supported.js
@@ -81,7 +81,7 @@ const isNotCompatibleThemes = ( themeId ) => {
  *
  * @see pbxlJb-3Uv-p2
  */
-export const isLivePreviewSupported = ( state, themeId, siteId ) => {
+export const getIsLivePreviewSupported = ( state, themeId, siteId ) => {
 	if ( ! config.isEnabled( 'themes/block-theme-previews' ) ) {
 		return false;
 	}

--- a/client/state/themes/selectors/is-live-preview-supported.js
+++ b/client/state/themes/selectors/is-live-preview-supported.js
@@ -80,7 +80,7 @@ const isNotCompatibleThemes = ( themeId ) => {
  *
  * @see pbxlJb-3Uv-p2
  */
-export const isLivePreviewSupported = ( state, { themeId, siteId } ) => {
+export const isLivePreviewSupported = ( state, themeId, siteId ) => {
 	// A user doesn't want to preview the active theme.
 	if ( isThemeActive( state, themeId, siteId ) ) {
 		return false;

--- a/client/state/themes/selectors/is-live-preview-supported.js
+++ b/client/state/themes/selectors/is-live-preview-supported.js
@@ -65,7 +65,7 @@ const isNotCompatibleThemes = ( themeId ) => {
 };
 
 /**
- * Live Preview leveraging Gutenberg's Block Theme Previews
+ * Check if Live Preview is supported.
  *
  * The scenarios where the Live Preview does NOT support;
  * - On both Simple and Atomic sites;
@@ -87,7 +87,7 @@ export const isLivePreviewSupported = ( state, { themeId, siteId } ) => {
 	}
 
 	// A theme should be FullSiteEditing compatible to use Block Theme Previews.
-	if ( ! isFullSiteEditingTheme( state, themeId, siteId ) ) {
+	if ( ! isFullSiteEditingTheme( state, themeId ) ) {
 		return false;
 	}
 
@@ -98,7 +98,7 @@ export const isLivePreviewSupported = ( state, { themeId, siteId } ) => {
 	 * @see pekYwv-284-p2#background
 	 */
 	if ( isNotCompatibleThemes( themeId ) ) {
-		return null;
+		return false;
 	}
 
 	// Block Theme Previews need the theme installed on Atomic sites.

--- a/client/state/themes/selectors/is-live-preview-supported.js
+++ b/client/state/themes/selectors/is-live-preview-supported.js
@@ -92,7 +92,7 @@ export const getIsLivePreviewSupported = ( state, themeId, siteId ) => {
 	}
 
 	// A theme should be FullSiteEditing compatible to use Block Theme Previews.
-	if ( ! isFullSiteEditingTheme( state, themeId ) ) {
+	if ( ! isFullSiteEditingTheme( state, themeId, siteId ) ) {
 		return false;
 	}
 

--- a/client/state/themes/selectors/is-live-preview-supported.js
+++ b/client/state/themes/selectors/is-live-preview-supported.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isSimpleSite } from 'calypso/state/sites/selectors';
 import {
@@ -83,6 +84,11 @@ const isNotCompatibleThemes = ( themeId ) => {
  */
 export const getIsLivePreviewSupported = ( state, themeId, siteId ) => {
 	if ( ! config.isEnabled( 'themes/block-theme-previews' ) ) {
+		return false;
+	}
+
+	// The "Live" Preview does not make sense for logged out users.
+	if ( ! isUserLoggedIn( state ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79219, https://github.com/Automattic/wp-calypso/issues/79218, https://github.com/Automattic/wp-calypso/pull/79775

## Proposed Changes

Extract functions added in https://github.com/Automattic/wp-calypso/pull/79775 into selectors. This allows us to reuse functions between #79219 and #79218. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Simple sites

- Patch D117384-code into your sandbox.
- Go to the Theme Showcase page.
- Click any theme and go to the Theme Detail page.
- See if clicking the "Live Preview" button redirects you to the Site Editor (Block Theme Previews).
	- You will not see the button when a theme is;
		- your active theme
		- is not FullSiteEditing compatible
		- a theme with a static page as a homepage 
		- a 3rd party theme
		- a premium theme
		- a woocommerce theme

Atomic sites 

- Go to the Theme Showcase page.
- Click any theme and go to the Theme Detail page. 
- You must install a theme before using the Live Preview on Atomic sites. pbxlJb-3Uv-p2#known-issues
	- When you're using Calypso, activate it once and then reactivate the original theme. 
	- When you're using the classic view, just install it.
- ~~See if clicking the "Live Preview" button redirects you to the Site Editor (Block Theme Previews).~~ -> I am not yet sure how to patch it to make BTP work (c.f. https://github.com/Automattic/dotcom-forge/issues/3322). We can just check if the "Live Preview" button exists or not. 
	- You will not see the button when a theme is;
		- your active theme
		- is not FullSiteEditing compatible
		- a theme with a static page as a homepage 
		- not installed (not listed in "My Themes")

Please see pbxlJb-3Uv-p2#known-issues about unsupported themes. 
I don't think we should go through everything in this PR since I just extracted some functions from #79219. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
