### PR TITLE
Twitter Ads event on thank you page for bulk domain transfers

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -271,6 +271,13 @@ export class CheckoutThankYou extends Component<
 				debug( 'recordOrderInFacebookAds: WPCom Bulk Domain Transfer Purchase', params );
 				window.fbq && window.fbq( ...params );
 			}
+
+			// Custom conversion for Twitter Ads.
+			if ( mayWeTrackByTracker( 'twitter' ) ) {
+				const params = [ 'event', 'tw-nvzbs-ofqri', {} ];
+				debug( 'recordOrder: [Twitter], BulkDomainTransfer', params );
+				window.twq( ...params );
+			}
 		}
 
 		recordTracksEvent( 'calypso_checkout_thank_you_view' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This adds a Twitter (X?) tracking pixel for the event `tw-nvzbs-ofqri` which is a new custom event used to track bulk domain transfers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**SETUP**
* Check out this branch
* Enable the `ad-tracking` and `cookie-banner` flag in development.json
* `yarn && yarn start`
* Ensure that correct privacy settings are disabled on browser level.
  * Make sure that browser `doNotTrack` setting is disabled. For example, in chrome, [follow these instructions to disable](https://support.google.com/chrome/answer/2790761?hl=en&co=GENIE.Platform%3DDesktop).
  * Enable the "Share information with our analytics tool about your use of services while logged in to your WordPress.com account" toggle in `/me` under the `Privacy` tab if you've turned it off previously.
*  To be able to test a domain transfer, without having an unlocked domain, you can patch D117230-code, and sandbox the API. This will allow you to fill in any domain, and use any transfer code, without validation failing.

**TESTING**
* Navigate to http://calypso.localhost:3000/setup/domain-transfer/domains
  * Enter domain to transfer
  * Enter auth code ( you can enter fake auth codes by following these instructions above).
  * Click on transfer button
* Click on Pay $0 now

* Verify that the Twitter ads conversion event was fired by checking the dev network tab for the `tw-nvzbs-ofqri` network request. There will likely be two, one for analytics, and one for t.co.

![Screenshot 2023-08-03 at 15 51 38](https://github.com/Automattic/wp-calypso/assets/52675688/706bf9d2-c38e-492a-b84c-7244dcb27ed6)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
