### PR TITLE
Partner Portal: fix banner spacing on the Licenses page

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -69,10 +69,10 @@ export default function Licenses( {
 			<QueryJetpackPartnerPortalLicenseCounts />
 
 			{ isAgencyUser && (
-				<>
+				<div>
 					<SiteSurveyBanner />
 					<SiteWelcomeBanner bannerKey="licenses-page" />
-				</>
+				</div>
 			) }
 			<SiteAddLicenseNotification />
 


### PR DESCRIPTION
Related to 1202619025189113-as-1205169702276123

## Proposed Changes

This PR fixes the spacing issues observed on the `Licenses` page

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/license-page-banner` and `yarn start-jetpack-cloud` or open the Jetpack Cloud live link. 
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on the "Licenses" top nav
4. Clear the Welcome Banner(jetpack-dashboard-welcome-banner-preference-licenses-page
) & Survey Banner(jetpack-dashboard-agency-program-survey-banner-preference) preferences
5. Verify there are no spacing issues, as shown below.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1649" alt="Screenshot 2023-07-31 at 3 29 03 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/fb5a83c6-72da-4eed-82ee-72718ccae0cc">
</td>
<td>
<img width="1646" alt="Screenshot 2023-07-31 at 3 29 19 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/dbb9578a-b71c-4c18-ac5c-02657b05b1c6">
</tr>
</table>

**How to reset the banner?**

In the Jetpack page at the bottom right. Hover on the debug icon and click preferences. Look for **jetpack-dashboard-welcome-banner-preference-licenses-page** & **jetpack-dashboard-agency-program-survey-banner-preference** and clear it by clicking the **X** button.

<img width="1174" alt="Screen Shot 2023-07-12 at 4 57 50 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/aeb0af42-c99b-409f-a652-fb2fb207b97b">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?