### PR TITLE
Help Center: don't prefetch the GPT response on the form screen

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -181,8 +181,8 @@ export const HelpCenterContactForm = () => {
 		supportSite = currentSite as HelpCenterSite;
 	}
 
-	const [ debouncedMessage ] = useDebounce( message || '', 5000 );
-	const [ debouncedSubject ] = useDebounce( subject || '', 5000 );
+	const [ debouncedMessage ] = useDebounce( message || '', 500 );
+	const [ debouncedSubject ] = useDebounce( subject || '', 500 );
 
 	const enableGPTResponse =
 		config.isEnabled( 'help/gpt-response' ) && ! ( params.get( 'disable-gpt' ) === 'true' );
@@ -443,7 +443,7 @@ export const HelpCenterContactForm = () => {
 		siteId: '9619154',
 		query: jpSearchAiQueryText,
 		stopAt: 'response',
-		enabled: enableGPTResponse,
+		enabled: enableGPTResponse && showingGPTResponse,
 	} );
 
 	const isCTADisabled = () => {
@@ -453,7 +453,7 @@ export const HelpCenterContactForm = () => {
 
 		// We're prefetching the GPT response,
 		// so only disabling the button while fetching if we're on the response screen
-		if ( isFetchingGPTResponse && ! showingGPTResponse ) {
+		if ( showingGPTResponse && isFetchingGPTResponse ) {
 			return true;
 		}
 


### PR DESCRIPTION
We currently prefetch the AI generated answer on the contact form (with a hefty debounce delay).
This is a leftover of a previous implementation that is causing unnecessary multiple requests to the AI endpoint (and some other UI quirks)

## Proposed Changes

* Only fetch the AI response on the result screen
* Lower the debounce rate 

## Testing Instructions

* In Help Center, click "still need help
* Choose one of the contact methods
* Start typing your message. Make sure that the continue button becomes active as soon as you've filled your message.
* Once you click continue, check that a request to the 'jetpack-search/ai/search' endpoint is triggered.
* The primary action button should be disabled and say "Gathering quick response" until the response is loaded.
* Once the response is loaded it becomes enabled with the text "Still (chat/email/contact) us"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
