### PR TITLE
Plans: Escape percent in plan features

### DIFF
--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -1717,7 +1717,7 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_10 ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_10,
 		getTitle: () =>
-			i18n.translate( '%(commission)d% transaction fee for payments', {
+			i18n.translate( '%(commission)d%% transaction fee for payments', {
 				args: { commission: 10 },
 			} ),
 		getDescription: () =>
@@ -1728,7 +1728,7 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_8 ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_8,
 		getTitle: () =>
-			i18n.translate( '%(commission)d% transaction fee for payments', {
+			i18n.translate( '%(commission)d%% transaction fee for payments', {
 				args: { commission: 8 },
 			} ),
 		getDescription: () =>
@@ -1739,7 +1739,7 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_4 ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_4,
 		getTitle: () =>
-			i18n.translate( '%(commission)d% transaction fee for payments', {
+			i18n.translate( '%(commission)d%% transaction fee for payments', {
 				args: { commission: 4 },
 			} ),
 		getDescription: () =>
@@ -1750,7 +1750,7 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_2 ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_2,
 		getTitle: () =>
-			i18n.translate( '%(commission)d% transaction fee for payments', {
+			i18n.translate( '%(commission)d%% transaction fee for payments', {
 				args: { commission: 2 },
 			} ),
 		getDescription: () =>
@@ -1761,7 +1761,7 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_0 ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_0,
 		getTitle: () =>
-			i18n.translate( '%(commission)d% transaction fee for payments', {
+			i18n.translate( '%(commission)d%% transaction fee for payments', {
 				args: { commission: 0 },
 			} ),
 		getDescription: () =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 661-gh-Automattic/i18n-issues

## Proposed Changes

* The `%(commission)d% transaction fee for payments` string did not escape the `%` character, resulting in the following issue if the character is followed by a parsable identifier (e.g. `d`, `u`): 
 
![image](https://github.com/Automattic/wp-calypso/assets/23708351/2bb1e09d-15a1-4341-88a4-b835abf213ca)

This PR escapes the character to prevent the issue. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the plan page for one of your sites: `<calypso.live>/plans/<site>`
* Confirm that the string is shown correctly. 
Note: The string will be displayed in English until we port the existing translations.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
