### PR TITLE
Launchpad: Add the layout category to meta

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -104,6 +104,18 @@ class Starter_Page_Templates {
 			},
 		);
 		register_meta( 'post', '_starter_page_template', $args );
+
+		$args = array(
+			'type'           => 'string',
+			'description'    => 'Selected category',
+			'single'         => true,
+			'show_in_rest'   => true,
+			'object_subtype' => 'page',
+			'auth_callback'  => function () {
+				return current_user_can( 'edit_posts' );
+			},
+		);
+		register_meta( 'post', '_wp_layout_category', $args );
 	}
 
 	/**

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -119,7 +119,7 @@ class Starter_Page_Templates {
 			'single'            => true,
 			'object_subtype'    => 'page',
 			'auth_callback'     => function () {
-				return current_user_can( 'edit_posts' );
+				return current_user_can( 'edit_pages' );
 			},
 			'sanitize_callback' => function ( $meta_value ) {
 				if ( ! is_array( $meta_value ) ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -106,16 +106,42 @@ class Starter_Page_Templates {
 		register_meta( 'post', '_starter_page_template', $args );
 
 		$args = array(
-			'type'           => 'string',
-			'description'    => 'Selected category',
-			'single'         => true,
-			'show_in_rest'   => true,
-			'object_subtype' => 'page',
-			'auth_callback'  => function () {
+			'type'              => 'array',
+			'description'       => 'Selected category',
+			'show_in_rest'      => array(
+				'schema' => array(
+					'type'  => 'array',
+					'items' => array(
+						'type' => 'string',
+					),
+				),
+			),
+			'single'            => true,
+			'object_subtype'    => 'page',
+			'auth_callback'     => function () {
 				return current_user_can( 'edit_posts' );
 			},
+			'sanitize_callback' => function ( $meta_value ) {
+				if ( ! is_array( $meta_value ) ) {
+					return array();
+				}
+
+				if ( ! class_exists( '\A8C\FSE\Starter_Page_Templates' ) ) {
+					return array();
+				}
+
+				$starter_page_templates = \A8C\FSE\Starter_Page_Templates::get_instance();
+				// We need to pass a locale in here, but we don't actually depend on it, so we use the default site locale to optimise hitting the pattern cache for the site.
+				$all_page_templates     = $starter_page_templates->get_page_templates( $starter_page_templates->get_verticals_locale() );
+				$all_categories = array_merge( ...array_map( 'array_keys', wp_list_pluck( $all_page_templates, 'categories' ) ) );
+
+				$unique_categories = array_unique( $all_categories );
+
+				// Only permit values that are valid categories.
+				return array_intersect( $meta_value, $unique_categories );
+			},
 		);
-		register_meta( 'post', '_wp_layout_category', $args );
+		register_meta( 'post', '_wpcom_template_layout_category', $args );
 	}
 
 	/**
@@ -309,7 +335,7 @@ class Starter_Page_Templates {
 	/**
 	 * Gets the locale to be used for fetching the site vertical
 	 */
