### PR TITLE
Checkout: Support 3DS challenge in web payment processor

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/web-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/web-pay-processor.ts
@@ -1,8 +1,10 @@
 import { makeSuccessResponse, makeErrorResponse } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
-import { recordTransactionBeginAnalytics } from '../lib/analytics';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { logStashEvent, recordTransactionBeginAnalytics } from '../lib/analytics';
 import getDomainDetails from './get-domain-details';
 import getPostalCode from './get-postal-code';
+import { doesTransactionResponseRequire3DS, handle3DSChallenge } from './stripe-3ds';
 import submitWpcomTransaction from './submit-wpcom-transaction';
 import {
 	createTransactionEndpointRequestPayload,
@@ -57,9 +59,43 @@ export default async function webPayProcessor(
 		paymentPartnerProcessorId: transactionOptions.stripeConfiguration?.processor_id,
 	} );
 	debug( 'submitting web-pay transaction', formattedTransactionData );
+	let paymentIntentId: string | undefined = undefined;
 	return submitWpcomTransaction( formattedTransactionData, transactionOptions )
+		.then( async ( stripeResponse ) => {
+			if ( doesTransactionResponseRequire3DS( stripeResponse ) ) {
+				debug( 'transaction requires authentication' );
+				paymentIntentId = stripeResponse.message.payment_intent_id;
+				await handle3DSChallenge(
+					transactionOptions.reduxDispatch,
+					submitData.stripe,
+					stripeResponse.message.payment_intent_client_secret,
+					paymentIntentId
+				);
+				// We must return the original authentication response in order
+				// to have access to the order_id so that we can display a
+				// pending page while we wait for Stripe to send a webhook to
+				// complete the purchase so we do not return the result of
+				// confirming the payment intent and instead fall through.
+			}
+			return stripeResponse;
+		} )
 		.then( makeSuccessResponse )
-		.catch( ( error ) => makeErrorResponse( error.message ) );
+		.catch( ( error ) => {
+			debug( 'transaction failed' );
+			transactionOptions.reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_web_pay_transaction_failed', {
+					payment_intent_id: paymentIntentId ?? '',
+				} )
+			);
+			logStashEvent( 'calypso_checkout__transaction_failed', {
+				payment_intent_id: paymentIntentId ?? '',
+				tags: [ `payment_intent_id:${ paymentIntentId }` ],
+			} );
+
+			// Errors here are "expected" errors, meaning that they (hopefully) come
+			// from the endpoint and not from some bug in the frontend code.
+			return makeErrorResponse( error.message );
+		} );
 }
 
 function isValidWebPayTransactionData(

--- a/client/my-sites/checkout/composite-checkout/test/web-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/web-pay-processor.ts
@@ -9,6 +9,7 @@ import {
 	countryCode,
 	postalCode,
 	contactDetailsForDomain,
+	mockLogStashEndpoint,
 } from './util';
 
 describe( 'webPayProcessor', () => {
@@ -57,6 +58,10 @@ describe( 'webPayProcessor', () => {
 			sensitive_pixel_options: '',
 		},
 	};
+
+	beforeEach( () => {
+		mockLogStashEndpoint();
+	} );
 
 	it( 'throws an error if there is no stripe object', async () => {
 		const submitData = { paymentPartner: 'stripe' };


### PR DESCRIPTION
## Proposed Changes

It appears that Web Pay cards (Apple Pay/Google Pay) can sometimes require a 3DS challenge.

In this PR we add the 3DS challenge handler code to the web payment processor function in the same way it exists on the credit card and existing credit card processor functions. It should not affect non-3DS cards but will prevent 3DS cards from incorrectly assuming that the transaction is complete (we've seen many instances of this in our logs).

To quote Stripe from a Slack thread:

> In general, Google generates a DPAN (device-specific tokenized card number) for the card added, and a cryptogram (one-time verification string that the issuer uses to verify the transaction). When both values are sent, it is considered to be authenticated and hence 3DS will not kick in... However, in some cases (we believe when a card is added via chrome), Google does not send the cryptogram info and this will be considered unauthenticated. These transactions might fall into the 3DS path.

## Testing Instructions

I'm not sure how to trigger this exactly. Testing Google Pay is hard enough and for this to work we'd also need a 3DS card inside Google Pay. We may just need to do static analysis of the code.