### PR TITLE
Jetpack Pro Dashboard: implement rules to show one JITM at a time on the Licenses page

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-banners/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-banners/index.tsx
@@ -30,6 +30,7 @@ export default function DashboardBanners() {
 		{
 			component: () => <SiteSurveyBanner isDashboardView />,
 			preference: useSelector( ( state ) => getPreference( state, surveyBannerPreferenceName ) ),
+			showDays: 30,
 		},
 	];
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/banners.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/banners.tsx
@@ -1,0 +1,32 @@
+import SiteSurveyBanner from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-survey-banner';
+import SiteWelcomeBanner from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner';
+import showBanner from 'calypso/jetpack-cloud/sections/utils/show-banner';
+import { useSelector } from 'calypso/state';
+import {
+	JETPACK_DASHBOARD_SURVEY_BANNER_PREFERENCE as surveyBannerPreferenceName,
+	JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE,
+	getJetpackDashboardPreference as getPreference,
+} from 'calypso/state/jetpack-agency-dashboard/selectors';
+
+export default function Banners() {
+	const bannerKey = 'licenses-page';
+	const welcomeBannerPreferenceName = `${ JETPACK_DASHBOARD_WELCOME_BANNER_PREFERENCE }-${ bannerKey }`;
+
+	// Only one banner will be shown at a time
+	// The order of the banners in the array determines the priority
+	// So the first banner in the array will be shown first
+	const banners = [
+		{
+			component: () => <SiteWelcomeBanner bannerKey={ bannerKey } />,
+			preference: useSelector( ( state ) => getPreference( state, welcomeBannerPreferenceName ) ),
+			showDays: 7,
+		},
+		{
+			component: () => <SiteSurveyBanner />,
+			preference: useSelector( ( state ) => getPreference( state, surveyBannerPreferenceName ) ),
+			showDays: 30,
+		},
+	];
+
+	return <div>{ showBanner( banners ) }</div>;
+}

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -3,8 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import CardHeading from 'calypso/components/card-heading';
 import QueryJetpackPartnerPortalLicenseCounts from 'calypso/components/data/query-jetpack-partner-portal-license-counts';
 import SiteAddLicenseNotification from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification';
-import SiteSurveyBanner from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-survey-banner';
-import SiteWelcomeBanner from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner';
 import LicenseList from 'calypso/jetpack-cloud/sections/partner-portal/license-list';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
 import LicenseStateFilter from 'calypso/jetpack-cloud/sections/partner-portal/license-state-filter';
@@ -25,6 +23,7 @@ import Layout from '../../layout';
 import LayoutHeader from '../../layout/header';
 import LicenseSearch from '../../license-search';
 import OnboardingWidget from '../onboarding-widget';
+import Banners from './banners';
 
 import './style.scss';
 
@@ -68,12 +67,7 @@ export default function Licenses( {
 		<Layout className="licenses" title={ translate( 'Licenses' ) } wide>
 			<QueryJetpackPartnerPortalLicenseCounts />
 
-			{ isAgencyUser && (
-				<div>
-					<SiteSurveyBanner />
-					<SiteWelcomeBanner bannerKey="licenses-page" />
-				</div>
-			) }
+			{ isAgencyUser && <Banners /> }
 			<SiteAddLicenseNotification />
 
 			<LicenseListContext.Provider value={ context }>


### PR DESCRIPTION
Related to 1202619025189113-as-1205181631315664

## Proposed Changes

This PR implements rules to show one JITM at a time on the Licenses page.

- Use the existing util to show one banner at a time on the Licenses page.

-----

**Before**

<img width="1646" alt="Screenshot 2023-08-01 at 1 47 26 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0787a68a-5844-4554-8d24-5fe1b995d0c1">

-----

**After**

https://github.com/Automattic/wp-calypso/assets/10586875/b7836224-343d-4a99-a749-570b50ae07c0

-----

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/implement-show-only-one-jitm-licenses-page` and `yarn start-jetpack-cloud` or open the Jetpack Cloud live link. 
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Reset the banners if you have already cleared them, as mentioned below.
4. Try clearing the first banner(Welcome Banner), and verify the next banner appears(Dashboard Survey) > Clear this and verify it disappears. 
5. Currently, there is no way to see if the banner will be shown only for X days. So, you need to make some changes in the UI to test this. 
6. Reset the banners again as mentioned below
7. Go to `client/jetpack-cloud/sections/partner-portal/primary/licenses/banners.tsx` > Replace preference for `SiteWelcomeBanner` as below

```
preference: {
        dismiss: false,
	view_date: 1650887935304,
},
```

and verify that you can now see `SiteSurveyBanner`. 

8. Do the same for `SiteSurveyBanner` and verify that you don't see any banners.
9. Close the survey banner and verify no banner is now shown.

**How to reset the banner?**

1. On the Jetpack page at the bottom right. Hover on the debug icon and click preferences. Look for **jetpack-dashboard-welcome-banner-preference-licenses-page** and clear it by clicking the **X** button.

<img width="1174" alt="Screen Shot 2023-07-12 at 4 57 50 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/aeb0af42-c99b-409f-a652-fb2fb207b97b">

2. Do the same for **jetpack-dashboard-agency-program-survey-banner-preference**.

3. This should reset the banner and will show up again on the Licenses screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?