### PR TITLE
Migration trial: Adapt import-focused flow connecting new Migration trial and Email verification steps

### DIFF
--- a/client/blocks/import/util.ts
+++ b/client/blocks/import/util.ts
@@ -73,16 +73,16 @@ export function getWpComOnboardingUrl(
 	let route;
 	switch ( framework ) {
 		case 'signup':
-			route = '/start/from/importing/{importer}?from={fromSite}&to={siteSlug}&run=true';
+			route = '/start/from/importing/{importer}?from={fromSite}&to={siteSlug}';
 			break;
 
 		case 'stepper':
 		default:
 			if ( platform === 'wordpress' && isEnabled( 'onboarding/import-redesign' ) ) {
-				route = 'importer{importer}?siteSlug={siteSlug}&from={fromSite}&option=everything&run=true';
+				route = 'importer{importer}?siteSlug={siteSlug}&from={fromSite}&option=everything';
 				break;
 			}
-			route = 'importer{importer}?siteSlug={siteSlug}&from={fromSite}&run=true';
+			route = 'importer{importer}?siteSlug={siteSlug}&from={fromSite}';
 			break;
 	}
 

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -174,8 +174,11 @@ export class ImportEverything extends SectionMigrate {
 					initImportRun={ this.props.initImportRun }
 					isTargetSitePlanCompatible={ isTargetSitePlanCompatible }
 					targetSite={ targetSite }
-					onContentOnlyClick={ onContentOnlySelection }
 					isMigrateFromWp={ isMigrateFromWp }
+					onContentOnlyClick={ onContentOnlySelection }
+					onFreeTrialClick={ () => {
+						stepNavigator?.navigate( `migrationTrial${ window.location.search }` );
+					} }
 				/>
 			);
 		}

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -31,6 +31,7 @@ import type { UrlData } from 'calypso/blocks/import/types';
 import type { StepNavigator } from 'calypso/blocks/importer/types';
 
 interface Props {
+	initImportRun?: boolean;
 	sourceSiteId: number | null;
 	targetSite: SiteDetails;
 	targetSiteId: number | null;
@@ -170,6 +171,7 @@ export class ImportEverything extends SectionMigrate {
 			return (
 				<PreMigrationScreen
 					startImport={ this.startMigration }
+					initImportRun={ this.props.initImportRun }
 					isTargetSitePlanCompatible={ isTargetSitePlanCompatible }
 					targetSite={ targetSite }
 					onContentOnlyClick={ onContentOnlySelection }

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { NextButton, Title } from '@automattic/onboarding';
@@ -35,8 +34,9 @@ interface PreMigrationProps {
 	startImport: ( props?: StartImportTrackingProps ) => void;
 	initImportRun?: boolean;
 	isTargetSitePlanCompatible: boolean;
-	onContentOnlyClick: () => void;
 	isMigrateFromWp: boolean;
+	onContentOnlyClick: () => void;
+	onFreeTrialClick: () => void;
 }
 
 export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = (
@@ -47,8 +47,9 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		initImportRun,
 		targetSite,
 		isTargetSitePlanCompatible,
-		onContentOnlyClick,
 		isMigrateFromWp,
+		onContentOnlyClick,
+		onFreeTrialClick,
 	} = props;
 
 	const translate = useTranslate();
@@ -108,7 +109,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		}
 	}, [ queryTargetSitePlanStatus, isRequestingTargetSitePlans, fetchMigrationEnabledStatus ] );
 
