### PR TITLE
I18N: Localize the Stats module names

### DIFF
--- a/client/blocks/stats-navigation/constants.ts
+++ b/client/blocks/stats-navigation/constants.ts
@@ -17,11 +17,20 @@ export const AVAILABLE_PAGE_MODULES = {
 	traffic: [
 		{
 			key: 'authors',
-			label: translate( 'Authors' ),
+			get label() {
+				return translate( 'Authors' );
+			},
 			icon: commentAuthorAvatar,
 			defaultValue: true,
 		},
-		{ key: 'videos', label: translate( 'Videos' ), icon: video, defaultValue: true },
+		{
+			key: 'videos',
+			get label() {
+				return translate( 'Videos' );
+			},
+			icon: video,
+			defaultValue: true,
+		},
 	],
 };
 
@@ -46,7 +55,9 @@ const insights = {
 // TODO: Consider adding subscriber counts into this nav item in the future.
 // See client/blocks/subscribers-count/index.jsx.
 const subscribers = {
-	label: translate( 'Subscribers' ),
+	get label() {
+		return translate( 'Subscribers' );
+	},
 	path: '/stats/subscribers',
 	showIntervals: false,
 } as NavItem;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 659-gh-Automattic/i18n-issues

## Proposed Changes

We ran into an issue with the Stats extensions being intermittently not localized:
![image](https://github.com/Automattic/wp-calypso/assets/23708351/aba28181-5787-47a3-a481-513386bf20ab)

This PR adds getters to the translated properties to make sure they re-render correctly. 

## Testing Instructions

1. Switch your locale to a Mag-16 locale
2. Navigate to the stats page of a site, click the Module settings menu and confirm the module names are localized
3. Switch to another site, go back to stats and confirm the module names are still localized.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
