### PR TITLE
Stats: Show new title for sites with free stats

### DIFF
--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -110,7 +110,7 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 			} ),
 			featured: true,
 			description: translate(
-				'Upgrade Jetpack Stats to unlock upcoming features, priority support, and an ad-free experience.'
+				'Upgrade Jetpack Stats to unlock priority support and all upcoming premium features.'
 			),
 		},
 	];

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -18,7 +18,7 @@ const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) =
 	return `https://wordpress.com${ purchasePath }`;
 };
 
-const DoYouLoveJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
+const DoYouLoveJetpackStatsNotice = ( { siteId, hasFreeStats }: StatsNoticeProps ) => {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
@@ -67,43 +67,59 @@ const DoYouLoveJetpackStatsNotice = ( { siteId }: StatsNoticeProps ) => {
 		return null;
 	}
 
+	const noticeArgs = {
+		components: {
+			p: <p />,
+			jetpackStatsProductLink: (
+				<button
+					type="button"
+					className="notice-banner__action-button"
+					onClick={ gotoJetpackStatsProduct }
+				/>
+			),
+			learnMoreLink: (
+				<a
+					className="notice-banner__action-link"
+					href="https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing"
+					target="_blank"
+					rel="noreferrer"
+				/>
+			),
+			learnMoreLinkText: <span />,
+			externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
+		},
+	};
+
 	return (
 		<div
 			className={ `inner-notice-container has-odyssey-stats-bg-color ${
 				! isOdysseyStats && 'inner-notice-container--calypso'
 			}` }
 		>
-			<NoticeBanner
-				level="info"
-				title={ translate( 'Do you love Jetpack Stats?' ) }
-				onClose={ dismissNotice }
-			>
-				{ translate(
-					'{{p}}Upgrade Jetpack Stats to unlock upcoming features and priority support.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{learnMoreLink}}{{learnMoreLinkText}}Learn more{{/learnMoreLinkText}}{{externalIcon /}}{{/learnMoreLink}}{{/p}}',
-					{
-						components: {
-							p: <p />,
-							jetpackStatsProductLink: (
-								<button
-									type="button"
-									className="notice-banner__action-button"
-									onClick={ gotoJetpackStatsProduct }
-								/>
-							),
-							learnMoreLink: (
-								<a
-									className="notice-banner__action-link"
-									href="https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing"
-									target="_blank"
-									rel="noreferrer"
-								/>
-							),
-							learnMoreLinkText: <span />,
-							externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
-						},
-					}
-				) }
-			</NoticeBanner>
+			{ ! hasFreeStats && (
+				<NoticeBanner
+					level="info"
+					title={ translate( 'Do you love Jetpack Stats?' ) }
+					onClose={ dismissNotice }
+				>
+					{ translate(
+						'{{p}}Upgrade Jetpack Stats to unlock upcoming features and priority support.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{learnMoreLink}}{{learnMoreLinkText}}Learn more{{/learnMoreLinkText}}{{externalIcon /}}{{/learnMoreLink}}{{/p}}',
+						noticeArgs
+					) }
+				</NoticeBanner>
+			) }
+			{ hasFreeStats && (
+				<NoticeBanner
+					level="info"
+					title={ translate( 'Want to get the most out of Jetpack Stats?' ) }
+					onClose={ dismissNotice }
+				>
+					{ translate(
+						'{{p}}Upgrade Jetpack Stats to unlock all of the upcoming premium features and priority support.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{learnMoreLink}}{{learnMoreLinkText}}Learn more{{/learnMoreLinkText}}{{externalIcon /}}{{/learnMoreLink}}{{/p}}',
+						noticeArgs
+					) }
+				</NoticeBanner>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -90,36 +90,25 @@ const DoYouLoveJetpackStatsNotice = ( { siteId, hasFreeStats }: StatsNoticeProps
 		},
 	};
 
+	const noPurchaseTitle = translate( 'Do you love Jetpack Stats?' );
+	const freeTitle = translate( 'Want to get the most out of Jetpack Stats?' );
+
 	return (
 		<div
 			className={ `inner-notice-container has-odyssey-stats-bg-color ${
 				! isOdysseyStats && 'inner-notice-container--calypso'
 			}` }
 		>
-			{ ! hasFreeStats && (
-				<NoticeBanner
-					level="info"
-					title={ translate( 'Do you love Jetpack Stats?' ) }
-					onClose={ dismissNotice }
-				>
-					{ translate(
-						'{{p}}Upgrade Jetpack Stats to unlock upcoming features and priority support.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{learnMoreLink}}{{learnMoreLinkText}}Learn more{{/learnMoreLinkText}}{{externalIcon /}}{{/learnMoreLink}}{{/p}}',
-						noticeArgs
-					) }
-				</NoticeBanner>
-			) }
-			{ hasFreeStats && (
-				<NoticeBanner
-					level="info"
-					title={ translate( 'Want to get the most out of Jetpack Stats?' ) }
-					onClose={ dismissNotice }
-				>
-					{ translate(
-						'{{p}}Upgrade Jetpack Stats to unlock all of the upcoming premium features and priority support.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{learnMoreLink}}{{learnMoreLinkText}}Learn more{{/learnMoreLinkText}}{{externalIcon /}}{{/learnMoreLink}}{{/p}}',
-						noticeArgs
-					) }
-				</NoticeBanner>
-			) }
+			<NoticeBanner
+				level="info"
+				title={ hasFreeStats ? freeTitle : noPurchaseTitle }
+				onClose={ dismissNotice }
+			>
+				{ translate(
+					'{{p}}Upgrade Jetpack Stats to unlock priority support and all upcoming premium features.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{learnMoreLink}}{{learnMoreLinkText}}Learn more{{/learnMoreLinkText}}{{externalIcon /}}{{/learnMoreLink}}{{/p}}',
+					noticeArgs
+				) }
+			</NoticeBanner>
 		</div>
 	);
 };

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -67,29 +67,6 @@ const DoYouLoveJetpackStatsNotice = ( { siteId, hasFreeStats }: StatsNoticeProps
 		return null;
 	}
 
-	const noticeArgs = {
-		components: {
-			p: <p />,
-			jetpackStatsProductLink: (
-				<button
-					type="button"
-					className="notice-banner__action-button"
-					onClick={ gotoJetpackStatsProduct }
-				/>
-			),
-			learnMoreLink: (
-				<a
-					className="notice-banner__action-link"
-					href="https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing"
-					target="_blank"
-					rel="noreferrer"
-				/>
-			),
-			learnMoreLinkText: <span />,
-			externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
-		},
-	};
-
 	const noPurchaseTitle = translate( 'Do you love Jetpack Stats?' );
 	const freeTitle = translate( 'Want to get the most out of Jetpack Stats?' );
 
@@ -106,7 +83,28 @@ const DoYouLoveJetpackStatsNotice = ( { siteId, hasFreeStats }: StatsNoticeProps
 			>
 				{ translate(
 					'{{p}}Upgrade Jetpack Stats to unlock priority support and all upcoming premium features.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{learnMoreLink}}{{learnMoreLinkText}}Learn more{{/learnMoreLinkText}}{{externalIcon /}}{{/learnMoreLink}}{{/p}}',
-					noticeArgs
+					{
+						components: {
+							p: <p />,
+							jetpackStatsProductLink: (
+								<button
+									type="button"
+									className="notice-banner__action-button"
+									onClick={ gotoJetpackStatsProduct }
+								/>
+							),
+							learnMoreLink: (
+								<a
+									className="notice-banner__action-link"
+									href="https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing"
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+							learnMoreLinkText: <span />,
+							externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
+						},
+					}
 				) }
 			</NoticeBanner>
 		</div>

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -8,6 +8,7 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
 import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
+import hasSiteProductJetpackStatsFree from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-free';
 import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-paid';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
@@ -30,6 +31,7 @@ const TEAM51_OWNER_ID = 70055110;
  */
 const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 	const hasPaidStats = useSelector( ( state ) => hasSiteProductJetpackStatsPaid( state, siteId ) );
+	const hasFreeStats = useSelector( ( state ) => hasSiteProductJetpackStatsFree( state, siteId ) );
 	// `is_vip` is not correctly placed in Odyssey, so we need to check `options.is_vip` as well.
 	const isVip = useSelector(
 		( state ) =>
@@ -69,7 +71,9 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 
 	return (
 		<>
-			{ showDoYouLoveJetpackStatsNotice && <DoYouLoveJetpackStatsNotice siteId={ siteId } /> }
+			{ showDoYouLoveJetpackStatsNotice && (
+				<DoYouLoveJetpackStatsNotice siteId={ siteId } hasFreeStats={ hasFreeStats } />
+			) }
 			{ isOdysseyStats && <OptOutNotice siteId={ siteId } /> }
 			{ isOdysseyStats && <FeedbackNotice siteId={ siteId } /> }
 		</>

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -5,6 +5,7 @@ export interface PaidPlanPurchaseSuccessJetpackStatsNoticeProps {
 export interface StatsNoticeProps {
 	siteId: number | null;
 	onNoticeViewed?: () => void;
+	hasFreeStats?: boolean;
 }
 
 export interface NoticeBodyProps {


### PR DESCRIPTION
Related to #80011 

## Proposed Changes

Show a different upgrade notice for site with Free Stats

## Testing Instructions

* Purchase Stats Free for a site that doesn't get the upgrade notice dismissed before
* Ensure when you are redirected back to Odyssey / Calypso Stats, the upgrade notice is like the following

<!-- old screenshot
<img width="1008" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/5ea95c03-f291-4ee5-abc3-f60361478d5a">
-->

<img width="1262" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4044428/d56982ae-4a60-49b1-a4b8-a5cdb13dabf7">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
