### PR TITLE
Fix masterbar in logged out reader mobile view

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -408,6 +408,10 @@ $masterbar-color-secondary: #101517;
 	padding-left: 0;
 	text-transform: uppercase;
 
+	@include breakpoint-deprecated( "<480px" ) {
+		display: none;
+	}
+
 	.masterbar__item-content {
 		display: block;
 
@@ -625,8 +629,10 @@ $masterbar-color-secondary: #101517;
 		padding-left: 0;
 	}
 
-	.masterbar__item:last-child {
-		margin-right: 20px;
+	@include breakpoint-deprecated( ">480px" ) {
+		.masterbar__item:last-child {
+			margin-right: 20px;
+		}
 	}
 }
 

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -385,13 +385,10 @@
 		background: transparent;
 		color: var(--studio-white);
 		position: static;
-
 		@include breakpoint-deprecated( "<480px" ) {
 			.masterbar__item {
 				padding: 0 4px;
-				&:last-child {
-					padding-right: 20px;
-				}
+				width: auto;
 			}
 		}
 	}


### PR DESCRIPTION
It looks like the mobile logged out view of the masterbar is a bit broken after adding new links

for an "Iphone SE" in chrome emulator

Before:
<img width="379" alt="Screen Shot 2023-08-04 at 11 33 57 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/f5cb12c4-a615-43d4-9a45-2da5575ce010">

After:
<img width="382" alt="Screen Shot 2023-08-04 at 11 42 50 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/9fa27991-a454-4ebb-8716-f4042838f8bb">

It still looks a bit cramped but is legible. I didn't want to spend too much time on this as it's not a very commonly used screen at the moment