### PR TITLE
Small style fix for license activation screen

### DIFF
--- a/client/components/jetpack/licensing-activation/style.scss
+++ b/client/components/jetpack/licensing-activation/style.scss
@@ -55,14 +55,15 @@
 	padding: 0;
 	border-radius: 4px;
 	box-shadow: 0 0 40px 0 #00000014;
-
 	width: 100%;
 	max-width: none;
+	margin-top: var(--masterbar-checkout-height);
 
 	@include break-large {
 		flex-direction: row;
 		width: auto;
 		max-width: 1200px;
+		margin-top: calc(var(--masterbar-checkout-height) + 24px);
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

* This PR fixes a spacing issue on the licensing activation screen

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Complete a Jetpack siteless checkout purchase
* Without this PR applied, notice that there is no space between the header and the license activation panel:
![Screenshot 2023-08-03 at 9 42 17 AM](https://github.com/Automattic/wp-calypso/assets/18016357/21b03701-26aa-4dbd-9d27-c44da46ce21a)

* With this PR applied, the spacing should be corrected
![Screenshot 2023-08-03 at 9 42 24 AM](https://github.com/Automattic/wp-calypso/assets/18016357/7c3862c8-a85d-4c5a-8a90-d0c1ef336e45)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
