### PR TITLE
Clarify google copy on checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/google-transfers-copy.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/google-transfers-copy.tsx
@@ -25,7 +25,7 @@ export function GoogleDomainsCopy( { responseCart }: { responseCart: ResponseCar
 		return (
 			<GoogleDomainsCopyStyle>
 				{ __(
-					"We're paying the first year of your domain transfer. We'll use the payment information below to renew your domain transfer starting next year."
+					'We’re paying to add an additional year on your domain registrations. We’ll use the payment information below to renew your domains when they’re back up for renewal.'
 				) }
 			</GoogleDomainsCopyStyle>
 		);

--- a/client/my-sites/checkout/composite-checkout/components/google-transfers-copy.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/google-transfers-copy.tsx
@@ -30,11 +30,11 @@ export function GoogleDomainsCopy( { responseCart }: { responseCart: ResponseCar
 		if (
 			englishLocales.includes( locale ) ||
 			hasTranslation(
-				'We’re paying to add an additional year on your domain registrations. We’ll use the payment information below to renew your domains when they’re back up for renewal.'
+				'We’re paying to extend your registration for an additional year. We’ll use the payment information below to renew your domain before it expires.'
 			)
 		) {
 			couponText = __(
-				'We’re paying to add an additional year on your domain registrations. We’ll use the payment information below to renew your domains when they’re back up for renewal.'
+				'We’re paying to extend your registration for an additional year. We’ll use the payment information below to renew your domain before it expires.'
 			);
 		}
 

--- a/client/my-sites/checkout/composite-checkout/components/google-transfers-copy.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/google-transfers-copy.tsx
@@ -1,4 +1,5 @@
 import { isDomainTransfer } from '@automattic/calypso-products';
+import { englishLocales, useLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import type { ResponseCart } from '@automattic/shopping-cart';
@@ -10,7 +11,8 @@ const GoogleDomainsCopyStyle = styled.p`
 `;
 
 export function GoogleDomainsCopy( { responseCart }: { responseCart: ResponseCart } ) {
-	const { __ } = useI18n();
+	const { __, hasTranslation } = useI18n();
+	const locale = useLocale();
 
 	const hasFreeCouponTransfersOnly = responseCart.products?.every( ( item ) => {
 		return (
@@ -22,13 +24,21 @@ export function GoogleDomainsCopy( { responseCart }: { responseCart: ResponseCar
 	} );
 
 	if ( hasFreeCouponTransfersOnly ) {
-		return (
-			<GoogleDomainsCopyStyle>
-				{ __(
-					'We’re paying to add an additional year on your domain registrations. We’ll use the payment information below to renew your domains when they’re back up for renewal.'
-				) }
-			</GoogleDomainsCopyStyle>
+		let couponText = __(
+			"We're paying the first year of your domain transfer. We'll use the payment information below to renew your domain transfer starting next year."
 		);
+		if (
+			englishLocales.includes( locale ) ||
+			hasTranslation(
+				'We’re paying to add an additional year on your domain registrations. We’ll use the payment information below to renew your domains when they’re back up for renewal.'
+			)
+		) {
+			couponText = __(
+				'We’re paying to add an additional year on your domain registrations. We’ll use the payment information below to renew your domains when they’re back up for renewal.'
+			);
+		}
+
+		return <GoogleDomainsCopyStyle>{ couponText }</GoogleDomainsCopyStyle>;
 	}
 	return null;
 }


### PR DESCRIPTION
p1691043327043879-slack-C05CT832K2T
Final copy here: p1691084746242239/1691043327.043879-slack-C05CT832K2T

Follow up on https://github.com/Automattic/wp-calypso/pull/80016

## Proposed Changes

* Update and clarify the payment method checkout copy on google domain transfers

## Testing Instructions

- http://calypso.localhost:3000/setup/google-transfer/domains
- Once on the checkout step to set payment details there should be updated copy below the payment options header
- If you don't have a google domain, sandbox pub-api and make init_registered_with_google_domains return true.

![Screenshot 2023-08-03 at 16-44-43 Checkout — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/b2e01f31-ec5d-46e0-89c8-6cd941dba149)