### PR TITLE
Paid Stats: default commercial plan for sites with personal plan already

### DIFF
--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -2,7 +2,6 @@ import {
 	PRODUCT_JETPACK_STATS_MONTHLY,
 	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
 	PRODUCT_JETPACK_STATS_FREE,
-	TYPE_PERSONAL,
 } from '@automattic/calypso-products';
 import { ProductsList } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
@@ -24,6 +23,7 @@ import StatsPurchaseWizard, {
 	SCREEN_PURCHASE,
 	SCREEN_TYPE_SELECTION,
 	TYPE_COMMERCIAL,
+	TYPE_PERSONAL,
 } from './stats-purchase-wizard';
 
 const isProductOwned = ( ownedProducts: SiteProduct[] | null, searchedProduct: string ) => {

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -50,6 +50,7 @@ const StatsPurchasePage = ( { query }: { query: { redirect_uri: string; from: st
 	const isRequestingSiteProducts = useSelector( isRequestingSites );
 
 	// Determine whether a product is owned.
+	// TODO we need to do plan check as well, because Stats products would be built into other plans.
 	const isFreeOwned = useMemo( () => {
 		return isProductOwned( siteProducts, PRODUCT_JETPACK_STATS_FREE );
 	}, [ siteProducts ] );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -13,10 +13,10 @@ import StatsPurchaseSVG from './stats-purchase-svg';
 import './styles.scss';
 
 const COMPONENT_CLASS_NAME = 'stats-purchase-wizard';
-export const SCREEN_TYPE_SELECTION = 0;
-export const SCREEN_PURCHASE = 1;
-export const TYPE_PERSONAL = 'Personal';
-export const TYPE_COMMERCIAL = 'Commercial';
+const SCREEN_TYPE_SELECTION = 0;
+const SCREEN_PURCHASE = 1;
+const TYPE_PERSONAL = 'Personal';
+const TYPE_COMMERCIAL = 'Commercial';
 
 const DEFAULT_STARTING_FRACTION = 0.6;
 const UI_EMOJI_HEART_TIER_THRESHOLD = 0.5;
@@ -250,4 +250,12 @@ const StatsPurchaseWizard = ( {
 	);
 };
 
-export { StatsPurchaseWizard as default, COMPONENT_CLASS_NAME, MIN_STEP_SPLITS };
+export {
+	StatsPurchaseWizard as default,
+	COMPONENT_CLASS_NAME,
+	MIN_STEP_SPLITS,
+	SCREEN_TYPE_SELECTION,
+	SCREEN_PURCHASE,
+	TYPE_PERSONAL,
+	TYPE_COMMERCIAL,
+};

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -47,8 +47,8 @@ const ProductCard = ( {
 	pwywProduct,
 	redirectUri,
 	from,
-	initialStep,
-	initialSiteType,
+	initialStep = SCREEN_TYPE_SELECTION,
+	initialSiteType = TYPE_PERSONAL,
 } ) => {
 	const maxSliderPrice = commercialProduct.cost;
 	const sliderStepPrice = pwywProduct.cost / MIN_STEP_SPLITS;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -236,7 +236,6 @@ const StatsPurchaseWizard = ( {
 	initialStep,
 	initialSiteType,
 } ) => {
-	// redirectTo is a relative URI.
 	return (
 		<ProductCard
 			siteSlug={ siteSlug }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -2,7 +2,7 @@
 import { Button, Card, Panel, PanelRow, PanelBody } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import statsPurchaseBackgroundSVG from 'calypso/assets/images/stats/purchase-background.svg';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -2,7 +2,7 @@
 import { Button, Card, Panel, PanelRow, PanelBody } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import statsPurchaseBackgroundSVG from 'calypso/assets/images/stats/purchase-background.svg';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
@@ -13,10 +13,10 @@ import StatsPurchaseSVG from './stats-purchase-svg';
 import './styles.scss';
 
 const COMPONENT_CLASS_NAME = 'stats-purchase-wizard';
-const SCREEN_TYPE_SELECTION = 0;
-const SCREEN_PURCHASE = 1;
-const TYPE_PERSONAL = 'Personal';
-const TYPE_COMMERCIAL = 'Commercial';
+export const SCREEN_TYPE_SELECTION = 0;
+export const SCREEN_PURCHASE = 1;
+export const TYPE_PERSONAL = 'Personal';
+export const TYPE_COMMERCIAL = 'Commercial';
 
 const DEFAULT_STARTING_FRACTION = 0.6;
 const UI_EMOJI_HEART_TIER_THRESHOLD = 0.5;
@@ -40,7 +40,16 @@ const TitleNode = ( { label, indicatorNumber, active } ) => {
 	);
 };
 
-const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redirectUri, from } ) => {
+const ProductCard = ( {
+	siteSlug,
+	siteId,
+	commercialProduct,
+	pwywProduct,
+	redirectUri,
+	from,
+	initialStep,
+	initialSiteType,
+} ) => {
 	const maxSliderPrice = commercialProduct.cost;
 	const sliderStepPrice = pwywProduct.cost / MIN_STEP_SPLITS;
 
@@ -51,8 +60,8 @@ const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redire
 	const uiImageCelebrationTier = steps * UI_IMAGE_CELEBRATION_TIER_THRESHOLD;
 
 	const [ subscriptionValue, setSubscriptionValue ] = useState( defaultStartingValue );
-	const [ wizardStep, setWizardStep ] = useState( SCREEN_TYPE_SELECTION );
-	const [ siteType, setSiteType ] = useState( null );
+	const [ wizardStep, setWizardStep ] = useState( initialStep );
+	const [ siteType, setSiteType ] = useState( initialSiteType );
 	const translate = useTranslate();
 	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 
@@ -224,6 +233,8 @@ const StatsPurchaseWizard = ( {
 	pwywProduct,
 	redirectUri,
 	from,
+	initialStep,
+	initialSiteType,
 } ) => {
 	// redirectTo is a relative URI.
 	return (
@@ -234,6 +245,8 @@ const StatsPurchaseWizard = ( {
 			pwywProduct={ pwywProduct }
 			redirectUri={ redirectUri }
 			from={ from }
+			initialStep={ initialStep }
+			initialSiteType={ initialSiteType }
 		/>
 	);
 };


### PR DESCRIPTION
Related to #79861 

## Proposed Changes

The PR proposes to set the initial step to purchase screen and site type set to Commercial for sites that already have Stats Personal.

## Testing Instructions

* Open Calypso Live Branch
* Purchase Stats Personal for a site
* Open `/stats/purchase/:siteSlug`
* Ensure you are on the purchase step and the product is set to Commercial

<img width="641" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/f7208dc5-2d1f-407f-a299-1a89c6788a95">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
