### PR TITLE
Launchpad: Change list visibility base on server state

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -25,7 +25,7 @@ const CustomerHomeLaunchpad = ( {
 
 	const translate = useTranslate();
 	const {
-		data: { checklist },
+		data: { checklist, is_visible: isChecklistVisible },
 	} = useLaunchpad( siteSlug, checklistSlug );
 
 	const numberOfSteps = checklist?.length || 0;
@@ -53,6 +53,11 @@ const CustomerHomeLaunchpad = ( {
 			} );
 		} );
 	}, [ checklist, checklistSlug, completedSteps, numberOfSteps, tasklistCompleted ] );
+
+	// return nothing if the launchpad is not visible
+	if ( ! isChecklistVisible ) {
+		return <></>;
+	}
 
 	return (
 		<div className="customer-home-launchpad">

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -25,7 +25,7 @@ const CustomerHomeLaunchpad = ( {
 
 	const translate = useTranslate();
 	const {
-		data: { checklist, is_visible: isChecklistVisible },
+		data: { checklist, is_dismissed: isChecklistDismissed },
 	} = useLaunchpad( siteSlug, checklistSlug );
 
 	const numberOfSteps = checklist?.length || 0;
@@ -54,8 +54,8 @@ const CustomerHomeLaunchpad = ( {
 		} );
 	}, [ checklist, checklistSlug, completedSteps, numberOfSteps, tasklistCompleted ] );
 
-	// return nothing if the launchpad is not visible
-	if ( ! isChecklistVisible ) {
+	// return nothing if the launchpad is dismissed
+	if ( isChecklistDismissed ) {
 		return <></>;
 	}
 

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -36,6 +36,7 @@ interface LaunchpadResponse {
 	checklist?: Task[] | null;
 	checklist_statuses?: ChecklistStatuses;
 	is_enabled: boolean;
+	is_visible: boolean;
 }
 
 type LaunchpadUpdateSettings = {
@@ -79,6 +80,7 @@ export const useLaunchpad = (
 			checklist_statuses: {},
 			checklist: null,
 			is_enabled: false,
+			is_visible: true,
 		},
 	} );
 };

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -36,7 +36,7 @@ interface LaunchpadResponse {
 	checklist?: Task[] | null;
 	checklist_statuses?: ChecklistStatuses;
 	is_enabled: boolean;
-	is_visible: boolean;
+	is_dismissed: boolean;
 }
 
 type LaunchpadUpdateSettings = {
@@ -80,7 +80,7 @@ export const useLaunchpad = (
 			checklist_statuses: {},
 			checklist: null,
 			is_enabled: false,
-			is_visible: true,
+			is_dismissed: false,
 		},
 	} );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Context: paYKcK-3hW-p2#comment-2358 
## Proposed Changes

Once this is merged https://github.com/Automattic/jetpack/pull/32200 this PR will toggle visibility based on the `is_dismissed` value returned by the backend

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Create a site with the build intent and launch the site.
* Apply the changes in this PR to your sandbox
* Go to dev API console and prepare it to run queries on `WP Rest API > wpcom/v2`
* Make a GET to `/sites/[YOUR_SITE]/launchpad?checklist_slug=intent-build`
* Verify that there's an `is_dismissed` key in the result and that it's set to `false`
* Make a POST to `/sites/[YOUR_SITE]/launchpad` with the following value in the `is_checklist_dismissed` param: `{"slug":"intent-build","is_dismissed":true}` (you can check this out to see how to do this from the dev console: p1690917561303459-slack-C0Q664T29)

* Verify the Launchpad on home disappears.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
