### PR TITLE
Fixes the contact support link in the Blaze Dashboard app

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -20,7 +20,6 @@ import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import { CampaignResponse } from 'calypso/data/promote-post/use-promote-post-campaigns-query-new';
 import useCancelCampaignMutation from 'calypso/data/promote-post/use-promote-post-cancel-campaign-mutation';
-import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import AdPreview from 'calypso/my-sites/promote-post-i2/components/ad-preview';
 import useOpenPromoteWidget from 'calypso/my-sites/promote-post-i2/hooks/use-open-promote-widget';
 import {
@@ -629,7 +628,10 @@ export default function CampaignItemDetails( props: Props ) {
 												{ cancelCampaignButtonText }
 											</Button>
 										) }
-										<Button href={ CALYPSO_CONTACT } target="_blank">
+										<Button
+											href={ localizeUrl( 'https://wordpress.com/help/contact' ) }
+											target="_blank"
+										>
 											{ icon }
 											{ translate( 'Contact Support' ) }
 										</Button>


### PR DESCRIPTION
Related to Jetpack Issue # [80099](https://github.com/Automattic/wp-calypso/issues/80099)

The contact support link on the Jetpack Blaze Dashboard app doesn't redirect the user to the correct wordpress.com page.

## Proposed Changes

This PR changes the link to use the correct wordpress.com link to the support page.

## Testing Instructions

### Wordpress.com side
* Open the live preview and navigate to Tools->Advertising
* Click on campaigns, and then click on any campaign on the list to access its details
* Click on the Contact Support link
* Verify that you get redirected to the `https://wordpress.com/help` page (the browser will first load `https://wordpress.com/help/contact`, which will redirect you to the `/help` page because you are logged in).


### Jetpack Blaze Dashbaord side
There are multiple alternatives to test the Blaze Dashboard app, I will describe the local testing steps in this PR, but you can also use your sandbox for testing this (let me know, and I can give you the testing steps for the sandbox option).

* Check out this branch
* In a terminal, go to `wp-calypso/apps/blaze-dashboard`
* Execute `BLAZE_DASHBOARD_PACKAGE_PATH=/path_to_local_jetpack_repo/jetpack/projects/packages/blaze yarn dev`. You need to change `path_to_local_jetpack_repo` for your local jetpack installation repo.
* In your Jurrasic tube local site, navigate to Tools->Advertising
* Click on campaigns, and then on any campaign in the list to access its details
* Click on the Contact Support link
* Verify that you are redirected to the correct support page: `https://wordpress.com/help/contact/`. If you are logged in to WordPress, you will end up on `https://wordpress.com/help` after the redirection; if you are not, then you will land on 
`https://wordpress.com/support/contact`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
