### PR TITLE
Hosting Metrics: Some basic tweaks to the page

### DIFF
--- a/client/my-sites/site-monitoring/main.tsx
+++ b/client/my-sites/site-monitoring/main.tsx
@@ -13,7 +13,7 @@ interface TimeRange {
 	end: number;
 }
 
-export function useTimeRange() {
+function useTimeRange() {
 	// State to store the selected time range
 	const [ selectedTimeRange, setSelectedTimeRange ] = useState( null as TimeRange | null );
 
@@ -37,7 +37,7 @@ export function useTimeRange() {
 	};
 }
 
-export function useSiteMetricsData( metric?: MetricsType ) {
+function useSiteMetricsData( metric?: MetricsType ) {
 	const siteId = useSelector( getSelectedSiteId );
 
 	// Use the custom hook for time range selection
@@ -79,7 +79,7 @@ export function useSiteMetricsData( metric?: MetricsType ) {
 	};
 }
 
-export function useAggregateSiteMetricsData( metric?: MetricsType, dimension?: DimensionParams ) {
+function useAggregateSiteMetricsData( metric?: MetricsType, dimension?: DimensionParams ) {
 	const siteId = useSelector( getSelectedSiteId );
 
 	// Use the custom hook for time range selection

--- a/client/my-sites/site-monitoring/main.tsx
+++ b/client/my-sites/site-monitoring/main.tsx
@@ -41,7 +41,7 @@ function useTimeRange() {
 	};
 }
 
-function useSiteMetricsData( metric?: MetricsType ) {
+export function useSiteMetricsData( metric?: MetricsType ) {
 	const siteId = useSelector( getSelectedSiteId );
 
 	// Use the custom hook for time range selection

--- a/client/my-sites/site-monitoring/main.tsx
+++ b/client/my-sites/site-monitoring/main.tsx
@@ -1,5 +1,9 @@
+import { useI18n } from '@wordpress/react-i18n';
 import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { SiteMonitoringPieChart } from './components/site-monitoring-pie-chart';
 import { calculateTimeRange, TimeDateChartControls } from './components/time-range-picker';
@@ -127,6 +131,10 @@ function getFormattedDataForPieChart(
 }
 
 export function SiteMetrics() {
+	const { __ } = useI18n();
+
+	const titleHeader = __( 'Site Monitoring' );
+
 	const { formattedData, handleTimeRangeChange } = useSiteMetricsData();
 	const { formattedData: cacheHitMissFormattedData } = useAggregateSiteMetricsData(
 		'requests_persec',
@@ -138,7 +146,17 @@ export function SiteMetrics() {
 	);
 
 	return (
-		<div className="site-monitoring">
+		<Main className="site-monitoring" fullWidthLayout>
+			<DocumentHead title={ titleHeader } />
+			<FormattedHeader
+				brandFont
+				headerText={ titleHeader }
+				subHeaderText={ __(
+					'Real time information to troubleshoot or debug problems with your site.'
+				) }
+				align="left"
+				className="site-monitoring__formatted-header"
+			></FormattedHeader>
 			<h2>Atomic site</h2>
 			<TimeDateChartControls onTimeRangeChange={ handleTimeRangeChange }></TimeDateChartControls>
 			<UplotChartMetrics data={ formattedData as uPlot.AlignedData }></UplotChartMetrics>
@@ -160,6 +178,6 @@ export function SiteMetrics() {
 					} ) }
 				></SiteMonitoringPieChart>
 			</div>
-		</div>
+		</Main>
 	);
 }

--- a/client/my-sites/site-monitoring/main.tsx
+++ b/client/my-sites/site-monitoring/main.tsx
@@ -157,7 +157,6 @@ export function SiteMetrics() {
 				align="left"
 				className="site-monitoring__formatted-header"
 			></FormattedHeader>
-			<h2>Atomic site</h2>
 			<TimeDateChartControls onTimeRangeChange={ handleTimeRangeChange }></TimeDateChartControls>
 			<UplotChartMetrics data={ formattedData as uPlot.AlignedData }></UplotChartMetrics>
 			<div className="site-monitoring__pie-charts">

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -6,6 +6,21 @@
 	gap: 16px;
 }
 
+.site-monitoring__formatted-header {
+	position: relative;
+	& ::before {
+		content: "";
+		display: block;
+		position: absolute;
+		background: var(--studio-white);
+		top: -47px;
+		right: -32px;
+		bottom: 20px;
+		left: -33px;
+		z-index: -1;
+	}
+}
+
 .site-monitoring__chart {
 	padding: 24px;
 	border: 1px solid var(--studio-gray-5);


### PR DESCRIPTION
## Proposed Changes

* Avoids exporting functions unnecessarily.
* Adds a document title and basic formatted header (see https://github.com/Automattic/dotcom-forge/issues/3389)

<img width="1413" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/a7371435-8eb6-4af8-bf14-06cd85992bc7">


## Testing Instructions

1. Navigate to `/site-monitoring/<site>` and verify everything appears as expected.