### PR TITLE
Add presales chat to checkout and thank you page

### DIFF
--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -4,11 +4,22 @@ import {
 	useZendeskMessaging,
 } from '@automattic/help-center/src/hooks';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import type { ZendeskConfigName } from '@automattic/help-center/src/hooks/use-zendesk-messaging';
 
 export type KeyType = 'akismet' | 'jpAgency' | 'jpCheckout' | 'jpGeneral' | 'wpcom';
+
+declare global {
+	interface Window {
+		zE: (
+			action: string,
+			value: string,
+			handler?: ( callback: ( data: string | number ) => void ) => void
+		) => void;
+	}
+}
 
 function getConfigName( keyType: KeyType ): ZendeskConfigName {
 	switch ( keyType ) {
@@ -53,11 +64,18 @@ export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabil
 
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const zendeskKeyName = getConfigName( keyType );
-	useZendeskMessaging(
+	const { isMessagingScriptLoaded } = useZendeskMessaging(
 		zendeskKeyName,
 		isEligibleForPresalesChat && isPresalesChatAvailable,
 		isLoggedIn
 	);
+
+	useEffect( () => {
+		// presales chat is always shown by default
+		if ( enabled && isPresalesChatAvailable && isMessagingScriptLoaded ) {
+			window.zE( 'messenger', 'show' );
+		}
+	}, [ enabled, isMessagingScriptLoaded, isPresalesChatAvailable ] );
 
 	return {
 		isChatActive: isPresalesChatAvailable && isEligibleForPresalesChat,

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -21,6 +21,7 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { preventWidows } from 'calypso/lib/formatting';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
 import { getTitanEmailUrl, hasTitanMailWithUs } from 'calypso/lib/titan';
 import { getTitanAppsUrlPrefix } from 'calypso/lib/titan/get-titan-urls';
 import {
@@ -568,6 +569,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 			primaryPurchase,
 			isRedesignV2,
 			selectedSite,
+			purchases,
 		} = this.props;
 		const classes = { 'is-placeholder': ! isDataLoaded };
 
@@ -586,6 +588,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 
 		return (
 			<div className={ classNames( 'checkout-thank-you__header', classes ) }>
+				{ isBulkDomainTransfer( purchases ) && <UsePresalesChat /> }
 				{ ! isRedesignV2 && (
 					<div className="checkout-thank-you__header-icon">
 						<img src={ `/calypso/images/upgrades/${ svg }` } alt="" />
@@ -654,6 +657,10 @@ export class CheckoutThankYouHeader extends PureComponent {
 			</ul>
 		);
 	}
+}
+
+export function UsePresalesChat() {
+	usePresalesChat( 'wpcom', true, true );
 }
 
 export default connect(

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -37,6 +37,7 @@ import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
@@ -358,6 +359,8 @@ function CheckoutSummaryFeaturesList( props: {
 	const hasDomainTransferProduct = responseCart.products.some( ( product ) =>
 		isDomainTransfer( product )
 	);
+
+	usePresalesChat( 'wpcom', hasDomainTransferProduct );
 
 	return (
 		<CheckoutSummaryFeaturesListWrapper>

--- a/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
@@ -54,6 +54,7 @@ import {
 import { checkoutTheme } from '@automattic/composite-checkout';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
 import { ThemeProvider } from '@emotion/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
@@ -174,6 +175,8 @@ const allAkismetFeatures = new Set(
 	}, [] )
 );
 
+const queryClient = new QueryClient();
+
 describe( 'WPCheckoutOrderSummary', () => {
 	let container: HTMLDivElement | null;
 	let MyCheckoutSummary: FC< { cartChanges: Partial< ResponseCart > } >;
@@ -232,7 +235,11 @@ describe( 'WPCheckoutOrderSummary', () => {
 					products: [ product ],
 				};
 
-				render( <MyCheckoutSummary cartChanges={ cartChanges } /> );
+				render(
+					<QueryClientProvider client={ queryClient }>
+						<MyCheckoutSummary cartChanges={ cartChanges } />
+					</QueryClientProvider>
+				);
 
 				await waitFor( () => {
 					productFeatures.map( ( feature ) => {
@@ -260,7 +267,11 @@ describe( 'WPCheckoutOrderSummary', () => {
 				products: allAkismetProducts,
 			};
 
-			render( <MyCheckoutSummary cartChanges={ cartChanges } /> );
+			render(
+				<QueryClientProvider client={ queryClient }>
+					<MyCheckoutSummary cartChanges={ cartChanges } />
+				</QueryClientProvider>
+			);
 
 			await waitFor( () => {
 				allAkismetFeatures.forEach( ( feature ) => {
@@ -272,7 +283,11 @@ describe( 'WPCheckoutOrderSummary', () => {
 		test( 'No feature list items show up if the cart is empty', async () => {
 			const cartChanges = { products: [] };
 
-			render( <MyCheckoutSummary cartChanges={ cartChanges } /> );
+			render(
+				<QueryClientProvider client={ queryClient }>
+					<MyCheckoutSummary cartChanges={ cartChanges } />
+				</QueryClientProvider>
+			);
 
 			await waitFor( async () => {
 				allAkismetFeatures.forEach( ( feature ) => {
@@ -294,7 +309,11 @@ describe( 'WPCheckoutOrderSummary', () => {
 					products: [ product ],
 				};
 
-				render( <MyCheckoutSummary cartChanges={ cartChanges } /> );
+				render(
+					<QueryClientProvider client={ queryClient }>
+						<MyCheckoutSummary cartChanges={ cartChanges } />
+					</QueryClientProvider>
+				);
 
 				await waitFor( () => {
 					productFeatures.map( ( feature ) => {
@@ -321,7 +340,11 @@ describe( 'WPCheckoutOrderSummary', () => {
 				products: allJetpackProducts,
 			};
 
-			render( <MyCheckoutSummary cartChanges={ cartChanges } /> );
+			render(
+				<QueryClientProvider client={ queryClient }>
+					<MyCheckoutSummary cartChanges={ cartChanges } />
+				</QueryClientProvider>
+			);
 
 			await waitFor( async () => {
 				allJetpackFeatures.forEach( ( feature ) => {
@@ -333,7 +356,11 @@ describe( 'WPCheckoutOrderSummary', () => {
 		test( 'No feature list items show up if the cart is empty', async () => {
 			const cartChanges = { products: [] };
 
-			render( <MyCheckoutSummary cartChanges={ cartChanges } /> );
+			render(
+				<QueryClientProvider client={ queryClient }>
+					<MyCheckoutSummary cartChanges={ cartChanges } />
+				</QueryClientProvider>
+			);
 
 			await waitFor( async () => {
 				allJetpackFeatures.forEach( ( feature ) => {

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -32,8 +32,6 @@ function useMessagingBindings( hasActiveChats: boolean, isMessagingScriptLoaded:
 			return;
 		}
 
-		window.zE( 'messenger', 'hide' );
-
 		window.zE( 'messenger:on', 'open', function () {
 			setShowMessagingWidget( true );
 		} );
@@ -51,8 +49,10 @@ function useMessagingBindings( hasActiveChats: boolean, isMessagingScriptLoaded:
 		if ( typeof window.zE !== 'function' || ! isMessagingScriptLoaded ) {
 			return;
 		}
-
-		window.zE( 'messenger', showMessagingLauncher ? 'show' : 'hide' );
+		// `showMessagingLauncher` starts off as undefined. This check means don't touch the widget if we're in default state.
+		if ( typeof showMessagingLauncher === 'boolean' ) {
+			window.zE( 'messenger', showMessagingLauncher ? 'show' : 'hide' );
+		}
 	}, [ showMessagingLauncher, isMessagingScriptLoaded ] );
 
 	useEffect( () => {
@@ -105,6 +105,7 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 		isEligibleForChat || hasActiveChats,
 		isEligibleForChat && hasActiveChats
 	);
+
 	useMessagingBindings( hasActiveChats, isMessagingScriptLoaded );
 
 	useEffect( () => {

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -72,6 +72,10 @@ function useMessagingBindings( hasActiveChats: boolean, isMessagingScriptLoaded:
 
 const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
+	const isHelpCenterShown = useSelect(
+		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
+		[]
+	);
 	const { setSite } = useDispatch( HELP_CENTER_STORE );
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -102,7 +106,7 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	const { hasActiveChats, isEligibleForChat } = useChatStatus( 'wpcom_messaging', false );
 	const { isMessagingScriptLoaded } = useZendeskMessaging(
 		'zendesk_support_chat_key',
-		isEligibleForChat || hasActiveChats,
+		( isHelpCenterShown && isEligibleForChat ) || hasActiveChats,
 		isEligibleForChat && hasActiveChats
 	);
 

--- a/packages/help-center/src/hooks/use-zendesk-messaging.ts
+++ b/packages/help-center/src/hooks/use-zendesk-messaging.ts
@@ -46,6 +46,7 @@ export default function useZendeskMessaging(
 				}
 				return;
 			}
+			window.zE( 'messenger', 'hide' );
 
 			setMessagingScriptLoaded( true );
 		}


### PR DESCRIPTION
Fixes 3319-gh-Automattic/dotcom-forge

Followup on https://github.com/Automattic/wp-calypso/pull/80018 to expand to all pages in the flow e2e.

## Proposed Changes

* Adds presales chat popup to checkout page
* Adds presales chat popup to the checkout thank you page
* @alshakero: Change the ZD widget to load hidden by default and whoever wants it can show it. It was shown by default and the Help Center had to hide it which hid it for other users as well. Now the Help Center doesn't touch it unless the user engages it.
* @alshakero: Add a condition to only load ZD widget when the Help Center is open. This way, the presales widget will load the script before, forcing the Help Center to yield for it. And if the Help Center is opened later, it will find a script pre-loaded under the presales key. Making the Help Center a presales tool (pretty great since it only happens to places where we add the presales widget). 

## Todo

- [ ] Figure out why this doesn't load
- [x] Unit test failures against JP/akismet checkouts

## Testing Instructions

* http://calypso.localhost:3000/setup/google-stransfer or http://calypso.localhost:3000/setup/domain-transfer/
* Checkout with a domain transfer (you can lock the domain / re-generate the auth code once you've got passed validation to prevent your domain transfer from completing.

Before
![Screenshot(93)](https://github.com/Automattic/wp-calypso/assets/811776/5a6fde8a-00b4-4bbb-9ccf-ddfd579b5981)

After

TBD