### PR TITLE
Assembler - Remove blockGap between header/sections/footer in new assembler theme

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -30,14 +30,6 @@
 	list-style-type: none;
 	overflow: auto;
 	background: var(--pattern-large-preview-background);
-
-	.pattern-large-preview__pattern-header {
-		margin-block-end: var(--pattern-large-preview-block-gap);
-	}
-
-	.pattern-large-preview__pattern-footer {
-		margin-block-start: var(--pattern-large-preview-block-gap);
-	}
 }
 
 .pattern-large-preview__pattern {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -57,7 +57,6 @@ const PatternLargePreview = ( {
 	const [ blockGap ] = useGlobalStyle( 'spacing.blockGap' );
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const [ patternLargePreviewStyle, setPatternLargePreviewStyle ] = useState( {
-		'--pattern-large-preview-block-gap': blockGap,
 		'--pattern-large-preview-background': backgroundColor,
 	} as CSSProperties );
 
@@ -181,7 +180,6 @@ const PatternLargePreview = ( {
 	// See https://github.com/Automattic/wp-calypso/pull/74033#issuecomment-1453056703
 	useEffect( () => {
 		setPatternLargePreviewStyle( {
-			'--pattern-large-preview-block-gap': blockGap,
 			'--pattern-large-preview-background': backgroundColor,
 		} as CSSProperties );
 	}, [ blockGap, backgroundColor ] );

--- a/packages/data-stores/src/site/utils.ts
+++ b/packages/data-stores/src/site/utils.ts
@@ -13,8 +13,9 @@ export const createCustomHomeTemplateContent = (
 	}
 
 	if ( hasSections ) {
+		// blockGap":"0" removes the theme blockGap from the main group while allowing users to change it from the editor
 		content.push( `
-<!-- wp:group {"tagName":"main"} -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0"}}} -->
 	<main class="wp-block-group">
 		${ mainHtml }
 	</main>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78097

## Proposed Changes
Remove the block gap between:
* header and footer patterns in the assembler large preview
* section patterns in the assembler large preview and the editor and front-end

**Notes**
- Users still can add margins between patterns or change the block gap from the editor

**Follow-up tasks**
- Create a PR to add styles on Creatio theme.json to remove the block gap between header and footer patterns in the editor and front-end. See https://github.com/Automattic/themes/pull/7288

### **Assembler Large Preview**

|BEFORE|AFTER|
|---|---|
|<img width="1004" alt="Screenshot 2566-08-04 at 14 06 28" src="https://github.com/Automattic/wp-calypso/assets/1881481/3d2e070a-7842-469a-bf25-d3b611920402">|<img width="997" alt="Screenshot 2566-08-04 at 14 06 06" src="https://github.com/Automattic/wp-calypso/assets/1881481/d8deb798-801e-4626-9980-ebb4b4c43918">|

### **Site Editor**

|BEFORE|AFTER|
|---|---|
|<img width="1728" alt="Screenshot 2566-08-04 at 14 10 33" src="https://github.com/Automattic/wp-calypso/assets/1881481/532f1033-4335-44e5-9a7d-33f26190295f">|<img width="1728" alt="Screenshot 2566-08-04 at 14 09 23" src="https://github.com/Automattic/wp-calypso/assets/1881481/2f6d4f3e-c57e-4425-85eb-f2898dccc92f">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }`
* Add a header, two section patterns, and a footer. Choose patterns with a background color, not white background, so it's easier to see if there are gaps
* Verify that there aren't gaps between patterns in the assembler large preview
* Click "Continue" and you will land on the editor
* Verify you still see gaps between header and footer patterns in the editor
* Sandbox your site and the public API
* Go to the folder `/wpcom/public_html/wp-content/themes/pub` in your sandbox and checkout the PR https://github.com/Automattic/themes/pull/7288
  * Alternatively you can manually edit the file on your sandbox 
* Refresh the editor to confirm that there aren't gaps between header and footer patterns


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
