### PR TITLE
Jetpack Pro Dashboard: show link with monitor paid upgrade cost

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/index.tsx
@@ -12,6 +12,7 @@ import {
 import FeatureRestrictionBadge from '../feature-restriction-badge';
 import SMSCounter from '../notification-settings/form-content/sms-counter';
 import { RestrictionType } from '../types';
+import UpgradeLink from '../upgrade-link';
 import ContactListItem from './item';
 import { getContactActionEventName, getContactItemValue } from './utils';
 
@@ -105,9 +106,10 @@ export default function ContactList( {
 					</div>
 				) }
 
-				{ showAddButton && restriction === 'upgrade_required' && (
+				{ showAddButton && restriction === 'upgrade_required' && type === 'email' && (
 					<div className="contact-list__upgrade-message">
 						{ translate( 'Multiple email recipients is part of the Basic plan.' ) }
+						<UpgradeLink isInline />
 					</div>
 				) }
 				{ showSMSCounter && type === 'sms' && <SMSCounter /> }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
@@ -5,8 +5,9 @@ import clockIcon from 'calypso/assets/images/jetpack/clock-icon.svg';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { availableNotificationDurations as durations } from '../../../sites-overview/utils';
 import FeatureRestrictionBadge from '../../feature-restriction-badge';
-import { RestrictionType } from '../../types';
+import UpgradeLink from '../../upgrade-link';
 import type { MonitorDuration } from '../../../sites-overview/types';
+import type { RestrictionType } from '../../types';
 
 interface Props {
 	selectedDuration?: MonitorDuration;
@@ -58,7 +59,12 @@ export default function NotificationDuration( {
 						disabled={ restriction !== 'none' && duration.isPaid }
 					>
 						{ duration.label }
-						{ duration.isPaid && <FeatureRestrictionBadge restriction={ restriction } /> }
+						{ duration.isPaid && (
+							<>
+								<FeatureRestrictionBadge restriction={ restriction } />
+								<UpgradeLink isInline />
+							</>
+						) }
 					</SelectDropdown.Item>
 				) ) }
 			</SelectDropdown>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
@@ -62,7 +62,7 @@ export default function NotificationDuration( {
 						{ duration.isPaid && (
 							<>
 								<FeatureRestrictionBadge restriction={ restriction } />
-								<UpgradeLink isInline />
+								{ restriction === 'upgrade_required' && <UpgradeLink isInline /> }
 							</>
 						) }
 					</SelectDropdown.Item>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
@@ -58,9 +58,11 @@ export default function SMSNotification( {
 					<div className="notification-settings__content-sub-heading">
 						{ translate( 'Set up text messages to send to one or more people.' ) }
 					</div>
-					<div>
-						<UpgradeLink />
-					</div>
+					{ restriction === 'upgrade_required' && (
+						<div>
+							<UpgradeLink />
+						</div>
+					) }
 				</div>
 			</div>
 			{ enableSMSNotification && (

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import ContactList from '../../contact-list';
 import FeatureRestrictionBadge from '../../feature-restriction-badge';
 import { RestrictionType } from '../../types';
+import UpgradeLink from '../../upgrade-link';
 import type { StateMonitorSettingsSMS } from '../../../sites-overview/types';
 
 interface Props {
@@ -56,6 +57,9 @@ export default function SMSNotification( {
 					</div>
 					<div className="notification-settings__content-sub-heading">
 						{ translate( 'Set up text messages to send to one or more people.' ) }
+					</div>
+					<div>
+						<UpgradeLink />
 					</div>
 				</div>
 			</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/index.tsx
@@ -1,0 +1,45 @@
+import { Button } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useContext } from 'react';
+import DashboardDataContext from '../../sites-overview/dashboard-data-context';
+
+import './style.scss';
+
+export default function UpgradeLink( { isInline = false } ) {
+	const translate = useTranslate();
+
+	const { products } = useContext( DashboardDataContext );
+
+	const monthlyProduct = products.find(
+		( product ) => product.slug === 'jetpack-monitor' && product.price_interval === 'month'
+	);
+
+	const price = monthlyProduct && formatCurrency( monthlyProduct.amount, monthlyProduct.currency );
+
+	const handleOnClick = () => {
+		// TODO: Add event tracking here
+		// TODO: Add redirect to upgrade link here
+		// Do not use href for redirect since it is being used inside an "a" tag
+		// and we cannot nest "a" tags
+	};
+
+	return (
+		<Button
+			className={ classNames( 'upgrade-link', { 'upgrade-link__inline': isInline } ) }
+			borderless
+			compact
+			onClick={ handleOnClick }
+		>
+			<span>
+				{ price
+					? translate( 'Upgrade (%(price)s/m)', {
+							args: { price },
+							comment: '%price is the price of the upgrade, e.g. $5/m where m is "month"',
+					  } )
+					: translate( 'Upgrade' ) }
+			</span>
+		</Button>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/index.tsx
@@ -27,7 +27,7 @@ export default function UpgradeLink( { isInline = false } ) {
 
 	return (
 		<Button
-			className={ classNames( 'upgrade-link', { 'upgrade-link__inline': isInline } ) }
+			className={ classNames( 'upgrade-link', { 'is-inline': isInline } ) }
 			borderless
 			compact
 			onClick={ handleOnClick }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/style.scss
@@ -7,7 +7,7 @@ button.upgrade-link {
 		text-decoration: underline;
 	}
 
-	&.upgrade-link__inline span {
+	&.is-inline span {
 		margin-inline-start: 4px;
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/style.scss
@@ -1,0 +1,13 @@
+button.upgrade-link {
+	font-size: 0.75rem;
+	font-weight: 400;
+	display: contents;
+
+	span {
+		text-decoration: underline;
+	}
+
+	&.upgrade-link__inline span {
+		margin-inline-start: 4px;
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context.ts
@@ -9,6 +9,7 @@ const DashboardDataContext = createContext< DashboardDataContextInterface >( {
 			return undefined;
 		},
 	},
+	products: [],
 } );
 
 export default DashboardDataContext;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -23,6 +23,7 @@ import {
 	getSelectedLicenses,
 	getSelectedLicensesSiteId,
 } from 'calypso/state/jetpack-agency-dashboard/selectors';
+import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
 import OnboardingWidget from '../../partner-portal/primary/onboarding-widget';
 import SitesOverviewContext from './context';
@@ -78,6 +79,8 @@ export default function SitesOverview() {
 		refetch: refetchContacts,
 		isError: fetchContactFailed,
 	} = useFetchMonitorVerfiedContacts( isPartnerOAuthTokenLoaded );
+
+	const { data: products } = useProductsQuery();
 
 	const selectedSiteIds = selectedSites.map( ( site ) => site.blog_id );
 
@@ -337,6 +340,7 @@ export default function SitesOverview() {
 											return;
 										},
 									},
+									products: products ?? [],
 								} }
 							>
 								<>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -7,12 +7,12 @@ import Pagination from 'calypso/components/pagination';
 import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { addQueryArgs } from 'calypso/lib/url';
-import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import EditButton from '../../dashboard-bulk-actions/edit-button';
 import {
 	useDashboardShowLargeScreen,
 	useJetpackAgencyDashboardRecordTrackEvent,
 } from '../../hooks';
+import DashboardDataContext from '../../sites-overview/dashboard-data-context';
 import SitesOverviewContext from '../context';
 import SiteBulkSelect from '../site-bulk-select';
 import SiteCard from '../site-card';
@@ -42,6 +42,7 @@ const SiteContent = ( { data, isLoading, currentPage, isFavoritesTab }: Props, r
 
 	const { isBulkManagementActive, currentLicenseInfo, hideLicenseInfo } =
 		useContext( SitesOverviewContext );
+	const { products } = useContext( DashboardDataContext );
 
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, ! isMobile );
 
@@ -56,8 +57,6 @@ const SiteContent = ( { data, isLoading, currentPage, isFavoritesTab }: Props, r
 	const isLargeScreen = useDashboardShowLargeScreen( siteTableRef, ref );
 
 	const firstColumn = siteColumns[ 0 ];
-
-	const { data: products } = useProductsQuery();
 
 	const currentLicenseProductSlug = currentLicenseInfo
 		? getProductSlugFromProductType( currentLicenseInfo )

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -1,3 +1,5 @@
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+
 // All types based on which the data is populated on the agency dashboard table rows
 export type AllowedTypes = 'site' | 'stats' | 'boost' | 'backup' | 'scan' | 'monitor' | 'plugin';
 
@@ -215,6 +217,7 @@ export interface DashboardDataContextInterface {
 		phoneNumbers: Array< string >;
 		refetchIfFailed: () => void;
 	};
+	products: APIProductFamilyProduct[];
 }
 
 export type AgencyDashboardFilterOption =


### PR DESCRIPTION
Related to 1204992567518369-as-1205042131904214

## Proposed Changes

This PR adds a link with the monitor paid upgrade cost.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/show-monitor-paid-ugrade-cost-link` and `yarn start-jetpack-cloud` or visit the Jetpack Cloud live link.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Apply D117122-code and follow the prerequisites mentioned here. 
4. Enable monitor if not enabled already > Click on the clock icon next to the monitor toggle.
5. Verify that you can see the Upgrade link on the 1-second option when you click on Duration, as shown below.

<img width="473" alt="Screenshot 2023-08-01 at 10 48 41 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/fa03cc3f-3cc0-4fe8-811a-0b81a938d944">

6. Verify that you can see the Upgrade link in the SMS & Email notification section, as shown below.

<img width="471" alt="Screenshot 2023-08-01 at 10 49 11 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b889d9fb-30e4-4dd3-971b-b91fde87129f">

Error case if failed to fetch the products or price not found

<img width="475" alt="Screenshot 2023-08-01 at 10 49 51 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/66253c8a-6eb8-4a73-b5f0-5cd96a6c4e54">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?