### PR TITLE
i18n: Fix loading translations of devices in preview toolbar

### DIFF
--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -72,17 +72,6 @@ class PreviewToolbar extends Component {
 		window.location.href = this.props.customizeUrl;
 	};
 
-	constructor( props ) {
-		super();
-
-		this.devices = {
-			computer: { title: props.translate( 'Desktop' ), icon: 'computer' },
-			tablet: { title: props.translate( 'Tablet' ), icon: 'tablet' },
-			phone: { title: props.translate( 'Phone' ), icon: 'phone' },
-			seo: { title: props.translate( 'Search & Social' ), icon: 'globe' },
-		};
-	}
-
 	render() {
 		const {
 			canUserEditThemeOptions,
@@ -103,7 +92,14 @@ class PreviewToolbar extends Component {
 			translate,
 		} = this.props;
 
-		const selectedDevice = this.devices[ currentDevice ];
+		const devices = {
+			computer: { title: translate( 'Desktop' ), icon: 'computer' },
+			tablet: { title: translate( 'Tablet' ), icon: 'tablet' },
+			phone: { title: translate( 'Phone' ), icon: 'phone' },
+			seo: { title: translate( 'Search & Social' ), icon: 'globe' },
+		};
+
+		const selectedDevice = devices[ currentDevice ];
 		const devicesToShow = showSEO ? possibleDevices.concat( 'seo' ) : possibleDevices;
 		return (
 			<div className="web-preview__toolbar">
@@ -131,10 +127,10 @@ class PreviewToolbar extends Component {
 								key={ device }
 								selected={ device === currentDevice }
 								onClick={ () => setDeviceViewport( device ) }
-								icon={ <Gridicon size={ 18 } icon={ this.devices[ device ].icon } /> }
+								icon={ <Gridicon size={ 18 } icon={ devices[ device ].icon } /> }
 								e2eTitle={ device }
 							>
-								{ this.devices[ device ].title }
+								{ devices[ device ].title }
 							</SelectDropdown.Item>
 						) ) }
 					</SelectDropdown>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 658-gh-Automattic/i18n-issues

## Proposed Changes

On https://wordpress.com/view/, the device list appeared untranslated when it was the first Calypso page being loaded. This was caused by the fact that the `translate` calls were made in the constructor of the `PreviewToolbar` component, before the translations were loaded. The problem is fixed by moving the list to `render`.

|Before|After|
|-|-|
|<img width="396" alt="image" src="https://github.com/Automattic/wp-calypso/assets/75777864/0ddb0126-976c-45b1-86a9-3bedb8edbf92">|<img width="426" alt="image" src="https://github.com/Automattic/wp-calypso/assets/75777864/cd879b88-7a8d-48dd-8c0c-d4516512f02b">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso.live or run Calypso locally using `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks yarn start`.
* Visit `/view/`, open the devices dropdown, and verify that the devices appear translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
