### PR TITLE
GS on Personal A/B: Use `ExPlat\assign_given_user`

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -613,7 +613,7 @@ function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) {
 		return false;
 	}
 
-	$experiment_assignment              = \ExPlat\assign_user( 'calypso_global_styles_personal_v2', $owner );
+	$experiment_assignment              = \ExPlat\assign_given_user( 'calypso_global_styles_personal_v2', $owner );
 	$has_global_styles_in_personal_plan = 'treatment' === $experiment_assignment;
 	// Cache the experiment assignment to prevent duplicate DB queries in the frontend.
 	wp_cache_set( $cache_key, $has_global_styles_in_personal_plan, 'a8c_experiments', MONTH_IN_SECONDS );


### PR DESCRIPTION
Part of https://github.com/Automattic/dotcom-forge/issues/3086

## Proposed Changes

Updates the gating logic of the GS on Personal A/B test to use the new `ExPlat\assign_given_user` function introduced in D117540-code.

That way, we'll be able to remove the deprecated `ExPlat\assign_user` function afterwards.

## Testing Instructions

- Apply these changes to your sandbox.
- Make sure you get the expected experience of the GS on Personal A/B test.