### PR TITLE
Marketplace: updates copy and aligns CTA

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -105,6 +105,7 @@
 		.thank-you__step {
 			display: flex;
 			flex-direction: column;
+			justify-content: space-between;
 			flex-wrap: wrap;
 			border-top: none;
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -30,8 +30,8 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 	// texts
 	const title = translate( 'Your site, more powerful than ever' );
 	const subtitle = translate(
-		'All set! Time to put your new plugin to work and take your site further.',
-		'All set! Time to put your new plugins to work and take your site further.',
+		'All set! Time to put your new plugin to work.',
+		'All set! Time to put your new plugins to work.',
 		{
 			count: pluginSlugs.length,
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1690560637424799-slack-C029JEQRVRT

## Proposed Changes

* Updates copy per

> really small copy nitpick… i was testing out installing mailpoet for something else and got to the confirm install screen. can we remove the “and take your site further” part? The line starts off strong “All set!” (good, basic confirmation whatever i did is completed and worked) and then “Time to put your new plugin to work…” (sounds cool, nice phrasing, makes me think i installed something powerful FOR a good use case)…then the “…and take your site further.” (i dont even know what that means, and makes me so confused I stall on that line and ruminate on and lose my excitement/energy.)

* Fixes link alignment

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Buy a marketplace plugin
* Inspect the thank you page for the changes

|Before | After|
|-------|------|
|![image](https://github.com/Automattic/wp-calypso/assets/12430020/c740c7dd-089e-4a5b-b2b4-13437cda8093)|![CleanShot 2023-07-31 at 16 46 06@2x](https://github.com/Automattic/wp-calypso/assets/12430020/00f17f58-716f-447d-8e27-d03cf16dfca3)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?