### PR TITLE
Domain Transfer: open step 3/4 by default

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/google-domains-transfer-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/google-domains-transfer-instructions/index.tsx
@@ -78,7 +78,7 @@ const GoogleDomainsModal: React.FC< Props > = ( { children, className, focusedSt
 							<source src="https://cldup.com/bYWgYH_hoP.mp4" type="video/mp4" />
 						</video>
 					</details>
-					<details open={ 4 === focusedStep }>
+					<details open={ 3 === focusedStep || 4 === focusedStep }>
 						<summary>{ __( 'Step 4: Get auth code' ) }</summary>
 						<p>
 							{ __(


### PR DESCRIPTION
When opening instructions with "unlock domain" also show how to get auth code by default.