### PR TITLE
Domain Transfer: Fix checkout back URL for Google transfer variant

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -19,6 +19,7 @@ import {
 	AssertConditionState,
 } from './internals/types';
 import type { UserSelect } from '@automattic/data-stores';
+
 const domainTransfer: Flow = {
 	name: DOMAIN_TRANSFER,
 	get title() {
@@ -88,8 +89,8 @@ const domainTransfer: Flow = {
 					setSignupCompleteFlowName( flowName );
 
 					const checkoutBackURL = new URL(
-						'google-transfer' === this.variantSlug
-							? '/setup/google-transfer/domains'
+						typeof this.variantSlug !== 'undefined'
+							? `/setup/${ this.variantSlug }/domains`
 							: '/setup/domain-transfer/domains',
 						window.location.href
 					);

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -87,7 +87,12 @@ const domainTransfer: Flow = {
 					setSignupCompleteSlug( providedDependencies?.siteSlug );
 					setSignupCompleteFlowName( flowName );
 
-					const checkoutBackURL = new URL( '/setup/domain-transfer/domains', window.location.href );
+					const checkoutBackURL = new URL(
+						'google-transfer' === this.variantSlug
+							? '/setup/google-transfer/domains'
+							: '/setup/domain-transfer/domains',
+						window.location.href
+					);
 
 					// use replace instead of assign to remove the processing URL from history
 					return window.location.replace(


### PR DESCRIPTION
## Proposed Changes

* Ensures that the back functionality from checkout works as expected with the new Google Transfer variant.

## Testing Instructions

- Checkout PR
- Go through `/setup/domain-transfer` until checkout. Click back. Ensure you land in `/setup/domain-transfer/domains`
- Go through `/setup/google-transfer` until checkout. Click back. Ensure that you land in `/setup/google-transfer/domains`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
