### PR TITLE
Migration Trial: Add migration notice to the manage purchase panel

### DIFF
--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -1042,7 +1042,7 @@ class PurchaseNotice extends Component<
 		const daysToExpiry = moment( expiry.diff( moment() ) ).format( 'D' );
 		const productType =
 			productSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY
-				? 'ecommerce'
+				? translate( 'ecommerce' )
 				: getPlan( PLAN_BUSINESS )?.getTitle();
 		return (
 			<Notice

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -6,6 +6,7 @@ import {
 	isDomainRegistration,
 	isMonthly,
 	isAkismetFreeProduct,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { isEmpty, merge, minBy } from 'lodash';
@@ -284,7 +285,7 @@ class PurchaseNotice extends Component<
 	};
 
 	renderPurchaseExpiringNotice() {
-		const EXCLUDED_PRODUCTS = [ 'ecommerce-trial-bundle-monthly' ];
+		const EXCLUDED_PRODUCTS = [ PLAN_ECOMMERCE_TRIAL_MONTHLY ];
 		const {
 			moment,
 			purchase,
@@ -1066,7 +1067,7 @@ class PurchaseNotice extends Component<
 			return null;
 		}
 
-		if ( purchase.productSlug === 'ecommerce-trial-bundle-monthly' ) {
+		if ( purchase.productSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY ) {
 			return this.renderECommerceTrialNotice();
 		}
 

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -1,12 +1,15 @@
 import config from '@automattic/calypso-config';
 import {
+	getPlan,
 	isDomainTransfer,
 	isConciergeSession,
 	isPlan,
 	isDomainRegistration,
 	isMonthly,
 	isAkismetFreeProduct,
+	PLAN_BUSINESS,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_MIGRATION_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { isEmpty, merge, minBy } from 'lodash';
@@ -285,7 +288,7 @@ class PurchaseNotice extends Component<
 	};
 
 	renderPurchaseExpiringNotice() {
-		const EXCLUDED_PRODUCTS = [ PLAN_ECOMMERCE_TRIAL_MONTHLY ];
+		const EXCLUDED_PRODUCTS = [ PLAN_ECOMMERCE_TRIAL_MONTHLY, PLAN_MIGRATION_TRIAL_MONTHLY ];
 		const {
 			moment,
 			purchase,
@@ -1030,26 +1033,33 @@ class PurchaseNotice extends Component<
 		);
 	}
 
-	renderECommerceTrialNotice() {
+	renderTrialNotice( productSlug: string ) {
 		const { moment, purchase, selectedSite, translate } = this.props;
 		const onClick = () => {
 			return page( `/plans/${ selectedSite?.slug }` );
 		};
 		const expiry = moment( purchase.expiryDate );
 		const daysToExpiry = moment( expiry.diff( moment() ) ).format( 'D' );
-
+		const productType =
+			productSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY
+				? 'ecommerce'
+				: getPlan( PLAN_BUSINESS )?.getTitle();
 		return (
 			<Notice
 				showDismiss={ false }
 				status="is-info"
-				text={ translate(
-					'You have %(expiry)s days remaining on your free trial. Upgrade your plan to keep your ecommerce features.',
-					{
-						args: {
-							expiry: daysToExpiry,
-						},
-					}
-				) }
+				text={
+					// translators: %expiry is the number of days remaining on the trial, %productType is the type of product (e.g. ecommerce)
+					translate(
+						'You have %(expiry)s days remaining on your free trial. Upgrade your plan to keep your %(productType)s features.',
+						{
+							args: {
+								expiry: daysToExpiry,
+								productType: productType,
+							},
+						}
+					)
+				}
 			>
 				<NoticeAction onClick={ onClick }>{ translate( 'Upgrade Now' ) }</NoticeAction>
 			</Notice>
@@ -1067,8 +1077,11 @@ class PurchaseNotice extends Component<
 			return null;
 		}
 
-		if ( purchase.productSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY ) {
-			return this.renderECommerceTrialNotice();
+		if (
+			purchase.productSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY ||
+			purchase.productSlug === PLAN_MIGRATION_TRIAL_MONTHLY
+		) {
+			return this.renderTrialNotice( purchase.productSlug );
 		}
 
 		if ( purchase.isLocked && purchase.isInAppPurchase ) {

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -1055,7 +1055,7 @@ class PurchaseNotice extends Component<
 						{
 							args: {
 								expiry: daysToExpiry,
-								productType: productType,
+								productType: productType as string,
 							},
 						}
 					)


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79834

## Proposed Changes

* Add a migration trial notice similar to eCommerce Trial notice

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start a free simple site and assign a migration trial plan to it or using your testing migration trial site.
* Navigate to `http://calypso.localhost:3000/me/` and choose a migration trial plan you have.
* You should see the update notice showing up like the following screenshot:

![Screen Shot 2023-07-31 at 8 08 57 PM](https://github.com/Automattic/wp-calypso/assets/4074459/971ad75a-6313-4fa6-af1a-0be2c63dff0d)
* Since this refactors the current eCommerce trial function, please make sure notice for eCommerce Trial plan shows correctly too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
