### PR TITLE
Hosting onboarding: even spacing between elements of the plans step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/new-hosted-site-flow.scss
+++ b/client/landing/stepper/declarative-flow/internals/new-hosted-site-flow.scss
@@ -1,9 +1,27 @@
+@import "@automattic/onboarding/styles/mixins";
+@import "@automattic/onboarding/styles/variables";
+
 .new-hosted-site .form-label {
 	font-weight: 600 !important;
 }
 
 .new-hosted-site .form-radios-bar.is-thumbnail {
 	flex-wrap: initial;
+}
+
+.new-hosted-site.plans .formatted-header__subtitle {
+	padding-bottom: 0; /* This is for mobile */
+}
+
+.new-hosted-site.plans .step-wrapper__header {
+	@media ( max-width: 660px ) {
+		&,
+		> #step-header {
+			margin-top: 0;
+		}
+	}
+
+	margin-bottom: 0;
 }
 
 .new-hosted-site .plan-faq {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3284.

## Proposed Changes

Let's remove some excessive spacing from between elements in the plans step.

### Mobile

| Before | After |
| ------ | ----- |
| ![Screenshot 2023-08-02 at 16 20 44](https://github.com/Automattic/wp-calypso/assets/26530524/41716dfb-afed-4e4b-ab3c-669b7f9dd3d5) | ![Screenshot 2023-08-02 at 16 20 17](https://github.com/Automattic/wp-calypso/assets/26530524/20d319f8-9b96-4b78-93d5-7678b8cfab7d) |

### Desktop

| Before | After |
| ------ | ----- |
| ![Screenshot 2023-08-02 at 16 21 18](https://github.com/Automattic/wp-calypso/assets/26530524/3ef9bb30-5b66-449f-969b-ee3a694616f1) | ![Screenshot 2023-08-02 at 16 21 51](https://github.com/Automattic/wp-calypso/assets/26530524/4a0ec2f5-be43-4c7b-b1a9-e1d2d29c8c35) |

## Testing Instructions

Visit `/setup/new-hosted-site`, proceed to plans and verify that's less spacing between the items.