### PR TITLE
Migration trial: Import flow: Create migration trial step

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -275,6 +275,7 @@ const importFlow: Flow = {
 					return navigate( `import?siteSlug=${ siteSlugParam }` );
 
 				case 'verifyEmail':
+				case 'migrationTrial':
 					return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
 			}
 		};

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -25,6 +25,7 @@ import ImporterSquarespace from './internals/steps-repository/importer-squarespa
 import ImporterWix from './internals/steps-repository/importer-wix';
 import ImporterWordpress from './internals/steps-repository/importer-wordpress';
 import MigrationHandler from './internals/steps-repository/migration-handler';
+import MigrationTrial from './internals/steps-repository/migration-trial';
 import PatternAssembler from './internals/steps-repository/pattern-assembler';
 import ProcessingStep from './internals/steps-repository/processing-step';
 import SiteCreationStep from './internals/steps-repository/site-creation-step';
@@ -54,6 +55,7 @@ const importFlow: Flow = {
 			{ slug: 'processing', component: ProcessingStep },
 			{ slug: 'siteCreationStep', component: SiteCreationStep },
 			{ slug: 'migrationHandler', component: MigrationHandler },
+			{ slug: 'migrationTrial', component: MigrationTrial },
 			{ slug: 'sitePicker', component: SitePickerStep },
 			{ slug: 'error', component: MigrationError },
 			{ slug: 'verifyEmail', component: ImportVerifyEmail },

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/hooks/use-unsupported-trial-feature-list.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/hooks/use-unsupported-trial-feature-list.ts
@@ -1,0 +1,13 @@
+import { useI18n } from '@wordpress/react-i18n';
+
+export default function useUnsupportedTrialFeatureList() {
+	const { __ } = useI18n();
+
+	return [
+		__( 'Your site will be unpublished' ),
+		__( 'No custom domains' ),
+		__( 'No SSH or SFTP access' ),
+		__( 'Limit of 200GB' ),
+		__( 'Limit of 100 subscribers' ),
+	];
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/index.tsx
@@ -5,8 +5,9 @@ import TrialPlan from './trial-plan';
 import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import './style.scss';
 
-const MigrationTrial: Step = function MigrationTrial() {
+const MigrationTrial: Step = function MigrationTrial( { navigation } ) {
 	const site = useSite();
+	const { goBack } = navigation;
 
 	if ( ! site ) {
 		return null;
@@ -17,8 +18,9 @@ const MigrationTrial: Step = function MigrationTrial() {
 			stepName="migration-trial"
 			className="import-layout__center"
 			hideSkip={ true }
-			hideBack={ true }
+			hideBack={ false }
 			hideFormattedHeader={ true }
+			goBack={ goBack }
 			isWideLayout={ false }
 			stepContent={ <TrialPlan site={ site } /> }
 			recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/index.tsx
@@ -1,17 +1,11 @@
 import { StepContainer } from '@automattic/onboarding';
-import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import TrialPlan from './trial-plan';
 import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import './style.scss';
 
 const MigrationTrial: Step = function MigrationTrial( { navigation } ) {
-	const site = useSite();
 	const { goBack } = navigation;
-
-	if ( ! site ) {
-		return null;
-	}
 
 	return (
 		<StepContainer
@@ -22,7 +16,7 @@ const MigrationTrial: Step = function MigrationTrial( { navigation } ) {
 			hideFormattedHeader={ true }
 			goBack={ goBack }
 			isWideLayout={ false }
-			stepContent={ <TrialPlan site={ site } /> }
+			stepContent={ <TrialPlan /> }
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/index.tsx
@@ -1,0 +1,29 @@
+import { StepContainer } from '@automattic/onboarding';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import TrialPlan from './trial-plan';
+import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import './style.scss';
+
+const MigrationTrial: Step = function MigrationTrial() {
+	const site = useSite();
+
+	if ( ! site ) {
+		return null;
+	}
+
+	return (
+		<StepContainer
+			stepName="migration-trial"
+			className="import-layout__center"
+			hideSkip={ true }
+			hideBack={ true }
+			hideFormattedHeader={ true }
+			isWideLayout={ false }
+			stepContent={ <TrialPlan site={ site } /> }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default MigrationTrial;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/style.scss
@@ -107,3 +107,34 @@
 		}
 	}
 }
+
+.trial-plan-features-modal {
+	.components-modal__header {
+		padding: 1rem 1.5rem !important;
+	}
+
+	.components-modal__content {
+		padding: 0 1.5rem 1rem 1.5rem !important;
+	}
+
+	ul {
+		margin-top: 0;
+	}
+
+	li {
+		color: var(--studio-gray-40);
+
+		svg {
+			fill: var(--color-success);
+		}
+	}
+
+	.button-container {
+		text-align: end;
+
+		.action_buttons__button {
+			min-width: 120px;
+			border-radius: 4px;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/style.scss
@@ -130,7 +130,14 @@
 	}
 
 	.button-container {
+		width: 100%;
+		position: relative;
+		left: -1.5rem;
+		right: -1.5rem;
+		bottom: -1rem;
+		padding: 1rem 1.5rem;
 		text-align: end;
+		border-top: 1px solid var(--studio-gray-5);
 
 		.action_buttons__button {
 			min-width: 120px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/style.scss
@@ -1,0 +1,22 @@
+.trial-plan--container {
+	max-width: 692px;
+	text-align: center;
+	margin: auto;
+
+	.onboarding-title {
+		margin-bottom: 0.5rem;
+	}
+
+	.onboarding-subtitle {
+		margin-bottom: 2rem;
+	}
+
+	p {
+		color: var(--studio-gray-100);
+
+		a {
+			color: inherit;
+			text-decoration: underline;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/style.scss
@@ -1,22 +1,109 @@
+@import "@automattic/onboarding/styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .trial-plan--container {
 	max-width: 692px;
-	text-align: center;
 	margin: auto;
+	padding: 1rem;
+	text-align: center;
 
 	.onboarding-title {
 		margin-bottom: 0.5rem;
 	}
 
 	.onboarding-subtitle {
-		margin-bottom: 2rem;
+		margin-bottom: 2.5rem;
+	}
+
+	.action-buttons__next {
+		padding-left: 1.5rem;
+		padding-right: 1.5rem;
 	}
 
 	p {
 		color: var(--studio-gray-100);
+		margin-bottom: 2.5rem;
 
 		a {
 			color: inherit;
 			text-decoration: underline;
+		}
+	}
+
+	.trial-plan--details {
+		display: flex;
+		text-align: initial;
+		flex-direction: column;
+		border: solid var(--studio-gray-5) 1px;
+		border-radius: 4px;
+		padding: 1.75em;
+		margin-bottom: 2.5rem;
+		gap: 1.5rem;
+
+		@include break-medium {
+			flex-direction: row;
+		}
+	}
+
+	.trial-plan--details-name,
+	.trial-plan--details-features {
+		display: flex;
+	}
+
+	.trial-plan--details-name {
+		min-width: 150px;
+		flex-direction: column;
+
+		.plan-title {
+			font-weight: 500;
+			font-size: 1.25rem;
+			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+			line-height: 1.25rem;
+			color: var(--studio-gray-60);
+		}
+
+		.plan-duration {
+			@include onboarding-font-recoleta;
+			font-weight: 500;
+			font-size: 2rem;
+			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+			line-height: 3rem;
+		}
+	}
+
+	.trial-plan--details-features {
+		flex-basis: 100%;
+
+		ul {
+			width: 100%;
+			margin: 0;
+			list-style: none;
+			column-count: 1;
+			column-gap: 2rem;
+
+			@include break-small {
+				column-count: 2;
+			}
+		}
+
+		li + li {
+			margin-top: 0.85rem;
+		}
+
+		li {
+			font-size: 0.875rem;
+			color: var(--studio-gray-40);
+
+			&::before {
+				content: "\2022";
+				color: var(--studio-blue-20);
+				font-weight: bold;
+				display: inline-block;
+				width: 1rem;
+				position: relative;
+				top: -1px;
+			}
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan-features-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan-features-modal.tsx
@@ -1,0 +1,50 @@
+import { JetpackPlan, Plan, WPComPlan } from '@automattic/calypso-products';
+import { NextButton } from '@automattic/onboarding';
+import { Modal } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
+import { check, Icon } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import { getFeatureByKey } from 'calypso/lib/plans/features-list';
+
+interface Props {
+	plan: Plan | JetpackPlan | WPComPlan | undefined;
+	onClose: () => void;
+}
+export default function TrialPlanFeaturesModal( props: Props ) {
+	const { __ } = useI18n();
+	const { plan, onClose } = props;
+
+	const title = sprintf(
+		/* translators: the planName could be "Pro" or "Business" */
+		__( "What's included in the %(planName)s Plan" ),
+		{
+			planName: plan?.getTitle(),
+		}
+	);
+	const features =
+		plan && 'getPlanCompareFeatures' in plan
+			? ( plan?.getPlanCompareFeatures?.() || [] )
+					.map( ( feature: string ) => getFeatureByKey( feature )?.getTitle() )
+					.filter( ( x ) => x )
+			: [];
+
+	return (
+		<Modal
+			className="import__details-modal trial-plan-features-modal"
+			title={ title }
+			onRequestClose={ () => onClose() }
+		>
+			<ul className="import__details-list">
+				{ features.map( ( feature, i ) => (
+					<li className="import__upgrade-plan-feature" key={ i }>
+						<Icon size={ 20 } icon={ check } />
+						<span>{ feature }</span>
+					</li>
+				) ) }
+			</ul>
+			<div className="button-container">
+				<NextButton onClick={ () => onClose() }>{ __( 'Continue' ) }</NextButton>
+			</div>
+		</Modal>
+	);
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
@@ -1,12 +1,15 @@
 import { getPlan, PLAN_BUSINESS, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
 import { SiteDetails } from '@automattic/data-stores';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Title, SubTitle, NextButton } from '@automattic/onboarding';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import React, { useState } from 'react';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { useSelector } from 'calypso/state';
 import useUnsupportedTrialFeatureList from './hooks/use-unsupported-trial-feature-list';
+import TrialPlanFeaturesModal from './trial-plan-features-modal';
 
 interface Props {
 	site: SiteDetails;
@@ -14,56 +17,74 @@ interface Props {
 const TrialPlan = function TrialPlan( props: Props ) {
 	const { __ } = useI18n();
 	const { site } = props;
+	const [ showPlanFeaturesModal, setShowPlanFeaturesModal ] = useState( false );
+
 	const targetSiteEligibleForProPlan = useSelector( ( state ) =>
 		isEligibleForProPlan( state, site?.ID )
 	);
-
 	const unsupportedTrialFeatureList = useUnsupportedTrialFeatureList();
 	const planType = targetSiteEligibleForProPlan ? PLAN_WPCOM_PRO : PLAN_BUSINESS;
 	const plan = getPlan( planType );
 
 	return (
-		<div className="trial-plan--container">
-			<Title>{ __( 'Try before you buy' ) }</Title>
-			<SubTitle>
-				{ sprintf(
-					/* translators: the planName could be "Pro" or "Business" */
-					__( 'Try the %(planName)s plan free for 7 days and migrate your site for free' ),
-					{ planName: plan?.getTitle() }
-				) }
-			</SubTitle>
+		<>
+			{ showPlanFeaturesModal && (
+				<TrialPlanFeaturesModal
+					plan={ plan }
+					onClose={ () => {
+						setShowPlanFeaturesModal( false );
+					} }
+				/>
+			) }
 
-			<p>
-				{ createInterpolateElement(
-					sprintf(
+			<div className="trial-plan--container">
+				<Title>{ __( 'Try before you buy' ) }</Title>
+				<SubTitle>
+					{ sprintf(
 						/* translators: the planName could be "Pro" or "Business" */
-						__(
-							'The 7-day trial includes <a>every feature in the %(planName)s plan</a> with a few exceptions. To enjoy all the features without limits, upgrade to the paid plan at any time before your trial ends.'
-						),
+						__( 'Try the %(planName)s plan free for 7 days and migrate your site for free' ),
 						{ planName: plan?.getTitle() }
-					),
-					{
-						a: createElement( 'a', { href: '#' } ),
-					}
-				) }
-			</p>
+					) }
+				</SubTitle>
 
-			<div className="trial-plan--details">
-				<div className="trial-plan--details-name">
-					<h3 className="plan-title">{ __( 'Trial' ) }</h3>
-					<h4 className="plan-duration">{ __( '7 days' ) }</h4>
+				<p>
+					{ createInterpolateElement(
+						sprintf(
+							/* translators: the planName could be "Pro" or "Business" */
+							__(
+								'The 7-day trial includes <a>every feature in the %(planName)s plan</a> with a few exceptions. To enjoy all the features without limits, upgrade to the paid plan at any time before your trial ends.'
+							),
+							{ planName: plan?.getTitle() }
+						),
+						{
+							a: createElement( 'a', {
+								href: localizeUrl( 'https://wordpress.com/pricing/' ),
+								onClick: ( e: React.MouseEvent< HTMLElement > ) => {
+									e.preventDefault();
+									setShowPlanFeaturesModal( true );
+								},
+							} ),
+						}
+					) }
+				</p>
+
+				<div className="trial-plan--details">
+					<div className="trial-plan--details-name">
+						<h3 className="plan-title">{ __( 'Trial' ) }</h3>
+						<h4 className="plan-duration">{ __( '7 days' ) }</h4>
+					</div>
+					<div className="trial-plan--details-features">
+						<ul>
+							{ unsupportedTrialFeatureList.map( ( feature, i ) => (
+								<li key={ i }>{ feature }</li>
+							) ) }
+						</ul>
+					</div>
 				</div>
-				<div className="trial-plan--details-features">
-					<ul>
-						{ unsupportedTrialFeatureList.map( ( feature, i ) => (
-							<li key={ i }>{ feature }</li>
-						) ) }
-					</ul>
-				</div>
+
+				<NextButton>{ __( 'Start the trial and migrate' ) }</NextButton>
 			</div>
-
-			<NextButton>{ __( 'Start the trial and migrate' ) }</NextButton>
-		</div>
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
@@ -1,30 +1,19 @@
-import { getPlan, PLAN_BUSINESS, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
-import { SiteDetails } from '@automattic/data-stores';
+import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Title, SubTitle, NextButton } from '@automattic/onboarding';
-import { createElement, createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useState } from 'react';
-import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
-import { useSelector } from 'calypso/state';
 import useUnsupportedTrialFeatureList from './hooks/use-unsupported-trial-feature-list';
 import TrialPlanFeaturesModal from './trial-plan-features-modal';
 
-interface Props {
-	site: SiteDetails;
-}
-const TrialPlan = function TrialPlan( props: Props ) {
+const TrialPlan = function TrialPlan() {
 	const { __ } = useI18n();
-	const { site } = props;
 	const [ showPlanFeaturesModal, setShowPlanFeaturesModal ] = useState( false );
 
-	const targetSiteEligibleForProPlan = useSelector( ( state ) =>
-		isEligibleForProPlan( state, site?.ID )
-	);
 	const unsupportedTrialFeatureList = useUnsupportedTrialFeatureList();
-	const planType = targetSiteEligibleForProPlan ? PLAN_WPCOM_PRO : PLAN_BUSINESS;
-	const plan = getPlan( planType );
+	const plan = getPlan( PLAN_BUSINESS );
 
 	return (
 		<>
@@ -57,13 +46,15 @@ const TrialPlan = function TrialPlan( props: Props ) {
 							{ planName: plan?.getTitle() }
 						),
 						{
-							a: createElement( 'a', {
-								href: localizeUrl( 'https://wordpress.com/pricing/' ),
-								onClick: ( e: React.MouseEvent< HTMLElement > ) => {
-									e.preventDefault();
-									setShowPlanFeaturesModal( true );
-								},
-							} ),
+							a: (
+								<a
+									href={ localizeUrl( 'https://wordpress.com/pricing/' ) }
+									onClick={ ( e: React.MouseEvent< HTMLElement > ) => {
+										e.preventDefault();
+										setShowPlanFeaturesModal( true );
+									} }
+								/>
+							),
 						}
 					) }
 				</p>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
@@ -1,0 +1,53 @@
+import { getPlan, PLAN_BUSINESS, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
+import { SiteDetails } from '@automattic/data-stores';
+import { Title, SubTitle, NextButton } from '@automattic/onboarding';
+import { createElement, createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+import { useSelector } from 'calypso/state';
+
+interface Props {
+	site: SiteDetails;
+}
+const TrialPlan = function TrialPlan( props: Props ) {
+	const { __ } = useI18n();
+	const { site } = props;
+	const targetSiteEligibleForProPlan = useSelector( ( state ) =>
+		isEligibleForProPlan( state, site?.ID )
+	);
+	const planType = targetSiteEligibleForProPlan ? PLAN_WPCOM_PRO : PLAN_BUSINESS;
+	const plan = getPlan( planType );
+
+	return (
+		<div className="trial-plan--container">
+			<Title>{ __( 'Try before you buy' ) }</Title>
+			<SubTitle>
+				{ sprintf(
+					/* translators: the planName could be "Pro" or "Business" */
+					__( 'Try the %(planName)s plan free for 7 days and migrate your site for free' ),
+					{ planName: plan?.getTitle() }
+				) }
+			</SubTitle>
+
+			<p>
+				{ createInterpolateElement(
+					sprintf(
+						/* translators: the planName could be "Pro" or "Business" */
+						__(
+							'The 7-day trial includes <a>every feature in the %(planName)s plan</a> with a few exceptions. To enjoy all the features without limits, upgrade to the paid plan at any time before your trial ends.'
+						),
+						{ planName: plan?.getTitle() }
+					),
+					{
+						a: createElement( 'a', { href: '#' } ),
+					}
+				) }
+			</p>
+
+			<NextButton>{ __( 'Start the trial and migrate' ) }</NextButton>
+		</div>
+	);
+};
+
+export default TrialPlan;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
@@ -6,6 +6,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { useSelector } from 'calypso/state';
+import useUnsupportedTrialFeatureList from './hooks/use-unsupported-trial-feature-list';
 
 interface Props {
 	site: SiteDetails;
@@ -16,6 +17,8 @@ const TrialPlan = function TrialPlan( props: Props ) {
 	const targetSiteEligibleForProPlan = useSelector( ( state ) =>
 		isEligibleForProPlan( state, site?.ID )
 	);
+
+	const unsupportedTrialFeatureList = useUnsupportedTrialFeatureList();
 	const planType = targetSiteEligibleForProPlan ? PLAN_WPCOM_PRO : PLAN_BUSINESS;
 	const plan = getPlan( planType );
 
@@ -44,6 +47,20 @@ const TrialPlan = function TrialPlan( props: Props ) {
 					}
 				) }
 			</p>
+
+			<div className="trial-plan--details">
+				<div className="trial-plan--details-name">
+					<h3 className="plan-title">{ __( 'Trial' ) }</h3>
+					<h4 className="plan-duration">{ __( '7 days' ) }</h4>
+				</div>
+				<div className="trial-plan--details-features">
+					<ul>
+						{ unsupportedTrialFeatureList.map( ( feature, i ) => (
+							<li key={ i }>{ feature }</li>
+						) ) }
+					</ul>
+				</div>
+			</div>
 
 			<NextButton>{ __( 'Start the trial and migrate' ) }</NextButton>
 		</div>


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/79968

## Proposed Changes

* Create **Migration trial** step
* Registered the step inside the import-focused flow

## Testing Instructions

* Go to `/setup/import-focused/migrationTrial?siteSlug={SITE_SLUG}&from={JN_SITE}&option=everything`
* Check if there is migrationTrial step there
* Click on `every feature in the Business plan` link and check if there is a modal with a feature list rendered
* Click `Continue` or close the modal
* Click back and check if redirect to the prev "Upgrade Plan" step

**NOTE:** The handler of "Start the trial and migrate" CTA will be implemented in the next iterations

![Screen Capture on 2023-08-01 at 12-11-31](https://github.com/Automattic/wp-calypso/assets/1241413/8bfde417-fd12-4113-a142-8de5c9c9eff0)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
