### PR TITLE
Update Jetpack deployment e2e CI to use finish build trigger

### DIFF
--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -71,7 +71,6 @@ open class E2EBuildType(
 		val buildTriggers = buildTriggers
 		val buildDependencies = buildDependencies
 		val params = params
-		val addWpcomVcsRoot = addWpcomVcsRoot
 		val buildSteps = buildSteps
 
 		id( buildId )
@@ -88,9 +87,6 @@ open class E2EBuildType(
 
 		vcs {
 			root(Settings.WpCalypso)
-			if (addWpcomVcsRoot) {
-				root(AbsoluteId("wpcom"), "-:.")
-			}
 			cleanCheckout = true
 		}
 

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -15,6 +15,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.buildReportT
 import jetbrains.buildServer.configs.kotlin.v2019_2.Triggers
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.exec
 
@@ -227,12 +228,8 @@ fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpack
 
 	val triggers: Triggers.() -> Unit = {
 		if (jetpackTarget == "wpcom-staging") {
-			vcs {
-				// Trigger only when changes are made to the Jetpack staging directories in our WPCOM connection
-				triggerRules = """
-					+:root=wpcom:**/mu-plugins/jetpack*-plugin/moon/*
-					+:root=wpcom:**/mu-plugins/jetpack*-plugin/sun/*
-				""".trimIndent()
+			finishBuildTrigger {
+				buildType = "JetpackStaging_JetpackSunMoonUpdated"
 			}
 		} else {
 			// For remote-site tests and production, we are just running daily for now.
@@ -267,8 +264,7 @@ fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpack
 			param("env.JETPACK_TARGET", jetpackTarget)
 		},
 		buildFeatures = {},
-		buildTriggers = triggers,
-		addWpcomVcsRoot = true
+		buildTriggers = triggers
 	)
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Lots of context here: p1689958187650989-slack-CQD1HH4MA

TL;DR -- It's actually turned out to be a little simpler, safer, and cleaner to move the SVN related triggers for Jetpack simple deployments elsewhere, and then just keep this TeamCity project focused on the E2E code found in the `wp-calypso` repo. So now, the Jetpack deployment E2E tests are based on a finished build trigger, rather than a VCS trigger. We've also removed the `wpcom` SVN VCS connection.

Worth noting: I haven't changed anything else about this E2E build. We probably will need to update the name and E2E strategy now to account for both simple and atomic deployments, and the phrase "staging" is also kind of outdated now. But, let's deal with that in a separate PR! The goal here is to get the triggering and connection working. 👍 

## Testing Instructions

Can't test in full until we deploy, but there should be no compilation errors!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?