### PR TITLE
Jetpack Pro Dashboard: Move Backup Add-ons to their own section on the license screen

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -55,6 +55,12 @@ export default function IssueMultipleLicensesForm( {
 		allProducts?.filter(
 			( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-packs'
 		) || [];
+	const backupAddons =
+		allProducts
+			?.filter(
+				( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-backup-storage'
+			)
+			.sort( ( a, b ) => a.product_id - b.product_id ) || [];
 	const wooExtensions =
 		allProducts?.filter(
 			( { family_slug }: { family_slug: string } ) =>
@@ -64,6 +70,7 @@ export default function IssueMultipleLicensesForm( {
 		allProducts?.filter(
 			( { family_slug }: { family_slug: string } ) =>
 				family_slug !== 'jetpack-packs' &&
+				family_slug !== 'jetpack-backup-storage' &&
 				family_slug.substring( 0, 'woocommerce-'.length ) !== 'woocommerce-'
 		) || [];
 
@@ -233,6 +240,28 @@ export default function IssueMultipleLicensesForm( {
 								isDisabled={ ! isReady && selectedBundle?.slug !== productOption.slug }
 								onSelectProduct={ onSelectBundle }
 								tabIndex={ 100 + ( products?.length || 0 ) + i }
+							/>
+						) ) }
+					</div>
+				</>
+			) }
+			{ backupAddons.length > 0 && (
+				<>
+					<hr className="issue-multiple-licenses-form__separator" />
+					<p className="issue-multiple-licenses-form__description">
+						{ translate( 'VaultPress Backup Add-on Storage:' ) }
+					</p>
+					<div className="issue-multiple-licenses-form__bottom">
+						{ backupAddons.map( ( productOption, i ) => (
+							<LicenseProductCard
+								isMultiSelect
+								key={ productOption.slug }
+								product={ productOption }
+								onSelectProduct={ onSelectProduct }
+								isSelected={ selectedProductSlugs.includes( productOption.slug ) }
+								isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
+								tabIndex={ 100 + i }
+								suggestedProduct={ suggestedProduct }
 							/>
 						) ) }
 					</div>


### PR DESCRIPTION
1204137270272763-as-1205008837541311

## Proposed Changes

* Jetpack Pro Dashboard: Move Backup Add-ons to their own section on the license screen

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open up http://jetpack.cloud.localhost:3000/partner-portal/issue-license and make sure there's no "VaultPress Backup Add-on Storage:" section yet.
* Apply billing scheme 871 to your partner key (please reach out to team Avalon if you're unsure what this means).
* Open up http://jetpack.cloud.localhost:3000/partner-portal/issue-license and make sure the "VaultPress Backup Add-on Storage:" section now shows up:

![Screenshot 2023-07-31 at 17 25 44](https://github.com/Automattic/wp-calypso/assets/22746396/bd7b9450-d386-46a5-9c85-94d8b0a48d08)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?