### PR TITLE
Virtual Themes - Don't copy starter content from Creatio demo site

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -531,7 +531,9 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		);
 
 		yield runThemeSetupOnSite( siteSlug, design, {
-			trimContent: false,
+			// trimContent true ensures that the starter content is trimmed in case sourceSiteId is defined
+			// For instance only a max of three posts will be added to the user site
+			trimContent: true,
 			posts_source_site_id: sourceSiteId,
 		} );
 

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,7 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { SiteGoal } from '../onboard';
 import { wpcomRequest } from '../wpcom-request-controls';
-import { PLACEHOLDER_SITE_ID } from './constants';
 import {
 	SiteLaunchError,
 	AtomicTransferError,
@@ -503,7 +502,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		siteSlug: string,
 		design: Design,
 		globalStyles: GlobalStyles | null = null,
-		sourceSiteId: number = PLACEHOLDER_SITE_ID
+		sourceSiteId?: number
 	) {
 		const stylesheet = design?.recipe?.stylesheet || '';
 		const theme = stylesheet?.split( '/' )[ 1 ] || design.theme;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/80128 https://github.com/Automattic/wp-calypso/pull/79132 https://github.com/Automattic/wp-calypso/pull/77152

## Proposed Changes

* Don't use the `PLACEHOLDER_SITE_ID` constant as the default value for `sourceSiteId` in `applyThemeWithPatterns`
  * So we won't copy starter content from Creatio demo site when users pick a virtual theme from the design picker
  * This boosts the processing time from about 15 to only 3 seconds when creating a new site using a virtual theme
* Ensure the starter content is trimmed in case `sourceSiteId` is defined
  * Instead of removing the feature to copy starter content from a source site, because it's not currently being used, I decided to leave it but only copy initial posts when we pass a `sourceSiteId`. See D117802-code
  * `sourceSiteId` is never passed in `applyThemeWithPatterns`. See the use cases:
    * [design-setup/unified-design-picker.tsx](https://github.com/Automattic/wp-calypso/blob/ab556f0c57359ec292996932e387d2ab2f88bbed/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx#L502)
    * [onboarding/src/setup-tailored-site-after-creation.ts](https://github.com/Automattic/wp-calypso/blob/ab556f0c57359ec292996932e387d2ab2f88bbed/packages/onboarding/src/setup-tailored-site-after-creation.ts#L74)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Sandbox code D117802-code
* Create a new site (Required)
* Continue until the design picker
* Find `Sketchbook` virtual theme to click on it
<img width="385" alt="Screenshot 2566-08-02 at 15 42 07" src="https://github.com/Automattic/wp-calypso/assets/1881481/4866bf4e-dbcd-496e-8949-57390e82b45a">

* Verify that the processing time is now around 3 seconds while before it was around 15 seconds 🎉
* Verify you land in the editor and that the homepage is displayed correctly
* Verify that no posts were created on your site by visiting https://wordpress.com/posts/{ YOUR SITE }

|BEFORE|AFTER|
|--|--|
|<img width="869" alt="Screenshot 2566-08-02 at 15 54 35" src="https://github.com/Automattic/wp-calypso/assets/1881481/f45c1327-c50c-4707-98cd-f92530e1f706">|<img width="860" alt="Screenshot 2566-08-02 at 15 39 17" src="https://github.com/Automattic/wp-calypso/assets/1881481/9e1b4b5b-c218-4796-ba9b-bc5382738db8">|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?