### PR TITLE
Hosting: Add a relative link to the Staging Site module

### DIFF
--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -137,7 +137,12 @@ const WebServerSettingsCard = ( {
 					<p className="web-server-settings-card__wp-version-description">
 						{ translate(
 							'Every WordPress.com site runs the latest WordPress version. ' +
-								'For testing purposes, you can switch to the beta version of the next WordPress release on your staging site.'
+								'For testing purposes, you can switch to the beta version of the next WordPress release on {{a}}your staging site{{/a}}.',
+							{
+								components: {
+									a: <a href="#staging-site" />,
+								},
+							}
 						) }
 					</p>
 				) }


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/3248
From pdKhl6-2oi-p2#comment-3675

## Proposed Changes

Adds a relative link to the Staging Site module:

<img width="914" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/2539c90a-63f1-4ab7-83ed-767e8830d4ff">

## Testing Instructions

1. Navigate to Hosting Configuration.
2. Click on the link and verify it takes you to the expected spot.