### PR TITLE
Newsletter Categories: Add react-query for getting newsletter categories

### DIFF
--- a/client/data/newsletter-categories/test/use-newsletter-categories-query.test.tsx
+++ b/client/data/newsletter-categories/test/use-newsletter-categories-query.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import request from 'wpcom-proxy-request';
+import useNewsletterCategories from '../use-newsletter-categories-query';
+
+jest.mock( 'wpcom-proxy-request', () => jest.fn() );
+
+describe( 'useNewsletterCategories', () => {
+	let queryClient: QueryClient;
+	let wrapper: any;
+
+	beforeEach( () => {
+		( request as jest.MockedFunction< typeof request > ).mockReset();
+
+		queryClient = new QueryClient( {
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		} );
+
+		wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should return expected data when successful', async () => {
+		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( {
+			newsletter_categories: [
+				{ term_id: 1, name: 'Category 1', description: 'Description 1', order: 1 },
+				{ term_id: 2, name: 'Category 2', description: 'Description 2', order: 2 },
+			],
+		} );
+
+		const { result } = renderHook( () => useNewsletterCategories( { blogId: 123 } ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( result.current.data ).toEqual( {
+			newsletterCategories: [
+				{ termId: 1, name: 'Category 1', description: 'Description 1', order: 1 },
+				{ termId: 2, name: 'Category 2', description: 'Description 2', order: 2 },
+			],
+		} );
+	} );
+
+	it( 'should handle empty response', async () => {
+		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( {
+			newsletter_categories: [],
+		} );
+
+		const { result } = renderHook( () => useNewsletterCategories( { blogId: 123 } ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( result.current.data ).toEqual( { newsletterCategories: [] } );
+	} );
+} );

--- a/client/data/newsletter-categories/test/use-newsletter-categories-query.test.tsx
+++ b/client/data/newsletter-categories/test/use-newsletter-categories-query.test.tsx
@@ -37,8 +37,8 @@ describe( 'useNewsletterCategories', () => {
 	it( 'should return expected data when successful', async () => {
 		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( {
 			newsletter_categories: [
-				{ term_id: 1, name: 'Category 1', description: 'Description 1', order: 1 },
-				{ term_id: 2, name: 'Category 2', description: 'Description 2', order: 2 },
+				{ id: 1, name: 'Category 1', slug: 'Slug 1', description: 'Description 1', parent: 1 },
+				{ id: 2, name: 'Category 2', slug: 'Slug 2', description: 'Description 2', parent: 2 },
 			],
 		} );
 
@@ -48,8 +48,8 @@ describe( 'useNewsletterCategories', () => {
 
 		expect( result.current.data ).toEqual( {
 			newsletterCategories: [
-				{ termId: 1, name: 'Category 1', description: 'Description 1', order: 1 },
-				{ termId: 2, name: 'Category 2', description: 'Description 2', order: 2 },
+				{ id: 1, name: 'Category 1', slug: 'Slug 1', description: 'Description 1', parent: 1 },
+				{ id: 2, name: 'Category 2', slug: 'Slug 2', description: 'Description 2', parent: 2 },
 			],
 		} );
 	} );

--- a/client/data/newsletter-categories/types.ts
+++ b/client/data/newsletter-categories/types.ts
@@ -1,11 +1,3 @@
-export type NewsletterCategoryQueryProps = {
-	blogId: number;
-};
-
-export type NewsletterCategoryResponse = {
-	newsletter_categories: NewsletterCategory[];
-};
-
 export type NewsletterCategories = {
 	newsletterCategories: NewsletterCategory[];
 };

--- a/client/data/newsletter-categories/types.ts
+++ b/client/data/newsletter-categories/types.ts
@@ -1,0 +1,19 @@
+export type NewsletterCategoryQueryProps = {
+	blogId: number;
+};
+
+export type NewsletterCategoryResponse = {
+	newsletter_categories: NewsletterCategory[];
+};
+
+export type NewsletterCategories = {
+	newsletterCategories: NewsletterCategory[];
+};
+
+export type NewsletterCategory = {
+	id: number;
+	name: string;
+	slug: string;
+	description: string;
+	parent: number;
+};

--- a/client/data/newsletter-categories/use-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-newsletter-categories-query.tsx
@@ -1,10 +1,14 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import request from 'wpcom-proxy-request';
-import {
-	NewsletterCategories,
-	NewsletterCategoryQueryProps,
-	NewsletterCategoryResponse,
-} from './types';
+import { NewsletterCategories, NewsletterCategory } from './types';
+
+type NewsletterCategoryQueryProps = {
+	blogId: number;
+};
+
+type NewsletterCategoryResponse = {
+	newsletter_categories: NewsletterCategory[];
+};
 
 const convertNewsletterCategoryResponse = (
 	response: NewsletterCategoryResponse
@@ -19,7 +23,7 @@ const useNewsletterCategories = ( {
 		queryKey: [ `newsletter-categories-${ blogId }` ],
 		queryFn: () =>
 			request< NewsletterCategoryResponse >( {
-				path: `/sites/${ blogId }/newsletter-categories?http_envelope=1`,
+				path: `/sites/${ blogId }/newsletter-categories`,
 				apiVersion: '2',
 			} ).then( convertNewsletterCategoryResponse ),
 	} );

--- a/client/data/newsletter-categories/use-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-newsletter-categories-query.tsx
@@ -1,0 +1,58 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import request from 'wpcom-proxy-request';
+
+type NewsletterCategoryQueryProps = {
+	blogId: number;
+};
+
+type NewsletterCategoryQueryResponse = {
+	newsletter_categories: NewsletterCategoryResponse[];
+};
+
+type NewsletterCategories = {
+	newsletterCategories: NewsletterCategory[];
+};
+
+type NewsletterCategoryResponse = {
+	term_id: number;
+	name: string;
+	description: string;
+	order: number;
+};
+
+type NewsletterCategory = {
+	termId: number;
+	name: string;
+	description: string;
+	order: number;
+};
+
+const convertNewsletterCategoryResponse = ( response: NewsletterCategoryQueryResponse ) => {
+	return {
+		newsletterCategories: response.newsletter_categories.map(
+			( { term_id, name, description, order }: NewsletterCategoryResponse ) => {
+				return {
+					termId: term_id,
+					name,
+					description,
+					order,
+				};
+			}
+		),
+	};
+};
+
+const useNewsletterCategories = ( {
+	blogId,
+}: NewsletterCategoryQueryProps ): UseQueryResult< NewsletterCategories > => {
+	return useQuery( {
+		queryKey: [ `newsletter-categories-${ blogId }` ],
+		queryFn: () =>
+			request< NewsletterCategoryQueryResponse >( {
+				path: `/sites/${ blogId }/newsletter-categories?http_envelope=1`,
+				apiVersion: '2',
+			} ).then( convertNewsletterCategoryResponse ),
+	} );
+};
+
+export default useNewsletterCategories;

--- a/client/data/newsletter-categories/use-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-newsletter-categories-query.tsx
@@ -3,7 +3,7 @@ import request from 'wpcom-proxy-request';
 import { NewsletterCategories, NewsletterCategory } from './types';
 
 type NewsletterCategoryQueryProps = {
-	blogId: number;
+	blogId?: number;
 };
 
 type NewsletterCategoryResponse = {
@@ -25,7 +25,9 @@ const useNewsletterCategories = ( {
 			request< NewsletterCategoryResponse >( {
 				path: `/sites/${ blogId }/newsletter-categories`,
 				apiVersion: '2',
+				apiNamespace: 'wpcom/v2',
 			} ).then( convertNewsletterCategoryResponse ),
+		enabled: !! blogId,
 	} );
 };
 

--- a/client/data/newsletter-categories/use-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-newsletter-categories-query.tsx
@@ -1,45 +1,15 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import request from 'wpcom-proxy-request';
+import {
+	NewsletterCategories,
+	NewsletterCategoryQueryProps,
+	NewsletterCategoryResponse,
+} from './types';
 
-type NewsletterCategoryQueryProps = {
-	blogId: number;
-};
-
-type NewsletterCategoryQueryResponse = {
-	newsletter_categories: NewsletterCategoryResponse[];
-};
-
-type NewsletterCategories = {
-	newsletterCategories: NewsletterCategory[];
-};
-
-type NewsletterCategoryResponse = {
-	term_id: number;
-	name: string;
-	description: string;
-	order: number;
-};
-
-type NewsletterCategory = {
-	termId: number;
-	name: string;
-	description: string;
-	order: number;
-};
-
-const convertNewsletterCategoryResponse = ( response: NewsletterCategoryQueryResponse ) => {
-	return {
-		newsletterCategories: response.newsletter_categories.map(
-			( { term_id, name, description, order }: NewsletterCategoryResponse ) => {
-				return {
-					termId: term_id,
-					name,
-					description,
-					order,
-				};
-			}
-		),
-	};
+const convertNewsletterCategoryResponse = (
+	response: NewsletterCategoryResponse
+): NewsletterCategories => {
+	return { newsletterCategories: response.newsletter_categories };
 };
 
 const useNewsletterCategories = ( {
@@ -48,7 +18,7 @@ const useNewsletterCategories = ( {
 	return useQuery( {
 		queryKey: [ `newsletter-categories-${ blogId }` ],
 		queryFn: () =>
-			request< NewsletterCategoryQueryResponse >( {
+			request< NewsletterCategoryResponse >( {
 				path: `/sites/${ blogId }/newsletter-categories?http_envelope=1`,
 				apiVersion: '2',
 			} ).then( convertNewsletterCategoryResponse ),


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/80053

## Proposed Changes

This PR adds the react-query hook for retrieving the Newsletter Categories for the current site.

## Testing Instructions

You can test this by running the tests: in your terminal, execute `yarn test-client client/data/newsletter-categories/test/use-newsletter-categories-query.test.tsx`. All the tests should be green.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
