### PR TITLE
Domain Transfer: Change copy tense to 'We’ll pay for an extra year' before checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -81,8 +81,8 @@ const DomainPrice = ( { rawPrice, saleCost, currencyCode = 'USD' }: DomainPriceP
 	}
 
 	let pricetext = __( 'First year free' );
-	if ( englishLocales.includes( locale ) || hasTranslation( 'We’ve paid for an extra year' ) ) {
-		pricetext = __( 'We’ve paid for an extra year' );
+	if ( englishLocales.includes( locale ) || hasTranslation( 'We’ll pay for an extra year' ) ) {
+		pricetext = __( 'We’ll pay for an extra year' );
 	}
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1690904693110259-slack-CKZHG0QCR & https://github.com/Automattic/wp-calypso/pull/80056

## Proposed Changes

* This PR changes the tense of 'We’ve paid for an extra year' to 'We’ll pay for an extra year' on `/setup/google-transfer/domains` since it occurs before checkout.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* On the transfer input page http://calypso.localhost:3000/setup/google-transfer/domains
* You can use this to test Google Domain (don't actually transfer it) p1690572496812839/1690568397.986559-slack-CKZHG0QCR

Before | After
--|--
![tense-before](https://github.com/Automattic/wp-calypso/assets/140841/3bfd9b7a-019a-47a3-9e14-0eb119fbdc4f) | ![tense-after](https://github.com/Automattic/wp-calypso/assets/140841/4a3f1604-ea02-4ba9-a5f6-bfbd46e12b7a)




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?