### PR TITLE
Sidebar: Trial site support, show badge and allow plan upgrade

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -10,7 +10,9 @@ import { connect } from 'react-redux';
 import SiteIcon from 'calypso/blocks/site-icon';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import SiteIndicator from 'calypso/my-sites/site-indicator';
+import SitesMigrationTrialBadge from 'calypso/sites-dashboard/components/sites-migration-trial-badge';
 import SitesStagingBadge from 'calypso/sites-dashboard/components/sites-staging-badge';
+import { isMigrationTrialSite } from 'calypso/sites-dashboard/utils';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
@@ -143,6 +145,7 @@ class Site extends Component {
 			'is-highlighted': this.props.isHighlighted,
 			'is-compact': this.props.compact,
 			'is-reskinned': this.props.isReskinned,
+			'is-migration-trial': isMigrationTrialSite( site ),
 		} );
 
 		// We show public coming soon badge only when the site is not private.
@@ -198,6 +201,11 @@ class Site extends Component {
 							<SitesStagingBadge className="site__badge" secondary>
 								{ translate( 'Staging' ) }
 							</SitesStagingBadge>
+						) }
+						{ isMigrationTrialSite( site ) && (
+							<SitesMigrationTrialBadge className="site__badge" secondary>
+								{ translate( 'Trial' ) }
+							</SitesMigrationTrialBadge>
 						) }
 						{ this.props.isP2Hub && (
 							<span className="site__badge is-p2-workspace">P2 Workspace</span>

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -106,7 +106,7 @@ export class SiteNotice extends Component {
 		const daysRemaining = this.daysRemaining( { endsAt: currentPlan.expiry } );
 
 		if ( daysRemaining < 0 ) {
-			bannerText = 'Your trial has expired';
+			bannerText = translate( 'Your trial has expired' );
 		} else if ( daysRemaining === 0 ) {
 			bannerText = createInterpolateElement(
 				translate( 'Your trial ends <strong>today</strong>' ),

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
+import { createInterpolateElement } from '@wordpress/element';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
 import PropTypes from 'prop-types';
@@ -12,12 +13,14 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
+import { isMigrationTrialSite } from 'calypso/sites-dashboard/utils';
 import getActiveDiscount from 'calypso/state/selectors/get-active-discount';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migration-active-route';
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 
 export class SiteNotice extends Component {
 	static propTypes = {
@@ -90,8 +93,62 @@ export class SiteNotice extends Component {
 		);
 	}
 
+	trialUpgradeNotice() {
+		const { translate, site, isTrialSite, currentPlan } = this.props;
+		const { expiry } = currentPlan || {};
+
+		if ( ! isTrialSite || ! expiry ) {
+			return null;
+		}
+
+		const eventProperties = { cta_name: 'migration-trial-upgrade-sidebar' };
+		const momentParams = { endsAt: currentPlan.expiry };
+		const daysRemaining = this.daysRemaining( momentParams );
+
+		const bannerText = this.promotionEndsToday( momentParams )
+			? createInterpolateElement( translate( 'Your trial ends <strong>today</strong>' ), {
+					strong: <strong />,
+			  } )
+			: createInterpolateElement(
+					translate(
+						'<strong>%(daysRemaining)d day</strong> left in your trial',
+						'<strong>%(daysRemaining)d days</strong> left in your trial',
+						{
+							count: daysRemaining,
+							args: {
+								daysRemaining,
+							},
+							comment: '%(daysRemaining) is the no of days, e.g. "1 day"',
+						}
+					),
+					{ strong: <strong /> }
+			  );
+
+		return (
+			<>
+				<QuerySitePlans siteId={ site.ID } />
+				<UpsellNudge
+					compact
+					forceDisplay
+					event="calypso_upgrade_nudge_impression"
+					tracksClickName="calypso_upgrade_nudge_cta_click"
+					tracksClickProperties={ eventProperties }
+					tracksImpressionName="calypso_upgrade_nudge_impression"
+					tracksImpressionProperties={ eventProperties }
+					callToAction={ translate( 'Upgrade' ) }
+					href={ `/checkout/${ site.slug }/business` }
+					title={ bannerText }
+				/>
+			</>
+		);
+	}
+
 	promotionEndsToday( { endsAt } ) {
 		return moment().isSame( endsAt, 'day' );
+	}
+
+	daysRemaining( { endsAt } ) {
+		return moment( endsAt ).diff( moment(), 'days' );
 	}
 
 	render() {
@@ -102,6 +159,7 @@ export class SiteNotice extends Component {
 
 		const discountOrFreeToPaid = this.activeDiscountNotice();
 		const siteRedirectNotice = this.getSiteRedirectNotice( site );
+		const siteTrialUpgrade = this.trialUpgradeNotice();
 
 		const showJitms =
 			! this.props.isSiteWPForTeams &&
@@ -112,6 +170,7 @@ export class SiteNotice extends Component {
 			<div className="current-site__notices">
 				<QueryActivePromotions />
 				{ siteRedirectNotice }
+				{ siteTrialUpgrade }
 				{ showJitms && (
 					<AsyncLoad
 						require="calypso/blocks/jitm"
@@ -127,15 +186,18 @@ export class SiteNotice extends Component {
 }
 
 export default connect( ( state, ownProps ) => {
+	const { site } = ownProps;
 	const siteId = ownProps.site && ownProps.site.ID ? ownProps.site.ID : null;
 	const isMigrationInProgress =
 		isSiteMigrationInProgress( state, siteId ) || isSiteMigrationActiveRoute( state );
 
 	return {
+		currentPlan: getCurrentPlan( state, siteId ),
 		isDomainOnly: isDomainOnlySite( state, siteId ),
 		activeDiscount: getActiveDiscount( state ),
 		isSiteWPForTeams: isSiteWPForTeams( state, siteId ),
 		isWpcomStagingSite: isSiteWpcomStaging( state, siteId ),
+		isTrialSite: isMigrationTrialSite( site ),
 		isMigrationInProgress,
 	};
 } )( localize( SiteNotice ) );

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -101,28 +101,35 @@ export class SiteNotice extends Component {
 			return null;
 		}
 
+		let bannerText;
 		const eventProperties = { cta_name: 'migration-trial-upgrade-sidebar' };
-		const momentParams = { endsAt: currentPlan.expiry };
-		const daysRemaining = this.daysRemaining( momentParams );
+		const daysRemaining = this.daysRemaining( { endsAt: currentPlan.expiry } );
 
-		const bannerText = this.promotionEndsToday( momentParams )
-			? createInterpolateElement( translate( 'Your trial ends <strong>today</strong>' ), {
+		if ( daysRemaining < 0 ) {
+			bannerText = 'Your trial has expired';
+		} else if ( daysRemaining === 0 ) {
+			bannerText = createInterpolateElement(
+				translate( 'Your trial ends <strong>today</strong>' ),
+				{
 					strong: <strong />,
-			  } )
-			: createInterpolateElement(
-					translate(
-						'<strong>%(daysRemaining)d day</strong> left in your trial',
-						'<strong>%(daysRemaining)d days</strong> left in your trial',
-						{
-							count: daysRemaining,
-							args: {
-								daysRemaining,
-							},
-							comment: '%(daysRemaining) is the no of days, e.g. "1 day"',
-						}
-					),
-					{ strong: <strong /> }
-			  );
+				}
+			);
+		} else {
+			bannerText = createInterpolateElement(
+				translate(
+					'<strong>%(daysRemaining)d day</strong> left in your trial',
+					'<strong>%(daysRemaining)d days</strong> left in your trial',
+					{
+						count: daysRemaining,
+						args: {
+							daysRemaining,
+						},
+						comment: '%(daysRemaining) is the no of days, e.g. "1 day"',
+					}
+				),
+				{ strong: <strong /> }
+			);
+		}
 
 		return (
 			<>

--- a/client/sites-dashboard/components/sites-migration-trial-badge.tsx
+++ b/client/sites-dashboard/components/sites-migration-trial-badge.tsx
@@ -1,9 +1,26 @@
 import styled from '@emotion/styled';
 import SitesLaunchStatusBadge from './sites-launch-status-badge';
 
-const SitesMigrationTrialBadge = styled( SitesLaunchStatusBadge )`
-	color: #02395c;
-	background-color: #bbe0fa;
-`;
+interface Props {
+	secondary?: boolean;
+}
+
+const COLOR = '#02395c';
+const BACKGROUND_COLOR = '#bbe0fa';
+
+const SitesMigrationTrialBadge = styled( SitesLaunchStatusBadge )( ( props: Props ) => ( {
+	color: COLOR,
+	backgroundColor: BACKGROUND_COLOR,
+	borderRadius: props.secondary ? 12 : 4,
+	'.layout__secondary .site-selector &.site__badge, .layout__secondary &.site__badge': {
+		color: COLOR,
+		backgroundColor: BACKGROUND_COLOR,
+	},
+	'.current-site .site:hover &, .notouch .layout__secondary .site-selector.is-hover-enabled .site:hover  &':
+		{
+			color: '#001621',
+			backgroundColor: '#68b3e8',
+		},
+} ) );
 
 export default SitesMigrationTrialBadge;


### PR DESCRIPTION
Closes #80175

## Proposed Changes

* Updated SitesMigrationTrialBadge component style
* Added Trial badge in the list of sites on sidebar component
* Added sidebar Upsale nudge for Migration Trial plan

## Testing Instructions

**NOTE:** This is branched out from `update/sites-trial-label`

* Make sure you have a site in Trial mode
* Go to the home page
* Click on the sidebar "Switch site" link
* Check if there is a website with a Trial label and select it
* Check if the selected site has the Trial label
* For more info, see ticket: #80175
* Check if the sidebar has a notification for the Plan upgrade

<img width="438" alt="Screenshot 2023-08-04 at 21 22 11" src="https://github.com/Automattic/wp-calypso/assets/1241413/47d51726-5637-41ff-b214-52e12dfbc595">

<img width="407" alt="Screenshot 2023-08-04 at 21 44 38" src="https://github.com/Automattic/wp-calypso/assets/1241413/fb3cb9f2-34ec-412a-957d-f5d9ce443b01">

<img width="273" alt="Screenshot 2023-08-04 at 21 57 00" src="https://github.com/Automattic/wp-calypso/assets/1241413/2707845d-86c1-4aae-b06f-bf6f0f1dbb90">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
