### PR TITLE
Storage Add-Ons: Display the storage label for multi-year plans

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -922,7 +922,7 @@ export class PlanFeatures2023Grid extends Component<
 
 				const shouldRenderStorageTitle =
 					storageOptions.length === 1 ||
-					( intervalType === 'monthly' && storageOptions.length !== 0 ) ||
+					( intervalType !== 'yearly' && storageOptions.length !== 0 ) ||
 					( ! showUpgradeableStorage && storageOptions.length !== 0 );
 				const canUpgradeStorageForPlan =
 					storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage;

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -922,8 +922,8 @@ export class PlanFeatures2023Grid extends Component<
 
 				const shouldRenderStorageTitle =
 					storageOptions.length === 1 ||
-					( intervalType !== 'yearly' && storageOptions.length !== 0 ) ||
-					( ! showUpgradeableStorage && storageOptions.length !== 0 );
+					( intervalType !== 'yearly' && storageOptions.length > 0 ) ||
+					( ! showUpgradeableStorage && storageOptions.length > 0 );
 				const canUpgradeStorageForPlan =
 					storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/79041#pullrequestreview-1559453091

## Proposed Changes

This PR fixes a bug where the storage label wasn't being displayed for multi-year plans.

<img width="1069" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1842898/04afe00d-c7c4-462e-97bb-4efed7953332">

## GIF

![2023-08-02 13 08 26](https://github.com/Automattic/wp-calypso/assets/5414230/9bedd458-fffd-42fc-a986-1968ae462167)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In calypso live or a local dev environment, navigate to `/start/onboarding-pm`
* Follow onboarding steps until at the plans page
* Ensure that the selected time interval is 2 years
* Verify that storage labels appear in the 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
