### PR TITLE
Jetpack Pro Dashboard: show the actual SMS counter values from API for the downtime monitoring

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/index.tsx
@@ -6,6 +6,7 @@ import AlertBanner from 'calypso/components/jetpack/alert-banner';
 import {
 	AllowedMonitorContactActions,
 	AllowedMonitorContactTypes,
+	MonitorSettings,
 	StateMonitorSettingsEmail,
 	StateMonitorSettingsSMS,
 } from '../../sites-overview/types';
@@ -28,6 +29,7 @@ export type Props = {
 	type: AllowedMonitorContactTypes;
 	verifiedItemKey?: string;
 	restriction?: RestrictionType;
+	settings?: MonitorSettings;
 };
 
 export default function ContactList( {
@@ -37,6 +39,7 @@ export default function ContactList( {
 	type,
 	verifiedItemKey,
 	restriction = 'none',
+	settings,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -66,7 +69,7 @@ export default function ContactList( {
 		}
 	}, [ items.length, type ] );
 
-	const showSMSCounter = false;
+	const showSMSCounter = type === 'sms' && items.length > 0 && !! settings;
 
 	return (
 		<>
@@ -112,7 +115,7 @@ export default function ContactList( {
 						<UpgradeLink isInline />
 					</div>
 				) }
-				{ showSMSCounter && type === 'sms' && <SMSCounter /> }
+				{ showSMSCounter && <SMSCounter settings={ settings } /> }
 			</div>
 		</>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-counter.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-counter.tsx
@@ -1,25 +1,31 @@
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { MonitorSettings } from '../../../sites-overview/types';
 
-export default function SMSCounter() {
+interface Props {
+	settings: MonitorSettings;
+}
+
+export default function SMSCounter( { settings }: Props ) {
 	const translate = useTranslate();
 
-	// TODO: Replace with real data
-	const monthlyUsedCount = 5;
-	const montlyLimit = 20;
+	const monthlyLimit = settings.sms_monthly_limit || 0;
+	const monthlyUsedCount = settings.sms_sent_count || 0;
 
-	const limitReached = monthlyUsedCount >= montlyLimit;
+	if ( ! monthlyLimit ) {
+		return null;
+	}
 
 	return (
 		<div
 			className={ classNames( 'notification-settings__sms-counter', {
-				'notification-settings__sms-counter-limit-reached': limitReached,
+				'notification-settings__sms-counter-limit-reached': settings.is_over_limit,
 			} ) }
 		>
-			{ translate( '%(monthlyUsedCount)d/%(montlyLimit)d SMS used this month on this site', {
-				args: { monthlyUsedCount, montlyLimit },
+			{ translate( '%(monthlyUsedCount)d/%(monthlyLimit)d SMS used this month on this site', {
+				args: { monthlyUsedCount, monthlyLimit },
 				comment:
-					'monthlyUsedCount is the number of SMS used in a month, montlyLimit is the maximum number of SMS allowed in a month',
+					'monthlyUsedCount is the number of SMS used in a month, monthlyLimit is the maximum number of SMS allowed in a month',
 			} ) }
 		</div>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
@@ -4,7 +4,7 @@ import ContactList from '../../contact-list';
 import FeatureRestrictionBadge from '../../feature-restriction-badge';
 import { RestrictionType } from '../../types';
 import UpgradeLink from '../../upgrade-link';
-import type { StateMonitorSettingsSMS } from '../../../sites-overview/types';
+import type { MonitorSettings, StateMonitorSettingsSMS } from '../../../sites-overview/types';
 
 interface Props {
 	recordEvent: ( action: string, params?: object ) => void;
@@ -14,6 +14,7 @@ interface Props {
 	allPhoneItems: Array< StateMonitorSettingsSMS >;
 	verifiedItem?: { [ key: string ]: string };
 	restriction: RestrictionType;
+	settings?: MonitorSettings;
 }
 
 export default function SMSNotification( {
@@ -24,6 +25,7 @@ export default function SMSNotification( {
 	allPhoneItems,
 	verifiedItem,
 	restriction,
+	settings,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -72,6 +74,7 @@ export default function SMSNotification( {
 					items={ allPhoneItems }
 					recordEvent={ recordEvent }
 					verifiedItemKey={ verifiedItem?.phone }
+					settings={ settings }
 				/>
 			) }
 		</>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -492,6 +492,7 @@ export default function NotificationSettings( {
 						allPhoneItems={ allPhoneItems }
 						verifiedItem={ verifiedItem }
 						restriction={ restriction }
+						settings={ settings }
 					/>
 				) }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -72,7 +72,7 @@ export default function ToggleActivateMonitoring( {
 
 	const isChecked = status !== 'disabled';
 	const isLoading = statuses?.[ site.blog_id ] === 'loading';
-	const smsLimitReached = false; // TODO: Get the sms limit reached status from the API.
+	const smsLimitReached = settings?.is_over_limit;
 
 	const currentSettings = () => {
 		const minutes = settings?.monitor_deferment_time;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -51,6 +51,9 @@ export interface MonitorSettings {
 	monitor_user_wp_note_notifications: boolean;
 	monitor_notify_additional_user_emails: Array< MonitorContactEmail >;
 	monitor_notify_additional_user_sms: Array< MonitorContactSMS >;
+	is_over_limit: boolean;
+	sms_sent_count: number;
+	sms_monthly_limit: number;
 }
 
 interface StatsObject {


### PR DESCRIPTION
Related to 1204992567518369-as-1205148919970019

## Proposed Changes

This PR integrates the API values to the SMS counter in the downtime monitoring. 

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/hook-api-values-to-monitor` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already > Click on the clock icon next to the monitor toggle.
4. Click on the Mobile notification toggle, and click the "+ Add phone number" button -> Enter all the fields and click "Verify".
5. Verify that the SMS counter is as shown below

<img width="473" alt="Screenshot 2023-08-04 at 10 50 59 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8bce632b-9e96-4afe-843d-ac82bcb05b21">

6. Save all the changes.
7. Now follow the instructions provided here to hit the SMS limit: D118091-code. Set the limit to 2.
8. Verify that the monitor column &  SMS counter  looks as shown below

<img width="353" alt="Screenshot 2023-08-04 at 10 45 17 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/031b24f0-13ec-4fa5-a8fc-7c2f3a5cdd3b">

<img width="462" alt="Screenshot 2023-08-04 at 10 45 42 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/fcafa97e-59f0-4571-9247-a1135cdbfeb2">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
