### PR TITLE
Domain Transfer: Update videos to be loaded from VideoPress

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/google-domains-transfer-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/google-domains-transfer-instructions/index.tsx
@@ -82,7 +82,7 @@ const GoogleDomainsModal: React.FC< Props > = ( { children, className, focusedSt
 							) }
 						</p>
 						{ /* eslint-disable jsx-a11y/media-has-caption */ }
-						<video autoPlay loop>
+						<video autoPlay loop width={ 1188 } height={ 720 } style={ { aspectRatio: '1.65' } }>
 							<source
 								src="https://videos.files.wordpress.com/BoWqyRoi/step-03-720p.mp4"
 								type="video/mp4"
@@ -97,7 +97,13 @@ const GoogleDomainsModal: React.FC< Props > = ( { children, className, focusedSt
 							) }
 						</p>
 						{ /* eslint-disable jsx-a11y/media-has-caption */ }
-						<video autoPlay loop>
+						<video
+							autoPlay
+							loop
+							width={ 1184 }
+							height={ 720 }
+							style={ { aspectRatio: '1.64444444' } }
+						>
 							<source
 								src="https://videos.files.wordpress.com/dZY2deS5/step-04-720p.mp4"
 								type="video/mp4"

--- a/client/landing/stepper/declarative-flow/internals/components/google-domains-transfer-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/google-domains-transfer-instructions/index.tsx
@@ -83,7 +83,10 @@ const GoogleDomainsModal: React.FC< Props > = ( { children, className, focusedSt
 						</p>
 						{ /* eslint-disable jsx-a11y/media-has-caption */ }
 						<video autoPlay loop>
-							<source src="https://cldup.com/bYWgYH_hoP.mp4" type="video/mp4" />
+							<source
+								src="https://videos.files.wordpress.com/BoWqyRoi/step-03-720p.mp4"
+								type="video/mp4"
+							/>
 						</video>
 					</details>
 					<details open={ 3 === focusedStep || 4 === focusedStep }>
@@ -95,7 +98,10 @@ const GoogleDomainsModal: React.FC< Props > = ( { children, className, focusedSt
 						</p>
 						{ /* eslint-disable jsx-a11y/media-has-caption */ }
 						<video autoPlay loop>
-							<source src="https://cldup.com/IM6wEuLIbc.mp4" type="video/mp4" />
+							<source
+								src="https://videos.files.wordpress.com/dZY2deS5/step-04-720p.mp4"
+								type="video/mp4"
+							/>
 							<track />
 						</video>
 					</details>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3332

## Proposed Changes

* Moves step 3 and 4 videos to VideoPress.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR
* Go to `/setup/google-transfer`
* Click "Show me how"
* Ensure that videos load and that there is minimal reflow
* Test in different browsers
* Test proxied/unproxied and logged in/out

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
