### PR TITLE
VideoPress: Fix e2e test due to blocked term

### DIFF
--- a/test/e2e/specs/onboarding/setup__videopress.ts
+++ b/test/e2e/specs/onboarding/setup__videopress.ts
@@ -19,7 +19,7 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'VideoPress Tailored Onboarding' ), () => {
 	const testUser = DataHelper.getNewTestUser( {
-		usernamePrefix: 'videopress_onboarding',
+		usernamePrefix: 'videoprss_onboarding', // removed the `e` from `press` because `videopress` is a blocked term for subdomains.
 	} );
 	const emailClient = new EmailClient();
 	let page: Page;

--- a/test/e2e/specs/onboarding/setup__videopress.ts
+++ b/test/e2e/specs/onboarding/setup__videopress.ts
@@ -19,7 +19,7 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'VideoPress Tailored Onboarding' ), () => {
 	const testUser = DataHelper.getNewTestUser( {
-		usernamePrefix: 'videoprss_onboarding', // removed the `e` from `press` because `videopress` is a blocked term for subdomains.
+		usernamePrefix: 'videoprss_onboarding', // removed the `e` from `press` because `videopress` is a blocked term for domains.
 	} );
 	const emailClient = new EmailClient();
 	let page: Page;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


This PR fixes the VideoPress onboarding e2e test which started failing after D116849-code was deployed because `videopress` is now a blocked term for sites.

## Proposed Changes

* edited site prefix to `videoprss` to no longer match on `videopress` (remove the `e` so it is still legible as "videopress")

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run the e2e test, it should not fail `yarn workspace wp-e2e-tests test -- specs/onboarding/setup__videopress.ts`
    * NOTE: You may need to setup your environment to run e2e tests. See `test/e2e/README.md`
* The test should take you all the way through to checkout (previously failed on the "setting up your site" progress bar screen)
   * you may see the error `Your card was declined. Your request was in live mode, but used a known test card.` upon checkout. This shouldn't happen when running on the test infra (as far as I know).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
