### PR TITLE
Create NavigationHeader for DomainHeader

### DIFF
--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -103,7 +103,7 @@ const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 		}
 		const [ item ] = items;
 		return (
-			<StyledItem className="breadcrumbs-single">
+			<StyledItem>
 				<StyledRootLabel>{ item.label }</StyledRootLabel>
 				{ renderHelpBubble( item ) }
 			</StyledItem>
@@ -114,7 +114,7 @@ const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 		const urlBack = mobileItem?.href ?? items[ items.length - 2 ].href;
 		const label = mobileItem?.label ?? translate( 'Back' );
 		return (
-			<StyledBackLink href={ urlBack }>
+			<StyledBackLink className="breadcrumbs-back" href={ urlBack }>
 				<Gridicon icon="chevron-left" size={ 18 } />
 				{ label }
 			</StyledBackLink>

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -90,16 +90,20 @@ interface Props {
 	items: Item[];
 	mobileItem?: Item;
 	compact?: boolean;
+	hideWhenOnlyOneLevel?: boolean;
 }
 
 const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 	const translate = useTranslate();
-	const { items, mobileItem, compact = false } = props;
+	const { items, mobileItem, compact = false, hideWhenOnlyOneLevel } = props;
 
 	if ( items.length === 1 ) {
+		if ( hideWhenOnlyOneLevel ) {
+			return null;
+		}
 		const [ item ] = items;
 		return (
-			<StyledItem>
+			<StyledItem className="breadcrumbs-single">
 				<StyledRootLabel>{ item.label }</StyledRootLabel>
 				{ renderHelpBubble( item ) }
 			</StyledItem>
@@ -119,7 +123,7 @@ const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 
 	if ( items.length > 1 ) {
 		return (
-			<StyledUl>
+			<StyledUl className="breadcrumbs">
 				{ items.map( ( item: { href?: string; label: string }, index: Key ) => (
 					<StyledLi key={ index }>
 						{ index !== 0 && <StyledGridicon icon="chevron-right" size={ 14 } /> }

--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -268,12 +268,7 @@ function ConnectDomainStep( {
 		}
 
 		return (
-			<DomainHeader
-				items={ items }
-				mobileItem={ mobileItem }
-				isRedesign2023Aug
-				titleOverride={ renderTitle() }
-			/>
+			<DomainHeader items={ items } mobileItem={ mobileItem } titleOverride={ renderTitle() } />
 		);
 	};
 

--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -203,7 +203,28 @@ function ConnectDomainStep( {
 		verifyConnection( false );
 	}, [ showErrors, verifyConnection ] );
 
-	const renderBreadcrumbs = () => {
+	const renderTitle = () => {
+		const headerText = sprintf(
+			/* translators: %s: domain name being connected (ex.: example.com) */
+			__( 'Connect %s' ),
+			domain
+		);
+
+		return (
+			<div className={ baseClassName + '__title' }>
+				<FormattedHeader
+					className={ baseClassName + '__page-heading' }
+					headerText={ headerText }
+					align="left"
+				/>
+				{ modeType.ADVANCED === mode && (
+					<Badge className={ baseClassName + '__badge' }>{ __( 'Advanced' ) }</Badge>
+				) }
+			</div>
+		);
+	};
+
+	const renderHeader = () => {
 		let items = [
 			{
 				label: isUnderDomainManagementAll( currentRoute ) ? __( 'All Domains' ) : __( 'Domains' ),
@@ -246,7 +267,14 @@ function ConnectDomainStep( {
 			};
 		}
 
-		return <DomainHeader items={ items } mobileItem={ mobileItem } />;
+		return (
+			<DomainHeader
+				items={ items }
+				mobileItem={ mobileItem }
+				isRedesign2023Aug
+				titleOverride={ renderTitle() }
+			/>
+		);
 	};
 
 	const goBack = () => {
@@ -255,28 +283,6 @@ function ConnectDomainStep( {
 		} else {
 			page( domainManagementList( selectedSite.slug, currentRoute ) );
 		}
-	};
-
-	const renderTitle = () => {
-		const headerText = sprintf(
-			/* translators: %s: domain name being connected (ex.: example.com) */
-			__( 'Connect %s' ),
-			domain
-		);
-
-		return (
-			<div className={ baseClassName + '__title' }>
-				<FormattedHeader
-					brandFont
-					className={ baseClassName + '__page-heading' }
-					headerText={ headerText }
-					align="left"
-				/>
-				{ modeType.ADVANCED === mode && (
-					<Badge className={ baseClassName + '__badge' }>{ __( 'Advanced' ) }</Badge>
-				) }
-			</div>
-		);
 	};
 
 	const renderContent = () => {
@@ -334,8 +340,7 @@ function ConnectDomainStep( {
 	return (
 		<>
 			<BodySectionCssClass bodyClass={ [ 'connect-domain-setup__body-white' ] } />
-			{ renderBreadcrumbs() }
-			{ renderTitle() }
+			{ renderHeader() }
 			{ isTwoColumnLayout ? (
 				<TwoColumnsLayout content={ renderContent() } sidebar={ renderSidebar() } />
 			) : (

--- a/client/components/domains/connect-domain-step/style.scss
+++ b/client/components/domains/connect-domain-step/style.scss
@@ -43,22 +43,6 @@ body.connect-domain-setup__body-white {
 		align-items: center;
 		margin-bottom: 16px;
 
-		.connect-domain-step__page-heading.formatted-header {
-			margin-bottom: 0;
-		}
-
-		.connect-domain-step__page-heading .formatted-header__title {
-			margin-bottom: 0;
-
-			@include break-zoomed-in {
-				font-size: $font-title-medium;
-			}
-
-			@include break-small {
-				font-size: $font-title-large;
-			}
-		}
-
 		div.connect-domain-step__badge {
 			display: inline-flex;
 			justify-content: center;

--- a/client/components/navigation-header/README.md
+++ b/client/components/navigation-header/README.md
@@ -1,13 +1,13 @@
-# FixedNavigationHeader (TSX)
+# NavigationHeader (TSX)
 
-Note: This will eventually be replaced by NavigationHeader.
+Note: This will eventually replace FixedNavigationHeader.
 This component displays a header with a breadcrumb.
 It can also include children items which will be positioned to the far right.
 
 ## How to use
 
 ```js
-import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+import NavigationHeader from 'calypso/components/navigation-header';
 
 const navigationItems = [
 	{ label: 'Plugins', href: `/plugins` },
@@ -15,9 +15,7 @@ const navigationItems = [
 ];
 
 function render() {
-	return (
-		<FixedNavigationHeader navigationItems={ navigationItems }>Children Item</FixedNavigationHeader>
-	);
+	return <NavigationHeader navigationItems={ navigationItems }>Children Item</NavigationHeader>;
 }
 ```
 

--- a/client/components/navigation-header/docs/example.jsx
+++ b/client/components/navigation-header/docs/example.jsx
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+import NavigationHeader from 'calypso/components/fixed-navigation-header';
+
+const NavigationHeaderStyled = styled( NavigationHeader )`
+	position: relative;
+	top: inherit;
+	left: inherit;
+	width: 100%;
+`;
+
+const NavigationHeaderExample = () => {
+	const navigationItems = [
+		{ label: 'Plugins', href: `/plugins` },
+		{ label: 'Search', href: `/plugins?s=woo` },
+	];
+	return (
+		<NavigationHeaderStyled navigationItems={ navigationItems }>
+			Some Children Elements
+		</NavigationHeaderStyled>
+	);
+};
+
+NavigationHeaderExample.displayName = 'NavigationHeader';
+
+export default NavigationHeaderExample;

--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -1,0 +1,75 @@
+import styled from '@emotion/styled';
+import React, { ReactNode } from 'react';
+import Breadcrumb, { Item as TBreadcrumbItem } from 'calypso/components/breadcrumb';
+import FormattedHeader from '../formatted-header';
+
+import './style.scss';
+
+const Container = styled.div`
+	@media ( max-width: 660px ) {
+		min-height: 60px;
+	}
+
+	.main.is-wide-layout & {
+		max-width: 1040px;
+		margin: auto;
+	}
+
+	.stats &,
+	.stats__email-detail & {
+		max-width: 1224px;
+		margin: auto;
+	}
+`;
+
+const ActionsContainer = styled.div`
+	display: flex;
+	align-items: center;
+`;
+
+interface Props {
+	id?: string;
+	className?: string;
+	children?: ReactNode;
+	navigationItems: TBreadcrumbItem[];
+	mobileItem?: TBreadcrumbItem;
+	compactBreadcrumb?: boolean;
+	title?: string;
+	subtitle?: string | ReactNode;
+}
+
+const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) => {
+	const {
+		id,
+		className,
+		children,
+		navigationItems,
+		mobileItem,
+		compactBreadcrumb,
+		title,
+		subtitle,
+	} = props;
+	return (
+		<header id={ id } className={ 'navigation-header__header ' + className } ref={ ref }>
+			<Container>
+				<Breadcrumb
+					items={ navigationItems }
+					mobileItem={ mobileItem }
+					compact={ compactBreadcrumb }
+					hideWhenOnlyOneLevel
+				/>
+				<div className="navigation-header__main">
+					<FormattedHeader align="left" headerText={ title } subHeaderText={ subtitle } />
+					<ActionsContainer>{ children }</ActionsContainer>
+				</div>
+			</Container>
+		</header>
+	);
+} );
+
+NavigationHeader.defaultProps = {
+	id: '',
+	className: '',
+};
+
+export default NavigationHeader;

--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -34,7 +34,7 @@ interface Props {
 	navigationItems: TBreadcrumbItem[];
 	mobileItem?: TBreadcrumbItem;
 	compactBreadcrumb?: boolean;
-	title?: string;
+	title?: string | ReactNode;
 	subtitle?: string | ReactNode;
 }
 

--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -50,7 +50,7 @@ const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) 
 		subtitle,
 	} = props;
 	return (
-		<header id={ id } className={ 'navigation-header__header ' + className } ref={ ref }>
+		<header id={ id } className={ 'navigation-header ' + className } ref={ ref }>
 			<Container>
 				<Breadcrumb
 					items={ navigationItems }

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.navigation-header__header {
+.navigation-header {
 	box-sizing: border-box;
 	width: 100%;
 	background-color: var(--studio-white);
@@ -23,6 +23,10 @@
 	@include break-large {
 		margin-top: calc(-1 * var(--masterbar-height) - 16px);
 		padding: 24px 0;
+	}
+
+	.breadcrumbs-back {
+		margin-top: 24px;
 	}
 }
 
@@ -48,6 +52,6 @@
 	}
 }
 
-#primary header.navigation-header__header header.formatted-header {
+#primary header.navigation-header header.formatted-header {
 	margin: 0;
 }

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -22,10 +22,13 @@
 
 	@include break-large {
 		margin-top: calc(-1 * var(--masterbar-height) - 16px);
-		padding: 24px 0;
 	}
 
 	.breadcrumbs-back {
+		margin-top: 24px;
+	}
+
+	.breadcrumbs {
 		margin-top: 24px;
 	}
 }

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -1,0 +1,46 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.navigation-header__header {
+	box-sizing: border-box;
+	width: 100%;
+	background-color: var(--studio-white);
+	padding: 0 16px;
+
+	@include break-small {
+		margin-top: 0;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		margin-top: calc(-1 * var(--masterbar-height) + 20px);
+	}
+
+	@include break-medium {
+		margin-top: calc(-1 * var(--masterbar-height) - 7px);
+	}
+
+	@include break-large {
+		margin-top: calc(-1 * var(--masterbar-height) - 16px);
+		padding: 24px 0;
+	}
+}
+
+.navigation-header__main {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	min-height: 70px;
+
+	.formatted-header__title {
+		font-size: $font-title-small;
+		font-weight: 500;
+		margin: 0;
+	}
+	.formatted-header__subtitle {
+		margin: 0;
+	}
+}
+
+#primary header.navigation-header__header header.formatted-header {
+	margin: 0;
+}

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -13,6 +13,7 @@
 
 	@include breakpoint-deprecated( ">660px" ) {
 		margin-top: calc(-1 * var(--masterbar-height) + 20px);
+		padding: 0;
 	}
 
 	@include break-medium {
@@ -30,6 +31,12 @@
 	justify-content: space-between;
 	align-items: center;
 	min-height: 70px;
+	box-sizing: border-box;
+	padding: 24px 0;
+
+	> .formatted-header {
+		flex: 1;
+	}
 
 	.formatted-header__title {
 		font-size: $font-title-small;

--- a/client/my-sites/domains/domain-management/components/domain-header/index.jsx
+++ b/client/my-sites/domains/domain-management/components/domain-header/index.jsx
@@ -1,8 +1,16 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+import NavigationHeader from 'calypso/components/navigation-header';
 import './style.scss';
 
-const DomainHeader = ( { items, mobileItem, buttons = null, mobileButtons = null } ) => {
+const DomainHeader = ( {
+	items,
+	mobileItem,
+	buttons = null,
+	mobileButtons = null,
+	// NOTE: temp flag to test the new header design
+	isRedesign2023Aug = false,
+} ) => {
 	const isWide = useDesktopBreakpoint();
 
 	const renderButtons = () => (
@@ -20,13 +28,25 @@ const DomainHeader = ( { items, mobileItem, buttons = null, mobileButtons = null
 
 	return (
 		<>
-			<FixedNavigationHeader
-				compactBreadcrumb={ ! isWide }
-				navigationItems={ items }
-				mobileItem={ mobileItem }
-			>
-				{ renderButtons() }
-			</FixedNavigationHeader>
+			{ isRedesign2023Aug ? (
+				<NavigationHeader
+					compactBreadcrumb={ ! isWide }
+					navigationItems={ items }
+					mobileItem={ mobileItem }
+					title={ items[ items.length - 1 ].label }
+					subtitle={ items[ items.length - 1 ].subtitle }
+				>
+					{ renderButtons() }
+				</NavigationHeader>
+			) : (
+				<FixedNavigationHeader
+					compactBreadcrumb={ ! isWide }
+					navigationItems={ items }
+					mobileItem={ mobileItem }
+				>
+					{ renderButtons() }
+				</FixedNavigationHeader>
+			) }
 		</>
 	);
 };

--- a/client/my-sites/domains/domain-management/components/domain-header/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain-header/index.tsx
@@ -1,7 +1,25 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import { ReactNode } from 'react';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import NavigationHeader from 'calypso/components/navigation-header';
+
 import './style.scss';
+
+type NavigationItem = {
+	label: string;
+	subtitle?: string;
+	href?: string;
+};
+
+type DomainHeaderProps = {
+	items: Array< NavigationItem >;
+	mobileItem: NavigationItem;
+	buttons?: Array< ReactNode > | null;
+	mobileButtons?: Array< ReactNode > | null;
+	isRedesign2023Aug?: boolean;
+	titleOverride?: ReactNode | null;
+	subtitleOverride?: ReactNode | null;
+};
 
 const DomainHeader = ( {
 	items,
@@ -10,7 +28,9 @@ const DomainHeader = ( {
 	mobileButtons = null,
 	// NOTE: temp flag to test the new header design
 	isRedesign2023Aug = false,
-} ) => {
+	titleOverride = null,
+	subtitleOverride = null,
+}: DomainHeaderProps ) => {
 	const isWide = useDesktopBreakpoint();
 
 	const renderButtons = () => (
@@ -33,8 +53,8 @@ const DomainHeader = ( {
 					compactBreadcrumb={ ! isWide }
 					navigationItems={ items }
 					mobileItem={ mobileItem }
-					title={ items[ items.length - 1 ].label }
-					subtitle={ items[ items.length - 1 ].subtitle }
+					title={ titleOverride || items[ items.length - 1 ].label }
+					subtitle={ subtitleOverride || items[ items.length - 1 ].subtitle }
 				>
 					{ renderButtons() }
 				</NavigationHeader>

--- a/client/my-sites/domains/domain-management/components/domain-header/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain-header/index.tsx
@@ -1,6 +1,5 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { ReactNode } from 'react';
-import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import NavigationHeader from 'calypso/components/navigation-header';
 
 import './style.scss';
@@ -16,7 +15,6 @@ type DomainHeaderProps = {
 	mobileItem: NavigationItem;
 	buttons?: Array< ReactNode > | null;
 	mobileButtons?: Array< ReactNode > | null;
-	isRedesign2023Aug?: boolean;
 	titleOverride?: ReactNode | null;
 	subtitleOverride?: ReactNode | null;
 };
@@ -26,8 +24,6 @@ const DomainHeader = ( {
 	mobileItem,
 	buttons = null,
 	mobileButtons = null,
-	// NOTE: temp flag to test the new header design
-	isRedesign2023Aug = false,
 	titleOverride = null,
 	subtitleOverride = null,
 }: DomainHeaderProps ) => {
@@ -47,27 +43,15 @@ const DomainHeader = ( {
 	);
 
 	return (
-		<>
-			{ isRedesign2023Aug ? (
-				<NavigationHeader
-					compactBreadcrumb={ ! isWide }
-					navigationItems={ items }
-					mobileItem={ mobileItem }
-					title={ titleOverride || items[ items.length - 1 ].label }
-					subtitle={ subtitleOverride || items[ items.length - 1 ].subtitle }
-				>
-					{ renderButtons() }
-				</NavigationHeader>
-			) : (
-				<FixedNavigationHeader
-					compactBreadcrumb={ ! isWide }
-					navigationItems={ items }
-					mobileItem={ mobileItem }
-				>
-					{ renderButtons() }
-				</FixedNavigationHeader>
-			) }
-		</>
+		<NavigationHeader
+			compactBreadcrumb={ ! isWide }
+			navigationItems={ items }
+			mobileItem={ mobileItem }
+			title={ titleOverride || items[ items.length - 1 ].label }
+			subtitle={ subtitleOverride || items[ items.length - 1 ].subtitle }
+		>
+			{ renderButtons() }
+		</NavigationHeader>
 	);
 };
 

--- a/client/my-sites/domains/domain-management/components/domain-header/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain-header/index.tsx
@@ -7,7 +7,7 @@ import './style.scss';
 
 type NavigationItem = {
 	label: string;
-	subtitle?: string;
+	subtitle?: string | ReactNode;
 	href?: string;
 };
 

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -92,7 +92,7 @@ class AddDnsRecord extends Component {
 			showBackArrow: true,
 		};
 
-		return <DomainHeader items={ items } mobileItem={ mobileItem } isRedesign2023Aug />;
+		return <DomainHeader items={ items } mobileItem={ mobileItem } />;
 	}
 
 	goBack = () => {

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -6,7 +6,6 @@ import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import QueryDomainDns from 'calypso/components/data/query-domain-dns';
 import ExternalLink from 'calypso/components/external-link';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import DomainHeader from 'calypso/my-sites/domains/domain-management/components/domain-header';
@@ -40,9 +39,16 @@ class AddDnsRecord extends Component {
 		return recordId ? dns.records?.find( ( record ) => recordId === record.id ) : null;
 	}
 
-	renderBreadcrumbs() {
+	renderHeader() {
 		const { translate, selectedSite, currentRoute, selectedDomainName } = this.props;
 		const recordBeingEdited = this.getRecordBeingEdited();
+		const dnsSupportPageLink = (
+			<ExternalLink
+				href={ localizeUrl( 'https://wordpress.com/support/domains/custom-dns/' ) }
+				target="_blank"
+				icon={ false }
+			/>
+		);
 
 		const items = [
 			{
@@ -66,7 +72,15 @@ class AddDnsRecord extends Component {
 			{
 				label: recordBeingEdited
 					? translate( 'Edit record', { comment: 'DNS record' } )
-					: translate( 'Add a record', { comment: 'DNS record' } ),
+					: translate( 'Add a new DNS record', { comment: 'DNS record' } ),
+				subtitle: translate(
+					'Add a new DNS record to your site. {{supportLink}}Learn more{{/supportLink}}',
+					{
+						components: {
+							supportLink: dnsSupportPageLink,
+						},
+					}
+				),
 			},
 		];
 
@@ -78,7 +92,7 @@ class AddDnsRecord extends Component {
 			showBackArrow: true,
 		};
 
-		return <DomainHeader items={ items } mobileItem={ mobileItem } />;
+		return <DomainHeader items={ items } mobileItem={ mobileItem } isRedesign2023Aug />;
 	}
 
 	goBack = () => {
@@ -95,14 +109,6 @@ class AddDnsRecord extends Component {
 				icon={ false }
 			/>
 		);
-		const mobileSubtitleText = translate(
-			'Add a new DNS record to your site. {{supportLink}}Learn more{{/supportLink}}',
-			{
-				components: {
-					supportLink: dnsSupportPageLink,
-				},
-			}
-		);
 		const explanationText = translate(
 			'Custom DNS records allow you to connect your domain to third-party services that are not hosted on WordPress.com, such as an email provider. {{supportLink}}Learn more{{/supportLink}}.',
 			{
@@ -112,18 +118,11 @@ class AddDnsRecord extends Component {
 			}
 		);
 		const recordBeingEdited = this.getRecordBeingEdited();
-		const headerText = recordBeingEdited
-			? translate( 'Edit DNS record' )
-			: translate( 'Add a new DNS record' );
 
 		return (
 			<Main wideLayout className="add-dns-record">
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
-				<div className="add-dns-record__fullwidth">
-					{ this.renderBreadcrumbs() }
-					<FormattedHeader brandFont headerText={ headerText } align="left" />
-					<p className="add-dns-record__mobile-subtitle">{ mobileSubtitleText }</p>
-				</div>
+				<div className="add-dns-record__fullwidth">{ this.renderHeader() }</div>
 				<div className="add-dns-record__main">
 					<DnsAddNew
 						isSubmittingForm={ dns.isSubmittingForm }

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.scss
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.scss
@@ -4,33 +4,6 @@
 @import "@wordpress/base-styles/colors";
 
 .add-dns-record {
-	header.formatted-header {
-		margin-bottom: 4px;
-
-		@include break-mobile {
-			margin-bottom: initial;
-		}
-
-		h1.formatted-header__title {
-			color: $gray-900;
-			font-size: $font-title-medium;
-
-			@include break-mobile {
-				font-size: $font-title-large;
-			}
-		}
-	}
-
-	.add-dns-record__mobile-subtitle {
-		padding: 0 16px;
-		color: var(--studio-gray-50);
-		font-size: $font-body-small;
-
-		@include break-mobile {
-			display: none;
-		}
-	}
-
 	.add-dns-record__sidebar {
 		display: none;
 		margin-top: 20px;

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -100,7 +100,6 @@ class DnsRecords extends Component {
 				mobileItem={ mobileItem }
 				buttons={ buttons }
 				mobileButtons={ mobileButtons }
-				isRedesign2023Aug
 			/>
 		);
 	};

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -4,7 +4,6 @@ import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryDomainDns from 'calypso/components/data/query-domain-dns';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import InfoNotice from 'calypso/my-sites/domains/domain-management/components/domain/info-notice';
@@ -37,7 +36,7 @@ class DnsRecords extends Component {
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	};
 
-	renderBreadcrumbs = () => {
+	renderHeader = () => {
 		const { domains, translate, selectedSite, currentRoute, selectedDomainName, dns } = this.props;
 		const selectedDomain = domains?.find( ( domain ) => domain?.name === selectedDomainName );
 		const pointsToWpcom = selectedDomain?.pointsToWpcom ?? false;
@@ -101,6 +100,7 @@ class DnsRecords extends Component {
 				mobileItem={ mobileItem }
 				buttons={ buttons }
 				mobileButtons={ mobileButtons }
+				isRedesign2023Aug
 			/>
 		);
 	};
@@ -114,8 +114,7 @@ class DnsRecords extends Component {
 			<Main wideLayout className="dns-records">
 				<BodySectionCssClass bodyClass={ [ 'dns__body-white' ] } />
 				<DocumentHead title={ headerText } />
-				{ this.renderBreadcrumbs() }
-				<FormattedHeader brandFont headerText={ headerText } align="left" />
+				{ this.renderHeader() }
 				{ selectedDomain?.canManageDnsRecords ? (
 					<>
 						<DnsDetails />
@@ -140,7 +139,7 @@ class DnsRecords extends Component {
 			<Fragment>
 				<QueryDomainDns domain={ selectedDomainName } />
 				{ showPlaceholder ? (
-					<DomainMainPlaceholder breadcrumbs={ this.renderBreadcrumbs } />
+					<DomainMainPlaceholder breadcrumbs={ this.renderHeader } />
 				) : (
 					this.renderMain()
 				) }

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -28,22 +28,6 @@ body.dns__body-white {
 }
 
 .dns-records {
-	.formatted-header {
-		&.is-left-align,
-		&.is-right-align {
-			margin-bottom: 4px;
-
-			h1.formatted-header__title {
-				color: $gray-900;
-				font-size: $font-title-medium;
-
-				@include break-mobile {
-					font-size: $font-title-large;
-				}
-			}
-		}
-	}
-
 	.dns__details {
 		color: var(--studio-gray-50);
 		font-size: $font-body-small;

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -33,7 +33,6 @@ body.dns__body-white {
 		font-size: $font-body-small;
 		margin: 4px 16px;
 		@include break-mobile {
-			margin: 0;
 			max-width: 677px;
 		}
 	}
@@ -58,7 +57,7 @@ body.dns__body-white {
 			}
 
 			@include break-mobile {
-				padding: 16px 0;
+				padding: 16px;
 				border-top: none;
 				border-bottom: 1px solid $gray-5;
 			}

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -83,7 +83,7 @@ const EditContactInfoPage = ( {
 			showBackArrow: true,
 		};
 
-		return <DomainHeader items={ items } mobileItem={ mobileItem } isRedesign2023Aug />;
+		return <DomainHeader items={ items } mobileItem={ mobileItem } />;
 	};
 
 	const renderContent = () => {

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -3,7 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layout';
 import ExternalLink from 'calypso/components/external-link';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain } from 'calypso/lib/domains';
@@ -46,7 +45,7 @@ const EditContactInfoPage = ( {
 		);
 	};
 
-	const renderBreadcrumbs = () => {
+	const renderHeader = () => {
 		if ( ! selectedSite ) {
 			return null;
 		}
@@ -72,7 +71,10 @@ const EditContactInfoPage = ( {
 				label: selectedDomainName,
 				href: previousPath,
 			},
-			{ label: translate( 'Edit contact infomation' ) },
+			{
+				label: translate( 'Edit contact infomation' ),
+				subtitle: translate( 'Domain owners are required to provide correct contact information.' ),
+			},
 		];
 
 		const mobileItem = {
@@ -81,7 +83,7 @@ const EditContactInfoPage = ( {
 			showBackArrow: true,
 		};
 
-		return <DomainHeader items={ items } mobileItem={ mobileItem } />;
+		return <DomainHeader items={ items } mobileItem={ mobileItem } isRedesign2023Aug />;
 	};
 
 	const renderContent = () => {
@@ -183,15 +185,7 @@ const EditContactInfoPage = ( {
 	return (
 		<Main className="edit-contact-info-page" wideLayout>
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
-			{ renderBreadcrumbs() }
-			<FormattedHeader
-				brandFont
-				headerText={ translate( 'Edit contact information' ) }
-				subHeaderText={ translate(
-					'Domain owners are required to provide correct contact information.'
-				) }
-				align="left"
-			/>
+			{ renderHeader() }
 			<TwoColumnsLayout content={ renderContent() } sidebar={ renderSidebar() } />
 		</Main>
 	);

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
@@ -32,18 +32,4 @@
 			}
 		}
 	}
-	.formatted-header__title {
-		font-weight: 400;
-		margin: 0 0 4px;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		line-height: 100%;
-
-		@include break-zoomed-in {
-			font-size: $font-title-medium;
-		}
-
-		@include break-small {
-			font-size: $font-title-large;
-		}
-	}
 }

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -667,14 +667,7 @@ class AllDomains extends Component {
 			? []
 			: [ <OptionsDomainButton key="breadcrumb_button_1" specificSiteActions allDomainsList /> ];
 
-		return (
-			<DomainHeader
-				items={ [ item ] }
-				buttons={ buttons }
-				mobileButtons={ mobileButtons }
-				isRedesign2023Aug
-			/>
-		);
+		return <DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ mobileButtons } />;
 	}
 
 	renderContent() {

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -636,6 +636,14 @@ class AllDomains extends Component {
 
 		const item = {
 			label: translate( 'All Domains' ),
+			subtitle: translate(
+				'Manage all your domains. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+				{
+					components: {
+						learnMoreLink: <InlineSupportLink supportContext="domains" showIcon={ false } />,
+					},
+				}
+			),
 			helpBubble: translate(
 				'Manage all your domains. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 				{
@@ -659,7 +667,14 @@ class AllDomains extends Component {
 			? []
 			: [ <OptionsDomainButton key="breadcrumb_button_1" specificSiteActions allDomainsList /> ];
 
-		return <DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ mobileButtons } />;
+		return (
+			<DomainHeader
+				items={ [ item ] }
+				buttons={ buttons }
+				mobileButtons={ mobileButtons }
+				isRedesign2023Aug
+			/>
+		);
 	}
 
 	renderContent() {

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -283,7 +283,7 @@ export class SiteDomains extends Component {
 		);
 	}
 
-	renderBreadcrumbs() {
+	renderHeader() {
 		const { translate } = this.props;
 
 		const item = {
@@ -315,7 +315,6 @@ export class SiteDomains extends Component {
 				mobileItem={ item }
 				buttons={ buttons }
 				mobileButtons={ mobileButtons }
-				isRedesign2023Aug
 			/>
 		);
 	}
@@ -388,7 +387,7 @@ export class SiteDomains extends Component {
 		return (
 			<Main wideLayout>
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
-				{ this.renderBreadcrumbs() }
+				{ this.renderHeader() }
 				<DocumentHead title={ headerText } />
 				{ this.renderNewDesign() }
 			</Main>

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -315,6 +315,7 @@ export class SiteDomains extends Component {
 				mobileItem={ item }
 				buttons={ buttons }
 				mobileButtons={ mobileButtons }
+				isRedesign2023Aug
 			/>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -316,25 +316,3 @@
 		border-top: 1px solid var(--studio-gray-5);
 	}
 }
-
-.is-section-domains main.main {
-	padding-top: 59px;
-}
-
-@include breakpoint-deprecated( ">660px" ) {
-	.is-section-domains main.main {
-		padding-top: 45px;
-	}
-}
-
-@include breakpoint-deprecated( ">800px" ) {
-	.is-section-domains main.main {
-		padding-top: 32px;
-	}
-}
-
-@include breakpoint-deprecated( ">960px" ) {
-	.is-section-domains main.main {
-		padding-top: 24px;
-	}
-}

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -81,7 +81,7 @@ const Settings = ( {
 
 	const hasConnectableSites = useSelector( ( state ) => canAnySiteConnectDomains( state ) );
 
-	const renderBreadcrumbs = () => {
+	const renderHeader = () => {
 		const previousPath = domainManagementList(
 			selectedSite?.slug,
 			currentRoute,
@@ -104,7 +104,18 @@ const Settings = ( {
 			showBackArrow: true,
 		};
 
-		return <DomainHeader items={ items } mobileItem={ mobileItem } />;
+		return (
+			<DomainHeader
+				items={ items }
+				mobileItem={ mobileItem }
+				isRedesign2023Aug
+				titleOverride={
+					domain ? (
+						<SettingsHeader domain={ domain } site={ selectedSite } purchase={ purchase } />
+					) : null
+				}
+			/>
+		);
 	};
 
 	const renderSecurityAccordion = () => {
@@ -481,7 +492,7 @@ const Settings = ( {
 
 	if ( ! domain ) {
 		// TODO: Update this placeholder
-		return <DomainMainPlaceholder breadcrumbs={ renderBreadcrumbs } />;
+		return <DomainMainPlaceholder breadcrumbs={ renderHeader } />;
 	}
 
 	return (
@@ -489,8 +500,7 @@ const Settings = ( {
 		<Main wideLayout className="domain-settings-page">
 			{ selectedSite?.ID && ! purchase && <QuerySitePurchases siteId={ selectedSite?.ID } /> }
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
-			{ renderBreadcrumbs() }
-			<SettingsHeader domain={ domain } site={ selectedSite } purchase={ purchase } />
+			{ renderHeader() }
 			<TwoColumnsLayout content={ renderMainContent() } sidebar={ renderSettingsCards() } />
 		</Main>
 	);

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -108,7 +108,6 @@ const Settings = ( {
 			<DomainHeader
 				items={ items }
 				mobileItem={ mobileItem }
-				isRedesign2023Aug
 				titleOverride={
 					domain ? (
 						<SettingsHeader domain={ domain } site={ selectedSite } purchase={ purchase } />

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -149,7 +149,6 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 		<div className="settings-header__container">
 			<div className="settings-header__container-title">
 				<FormattedHeader
-					brandFont
 					className="settings-header__title"
 					headerText={ domain.name }
 					align="left"

--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -25,24 +25,6 @@ body.edit__body-white.theme-default.color-scheme {
 			header.settings-header__title {
 				margin: 8px 0;
 				text-transform: lowercase;
-
-				.formatted-header__title {
-					font-weight: 400;
-					margin: 0;
-					line-height: 100%; /* stylelint-disable-line declaration-property-unit-allowed-list */
-
-					@include break-zoomed-in {
-						font-size: $font-title-medium;
-					}
-
-					@include break-small {
-						font-size: $font-title-large;
-					}
-				}
-			}
-
-			@include breakpoint-deprecated( "<660px" ) {
-				margin: 8px 16px 24px;
 			}
 		}
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -11,7 +11,6 @@ import { connect } from 'react-redux';
 import ActionCard from 'calypso/components/action-card';
 import CardHeading from 'calypso/components/card-heading';
 import QueryDomainInfo from 'calypso/components/data/query-domain-info';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
 import Main from 'calypso/components/main';
@@ -81,7 +80,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 	const [ isLockingOrUnlockingDomain, setIsLockingOrUnlockingDomain ] = useState( false );
 	const domain = getSelectedDomain( props );
 
-	const renderBreadcrumbs = () => {
+	const renderHeader = () => {
 		const items = [
 			{
 				// translators: Internet domains, e.g. mygroovydomain.com
@@ -112,7 +111,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 			showBackArrow: true,
 		};
 
-		return <DomainHeader items={ items } mobileItem={ mobileItem } />;
+		return <DomainHeader items={ items } mobileItem={ mobileItem } isRedesign2023Aug />;
 	};
 
 	const renderTransferOptions = () => {
@@ -385,8 +384,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 		<Main className="transfer-page" wideLayout>
 			<QueryDomainInfo domainName={ selectedDomainName } />
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
-			{ renderBreadcrumbs() }
-			<FormattedHeader brandFont headerText={ __( 'Transfer' ) } align="left" />
+			{ renderHeader() }
 			<Layout>
 				<Column type="main">{ renderContent() }</Column>
 				<Column type="sidebar">

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -111,7 +111,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 			showBackArrow: true,
 		};
 
-		return <DomainHeader items={ items } mobileItem={ mobileItem } isRedesign2023Aug />;
+		return <DomainHeader items={ items } mobileItem={ mobileItem } />;
 	};
 
 	const renderTransferOptions = () => {

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
@@ -3,19 +3,6 @@
 @import "@wordpress/base-styles/colors";
 
 .transfer-page {
-	header.formatted-header {
-		margin: 24px 16px;
-
-		h1.formatted-header__title {
-			color: $gray-900;
-			font-size: $font-title-medium;
-
-			@include break-mobile {
-				font-size: $font-title-large;
-			}
-		}
-	}
-
 	.card {
 		color: var(--studio-gray-50);
 		padding: 16px;

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/style.scss
@@ -5,15 +5,6 @@
 .transfer-domain-to-other-site {
 	background: var(--studio-white);
 
-	.formatted-header__title {
-		font-size: $font-title-medium;
-
-		@include break-medium {
-			font-size: $font-title-large;
-		}
-
-	}
-
 	&__card {
 		padding: 0;
 		box-shadow: none;

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -191,7 +191,6 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 			<DomainHeader
 				items={ items }
 				mobileItem={ mobileItem }
-				isRedesign2023Aug
 				titleOverride={
 					<FormattedHeader
 						hasScreenOptions={ false }

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -127,13 +127,13 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 	}
 
 	render() {
-		const { selectedSite, selectedDomainName, currentRoute, translate } = this.props;
+		const { selectedSite, selectedDomainName, currentRoute } = this.props;
 		const slug = selectedSite?.slug;
 		const componentClassName = 'transfer-domain-to-other-site';
 		if ( ! this.isDataReady() ) {
 			return (
 				<DomainMainPlaceholder
-					breadcrumbs={ this.renderBreadcrumbs }
+					breadcrumbs={ this.renderHeader }
 					backHref={ domainManagementTransfer( slug, selectedDomainName, currentRoute ) }
 				/>
 			);
@@ -146,13 +146,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 					group={ componentClassName }
 					section={ componentClassName }
 				/>
-				{ this.renderBreadcrumbs() }
-				<FormattedHeader
-					hasScreenOptions={ false }
-					brandFont
-					headerText={ translate( 'Connect to another WordPress.com site' ) }
-					align="left"
-				/>
+				{ this.renderHeader() }
 				<div className={ `${ componentClassName }__container` }>
 					<div className={ `${ componentClassName }__main` }>{ this.renderSection() }</div>
 				</div>
@@ -160,7 +154,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		);
 	}
 
-	renderBreadcrumbs = () => {
+	renderHeader = () => {
 		const { translate, selectedSite, selectedDomainName, currentRoute } = this.props;
 
 		const items = [
@@ -182,7 +176,9 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 				label: translate( 'Connect' ),
 				href: domainManagementTransfer( selectedSite?.slug, selectedDomainName, currentRoute ),
 			},
-			{ label: translate( 'To another WordPress.com site' ) },
+			{
+				label: translate( 'To another WordPress.com site' ),
+			},
 		];
 
 		const mobileItem = {
@@ -191,7 +187,20 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 			showBackArrow: true,
 		};
 
-		return <DomainHeader items={ items } mobileItem={ mobileItem } />;
+		return (
+			<DomainHeader
+				items={ items }
+				mobileItem={ mobileItem }
+				isRedesign2023Aug
+				titleOverride={
+					<FormattedHeader
+						hasScreenOptions={ false }
+						headerText={ translate( 'Connect to another WordPress.com site' ) }
+						align="left"
+					/>
+				}
+			/>
+		);
 	};
 
 	renderSection() {

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/style.scss
@@ -38,22 +38,6 @@ body.transfer-to-other-user.theme-default.color-scheme {
 }
 
 body.transfer-to-other-user {
-	.formatted-header {
-		&.is-left-align,
-		&.is-right-align {
-			margin-bottom: 24px;
-
-			h1.formatted-header__title {
-				color: $gray-900;
-				font-size: $font-title-medium;
-
-				@include break-mobile {
-					font-size: $font-title-large;
-				}
-			}
-		}
-	}
-
 	.transfer-to-other-user__container {
 		.transfer-to-other-user__main {
 			margin: 16px;

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -171,7 +171,7 @@ class TransferDomainToOtherUser extends Component {
 			showBackArrow: true,
 		};
 
-		return <DomainHeader items={ items } mobileItem={ mobileItem } isRedesign2023Aug />;
+		return <DomainHeader items={ items } mobileItem={ mobileItem } />;
 	}
 
 	render() {

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -5,7 +5,6 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect, useSelector } from 'react-redux';
-import FormattedHeader from 'calypso/components/formatted-header';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
@@ -141,7 +140,7 @@ class TransferDomainToOtherUser extends Component {
 		return first_name && last_name ? `${ first_name } ${ last_name } (${ nice_name })` : nice_name;
 	}
 
-	renderBreadcrumbs() {
+	renderHeader() {
 		const { translate, selectedSite, selectedDomainName, currentRoute } = this.props;
 
 		const items = [
@@ -172,7 +171,7 @@ class TransferDomainToOtherUser extends Component {
 			showBackArrow: true,
 		};
 
-		return <DomainHeader items={ items } mobileItem={ mobileItem } />;
+		return <DomainHeader items={ items } mobileItem={ mobileItem } isRedesign2023Aug />;
 	}
 
 	render() {
@@ -184,18 +183,10 @@ class TransferDomainToOtherUser extends Component {
 				</>
 			);
 		}
-
-		const { translate } = this.props;
-
 		return (
 			<Main wideLayout>
 				<BodySectionCssClass bodyClass={ [ 'transfer-to-other-user' ] } />
-				{ this.renderBreadcrumbs() }
-				<FormattedHeader
-					brandFont
-					headerText={ translate( 'Transfer to another user' ) }
-					align="left"
-				/>
+				{ this.renderHeader() }
 				<div className="transfer-to-other-user__container">
 					<div className="transfer-to-other-user__main">{ this.renderSection() }</div>
 				</div>

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -56,11 +56,3 @@ body.is-section-domains.is-domain-plan-package-flow {
 .is-section-domains #primary header.formatted-header {
 	margin: 24px 0;
 }
-
-.is-section-domains #primary .settings-header__container {
-	margin: 24px 0;
-
-	header.formatted-header {
-		margin: 0;
-	}
-}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3353

## Proposed Changes

Context: p9Jlb4-8ec

> [!NOTE]  
> Nothing functional has been changed so this review can be focused on visual aspects.


* Changes to the <DomainHeader> component to align with the new consolidated Header design
* That is a total of 10 instances
(checklist to help with testing)
- [x] 1. Connect another domain: `/domains/mapping/:siteSlug/setup/:connectToDomain` File: `client/components/domains/connect-domain-step/index.jsx`
- [x] 2. DNS > Add a DNS Record: `/domains/manage/all/:domain/add-dns-record/:siteSlug` File: `client/my-sites/domains/domain-management/dns/add-dns-record.jsx`
- [x] 3. DNS: `/domains/manage/all/:domain/dns/:siteSlug` File: `client/my-sites/domains/domain-management/dns/dns-records.jsx`
- [x] 4. Edit contact information: `/domains/manage/all/:domain/edit-contact-info/:siteSlug` File: `client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx`
- [x] 5. Domain management: `/domains/manage` File: `client/my-sites/domains/domain-management/list/all-domains.jsx`
- [x] 6. Domain management (site): `/domains/manage/:siteSlug` File: `client/my-sites/domains/domain-management/list/site-domains.jsx`
- [x] 7. Domain Settings: `/domains/manage/all/:domain/edit/:siteSlug` File: `client/my-sites/domains/domain-management/settings/index.tsx`
- [x] 8. Transfer: `/domains/manage/all/:domain/transfer/:siteSlug` File: `client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx`
- [x] 9. Transfer > Transfer to another WP.com site: `/domains/manage/all/:domain/transfer/other-site/:siteSlug` File: `client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx`
- [x] 10. Transfer > Transfer to another user: `/domains/manage/all/:siteSlug/transfer/other-user/:siteSlug` File: `client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx`

Here's the Header's intended behavior (domain data redacted, only showing the Header)

### Before:

https://github.com/Automattic/wp-calypso/assets/6586048/7a8c32c8-f792-4100-ac01-55b584745018

### After:

https://github.com/Automattic/wp-calypso/assets/6586048/960c69c0-b8b1-4171-829d-ce0726d76cb2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Please check the checklist above for all the pages that need testing
* Test for all screen sizes

| Page | Screenshots |
| :-------------: | :-------------: |
| Connect another domain | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/ab4768e8-2919-4e88-a7e9-756edca5761e">  |
| DNS > Add a DNS Record | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/a484d815-7601-4fb4-9581-661fed144c1f"> |
| DNS | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/86f88571-7fa0-43bb-bf93-0de12e17e4ad"> |
| Edit contact information | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/6937be7f-0e93-41cb-8cbb-06d6109580b1"> |
| Domain management | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/7680d697-625f-4d07-8c18-3bc70ddc644d"> |
| Domain management (site) | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/5961dcff-030f-49f2-b279-0dbb6dccddc6"> |
| Domain Settings | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/faa2a7e6-977d-4b59-acda-818ab9a75ff7"> |
| Transfer | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/bf5e64aa-e5bb-4a89-b244-554cb5607b7e"> |
| Transfer > Transfer to another WP.com site | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/0da10f71-5e75-4475-8328-c0d91d5b0986"> |
| Transfer > Transfer to another user | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/bb4898a2-9db6-48c9-8f1a-cedf673e1608"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
