### PR TITLE
Domain Transfers: display dynamic messages for domain transfer products on manage purchases page

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -52,6 +52,7 @@ import { localize, LocalizeProps } from 'i18n-calypso';
 import page from 'page';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { SupportedSlugs } from 'calypso/../packages/components/src/product-icon/config';
 import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
 import AsyncLoad from 'calypso/components/async-load';
@@ -1502,74 +1503,81 @@ function PurchasesQueryComponent( {
 	return <QueryUserPurchases />;
 }
 
-export default connect(
-	( state: IAppState, props: ManagePurchaseProps ) => {
-		const purchase = getByPurchaseId( state, props.purchaseId );
+export default connect( ( state: IAppState, props: ManagePurchaseProps ) => {
+	const purchase = getByPurchaseId( state, props.purchaseId );
 
-		const purchaseAttachedTo =
-			purchase && purchase.attachedToPurchaseId
-				? getByPurchaseId( state, purchase.attachedToPurchaseId )
-				: null;
-		const selectedSiteId = getSelectedSiteId( state );
-		const siteId = purchase?.siteId ?? null;
-		const purchases = purchase && getSitePurchases( state, purchase.siteId );
-		const userId = getCurrentUserId( state );
-		const isProductOwner = purchase && purchase.userId === userId;
-		const renewableSitePurchases = getRenewableSitePurchases( state, siteId );
-		const isPurchasePlan = purchase && isPlan( purchase );
-		const isPurchaseTheme = purchase && isThemePurchase( purchase );
-		const productsList = getProductsList( state );
-		const site = getSite( state, siteId ?? undefined );
-		const hasLoadedSites = ! isRequestingSites( state );
-		const hasLoadedDomains = hasLoadedSiteDomains( state, siteId );
-		const relatedMonthlyPlanSlug = getMonthlyPlanByYearly( purchase?.productSlug ?? '' );
-		const relatedMonthlyPlanPrice = siteId
-			? getSitePlanRawPrice( state, siteId, relatedMonthlyPlanSlug ) ?? 0
-			: 0;
-		const primaryDomain = getPrimaryDomainBySiteId( state, siteId );
-		const currentRoute = getCurrentRoute( state );
+	const purchaseAttachedTo =
+		purchase && purchase.attachedToPurchaseId
+			? getByPurchaseId( state, purchase.attachedToPurchaseId )
+			: null;
+	const selectedSiteId = getSelectedSiteId( state );
+	const siteId = purchase?.siteId ?? null;
+	const purchases = purchase && getSitePurchases( state, purchase.siteId );
+	const userId = getCurrentUserId( state );
+	const isProductOwner = purchase && purchase.userId === userId;
+	const renewableSitePurchases = getRenewableSitePurchases( state, siteId );
+	const isPurchasePlan = purchase && isPlan( purchase );
+	const isPurchaseTheme = purchase && isThemePurchase( purchase );
+	const productsList = getProductsList( state );
+	const site = getSite( state, siteId ?? undefined );
+	const hasLoadedSites = ! isRequestingSites( state );
+	const hasLoadedDomains = hasLoadedSiteDomains( state, siteId );
+	const relatedMonthlyPlanSlug = getMonthlyPlanByYearly( purchase?.productSlug ?? '' );
+	const relatedMonthlyPlanPrice = siteId
+		? getSitePlanRawPrice( state, siteId, relatedMonthlyPlanSlug ) ?? 0
+		: 0;
+	const primaryDomain = getPrimaryDomainBySiteId( state, siteId );
+	const currentRoute = getCurrentRoute( state );
 
-		return {
-			currentRoute,
-			domainsDetails: getAllDomains( state ),
-			hasCustomPrimaryDomain: hasCustomDomain( site ),
-			hasLoadedDomains,
-			hasLoadedPurchasesFromServer: props.isSiteLevel
-				? hasLoadedSitePurchasesFromServer( state )
-				: hasLoadedUserPurchasesFromServer( state ),
-			hasLoadedSites,
-			hasNonPrimaryDomainsFlag: getCurrentUser( state )
-				? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
-				: false,
-			hasSetupAds: Boolean(
-				site?.options?.wordads || isRequestingWordAdsApprovalForSite( state, site )
-			),
-			isAtomicSite: isSiteAtomic( state, siteId ),
-			isDomainOnlySite: purchase && isDomainOnly( state, purchase.siteId ),
-			isProductOwner,
-			isPurchaseTheme,
-			plan: isPurchasePlan && applyTestFiltersToPlansList( purchase.productSlug, undefined ),
-			primaryDomain: primaryDomain,
-			productsList,
-			purchase,
-			purchaseAttachedTo,
-			purchases,
-			relatedMonthlyPlanPrice,
-			relatedMonthlyPlanSlug,
-			renewableSitePurchases,
-			selectedSiteId,
-			site,
-			siteId,
-			theme: isPurchaseTheme && siteId && getCanonicalTheme( state, siteId, purchase.meta ?? null ),
-		};
-	},
-	{
-		handleRenewNowClick,
-		handleRenewMultiplePurchasesClick,
-		errorNotice,
-		successNotice,
-	}
-)( localize( ManagePurchase ) );
+	return {
+		currentRoute,
+		domainsDetails: getAllDomains( state ),
+		hasCustomPrimaryDomain: hasCustomDomain( site ),
+		hasLoadedDomains,
+		hasLoadedPurchasesFromServer: props.isSiteLevel
+			? hasLoadedSitePurchasesFromServer( state )
+			: hasLoadedUserPurchasesFromServer( state ),
+		hasLoadedSites,
+		hasNonPrimaryDomainsFlag: getCurrentUser( state )
+			? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
+			: false,
+		hasSetupAds: Boolean(
+			site?.options?.wordads || isRequestingWordAdsApprovalForSite( state, site )
+		),
+		isAtomicSite: isSiteAtomic( state, siteId ),
+		isDomainOnlySite: purchase && isDomainOnly( state, purchase.siteId ),
+		isProductOwner,
+		isPurchaseTheme,
+		plan: isPurchasePlan && applyTestFiltersToPlansList( purchase.productSlug, undefined ),
+		primaryDomain: primaryDomain,
+		productsList,
+		purchase,
+		purchaseAttachedTo,
+		purchases,
+		relatedMonthlyPlanPrice,
+		relatedMonthlyPlanSlug,
+		renewableSitePurchases,
+		selectedSiteId,
+		site,
+		siteId,
+		theme: isPurchaseTheme && siteId && getCanonicalTheme( state, siteId, purchase.meta ?? null ),
+	};
+}, mapDispatchToProps )( localize( ManagePurchase ) );
+
+function mapDispatchToProps( dispatch: CalypsoDispatch ) {
+	return {
+		dispatch,
+		...bindActionCreators(
+			{
+				handleRenewNowClick,
+				handleRenewMultiplePurchasesClick,
+				errorNotice,
+				successNotice,
+			},
+			dispatch
+		),
+	};
+}
 
 function getCancelPurchaseNavText(
 	purchase: Purchase,

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1095,25 +1095,31 @@ class ManagePurchase extends Component<
 			},
 		};
 		const supportText = translate(
-			' Need help? {{a}}Get in touch with one of our Happiness Engineers{{/a}}.',
+			'Need help? {{a}}Get in touch with one of our Happiness Engineers{{/a}}.',
 			helpOptions
 		);
 
 		const cancelText = translate(
-			' Cancel Domain and Refund? Please {{a}}click here.{{/a}}',
+			'Cancel Domain and Refund? Please {{a}}click here.{{/a}}',
 			cancelOptions
 		);
 
 		const domainTransferDuration = translate(
-			' Domain transfers can take anywhere from five to seven days to complete'
+			'Domain transfers can take anywhere from five to seven days to complete.'
 		);
 		return (
 			<div className="manage-purchase__content">
 				<span className="manage-purchase__description">
-					{ this.getPurchaseDescription() }
-					{ purchase.productType === 'domain_transfer' && supportText }
-					{ purchase.productType === 'domain_transfer' && cancelText }
-					{ purchase.productType === 'domain_transfer' && domainTransferDuration }
+					<div className="manage-purchase__content-domain-description">
+						{ this.getPurchaseDescription() }
+					</div>
+					<div className="manage-purchase__content-domain-description">
+						{ purchase.productType === 'domain_transfer' && cancelText }
+						{ purchase.productType === 'domain_transfer' && ' ' + domainTransferDuration }
+					</div>
+					<div className="manage-purchase__content-domain-description">
+						{ purchase.productType === 'domain_transfer' && supportText }
+					</div>
 				</span>
 
 				<span className="manage-purchase__settings-link">

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1114,8 +1114,11 @@ class ManagePurchase extends Component<
 						{ this.getPurchaseDescription() }
 					</div>
 					<div className="manage-purchase__content-domain-description">
-						{ purchase.productType === 'domain_transfer' && cancelText }
-						{ purchase.productType === 'domain_transfer' && ' ' + domainTransferDuration }
+						{ purchase.productType === 'domain_transfer' && (
+							<>
+								{ cancelText } { domainTransferDuration }
+							</>
+						) }
 					</div>
 					<div className="manage-purchase__content-domain-description">
 						{ purchase.productType === 'domain_transfer' && supportText }

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -46,6 +46,7 @@ import {
 	ProductIcon,
 	Gridicon,
 } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import page from 'page';
@@ -94,6 +95,7 @@ import {
 import { getPurchaseCancellationFlowType } from 'calypso/lib/purchases/utils';
 import { hasCustomDomain } from 'calypso/lib/site/utils';
 import { addQueryArgs } from 'calypso/lib/url';
+import { DOMAIN_CANCEL, SUPPORT_ROOT } from 'calypso/lib/url/support';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import { PreCancellationDialog } from 'calypso/me/purchases/pre-cancellation-dialog';
 import ProductLink from 'calypso/me/purchases/product-link';
@@ -1078,9 +1080,40 @@ class ManagePurchase extends Component<
 		const registrationAgreementUrl = getDomainRegistrationAgreementUrl( purchase );
 		const domainRegistrationAgreementLinkText = translate( 'Domain Registration Agreement' );
 
+		const helpOptions = {
+			components: {
+				strong: <strong />,
+				a: <a href={ localizeUrl( SUPPORT_ROOT ) } rel="noopener noreferrer" target="_blank" />,
+			},
+		};
+
+		const cancelOptions = {
+			components: {
+				strong: <strong />,
+				a: <a href={ localizeUrl( DOMAIN_CANCEL ) } rel="noopener noreferrer" target="_blank" />,
+			},
+		};
+		const supportText = translate(
+			' Need help? {{a}}Get in touch with one of our Happiness Engineers{{/a}}.',
+			helpOptions
+		);
+
+		const cancelText = translate(
+			' Cancel Domain and Refund? Please {{a}}click here.{{/a}}',
+			cancelOptions
+		);
+
+		const domainTransferDuration = translate(
+			' Domain transfers can take anywhere from five to seven days to complete'
+		);
 		return (
 			<div className="manage-purchase__content">
-				<span className="manage-purchase__description">{ this.getPurchaseDescription() }</span>
+				<span className="manage-purchase__description">
+					{ this.getPurchaseDescription() }
+					{ purchase.productType === 'domain_transfer' && supportText }
+					{ purchase.productType === 'domain_transfer' && cancelText }
+					{ purchase.productType === 'domain_transfer' && domainTransferDuration }
+				</span>
 
 				<span className="manage-purchase__settings-link">
 					{ ! isJetpackCloud() && site && (

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -127,6 +127,10 @@
 	}
 }
 
+.manage-purchase__content-domain-description {
+	margin-bottom: 4px;
+}
+
 .manage-purchase__header {
 	overflow: auto;
 	border-bottom: 2px solid var(--color-accent);


### PR DESCRIPTION
**Summary:**

The Manage Purchase page for a pending domain transfer (before it turns into a Domain Registration) is very bare. It could benefit from some information about the pending transfer and what to do about it.

Fixes https://github.com/Automattic/wp-calypso/issues/79751

![VU7C61.png](https://github.com/Automattic/wp-calypso/assets/552016/1cba0ded-04bf-4aa0-8e1a-5adafe579a4b)

## Proposed Changes

- [x] Display additional details like the dynamic messages [like this](https://wordpress.com/support/domains/incoming-domain-transfer/#step-4-check-your-transfer-status) on the purchase page of Domain transfer products
- [x] How to cancel if they want to bail
- [x] How long it should take (generally 5 -7 business days)
- [x] Where to get help

![npzM3g.png](https://github.com/Automattic/wp-calypso/assets/552016/04da722e-cf3e-4371-9488-87fe47054a08)

## Testing Instructions

1. We need have a domain transfer purchased, more importantly it should not have converted to `Domain Registration` product which will happen eventually.
2. Apply this D117230-code to the backend and sandbox, it will disable the auth code check and transfer lock check.
3. Apply this patch and visit `http://calypso.localhost:3000/setup/domain-transfer/domains`
4. Enter a domain name that hasn't been used yet for Domain and `testtest232` for authcode, then click `Start Transfer` as soon as it becomes active.
5. On the checkout page, select `Assign a payment method later` as payment method and click `Complete Checkout` button. 