### PR TITLE
Remove no longer needed confetti logic

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -96,7 +96,7 @@ import PremiumPlanDetails from './premium-plan-details';
 import ProPlanDetails from './pro-plan-details';
 import CheckoutMasterbar from './redesign-v2/sections/CheckoutMasterbar';
 import Footer from './redesign-v2/sections/Footer';
-import { isRedesignV2, shouldShowConfettiExplosion } from './redesign-v2/utils';
+import { isRedesignV2 } from './redesign-v2/utils';
 import SiteRedirectDetails from './site-redirect-details';
 import StarterPlanDetails from './starter-plan-details';
 import TransferPending from './transfer-pending';
@@ -671,9 +671,9 @@ export class CheckoutThankYou extends Component<
 				} ) }
 			>
 				<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
-				{ this.isDataLoaded() &&
-					isRedesignV2( this.props ) &&
-					shouldShowConfettiExplosion( purchases ) && <ConfettiAnimation delay={ 1000 } /> }
+				{ this.isDataLoaded() && isRedesignV2( this.props ) && (
+					<ConfettiAnimation delay={ 1000 } />
+				) }
 				{ isRedesignV2( this.props ) && (
 					<CheckoutMasterbar
 						siteId={ this.props.selectedSite?.ID }

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
@@ -1,5 +1,4 @@
 import { isWpComPlan } from '@automattic/calypso-products';
-import { ReceiptPurchase } from 'calypso/state/receipts/types';
 import { CheckoutThankYouCombinedProps, getFailedPurchases, getPurchases } from '..';
 import { isBulkDomainTransfer } from '../utils';
 
@@ -29,11 +28,3 @@ export const isRedesignV2 = ( props: CheckoutThankYouCombinedProps ) => {
 	}
 	return false;
 };
-
-export function shouldShowConfettiExplosion( purchases: ReceiptPurchase[] ) {
-	if ( isBulkDomainTransfer( purchases ) ) {
-		return true;
-	}
-
-	return true;
-}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/80058

## Proposed Changes

* Remove `shouldShowConfettiExplosion` since we're now showing the confetti on the Bulk Domain Transfer Thank You page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that confetti shows on a domain purchase thank you page, and all other thank you pages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
