### PR TITLE
Newsletter Categories: Add react query for subscribed newsletter categories (with tests).

### DIFF
--- a/client/data/newsletter-categories/test/use-subscriber-newsletter-categories-query.test.tsx
+++ b/client/data/newsletter-categories/test/use-subscriber-newsletter-categories-query.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import request from 'wpcom-proxy-request';
+import useSubscriberNewsletterCategories from '../use-subscriber-newsletter-categories-query';
+
+jest.mock( 'wpcom-proxy-request', () => jest.fn() );
+
+describe( 'useSubscriberNewsletterCategories', () => {
+	let queryClient: QueryClient;
+	let wrapper: any;
+
+	beforeEach( () => {
+		( request as jest.MockedFunction< typeof request > ).mockReset();
+
+		queryClient = new QueryClient( {
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		} );
+
+		wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should return expected data when successful', async () => {
+		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( {
+			newsletter_categories: [
+				{
+					id: 1,
+					name: 'Category 1',
+					slug: 'Slug 1',
+					description: 'Description 1',
+					parent: 1,
+					subscribed: true,
+				},
+				{
+					id: 2,
+					name: 'Category 2',
+					slug: 'Slug 2',
+					description: 'Description 2',
+					parent: 2,
+					subscribed: false,
+				},
+			],
+		} );
+
+		const { result } = renderHook( () => useSubscriberNewsletterCategories( { blogId: 123 } ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( result.current.data ).toEqual( {
+			newsletterCategories: [
+				{
+					id: 1,
+					name: 'Category 1',
+					slug: 'Slug 1',
+					description: 'Description 1',
+					parent: 1,
+					subscribed: true,
+				},
+				{
+					id: 2,
+					name: 'Category 2',
+					slug: 'Slug 2',
+					description: 'Description 2',
+					parent: 2,
+					subscribed: false,
+				},
+			],
+		} );
+	} );
+
+	it( 'should handle empty response', async () => {
+		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( {
+			newsletter_categories: [],
+		} );
+
+		const { result } = renderHook( () => useSubscriberNewsletterCategories( { blogId: 123 } ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( result.current.data ).toEqual( { newsletterCategories: [] } );
+	} );
+} );

--- a/client/data/newsletter-categories/types.ts
+++ b/client/data/newsletter-categories/types.ts
@@ -8,4 +8,5 @@ export type NewsletterCategory = {
 	slug: string;
 	description: string;
 	parent: number;
+	subscribed?: boolean;
 };

--- a/client/data/newsletter-categories/use-subscriber-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-subscriber-newsletter-categories-query.tsx
@@ -1,0 +1,32 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import request from 'wpcom-proxy-request';
+import { NewsletterCategories, NewsletterCategory } from './types';
+
+type NewsletterCategoryQueryProps = {
+	blogId: number;
+};
+
+type NewsletterCategoryResponse = {
+	newsletter_categories: NewsletterCategory[];
+};
+
+const convertNewsletterCategoryResponse = (
+	response: NewsletterCategoryResponse
+): NewsletterCategories => {
+	return { newsletterCategories: response.newsletter_categories };
+};
+
+const useSubscriberNewsletterCategories = ( {
+	blogId,
+}: NewsletterCategoryQueryProps ): UseQueryResult< NewsletterCategories > => {
+	return useQuery( {
+		queryKey: [ `newsletter-categories-${ blogId }` ],
+		queryFn: () =>
+			request< NewsletterCategoryResponse >( {
+				path: `/sites/${ blogId }/newsletter-categories/subscription/mine`,
+				apiVersion: '2',
+			} ).then( convertNewsletterCategoryResponse ),
+	} );
+};
+
+export default useSubscriberNewsletterCategories;

--- a/client/data/newsletter-categories/use-subscriber-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-subscriber-newsletter-categories-query.tsx
@@ -23,9 +23,11 @@ const useSubscriberNewsletterCategories = ( {
 		queryKey: [ `newsletter-categories-${ blogId }` ],
 		queryFn: () =>
 			request< NewsletterCategoryResponse >( {
-				path: `/sites/${ blogId }/newsletter-categories/subscription/mine`,
+				path: `/sites/${ blogId }/newsletter-categories/subscriptions`,
 				apiVersion: '2',
+				apiNamespace: 'wpcom/v2',
 			} ).then( convertNewsletterCategoryResponse ),
+		enabled: !! blogId,
 	} );
 };
 


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/80054

## Proposed Changes

This PR adds the react-query hook for retrieving the Newsletter Categories for the current site and the current subscriber, with information about being subscribed or not.

## Testing Instructions

You can test this by running the tests: in your terminal, execute `yarn test-client client/data/newsletter-categories/test/use-subscriber-newsletter-categories-query.test.tsx`. All the tests should be green.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
