### PR TITLE
BackupBrowser: Add scaffolding and feature flag for granular restores

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@wordpress/components';
+import { FunctionComponent, useState } from '@wordpress/element';
+import { FileBrowserCheckTracker } from './types';
+
+interface FileBrowserHeaderProps {
+	controls: FileBrowserCheckTracker;
+}
+
+const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( { controls } ) => {
+	const displayButtonLabel = () => {
+		return controls.showCheckbox ? 'Disable Select' : 'Enable Select';
+	};
+
+	const [ buttonLabel, setButtonLabel ] = useState< string >( displayButtonLabel() );
+
+	const onButtonClick = () => {
+		controls.showCheckbox = ! controls.showCheckbox;
+		setButtonLabel( displayButtonLabel() );
+	};
+
+	return (
+		<div className="file-browser-header">
+			<Button className="file-browser-header__select-button" onClick={ onButtonClick } isSecondary>
+				{ buttonLabel }
+			</Button>
+		</div>
+	);
+};
+
+export default FileBrowserHeader;

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
@@ -1,28 +1,44 @@
 import { Button } from '@wordpress/components';
-import { FunctionComponent, useState } from '@wordpress/element';
-import { FileBrowserCheckTracker } from './types';
+import { FunctionComponent } from '@wordpress/element';
+import { close } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 
 interface FileBrowserHeaderProps {
-	controls: FileBrowserCheckTracker;
+	setShowCheckboxes: ( enabled: boolean ) => void;
+	showCheckboxes: boolean;
 }
 
