### PR TITLE
Update documentation link for the blaze dashboard app

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -234,8 +234,7 @@ private object BlazeDashboard : WPComPluginBuild(
 	pluginSlug = "blaze-dashboard",
 	archiveDir = "./dist/",
 	withPRNotify = "false",
-	// TODO: Update doc link when the doc is released
-	docsLink = "TODO",
+	docsLink = "PCYsg-SuD-p2",
 	buildSteps = {
 		bashNodeScript {
 			name = "Translate Blaze Dashboard"

--- a/apps/blaze-dashboard/README.md
+++ b/apps/blaze-dashboard/README.md
@@ -1,6 +1,6 @@
 # Blaze Dashboard App
 
-Blaze Dashboard is built as a standalone application to be used inside Jetpack, and in the future, into WooCommerce. TBD: The counterpart of the project in Jetpack
+Blaze Dashboard is built as a standalone application to be used inside Jetpack, and in the future, into WooCommerce. The Jetpack counterpart of the project is in [here](https://github.com/Automattic/jetpack/tree/trunk/projects/packages/blaze).
 
 ## Hiarachy
 


### PR DESCRIPTION
## Proposed Changes

I am updating the README file for the blaze-app and the corresponding teamcity build with a link to the correct documentation page.

## Testing Instructions

Code review. Verify that the links are correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
