### PR TITLE
Adds redirection in promote-post campaign details route

### DIFF
--- a/client/my-sites/promote-post-i2/controller.js
+++ b/client/my-sites/promote-post-i2/controller.js
@@ -1,5 +1,6 @@
 import page from 'page';
 import BlazePressWidget from 'calypso/components/blazepress-widget';
+import { addQueryArgs } from 'calypso/lib/url';
 import CampaignItemPage from 'calypso/my-sites/promote-post-i2/components/campaign-item-page';
 import PromotedPostsRedesignI2, { TAB_OPTIONS } from 'calypso/my-sites/promote-post-i2/main';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
@@ -10,7 +11,10 @@ import { getAdvertisingDashboardPath } from './utils';
 export const checkValidTabInNavigation = ( context, next ) => {
 	const { site, tab } = context.params;
 	if ( site && tab && ! TAB_OPTIONS.includes( tab ) ) {
-		return page.redirect( getAdvertisingDashboardPath( `/${ site }/${ tab }` ) );
+		const urlQueryArgs = context.query;
+		return page.redirect(
+			addQueryArgs( urlQueryArgs, getAdvertisingDashboardPath( `/${ site }/${ tab }` ) )
+		);
 	}
 
 	next();

--- a/client/my-sites/promote-post-i2/index.js
+++ b/client/my-sites/promote-post-i2/index.js
@@ -1,6 +1,6 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { getSiteFragment } from 'calypso/lib/route';
+import { addQueryArgs, getSiteFragment } from 'calypso/lib/route';
 import { navigation, sites, siteSelection } from 'calypso/my-sites/controller';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
 import {
@@ -61,6 +61,17 @@ export default () => {
 	);
 
 	promotePage( getAdvertisingDashboardPath( '/campaigns/:campaignId/:site?' ), campaignDetails );
+
+	page( getAdvertisingDashboardPath( '/:site/campaigns/:campaignId' ), ( context ) => {
+		const { site, campaignId } = context.params;
+		const urlQueryArgs = context.query;
+		page.redirect(
+			addQueryArgs(
+				urlQueryArgs,
+				getAdvertisingDashboardPath( `/campaigns/${ campaignId }/${ site }` )
+			)
+		);
+	} );
 
 	promotePage( getAdvertisingDashboardPath( '/promote/:item?/:site?' ), promoteWidget );
 

--- a/client/my-sites/promote-post/index.js
+++ b/client/my-sites/promote-post/index.js
@@ -1,5 +1,6 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { addQueryArgs } from 'calypso/lib/url';
 import { navigation, sites, siteSelection } from 'calypso/my-sites/controller';
 import {
 	campaignDetails,
@@ -41,6 +42,18 @@ export default () => {
 	);
 
 	promotePage( getAdvertisingDashboardPath( '/campaigns/:campaignId/:site?' ), campaignDetails );
+
+	// Compatibility: Redirects request from clients that are using the old navigation style
+	page( getAdvertisingDashboardPath( '/:site/campaigns/:campaignId' ), ( context ) => {
+		const { site, campaignId } = context.params;
+		const urlQueryArgs = context.query;
+		page.redirect(
+			addQueryArgs(
+				urlQueryArgs,
+				getAdvertisingDashboardPath( `/campaigns/${ campaignId }/${ site }` )
+			)
+		);
+	} );
 
 	promotePage( getAdvertisingDashboardPath( '/promote/:item?/:site?' ), promoteWidget );
 


### PR DESCRIPTION
The last PR that changed the navigation in the Advertising section missed a compatibility redirect for the campaign details route. The Jetpack app is using that route to load the details of the campaigns, so we need to add a compatibility redirect until the apps are able to change to the new URL style.

The previous route was `/:site/campaigns/:campaignId` and we need to move them to the new route style `campaigns/:campaignId/:site` (the site at the end).

## Proposed Changes

I am adding a redirection in the promote-post section from the old campaign details route to the new one.

## Testing Instructions

* Open the live preview and then navigate to Tools->Advertising
* Click on Campaigns and then on a details for one of your campaigns
* Copy the current URL, change it to the old style, and add a source query parameter to test that we are not losing those params. The final URL should look like this `https://wordpress.com/advertising/{site_url}/campaigns/{campaign_id}?source=random_srouce`
* Verify that by loading that URL, you are redirected to the campaign details, and we maintain the correct source query param.
* Do the same for the campaigns list page. The final route for the campaign list page should be this: `https://wordpress.com/advertising/{site_url}/campaigns?source=random_srouce`
* Verify that you land in the campaign list page with the correct source query param

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
