### PR TITLE
Jetpack Cloud Agency Signup: Add new "business type" question to form

### DIFF
--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -54,6 +54,7 @@ export default function AgencySignupForm() {
 					name: payload.name,
 					contact_person: payload.contactPerson,
 					company_website: payload.companyWebsite,
+					company_type: payload.companyType,
 					city: payload.city,
 					line1: payload.line1,
 					line2: payload.line2,

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -130,7 +130,6 @@ export default function CompanyDetailsForm( {
 						disabled={ isLoading }
 					/>
 				</FormFieldset>
-
 				<FormFieldset>
 					<FormLabel htmlFor="contactPerson">
 						{ translate( 'Contact first and last name' ) }
@@ -145,7 +144,6 @@ export default function CompanyDetailsForm( {
 						disabled={ isLoading }
 					/>
 				</FormFieldset>
-
 				<FormFieldset>
 					<FormLabel htmlFor="companyWebsite">{ translate( 'Company website' ) }</FormLabel>
 					<FormTextInput
@@ -158,14 +156,15 @@ export default function CompanyDetailsForm( {
 						disabled={ isLoading }
 					/>
 				</FormFieldset>
-
 				<FormFieldset>
 					<FormLabel>{ translate( 'Which answer below best describes your company:' ) }</FormLabel>
 					<FormRadio
 						label={ translate( 'Agency' ) }
 						value="Agency"
 						checked={ companyType === 'Agency' }
-						onChange={ () => setCompanyType( 'Agency' ) }
+						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
+							setCompanyType( event.target.value )
+						}
 						disabled={ isLoading }
 						className={ undefined }
 					/>
@@ -173,7 +172,9 @@ export default function CompanyDetailsForm( {
 						label={ translate( 'Freelancer/Pro' ) }
 						value="Freelancer/Pro"
 						checked={ companyType === 'Freelancer/Pro' }
-						onChange={ () => setCompanyType( 'Freelancer/Pro' ) }
+						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
+							setCompanyType( event.target.value )
+						}
 						disabled={ isLoading }
 						className={ undefined }
 					/>
@@ -181,12 +182,14 @@ export default function CompanyDetailsForm( {
 						label={ translate( 'A business with multiple sites' ) }
 						value="A business with multiple sites"
 						checked={ companyType === 'A business with multiple sites' }
-						onChange={ () => setCompanyType( 'A business with multiple sites' ) }
+						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
+							setCompanyType( event.target.value )
+						}
 						disabled={ isLoading }
 						className={ undefined }
 					/>
 				</FormFieldset>
-
+				ß
 				<FormFieldset>
 					<FormLabel>{ translate( 'Country' ) }</FormLabel>
 					{ showCountryFields && (
@@ -202,7 +205,6 @@ export default function CompanyDetailsForm( {
 
 					{ ! showCountryFields && <TextPlaceholder /> }
 				</FormFieldset>
-
 				{ showCountryFields && stateOptions && (
 					<FormFieldset>
 						<FormLabel>{ translate( 'State' ) }</FormLabel>
@@ -215,7 +217,6 @@ export default function CompanyDetailsForm( {
 						/>
 					</FormFieldset>
 				) }
-
 				<FormFieldset className="company-details-form__business-address">
 					<FormLabel>{ translate( 'Business address' ) }</FormLabel>
 					<FormTextInput
@@ -239,7 +240,6 @@ export default function CompanyDetailsForm( {
 						disabled={ isLoading }
 					/>
 				</FormFieldset>
-
 				<FormFieldset>
 					<FormLabel htmlFor="city">{ translate( 'City' ) }</FormLabel>
 					<FormTextInput
@@ -250,7 +250,6 @@ export default function CompanyDetailsForm( {
 						disabled={ isLoading }
 					/>
 				</FormFieldset>
-
 				<FormFieldset>
 					<FormLabel htmlFor="postalCode">{ translate( 'Postal code' ) }</FormLabel>
 					<FormTextInput
@@ -263,7 +262,6 @@ export default function CompanyDetailsForm( {
 						disabled={ isLoading }
 					/>
 				</FormFieldset>
-
 				{ includeTermsOfService && (
 					<div className="company-details-form__tos">
 						<p>
@@ -287,7 +285,6 @@ export default function CompanyDetailsForm( {
 						</p>
 					</div>
 				) }
-
 				<div className="company-details-form__controls">
 					<Button
 						primary

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -167,6 +167,7 @@ export default function CompanyDetailsForm( {
 						checked={ companyType === 'Agency' }
 						onChange={ () => setCompanyType( 'Agency' ) }
 						disabled={ isLoading }
+						className={ undefined }
 					/>
 					<FormRadio
 						label={ translate( 'Freelancer/Pro' ) }
@@ -174,6 +175,7 @@ export default function CompanyDetailsForm( {
 						checked={ companyType === 'Freelancer/Pro' }
 						onChange={ () => setCompanyType( 'Freelancer/Pro' ) }
 						disabled={ isLoading }
+						className={ undefined }
 					/>
 					<FormRadio
 						label={ translate( 'A business with multiple sites' ) }
@@ -181,6 +183,7 @@ export default function CompanyDetailsForm( {
 						checked={ companyType === 'A business with multiple sites' }
 						onChange={ () => setCompanyType( 'A business with multiple sites' ) }
 						disabled={ isLoading }
+						className={ undefined }
 					/>
 				</FormFieldset>
 

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useMemo, ChangeEvent, useEffect } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
+import FormRadio from 'calypso/components/forms/form-radio';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { PartnerDetailsPayload } from 'calypso/state/partner-portal/types';
@@ -33,6 +34,7 @@ interface Props {
 		name?: string;
 		contactPerson?: string;
 		companyWebsite?: string;
+		companyType?: string;
 		city?: string;
 		line1?: string;
 		line2?: string;
@@ -63,6 +65,7 @@ export default function CompanyDetailsForm( {
 	const [ addressState, setAddressState ] = useState( initialValues.state ?? '' );
 	const [ contactPerson, setContactPerson ] = useState( initialValues.contactPerson ?? '' );
 	const [ companyWebsite, setCompanyWebsite ] = useState( initialValues.companyWebsite ?? '' );
+	const [ companyType, setCompanyType ] = useState( initialValues.companyType ?? '' );
 
 	const country = getCountry( countryValue, countryOptions );
 	const stateOptions = stateOptionsMap[ country ];
@@ -77,6 +80,7 @@ export default function CompanyDetailsForm( {
 			name,
 			contactPerson,
 			companyWebsite,
+			companyType,
 			city,
 			line1,
 			line2,
@@ -89,6 +93,7 @@ export default function CompanyDetailsForm( {
 			name,
 			contactPerson,
 			companyWebsite,
+			companyType,
 			city,
 			line1,
 			line2,
@@ -150,6 +155,31 @@ export default function CompanyDetailsForm( {
 						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
 							setCompanyWebsite( event.target.value )
 						}
+						disabled={ isLoading }
+					/>
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel>{ translate( 'Which answer below best describes your company:' ) }</FormLabel>
+					<FormRadio
+						label={ translate( 'Agency' ) }
+						value="Agency"
+						checked={ companyType === 'Agency' }
+						onChange={ () => setCompanyType( 'Agency' ) }
+						disabled={ isLoading }
+					/>
+					<FormRadio
+						label={ translate( 'Freelancer/Pro' ) }
+						value="Freelancer/Pro"
+						checked={ companyType === 'Freelancer/Pro' }
+						onChange={ () => setCompanyType( 'Freelancer/Pro' ) }
+						disabled={ isLoading }
+					/>
+					<FormRadio
+						label={ translate( 'A business with multiple sites' ) }
+						value="A business with multiple sites"
+						checked={ companyType === 'A business with multiple sites' }
+						onChange={ () => setCompanyType( 'A business with multiple sites' ) }
 						disabled={ isLoading }
 					/>
 				</FormFieldset>

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -189,7 +189,6 @@ export default function CompanyDetailsForm( {
 						className={ undefined }
 					/>
 				</FormFieldset>
-				ß
 				<FormFieldset>
 					<FormLabel>{ translate( 'Country' ) }</FormLabel>
 					{ showCountryFields && (

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -160,7 +160,7 @@ export default function CompanyDetailsForm( {
 					<FormLabel>{ translate( 'Which answer below best describes your company:' ) }</FormLabel>
 					<FormRadio
 						label={ translate( 'Agency' ) }
-						value="Agency"
+						value="agency"
 						checked={ companyType === 'Agency' }
 						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
 							setCompanyType( event.target.value )
@@ -170,7 +170,7 @@ export default function CompanyDetailsForm( {
 					/>
 					<FormRadio
 						label={ translate( 'Freelancer/Pro' ) }
-						value="Freelancer/Pro"
+						value="freelancer"
 						checked={ companyType === 'Freelancer/Pro' }
 						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
 							setCompanyType( event.target.value )
@@ -180,7 +180,7 @@ export default function CompanyDetailsForm( {
 					/>
 					<FormRadio
 						label={ translate( 'A business with multiple sites' ) }
-						value="A business with multiple sites"
+						value="business"
 						checked={ companyType === 'A business with multiple sites' }
 						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
 							setCompanyType( event.target.value )

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -161,7 +161,7 @@ export default function CompanyDetailsForm( {
 					<FormRadio
 						label={ translate( 'Agency' ) }
 						value="agency"
-						checked={ companyType === 'Agency' }
+						checked={ companyType === 'agency' }
 						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
 							setCompanyType( event.target.value )
 						}
@@ -171,7 +171,7 @@ export default function CompanyDetailsForm( {
 					<FormRadio
 						label={ translate( 'Freelancer/Pro' ) }
 						value="freelancer"
-						checked={ companyType === 'Freelancer/Pro' }
+						checked={ companyType === 'freelancer' }
 						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
 							setCompanyType( event.target.value )
 						}
@@ -181,7 +181,7 @@ export default function CompanyDetailsForm( {
 					<FormRadio
 						label={ translate( 'A business with multiple sites' ) }
 						value="business"
-						checked={ companyType === 'A business with multiple sites' }
+						checked={ companyType === 'business' }
 						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
 							setCompanyType( event.target.value )
 						}

--- a/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
@@ -62,7 +62,7 @@ export default function UpdateCompanyDetailsForm() {
 					name: payload.name,
 					contact_person: payload.contactPerson,
 					company_website: payload.companyWebsite,
-					company_type: companyType,
+					company_type: payload.companyType,
 					city: payload.city,
 					line1: payload.line1,
 					line2: payload.line2,

--- a/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
@@ -21,6 +21,7 @@ export default function UpdateCompanyDetailsForm() {
 	const name = partner?.name ?? '';
 	const contactPerson = partner?.contact_person ?? '';
 	const companyWebsite = partner?.company_website ?? '';
+	const companyType = partner?.company_type ?? '';
 	const country = partner?.address.country ?? '';
 	const city = partner?.address.city ?? '';
 	const line1 = partner?.address.line1 ?? '';
@@ -61,6 +62,7 @@ export default function UpdateCompanyDetailsForm() {
 					name: payload.name,
 					contact_person: payload.contactPerson,
 					company_website: payload.companyWebsite,
+					company_type: companyType,
 					city: payload.city,
 					line1: payload.line1,
 					line2: payload.line2,
@@ -70,7 +72,7 @@ export default function UpdateCompanyDetailsForm() {
 				} )
 			);
 		},
-		[ notificationId, partner?.id, updateCompanyDetails.mutate, dispatch ]
+		[ dispatch, updateCompanyDetails, partner?.id, companyType ]
 	);
 
 	return (
@@ -79,6 +81,7 @@ export default function UpdateCompanyDetailsForm() {
 				name,
 				contactPerson,
 				companyWebsite,
+				companyType,
 				country,
 				city,
 				line1,

--- a/client/state/partner-portal/partner/hooks/use-create-partner-mutation.ts
+++ b/client/state/partner-portal/partner/hooks/use-create-partner-mutation.ts
@@ -10,6 +10,7 @@ function createPartner( details: PartnerDetailsPayload ): Promise< APIPartner > 
 			name: details.name,
 			contact_person: details.contactPerson,
 			company_website: details.companyWebsite,
+			company_type: details.companyType,
 			city: details.city,
 			line1: details.line1,
 			line2: details.line2,

--- a/client/state/partner-portal/partner/hooks/use-update-company-details-mutation.ts
+++ b/client/state/partner-portal/partner/hooks/use-update-company-details-mutation.ts
@@ -11,6 +11,7 @@ function updateCompanyDetails( details: CompanyDetailsPayload ): Promise< APIPar
 			name: details.name,
 			contact_person: details.contactPerson,
 			company_website: details.companyWebsite,
+			company_type: details.companyType,
 			city: details.city,
 			line1: details.line1,
 			line2: details.line2,

--- a/client/state/partner-portal/partner/utils.ts
+++ b/client/state/partner-portal/partner/utils.ts
@@ -12,6 +12,7 @@ export function translateInvalidPartnerParameterError( parameters: object, detai
 		name: __( 'Company name' ),
 		contact_person: __( 'Contact person' ),
 		company_website: __( 'Company website' ),
+		company_type: __( 'Company type' ),
 		city: __( 'City' ),
 		country: __( 'Country' ),
 		line1: __( 'Address line 1' ),

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -157,6 +157,7 @@ export interface CompanyDetailsPayload {
 }
 
 export interface PartnerDetailsPayload extends CompanyDetailsPayload {
+	companyType: string;
 	tos?: 'consented';
 }
 

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -149,6 +149,7 @@ export interface CompanyDetailsPayload {
 	name: string;
 	contactPerson: string;
 	companyWebsite: string;
+	companyType: string;
 	city: string;
 	line1: string;
 	line2: string;

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -74,6 +74,7 @@ export interface APIPartner {
 	name: string;
 	contact_person: string;
 	company_website: string;
+	company_type: string;
 	address: APIPartnerAddress;
 	keys: APIPartnerKey[];
 	tos: string;
@@ -186,6 +187,7 @@ export interface Partner {
 	slug: string;
 	contact_person: string;
 	company_website: string;
+	company_type: string;
 	name: string;
 	address: PartnerAddress;
 	keys: PartnerKey[];


### PR DESCRIPTION
Related to # 1202619025189113-as-1205166491602848/f

## Proposed Changes

* A request was made to add a new field to the agency sign up form with a series of radio buttons to track the type of business.
* A new fieldset was added using the FormRadio shared component.
* The new fields were configured the same as existing fields to add the data into the payload and tracks events for tracking and reporting of this new data.
* The extended type for the form was updated for this new field.
* An "undefined" className was added to keep the unit tests happy since we don't actually need to do any special CSS styling and no custom class is required.I suppose the component can be refactored, but since a bunch of places in Calypso use that, it's best to just modify our code to play along with what the component wants.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You need to NOT be a partner for this to work.
* You will need to apply the Diff D118013 on WPCOM and sandbox public-api.wordpress.com
* You will need access to the Jetpack Team on stripe to verify the results
* Fire up the Cloud live link, or checkout this PR and run it locally
* Head over to /agency/signup to see the new form.
* The form should look like the screenshot below.
* Fill in the form, including the company type and submit
* To verify the data was stored correctly, access the Jetpack team on Stripe
* Click the customers tab and find your account (it should be near the top)
* Click for details and in the lower left, there is a metadata field.  Verify the company_type was recorded

![Screenshot 2023-08-02 at 8 10 37 AM](https://github.com/Automattic/wp-calypso/assets/12895386/5ef831dd-9624-4b1f-b102-b1c1e111adff)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205166491602848