### PR TITLE
WIP: Add sticky behavior to the plan comparison grid header.

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/sticky-container.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/sticky-container.tsx
@@ -4,20 +4,35 @@ import { useRef, type ElementType, useState, useLayoutEffect, ReactNode } from '
 
 type Props = {
 	children: ( isStuck: boolean ) => ReactNode;
-	stickyClass?: string;
-	element?: ElementType;
+	stickyClass?: string; // class to apply when the element is "stuck"
+	element?: ElementType; // which element to render, defaults to div
 	stickyOffset?: number; // offset from the top of the scrolling container to control when the element should start sticking, default 0
 	topOffset?: number; // offset from the top of the scrolling container to control the position of the sticky element, default 0
+	disabled?: boolean; // force disabled sticky behaviour if set to true
 };
 
-const Container = styled.div< { topOffset: number } >`
-	position: sticky;
-	top: ${ ( props ) => props.topOffset + 'px' };
-	z-index: 1;
+const styles = ( { disabled, topOffset }: { disabled: boolean; topOffset: number } ) =>
+	disabled
+		? ''
+		: css`
+				position: sticky;
+				top: ${ topOffset + 'px' };
+				z-index: 1;
+		  `;
+
+const Container = styled.div`
+	${ styles }
 `;
 
 export function StickyContainer( props: Props ) {
-	const { stickyOffset = 0, topOffset = 0, stickyClass = '', element = 'div', children } = props;
+	const {
+		stickyOffset = 0,
+		topOffset = 0,
+		stickyClass = '',
+		element = 'div',
+		disabled = false,
+		children,
+	} = props;
 
 	const stickyRef = useRef( null );
 	const [ isStuck, setIsStuck ] = useState( false );
@@ -70,11 +85,13 @@ export function StickyContainer( props: Props ) {
 					}
 				` }
 			/>
+
 			<Container
 				{ ...props }
 				as={ element }
 				ref={ stickyRef }
 				topOffset={ topOffset }
+				disabled={ disabled }
 				className={ isStuck ? stickyClass : '' }
 			>
 				{ children( isStuck ) }

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -289,6 +289,7 @@ export class PlanFeatures2023Grid extends Component<
 			planRecords,
 			visiblePlans,
 			showLegacyStorageFeature,
+			stickyRowOffset,
 		} = this.props;
 		return (
 			<PlansGridContextProvider
@@ -345,6 +346,7 @@ export class PlanFeatures2023Grid extends Component<
 								selectedFeature={ selectedFeature }
 								isGlobalStylesOnPersonal={ isGlobalStylesOnPersonal }
 								showLegacyStorageFeature={ showLegacyStorageFeature }
+								stickyRowOffset={ stickyRowOffset }
 							/>
 							<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
 								<Button onClick={ this.toggleShowPlansComparisonGrid }>

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -851,6 +851,11 @@ body.is-section-signup.is-white-signup,
 					/* stylelint-disable-next-line */
 					border-radius: 5px 5px 0 0;
 					border-style: solid;
+					transition: top 0.2s ease;
+				}
+
+				.popular-badge-is-stuck {
+					top: -10px;
 				}
 
 				&.is-left-of-highlight {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1392

## Proposed Changes

* Adds sticky behaviour to the plan comparison grid header.


### TODO
- [ ] Fix styling of interval selector in sticky mode. 
<img width="717" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/868041eb-fe3f-4a8b-a9d1-8e207a28043e">

- [ ] Bottom padding of the header in sticky mode should be 16px.
<img width="1003" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/274abed9-8d4f-4874-a27f-ff57bef63199">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` and open the plans comparison grid. Confirm that the sticky header gets activated.
* If the bottom header is in view, the header bar should no longer stick.
* Confirm that the plan interval selector is shown and works when the header is sticky.
* Confirm that it matches the design on https://wordpress.com/pricing
* Repeat the above steps on `/plans/<site slug>`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
