### PR TITLE
Add zenchat to all domains pages

### DIFF
--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -69,7 +69,7 @@ class DomainManagementData extends Component {
 }
 
 export function UsePresalesChat() {
-	usePresalesChat( 'wpcom' );
+	usePresalesChat( 'wpcom', true, true );
 }
 
 export default connect( ( state ) => {

--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -7,6 +7,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
@@ -61,9 +62,14 @@ class DomainManagementData extends Component {
 						user: this.props.currentUser,
 					} ) }
 				</CalypsoShoppingCartProvider>
+				<UsePresalesChat />
 			</div>
 		);
 	}
+}
+
+export function UsePresalesChat() {
+	usePresalesChat( 'wpcom' );
 }
 
 export default connect( ( state ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -13,7 +13,7 @@ const Intro: Step = function Intro( { navigation, flow, variantSlug } ) {
 	const { submit, goBack } = navigation;
 	const { __ } = useI18n();
 
-	usePresalesChat( 'wpcom' );
+	usePresalesChat( 'wpcom', true, true );
 
 	const handleSubmit = () => {
 		submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
@@ -13,7 +13,7 @@ const Intro: Step = function Intro( { navigation, variantSlug } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
 
-	usePresalesChat( 'wpcom' );
+	usePresalesChat( 'wpcom', true, true );
 
 	const handleSubmit = () => {
 		submit?.();

--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -1,4 +1,8 @@
-import { useMessagingAvailability, useZendeskMessaging } from '@automattic/help-center/src/hooks';
+import {
+	useChatStatus,
+	useMessagingAvailability,
+	useZendeskMessaging,
+} from '@automattic/help-center/src/hooks';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -36,7 +40,8 @@ function getGroupName( keyType: KeyType ) {
 
 export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabilityCheck = false ) {
 	const isEnglishLocale = useIsEnglishLocale();
-	const isEligibleForPresalesChat = enabled && isEnglishLocale;
+	const { canConnectToZendesk } = useChatStatus();
+	const isEligibleForPresalesChat = enabled && isEnglishLocale && canConnectToZendesk;
 
 	const group = getGroupName( keyType );
 

--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -1,8 +1,4 @@
-import {
-	useChatStatus,
-	useMessagingAvailability,
-	useZendeskMessaging,
-} from '@automattic/help-center/src/hooks';
+import { useMessagingAvailability, useZendeskMessaging } from '@automattic/help-center/src/hooks';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -40,8 +36,7 @@ function getGroupName( keyType: KeyType ) {
 
 export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabilityCheck = false ) {
 	const isEnglishLocale = useIsEnglishLocale();
-	const { canConnectToZendesk } = useChatStatus();
-	const isEligibleForPresalesChat = enabled && isEnglishLocale && canConnectToZendesk;
+	const isEligibleForPresalesChat = enabled && isEnglishLocale;
 
 	const group = getGroupName( keyType );
 

--- a/packages/help-center/src/hooks/use-chat-status.ts
+++ b/packages/help-center/src/hooks/use-chat-status.ts
@@ -28,7 +28,7 @@ export default function useChatStatus(
 	const { status: zendeskStatus } = useZendeskConfig( isEligibleForChat );
 
 	return {
-		canConnectToZendesk: zendeskStatus !== 'error' && zendeskStatus !== 'loading',
+		canConnectToZendesk: zendeskStatus !== 'error',
 		hasActiveChats,
 		isChatAvailable: Boolean( chatAvailability?.is_available ),
 		isEligibleForChat,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3270

## Proposed Changes

* Adds zendesk chat bubble to all domains pages
* Reverts a change to `use-chat-status` that seemed partially responsible for presales chat not showing as often as it should.
* Skips availability check across the domain management UI and transfer flow.


<img width="1309" alt="Screenshot 2023-07-31 at 3 15 11 PM" src="https://github.com/Automattic/wp-calypso/assets/1126811/f7948aed-b2f8-4551-bc3d-b6ee8e4e4354">

## Todo:

We should create a domains context group for this, the wpcom group is not all that relevant:

![Screenshot_2023-07-31_16-44-33](https://github.com/Automattic/wp-calypso/assets/811776/651870f2-19ec-45a7-bba1-ab2bf847a6c7)




## Testing Instructions

* Visit http://calypso.localhost:3000/domains/manage, all pages under domains management should show the chat bubble.

After:
![Screenshot (1)](https://github.com/Automattic/wp-calypso/assets/811776/ee1bae7d-f4de-43e3-96af-9ea86913d429)
