### PR TITLE
Hosting onboarding: add padding to the bottom of the FAQ in the plans step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/new-hosted-site-flow.scss
+++ b/client/landing/stepper/declarative-flow/internals/new-hosted-site-flow.scss
@@ -9,4 +9,5 @@
 .new-hosted-site .plan-faq {
 	max-width: 1240px;
 	margin: 0 auto;
+	padding-bottom: 128px;
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3284.

## Proposed Changes

Right now the FAQ section of the plans step abruptly ends, giving the impression that the step is broken. This PR fixes it.

We could add the WordPress logo if we feel like it to indicate the end of the page, but I don't think it's strictly necessary.

| Before | After |
| ------- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/7e8078b2-b46f-44b9-b915-1ae5418c270b) | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/0835239a-a7cb-49c2-8976-0f46d7b67cd8) |


## Testing Instructions

Go to `/setup/new-hosted-site`, advance to the plans step, and check that there is some room to breathe after the FAQ at the bottom has room ends.