### PR TITLE
Assembler - Use Creatio theme demo site to preview posts patterns

### DIFF
--- a/packages/data-stores/src/site/constants.ts
+++ b/packages/data-stores/src/site/constants.ts
@@ -1,3 +1,3 @@
 export const STORE_KEY = 'automattic/site';
 
-export const PLACEHOLDER_SITE_ID = 211865921; // blankcanvas3demo.wordpress.com
+export const PLACEHOLDER_SITE_ID = 220580624; // creatiodemo.wordpress.com


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/79282

## Proposed Changes

* Update `PLACEHOLDER_SITE_ID` to use Creatio theme demo site to preview posts patterns

|BEFORE|AFTER|
|--|--|
|<img width="1405" alt="Screenshot 2566-08-02 at 11 34 27" src="https://github.com/Automattic/wp-calypso/assets/1881481/517da852-0f64-4a5f-b360-46aa691a4ef2">|<img width="1444" alt="Screenshot 2566-08-02 at 12 55 26" src="https://github.com/Automattic/wp-calypso/assets/1881481/12f34845-c891-4097-a9e7-79411b1f9993">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* Continue until the design picker, scroll to click on `Start designing`
* Add a pattern from the category `Blog Posts`
* Verify the preview uses the 3 posts rather than 4, they are from https://creatiodemo.wordpress.com




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
