### PR TITLE
GF Signup : Wire up experiment for the free/free modal

### DIFF
--- a/client/my-sites/plans-features-main/components/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-free-domain-dialog.tsx
@@ -4,13 +4,15 @@ import formatCurrency from '@automattic/format-currency';
 import { css, Global } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { DataResponse } from 'calypso/my-sites/plan-features-2023-grid/types';
 import usePlanPrices from 'calypso/my-sites/plans/hooks/use-plan-prices';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
-import { DialogContainer } from './free-plan-paid-domain-dialog';
+import { DialogContainer, MODAL_VIEW_EVENT_NAME } from './free-plan-paid-domain-dialog';
 import { LoadingPlaceHolder } from './loading-placeholder';
 import type { TranslateResult } from 'i18n-calypso';
 
@@ -161,6 +163,12 @@ export function FreePlanFreeDomainDialog( {
 		monthlyPlanPriceObject.discountedRawPrice || monthlyPlanPriceObject.rawPrice;
 	const annualPlanPrice =
 		annualPlanPriceObject.discountedRawPrice || annualPlanPriceObject.rawPrice;
+
+	useEffect( () => {
+		recordTracksEvent( MODAL_VIEW_EVENT_NAME, {
+			dialog_type: 'paid_plan_is_required',
+		} );
+	}, [] );
 
 	return (
 		<Dialog

--- a/client/my-sites/plans-features-main/components/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-free-domain-dialog.tsx
@@ -166,7 +166,7 @@ export function FreePlanFreeDomainDialog( {
 
 	useEffect( () => {
 		recordTracksEvent( MODAL_VIEW_EVENT_NAME, {
-			dialog_type: 'paid_plan_is_required',
+			dialog_type: 'free_plan_free_domain',
 		} );
 	}, [] );
 

--- a/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-paid-domain-dialog.tsx
@@ -169,7 +169,7 @@ type DomainPlanDialogProps = {
 };
 
 // See p2-pbxNRc-2Ri#comment-4703 for more context
-const MODAL_VIEW_EVENT_NAME = 'calypso_plan_upsell_modal_view';
+export const MODAL_VIEW_EVENT_NAME = 'calypso_plan_upsell_modal_view';
 
 function DialogPaidPlanIsRequired( {
 	paidDomainName,

--- a/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
@@ -8,14 +8,9 @@ export const useIsPlanUpsellEnabledOnFreeDomain = (
 	const ONBOARDING_PM_EXPERIMENT = 'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal';
 	const relevantExperiment =
 		flowName === 'onboarding' ? ONBOARDING_EXPERIMENT : ONBOARDING_PM_EXPERIMENT;
-	const [ isLoading, experimentAssignment ] = useExperiment( relevantExperiment );
-
-	if ( ! [ 'onboarding', 'onboarding-pm' ].includes( flowName ?? '' ) ) {
-		return {
-			isLoading: false,
-			result: false,
-		};
-	}
+	const [ isLoading, experimentAssignment ] = useExperiment( relevantExperiment, {
+		isEligible: [ 'onboarding', 'onboarding-pm' ].includes( flowName ?? '' ),
+	} );
 	return {
 		isLoading,
 		result: experimentAssignment?.variationName === 'treatment',

--- a/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
@@ -1,0 +1,23 @@
+import { useExperiment } from 'calypso/lib/explat';
+import type { DataResponse } from 'calypso/my-sites/plan-features-2023-grid/types';
+
+export const useIsPlanUpsellEnabledOnFreeDomain = (
+	flowName?: string | null
+): DataResponse< boolean > => {
+	const ONBOARDING_EXPERIMENT = 'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal';
+	const ONBOARDING_PM_EXPERIMENT = 'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal';
+	const relevantExperiment =
+		flowName === 'onboarding' ? ONBOARDING_EXPERIMENT : ONBOARDING_PM_EXPERIMENT;
+	const [ isLoading, experimentAssignment ] = useExperiment( relevantExperiment );
+
+	if ( ! [ 'onboarding', 'onboarding-pm' ].includes( flowName ?? '' ) ) {
+		return {
+			isLoading: false,
+			result: false,
+		};
+	}
+	return {
+		isLoading,
+		result: experimentAssignment?.variationName === 'treatment',
+	};
+};

--- a/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
@@ -1,18 +1,21 @@
 import { useExperiment } from 'calypso/lib/explat';
 import type { DataResponse } from 'calypso/my-sites/plan-features-2023-grid/types';
 
-export const useIsPlanUpsellEnabledOnFreeDomain = (
-	flowName?: string | null
+const useIsPlanUpsellEnabledOnFreeDomain = (
+	flowName?: string | null,
+	hasPaidDomain?: boolean
 ): DataResponse< boolean > => {
 	const ONBOARDING_EXPERIMENT = 'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal';
 	const ONBOARDING_PM_EXPERIMENT = 'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal';
 	const relevantExperiment =
 		flowName === 'onboarding' ? ONBOARDING_EXPERIMENT : ONBOARDING_PM_EXPERIMENT;
 	const [ isLoading, experimentAssignment ] = useExperiment( relevantExperiment, {
-		isEligible: [ 'onboarding', 'onboarding-pm' ].includes( flowName ?? '' ),
+		isEligible: [ 'onboarding', 'onboarding-pm' ].includes( flowName ?? '' ) && ! hasPaidDomain,
 	} );
 	return {
 		isLoading,
 		result: experimentAssignment?.variationName === 'treatment',
 	};
 };
+
+export default useIsPlanUpsellEnabledOnFreeDomain;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -293,10 +293,7 @@ const PlansFeaturesMain = ( {
 		flowName,
 		paidDomainName
 	);
-	const isPlanUpsellEnabledOnFreeDomain = useIsPlanUpsellEnabledOnFreeDomain(
-		flowName,
-		signupFlowSubdomain
-	);
+	const isPlanUpsellEnabledOnFreeDomain = useIsPlanUpsellEnabledOnFreeDomain( flowName );
 
 	let _customerType = chooseDefaultCustomerType( {
 		currentCustomerType: customerType,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	chooseDefaultCustomerType,
 	getPlan,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -41,7 +41,7 @@ import { FreePlanFreeDomainDialog } from './components/free-plan-free-domain-dia
 import { FreePlanPaidDomainDialog } from './components/free-plan-paid-domain-dialog';
 import useFilterPlansForPlanFeatures from './hooks/use-filter-plans-for-plan-features';
 import useIsCustomDomainAllowedOnFreePlan from './hooks/use-is-custom-domain-allowed-on-free-plan';
-import { useIsPlanUpsellEnabledOnFreeDomain } from './hooks/use-is-plan-upsell-enabled-on-free-domain';
+import useIsPlanUpsellEnabledOnFreeDomain from './hooks/use-is-plan-upsell-enabled-on-free-domain';
 import usePlanBillingPeriod from './hooks/use-plan-billing-period';
 import usePlanFromUpsells from './hooks/use-plan-from-upsells';
 import usePlanIntentFromSiteMeta from './hooks/use-plan-intent-from-site-meta';
@@ -294,7 +294,10 @@ const PlansFeaturesMain = ( {
 		flowName,
 		paidDomainName
 	);
-	const isPlanUpsellEnabledOnFreeDomain = useIsPlanUpsellEnabledOnFreeDomain( flowName );
+	const isPlanUpsellEnabledOnFreeDomain = useIsPlanUpsellEnabledOnFreeDomain(
+		flowName,
+		!! paidDomainName
+	);
 
 	let _customerType = chooseDefaultCustomerType( {
 		currentCustomerType: customerType,

--- a/config/development.json
+++ b/config/development.json
@@ -125,7 +125,6 @@
 		"network-connection": true,
 		"newsletter/stats": true,
 		"oauth": false,
-		"onboarding-pm/free-free-modal": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -78,7 +78,6 @@
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"newsletter/stats": true,
-		"onboarding-pm/free-free-modal": true,
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redesign": true,
 		"p2/p2-plus": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -65,7 +65,6 @@
 		"marketplace-domain-bundle": false,
 		"marketplace-test": false,
 		"oauth": true,
-		"onboarding-pm/free-free-modal": false,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -59,7 +59,6 @@
 		"marketplace-domain-bundle": false,
 		"marketplace-test": false,
 		"oauth": false,
-		"onboarding-pm/free-free-modal": false,
 		"purchases/new-payment-methods": true,
 		"site-indicator": false,
 		"upgrades/redirect-payments": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -61,7 +61,6 @@
 		"marketplace-domain-bundle": false,
 		"marketplace-test": false,
 		"oauth": true,
-		"onboarding-pm/free-free-modal": false,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -62,7 +62,6 @@
 		"marketplace-domain-bundle": false,
 		"marketplace-test": false,
 		"oauth": true,
-		"onboarding-pm/free-free-modal": false,
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,

--- a/config/production.json
+++ b/config/production.json
@@ -92,7 +92,6 @@
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
 		"newsletter/stats": false,
-		"onboarding-pm/free-free-modal": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -87,7 +87,6 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
-		"onboarding-pm/free-free-modal": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/test.json
+++ b/config/test.json
@@ -69,7 +69,6 @@
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
-		"onboarding-pm/free-free-modal": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -98,7 +98,6 @@
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"newsletter/stats": false,
-		"onboarding-pm/free-free-modal": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 
- https://github.com/Automattic/growth-foundations/issues/139

## Proposed Changes

* Wires up the experiment for the free/free modal feature and removes the feature flag


## Testing Instructions

###  Testing Control
* Go to the
    *  Onboarding Flow - `/start` OR 
    *  Paid Media Flow - `/start/onboarding-pm` 
* Select the free subdomain OR select `Choose my domain later`
   * Select the free plan
       * Make sure you are taken to site creation step and then My Home
   * Select the paid plan 
       * Make sure you are taken to site creation step and then Checkout

###  Testing Treatment
* Go to the 
     * Onboarding Flow Experiment 21318-explat-experiment OR 
     * Paid Media Flow Experiment  21319-explat-experiment
* Assign yourself to the treatment variant
* Depending on the experiment selected above Go to the
    *  Onboarding Flow - `/start` OR 
    *  Paid Media Flow - `/start/onboarding-pm`
* Select the  
      * Free subdomain OR 
      * `Choose my domain later`
* On the plans step
     * Select the free plan - Make sure you see the plan upsell modal
     * Select the paid plan - Make sure you are taken to site creation step and then My Home
* On the plan upsell modal
     * Select `Continue with free` - Make sure you are taken to site creation step and then My Home
     * Select the paid plan - Make sure you are taken to site creation step and then checkout with the personal plan


<img width="718" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/fc8aa0bb-c5cd-4148-8adb-dee7974aaca5">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?