### PR TITLE
Domain transfer: Improve mobile text alignment

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -144,41 +144,39 @@ export function DomainCodePair( {
 	}, [ shouldReportError, valid, domain, message, errorStatus ] );
 
 	const domainActions = () => (
-		<>
-			<span className="validation-actions">
-				{ isGoogleDomainsTransferFlow &&
-					// this means that the domain is locked and we need to show the instructions
-					errorStatus === domainAvailability.SERVER_TRANSFER_PROHIBITED_NOT_TRANSFERRABLE && (
-						<GoogleDomainsModal
-							className={ classnames( {
-								'is-first-row': showLabels,
-							} ) }
-							focusedStep={ 3 }
-						>
-							<span className="unlock-label">{ __( 'How to unlock' ) }</span>
-						</GoogleDomainsModal>
-					) }
-				<Button
-					// Disable the delete button on initial state meaning. no domain, no auth and one row.
-					disabled={ ! domain && ! auth && domainCount === 1 }
-					onClick={ () => onRemove( id ) }
-					variant="link"
-				>
-					<span className="delete-label">{ __( 'Clear domain' ) }</span>
-				</Button>
-				<Button
-					title={ __( 'Refresh' ) }
-					disabled={ ! refetch }
-					onClick={ () => refetch?.() }
-					className={ classnames( 'domains__domain-refresh', {
-						'is-invisible-field': ! refetch,
-					} ) }
-					variant="link"
-				>
-					<span className="refresh-label">{ __( 'Try again' ) }</span>
-				</Button>
-			</span>
-		</>
+		<span className="validation-actions">
+			{ isGoogleDomainsTransferFlow &&
+				// this means that the domain is locked and we need to show the instructions
+				errorStatus === domainAvailability.SERVER_TRANSFER_PROHIBITED_NOT_TRANSFERRABLE && (
+					<GoogleDomainsModal
+						className={ classnames( {
+							'is-first-row': showLabels,
+						} ) }
+						focusedStep={ 3 }
+					>
+						<span className="unlock-label">{ __( 'How to unlock' ) }</span>
+					</GoogleDomainsModal>
+				) }
+			<Button
+				// Disable the delete button on initial state meaning. no domain, no auth and one row.
+				disabled={ ! domain && ! auth && domainCount === 1 }
+				onClick={ () => onRemove( id ) }
+				variant="link"
+			>
+				<span className="delete-label">{ __( 'Clear domain' ) }</span>
+			</Button>
+			<Button
+				title={ __( 'Refresh' ) }
+				disabled={ ! refetch }
+				onClick={ () => refetch?.() }
+				className={ classnames( 'domains__domain-refresh', {
+					'is-invisible-field': ! refetch,
+				} ) }
+				variant="link"
+			>
+				<span className="refresh-label">{ __( 'Try again' ) }</span>
+			</Button>
+		</span>
 	);
 
 	const renderGoogleDomainsModal = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -143,40 +143,41 @@ export function DomainCodePair( {
 		}
 	}, [ shouldReportError, valid, domain, message, errorStatus ] );
 
