### PR TITLE
Launchpad: Add dismiss button

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -86,6 +86,11 @@ const CustomerHomeLaunchpad = ( {
 										is_visible: false,
 									},
 								} );
+
+								recordTracksEvent( 'calypso_launchpad_dismiss_guide', {
+									checklist_slug: checklistSlug,
+									context: 'customer-home',
+								} );
 							} }
 						>
 							<div> { translate( 'Dismiss guide' ) } </div>

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -76,7 +76,6 @@ const CustomerHomeLaunchpad = ( {
 					</div>
 				) : (
 					<div className="customer-home-launchpad__dismiss-button">
-						<span> { translate( 'Dismiss guide' ) } </span>
 						<Button
 							className="themes__activation-modal-close-icon"
 							borderless
@@ -89,6 +88,7 @@ const CustomerHomeLaunchpad = ( {
 								} );
 							} }
 						>
+							<div> { translate( 'Dismiss guide' ) } </div>
 							<Gridicon icon="cross" size={ 12 } />
 						</Button>
 					</div>

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -1,5 +1,5 @@
 import { Button, CircularProgressBar, Gridicon } from '@automattic/components';
-import { useLaunchpad } from '@automattic/data-stores';
+import { updateLaunchpadSettings, useLaunchpad } from '@automattic/data-stores';
 import { Launchpad, Task } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -81,7 +81,12 @@ const CustomerHomeLaunchpad = ( {
 							className="themes__activation-modal-close-icon"
 							borderless
 							onClick={ () => {
-								alert( 1 );
+								updateLaunchpadSettings( siteSlug, {
+									is_checklist_visible: {
+										slug: checklistSlug,
+										is_visible: false,
+									},
+								} );
 							} }
 						>
 							<Gridicon icon="cross" size={ 12 } />

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -1,4 +1,4 @@
-import { CircularProgressBar } from '@automattic/components';
+import { Button, CircularProgressBar, Gridicon } from '@automattic/components';
 import { useLaunchpad } from '@automattic/data-stores';
 import { Launchpad, Task } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
@@ -65,14 +65,29 @@ const CustomerHomeLaunchpad = ( {
 				<h2 className="customer-home-launchpad__title">
 					{ translate( 'Next steps for your site' ) }
 				</h2>
-				<div className="customer-home-launchpad__progress-bar-container">
-					<CircularProgressBar
-						size={ 40 }
-						enableDesktopScaling
-						numberOfSteps={ numberOfSteps }
-						currentStep={ completedSteps }
-					/>
-				</div>
+				{ numberOfSteps > completedSteps ? (
+					<div className="customer-home-launchpad__progress-bar-container">
+						<CircularProgressBar
+							size={ 40 }
+							enableDesktopScaling
+							numberOfSteps={ numberOfSteps }
+							currentStep={ completedSteps }
+						/>
+					</div>
+				) : (
+					<div className="customer-home-launchpad__dismiss-button">
+						<span> { translate( 'Dismiss guide' ) } </span>
+						<Button
+							className="themes__activation-modal-close-icon"
+							borderless
+							onClick={ () => {
+								alert( 1 );
+							} }
+						>
+							<Gridicon icon="cross" size={ 12 } />
+						</Button>
+					</div>
+				) }
 			</div>
 			<Launchpad siteSlug={ siteSlug } checklistSlug={ checklistSlug } taskFilter={ taskFilter } />
 		</div>

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -81,9 +81,9 @@ const CustomerHomeLaunchpad = ( {
 							borderless
 							onClick={ () => {
 								updateLaunchpadSettings( siteSlug, {
-									is_checklist_visible: {
+									is_checklist_dismissed: {
 										slug: checklistSlug,
-										is_visible: false,
+										is_dismissed: true,
 									},
 								} );
 

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -2,7 +2,7 @@ import { Button, CircularProgressBar, Gridicon } from '@automattic/components';
 import { updateLaunchpadSettings, useLaunchpad } from '@automattic/data-stores';
 import { Launchpad, Task } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -24,9 +24,14 @@ const CustomerHomeLaunchpad = ( {
 	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
 
 	const translate = useTranslate();
+	const [ isDismissed, setIsDismissed ] = useState( false );
 	const {
-		data: { checklist, is_dismissed: isChecklistDismissed },
+		data: { checklist, is_dismissed: initialIsChecklistDismissed },
 	} = useLaunchpad( siteSlug, checklistSlug );
+
+	useEffect( () => {
+		setIsDismissed( initialIsChecklistDismissed );
+	}, [ initialIsChecklistDismissed ] );
 
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
@@ -55,7 +60,7 @@ const CustomerHomeLaunchpad = ( {
 	}, [ checklist, checklistSlug, completedSteps, numberOfSteps, tasklistCompleted ] );
 
 	// return nothing if the launchpad is dismissed
-	if ( isChecklistDismissed ) {
+	if ( isDismissed ) {
 		return <></>;
 	}
 
@@ -86,6 +91,7 @@ const CustomerHomeLaunchpad = ( {
 										is_dismissed: true,
 									},
 								} );
+								setIsDismissed( true );
 
 								recordTracksEvent( 'calypso_launchpad_dismiss_guide', {
 									checklist_slug: checklistSlug,

--- a/client/my-sites/customer-home/cards/launchpad/style.scss
+++ b/client/my-sites/customer-home/cards/launchpad/style.scss
@@ -31,7 +31,7 @@
 				height: 24px;
 
 				div {
-					padding-right: 8px;
+					padding-right: 4px;
 				}
 
 				svg {

--- a/client/my-sites/customer-home/cards/launchpad/style.scss
+++ b/client/my-sites/customer-home/cards/launchpad/style.scss
@@ -24,17 +24,18 @@
 		}
 
 		.customer-home-launchpad__dismiss-button {
-			align-items: center;
-			display: flex;
-
-			span {
-				padding-right: 8px;
-			}
 			button {
+				align-items: center;
+				display: flex;
 				padding: 0;
 				height: 24px;
+
+				div {
+					padding-right: 8px;
+				}
+
 				svg {
-					top: 3px;
+					top: 2px;
 				}
 			}
 		}

--- a/client/my-sites/customer-home/cards/launchpad/style.scss
+++ b/client/my-sites/customer-home/cards/launchpad/style.scss
@@ -22,5 +22,21 @@
 			font-weight: 500;
 			font-family: $font-sf-pro-display;
 		}
+
+		.customer-home-launchpad__dismiss-button {
+			align-items: center;
+			display: flex;
+
+			span {
+				padding-right: 8px;
+			}
+			button {
+				padding: 0;
+				height: 24px;
+				svg {
+					top: 3px;
+				}
+			}
+		}
 	}
 }

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -41,6 +41,10 @@ interface LaunchpadResponse {
 
 type LaunchpadUpdateSettings = {
 	checklist_statuses?: Record< string, boolean >;
+	is_checklist_visible?: {
+		slug: string;
+		is_visible: boolean;
+	};
 };
 
 export const fetchLaunchpad = (

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -41,9 +41,9 @@ interface LaunchpadResponse {
 
 type LaunchpadUpdateSettings = {
 	checklist_statuses?: Record< string, boolean >;
-	is_checklist_visible?: {
+	is_checklist_dismissed?: {
 		slug: string;
-		is_visible: boolean;
+		is_dismissed: boolean;
 	};
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Context: paYKcK-3hW-p2#comment-2358 

## Proposed Changes

This diff adds a dismiss button to the Launchpad that is shown when the set of tasks is complete. 
<img width="690" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/daaea200-c967-4470-b136-8ffa532175e1">


This diff depends on the following PRs being merged:
 * https://github.com/Automattic/jetpack/pull/32200
 * https://github.com/Automattic/wp-calypso/pull/80116



## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /home.
* Verify you don't see the cross to dismiss the launchpad.
* Complete all tasks.
* Verify you now see the `Dismiss guide x` on the top right of the launchpad.
* Click the dismiss button.
* Verify the Launchpad disappears.
* Verify the `calypso_launchpad_dismiss_guide` track is triggered.

## Testing on Atomic
* Create a new site, launch it and move it to Atomic using WoA.
* Access the site /home using the calypso.live link or your local env.
* Make sure all tasks are complete, you can force them by replacing the `get_data` function on this file: `htdocs/wp-content/mu-plugins/wpcomsh/vendor/automattic/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php` on your Atomic site by
```
	public function get_data( $request ) {
		$checklist_slug = isset( $request['checklist_slug'] ) ? $request['checklist_slug'] : get_option( 'site_intent' );

		$data = wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug );
		$data = array_map( function( $item ) {
			$item['completed'] = true;
			return $item;
		}, $data );
		return array(
			'site_intent'        => get_option( 'site_intent' ),
			'launchpad_screen'   => get_option( 'launchpad_screen' ),
			'checklist_statuses' => get_option( 'launchpad_checklist_tasks_statuses', array() ),
			'checklist'          => $data,
			'is_enabled'         => wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ),
			'is_dismissed'       => wpcom_launchpad_is_task_list_dismissed( $checklist_slug ),
		);
	}
```
* Make sure you see the `Dismiss guide` button.
* Press the button and verify the launchpad disappears 
* Reload and verify the launchpad is not present
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
