### PR TITLE
Reader: add labels to icon buttons

### DIFF
--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import { translate } from 'i18n-calypso';
 import { omitBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { createElement } from 'react';
@@ -20,6 +21,7 @@ function CommentButton( props ) {
 				href: 'a' === tagName ? href : null,
 				onClick,
 				target: 'a' === tagName ? target : null,
+				title: translate( 'Comment' ),
 			},
 			( prop ) => prop === null
 		),

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -1,6 +1,6 @@
 import { getUrlParts } from '@automattic/calypso-url';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 import { omitBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { createElement, PureComponent } from 'react';
@@ -101,6 +101,7 @@ class LikeButton extends PureComponent {
 					onClick: ! isLink ? this.toggleLiked : null,
 					onMouseEnter,
 					onMouseLeave,
+					title: this.props.liked ? translate( 'Liked' ) : translate( 'Like' ),
 				},
 				( prop ) => prop === null
 			),

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -119,6 +119,7 @@ class ReaderShare extends Component {
 					onMouseEnter={ preloadEditor }
 					onTouchStart={ preloadEditor }
 					ref={ this.shareButton }
+					title={ this.props.isReblogSelection ? translate( 'Reblog' ) : translate( 'Share' ) }
 				>
 					{ ! this.props.isReblogSelection ? (
 						ReaderShareIcon( {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/80122

<img width="563" alt="Screen Shot 2023-08-04 at 10 23 57 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/64c61a86-576c-4771-adbc-146b5234f5b3">

Adds titles to the action buttons in the reader cards.
This should affect the icon buttons everywhere they appear including comments and post details.

