### PR TITLE
Odyssey Stats: change page base after replacing state

### DIFF
--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -87,12 +87,14 @@ const PostPurchaseNotices = ( {
 		// Ensure it runs only once.
 		setParamRemoved( true );
 		const newUrlObj = removeStatsPurchaseSuccessParam( window.location.href, !! isOdysseyStats );
-		if ( isOdysseyStats ) {
-			// We need to update the page base if it changed. Otherwise, pagejs won't be able to find the routes.
-			page.base( `${ newUrlObj.pathname }${ newUrlObj.search }` );
-		}
 		// Odyssey would try to hack the URL on load to remove duplicate params. We need to wait for that to finish.
-		setTimeout( () => window.history.replaceState( null, '', newUrlObj.toString() ), 300 );
+		setTimeout( () => {
+			window.history.replaceState( null, '', newUrlObj.toString() );
+			if ( isOdysseyStats ) {
+				// We need to update the page base if it changed. Otherwise, pagejs won't be able to find the routes.
+				page.base( `${ newUrlObj.pathname }${ newUrlObj.search }` );
+			}
+		}, 300 );
 	};
 
 	return (


### PR DESCRIPTION
Follow up for https://github.com/Automattic/wp-calypso/pull/80066 addressing https://github.com/Automattic/wp-calypso/pull/80066/files#r1279927299

## Proposed Changes

* Change page.base after replaceState

## Testing Instructions

Please follow instructions from: https://github.com/Automattic/wp-calypso/pull/80066

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
