### PR TITLE
Updates the app version check we have in promote post in the widget

### DIFF
--- a/client/lib/mobile-app/README.md
+++ b/client/lib/mobile-app/README.md
@@ -23,3 +23,12 @@ if ( isWcMobileApp() ) {
 	// Perform a mobile app-specific logic.
 }
 ```
+
+Utility methods:
+
+```js
+import { getMobileDeviceInfo } from 'calypso/lib/mobile-app';
+
+const { device, version } = getMobileDeviceInfo();
+// Perform app-specific logic depending on the device and version
+```

--- a/client/lib/mobile-app/index.js
+++ b/client/lib/mobile-app/index.js
@@ -30,7 +30,7 @@ const deviceUnknown = {
 export function getMobileDeviceInfo() {
 	try {
 		const userAgent = navigator.userAgent.toLowerCase();
-		const regex = /wp-(android|iphone)\/(\d+.\d+)/;
+		const regex = /w[pc]-(android|iphone|ios)\/(\d+.\d+)/;
 		const match = userAgent.match( regex );
 
 		if ( ! match ) {

--- a/client/lib/mobile-app/test/index.js
+++ b/client/lib/mobile-app/test/index.js
@@ -1,4 +1,4 @@
-import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
+import { isWpMobileApp, isWcMobileApp, getMobileDeviceInfo } from 'calypso/lib/mobile-app';
 
 describe( 'isWpMobileApp', () => {
 	test( 'should identify the WordPress for iOS mobile app', () => {
@@ -55,5 +55,52 @@ describe( 'isWcMobileApp', () => {
 		};
 
 		expect( isWcMobileApp() ).toBeFalsy();
+	} );
+} );
+
+describe( 'getMobileDeviceInfo', () => {
+	test( 'should return the correct device/version for WordPress iOS mobile app', () => {
+		global.navigator = {
+			userAgent:
+				'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B91 wp-iphone/12.1',
+		};
+
+		expect( getMobileDeviceInfo() ).toStrictEqual( { device: 'iphone', version: '12.1' } );
+	} );
+
+	test( 'should return the correct device/version for WordPress Android mobile app', () => {
+		global.navigator = {
+			userAgent:
+				'Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36 wp-android/4.7',
+		};
+
+		expect( getMobileDeviceInfo() ).toStrictEqual( { device: 'android', version: '4.7' } );
+	} );
+
+	test( 'should return the correct device/version for WooCommerce for iOS mobile app', () => {
+		global.navigator = {
+			userAgent:
+				'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B91 wc-ios/12.1',
+		};
+
+		expect( getMobileDeviceInfo() ).toStrictEqual( { device: 'ios', version: '12.1' } );
+	} );
+
+	test( 'should return the correct device/version for WooCommerce Android mobile app', () => {
+		global.navigator = {
+			userAgent:
+				'Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36 wc-android/4.7',
+		};
+
+		expect( getMobileDeviceInfo() ).toStrictEqual( { device: 'android', version: '4.7' } );
+	} );
+
+	test( 'should return unknown for an any other user agent', () => {
+		global.navigator = {
+			userAgent:
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36',
+		};
+
+		expect( getMobileDeviceInfo() ).toStrictEqual( { device: 'unknown', version: 'unknown' } );
 	} );
 } );

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -4,6 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { translate } from 'i18n-calypso/types';
 import { getHotjarSiteSettings, mayWeLoadHotJarScript } from 'calypso/lib/analytics/hotjar';
 import { getMobileDeviceInfo, isWpMobileApp } from 'calypso/lib/mobile-app';
+import versionCompare from 'calypso/lib/version-compare';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -72,7 +73,7 @@ export async function loadDSPWidgetJS(): Promise< void > {
 	await import( './string' );
 }
 
-const ANDROID_VERSION_HIDE_CAMPAIGNS_BUTTON = 22.9;
+const ANDROID_VERSION_HIDE_CAMPAIGNS_BUTTON = '22.9.rc-1';
 
 type DeviceInfo = {
 	device: string;
@@ -80,11 +81,11 @@ type DeviceInfo = {
 };
 
 const shouldHideGoToCampaignButton = () => {
-	// Android versions higher or equal than 22.9 should hide the button
+	// Android versions higher or equal than 22.9.rc-1 should hide the button
 	const deviceInfo = getMobileDeviceInfo() as DeviceInfo;
 	return (
 		deviceInfo.device.includes( 'android' ) &&
-		parseFloat( deviceInfo?.version ) >= ANDROID_VERSION_HIDE_CAMPAIGNS_BUTTON
+		versionCompare( deviceInfo?.version, ANDROID_VERSION_HIDE_CAMPAIGNS_BUTTON, '>=' )
 	);
 };
 

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -73,20 +73,10 @@ export async function loadDSPWidgetJS(): Promise< void > {
 	await import( './string' );
 }
 
-const ANDROID_VERSION_HIDE_CAMPAIGNS_BUTTON = '22.9.rc-1';
-
-type DeviceInfo = {
-	device: string;
-	version: string;
-};
-
 const shouldHideGoToCampaignButton = () => {
-	// Android versions higher or equal than 22.9.rc-1 should hide the button
-	const deviceInfo = getMobileDeviceInfo() as DeviceInfo;
-	return (
-		deviceInfo.device.includes( 'android' ) &&
-		versionCompare( deviceInfo?.version, ANDROID_VERSION_HIDE_CAMPAIGNS_BUTTON, '>=' )
-	);
+	// App versions higher or equal than 22.9.rc-1 should hide the button
+	const deviceInfo = getMobileDeviceInfo();
+	return versionCompare( deviceInfo?.version, '22.9.rc-1', '>=' );
 };
 
 const getWidgetOptions = () => {


### PR DESCRIPTION
Related to [PR comment](https://github.com/Automattic/wp-calypso/pull/79966#issuecomment-1662011776)

We need to update the app version check logic we have in the Advertising page (create campaign widget), to release candidate versions.

## Proposed Changes

I am changing the logic to use the already existing utility library `calypso/lib/version-compare`. 
To be compatible with that library, I am changing the minimum version from `22.9` to `22.9.rc-1`. This is because that library assumes that release candidates are a previous version from release one, which is correct.

I took the change to update the mobile-app library README and tests.

## Testing Instructions

* Open the live preview
* Change your browser to a mobile screen, and also change the user agent to this: 
`Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36 wp-android/22.9.rc-1`
* Refresh the page and navigate to Tools->Advertising
* Click on the promote button for any of your posts
* Complete the promote process and verify that at the confirmation step, the Go to campaigns button is not displayed.
* Change the user-agent to a previous version of the app:
`Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36 wp-android/22.8`
* Refresh the page, then promote another post and verify that the Go to campaigns button is displayed in the confirmation screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
