### PR TITLE
Update the Jetpack E2E CI for simple deployments to match current process

### DIFF
--- a/.teamcity/_self/lib/utils/E2EBuildLibrary.kt
+++ b/.teamcity/_self/lib/utils/E2EBuildLibrary.kt
@@ -1,0 +1,94 @@
+package _self.lib.utils
+
+import _self.bashNodeScript
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.ParametrizedWithType
+import jetbrains.buildServer.configs.kotlin.v2019_2.FailureConditions
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+
+
+fun BuildSteps.prepareE2eEnvironment(): ScriptBuildStep {
+    return bashNodeScript {
+        name = "Prepare e2e environment"
+        scriptContent = """
+            # Install deps
+            yarn workspaces focus wp-e2e-tests @automattic/calypso-e2e
+
+            # Decrypt secrets
+            # Must do before build so the secrets are in the dist output
+            E2E_SECRETS_KEY="%E2E_SECRETS_ENCRYPTION_KEY_CURRENT%" yarn workspace @automattic/calypso-e2e decrypt-secrets
+
+            # Build packages
+            yarn workspace @automattic/calypso-e2e build
+        """.trimIndent()
+        dockerImage = "%docker_image_e2e%"
+    }
+}
+
+fun BuildSteps.collectE2eResults(): ScriptBuildStep {
+	return bashNodeScript {
+		name = "Collect results"
+		executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+		scriptContent = """
+			set -x
+
+			mkdir -p screenshots
+			find test/e2e/results -type f \( -iname \*.webm -o -iname \*.png \) -print0 | xargs -r -0 mv -t screenshots
+
+			mkdir -p logs
+			find test/e2e/results -name '*.log' -print0 | xargs -r -0 mv -t logs
+
+			mkdir -p trace
+			find test/e2e/results -name '*.zip' -print0 | xargs -r -0 mv -t trace
+		""".trimIndent()
+		dockerImage = "%docker_image_e2e%"
+	}
+}
+
+fun ParametrizedWithType.defaultE2eParams() {
+    param("env.NODE_CONFIG_ENV", "test")
+    param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
+    param("env.TEAMCITY_VERSION", "2021")
+    param("env.HEADLESS", "true")
+    param("env.LOCALE", "en")
+	param("env.DEBUG", "")
+}
+
+fun ParametrizedWithType.calypsoBaseUrlParam( defaultUrl: String = "https://wordpress.com" ) {
+	text(
+		name = "env.CALYPSO_BASE_URL",
+		value = defaultUrl,
+		label = "Test URL",
+		description = "URL to test against",
+		allowEmpty = false
+	)
+}
+
+fun FailureConditions.defaultE2eFailureConditions() {
+	executionTimeoutMin = 20
+	// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have been muted previously.
+	nonZeroExitCode = false
+
+	// Support retries using the --onlyFailures flag in Jest.
+	supportTestRetry = true
+
+	// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner crashes and no tests are run.
+	failOnMetricChange {
+		metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
+		threshold = 50
+		units = BuildFailureOnMetric.MetricUnit.PERCENTS
+		comparison = BuildFailureOnMetric.MetricComparison.LESS
+		compareTo = build {
+			buildRule = lastSuccessful()
+		}
+	}
+}
+
+fun defaulE2eArtifactRules(): String = """
+    logs => logs.tgz
+    screenshots => screenshots
+    trace => trace
+""".trimIndent()

--- a/.teamcity/_self/lib/utils/E2EBuildLibrary.kt
+++ b/.teamcity/_self/lib/utils/E2EBuildLibrary.kt
@@ -87,7 +87,7 @@ fun FailureConditions.defaultE2eFailureConditions() {
 	}
 }
 
-fun defaulE2eArtifactRules(): String = """
+fun defaultE2eArtifactRules(): String = """
     logs => logs.tgz
     screenshots => screenshots
     trace => trace

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -3,6 +3,7 @@ package _self.projects
 import Settings
 import _self.bashNodeScript
 import _self.lib.customBuildType.E2EBuildType
