### PR TITLE
Hosting onboarding: use custom heading and subheading copies in the plans step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -166,11 +166,11 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	};
 
 	const getHeaderText = () => {
-		if (
-			flowName === DOMAIN_UPSELL_FLOW ||
-			isNewHostedSiteCreationFlow( flowName ) ||
-			isOnboardingPMFlow( flowName )
-		) {
+		if ( isNewHostedSiteCreationFlow( flowName ) ) {
+			return __( 'The right plan for the right project' );
+		}
+
+		if ( flowName === DOMAIN_UPSELL_FLOW || isOnboardingPMFlow( flowName ) ) {
 			return __( 'Choose your flavor of WordPress' );
 		}
 
@@ -205,7 +205,9 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		}
 
 		if ( isNewHostedSiteCreationFlow( flowName ) ) {
-			return translate( 'Welcome to the best place for your WordPress website.' );
+			return translate(
+				'Get the advanced features you need without ever thinking about overages.'
+			);
 		}
 
 		if ( ! hideFreePlan ) {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3284.

## Proposed Changes

Let's roll with new heading and subheading copies on the plans step for the `/setup/new-hosted-site` flow:

![image](https://github.com/Automattic/wp-calypso/assets/26530524/255fef04-014f-41c9-a9e0-a4f76add6edc)

@michaelpick this is a mix from your suggestions, hope they make sense. The intention is to highlight that we don't overage, but "No-surprises pricing" didn't really look good so I picked a longer, more assertive heading copy. 

## Testing Instructions

Open `/setup/new-hosted-site` and advance to the plans step. Check that the copies match the screenshot.