-	const { addHostingTrial, isLoading: isAddingTrial } = useAddHostingTrialMutation( {
+	const { isLoading: isAddingTrial } = useAddHostingTrialMutation( {
 		onSuccess: () => {
 			setQueryTargetSitePlanStatus( 'fetching' );
 		},
@@ -137,9 +138,10 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		fetchMigrationEnabledStatus();
 	};
 
-	const onFreeTrialClick = () => {
-		addHostingTrial( targetSite.ID, PLAN_MIGRATION_TRIAL_MONTHLY );
-	};
+	// Initiate the migration if initImportRun is set
+	useEffect( () => {
+		initImportRun && startImport( { type: 'without-credentials' } );
+	}, [] );
 
 	useEffect( () => {
 		if ( isTargetSitePlanCompatible && sourceSiteId ) {

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -33,6 +33,7 @@ import './style.scss';
 interface PreMigrationProps {
 	targetSite: SiteDetails;
 	startImport: ( props?: StartImportTrackingProps ) => void;
+	initImportRun?: boolean;
 	isTargetSitePlanCompatible: boolean;
 	onContentOnlyClick: () => void;
 	isMigrateFromWp: boolean;
@@ -43,6 +44,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 ) => {
 	const {
 		startImport,
+		initImportRun,
 		targetSite,
 		isTargetSitePlanCompatible,
 		onContentOnlyClick,

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
@@ -71,8 +71,7 @@ export const PreMigrationUpgradePlan: React.FunctionComponent< Props > = ( props
 						className="action-buttons__borderless"
 						onClick={ onFreeTrialClick }
 					>
-						{ /* Untranslated until we've confirmed the design */ }
-						Try for free
+						{ translate( 'Try it for free' ) }
 					</Button>
 				) }
 				<Button

--- a/client/blocks/importer/wordpress/index.tsx
+++ b/client/blocks/importer/wordpress/index.tsx
@@ -25,10 +25,9 @@ import type { OnboardSelect } from '@automattic/data-stores';
 
 import './style.scss';
 
-/* eslint-disable wpcalypso/jsx-classname-namespace */
-
 interface Props {
 	job?: ImportJob;
+	run?: boolean;
 	siteId: number;
 	siteSlug: string;
 	fromSite: string;
@@ -46,7 +45,15 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	const [ option, setOption ] = useState< WPImportOption | undefined >(
 		getValidOptionParam( queryParams.get( 'option' ) )
 	);
-	const { job, fromSite, siteSlug, siteId, stepNavigator, showConfirmDialog } = props;
+	const {
+		job,
+		run: initImportRun,
+		fromSite,
+		siteSlug,
+		siteId,
+		stepNavigator,
+		showConfirmDialog,
+	} = props;
 	const siteItem = useSelector( ( state ) => getSite( state, siteId ) );
 	const fromSiteItem = useSelector( ( state ) =>
 		getSiteBySlug( state, fromSite ? convertToFriendlyWebsiteName( fromSite ) : '' )
@@ -171,6 +178,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 							isMigrateFromWp={ isMigrateFromWp }
 							showConfirmDialog={ showConfirmDialog }
 							onContentOnlySelection={ switchToContentUploadScreen }
+							initImportRun={ initImportRun }
 						/>
 					);
 				} else if ( WPImportOption.CONTENT_ONLY === option ) {

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -201,6 +201,11 @@ const importFlow: Flow = {
 					switch ( providedDependencies?.action ) {
 						case 'verify-email':
 							return navigate( `verifyEmail?${ urlQueryParams.toString() }` );
+						case 'importer':
+							// This param init the migration process
+							urlQueryParams.set( 'run', 'true' );
+
+							return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
 						default:
 							return;
 					}

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -197,12 +197,20 @@ const importFlow: Flow = {
 					return handleMigrationRedirects( providedDependencies );
 				}
 
+				case 'migrationTrial': {
+					switch ( providedDependencies?.action ) {
+						case 'verify-email':
+							return navigate( `verifyEmail?${ urlQueryParams.toString() }` );
+						default:
+							return;
+					}
+				}
+
 				case 'error':
 					return navigate( providedDependencies?.url as string );
 
 				case 'verifyEmail':
-					// TODO: handle verify email submission, navigate to the next step
-					return;
+					return navigate( `migrationTrial?${ urlQueryParams.toString() }` );
 
 				case 'sitePicker': {
 					switch ( providedDependencies?.action ) {

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -202,9 +202,6 @@ const importFlow: Flow = {
 						case 'verify-email':
 							return navigate( `verifyEmail?${ urlQueryParams.toString() }` );
 						case 'importer':
-							// This param init the migration process
-							urlQueryParams.set( 'run', 'true' );
-
 							return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
 						default:
 							return;

--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -16,7 +16,9 @@ import ImportReady from './internals/steps-repository/import-ready';
 import ImportReadyNot from './internals/steps-repository/import-ready-not';
 import ImportReadyPreview from './internals/steps-repository/import-ready-preview';
 import ImportReadyWpcom from './internals/steps-repository/import-ready-wpcom';
+import ImportVerifyEmail from './internals/steps-repository/import-verify-email';
 import ImporterWordpress from './internals/steps-repository/importer-wordpress';
+import MigrationTrial from './internals/steps-repository/migration-trial';
 import ProcessingStep from './internals/steps-repository/processing-step';
 import SitePickerStep from './internals/steps-repository/site-picker';
 import { Flow, ProvidedDependencies } from './internals/types';
@@ -41,6 +43,8 @@ const importHostedSiteFlow: Flow = {
 			{ slug: 'sitePicker', component: SitePickerStep },
 			{ slug: 'siteCreationStep', component: SiteCreationStep },
 			{ slug: 'importerWordpress', component: ImporterWordpress },
+			{ slug: 'migrationTrial', component: MigrationTrial },
+			{ slug: 'verifyEmail', component: ImportVerifyEmail },
 			{ slug: 'processing', component: ProcessingStep },
 			{ slug: 'error', component: MigrationError },
 		];
@@ -144,6 +148,20 @@ const importHostedSiteFlow: Flow = {
 					return navigate( providedDependencies?.url as string );
 				}
 
+				case 'migrationTrial': {
+					switch ( providedDependencies?.action ) {
+						case 'verify-email':
+							return navigate( `verifyEmail?${ urlQueryParams.toString() }` );
+						case 'importer':
+							return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
+						default:
+							return;
+					}
+				}
+
+				case 'verifyEmail':
+					return navigate( `migrationTrial?${ urlQueryParams.toString() }` );
+
 				case 'processing': {
 					const processingResult = params[ 0 ] as ProcessingResult;
 					if ( processingResult === ProcessingResult.FAILURE ) {
@@ -201,6 +219,10 @@ const importHostedSiteFlow: Flow = {
 					// destination site
 					urlQueryParams.delete( 'siteSlug' );
 					return navigate( `import?${ urlQueryParams.toString() }` );
+
+				case 'verifyEmail':
+				case 'migrationTrial':
+					return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
 			}
 		};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
@@ -72,7 +72,7 @@ export function useStepNavigator(
 			siteSlug: siteSlug,
 			from: fromSite,
 			option: WPImportOption.EVERYTHING,
-			run: true,
+			run: false,
 			...extraArgs,
 		};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/index.tsx
@@ -1,11 +1,21 @@
 import { StepContainer } from '@automattic/onboarding';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSelector } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import TrialPlan from './trial-plan';
 import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import type { UserData } from 'calypso/lib/user/user';
 import './style.scss';
 
 const MigrationTrial: Step = function MigrationTrial( { navigation } ) {
-	const { goBack } = navigation;
+	const site = useSite();
+	const user = useSelector( getCurrentUser ) as UserData;
+	const { goBack, submit } = navigation;
+
+	if ( ! site ) {
+		return null;
+	}
 
 	return (
 		<StepContainer
@@ -16,7 +26,7 @@ const MigrationTrial: Step = function MigrationTrial( { navigation } ) {
 			hideFormattedHeader={ true }
 			goBack={ goBack }
 			isWideLayout={ false }
-			stepContent={ <TrialPlan /> }
+			stepContent={ <TrialPlan user={ user } site={ site } submit={ submit } /> }
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
@@ -7,13 +7,29 @@ import { useI18n } from '@wordpress/react-i18n';
 import React, { useState } from 'react';
 import useUnsupportedTrialFeatureList from './hooks/use-unsupported-trial-feature-list';
 import TrialPlanFeaturesModal from './trial-plan-features-modal';
+import type { ProvidedDependencies } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import type { UserData } from 'calypso/lib/user/user';
 
-const TrialPlan = function TrialPlan() {
+interface Props {
+	user: UserData;
+	site: SiteDetails;
+	submit?: ( providedDependencies?: ProvidedDependencies, ...params: string[] ) => void;
+}
+const TrialPlan = function TrialPlan( props: Props ) {
 	const { __ } = useI18n();
+	const { user, site, submit } = props;
 	const [ showPlanFeaturesModal, setShowPlanFeaturesModal ] = useState( false );
 
 	const unsupportedTrialFeatureList = useUnsupportedTrialFeatureList();
 	const plan = getPlan( PLAN_BUSINESS );
+
+	const onStartTrialClick = () => {
+		if ( ! user?.email_verified ) {
+			submit?.( { action: 'verify-email' } );
+		} else {
+			// TODO: Trigger the trial start
+		}
+	};
 
 	return (
 		<>
@@ -73,7 +89,9 @@ const TrialPlan = function TrialPlan() {
 					</div>
 				</div>
 
-				<NextButton>{ __( 'Start the trial and migrate' ) }</NextButton>
+				<NextButton onClick={ onStartTrialClick }>
+					{ __( 'Start the trial and migrate' ) }
+				</NextButton>
 			</div>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
@@ -1,10 +1,12 @@
-import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { getPlan, PLAN_BUSINESS, PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { SiteDetails } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Title, SubTitle, NextButton } from '@automattic/onboarding';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useState } from 'react';
+import useAddHostingTrialMutation from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import useUnsupportedTrialFeatureList from './hooks/use-unsupported-trial-feature-list';
 import TrialPlanFeaturesModal from './trial-plan-features-modal';
 import type { ProvidedDependencies } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -22,14 +24,27 @@ const TrialPlan = function TrialPlan( props: Props ) {
 
 	const unsupportedTrialFeatureList = useUnsupportedTrialFeatureList();
 	const plan = getPlan( PLAN_BUSINESS );
+	const { addHostingTrial, isLoading: isAddingTrial } = useAddHostingTrialMutation( {
+		onSuccess: () => {
+			navigateToImporterStep();
+		},
+	} );
 
-	const onStartTrialClick = () => {
+	function navigateToVerifyEmailStep() {
+		submit?.( { action: 'verify-email' } );
+	}
+
+	function navigateToImporterStep() {
+		submit?.( { action: 'importer' } );
+	}
+
+	function onStartTrialClick() {
 		if ( ! user?.email_verified ) {
-			submit?.( { action: 'verify-email' } );
+			navigateToVerifyEmailStep();
 		} else {
-			// TODO: Trigger the trial start
+			addHostingTrial( site.ID, PLAN_MIGRATION_TRIAL_MONTHLY );
 		}
-	};
+	}
 
 	return (
 		<>
@@ -89,7 +104,7 @@ const TrialPlan = function TrialPlan( props: Props ) {
 					</div>
 				</div>
 
-				<NextButton onClick={ onStartTrialClick }>
+				<NextButton isBusy={ isAddingTrial } onClick={ onStartTrialClick }>
 					{ __( 'Start the trial and migrate' ) }
 				</NextButton>
 			</div>

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -36,12 +36,14 @@ import ImportReady from './internals/steps-repository/import-ready';
 import ImportReadyNot from './internals/steps-repository/import-ready-not';
 import ImportReadyPreview from './internals/steps-repository/import-ready-preview';
 import ImportReadyWpcom from './internals/steps-repository/import-ready-wpcom';
+import ImportVerifyEmail from './internals/steps-repository/import-verify-email';
 import ImporterBlogger from './internals/steps-repository/importer-blogger';
 import ImporterMedium from './internals/steps-repository/importer-medium';
 import ImporterSquarespace from './internals/steps-repository/importer-squarespace';
 import ImporterWix from './internals/steps-repository/importer-wix';
 import ImporterWordpress from './internals/steps-repository/importer-wordpress';
 import IntentStep from './internals/steps-repository/intent-step';
+import MigrationTrial from './internals/steps-repository/migration-trial';
 import PatternAssembler from './internals/steps-repository/pattern-assembler/lazy';
 import ProcessingStep from './internals/steps-repository/processing-step';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
@@ -105,6 +107,8 @@ const siteSetupFlow: Flow = {
 			{ slug: 'importerMedium', component: ImporterMedium },
 			{ slug: 'importerSquarespace', component: ImporterSquarespace },
 			{ slug: 'importerWordpress', component: ImporterWordpress },
+			{ slug: 'verifyEmail', component: ImportVerifyEmail },
+			{ slug: 'migrationTrial', component: MigrationTrial },
 			{ slug: 'businessInfo', component: BusinessInfo },
 			{ slug: 'storeAddress', component: StoreAddress },
 			{ slug: 'processing', component: ProcessingStep },
@@ -468,6 +472,20 @@ const siteSetupFlow: Flow = {
 					return navigate( providedDependencies?.url as string );
 				}
 
+				case 'migrationTrial': {
+					switch ( providedDependencies?.action ) {
+						case 'verify-email':
+							return navigate( `verifyEmail?${ urlQueryParams.toString() }` );
+						case 'importer':
+							return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
+						default:
+							return;
+					}
+				}
+
+				case 'verifyEmail':
+					return navigate( `migrationTrial?${ urlQueryParams.toString() }` );
+
 				case 'difmStartingPoint': {
 					return exitFlow( `/start/website-design-services/?siteSlug=${ siteSlug }` );
 				}
@@ -537,6 +555,10 @@ const siteSetupFlow: Flow = {
 
 				case 'import':
 					return navigate( 'goals' );
+
+				case 'verifyEmail':
+				case 'migrationTrial':
+					return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
 
 				case 'difmStartingPoint':
 					return navigate( 'goals' );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/79915

## Proposed Changes

* Adapt **import-focused** flow connecting new **Migration trial** and **Email verification** steps.
* Transition from Simple to Atomic logic is moved from the `Upgrade` to `Migration Trial` step

**NOTE:** For easier code review, follow the commits.


## Testing Instructions

**Verified account test case:**
* Go to `/setup/import-focused?siteSlug={SIMPLE_SITE_SLUG}`
* Enter a self-hosted website URL (Jurassic Ninja)
* [Import preview step]: press the `Import your content` button
* [Upgrade plan step]: press the `Try it for free` button
* [Migration trial step]: press the `Start the trial and migrate`
* Check if the button is in a busy state
* After some time, check if the progress screen is rendered

**Non-verified account test case**
* Pick an existing JN site
* Make JP connection with non verified account
* Go to `/setup/import-focused?siteSlug={SIMPLE_SITE_SLUG}`
* Enter a JN URL
* [Import preview step]: press the `Import your content` button
* [Upgrade plan step]: press the `Try it for free` button
* [Migration trial step]: press the `Start the trial and migrate`
* Check if the Email verification step is rendered
* Press verify email CTA
* Go to your email box and verify your email
* Check if the Email verification step disappeared and the migration trial step is rendered
* [Migration trial step]: press the `Start the trial and migrate`
* Check if the button is in a busy state
* After some time, check if the progress screen is rendered

**site-setup flow**
* Go to `/setup/site-setup/import?siteSlug={SIMPLE_SITE_SLUG}`
* The rest is the same as the first testing scenario

**import-hosted-site flow**
* Go to `/setup/import-hosted-site/import`
* The rest is the same as the first testing scenario

![Screen Capture on 2023-08-02 at 19-29-45](https://github.com/Automattic/wp-calypso/assets/1241413/9f1c1a29-185b-4ad2-aa3a-3e9fc0b8762f)

**UPDATE:**

- We decided not to run the migration immediately, so after the `Start the trial and migrate` CTA, we are going to show an additional step with the option to populate SSH credentials to speed up the migration process.
<img width="679" alt="Screenshot 2023-08-03 at 12 39 35" src="https://github.com/Automattic/wp-calypso/assets/1241413/a87e00f8-894e-47ab-a625-03e92be53d48">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
