### PR TITLE
Limited GS: Update stickers notes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -389,8 +389,9 @@ function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
 	switch_to_blog( $blog_id );
 
 	$note = 'Automated sticker. See https://wp.me/p7DVsv-fY6#comment-44778';
+	$user = 'a8c'; // A non-empty string avoids storing the current user as author of the sticker change.
 
-	add_blog_sticker( 'wpcom-premium-global-styles-exemption-checked', $note, 'a8c', $blog_id );
+	add_blog_sticker( 'wpcom-premium-global-styles-exemption-checked', $note, $user, $blog_id );
 
 	$global_styles_used = false;
 
@@ -408,7 +409,7 @@ function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
 	}
 
 	if ( $global_styles_used ) {
-		add_blog_sticker( 'wpcom-premium-global-styles-exempt', $note, 'a8c', $blog_id );
+		add_blog_sticker( 'wpcom-premium-global-styles-exempt', $note, $user, $blog_id );
 	}
 
 	restore_current_blog();
@@ -663,12 +664,13 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 		 */
 		$has_personal_plan = wpcom_site_has_personal_plan( $blog_id );
 		$note              = 'Automated sticker. See https://wp.me/paYJgx-3yE';
+		$user              = 'a8c'; // A non-empty string avoids storing the current user as author of the sticker change.
 		if ( $has_personal_plan ) {
 			if ( ! wpcom_global_styles_has_blog_sticker( 'wpcom-global-styles-personal-plan', $blog_id ) ) {
-				add_blog_sticker( 'wpcom-global-styles-personal-plan', $note, 'a8c', $blog_id );
+				add_blog_sticker( 'wpcom-global-styles-personal-plan', $note, $user, $blog_id );
 			}
 		} else {
-			remove_blog_sticker( 'wpcom-global-styles-personal-plan', $note, 'a8c', $blog_id );
+			remove_blog_sticker( 'wpcom-global-styles-personal-plan', $note, $user, $blog_id );
 		}
 		return $has_personal_plan;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -388,9 +388,9 @@ function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
 
 	switch_to_blog( $blog_id );
 
-	$note = 'See https://wp.me/p7DVsv-fY6#comment-44778';
+	$note = 'Automated sticker. See https://wp.me/p7DVsv-fY6#comment-44778';
 
-	add_blog_sticker( 'wpcom-premium-global-styles-exemption-checked', $note, null, $blog_id );
+	add_blog_sticker( 'wpcom-premium-global-styles-exemption-checked', $note, 'a8c', $blog_id );
 
 	$global_styles_used = false;
 
@@ -408,7 +408,7 @@ function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
 	}
 
 	if ( $global_styles_used ) {
-		add_blog_sticker( 'wpcom-premium-global-styles-exempt', $note, null, $blog_id );
+		add_blog_sticker( 'wpcom-premium-global-styles-exempt', $note, 'a8c', $blog_id );
 	}
 
 	restore_current_blog();
@@ -662,13 +662,13 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 		 * in the Personal plan.
 		 */
 		$has_personal_plan = wpcom_site_has_personal_plan( $blog_id );
-		$note              = 'See https://wp.me/paYJgx-3yE';
+		$note              = 'Automated sticker. See https://wp.me/paYJgx-3yE';
 		if ( $has_personal_plan ) {
 			if ( ! wpcom_global_styles_has_blog_sticker( 'wpcom-global-styles-personal-plan', $blog_id ) ) {
-				add_blog_sticker( 'wpcom-global-styles-personal-plan', $note, null, $blog_id );
+				add_blog_sticker( 'wpcom-global-styles-personal-plan', $note, 'a8c', $blog_id );
 			}
 		} else {
-			remove_blog_sticker( 'wpcom-global-styles-personal-plan', $note, null, $blog_id );
+			remove_blog_sticker( 'wpcom-global-styles-personal-plan', $note, 'a8c', $blog_id );
 		}
 		return $has_personal_plan;
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3184

## Proposed Changes

Updates the blog stickers added as part of the Limited Globals Styles logic so they are less confusing for HEs:
- The current user is no longer tracked. This was causing HEs to think they were accidentally adding these stickers.
- Added a "Automated sticker" to the sticker notes to make clear the sticker has not been added manually.

Before | After
--- | ---
<img width="568" alt="Screenshot 2023-07-31 at 16 37 21" src="https://github.com/Automattic/wp-calypso/assets/1233880/de69754b-66b0-48d8-abe7-8ea4c7054375"> | <img width="565" alt="Screenshot 2023-07-31 at 16 37 06" src="https://github.com/Automattic/wp-calypso/assets/1233880/8e19caf3-6a87-4e5b-a269-f045d5e4037e">



## Testing Instructions

- Apply these changes to your sandbox.
- Sandbox a Free site with limited GS.
- Assign yourself to the `treatment` group of the GS on Personal A/B test.
- Purchase a Personal plan.
- Visit the frontend of your site.
- Go to the Blog RC.
- In the Audit Trail, check the "add sticker" event of the `wpcom-global-styles-personal-plan` sticker.
- Make sure the user is empty.
- Make sure the notes say "Automated sticker".