+import _self.lib.utils.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
@@ -56,17 +57,9 @@ object WPComTests : Project({
 	// Editor Tracking Edge
 	buildType(editorTrackingBuildType("desktop", "c752ca9a-e77d-11ec-8fea-0242ac120002", atomic=false, edge=true));
 
-	// Jetpack for Connected Non-WPCOM Sites
-	buildType(jetpackPlaywrightBuildType("desktop", "68fe6336-5869-4244-b236-cca23ba03487", jetpackTarget="remote-site"));
-	buildType(jetpackPlaywrightBuildType("mobile", "a80b5c10-1fef-4c7f-9e2c-5c5c30d637c8", jetpackTarget="remote-site"));
-
-	// Jetpack for WPCOM Sites Running Staging
-	buildType(jetpackPlaywrightBuildType("desktop", "3007d7a1-5642-4dbf-9935-d93f3cdb4dcc", jetpackTarget="wpcom-staging"));
-	buildType(jetpackPlaywrightBuildType("mobile", "ccfe7d2c-8f04-406b-8b83-3db6c8475661", jetpackTarget="wpcom-staging"));
-
-	// Jetpack for WPCOM Sites Running Prod
-	buildType(jetpackPlaywrightBuildType("desktop", "de6df2e1-3bad-46a4-9764-9c7e0974d4ff", jetpackTarget="wpcom-production"));
-	buildType(jetpackPlaywrightBuildType("mobile", "79479054-e30e-4177-937f-4197c4846a0f", jetpackTarget="wpcom-production"));
+	// E2E Tests for Jetpack Simple Deployment
+	buildType(jetpackSimpleDeploymentE2eBuildType("desktop", "3007d7a1-5642-4dbf-9935-d93f3cdb4dcc"));
+	buildType(jetpackSimpleDeploymentE2eBuildType("mobile", "ccfe7d2c-8f04-406b-8b83-3db6c8475661"));
 
 	buildType(I18NTests);
 	buildType(P2E2ETests)
@@ -222,50 +215,88 @@ fun editorTrackingBuildType( targetDevice: String, buildUuid: String, atomic: Bo
 	)
 }
 
-fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpackTarget: String = "wpcom-production" ): E2EBuildType {
-	val idSafeJetpackTarget = jetpackTarget.replace( "-", "_" );
-	val targetJestGroup = if (jetpackTarget == "remote-site") "jetpack-remote-site" else "jetpack-wpcom-integration";
+fun jetpackSimpleDeploymentE2eBuildType( targetDevice: String, buildUuid: String ): BuildType {
+	return BuildType({
+		id("WPComTests_jetpack_simple_deployment_e2e_$targetDevice")
+		uuid = buildUuid
+		name = "Jetpack Simple Deployment E2E Tests ($targetDevice)"
+		description = "Runs E2E tests validating the deployment of Jetpack on Simple sites on $targetDevice viewport"
+		
+		artifactRules = defaulE2eArtifactRules();
 
-	val triggers: Triggers.() -> Unit = {
-		if (jetpackTarget == "wpcom-staging") {
+		vcs {
+			root(Settings.WpCalypso)
+			cleanCheckout = true
+		}
+
+		params {
+			defaultE2eParams()
+			calypsoBaseUrlParam()
+			param("env.VIEWPORT_NAME", "$targetDevice")
+			param("env.JETPACK_TARGET", "wpcom-deployment")
+		}
+
+		triggers {
 			finishBuildTrigger {
 				buildType = "JetpackStaging_JetpackSunMoonUpdated"
 			}
-		} else {
-			// For remote-site tests and production, we are just running daily for now.
-			schedule {
-				schedulingPolicy = daily {
-					hour = 5
+		}
+
+		steps {
+			prepareE2eEnvironment()
+
+			bashNodeScript {
+				name = "Run tests"
+				scriptContent = """
+					# Configure bash shell.
+					shopt -s globstar
+					set -x
+
+					# Enter testing directory.
+					cd test/e2e
+					mkdir temp
+
+					# Disable exit on error to support retries.
+					set +o errexit
+
+					# Run suite.
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=jetpack-wpcom-integration
+
+					# Restore exit on error.
+					set -o errexit
+
+					# Retry failed tests only.
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=jetpack-wpcom-integration --onlyFailures
+				"""
+				dockerImage = "%docker_image_e2e%"
+			}
+
+			collectE2eResults()
+		}
+
+		features {
+			perfmon {}
+
+			notifications {
+				notifierSettings = slackNotifier {
+					connection = "PROJECT_EXT_11"
+					sendTo = "#jetpack-alerts"
+					messageFormat = verboseMessageFormat {
+						addStatusText = true
+					}
 				}
-				branchFilter = """
-					+:trunk
-				""".trimIndent()
-				triggerBuild = always()
-				withPendingChangesOnly = false
+				branchFilter = "+:<default>"
+				buildFailedToStart = true
+				buildFailed = true
+				buildFinishedSuccessfully = false
+				buildProbablyHanging = true
 			}
 		}
-	}
 
-	return E2EBuildType (
-		buildId = "WPComTests_jetpack_Playwright_${idSafeJetpackTarget}_$targetDevice",
-		buildUuid = buildUuid,
-		buildName = "Jetpack E2E Tests [${jetpackTarget}] ($targetDevice)",
-		buildDescription = "Runs Jetpack E2E tests as $targetDevice against Jetpack install $jetpackTarget",
-		testGroup = targetJestGroup,
-		buildParams = {
-			text(
-				name = "env.CALYPSO_BASE_URL",
-				value = "https://wordpress.com",
-				label = "Test URL",
-				description = "URL to test against",
-				allowEmpty = false
-			)
-			param("env.VIEWPORT_NAME", "$targetDevice")
-			param("env.JETPACK_TARGET", jetpackTarget)
-		},
-		buildFeatures = {},
-		buildTriggers = triggers
-	)
+		failureConditions {
+			defaultE2eFailureConditions()
+		}
+	});
 }
 
 private object I18NTests : E2EBuildType(

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -222,7 +222,7 @@ fun jetpackSimpleDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 		name = "Jetpack Simple Deployment E2E Tests ($targetDevice)"
 		description = "Runs E2E tests validating the deployment of Jetpack on Simple sites on $targetDevice viewport"
 		
-		artifactRules = defaulE2eArtifactRules();
+		artifactRules = defaultE2eArtifactRules();
 
 		vcs {
 			root(Settings.WpCalypso)

--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -114,7 +114,7 @@ const castKnownEnvVariable = ( name: string, value: string ): EnvVariableValue =
 			const supportedValues: JetpackTarget[] = [
 				'remote-site',
 				'wpcom-production',
-				'wpcom-staging',
+				'wpcom-deployment',
 			];
 			if ( ! supportedValues.includes( output as JetpackTarget ) ) {
 				throw new Error(

--- a/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
+++ b/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
@@ -97,13 +97,13 @@ const defaultCriteria: FeatureCriteria[] = [
 	// Jetpack users
 	{
 		siteType: 'simple',
-		jetpackTarget: 'wpcom-staging',
+		jetpackTarget: 'wpcom-deployment',
 		gutenberg: 'stable',
 		accountName: 'jetpackStagingUser',
 	},
 	{
 		siteType: 'simple',
-		jetpackTarget: 'wpcom-staging',
+		jetpackTarget: 'wpcom-deployment',
 		gutenberg: 'stable',
 		variant: 'siteEditor',
 		accountName: 'jetpackStagingFseUser',

--- a/packages/calypso-e2e/src/lib/utils/test/get-account-by-feature.test.ts
+++ b/packages/calypso-e2e/src/lib/utils/test/get-account-by-feature.test.ts
@@ -211,11 +211,11 @@ describe( 'envToFeatureKey', () => {
 	} );
 
 	it( 'will include the value for "jetpackTarget" if it is not "wpcom-production"', () => {
-		expect( envToFeatureKey( { ...envVariables, JETPACK_TARGET: 'wpcom-staging' } ) ).toMatchObject(
-			{
-				jetpackTarget: 'wpcom-staging',
-			}
-		);
+		expect(
+			envToFeatureKey( { ...envVariables, JETPACK_TARGET: 'wpcom-deployment' } )
+		).toMatchObject( {
+			jetpackTarget: 'wpcom-deployment',
+		} );
 	} );
 
 	it( 'will set atomic to true if "jetpackTarget" is "remote-site"', () => {

--- a/packages/calypso-e2e/src/types/env-variables.types.ts
+++ b/packages/calypso-e2e/src/types/env-variables.types.ts
@@ -7,7 +7,7 @@ export type EnvVariables = {
 
 export type ViewportName = string;
 export type TestLocales = string[];
-export type JetpackTarget = 'remote-site' | 'wpcom-production' | 'wpcom-staging';
+export type JetpackTarget = 'remote-site' | 'wpcom-production' | 'wpcom-deployment';
 
 export interface SupportedEnvVariables extends EnvVariables {
 	VIEWPORT_NAME: ViewportName;

--- a/test/e2e/docs/environment_variables.md
+++ b/test/e2e/docs/environment_variables.md
@@ -6,20 +6,20 @@ Environment Variables control much of the runtime configuration for E2E tests.
 
 ## Current Environment Variables
 
-| Name                  | Description                                                                                                 | Default                                           |
-| --------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| ARTIFACTS_PATH        | Path on disk to test artifacts (screenshots, logs, etc).                                                    | ./results/                                        |
-| AUTHENTICATE_ACCOUNTS | Comma-delimited list of accounts to pre-authenticate for later use.                                         | simpleSitePersonalPlanUser,atomicUser,defaultUser |
-| CALYPSO_BASE_URL      | The base URL to use for Calypso                                                                             | <https://wordpress.com>                           |
-| COBLOCKS_EDGE         | Use the bleeding edge CoBlocks build.                                                                       | false                                             |
-| COOKIES_PATH          | Path on disk to the saved authenticated cookies.                                                            | ./cookies/                                        |
-| GUTENBERG_EDGE        | Use the bleeding edge Gutenberg build.                                                                      | false                                             |
-| HEADLESS              | Configure browser headless/headful mode.                                                                    | false                                             |
-| JETPACK_TARGET        | Which Jetpack install ("wpcom-production", "wpcom-staging", "remote-site") we are targeting through Calypso | wpcom-production                                  |
-| SLOW_MO               | Slow down the execution by given milliseconds.                                                              | 0                                                 |
-| TEST_LOCALES          | The locales to target for I18N testing                                                                      | A long list of currently supported locales.       |
-| TEST_ON_ATOMIC        | Use a user with an Atomic site.                                                                             | false                                             |
-| VIEWPORT_NAME         | Specify the viewport to be used.                                                                            | desktop                                           |
+| Name                  | Description                                                                                                    | Default                                           |
+| --------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| ARTIFACTS_PATH        | Path on disk to test artifacts (screenshots, logs, etc).                                                       | ./results/                                        |
+| AUTHENTICATE_ACCOUNTS | Comma-delimited list of accounts to pre-authenticate for later use.                                            | simpleSitePersonalPlanUser,atomicUser,defaultUser |
+| CALYPSO_BASE_URL      | The base URL to use for Calypso                                                                                | <https://wordpress.com>                           |
+| COBLOCKS_EDGE         | Use the bleeding edge CoBlocks build.                                                                          | false                                             |
+| COOKIES_PATH          | Path on disk to the saved authenticated cookies.                                                               | ./cookies/                                        |
+| GUTENBERG_EDGE        | Use the bleeding edge Gutenberg build.                                                                         | false                                             |
+| HEADLESS              | Configure browser headless/headful mode.                                                                       | false                                             |
+| JETPACK_TARGET        | Which Jetpack install ("wpcom-production", "wpcom-deployment", "remote-site") we are targeting through Calypso | wpcom-production                                  |
+| SLOW_MO               | Slow down the execution by given milliseconds.                                                                 | 0                                                 |
+| TEST_LOCALES          | The locales to target for I18N testing                                                                         | A long list of currently supported locales.       |
+| TEST_ON_ATOMIC        | Use a user with an Atomic site.                                                                                | false                                             |
+| VIEWPORT_NAME         | Specify the viewport to be used.                                                                               | desktop                                           |
 
 <!-- When adding new rows, run the following command to sort the resulting sub-table in alphabetical order:
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Primarily, this updates our Jetpack e2e CI to better match and setup our current strategy.

There are a few changes that go along with this:
- I've removed the "remote-site" and "production" TeamCity builds for now -- they have no use case in the current process as of now, and we aren't really monitoring them. We can add them back later as we need!
- I renamed the `wpcom-staging` value for `JETPACK_TARGET` to `wpcom-deployment`. "Staging" isn't a thing anymore. Really, what we're doing is providing tests and environments to be used during Jetpack deployment in various capacities.
- I added Slack notifications for the simple deployment e2e build -- now failures will go to `#jetpack-alerts`.
- I've refactored and taken a new approach to our E2E build definitions... (continued below)

### New Approach to E2E Builds

As our E2E builds have grown in complexity, they've started to outgrow our originally very helpful `E2EBuildType`. We want to centralize a lot of things, but to handle the growing complexity, we keep having to add parameters and logical handlers to that build type.

I wanted to try out a new approach, where we modularize small pieces of a `BuildType` definition. These can be simple extension functions that apply a bunch of defaults, or maybe more complex builders that take in parameters and make some small piece of the `BuildType` configuration.

The idea is that E2E builds then can apply whatever pieces of that centralized library make sense while still defining the customizations they need. This fits a little bit better with the "Open / Closed" style of designing!

I haven't added a lot here -- just some really basic extension functions, but I hope to grow it in coming PRs!

## Testing Instructions

I believe the bulk of this will only be testable post-merge 😬 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
