### PR TITLE
Paid Stats: Starting pricing from non-zero for slider when user already has stats free

### DIFF
--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -111,6 +111,7 @@ const StatsPurchasePage = ( { query }: { query: { redirect_uri: string; from: st
 							siteId={ siteId }
 							redirectUri={ query.redirect_uri ?? '' }
 							from={ query.from ?? '' }
+							disableFreeProduct={ isFreeOwned && ! isCommercialOwned && ! isPWYWOwned }
 						/>
 					</>
 				) }

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -111,7 +111,7 @@ const StatsPurchasePage = ( { query }: { query: { redirect_uri: string; from: st
 							siteId={ siteId }
 							redirectUri={ query.redirect_uri ?? '' }
 							from={ query.from ?? '' }
-							disableFreeProduct={ isFreeOwned && ! isCommercialOwned && ! isPWYWOwned }
+							disableFreeProduct={ isFreeOwned || isCommercialOwned || isPWYWOwned }
 						/>
 					</>
 				) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -17,6 +17,7 @@ interface PersonalPurchaseProps {
 	siteSlug: string;
 	sliderSettings: {
 		sliderStepPrice: number;
+		minSliderPrice: number;
 		maxSliderPrice: number;
 		uiEmojiHeartTier: number;
 		uiImageCelebrationTier: number;
@@ -42,8 +43,13 @@ const PersonalPurchase = ( {
 	const [ isAdsChecked, setAdsChecked ] = useState( false );
 	const [ isSellingChecked, setSellingChecked ] = useState( false );
 	const [ isBusinessChecked, setBusinessChecked ] = useState( false );
-	const { sliderStepPrice, maxSliderPrice, uiEmojiHeartTier, uiImageCelebrationTier } =
-		sliderSettings;
+	const {
+		sliderStepPrice,
+		minSliderPrice,
+		maxSliderPrice,
+		uiEmojiHeartTier,
+		uiImageCelebrationTier,
+	} = sliderSettings;
 
 	const sliderLabel = ( ( props, state ) => {
 		let emoji;
@@ -93,6 +99,7 @@ const PersonalPurchase = ( {
 				renderThumb={ sliderLabel }
 				onChange={ setSubscriptionValue }
 				maxValue={ Math.floor( maxSliderPrice / sliderStepPrice ) }
+				minValue={ Math.round( minSliderPrice / sliderStepPrice ) }
 			/>
 
 			<p className={ `${ COMPONENT_CLASS_NAME }__average-price` }>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -40,7 +40,15 @@ const TitleNode = ( { label, indicatorNumber, active } ) => {
 	);
 };
 
-const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redirectUri, from } ) => {
+const ProductCard = ( {
+	siteSlug,
+	siteId,
+	commercialProduct,
+	pwywProduct,
+	redirectUri,
+	from,
+	disableFreeProduct = false,
+} ) => {
 	const maxSliderPrice = commercialProduct.cost;
 	const sliderStepPrice = pwywProduct.cost / MIN_STEP_SPLITS;
 
@@ -173,6 +181,7 @@ const ProductCard = ( { siteSlug, siteId, commercialProduct, pwywProduct, redire
 											currencyCode={ pwywProduct?.currency_code }
 											siteSlug={ siteSlug }
 											sliderSettings={ {
+												minSliderPrice: disableFreeProduct ? sliderStepPrice : 0,
 												sliderStepPrice,
 												maxSliderPrice,
 												uiEmojiHeartTier,
@@ -224,6 +233,7 @@ const StatsPurchaseWizard = ( {
 	pwywProduct,
 	redirectUri,
 	from,
+	disableFreeProduct,
 } ) => {
 	// redirectTo is a relative URI.
 	return (
@@ -234,6 +244,7 @@ const StatsPurchaseWizard = ( {
 			pwywProduct={ pwywProduct }
 			redirectUri={ redirectUri }
 			from={ from }
+			disableFreeProduct={ disableFreeProduct }
 		/>
 	);
 };


### PR DESCRIPTION
Related to #80156 

## Proposed Changes

If a site already has Stats Free, then we do not want Stats Free to be available on the purchase page. The PR proposes to set the starting price to the minimum price, when the site already has Stats Free, so that we could save some confusion, and also make the experience better for users to choose from.

## Testing Instructions

* Open Calypso Live Branch
* Purchase Stats Free for a site
* Remove any Paid Stats for the site
* Open `/stats/purchase/:siteSlug`
* Ensure the value at the very left of slider is at minimum step price (>0)

<img width="605" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/196f91a6-8ed0-4799-bc74-0b1793642c1f">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
