### PR TITLE
Call upsert method if the DSP call to get campaigns fail

### DIFF
--- a/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
@@ -2,12 +2,18 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { requestDSP } from 'calypso/lib/promote-post';
 import { SearchOptions } from 'calypso/my-sites/promote-post-i2/components/search-bar';
 import { Campaign } from './types';
+const DSP_ERROR_NO_LOCAL_USER = 'no_local_user';
 
 type CampaignQueryResult = {
 	campaigns: Campaign[];
 	total_items: number;
 	total_pages: number;
 	page: number;
+	has_more_pages: boolean;
+};
+
+type NewDSPUserResult = {
+	new_dsp_user: boolean;
 };
 
 type CampaignQueryOptions = {
@@ -29,6 +35,32 @@ const getSearchOptionsQueryParams = ( searchOptions: SearchOptions ) => {
 	return searchQueryParams;
 };
 
+async function getCampaigns( siteId: number, pageParam: number, searchQueryParams: string ) {
+	const searchCampaignsUrl = `/search/campaigns/site/${ siteId }?order=asc&order_by=post_date&page=${ pageParam }${ searchQueryParams }`;
+	try {
+		return await requestDSP< CampaignQueryResult >( siteId, searchCampaignsUrl );
+	} catch ( e ) {
+		await handleDSPError( e, siteId, pageParam, searchQueryParams );
+		throw new Error( 'Error while fetching campaigns' );
+	}
+}
+
+async function handleDSPError(
+	error: any,
+	siteId: number,
+	pageParam: number,
+	searchQueryParams: string
+) {
+	if ( error.errorCode === DSP_ERROR_NO_LOCAL_USER ) {
+		const createUserQuery = await requestDSP< NewDSPUserResult >( siteId, `/user/check` );
+		if ( ! createUserQuery.new_dsp_user ) {
+			// then we should retry the original query
+			return await getCampaigns( siteId, pageParam, searchQueryParams );
+		}
+	}
+	throw error;
+}
+
 const useCampaignsQueryPaged = (
 	siteId: number,
 	searchOptions: SearchOptions,
@@ -39,10 +71,7 @@ const useCampaignsQueryPaged = (
 	return useInfiniteQuery(
 		[ 'promote-post-campaigns', siteId, searchQueryParams ],
 		async ( { pageParam = 1 } ) => {
-			const resultQuery = await requestDSP< CampaignQueryResult >(
-				siteId,
-				`/search/campaigns/site/${ siteId }?order=asc&order_by=post_date&page=${ pageParam }${ searchQueryParams }`
-			);
+			const resultQuery = await getCampaigns( siteId, pageParam, searchQueryParams );
 
 			const { campaigns, page, total_items, total_pages } = resultQuery;
 			const has_more_pages = page < total_pages;


### PR DESCRIPTION
Related to #

## Proposed Changes

* The user would receive an error if tries to open the campaign list in blazepress when a user is not created in the DSP. This would be fixed as soon as the user enters into the widget, which would create a campaign
* This PR will call the url that upserts an user if the /campaigns endpoint returns an error saying that the user has not been created in the DSP database. The DSP user will be created and we will display the campaigns without them noticing anything

## Testing Instructions
- Run calypso and tunnel your DSP to it (ssh tunnel, wordads_dsp_proxy pointing to your local instance ...)
- Delete your DSP user  in the local DSP database: in dsp_social_logins and dsp_users tables
- Go to /campaigns list in calypso
- After a few seconds you should see the "no campaigns" message or see other campaigns created by other users in your site
- You should see the brand new user created in the DSP database

Ping @jjolmo if you want a loom. I haven't added it here for some security concerns

## Pre-merge Checklist


- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
