### PR TITLE
Odyssey Stats: Skip building in Run Size Test check

### DIFF
--- a/apps/odyssey-stats/package.json
+++ b/apps/odyssey-stats/package.json
@@ -24,7 +24,7 @@
 		"show-stats": "NODE_ENV=production EMIT_STATS=true yarn build",
 		"test:js": "yarn run -T test-apps apps/odyssey-stats",
 		"test:js:watch": "yarn test:js --watch",
-		"test:size": "yarn run build && size-limit",
+		"test:size": "size-limit",
 		"translate": "rm -rf dist/strings && mkdirp dist && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base '../../' --dir './dist/strings' --output './dist/odyssey-strings.pot' && node bin/build-languages.js"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Proposed Changes

Remove the build process from `test:size`. Otherwise the building would be run twice, which is a little slow now because the translation process is combined in there.

## Testing Instructions

* Open Odyssey building task on TeamCity
* Ensure the `Run Size Test` process takes only several of seconds to finish

| Before      | After |
| ----------- | ----------- |
|   <img width="300" alt="Screenshot 2023-08-03 at 4 22 57 PM" src="https://github.com/Automattic/wp-calypso/assets/1425433/cf9f2322-640b-43bf-84d1-36b65404edb6">   |  <img width="300" src="https://github.com/Automattic/wp-calypso/assets/1425433/3cd6d258-0d21-4623-9af2-d1ed940b0d92">       |




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
