### PR TITLE
Reader comments reblogging - update stats and tracks names for reblogging comments.

### DIFF
--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -59,10 +59,16 @@ class ReaderShare extends Component {
 
 	toggle = () => {
 		if ( ! this.state.showingMenu ) {
-			const actionName = this.props.isReblogSelection ? 'open_reader_reblog' : 'open_share';
-			const eventName = this.props.isReblogSelection ? 'Opened Reader Reblog' : 'Opened Share';
+			// Determine if we want to use reblog or share for stat/tracks names.
+			// If reblogging a comment, add comment to the reblog stat/tracks names.
+			const actionName = this.props.isReblogSelection
+				? `open_reader_${ this.props.comment ? 'comment_' : '' }reblog`
+				: 'open_share';
+			const eventName = this.props.isReblogSelection
+				? `Opened Reader ${ this.props.comment ? 'Comment ' : '' }Reblog`
+				: 'Opened Share';
 			const trackName = this.props.isReblogSelection
-				? 'calypso_reader_reblog_opened'
+				? `calypso_reader_${ this.props.comment ? 'comment_' : '' }reblog_opened`
 				: 'calypso_reader_share_opened';
 			stats.recordAction( actionName );
 			stats.recordGaEvent( eventName );

--- a/client/blocks/reader-share/reblog.jsx
+++ b/client/blocks/reader-share/reblog.jsx
@@ -2,9 +2,12 @@ import { useTranslate } from 'i18n-calypso';
 import SiteSelector from 'calypso/components/site-selector';
 import ReaderPopoverMenu from 'calypso/reader/components/reader-popover/menu';
 import * as stats from 'calypso/reader/stats';
+import { useDispatch } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 const ReaderReblogSelection = ( props ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const buildQuerystringForPost = ( post, comment ) => {
 		const args = {};
@@ -22,9 +25,12 @@ const ReaderReblogSelection = ( props ) => {
 	};
 
 	const pickSiteToShareTo = ( slug ) => {
-		stats.recordAction( 'share_wordpress' );
-		stats.recordGaEvent( 'Clicked on Share to WordPress' );
-		stats.recordTrack( 'calypso_reader_share_to_site' );
+		// Add 'comment' specificity to stats and tracks names if this is for a comment.
+		stats.recordAction( `share_wordpress${ props.comment ? '_comment' : '' }` );
+		stats.recordGaEvent( `Clicked on Share${ props.comment ? ' Comment' : '' } to WordPress` );
+		dispatch(
+			recordReaderTracksEvent( `calypso_reader_share${ props.comment ? '_comment' : '' }_to_site` )
+		);
 		window.open(
 			`/post/${ slug }?${ buildQuerystringForPost( props.post, props.comment ) }`,
 			'reblog post',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-13E-p2

## Proposed Changes

* We have recently enabled reblogging of comments through the reader. However, these are still sending the same stats/tracks names as reblogging regular posts. This PR updates the names of those stats and tracks events to specify if it is a comment being reblogged. This updates events for both opening the popover, and selecting a site to reblog to.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Open the reblog popover from a main post (such as on the recent page).
* Verify the tracks and stats names to not contain "comment", and have the same name/behavior as before.
* Select a site in the popover to reblog to, verify the tracks and stats names are still the same.
* Visit the conversations tab to find some comments to test.
* Open the reblog popover for reblogging a comment.
* Verify the stats and tracks names now are updated to specify that it is a 'comment'.
* Select a site to reblog to. Verify the stats and tracks names are also updated to specify that it is a comment.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?