### PR TITLE
Domain transfer: Update google domain transfer helper copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/google-domains-transfer-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/google-domains-transfer-instructions/index.tsx
@@ -1,3 +1,4 @@
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { Button, Modal } from '@wordpress/components';
 import { useState, createElement, createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
@@ -16,6 +17,11 @@ const GoogleDomainsModal: React.FC< Props > = ( { children, className, focusedSt
 	const [ isOpen, setOpen ] = useState( false );
 	const openModal = () => setOpen( true );
 	const closeModal = () => setOpen( false );
+	const step2Text = useHasEnTranslation()(
+		'Select the domain you want to transfer in the "My domains" section.'
+	)
+		? __( 'Select the domain you want to transfer in the "My domains" section.' )
+		: __( "Click on the name of the domain that you'd like to transfer." );
 
 	return (
 		<>
@@ -56,12 +62,12 @@ const GoogleDomainsModal: React.FC< Props > = ( { children, className, focusedSt
 					</details>
 					<details open={ 2 === focusedStep }>
 						<summary>{ __( 'Step 2: Select your domain' ) }</summary>
-						<p>{ __( "Click on the name of the domain that you'd like to transfer." ) }</p>
+						<p>{ step2Text }</p>
 						<img
 							className="google-domains-transfer-instructions__image"
 							src={ pickDomainImgSrc }
 							loading="lazy"
-							alt={ __( "Click on the name of the domain that you'd like to transfer." ) }
+							alt={ step2Text }
 							width={ 737 }
 							height={ 410 }
 						/>

--- a/client/landing/stepper/declarative-flow/internals/components/google-domains-transfer-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/google-domains-transfer-instructions/index.tsx
@@ -56,12 +56,12 @@ const GoogleDomainsModal: React.FC< Props > = ( { children, className, focusedSt
 					</details>
 					<details open={ 2 === focusedStep }>
 						<summary>{ __( 'Step 2: Select your domain' ) }</summary>
-						<p>{ __( 'Select the domain you want to transfer in the "My domains" section.' ) }</p>
+						<p>{ __( "Click on the name of the domain that you'd like to transfer." ) }</p>
 						<img
 							className="google-domains-transfer-instructions__image"
 							src={ pickDomainImgSrc }
 							loading="lazy"
-							alt={ __( 'Select the domain you want to transfer in the "My domains" section.' ) }
+							alt={ __( "Click on the name of the domain that you'd like to transfer." ) }
 							width={ 737 }
 							height={ 410 }
 						/>

--- a/client/landing/stepper/declarative-flow/internals/components/google-domains-transfer-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/google-domains-transfer-instructions/index.tsx
@@ -18,10 +18,12 @@ const GoogleDomainsModal: React.FC< Props > = ( { children, className, focusedSt
 	const openModal = () => setOpen( true );
 	const closeModal = () => setOpen( false );
 	const step2Text = useHasEnTranslation()(
-		'Select the domain you want to transfer in the "My domains" section.'
+		'Click on the name of the domain that you\'d like to transfer in the "My domains" section.'
 	)
-		? __( 'Select the domain you want to transfer in the "My domains" section.' )
-		: __( "Click on the name of the domain that you'd like to transfer." );
+		? __(
+				'Click on the name of the domain that you\'d like to transfer in the "My domains" section.'
+		  )
+		: __( 'Select the domain you want to transfer in the "My domains" section.' );
 
 	return (
 		<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 30-gh-Automattic/dotcom-marketing

## Proposed Changes

* Updated text of step 2 to be more assertive on google

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open http://calypso.localhost:3000/setup/google-transfer/intro and validate the new text

![image](https://github.com/Automattic/wp-calypso/assets/1044309/678a21ad-977d-43d6-9551-bfe63a9b3dc8)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?