### PR TITLE
Jetpack Error UX: Hook new Jetpack connection health API with existing UI

### DIFF
--- a/client/components/data/query-site-connection-status/index.jsx
+++ b/client/components/data/query-site-connection-status/index.jsx
@@ -10,6 +10,8 @@ import {
 
 const request = ( siteId ) => ( dispatch, getState ) => {
 	if ( siteId && ! isRequestingSiteConnectionStatus( getState(), siteId ) ) {
+		// Existing Jetpack Error UX in the sidebar is enabled only for non-Atomic Jetpack sites, and we may
+		// enable it for all Jetpack sites at some point. For now, we want to use new API endpoint.
 		const isJetpackErrorUxEnabled = isEnabled( 'yolo/jetpack-error-ux-i1' );
 		if ( isJetpackErrorUxEnabled ) {
 			dispatch( requestConnectionStatusV2( siteId ) );

--- a/client/components/data/query-site-connection-status/index.jsx
+++ b/client/components/data/query-site-connection-status/index.jsx
@@ -1,12 +1,21 @@
+import { isEnabled } from '@automattic/calypso-config';
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import isRequestingSiteConnectionStatus from 'calypso/state/selectors/is-requesting-site-connection-status';
-import { requestConnectionStatus } from 'calypso/state/site-connection/actions';
+import {
+	requestConnectionStatus,
+	requestConnectionStatusV2,
+} from 'calypso/state/site-connection/actions';
 
 const request = ( siteId ) => ( dispatch, getState ) => {
 	if ( siteId && ! isRequestingSiteConnectionStatus( getState(), siteId ) ) {
-		dispatch( requestConnectionStatus( siteId ) );
+		const isJetpackErrorUxEnabled = isEnabled( 'yolo/jetpack-error-ux-i1' );
+		if ( isJetpackErrorUxEnabled ) {
+			dispatch( requestConnectionStatusV2( siteId ) );
+		} else {
+			dispatch( requestConnectionStatus( siteId ) );
+		}
 	}
 };
 

--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -1,0 +1,25 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+
+export const JetpackConnectionHealthBanner = () => {
+	const translate = useTranslate();
+
+	return (
+		<Notice
+			status="is-error"
+			showDismiss={ false }
+			text={ translate( 'Jetpack connection failed.' ) }
+		>
+			<NoticeAction
+				href={ localizeUrl(
+					'https://wordpress.com/support/why-is-my-site-down/#theres-an-issue-with-your-sites-jetpack-connection'
+				) }
+				external
+			>
+				Attempt reconnection
+			</NoticeAction>
+		</Notice>
+	);
+};

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -5,6 +6,7 @@ import titlecase from 'to-title-case';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -12,6 +14,8 @@ import { mapPostStatus } from 'calypso/lib/route';
 import PostTypeFilter from 'calypso/my-sites/post-type-filter';
 import PostTypeList from 'calypso/my-sites/post-type-list';
 import { POST_STATUSES } from 'calypso/state/posts/constants';
+import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 class PostsMain extends Component {
@@ -45,7 +49,17 @@ class PostsMain extends Component {
 	}
 
 	render() {
-		const { author, category, search, siteId, statusSlug, tag, translate } = this.props;
+		const {
+			author,
+			category,
+			search,
+			siteId,
+			statusSlug,
+			tag,
+			translate,
+			isJetpack,
+			siteIsConnected,
+		} = this.props;
 		const status = mapPostStatus( statusSlug );
 		/* Check if All Sites Mode */
 		const isAllSites = siteId ? 1 : 0;
@@ -67,9 +81,13 @@ class PostsMain extends Component {
 		// Since searches are across all statuses, the status needs to be shown
 		// next to each post.
 		const showPublishedStatus = Boolean( query.search );
+		const isJetpackErrorUxEnabled = isEnabled( 'yolo/jetpack-error-ux-i1' );
 
 		return (
 			<Main wideLayout className="posts">
+				{ isJetpack && ! siteIsConnected && isJetpackErrorUxEnabled && (
+					<JetpackConnectionHealthBanner siteId={ siteId } />
+				) }
 				<ScreenOptionsTab wpAdminPath="edit.php" />
 				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />
 				<DocumentHead title={ translate( 'Posts' ) } />
@@ -101,6 +119,11 @@ class PostsMain extends Component {
 	}
 }
 
-export default connect( ( state ) => ( {
-	siteId: getSelectedSiteId( state ),
-} ) )( localize( PostsMain ) );
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		siteId,
+		isJetpack: isJetpackSite( state, siteId ),
+		siteIsConnected: getSiteConnectionStatus( state, siteId ),
+	};
+} )( localize( PostsMain ) );

--- a/client/my-sites/site-indicator/index.jsx
+++ b/client/my-sites/site-indicator/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -47,11 +48,15 @@ class SiteIndicator extends Component {
 	showIndicator() {
 		const { siteIsAutomatedTransfer, siteIsJetpack, userCanManage } = this.props;
 
+		// Existing Jetpack Error UX was enabled only for non-Atomic Jetpack sites
+		// We want to enable it for all Jetpack sites, but keep it behind a feature flag
+		const isJetpackErrorUxEnabled = isEnabled( 'yolo/jetpack-error-ux-i1' );
+
 		// Until WP.com sites have indicators (upgrades expiring, etc) we only show them for Jetpack sites
 		return (
 			userCanManage &&
 			siteIsJetpack &&
-			! siteIsAutomatedTransfer &&
+			( ! siteIsAutomatedTransfer || isJetpackErrorUxEnabled ) &&
 			( this.hasUpdate() || this.hasError() )
 		);
 	}

--- a/client/my-sites/site-indicator/index.jsx
+++ b/client/my-sites/site-indicator/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -48,15 +47,11 @@ class SiteIndicator extends Component {
 	showIndicator() {
 		const { siteIsAutomatedTransfer, siteIsJetpack, userCanManage } = this.props;
 
-		// Existing Jetpack Error UX was enabled only for non-Atomic Jetpack sites
-		// We want to enable it for all Jetpack sites, but keep it behind a feature flag
-		const isJetpackErrorUxEnabled = isEnabled( 'yolo/jetpack-error-ux-i1' );
-
 		// Until WP.com sites have indicators (upgrades expiring, etc) we only show them for Jetpack sites
 		return (
 			userCanManage &&
 			siteIsJetpack &&
-			( ! siteIsAutomatedTransfer || isJetpackErrorUxEnabled ) &&
+			! siteIsAutomatedTransfer &&
 			( this.hasUpdate() || this.hasError() )
 		);
 	}

--- a/client/state/site-connection/actions.js
+++ b/client/state/site-connection/actions.js
@@ -44,3 +44,46 @@ export const requestConnectionStatus = ( siteId ) => {
 			} );
 	};
 };
+
+/**
+ * Request the Jetpack connection status for a certain site.
+ *
+ * It's a second version, using the new Jetpack connection health endpoint.
+ *
+ * @param  {number}       siteId  ID of the site.
+ * @returns {Function}          Action thunk to request the Jetpack connection status when called.
+ */
+export const requestConnectionStatusV2 = ( siteId ) => {
+	return ( dispatch ) => {
+		dispatch( {
+			type: SITE_CONNECTION_STATUS_REQUEST,
+			siteId,
+		} );
+
+		return wp.req
+			.get( {
+				path: `/sites/${ siteId }/jetpack-connection-health`,
+				apiNamespace: 'wpcom/v2',
+			} )
+			.then( ( response ) => {
+				dispatch( {
+					type: SITE_CONNECTION_STATUS_RECEIVE,
+					siteId,
+					status: !! response.is_healthy,
+					error: response?.error,
+				} );
+
+				dispatch( {
+					type: SITE_CONNECTION_STATUS_REQUEST_SUCCESS,
+					siteId,
+				} );
+			} )
+			.catch( ( error ) => {
+				dispatch( {
+					type: SITE_CONNECTION_STATUS_REQUEST_FAILURE,
+					siteId,
+					error,
+				} );
+			} );
+	};
+};

--- a/client/state/site-connection/reducer.js
+++ b/client/state/site-connection/reducer.js
@@ -41,7 +41,23 @@ export const requesting = ( state = {}, action ) => {
 	return state;
 };
 
+export const errors = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SITE_CONNECTION_STATUS_RECEIVE: {
+			const { siteId, error } = action;
+
+			return {
+				...state,
+				[ siteId ]: error,
+			};
+		}
+	}
+
+	return state;
+};
+
 export default combineReducers( {
 	items,
 	requesting,
+	errors,
 } );

--- a/config/development.json
+++ b/config/development.json
@@ -210,6 +210,7 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
-		"yolo/hosting-metrics-i1": true
+		"yolo/hosting-metrics-i1": true,
+		"yolo/jetpack-error-ux-i1": true
 	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -146,7 +146,8 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/hosting-metrics-i1": false
+		"yolo/hosting-metrics-i1": false,
+		"yolo/jetpack-error-ux-i1": false
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/production.json
+++ b/config/production.json
@@ -174,7 +174,8 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/hosting-metrics-i1": false
+		"yolo/hosting-metrics-i1": false,
+		"yolo/jetpack-error-ux-i1": false
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -168,7 +168,8 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"newsletter/stats": false,
-		"yolo/hosting-metrics-i1": false
+		"yolo/hosting-metrics-i1": false,
+		"yolo/jetpack-error-ux-i1": false
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/test.json
+++ b/config/test.json
@@ -107,6 +107,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
-		"yolo/hosting-metrics-i1": true
+		"yolo/hosting-metrics-i1": true,
+		"yolo/jetpack-error-ux-i1": false
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -179,7 +179,8 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/hosting-metrics-i1": true
+		"yolo/hosting-metrics-i1": true,
+		"yolo/jetpack-error-ux-i1": false
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -180,7 +180,7 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"yolo/hosting-metrics-i1": true,
-		"yolo/jetpack-error-ux-i1": false
+		"yolo/jetpack-error-ux-i1": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3202

## Proposed Changes

In this diff, I propose hooking the existing Jetpack error UI with a new API endpoint that checks Jetpack connection health. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply patch D116410-code
2. Load the posts page for a blog with a broken connection
3. Confirm that the message is displayed
4. Confirm that the error indicator is still displayed in the sidebar's site card and in the sidebar's site selector only for non-Atomic sites 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
