### PR TITLE
Odyssey Stats: fix page base when changed

### DIFF
--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -88,7 +88,7 @@ const PostPurchaseNotices = ( {
 		setParamRemoved( true );
 		const newUrlObj = removeStatsPurchaseSuccessParam( window.location.href, !! isOdysseyStats );
 		if ( isOdysseyStats ) {
-			// We need to update the page base if it changed. Otherwise, then pagejs won't be able to find the routes.
+			// We need to update the page base if it changed. Otherwise, pagejs won't be able to find the routes.
 			page.base( `${ newUrlObj.pathname }${ newUrlObj.search }` );
 		}
 		// Odyssey would try to hack the URL on load to remove duplicate params. We need to wait for that to finish.

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -1,4 +1,6 @@
 import config from '@automattic/calypso-config';
+import page from 'page';
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import version_compare from 'calypso/lib/version-compare';
 import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
@@ -67,18 +69,30 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 	);
 };
 
-const PostPurchaseNotices = ( { siteId, statsPurchaseSuccess }: StatsNoticesProps ) => {
+const PostPurchaseNotices = ( {
+	siteId,
+	statsPurchaseSuccess,
+	isOdysseyStats,
+}: StatsNoticesProps ) => {
 	// Check if the GET param is passed to show the Free or Paid plan purchase notices
 	const showFreePlanPurchaseSuccessNotice = statsPurchaseSuccess === 'free';
 	const showPaidPlanPurchaseSuccessNotice = statsPurchaseSuccess === 'paid';
 
+	const [ paramRemoved, setParamRemoved ] = useState( false );
+
 	const removeParam = () => {
-		if ( ! statsPurchaseSuccess ) {
+		if ( ! statsPurchaseSuccess || paramRemoved ) {
 			return;
 		}
-		const newUrl = removeStatsPurchaseSuccessParam( window.location.href );
+		// Ensure it runs only once.
+		setParamRemoved( true );
+		const newUrlObj = removeStatsPurchaseSuccessParam( window.location.href, !! isOdysseyStats );
+		if ( isOdysseyStats ) {
+			// We need to update the page base if it changed. Otherwise, then pagejs won't be able to find the routes.
+			page.base( `${ newUrlObj.pathname }${ newUrlObj.search }` );
+		}
 		// Odyssey would try to hack the URL on load to remove duplicate params. We need to wait for that to finish.
-		setTimeout( () => window.history.replaceState( null, '', newUrl ), 300 );
+		setTimeout( () => window.history.replaceState( null, '', newUrlObj.toString() ), 300 );
 	};
 
 	return (
@@ -115,7 +129,11 @@ export default function StatsNotices( {
 
 	return supportNewStatsNotices ? (
 		<>
-			<PostPurchaseNotices siteId={ siteId } statsPurchaseSuccess={ statsPurchaseSuccess } />
+			<PostPurchaseNotices
+				siteId={ siteId }
+				statsPurchaseSuccess={ statsPurchaseSuccess }
+				isOdysseyStats={ isOdysseyStats }
+			/>
 			<NewStatsNotices siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
 		</>
 	) : (

--- a/client/my-sites/stats/stats-notices/lib/remove-stats-purchase-success-param.ts
+++ b/client/my-sites/stats/stats-notices/lib/remove-stats-purchase-success-param.ts
@@ -1,15 +1,15 @@
-const removeStatsPurchaseSuccessParam = ( url: string ) => {
+const getUrlwithStatsPurchaseSuccessParamRemoved = ( url: string, isOdysseyStats: boolean ) => {
 	// Delete param in GET params.
 	const currentUrl = new URL( url );
 	currentUrl.searchParams.delete( 'statsPurchaseSuccess' );
 
-	// Delete param in hash URL if any.
-	if ( currentUrl.hash ) {
+	// Delete param in hash URL for Odyssey Stats if any.
+	if ( isOdysseyStats && currentUrl.hash.startsWith( '#!' ) ) {
 		const hashUrl = new URL( currentUrl.hash.substring( 2 ), currentUrl.origin );
 		hashUrl.searchParams.delete( 'statsPurchaseSuccess' );
 		currentUrl.hash = `#!${ hashUrl.pathname }${ hashUrl.search }`;
 	}
-	return currentUrl.toString();
+	return currentUrl;
 };
 
-export { removeStatsPurchaseSuccessParam as default };
+export { getUrlwithStatsPurchaseSuccessParamRemoved as default };

--- a/client/my-sites/stats/stats-notices/lib/test/remove-stats-purchase-success-param.js
+++ b/client/my-sites/stats/stats-notices/lib/test/remove-stats-purchase-success-param.js
@@ -4,50 +4,66 @@ describe( 'removeStatsPurchaseSuccessParam', () => {
 	it( 'should return the original path if nothing removed', () => {
 		expect(
 			removeStatsPurchaseSuccessParam(
-				'https://wp.com/statsPurchaseSuccess=1/?page=page1&c=d#!/ab/c?e=f'
-			)
+				'https://wp.com/statsPurchaseSuccess=1/?page=page1&c=d#!/ab/c?e=f',
+				true
+			).toString()
 		).toEqual( 'https://wp.com/statsPurchaseSuccess=1/?page=page1&c=d#!/ab/c?e=f' );
-		expect( removeStatsPurchaseSuccessParam( 'https://wp.com/statsPurchaseSuccess=1' ) ).toEqual(
-			'https://wp.com/statsPurchaseSuccess=1'
-		);
+		expect(
+			removeStatsPurchaseSuccessParam( 'https://wp.com/statsPurchaseSuccess=1', true ).toString()
+		).toEqual( 'https://wp.com/statsPurchaseSuccess=1' );
 	} );
 
 	it( 'should return the path with the statsPurchaseSuccess in GET params removed', () => {
 		expect(
-			removeStatsPurchaseSuccessParam( 'https://wp.com/?statsPurchaseSuccess=1&page=page1' )
+			removeStatsPurchaseSuccessParam(
+				'https://wp.com/?statsPurchaseSuccess=1&page=page1',
+				false
+			).toString()
 		).toEqual( 'https://wp.com/?page=page1' );
 		expect(
-			removeStatsPurchaseSuccessParam( 'https://wp.com/?page=page1&statsPurchaseSuccess=1' )
+			removeStatsPurchaseSuccessParam(
+				'https://wp.com/?page=page1&statsPurchaseSuccess=1',
+				false
+			).toString()
 		).toEqual( 'https://wp.com/?page=page1' );
 		expect(
-			removeStatsPurchaseSuccessParam( 'https://wp.com/?page=page1&statsPurchaseSuccess=1&c=d' )
+			removeStatsPurchaseSuccessParam(
+				'https://wp.com/?page=page1&statsPurchaseSuccess=1&c=d',
+				false
+			).toString()
 		).toEqual( 'https://wp.com/?page=page1&c=d' );
-		expect( removeStatsPurchaseSuccessParam( 'https://wp.com/?statsPurchaseSuccess=1' ) ).toEqual(
-			'https://wp.com/'
-		);
+		expect(
+			removeStatsPurchaseSuccessParam( 'https://wp.com/?statsPurchaseSuccess=1', false ).toString()
+		).toEqual( 'https://wp.com/' );
 	} );
 
 	it( 'should return the path with the statsPurchaseSuccess in hash removed', () => {
 		expect(
-			removeStatsPurchaseSuccessParam( 'https://wp.com/?page=page1#!/ab/c?statsPurchaseSuccess=1' )
+			removeStatsPurchaseSuccessParam(
+				'https://wp.com/?page=page1#!/ab/c?statsPurchaseSuccess=1',
+				true
+			).toString()
 		).toEqual( 'https://wp.com/?page=page1#!/ab/c' );
 		expect(
 			removeStatsPurchaseSuccessParam(
-				'https://wp.com/?page=page1#!/ab/c?statsPurchaseSuccess=1&d=e'
-			)
+				'https://wp.com/?page=page1#!/ab/c?statsPurchaseSuccess=1&d=e',
+				true
+			).toString()
 		).toEqual( 'https://wp.com/?page=page1#!/ab/c?d=e' );
 		expect(
 			removeStatsPurchaseSuccessParam(
-				'https://wp.com/?page=page1#!/ab/c?d=e&statsPurchaseSuccess=1&f=g'
-			)
+				'https://wp.com/?page=page1#!/ab/c?d=e&statsPurchaseSuccess=1&f=g',
+				true
+			).toString()
 		).toEqual( 'https://wp.com/?page=page1#!/ab/c?d=e&f=g' );
 	} );
 
 	it( 'should return the path with the statsPurchaseSuccess in hash and query removed', () => {
 		expect(
 			removeStatsPurchaseSuccessParam(
-				'https://wp.com/?page=page1&statsPurchaseSuccess=1&c=d#!/ab/c?statsPurchaseSuccess=1&e=f'
-			)
+				'https://wp.com/?page=page1&statsPurchaseSuccess=1&c=d#!/ab/c?statsPurchaseSuccess=1&e=f',
+				true
+			).toString()
 		).toEqual( 'https://wp.com/?page=page1&c=d#!/ab/c?e=f' );
 	} );
 } );


### PR DESCRIPTION
Related to p1690781586002749/1690751976.487669-slack-C0438NHCLSY

## Proposed Changes

- Change`page.base` when base URL is changed by `replaceState`. Otherwise `page.js` wouldn't be able to find defined routes.
- Add a state `paramRemoved` to ensure `removeParam` runs only once 

## Testing Instructions

* Remove any paid Stats proudcts for your local test site
* Build Odyssey locally `STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
* Build Jetpack if needed `jetpack build plugins/jetpack`
* Open `/wp-admin/admin.php?page=stats`
* Purchase a Stats product from the upgrade notice
* Ensure when you are redirected back after purchase, the tabs and other links work on Stats Dashboard

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?