-	private function get_verticals_locale() {
+	public function get_verticals_locale() {
 		// Make sure to get blog locale, not user locale.
 		$language = function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_locale();
 		return get_iso_639_locale( $language );

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
@@ -62,7 +62,7 @@ export function PagePatternsPlugin( props: PagePatternsPluginProps ) {
 	}, [] );
 
 	const savePatternChoice = useCallback(
-		( name: string, selectedCategory?: string ) => {
+		( name: string, selectedCategory: string | null ) => {
 			// Save selected pattern slug in meta.
 			const currentMeta = getMeta() as Record< string, unknown >;
 			const currentCategory =

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
@@ -65,11 +65,15 @@ export function PagePatternsPlugin( props: PagePatternsPluginProps ) {
 		( name: string, selectedCategory?: string ) => {
 			// Save selected pattern slug in meta.
 			const currentMeta = getMeta() as Record< string, unknown >;
+			const currentCategory =
+				( Array.isArray( currentMeta._wpcom_template_layout_category ) &&
+					currentMeta._wpcom_template_layout_category ) ||
+				[];
 			editPost( {
 				meta: {
 					...currentMeta,
 					_starter_page_template: name,
-					_wp_layout_category: selectedCategory,
+					_wpcom_template_layout_category: [ ...currentCategory, selectedCategory ],
 				},
 			} );
 		},

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
@@ -62,7 +62,7 @@ export function PagePatternsPlugin( props: PagePatternsPluginProps ) {
 	}, [] );
 
 	const savePatternChoice = useCallback(
-		( name: string, selectedCategory: string ) => {
+		( name: string, selectedCategory?: string ) => {
 			// Save selected pattern slug in meta.
 			const currentMeta = getMeta() as Record< string, unknown >;
 			editPost( {

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
@@ -62,13 +62,14 @@ export function PagePatternsPlugin( props: PagePatternsPluginProps ) {
 	}, [] );
 
 	const savePatternChoice = useCallback(
-		( name: string ) => {
+		( name: string, selectedCategory: string ) => {
 			// Save selected pattern slug in meta.
 			const currentMeta = getMeta() as Record< string, unknown >;
 			editPost( {
 				meta: {
 					...currentMeta,
 					_starter_page_template: name,
+					_wp_layout_category: selectedCategory,
 				},
 			} );
 		},

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -20,7 +20,7 @@ interface PagePatternModalProps {
 	instanceId: string | number;
 	isOpen: boolean;
 	isWelcomeGuideActive?: boolean;
-	savePatternChoice: ( name: string ) => void;
+	savePatternChoice: ( name: string, selectedCategory: string ) => void;
 	onClose: () => void;
 	siteInformation?: Record< string, string >;
 	patterns: PatternDefinition[];
@@ -131,7 +131,8 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 	setPattern = ( name: string ) => {
 		// Track selection and mark post as using a pattern in its postmeta.
 		trackSelection( name );
-		this.props.savePatternChoice( name );
+		const { selectedCategory } = this.state;
+		this.props.savePatternChoice( name, selectedCategory );
 
 		// Check to see if this is a blank pattern selection
 		// and reset the pattern if so.

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -20,7 +20,7 @@ interface PagePatternModalProps {
 	instanceId: string | number;
 	isOpen: boolean;
 	isWelcomeGuideActive?: boolean;
-	savePatternChoice: ( name: string, selectedCategory?: string ) => void;
+	savePatternChoice: ( name: string, selectedCategory: string | null ) => void;
 	onClose: () => void;
 	siteInformation?: Record< string, string >;
 	patterns: PatternDefinition[];

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -20,7 +20,7 @@ interface PagePatternModalProps {
 	instanceId: string | number;
 	isOpen: boolean;
 	isWelcomeGuideActive?: boolean;
-	savePatternChoice: ( name: string, selectedCategory: string ) => void;
+	savePatternChoice: ( name: string, selectedCategory?: string ) => void;
 	onClose: () => void;
 	siteInformation?: Record< string, string >;
 	patterns: PatternDefinition[];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* https://github.com/Automattic/jetpack/pull/32245
* https://github.com/Automattic/wp-calypso/issues/79795

## Proposed Changes

* Adds a new post meta so we can know which category for the template the user is using. This will be useful to identify if the user is adding an "About me" page, which is a task for the Newsletter task lists.

At first, I thought of limiting it only to the "About" page, but it can be useful in other task lists in the future to have a category for the pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/setup/newsletter/intro` and create a new Newsletter site.
* On your sandbox run `install-plugin.sh etk add/layout-category-to-meta` to apply these changes.
* Make sure the public API and your new site are sandboxed.
* Navigate to `/page/:siteSlug`
* Select the "About" category and select any pattern.
* Publish the page
* On your sandbox run `wpsh` and type in the following code:
```php
$blog_id = YOUR-BLOG-ID;
$post_id = <ID of the page you just created>;
switch_to_blog( $blog_id );
var_dump(get_post_meta( $post_id, '_wpcom_template_layout_category', true ));
```
* The code above should output:
```php
array(1) {
  [0]=>
  string(5) "about"
}
```


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
