### PR TITLE
Pass siteSlug along with siteDomain to autorenew toggle

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -200,6 +200,7 @@ class DomainRow extends PureComponent {
 				<AutoRenewToggle
 					planName={ site.plan.product_name_short }
 					siteDomain={ site.domain }
+					siteSlug={ site.slug }
 					purchase={ purchase }
 					shouldDisable={ isManagingAllSites && showCheckbox }
 					withTextStatus={ false }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3316

## Proposed Changes

* Pass site slug alongside domain slug. Not sure what the difference is but the renew toggle uses site slug for linking to site purchases when re-enabling auto renew but domain name for disabling it.

## Testing Instructions

* Turn off auto renew from the domains page
* Turn it back on again, click add a payment.
* Should be taken to the payment screen to add a credit card.
* Adding a credit card should enable auto renew for the domain. (currently leaves you on the purchases screen)
what data or activity we track or use (p4TIVU-ajp-p2)?
