### PR TITLE
Site editor: Fix misaligned icon in styles onboarding popup

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.scss
@@ -12,10 +12,6 @@
 		height: auto;
 		position: absolute;
 		border-bottom-width: 0;
-
-		.components-button {
-			top: 16px;
-		}
 	}
 
 	.wpcom-global-styles-modal__content {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76603

## Proposed Changes

This PR fixes the misaligned close icon in the global styles modal of the Site Editor.

| Before | After |
| --- | --- |
| ![Screenshot 2023-08-02 at 3 42 12 PM](https://github.com/Automattic/wp-calypso/assets/797888/3db81fdc-0916-42bc-a74b-d65121d1bafc) | ![Screenshot 2023-08-02 at 3 42 24 PM](https://github.com/Automattic/wp-calypso/assets/797888/77e5741a-225e-43c9-b08a-850e86709783) |
  

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply these changes to your sandbox: `install-plugin.sh editing-toolkit fix/wpcom-global-styles-modal-css-close-icon`
- Create a new site
- Sandbox the new site
- Skip the onboarding
- Go to Appearance > Editor
- Open the Styles side panel
- Ensure that when you see the modal, the close icon is positioned properly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
