### PR TITLE
Migration trial: Show LoadingEllipsis when applying the trial plan

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/style.scss
@@ -2,6 +2,13 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.step-container.migration-trial {
+	.wpcom__loading-ellipsis {
+		display: block;
+		margin: 25vh auto auto;
+	}
+}
+
 .trial-plan--container {
 	max-width: 692px;
 	margin: auto;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
@@ -6,6 +6,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useState } from 'react';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import useAddHostingTrialMutation from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import useUnsupportedTrialFeatureList from './hooks/use-unsupported-trial-feature-list';
 import TrialPlanFeaturesModal from './trial-plan-features-modal';
@@ -44,6 +45,10 @@ const TrialPlan = function TrialPlan( props: Props ) {
 		} else {
 			addHostingTrial( site.ID, PLAN_MIGRATION_TRIAL_MONTHLY );
 		}
+	}
+
+	if ( isAddingTrial ) {
+		return <LoadingEllipsis />;
 	}
 
 	return (


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80190

## Proposed Changes

* Show LoadingEllipsis when applying the trial plan

## Testing Instructions

**NOTE:** For the review, see [the latest commit](https://github.com/Automattic/wp-calypso/commit/252f0d27477328f61aa9e06978aac9b840ab288b) since it's branched out from `update/import-flow-migration-trial`

* Go to /setup/import-focused?siteSlug={SIMPLE_SITE_SLUG}
* Enter a self-hosted website URL (Jurassic Ninja)
* [Import preview step]: press the Import your content button
* [Upgrade plan step]: press the Try it for free button
* [Migration trial step]: press the Start the trial and migrate
* Check if there is the loading screen

<img width="331" alt="Screenshot 2023-08-03 at 22 12 39" src="https://github.com/Automattic/wp-calypso/assets/1241413/6658f5d9-394d-4dc6-8792-00b540391247">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
