### PR TITLE
Security settings: Redirect if no site id

### DIFF
--- a/client/my-sites/site-settings/settings-security/controller.js
+++ b/client/my-sites/site-settings/settings-security/controller.js
@@ -10,8 +10,8 @@ export function security( context, next ) {
 	// Otherwise, redirect to site selection.
 	if ( siteId ) {
 		context.primary = createElement( SecurityMain );
-		next();
-	} else {
-		return page.redirect( '/settings/security' );
+		return next();
 	}
+	page.redirect( '/settings/security' );
+	return;
 }

--- a/client/my-sites/site-settings/settings-security/controller.js
+++ b/client/my-sites/site-settings/settings-security/controller.js
@@ -1,7 +1,17 @@
+import page from 'page';
 import { createElement } from 'react';
 import SecurityMain from 'calypso/my-sites/site-settings/settings-security/main';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export function security( context, next ) {
-	context.primary = createElement( SecurityMain );
-	next();
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	// If we have a site ID, render the main component
+	// Otherwise, redirect to site selection.
+	if ( siteId ) {
+		context.primary = createElement( SecurityMain );
+		next();
+	} else {
+		return page.redirect( '/settings/security' );
+	}
 }

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -34,9 +34,9 @@ export const SiteSettingsSecurity = ( {
 		return (
 			<EmptyContent
 				action={ translate( 'Manage general settings for %(site)s', {
-					args: { site: site.name || site.slug },
+					args: { site: site?.name || site?.slug },
 				} ) }
-				actionURL={ '/settings/general/' + site.slug }
+				actionURL={ '/settings/general/' + site?.slug }
 				title={ translate( 'No security configuration is required.' ) }
 				line={ translate( 'Security management is automatic for WordPress.com sites.' ) }
 				illustration="/calypso/images/illustrations/illustration-jetpack.svg"
@@ -65,7 +65,7 @@ export const SiteSettingsSecurity = ( {
 			/>
 			<SiteSettingsNavigation site={ site } section="security" />
 			{ showCredentials && <JetpackCredentials /> }
-			{ showJetpackBanner && <JetpackCredentialsBanner siteSlug={ site.slug } /> }
+			{ showJetpackBanner && <JetpackCredentialsBanner siteSlug={ site?.slug } /> }
 			<JetpackMonitor />
 			<FormSecurity />
 		</Main>

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -34,9 +34,9 @@ export const SiteSettingsSecurity = ( {
 		return (
 			<EmptyContent
 				action={ translate( 'Manage general settings for %(site)s', {
-					args: { site: site?.name || site?.slug },
+					args: { site: site.name || site.slug },
 				} ) }
-				actionURL={ '/settings/general/' + site?.slug }
+				actionURL={ '/settings/general/' + site.slug }
 				title={ translate( 'No security configuration is required.' ) }
 				line={ translate( 'Security management is automatic for WordPress.com sites.' ) }
 				illustration="/calypso/images/illustrations/illustration-jetpack.svg"
@@ -65,7 +65,7 @@ export const SiteSettingsSecurity = ( {
 			/>
 			<SiteSettingsNavigation site={ site } section="security" />
 			{ showCredentials && <JetpackCredentials /> }
-			{ showJetpackBanner && <JetpackCredentialsBanner siteSlug={ site?.slug } /> }
+			{ showJetpackBanner && <JetpackCredentialsBanner siteSlug={ site.slug } /> }
 			<JetpackMonitor />
 			<FormSecurity />
 		</Main>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See p1690769806769059-slack-C04U5A26MJB

## Proposed Changes

* Add redirect to fix reported error.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /settings/security/test and confirm that you're redirected to /settings/security.
* Go to Settings > Security or /settings/security for a Simple site.
* Confirm that you see the correct site name on the CTA and can click through to access General Settings.
<img width="870" alt="Screen Shot 2023-07-31 at 5 01 12 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/110be854-0b4c-4972-968e-b7fa5497c2b0">

* Go to an Atomic site and a Jetpack site.
* Confirm that you're able to access and update settings.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?