### PR TITLE
Sites dashboard: add migration TRIAL badge

### DIFF
--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -157,7 +157,9 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 						<div className={ badges }>
 							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
 							{ isWpcomStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
-							{ isTrialSite && <SitesMigrationTrialBadge>Trial</SitesMigrationTrialBadge> }
+							{ isTrialSite && (
+								<SitesMigrationTrialBadge>{ __( 'Trial' ) }</SitesMigrationTrialBadge>
+							) }
 							{ getSiteLaunchStatus( site ) !== 'public' && (
 								<SitesLaunchStatusBadge>{ translatedStatus }</SitesLaunchStatusBadge>
 							) }

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -7,7 +7,8 @@ import { useI18n } from '@wordpress/react-i18n';
 import { memo } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
-import { displaySiteUrl, getDashboardUrl, isStagingSite } from '../utils';
+import SitesMigrationTrialBadge from 'calypso/sites-dashboard/components/sites-migration-trial-badge';
+import { displaySiteUrl, getDashboardUrl, isMigrationTrialSite, isStagingSite } from '../utils';
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
 import { SitesGridActionRenew } from './sites-grid-action-renew';
 import { SitesGridTile } from './sites-grid-tile';
@@ -105,6 +106,7 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 
 	const isP2Site = site.options?.is_wpforteams_site;
 	const isWpcomStagingSite = isStagingSite( site );
+	const isTrialSite = isMigrationTrialSite( site );
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 	const isECommerceTrialSite = site.plan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 
@@ -155,6 +157,7 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 						<div className={ badges }>
 							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
 							{ isWpcomStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
+							{ isTrialSite && <SitesMigrationTrialBadge>Trial</SitesMigrationTrialBadge> }
 							{ getSiteLaunchStatus( site ) !== 'public' && (
 								<SitesLaunchStatusBadge>{ translatedStatus }</SitesLaunchStatusBadge>
 							) }

--- a/client/sites-dashboard/components/sites-migration-trial-badge.tsx
+++ b/client/sites-dashboard/components/sites-migration-trial-badge.tsx
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+import SitesLaunchStatusBadge from './sites-launch-status-badge';
+
+const SitesMigrationTrialBadge = styled( SitesLaunchStatusBadge )`
+	color: #02395c;
+	background-color: #bbe0fa;
+`;
+
+export default SitesMigrationTrialBadge;

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -184,7 +184,9 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 							</SiteName>
 							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
 							{ isWpcomStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
-							{ isTrialSite && <SitesMigrationTrialBadge>Trial</SitesMigrationTrialBadge> }
+							{ isTrialSite && (
+								<SitesMigrationTrialBadge>{ __( 'Trial' ) }</SitesMigrationTrialBadge>
+							) }
 						</ListTileTitle>
 					}
 					subtitle={

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -8,10 +8,17 @@ import { memo, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import StatsSparkline from 'calypso/blocks/stats-sparkline';
 import TimeSince from 'calypso/components/time-since';
+import SitesMigrationTrialBadge from 'calypso/sites-dashboard/components/sites-migration-trial-badge';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { hasSiteStatsQueryFailed } from 'calypso/state/stats/lists/selectors';
-import { displaySiteUrl, getDashboardUrl, isStagingSite, MEDIA_QUERIES } from '../utils';
+import {
+	displaySiteUrl,
+	getDashboardUrl,
+	isMigrationTrialSite,
+	isStagingSite,
+	MEDIA_QUERIES,
+} from '../utils';
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
 import SitesP2Badge from './sites-p2-badge';
 import { SiteItemThumbnail } from './sites-site-item-thumbnail';
@@ -141,6 +148,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 
 	const isP2Site = site.options?.is_wpforteams_site;
 	const isWpcomStagingSite = isStagingSite( site );
+	const isTrialSite = isMigrationTrialSite( site );
 
 	const hasStatsLoadingError = useSelector( ( state ) => {
 		const siteId = site.ID;
@@ -176,6 +184,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 							</SiteName>
 							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
 							{ isWpcomStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
+							{ isTrialSite && <SitesMigrationTrialBadge>Trial</SitesMigrationTrialBadge> }
 						</ListTileTitle>
 					}
 					subtitle={

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -1,3 +1,4 @@
+import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { SiteExcerptNetworkData } from 'calypso/data/sites/site-excerpt-types';
 
 export const TRACK_SOURCE_NAME = 'sites-dashboard';
@@ -48,6 +49,10 @@ export const isP2Site = ( site: SiteExcerptNetworkData ) => {
 
 export const isStagingSite = ( site: SiteExcerptNetworkData | undefined ) => {
 	return site?.is_wpcom_staging_site;
+};
+
+export const isMigrationTrialSite = ( site: SiteExcerptNetworkData ) => {
+	return site?.plan?.product_slug === PLAN_MIGRATION_TRIAL_MONTHLY;
 };
 
 export const SMALL_MEDIA_QUERY = 'screen and ( max-width: 600px )';


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80176

## Proposed Changes

* Add a "Trial" badge to the site dashboard's row and grid item views.

## Testing Instructions

* Make sure that you have a Migration Trial website
* Go to `/sites`
* Check if there is a "Trial" badge
* Switch to row/grid view
* Check if there is a "Trial" badge

<img width="949" alt="Screenshot 2023-08-04 at 09 38 50" src="https://github.com/Automattic/wp-calypso/assets/1241413/c96b5578-ffc2-4454-8b7d-c88f330be990">
<img width="742" alt="Screenshot 2023-08-04 at 09 39 26" src="https://github.com/Automattic/wp-calypso/assets/1241413/6e4d4ffe-d05d-47f8-84d4-a5bba6038006">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
