### PR TITLE
Change 'We pay the first year' to 'We’ve paid for an extra year'

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -81,8 +81,8 @@ const DomainPrice = ( { rawPrice, saleCost, currencyCode = 'USD' }: DomainPriceP
 	}
 
 	let pricetext = __( 'First year free' );
-	if ( englishLocales.includes( locale ) || hasTranslation( 'We pay the first year' ) ) {
-		pricetext = __( 'We pay the first year' );
+	if ( englishLocales.includes( locale ) || hasTranslation( 'We’ve paid for an extra year' ) ) {
+		pricetext = __( 'We’ve paid for an extra year' );
 	}
 
 	return (

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/DomainsTransferredList.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/DomainsTransferredList.tsx
@@ -26,10 +26,10 @@ const DomainsTransferredList = ( { purchases, currency = 'USD' }: Props ) => {
 	const purchaseLabel = ( priceInteger: number ) => {
 		const hasTranslation =
 			englishLocales.includes( String( getLocaleSlug() ) ) ||
-			i18n.hasTranslation( 'We pay the first year' );
+			i18n.hasTranslation( 'We’ve paid for an extra year' );
 
 		if ( priceInteger === 0 ) {
-			return hasTranslation ? __( 'We pay the first year' ) : __( 'Free for one year' );
+			return hasTranslation ? __( 'We’ve paid for an extra year' ) : __( 'Free for one year' );
 		}
 
 		const priceFormatted = formatCurrency( priceInteger, currency, {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3309

## Proposed Changes

* This PR changes 'We pay the first year' copy to 'We’ve paid for an extra year' on the Google Domains transfer Thank You page and domain input page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On the transfer input page http://calypso.localhost:3000/setup/google-transfer/domains
* You can use this to test Google Domain (don't actually transfer it) p1690572496812839/1690568397.986559-slack-CKZHG0QCR

Before | After
--|--
![transfer-before](https://github.com/Automattic/wp-calypso/assets/140841/dbef09d5-f0b3-4c6b-9bfd-e9336bd9761f) | ![transfer-after](https://github.com/Automattic/wp-calypso/assets/140841/d1b51f34-dc34-499f-bf28-50d4f683a804)

* Check the Thank You page /checkout/thank-you/no-site/:receipt-id

Ensure that the old translation 'Free for one year' is used if translations for 'We’ve paid for an extra year' do not yet exist.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?