### PR TITLE
Use subpixel-antialiased for webkit-font-smoothing on the core-profiler pages

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -259,6 +259,7 @@
 		padding-bottom: 0;
 		margin: 0;
 		line-height: 24px;
+		-webkit-font-smoothing: subpixel-antialiased;
 
 		a {
 			color: $woo-purple-70;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79113 


## Proposed Changes

* This PR updates the style of formatted header to use subpixel-antialiased for webkit-font-smoothing to match the WooCommrece Core style.

## Testing Instructions

1. Create a new JN site with the latest WooCommerce
2. Start the core profiler and proceed to the Jetpack Connection page. Copy the URL.
3. Checkout this branch and build the changes.
4. Replace the Jetpack Connection URL with your local calypso.

Example URL: `http://calypso.localhost:3000/jetpack/connect/authorize?client_id=156969816&redirect_uri=https%3A%2F%2Frough-finch.j....`

5. Access the page.
6. Compare the subheading style against the core-profiler subheading in WooCommerce Core.
7. Confirm the subheading has `subpixel-antialiased` for `-webkit-font-smoothing ` style (Look at the computed tab)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
