### PR TITLE
Newsletter Categories: Add mutation for marking a category as newsletter category

### DIFF
--- a/client/data/newsletter-categories/test/use-set-newsletter-category-mutation.test.tsx
+++ b/client/data/newsletter-categories/test/use-set-newsletter-category-mutation.test.tsx
@@ -1,0 +1,115 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act } from '@testing-library/react-hooks';
+import React from 'react';
+import request from 'wpcom-proxy-request';
+import useSetNewsletterCategoryMutation from '../use-set-newsletter-category-mutation';
+
+jest.mock( 'wpcom-proxy-request', () => jest.fn() );
+
+describe( 'useSetNewsletterCategoryMutation', () => {
+	let queryClient: QueryClient;
+	let wrapper: any;
+	const siteId = 123;
+
+	beforeEach( () => {
+		( request as jest.MockedFunction< typeof request > ).mockReset();
+
+		queryClient = new QueryClient( {
+			defaultOptions: {
+				mutations: {
+					retry: false,
+				},
+			},
+		} );
+
+		wrapper = ( { children }: React.PropsWithChildren< unknown > ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should call request with correct arguments', async () => {
+		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( {
+			success: true,
+		} );
+
+		const { result, waitFor } = renderHook( () => useSetNewsletterCategoryMutation( { siteId } ), {
+			wrapper,
+		} );
+
+		act( () => {
+			result.current.mutate( { id: 1 } );
+		} );
+
+		await waitFor( () => expect( request ).toHaveBeenCalled() );
+
+		expect( request ).toHaveBeenCalledWith( {
+			path: `/sites/123/newsletter-categories/1`,
+			method: 'POST',
+			apiVersion: '2',
+			apiNamespace: 'wpcom/v2',
+		} );
+	} );
+
+	it( 'should invalidate cache on mutation', async () => {
+		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( {
+			success: true,
+		} );
+
+		const invalidateQueriesSpy = jest.spyOn( queryClient, 'invalidateQueries' );
+		const { result } = renderHook( () => useSetNewsletterCategoryMutation( { siteId } ), {
+			wrapper,
+		} );
+		const params = { id: 1 };
+
+		await act( async () => {
+			await result.current.mutateAsync( params );
+		} );
+
+		expect( invalidateQueriesSpy ).toHaveBeenCalledWith( [ `newsletter-categories-123` ] );
+	} );
+
+	it( 'should throw an error when ID is missing', async () => {
+		const { result, waitFor } = renderHook( () => useSetNewsletterCategoryMutation( { siteId } ), {
+			wrapper,
+		} );
+
+		const consoleError = console.error;
+		console.error = jest.fn();
+
+		act( () => {
+			// @ts-expect-error The mutation doesn't expect category id to be undefined, but we want to test this case.
+			result.current.mutate( {} );
+		} );
+
+		await waitFor( () => expect( result.current.error ).toEqual( Error( 'ID is missing.' ) ) );
+
+		console.error = consoleError;
+	} );
+
+	it( 'should throw an error when API response is unsuccessful', async () => {
+		( request as jest.Mock ).mockResolvedValue( { success: false } );
+
+		const { result, waitFor } = renderHook( () => useSetNewsletterCategoryMutation( { siteId } ), {
+			wrapper,
+		} );
+
+		const consoleError = console.error;
+		console.error = jest.fn();
+
+		act( () => {
+			result.current.mutate( { id: 1 } );
+		} );
+
+		await waitFor( () =>
+			expect( result.current.error ).toEqual(
+				Error( 'Something went wrong while setting category as newsletter category.' )
+			)
+		);
+
+		console.error = consoleError;
+	} );
+} );

--- a/client/data/newsletter-categories/test/use-set-newsletter-category-mutation.test.tsx
+++ b/client/data/newsletter-categories/test/use-set-newsletter-category-mutation.test.tsx
@@ -10,6 +10,7 @@ describe( 'useSetNewsletterCategoryMutation', () => {
 	let queryClient: QueryClient;
 	let wrapper: any;
 	const siteId = 123;
+	const categoryId = 1;
 
 	beforeEach( () => {
 		( request as jest.MockedFunction< typeof request > ).mockReset();
@@ -36,12 +37,12 @@ describe( 'useSetNewsletterCategoryMutation', () => {
 			success: true,
 		} );
 
-		const { result, waitFor } = renderHook( () => useSetNewsletterCategoryMutation( { siteId } ), {
+		const { result, waitFor } = renderHook( () => useSetNewsletterCategoryMutation( siteId ), {
 			wrapper,
 		} );
 
 		act( () => {
-			result.current.mutate( { id: 1 } );
+			result.current.mutate( categoryId );
 		} );
 
 		await waitFor( () => expect( request ).toHaveBeenCalled() );
@@ -60,20 +61,19 @@ describe( 'useSetNewsletterCategoryMutation', () => {
 		} );
 
 		const invalidateQueriesSpy = jest.spyOn( queryClient, 'invalidateQueries' );
-		const { result } = renderHook( () => useSetNewsletterCategoryMutation( { siteId } ), {
+		const { result } = renderHook( () => useSetNewsletterCategoryMutation( siteId ), {
 			wrapper,
 		} );
-		const params = { id: 1 };
 
 		await act( async () => {
-			await result.current.mutateAsync( params );
+			await result.current.mutateAsync( categoryId );
 		} );
 
 		expect( invalidateQueriesSpy ).toHaveBeenCalledWith( [ `newsletter-categories-123` ] );
 	} );
 
 	it( 'should throw an error when ID is missing', async () => {
-		const { result, waitFor } = renderHook( () => useSetNewsletterCategoryMutation( { siteId } ), {
+		const { result, waitFor } = renderHook( () => useSetNewsletterCategoryMutation( siteId ), {
 			wrapper,
 		} );
 
@@ -82,7 +82,7 @@ describe( 'useSetNewsletterCategoryMutation', () => {
 
 		act( () => {
 			// @ts-expect-error The mutation doesn't expect category id to be undefined, but we want to test this case.
-			result.current.mutate( {} );
+			result.current.mutate();
 		} );
 
 		await waitFor( () => expect( result.current.error ).toEqual( Error( 'ID is missing.' ) ) );
@@ -93,7 +93,7 @@ describe( 'useSetNewsletterCategoryMutation', () => {
 	it( 'should throw an error when API response is unsuccessful', async () => {
 		( request as jest.Mock ).mockResolvedValue( { success: false } );
 
-		const { result, waitFor } = renderHook( () => useSetNewsletterCategoryMutation( { siteId } ), {
+		const { result, waitFor } = renderHook( () => useSetNewsletterCategoryMutation( siteId ), {
 			wrapper,
 		} );
 
@@ -101,7 +101,7 @@ describe( 'useSetNewsletterCategoryMutation', () => {
 		console.error = jest.fn();
 
 		act( () => {
-			result.current.mutate( { id: 1 } );
+			result.current.mutate( categoryId );
 		} );
 
 		await waitFor( () =>

--- a/client/data/newsletter-categories/types.ts
+++ b/client/data/newsletter-categories/types.ts
@@ -1,0 +1,11 @@
+export type NewsletterCategories = {
+	newsletterCategories: NewsletterCategory[];
+};
+
+export type NewsletterCategory = {
+	id: number;
+	name: string;
+	slug: string;
+	description: string;
+	parent: number;
+};

--- a/client/data/newsletter-categories/use-set-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-set-newsletter-category-mutation.tsx
@@ -1,23 +1,15 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import request from 'wpcom-proxy-request';
 
-type useSetNewsletterCategoryMutationParams = {
-	siteId: number;
-};
-
-type SetNewsletterCategoryParams = {
-	id: number;
-};
-
 type SetNewsletterCategoryResponse = {
 	success: boolean;
 };
 
-const useSetNewsletterCategoryMutation = ( { siteId }: useSetNewsletterCategoryMutationParams ) => {
+const useSetNewsletterCategoryMutation = ( siteId: string | number ) => {
 	const queryClient = useQueryClient();
 	const cacheKey = [ `newsletter-categories-${ siteId }` ];
 	return useMutation( {
-		mutationFn: async ( { id }: SetNewsletterCategoryParams ) => {
+		mutationFn: async ( id: number ) => {
 			if ( ! id ) {
 				throw new Error( 'ID is missing.' );
 			}

--- a/client/data/newsletter-categories/use-set-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-set-newsletter-category-mutation.tsx
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import request from 'wpcom-proxy-request';
+
+type useSetNewsletterCategoryMutationParams = {
+	siteId: number;
+};
+
+type SetNewsletterCategoryParams = {
+	id: number;
+};
+
+type SetNewsletterCategoryResponse = {
+	success: boolean;
+};
+
+const useSetNewsletterCategoryMutation = ( { siteId }: useSetNewsletterCategoryMutationParams ) => {
+	const queryClient = useQueryClient();
+	const cacheKey = [ `newsletter-categories-${ siteId }` ];
+	return useMutation( {
+		mutationFn: async ( { id }: SetNewsletterCategoryParams ) => {
+			if ( ! id ) {
+				throw new Error( 'ID is missing.' );
+			}
+
+			const response = await request< SetNewsletterCategoryResponse >( {
+				path: `/sites/${ siteId }/newsletter-categories/${ id }`,
+				method: 'POST',
+				apiVersion: '2',
+				apiNamespace: 'wpcom/v2',
+			} );
+
+			if ( ! response.success ) {
+				throw new Error( 'Something went wrong while setting category as newsletter category.' );
+			}
+
+			return response;
+		},
+		onMutate: async () => {
+			await queryClient.cancelQueries( cacheKey );
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries( cacheKey );
+		},
+	} );
+};
+
+export default useSetNewsletterCategoryMutation;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/80178

## Proposed Changes

This PR adds a mutation to use the endpoint to mark a category as "Newsletter Category". 

## Testing Instructions

You can test this by running the tests: in your terminal, execute `yarn test-client client/data/newsletter-categories/test/use-set-newsletter-category-mutation.test.tsx`. All the tests should be green.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
