### PR TITLE
Jetpack Pro Dashboard: Use "has_paid_agency_monitor" to show monitor upgrade options

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -101,8 +101,8 @@ export default function NotificationSettings( {
 
 	const isPaidTierEnabled = isEnabled( 'jetpack/pro-dashboard-monitor-paid-tier' );
 
-	// TODO: Need to figure out if current site or one of the sites selected is on a free tier.
-	const hasPaidLicenses = false;
+	// Check if current site or all sites selected has a paid license.
+	const hasPaidLicenses = ! sites.find( ( site ) => ! site.has_paid_agency_monitor );
 
 	let restriction: RestrictionType = 'none';
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -46,8 +46,8 @@ export default function ToggleActivateMonitoring( {
 
 	const isPaidTierEnabled = isEnabled( 'jetpack/pro-dashboard-monitor-paid-tier' );
 
-	// TODO: Need to figure out if current site has no existing paid version of downtime monitoring.
-	const shouldDisplayUpgradePopover = status === 'success' && isPaidTierEnabled;
+	const shouldDisplayUpgradePopover =
+		status === 'success' && isPaidTierEnabled && ! site.has_paid_agency_monitor;
 
 	const handleShowTooltip = () => {
 		setShowTooltip( true );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -91,6 +91,7 @@ export interface Site {
 	jetpack_boost_scores: BoostData;
 	php_version_num: number;
 	is_connected: boolean;
+	has_paid_agency_monitor: boolean;
 }
 export interface SiteNode {
 	value: Site;


### PR DESCRIPTION
Related to 1204992567518369-as-1204996562476738

## Proposed Changes

This PR uses `has_paid_agency_monitor` to show monitor upgrade options.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/implement-api-values-to-show-monitor-upgrade` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already > Click on the clock icon next to the monitor toggle.
4. Patch this D117979-code and follow how to add a monitor product here.
5. Verify that upgrade paths are shown only if the site doesn't have a paid monitor plan.

----

Unpaid

<img width="476" alt="Screenshot 2023-08-03 at 2 20 14 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b43b680f-0e31-465b-b7c3-f4d7a5a9c699">

----

Paid

<img width="472" alt="Screenshot 2023-08-03 at 2 21 09 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/73a876cf-c2ac-471d-a890-13269de08d99">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
