### PR TITLE
Stats Notice: Refactor upgrade notice conditions for better readability

### DIFF
--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -47,22 +47,29 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 	// TODO: Display error messages on the notice.
 	const { hasLoadedPurchases } = usePurchasesToUpdateSiteProducts( isOdysseyStats, siteId );
 
-	const showPaidStatsNotice =
-		// Show the notice if the site is Jetpack or it is Odyssey Stats.
-		( ( config.isEnabled( 'stats/paid-stats' ) && ( isOdysseyStats || isSiteJetpackNotAtomic ) ) ||
-			// Gate notices for WPCOM sites behind a flag.
-			( config.isEnabled( 'stats/paid-wpcom-stats' ) &&
-				isWpcom &&
-				! isVip &&
-				! isP2 &&
-				! isOwnedByTeam51 ) ) &&
+	// Gate notices for WPCOM sites behind a flag.
+	const showUpgradeNoticeForWpcomSites =
+		config.isEnabled( 'stats/paid-wpcom-stats' ) &&
+		isWpcom &&
+		! isVip &&
+		! isP2 &&
+		! isOwnedByTeam51;
+	// Show the notice if the site is Jetpack or it is Odyssey Stats.
+	const showUpgradeNoticeOnOdyssey = config.isEnabled( 'stats/paid-stats' ) && isOdysseyStats;
+	const showUpgradeNoticeForJetpackNotAtomic =
+		config.isEnabled( 'stats/paid-stats' ) && isSiteJetpackNotAtomic;
+
+	const showDoYouLoveJetpackStatsNotice =
+		( showUpgradeNoticeOnOdyssey ||
+			showUpgradeNoticeForJetpackNotAtomic ||
+			showUpgradeNoticeForWpcomSites ) &&
 		// Show the notice if the site has not purchased the paid stats product.
 		! hasPaidStats &&
 		hasLoadedPurchases;
 
 	return (
 		<>
-			{ showPaidStatsNotice && <DoYouLoveJetpackStatsNotice siteId={ siteId } /> }
+			{ showDoYouLoveJetpackStatsNotice && <DoYouLoveJetpackStatsNotice siteId={ siteId } /> }
 			{ isOdysseyStats && <OptOutNotice siteId={ siteId } /> }
 			{ isOdysseyStats && <FeedbackNotice siteId={ siteId } /> }
 		</>


### PR DESCRIPTION
## Proposed Changes

Refactor the conditions to show the upsell nudge for better readability.

## Testing Instructions

* Ensure the conditions are equivalent to the old ones
* Ensure for WPCOM sites, the notice is behind feature flag
* Ensure self hosted sites, the notice is still showing up

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