-	const domainActions = ( inputValidationTextDisplayed = true ) => (
+	const domainActions = () => (
 		<>
-			{ inputValidationTextDisplayed ? <span>&nbsp;</span> : '' }
-			{ isGoogleDomainsTransferFlow &&
-				// this means that the domain is locked and we need to show the instructions
-				errorStatus === domainAvailability.SERVER_TRANSFER_PROHIBITED_NOT_TRANSFERRABLE && (
-					<GoogleDomainsModal
-						className={ classnames( {
-							'is-first-row': showLabels,
-						} ) }
-						focusedStep={ 3 }
-					>
-						<span className="unlock-label">{ __( 'How to unlock' ) }</span>
-					</GoogleDomainsModal>
-				) }
-			<Button
-				// Disable the delete button on initial state meaning. no domain, no auth and one row.
-				disabled={ ! domain && ! auth && domainCount === 1 }
-				onClick={ () => onRemove( id ) }
-				variant="link"
-			>
-				<span className="delete-label">{ __( 'Clear domain' ) }</span>
-			</Button>
-			<Button
-				title={ __( 'Refresh' ) }
-				disabled={ ! refetch }
-				onClick={ () => refetch?.() }
-				className={ classnames( 'domains__domain-refresh', {
-					'is-invisible-field': ! refetch,
-				} ) }
-				variant="link"
-			>
-				<span className="refresh-label">{ __( 'Try again' ) }</span>
-			</Button>
+			<span className="validation-actions">
+				{ isGoogleDomainsTransferFlow &&
+					// this means that the domain is locked and we need to show the instructions
+					errorStatus === domainAvailability.SERVER_TRANSFER_PROHIBITED_NOT_TRANSFERRABLE && (
+						<GoogleDomainsModal
+							className={ classnames( {
+								'is-first-row': showLabels,
+							} ) }
+							focusedStep={ 3 }
+						>
+							<span className="unlock-label">{ __( 'How to unlock' ) }</span>
+						</GoogleDomainsModal>
+					) }
+				<Button
+					// Disable the delete button on initial state meaning. no domain, no auth and one row.
+					disabled={ ! domain && ! auth && domainCount === 1 }
+					onClick={ () => onRemove( id ) }
+					variant="link"
+				>
+					<span className="delete-label">{ __( 'Clear domain' ) }</span>
+				</Button>
+				<Button
+					title={ __( 'Refresh' ) }
+					disabled={ ! refetch }
+					onClick={ () => refetch?.() }
+					className={ classnames( 'domains__domain-refresh', {
+						'is-invisible-field': ! refetch,
+					} ) }
+					variant="link"
+				>
+					<span className="refresh-label">{ __( 'Try again' ) }</span>
+				</Button>
+			</span>
 		</>
 	);
 
@@ -287,7 +288,7 @@ export function DomainCodePair( {
 							<FormInputValidation
 								isError={ ! valid }
 								text={ message }
-								children={ domainActions( true ) }
+								children={ domainActions() }
 							></FormInputValidation>
 						) }
 						{ message && loading && (
@@ -303,7 +304,7 @@ export function DomainCodePair( {
 								isError={ false }
 								text=""
 								isMuted={ true }
-								children={ domainCount > 1 && domainActions( false ) }
+								children={ domainCount > 1 && domainActions() }
 							/>
 						) }
 					</div>
@@ -331,7 +332,7 @@ export function DomainCodePair( {
 					<FormInputValidation
 						isError={ ! valid }
 						text={ message }
-						children={ domainActions( true ) }
+						children={ domainActions() }
 					></FormInputValidation>
 				) }
 				{ message && loading && (
@@ -347,7 +348,7 @@ export function DomainCodePair( {
 						isError={ false }
 						isMuted={ true }
 						text=""
-						children={ domainCount > 1 && domainActions( false ) }
+						children={ domainCount > 1 && domainActions() }
 					/>
 				) }
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -163,14 +163,24 @@
 			text-decoration: underline;
 		}
 
-
-		.components-button:has(.delete-label),
-		.components-button:has(.refresh-label),
-		.components-button:has(.unlock-label), {
-			color: var(--gray-gray-100, #101517);
-			text-decoration-color: var(--gray-gray-100, #101517);
+		.validation-actions {
+			margin-left: 5px;
+			@media (max-width: $break-medium ) {
+				display: block;
+				margin-left: 0;
+			}
+			.components-button:has(.delete-label),
+			.components-button:has(.refresh-label),
+			.components-button:has(.unlock-label), {
+				color: var(--gray-gray-100, #101517);
+				text-decoration-color: var(--gray-gray-100, #101517);
+				@media (max-width: $break-medium ) {
+					&.is-first-row {
+						margin-left: 0;
+					}
+				}
+			}
 		}
-
 		.is-muted.is-checking-domain {
 			@keyframes animate-dots {
 				0% {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -172,8 +172,8 @@
 			.components-button:has(.delete-label),
 			.components-button:has(.refresh-label),
 			.components-button:has(.unlock-label), {
-				color: var(--gray-gray-100, #101517);
-				text-decoration-color: var(--gray-gray-100, #101517);
+				color: var(--studio-gray-100, #101517);
+				text-decoration-color: var(--studio-gray-100, #101517);
 				@media (max-width: $break-medium ) {
 					&.is-first-row {
 						margin-left: 0;


### PR DESCRIPTION
[Context](p1690806682853719/1690804785.382209-slack-C05CT832K2T)

## Proposed Changes

Improve validation messages style on mobile

## Testing Instructions

Pull and run this branch or use live link
Simulate a mobile view port
Navigate to `setup/google-transfer/domains`
On domains, add `wp.dev` code `123456`.
The validation message should be entirely in one line below the red message.
<img width="394" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/b6eba54b-5fa3-4657-9144-87e53bbe309c">

On desktop it should look like:
<img width="1022" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/e1ae2712-9bfb-4a60-86af-533ee915122f">


