### PR TITLE
Signup: Add the plans-business-with-plugin-step

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -109,7 +109,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'with-plugin',
-			steps: [ 'user', 'domains', 'plans-business' ],
+			steps: [ 'user', 'domains', 'plans-business-with-plugin' ],
 			destination: getWithPluginDestination,
 			description: 'Preselect a plugin to activate/buy, a Business plan is needed',
 			lastModified: '2023-07-19',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -28,6 +28,7 @@ const stepNameToModuleName = {
 	plans: 'plans',
 	'plans-new': 'plans',
 	'plans-business': 'plans',
+	'plans-business-with-plugin': 'plans',
 	'plans-hosting': 'plans',
 	'plans-pm': 'plans',
 	'plans-pro': 'plans',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -301,6 +301,17 @@ export function generateSteps( {
 			stepName: 'plans-business',
 			apiRequestFunction: addPlanToCart,
 			fulfilledStepCallback: isPlanFulfilled,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem' ],
+			defaultDependencies: {
+				cartItem: PLAN_BUSINESS,
+			},
+		},
+
+		'plans-business-with-plugin': {
+			stepName: 'plans-business',
+			apiRequestFunction: addPlanToCart,
+			fulfilledStepCallback: isPlanFulfilled,
 			dependencies: [ 'siteSlug', 'plugin', 'billing_period' ],
 			providesDependencies: [ 'cartItem' ],
 			defaultDependencies: {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -309,7 +309,7 @@ export function generateSteps( {
 		},
 
 		'plans-business-with-plugin': {
-			stepName: 'plans-business',
+			stepName: 'plans-business-with-plugin',
 			apiRequestFunction: addPlanToCart,
 			fulfilledStepCallback: isPlanFulfilled,
 			dependencies: [ 'siteSlug', 'plugin', 'billing_period' ],


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/79705


## Proposed Changes

Add the `plans-business-with-plugin-step` and use it for the `with-plugin` flow.

## Testing Instructions

* Check all flows from https://github.com/Automattic/wp-calypso/pull/79705
* Check if /start/business is working correctly and not asking for plan selection.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
