### PR TITLE
Domain Transfer: Update intro step badge to be more consistent with copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
@@ -58,7 +58,7 @@ const Intro: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 						title: __( 'Checkout' ),
 						badge: isGoogleDomainsTransferFlow
 							? __( 'We pay the first year' )
-							: __( 'Free for Google Domains' ),
+							: __( 'We pay the first year for Google domains' ),
 						description: (
 							<p>
 								{ isEnglishLocale ||

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/styles.scss
@@ -113,6 +113,10 @@ $heading-font-family: "SF Pro Display", $sans;
 						margin-left: 16px;
 						vertical-align: middle;
 						font-size: rem(12px);
+
+						@media (max-width: $break-mobile) {
+							height: auto;
+						}
 					}
 
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3309

## Proposed Changes

* Changes intro step badge text to be more consistent with copy elsewhere.

<img width="1017" alt="Screenshot 2023-07-31 at 11 41 13 AM" src="https://github.com/Automattic/wp-calypso/assets/1126811/c155818f-0fa2-4bb6-a6f3-783ef5c41d9f">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout patch
* Go to `/setup/domain-transfer` and verify copy changes
* Make viewport small and ensure wrapping
* Go to `/setup/google-transfer` and ensure no changes to copy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
