### PR TITLE
Domains manage: Link site name to site's /home

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -33,7 +33,6 @@ import TransferConnectedDomainNudge from 'calypso/my-sites/domains/domain-manage
 import {
 	domainManagementDns,
 	domainManagementEditContactInfo,
-	domainManagementList,
 	domainUseMyDomain,
 } from 'calypso/my-sites/domains/paths';
 import {
@@ -98,10 +97,10 @@ class DomainRow extends PureComponent {
 	}
 
 	renderSite() {
-		const { site, currentRoute } = this.props;
+		const { site } = this.props;
 		return (
 			<div className="domain-row__site-cell">
-				<Button href={ domainManagementList( site?.slug, currentRoute ) } plain>
+				<Button href={ '/home/' + site?.slug } plain>
 					{ ! site.options?.is_domain_only ? site?.title || site?.slug : '' }
 				</Button>
 			</div>


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3317

## Proposed Changes

Link the Site Name on the domains list to the site's `/home` page.

## Testing Instructions

* Go to `/domains/manage`
* Click on a Site name (2nd column)
* You should redirect to the site `/home`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
