### PR TITLE
States: hide upgrade notice on purchase success notice shown

### DIFF
--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -143,7 +143,9 @@ export default function StatsNotices( {
 				statsPurchaseSuccess={ statsPurchaseSuccess }
 				isOdysseyStats={ isOdysseyStats }
 			/>
-			<NewStatsNotices siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
+			{ ! statsPurchaseSuccess && (
+				<NewStatsNotices siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
+			) }
 		</>
 	) : (
 		<LegacyStatsNotices siteId={ siteId } />


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80011

## Proposed Changes

After successful purchase of Stats Free, the success notice and upgrade notice would be shown at the same time, which is not ideal. The PR proposes to hide the upgrade notice in the case.

## Testing Instructions

* Open a site with upgrade notice not dismissed before
* Purchase Stats Free
* Ensure when you are redirected to Calypso or Odyssey Stats, you only see the purchase success notice

<img width="995" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/4aa6fb4d-75b2-4eda-9f33-9d62613977c4">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
