### PR TITLE
Launchpad: Add share site modal to the newsletter task lists

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/intent-newsletter.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-newsletter.tsx
@@ -1,9 +1,11 @@
 import { useLaunchpad } from '@automattic/data-stores';
 import { setUpActionsForTasks } from '@automattic/launchpad';
+import { useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import ShareSiteModal from '../../components/share-site-modal';
 import CustomerHomeLaunchpad from '.';
 import type { Task } from '@automattic/launchpad';
 import type { AppState } from 'calypso/types';
@@ -11,26 +13,35 @@ import type { AppState } from 'calypso/types';
 const LaunchpadIntentNewsletter = ( { checklistSlug }: { checklistSlug: string } ): JSX.Element => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
+	const site = useSelector( ( state: AppState ) => siteId && getSite( state, siteId ) );
 	const launchpadContext = 'customer-home';
 
 	const {
 		data: { checklist },
 	} = useLaunchpad( siteSlug, checklistSlug );
 
+	const [ shareSiteModalIsOpen, setShareSiteModalIsOpen ] = useState( false );
+
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
 	const tasklistCompleted = numberOfSteps > 0 && completedSteps === numberOfSteps;
 	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext };
+	const extraActions = { setShareSiteModalIsOpen };
 
 	const sortedTasksWithActions = ( tasks: Task[] ) => {
-		return setUpActionsForTasks( { tasks, siteSlug, tracksData } );
+		return setUpActionsForTasks( { tasks, siteSlug, tracksData, extraActions } );
 	};
 
 	return (
-		<CustomerHomeLaunchpad
-			checklistSlug={ checklistSlug }
-			taskFilter={ sortedTasksWithActions }
-		></CustomerHomeLaunchpad>
+		<>
+			<CustomerHomeLaunchpad
+				checklistSlug={ checklistSlug }
+				taskFilter={ sortedTasksWithActions }
+			></CustomerHomeLaunchpad>
+			{ shareSiteModalIsOpen && site && (
+				<ShareSiteModal setModalIsOpen={ setShareSiteModalIsOpen } site={ site } />
+			) }
+		</>
 	);
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80050

## Proposed Changes

The task `Share your site` could not be completed because it was missing the ShareSiteModal component on the`LaunchpadIntentNewsletter` component.

* Adds the `ShareSiteModal` component to the Newsletter task lists so the task `Share your site` can work properly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new Newsletter `/setup/newsletter/intro`
* Go through the flow until you land on the Customer Home
* Click on the `Share your site` task on the launchpad
* The modal should pop up

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
