### PR TITLE
Avoid showing the Live Preview for unsupported themes

### DIFF
--- a/client/my-sites/theme/live-preview-button/index.jsx
+++ b/client/my-sites/theme/live-preview-button/index.jsx
@@ -8,10 +8,10 @@ import { getIsLivePreviewSupported, getLivePreviewUrl } from 'calypso/state/them
  *
  * @see pbxlJb-3Uv-p2
  */
-export const LivePreviewButton = ( { themeId, siteId, sourceSiteId } ) => {
+export const LivePreviewButton = ( { themeId, siteId } ) => {
 	const translate = useTranslate();
 	const isLivePreviewSupported = useSelector( ( state ) =>
-		getIsLivePreviewSupported( state, themeId, siteId, sourceSiteId )
+		getIsLivePreviewSupported( state, themeId, siteId )
 	);
 	const livePreviewUrl = useSelector( ( state ) => getLivePreviewUrl( state, themeId, siteId ) );
 	if ( ! isLivePreviewSupported ) {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -34,6 +34,7 @@ import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import QueryTheme from 'calypso/components/data/query-theme';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import SyncActiveTheme from 'calypso/components/data/sync-active-theme';
 import HeaderCake from 'calypso/components/header-cake';
@@ -1278,6 +1279,19 @@ class ThemeSheet extends Component {
 		return (
 			<Main className={ className }>
 				<QueryCanonicalTheme themeId={ this.props.themeId } siteId={ siteId } />
+
+				{ /* 
+					FIXME: 
+					This is for showing the Live Preview button 
+					when the site is on Atomic AND the theme is installed.
+					We need to query a theme with the siteId to always know if it's installed on the site or not
+					(e.g. If a user go to the Theme Detail page directly).
+					This can be removed once we addressed https://github.com/Automattic/wp-calypso/issues/80089.
+				*/ }
+				{ config.isEnabled( 'themes/block-theme-previews' ) && (
+					<QueryTheme themeId={ this.props.themeId } siteId={ siteId } />
+				) }
+
 				<QueryProductsList />
 				<QueryUserPurchases />
 				{

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -540,9 +540,7 @@ class ThemeSheet extends Component {
 		const {
 			author,
 			isLoggedIn,
-			isWpcomTheme,
 			isWPForTeamsSite,
-			isWporg,
 			name,
 			retired,
 			siteId,
@@ -576,15 +574,7 @@ class ThemeSheet extends Component {
 							( this.shouldRenderUnlockStyleButton()
 								? this.renderUnlockStyleButton()
 								: this.renderButton() ) }
-						<LivePreviewButton
-							siteId={ siteId }
-							/**
-							 * Pass the siteId that QueryCanonicalTheme component will use to fetch the theme.
-							 * This avoids LivePreviewButton appearing a moment later.
-							 */
-							sourceSiteId={ ( isWpcomTheme && 'wpcom' ) || ( isWporg && 'wporg' ) || siteId }
-							themeId={ themeId }
-						/>
+						<LivePreviewButton siteId={ siteId } themeId={ themeId } />
 						{ this.shouldRenderPreviewButton() && (
 							<Button
 								onClick={ ( e ) => {

--- a/client/state/themes/selectors/get-is-live-preview-supported.js
+++ b/client/state/themes/selectors/get-is-live-preview-supported.js
@@ -82,7 +82,7 @@ const isNotCompatibleThemes = ( themeId ) => {
  *
  * @see pbxlJb-3Uv-p2
  */
-export const getIsLivePreviewSupported = ( state, themeId, siteId, sourceSiteId ) => {
+export const getIsLivePreviewSupported = ( state, themeId, siteId ) => {
 	if ( ! config.isEnabled( 'themes/block-theme-previews' ) ) {
 		return false;
 	}
@@ -98,7 +98,7 @@ export const getIsLivePreviewSupported = ( state, themeId, siteId, sourceSiteId 
 	}
 
 	// A theme should be FullSiteEditing compatible to use Block Theme Previews.
-	if ( ! isFullSiteEditingTheme( state, themeId, sourceSiteId ) ) {
+	if ( ! isFullSiteEditingTheme( state, themeId, siteId ) ) {
 		return false;
 	}
 
@@ -114,7 +114,7 @@ export const getIsLivePreviewSupported = ( state, themeId, siteId, sourceSiteId 
 
 	// Block Theme Previews need the theme installed on Atomic sites.
 	const isAtomic = isSiteAutomatedTransfer( state, siteId );
-	const isThemeInstalledOnAtomicSite = isAtomic && !! getTheme( state, sourceSiteId, themeId );
+	const isThemeInstalledOnAtomicSite = isAtomic && !! getTheme( state, siteId, themeId );
 	if ( isAtomic && ! isThemeInstalledOnAtomicSite ) {
 		return false;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80133

## Proposed Changes

This PR fixes https://github.com/Automattic/wp-calypso/issues/80133, which was caused by the `isThemeInstalledOnAtomicSite` condition that was wrongly evaluated. Fixed it by always using `siteId` to know if it's live preview compatible AND adding `<QueryTheme/>`. 

We also need to query themes with `siteId` in the Theme Showcase page since it does not show the "Live Preview" option currently unless we go to the "My Themes" tab. But I did not address that in this PR since we can see the option in the "My Themes" tab at least, and querying themes would not be necessary when we address https://github.com/Automattic/wp-calypso/issues/80089.

_I'll take care of Layout Shift if that happens on production._ 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create an Atomic site.
- Go to the Theme Showcase page and Click any theme and go to the Theme Detail page. 
	- You can also try directly visiting the Theme Detail page.
- See if clicking the "Live Preview" button redirects you to the Site Editor (Block Theme Previews).
	- You will not see the button when a theme is;
		- your active theme
		- not FullSiteEditing compatible
		- a theme with a static page as a homepage 
		- not installed (not listed in "My Themes")
			- You must install a theme before using the Live Preview on Atomic sites.
				- When you're using Calypso, activate it once and then reactivate the original theme. 
				- When you're using the classic view, just install it.

Please see pbxlJb-3Uv-p2#known-issues about unsupported themes. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
