### PR TITLE
Stepper: hide progress bar in all stepper flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -1,9 +1,5 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { ProgressBar } from '@automattic/components';
-import {
-	CONNECT_DOMAIN_FLOW,
-	isTransferringHostedSiteCreationFlow,
-	SITE_SETUP_FLOW,
-} from '@automattic/onboarding';
 import classnames from 'classnames';
 import kebabCase from 'calypso/landing/stepper/utils/kebabCase';
 import SignupHeader from 'calypso/signup/signup-header';
@@ -28,12 +24,12 @@ const StepRoute = ( {
 	renderStep,
 }: StepRouteProps ) => {
 	const renderProgressBar = () => {
-		// The progress bar is removed from the site-setup due to its fragility.
-		// See https://github.com/Automattic/wp-calypso/pull/73653
-		if (
-			[ SITE_SETUP_FLOW, CONNECT_DOMAIN_FLOW ].includes( flow.name ) ||
-			isTransferringHostedSiteCreationFlow( flow.name )
-		) {
+		// The visual progress bar is removed due to its fragility.
+		// The component will be cleaned up but it'll require more untangling as the component
+		// is involved in some framework mechanisms and Tracks events
+		// See https://github.com/Automattic/dotcom-forge/issues/3160
+
+		if ( ! isEnabled( 'onboarding/stepper-loading-bar' ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3160

The progress bar is fragile, and tends to break across flows randomly:

![image](https://github.com/Automattic/wp-calypso/assets/87168/255afdc3-6a5a-4ca6-adcf-441217367a81)


Instead of a proper fix, we're hiding it temporarily. Later we'll remove the component entirely.

Removing is a bit more complicated potentially because progress mechanisms are so tangled in the stepper framework, and involved in tracking events.

## Proposed Changes

* Hides the progress component from all onboarding flows.
* Adds feature flag check to enable it for testing, just append `?flags=onboarding/stepper-loading-bar` to the URLs

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test various `/setup` onboarding flows
* Ensure signup Track events fire normally

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