-const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( { controls } ) => {
-	const displayButtonLabel = () => {
-		return controls.showCheckbox ? 'Disable Select' : 'Enable Select';
+const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
+	setShowCheckboxes,
+	showCheckboxes,
+} ) => {
+	const translate = useTranslate();
+	const onSelectClick = () => {
+		setShowCheckboxes( true );
 	};
-
-	const [ buttonLabel, setButtonLabel ] = useState< string >( displayButtonLabel() );
-
-	const onButtonClick = () => {
-		controls.showCheckbox = ! controls.showCheckbox;
-		setButtonLabel( displayButtonLabel() );
+	const onCancelClick = () => {
+		setShowCheckboxes( false );
 	};
 
 	return (
 		<div className="file-browser-header">
-			<Button className="file-browser-header__select-button" onClick={ onButtonClick } isSecondary>
-				{ buttonLabel }
-			</Button>
+			{ ! showCheckboxes && (
+				<Button
+					className="file-browser-header__select-button"
+					onClick={ onSelectClick }
+					isSecondary
+				>
+					{ translate( 'Select' ) }
+				</Button>
+			) }
+			{ showCheckboxes && (
+				<Button
+					className="file-browser-header__cancel-button"
+					icon={ close }
+					onClick={ onCancelClick }
+					isSecondary
+				/>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
-import { FunctionComponent } from '@wordpress/element';
 import { close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
 
 interface FileBrowserHeaderProps {
 	setShowCheckboxes: ( enabled: boolean ) => void;
@@ -26,7 +26,7 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
 				<Button
 					className="file-browser-header__select-button"
 					onClick={ onSelectClick }
-					isSecondary
+					variant="secondary"
 				>
 					{ translate( 'Select' ) }
 				</Button>
@@ -36,7 +36,7 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
 					className="file-browser-header__cancel-button"
 					icon={ close }
 					onClick={ onCancelClick }
-					isSecondary
+					variant="secondary"
 				/>
 			) }
 		</div>

--- a/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
@@ -1,4 +1,6 @@
+import config from '@automattic/calypso-config';
 import { FunctionComponent, useState } from 'react';
+import FileBrowserHeader from './file-browser-header';
 import FileBrowserNode from './file-browser-node';
 import { FileBrowserItem } from './types';
 
@@ -21,16 +23,28 @@ const FileBrowser: FunctionComponent< FileBrowserProps > = ( { siteId, rewindId 
 		hasChildren: true,
 	};
 
+	const controls: FileBrowserCheckTracker = {
+		showCheckbox: false,
+		includedFiles: [],
+		excludedFiles: [],
+	};
+
+	const isGranularEnabled = config.isEnabled( 'jetpack/backup-granular' );
+
 	return (
-		<FileBrowserNode
-			siteId={ siteId }
-			rewindId={ rewindId }
-			item={ rootItem }
-			path="/"
-			isAlternate={ true }
-			setActiveNodePath={ handleClick }
-			activeNodePath={ activeNodePath }
-		/>
+		<div>
+			{ isGranularEnabled && <FileBrowserHeader controls={ controls } /> }
+			<FileBrowserNode
+				siteId={ siteId }
+				rewindId={ rewindId }
+				item={ rootItem }
+				path="/"
+				isAlternate={ true }
+				setActiveNodePath={ handleClick }
+				activeNodePath={ activeNodePath }
+				showCheckbox={ controls.showCheckbox }
+			/>
+		</div>
 	);
 };
 

--- a/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
@@ -12,6 +12,7 @@ interface FileBrowserProps {
 const FileBrowser: FunctionComponent< FileBrowserProps > = ( { siteId, rewindId } ) => {
 	// This is the path of the node that is clicked
 	const [ activeNodePath, setActiveNodePath ] = useState< string >( '' );
+	const [ showCheckboxes, setShowCheckboxes ] = useState< boolean >( false );
 
 	const handleClick = ( path: string ) => {
 		setActiveNodePath( path );
@@ -23,17 +24,16 @@ const FileBrowser: FunctionComponent< FileBrowserProps > = ( { siteId, rewindId 
 		hasChildren: true,
 	};
 
-	const controls: FileBrowserCheckTracker = {
-		showCheckbox: false,
-		includedFiles: [],
-		excludedFiles: [],
-	};
-
 	const isGranularEnabled = config.isEnabled( 'jetpack/backup-granular' );
 
 	return (
 		<div>
-			{ isGranularEnabled && <FileBrowserHeader controls={ controls } /> }
+			{ isGranularEnabled && (
+				<FileBrowserHeader
+					showCheckboxes={ showCheckboxes }
+					setShowCheckboxes={ setShowCheckboxes }
+				/>
+			) }
 			<FileBrowserNode
 				siteId={ siteId }
 				rewindId={ rewindId }
@@ -42,7 +42,6 @@ const FileBrowser: FunctionComponent< FileBrowserProps > = ( { siteId, rewindId 
 				isAlternate={ true }
 				setActiveNodePath={ handleClick }
 				activeNodePath={ activeNodePath }
-				showCheckbox={ controls.showCheckbox }
 			/>
 		</div>
 	);

--- a/client/my-sites/backup/backup-contents-page/file-browser/types.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/types.ts
@@ -66,3 +66,9 @@ export interface FileBrowserItemInfo {
 	dataType?: number;
 	manifestFilter?: string;
 }
+
+export interface FileBrowserCheckTracker {
+	showCheckBoxes: boolean;
+	includedFiles: string[];
+	excludedFiles: string[];
+}

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -191,4 +191,8 @@
 			}
 		}
 	}
+
+	.file-browser-header {
+		text-align: end;
+	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -84,6 +84,7 @@
 		"jetpack/backup-contents-page": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
+		"jetpack/backup-granular": true,
 		"jetpack/cancel-through-main-flow": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -43,6 +43,7 @@
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
+		"jetpack/backup-granular": true,
 		"jetpack/golden-token": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Creates the feature flag for the Granular restore project
* Adds a basic button to toggle the state of setCheckboxes, largely to show the feature flag functions properly
* Positioning of the buttons aren't final, but the two buttons are based on i1 designs for the header

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this branch up in a live container and ensure the 'Select' button is not visible.
* Add ?flags=jetpack/backup-granular to the url and see the 'Select' button and 'X' button exist and swap states
* View it locally and you should see it in both cases since the flag is on for development environments

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
