### PR TITLE
Billing: Remove taxamo external link

### DIFF
--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -172,11 +172,6 @@ export function ReceiptBody( {
 					</Button>
 				</div>
 			</Card>
-			{ /* Temporarily disable taxamo receipt link until we can get a go ahead
-
-            { transaction.tax_external_id && transaction.tax_external_id.length > 0 && (
-				<ReceiptExternalLink transaction={ transaction } />
-			) } */ }
 		</div>
 	);
 }

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { Button, Card, CompactCard } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
@@ -173,25 +173,6 @@ export function ReceiptBody( {
 				</div>
 			</Card>
 		</div>
-	);
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function ReceiptExternalLink( { transaction }: { transaction: BillingTransaction } ) {
-	const translate = useTranslate();
-	const externalTaxlink =
-		'https://invoicestaxamo.s3.amazonaws.com/' + transaction.tax_external_id + '/invoice.html';
-	const labelContent = translate( 'View tax invoice' );
-
-	return (
-		<CompactCard
-			href={ externalTaxlink }
-			rel="noopener noreferrer"
-			target="_blank"
-			className="billing-history__tax-receipt-link"
-		>
-			{ labelContent }
-		</CompactCard>
 	);
 }
 


### PR DESCRIPTION
Simple code cleanup PR. This PR will remove the already commented out code for the taxamo external link. This link was removed in https://github.com/Automattic/wp-calypso/pull/74913

## Testing Instructions

* This one is rather hard to test unless you have an existing taxamo receipt (maybe @martian77 has one?)
* You can also go to Billing and see if there are any visual, functional, or logged issues. This should simply remove just the taxamo receipt external link found on the billing page (only shows if your product has a taxamo receipt)
