### PR TITLE
Stats: Fix views count on the most popular post of the past year

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/post-cards-group.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/post-cards-group.tsx
@@ -18,7 +18,6 @@ import {
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import {
 	getTopPostAndPage,
-	isRequestingSiteStatsForQuery,
 	hasSiteStatsForQueryFinished,
 } from 'calypso/state/stats/lists/selectors';
 import LatestPostCard from './latest-post-card';
@@ -60,9 +59,9 @@ const getStatsQueries = createSelector(
 	( state, siteId ) => getSiteOption( state, siteId, 'gmt_offset' )
 );
 
-const getStatsData = createSelector(
+const getStatsTopPostsData = createSelector(
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	( state, siteId, topPostsQuery, isTopViewedPostRequesting ) => {
+	( state, siteId, topPostsQuery, hasTopViewedPostQueryFinished ) => {
 		const { post: topPost, page: topPage } = getTopPostAndPage( state, siteId, topPostsQuery );
 
 		return {
@@ -99,11 +98,11 @@ export default function PostCardsGroup( {
 
 	// Get the most `viewed` post from the past period defined in the `topPostsQuery`.
 	const { topPostsQuery } = useSelector( ( state ) => getStatsQueries( state, siteId ) );
-	const isTopViewedPostRequesting = useSelector( ( state ) =>
-		isRequestingSiteStatsForQuery( state, siteId, 'statsTopPosts', topPostsQuery )
+	const hasTopViewedPostQueryFinished = useSelector( ( state ) =>
+		hasSiteStatsForQueryFinished( state, siteId, 'statsTopPosts', topPostsQuery )
 	);
 	const { topPost: topViewedPost } = useSelector( ( state ) =>
-		getStatsData( state, siteId, topPostsQuery, isTopViewedPostRequesting )
+		getStatsTopPostsData( state, siteId, topPostsQuery, hasTopViewedPostQueryFinished )
 	);
 
 	// Prepare the most popular post card.
@@ -122,9 +121,6 @@ export default function PostCardsGroup( {
 	};
 
 	// Check if the most popular post is ready to be displayed.
-	const hasTopViewedPostQueryFinished = useSelector( ( state ) =>
-		hasSiteStatsForQueryFinished( state, siteId, 'statsTopPosts', topPostsQuery )
-	);
 	const isRequestingMostPopularPost = useSelector( ( state ) =>
 		isRequestingSitePost( state, siteId, topViewedPost?.id )
 	);

--- a/client/my-sites/stats/all-time-highlights-section/post-cards-group.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/post-cards-group.tsx
@@ -71,10 +71,7 @@ const getStatsTopPostsData = createSelector(
 			topPage,
 		};
 	},
-	( state, siteId, topPostsQuery ) => [
-		topPostsQuery,
-		getSiteOption( state, siteId, 'gmt_offset' ),
-	]
+	( state, siteId, topPostsQuery ) => [ topPostsQuery ]
 );
 
 export default function PostCardsGroup( {

--- a/client/my-sites/stats/all-time-highlights-section/post-cards-group.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/post-cards-group.tsx
@@ -69,10 +69,9 @@ const getStatsTopPostsData = createSelector(
 			topPage,
 		};
 	},
-	// Refresh memoized data from createSelector with the loading flag
-	( state, siteId, topPostsQuery, isTopViewedPostRequesting ) => [
+	( state, siteId, topPostsQuery ) => [
 		topPostsQuery,
-		isTopViewedPostRequesting,
+		getSiteOption( state, siteId, 'gmt_offset' ),
 	]
 );
 

--- a/client/my-sites/stats/all-time-highlights-section/post-cards-group.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/post-cards-group.tsx
@@ -3,6 +3,7 @@ import { PostStatsCard, ComponentSwapper } from '@automattic/components';
 import { createSelector } from '@automattic/state-utils';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
+import QueryPostStats from 'calypso/components/data/query-post-stats';
 import QueryPosts from 'calypso/components/data/query-posts';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import DotPager from 'calypso/components/dot-pager';
@@ -20,6 +21,7 @@ import {
 	getTopPostAndPage,
 	hasSiteStatsForQueryFinished,
 } from 'calypso/state/stats/lists/selectors';
+import { getPostStat } from 'calypso/state/stats/posts/selectors';
 import LatestPostCard from './latest-post-card';
 
 const POST_STATS_CARD_TITLE_LIMIT = 60;
@@ -108,6 +110,11 @@ export default function PostCardsGroup( {
 	const mostPopularPost = useSelector( ( state ) =>
 		getSitePost( state, siteId, topViewedPost?.id )
 	);
+
+	const mostPopularPostViewCount = useSelector(
+		( state ) => getPostStat( state, siteId, topViewedPost?.id, 'views' ) || 0
+	);
+
 	const mostPopularPostData = {
 		date: mostPopularPost?.date,
 		post_thumbnail: mostPopularPost?.post_thumbnail?.URL || null,
@@ -115,7 +122,7 @@ export default function PostCardsGroup( {
 			stripHTML( textTruncator( mostPopularPost?.title, POST_STATS_CARD_TITLE_LIMIT ) )
 		),
 		likeCount: mostPopularPost?.like_count,
-		viewCount: topViewedPost?.views,
+		viewCount: mostPopularPostViewCount,
 		commentCount: mostPopularPost?.discussion?.comment_count,
 	};
 
@@ -172,6 +179,7 @@ export default function PostCardsGroup( {
 			{ siteId && topViewedPost && (
 				<>
 					<QueryPosts siteId={ siteId } postId={ topViewedPost.id } query={ {} } />
+					<QueryPostStats siteId={ siteId } postId={ topViewedPost.id } />
 				</>
 			) }
 

--- a/client/my-sites/stats/all-time-highlights-section/post-cards-group.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/post-cards-group.tsx
@@ -62,8 +62,7 @@ const getStatsQueries = createSelector(
 );
 
 const getStatsTopPostsData = createSelector(
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	( state, siteId, topPostsQuery, hasTopViewedPostQueryFinished ) => {
+	( state, siteId, topPostsQuery ) => {
 		const { post: topPost, page: topPage } = getTopPostAndPage( state, siteId, topPostsQuery );
 
 		return {
@@ -71,7 +70,7 @@ const getStatsTopPostsData = createSelector(
 			topPage,
 		};
 	},
-	( state, siteId, topPostsQuery ) => [ topPostsQuery ]
+	( state, siteId, topPostsQuery ) => [ state, siteId, topPostsQuery ]
 );
 
 export default function PostCardsGroup( {
@@ -96,11 +95,8 @@ export default function PostCardsGroup( {
 
 	// Get the most `viewed` post from the past period defined in the `topPostsQuery`.
 	const { topPostsQuery } = useSelector( ( state ) => getStatsQueries( state, siteId ) );
-	const hasTopViewedPostQueryFinished = useSelector( ( state ) =>
-		hasSiteStatsForQueryFinished( state, siteId, 'statsTopPosts', topPostsQuery )
-	);
 	const { topPost: topViewedPost } = useSelector( ( state ) =>
-		getStatsTopPostsData( state, siteId, topPostsQuery, hasTopViewedPostQueryFinished )
+		getStatsTopPostsData( state, siteId, topPostsQuery )
 	);
 
 	// Prepare the most popular post card.
@@ -128,6 +124,9 @@ export default function PostCardsGroup( {
 	// Check if the most popular post is ready to be displayed.
 	const isRequestingMostPopularPost = useSelector( ( state ) =>
 		isRequestingSitePost( state, siteId, topViewedPost?.id )
+	);
+	const hasTopViewedPostQueryFinished = useSelector( ( state ) =>
+		hasSiteStatsForQueryFinished( state, siteId, 'statsTopPosts', topPostsQuery )
 	);
 	const isPreparingMostPopularPost = ! hasTopViewedPostQueryFinished || isRequestingMostPopularPost;
 

--- a/client/my-sites/stats/all-time-highlights-section/post-cards-group.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/post-cards-group.tsx
@@ -108,6 +108,8 @@ export default function PostCardsGroup( {
 		getSitePost( state, siteId, topViewedPost?.id )
 	);
 
+	// Determine the most popular post in the past year by the `stats/top-posts` API.
+	// Align the most popular post views count with the Post Details page by the `stats/post` API to avoid confusion.
 	const mostPopularPostViewCount = useSelector(
 		( state ) => getPostStat( state, siteId, topViewedPost?.id, 'views' ) || 0
 	);

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -270,7 +270,8 @@ const getSortedPostsAndPages = ( data ) => {
 			if ( post.id in topPosts ) {
 				topPosts[ post.id ].views += post.views;
 			} else {
-				topPosts[ post.id ] = post;
+				// Use the shallow copy of the post object to avoid mutating the original data.
+				topPosts[ post.id ] = Object.assign( {}, post );
 			}
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79292 

## Proposed Changes

* ~Fix param dependents of the top posts selector to prevent data from unexpectedly accumulating.~
* Use shallow copy to resolve the original post object mutation when accumulating the post views count.
* Align the views count on the `Most popular post in the past year` with numbers on the All-time stats of the post detail page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the change with the Calypso Live link.
* Navigate to Stats > `Insights` page.
* Ensure the `Most popular post in the past year` views count is stable when refreshing the page multiple times.
* Go to the `Post Detail` page by clicking on the `Most popular post in the past year` title.
* Ensure the All-time stats views count is the same as the number on the `Most popular post in the past year` card.
* Go back to the `Insights` page.
* Ensure the `Most popular post in the past year` views count is unchanged.

| Most popular post in the past year | All-time stats of the post |
|-|-|
|<img width="1273" alt="截圖 2023-08-04 上午2 35 35" src="https://github.com/Automattic/wp-calypso/assets/6869813/e5683fcd-9ce9-4af7-a7fa-3ef27e1ac7f5">|<img width="1293" alt="截圖 2023-08-04 上午2 35 57" src="https://github.com/Automattic/wp-calypso/assets/6869813/268a4966-27c4-45f9-942e-489550c273c2">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
