### PR TITLE
Assembler: Add the shuffle button to the action bar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
@@ -50,6 +50,8 @@ export const PATTERN_ASSEMBLER_EVENTS = {
 	PATTERN_MOVEDOWN_CLICK: 'calypso_signup_pattern_assembler_pattern_movedown_click',
 	PATTERN_REPLACE_CLICK: 'calypso_signup_pattern_assembler_pattern_replace_click',
 	PATTERN_DELETE_CLICK: 'calypso_signup_pattern_assembler_pattern_delete_click',
+	PATTERN_SHUFFLE_CLICK: 'calypso_signup_pattern_assembler_pattern_shuffle_click',
+
 	PREVIEW_DEVICE_CLICK: 'calypso_signup_pattern_assembler_preview_device_click',
 
 	/**

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
@@ -1,8 +1,9 @@
 import { Button } from '@wordpress/components';
-import { chevronUp, chevronDown, close, edit } from '@wordpress/icons';
+import { chevronUp, chevronDown, close, edit, shuffle } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
+import type { Category } from './types';
 import './pattern-action-bar.scss';
 
 type PatternActionBarProps = {
@@ -10,9 +11,11 @@ type PatternActionBarProps = {
 	onDelete: () => void;
 	onMoveUp?: () => void;
 	onMoveDown?: () => void;
+	onShuffle: () => void;
 	disableMoveUp?: boolean;
 	disableMoveDown?: boolean;
 	patternType: string;
+	category?: Category;
 	isRemoveButtonTextOnly?: boolean;
 	source: 'list' | 'large_preview';
 };
@@ -22,13 +25,21 @@ const PatternActionBar = ( {
 	onDelete,
 	onMoveUp,
 	onMoveDown,
+	onShuffle,
 	disableMoveUp,
 	disableMoveDown,
 	patternType,
+	category,
 	isRemoveButtonTextOnly,
 	source,
 }: PatternActionBarProps ) => {
 	const translate = useTranslate();
+	const eventProps = {
+		pattern_type: patternType,
+		pattern_category: category?.name,
+		source,
+	};
+
 	return (
 		<div
 			className="pattern-action-bar"
@@ -43,9 +54,7 @@ const PatternActionBar = ( {
 						role="menuitem"
 						label={ translate( 'Move up' ) }
 						onClick={ () => {
-							recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_MOVEUP_CLICK, {
-								source,
-							} );
+							recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_MOVEUP_CLICK, eventProps );
 							onMoveUp?.();
 						} }
 						icon={ chevronUp }
@@ -57,9 +66,7 @@ const PatternActionBar = ( {
 						role="menuitem"
 						label={ translate( 'Move down' ) }
 						onClick={ () => {
-							recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_MOVEDOWN_CLICK, {
-								source,
-							} );
+							recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_MOVEDOWN_CLICK, eventProps );
 							onMoveDown?.();
 						} }
 						icon={ chevronDown }
@@ -67,16 +74,24 @@ const PatternActionBar = ( {
 					/>
 				</div>
 			) }
+			<Button
+				className="pattern-action-bar__block pattern-action-bar__action"
+				role="menuitem"
+				label={ translate( 'Shuffle' ) }
+				onClick={ () => {
+					recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_SHUFFLE_CLICK, eventProps );
+					onShuffle();
+				} }
+				icon={ shuffle }
+				iconSize={ 23 }
+			/>
 			{ onReplace && (
 				<Button
 					className="pattern-action-bar__block pattern-action-bar__action"
 					role="menuitem"
 					label={ translate( 'Replace' ) }
 					onClick={ () => {
-						recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_REPLACE_CLICK, {
-							pattern_type: patternType,
-							source,
-						} );
+						recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_REPLACE_CLICK, eventProps );
 						onReplace();
 					} }
 					icon={ edit }
@@ -88,10 +103,7 @@ const PatternActionBar = ( {
 				role="menuitem"
 				label={ translate( 'Remove' ) }
 				onClick={ () => {
-					recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_DELETE_CLICK, {
-						pattern_type: patternType,
-						source,
-					} );
+					recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_DELETE_CLICK, eventProps );
 					onDelete();
 				} }
 				icon={ ! isRemoveButtonTextOnly ? close : null }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -23,6 +23,7 @@ interface Props {
 	onMoveDownSection: ( position: number ) => void;
 	onDeleteHeader: () => void;
 	onDeleteFooter: () => void;
+	onShuffle: ( type: string, pattern: Pattern, position?: number ) => void;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 }
 
@@ -39,6 +40,7 @@ const PatternLargePreview = ( {
 	onMoveDownSection,
 	onDeleteHeader,
 	onDeleteFooter,
+	onShuffle,
 	recordTracksEvent,
 }: Props ) => {
 	const translate = useTranslate();
@@ -95,11 +97,12 @@ const PatternLargePreview = ( {
 
 	const renderPattern = ( type: string, pattern: Pattern, position = -1 ) => {
 		const key = type === 'section' ? pattern.key : type;
+		const handleShuffle = () => onShuffle( type, pattern, position );
 		const getActionBarProps = () => {
 			if ( type === 'header' ) {
-				return { onDelete: onDeleteHeader };
+				return { onDelete: onDeleteHeader, onShuffle: handleShuffle };
 			} else if ( type === 'footer' ) {
-				return { onDelete: onDeleteFooter };
+				return { onDelete: onDeleteFooter, onShuffle: handleShuffle };
 			}
 
 			return {
@@ -108,6 +111,7 @@ const PatternLargePreview = ( {
 				onDelete: () => onDeleteSection( position ),
 				onMoveUp: () => onMoveUpSection( position ),
 				onMoveDown: () => onMoveDownSection( position ),
+				onShuffle: handleShuffle,
 			};
 		};
 
@@ -128,6 +132,7 @@ const PatternLargePreview = ( {
 				/>
 				<PatternActionBar
 					patternType={ type }
+					category={ pattern.category }
 					isRemoveButtonTextOnly
 					source="large_preview"
 					{ ...getActionBarProps() }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -19,6 +19,7 @@ type PatternLayoutProps = {
 	onAddFooter?: () => void;
 	onReplaceFooter?: () => void;
 	onDeleteFooter?: () => void;
+	onShuffle: ( type: string, pattern: Pattern, position?: number ) => void;
 };
 
 const PatternLayout = ( {
@@ -28,6 +29,7 @@ const PatternLayout = ( {
 	onDeleteSection,
 	onMoveUpSection,
 	onMoveDownSection,
+	onShuffle,
 }: PatternLayoutProps ) => {
 	const translate = useTranslate();
 
@@ -37,7 +39,8 @@ const PatternLayout = ( {
 				<AsyncLoad require="./animate-list" featureName="domMax" placeholder={ <div /> }>
 					{ ( m: any ) => (
 						<m.ul className="pattern-layout__list" layoutScroll>
-							{ sections.map( ( { title, category, key }: Pattern, index ) => {
+							{ sections.map( ( pattern: Pattern, index ) => {
+								const { title, category, key } = pattern;
 								return (
 									<m.li
 										key={ key }
@@ -55,6 +58,7 @@ const PatternLayout = ( {
 											onDelete={ () => onDeleteSection( index ) }
 											onMoveUp={ () => onMoveUpSection( index ) }
 											onMoveDown={ () => onMoveDownSection( index ) }
+											onShuffle={ () => onShuffle( 'sections', pattern, index ) }
 											disableMoveUp={ index === 0 }
 											disableMoveDown={ sections?.length === index + 1 }
 										/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -1,4 +1,5 @@
 import { PATTERN_SOURCE_SITE_ID, CATEGORY_ALL_SLUG } from './constants';
+import type { Pattern, Category } from './types';
 
 export const encodePatternId = ( patternId: number ) =>
 	`${ patternId }-${ PATTERN_SOURCE_SITE_ID }`;
@@ -8,3 +9,37 @@ export const decodePatternId = ( encodedPatternId: number | string ) =>
 
 export const replaceCategoryAllName = ( name?: string ) =>
 	name === CATEGORY_ALL_SLUG ? 'all' : name;
+
+export const getShuffledPattern = ( candidates: Pattern[], current: Pattern ) => {
+	const filteredCandidates = candidates.filter( ( { ID } ) => ID !== current.ID );
+	const shuffledIndex = Math.floor( Math.random() * filteredCandidates.length );
+	return filteredCandidates[ shuffledIndex ];
+};
+
+export const injectCategoryToPattern = (
+	pattern: Pattern,
+	categories: Category[],
+	selectedCategory?: string | null
+) => {
+	// Inject the selected pattern category or the first category
+	// to be used in tracks and as selected pattern name.
+	const [ firstCategory ] = Object.keys( pattern.categories );
+	let category = categories.find( ( { name } ) => {
+		if ( selectedCategory === CATEGORY_ALL_SLUG ) {
+			return name === firstCategory;
+		}
+		return name === ( selectedCategory || firstCategory );
+	} );
+
+	if ( selectedCategory === CATEGORY_ALL_SLUG ) {
+		// Use 'all' rather than 'featured' as slug for tracks.
+		// Use the first category label as selected pattern name.
+		category = {
+			name: 'all',
+			label: pattern.category?.label,
+		};
+	}
+
+	pattern.category = category;
+	return pattern;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79656

## Proposed Changes

* Added the shuffle button to the action bar so users can quickly preview other patterns with the same category
* Added the new event called `calypso_signup_pattern_assembler_pattern_shuffle_click` to track how many users click the shuffle button.

**Demo**

https://github.com/Automattic/wp-calypso/assets/13596067/d2a815ad-17d5-4758-9264-4d6e5fe45972

**Event**

![image](https://github.com/Automattic/wp-calypso/assets/13596067/229df298-2db6-4a64-a9df-aa59b536cbca)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/with-theme-assembler?siteSlug=<your_site>`
* Select any header, sections, footer
* Hover on the patterns in the large preview
* Click the shuffle button on the action bar
* Ensure you're able to shuffle to another pattern with the same category

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
