### PR TITLE
Fix edit dns record links when coming from /domains/manage/all

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -115,8 +115,8 @@ class DnsRecordsList extends Component {
 			domainManagementDnsEditRecord(
 				selectedSite.slug,
 				selectedDomainName,
-				record.id,
-				currentRoute
+				currentRoute,
+				record.id
 			)
 		);
 	};

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -156,7 +156,7 @@ export function domainManagementDnsAddRecord( siteName, domainName, relativeTo =
 	return domainManagementEditBase( siteName, domainName, 'add-dns-record', relativeTo );
 }
 
-export function domainManagementDnsEditRecord( siteName, domainName, recordId, relativeTo = null ) {
+export function domainManagementDnsEditRecord( siteName, domainName, relativeTo = null, recordId ) {
 	let path = domainManagementEditBase( siteName, domainName, 'edit-dns-record', relativeTo );
 	if ( recordId ) {
 		path += '?recordId=' + encodeURI( recordId );

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -156,7 +156,12 @@ export function domainManagementDnsAddRecord( siteName, domainName, relativeTo =
 	return domainManagementEditBase( siteName, domainName, 'add-dns-record', relativeTo );
 }
 
-export function domainManagementDnsEditRecord( siteName, domainName, relativeTo = null, recordId ) {
+export function domainManagementDnsEditRecord(
+	siteName,
+	domainName,
+	relativeTo = null,
+	recordId = null
+) {
 	let path = domainManagementEditBase( siteName, domainName, 'edit-dns-record', relativeTo );
 	if ( recordId ) {
 		path += '?recordId=' + encodeURI( recordId );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3337

## Proposed Changes

* Reverses the parameter ordering of `currentRoute` and `recordId` in `domainManagementDnsEditRecord` to ensure `currentRoute` is in the third position as required/expected by [this calling code](https://github.com/Automattic/wp-calypso/blob/8caec7413604b7007a25f622e2af84e1f27d1f7f/client/my-sites/domains/index.js#L24) in `registerStandardDomainManagementPages`.
* This ensures the default site specific edit dns path and the /all/ (sites) edit dns path are both registered.
* When only the default path was registered, access to the /all/ page resulted in an empty white page with the master bar shown, it was technically a 404 route but we don't respond with any error code and just render a blank page.

## Testing Instructions

Before

https://github.com/Automattic/wp-calypso/assets/811776/d724f0b7-6cd0-4db5-9958-d3a82e21a1d8

After

https://github.com/Automattic/wp-calypso/assets/811776/217e2d59-b3c3-4403-bb09-350385f220e8

Non `/all` links should continue to work as before:

https://github.com/Automattic/wp-calypso/assets/811776/da7442f6-1e2a-4d5e-858f-cb6f0e6dd898