### PR TITLE
Launchpad: add 'Manage paid Newsletter' task completion logic

### DIFF
--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -4,6 +4,7 @@ import {
 	FEATURE_RECURRING_PAYMENTS,
 } from '@automattic/calypso-products';
 import { Badge, Button, CompactCard, Gridicon } from '@automattic/components';
+import { updateLaunchpadSettings } from '@automattic/data-stores';
 import formatCurrency from '@automattic/format-currency';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
@@ -40,6 +41,12 @@ class MembershipsProductsSection extends Component {
 		showDeleteDialog: false,
 		product: null,
 	};
+
+	componentDidMount() {
+		updateLaunchpadSettings( this.props.siteSlug, {
+			checklist_statuses: { manage_paid_newsletter_plan: true },
+		} );
+	}
 
 	renderEllipsisMenu( productId ) {
 		return (


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80032

## Proposed changes:
* This PR adds code to complete the `manage_paid_newsletter_plan` task when the `/earn/payments-plans/{site}` is visited.

## Testing instructions:

* Enable the newsletter launchpad (possibly with D117910-code)
* Create a new site with paid `newsletter` intent
* Check that there is a new `Manage your paid Newsletter plan` task
* Clicking the task should take you to `/earn/payments-plans/{site}`
* Go back to home and check that the task is completed
![image](https://github.com/Automattic/wp-calypso/assets/3801502/604756de-dc85-4c92-ae6b-85a729a9de96)

