### PR TITLE
Bulk Domain Transfers: disable track events for invalid input

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -120,6 +120,7 @@ export function DomainCodePair( {
 	const {
 		valid,
 		loading,
+		shouldLogError = true,
 		message,
 		rawPrice = 0,
 		saleCost,
@@ -135,7 +136,7 @@ export function DomainCodePair( {
 	const shouldReportError = hasDuplicates || ( ! loading && domain && auth ? true : false );
 
 	useEffect( () => {
-		if ( shouldReportError && ! valid && message ) {
+		if ( shouldLogError && shouldReportError ) {
 			recordTracksEvent( 'calypso_domain_transfer_domain_error', {
 				domain,
 				error: errorStatus ? errorStatus : String( message ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -36,6 +36,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		return {
 			valid: false,
 			loading: false,
+			shouldLogError: false,
 			message: __( 'This domain has already been entered.' ),
 		};
 	}
@@ -44,6 +45,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		return {
 			valid: false,
 			loading: false,
+			shouldLogError: false,
 			message: __( 'Please enter a valid domain name.' ),
 		};
 	}
@@ -52,6 +54,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		return {
 			valid: false,
 			loading: false,
+			shouldLogError: false,
 			message: __( 'Please enter a valid authentication code.' ),
 		};
 	}
@@ -61,6 +64,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		return {
 			valid: false,
 			loading: true,
+			shouldLogError: false,
 			message: __( 'Checking domain lock status.' ),
 		};
 	}


### PR DESCRIPTION
Related to #

## Proposed Changes

* The tracks events will exclude invalid form input

## Testing Instructions

* Navigate to `/setup/google-transfer/domains`
* Open Developer Tools ( `F12` ) and clear the screen ( `CTRL + L` or  `cmd + k` )
* Type anything in `auth code` input.
* Start typing a domain name.
* Make sure that there are no requests showing in the Network tab with every character, and only when both domain and auth code inputs are valid you will start seeing the requests.

## Before

https://github.com/Automattic/wp-calypso/assets/1080253/cb2393ed-57df-4d5e-bf96-9b8ce8071582

## After

https://github.com/Automattic/wp-calypso/assets/1080253/bfa89474-75e9-4162-a000-25bb2e38331e


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
