### PR TITLE
Stats: Update learn more links

### DIFF
--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -1,6 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
-import { JETPACK_STATS_PRODUCT_LANDING_PAGE_URL } from '@automattic/calypso-products';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -94,7 +93,7 @@ const DoYouLoveJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
 							learnMoreLink: (
 								<a
 									className="notice-banner__action-link"
-									href={ JETPACK_STATS_PRODUCT_LANDING_PAGE_URL }
+									href="https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing"
 									target="_blank"
 									rel="noreferrer"
 								/>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
@@ -40,7 +40,7 @@ const CommercialPurchase = ( {
 				) }
 				<Button
 					variant="link"
-					href="https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing"
+					href="https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-site-types"
 					target="_blank"
 					rel="noopener noreferrer"
 				>


### PR DESCRIPTION
Related to p1690879114075769-slack-C82FZ5T4G

## Proposed Changes

* Upsell notice to use: https://jetpack.com/blog/changes-to-jetpack-stats-for-commercial-sites/
* Purchase page to use: https://jetpack.com/support/jetpack-stats/free-or-paid/

## Testing Instructions

* Ensure the learn more links redirect to correct docs as described 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?