### PR TITLE
Domains: Show transfer error when starting a domain transfer manually

### DIFF
--- a/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
+++ b/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
@@ -81,12 +81,13 @@ export const transferDomainAction: AuthCodeValidationHandler =
 					await startInboundTransfer( selectedSite.ID, domain, authCode );
 					page( domainManagementTransferIn( selectedSite.slug, domain ) );
 				} catch ( error ) {
-					const errorMessage =
+					const errorMessage = error instanceof Error ? error.message : String( error );
+					const message =
 						transferDomainError.GENERIC_ERROR +
 						' ' +
 						__( 'Error message: ' ) +
-						`"${ error.message }"`;
-					onDone( { message: errorMessage } );
+						`"${ errorMessage }"`;
+					onDone( { message } );
 				}
 			};
 

--- a/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
+++ b/client/components/domains/use-my-domain/utilities/transfer-domain-action.ts
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import page from 'page';
 import {
 	transferDomainError,
@@ -80,7 +81,12 @@ export const transferDomainAction: AuthCodeValidationHandler =
 					await startInboundTransfer( selectedSite.ID, domain, authCode );
 					page( domainManagementTransferIn( selectedSite.slug, domain ) );
 				} catch ( error ) {
-					onDone( { message: transferDomainError.GENERIC_ERROR } );
+					const errorMessage =
+						transferDomainError.GENERIC_ERROR +
+						' ' +
+						__( 'Error message: ' ) +
+						`"${ error.message }"`;
+					onDone( { message: errorMessage } );
 				}
 			};
 


### PR DESCRIPTION
## Proposed Changes

- When a domain transfer is in the "delayed provisioning" state, the user has to start it manually. If an error happens when starting the transfer, a generic message `We were unable to start the transfer` is shown.
- This PR updates Calypso so that the actual error message is shown in addition to the generic message. That way, users might have more information on what went wrong and what to do from there.

### Screenshots

- Before

> <img width="1076" alt="Screenshot 2023-07-31 at 19 24 27" src="https://github.com/Automattic/wp-calypso/assets/5324818/7e9c0d87-8c03-48bf-b814-b5f0a7946ef1">

- After

> <img width="1078" alt="Screenshot 2023-07-31 at 19 14 33" src="https://github.com/Automattic/wp-calypso/assets/5324818/e35923ba-4fa7-48a6-83e2-5613fdc58323">

## Testing Instructions

- Please follow the same testing instructions in D117601-code, as this PR depends on that diff

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?