### PR TITLE
Jetpack Composite Checkout: Add tracks event for Jetpack Redirect Modal Show

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/index.tsx
@@ -63,6 +63,8 @@ export default function JetpackProRedirectModal( { redirectTo, productSourceFrom
 		return null;
 	}
 
+	dispatch( recordTracksEvent( 'jetpack_dashboard_agency_checkout_redirect_modal_show' ) );
+
 	return (
 		<Modal onRequestClose={ dismissAndRecordEvent } title="" className="jetpack-pro-redirect-modal">
 			<div className="jetpack-pro-redirect-modal__container">

--- a/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/index.tsx
@@ -50,35 +50,24 @@ export default function JetpackProRedirectModal( { redirectTo, productSourceFrom
 
 	const isAgencyPartner = useSelector( isAgencyUser );
 
+	const isJetpackSource =
+		productSourceFromUrl === 'jetpack-plans' ||
+		redirectURLPage === 'my-jetpack' ||
+		redirectURLPage === 'jetpack';
+
 	// Function to record the event when the modal is displayed.
 	// It is in a separate useEffect to avoid unecessary re-renders.
 	useEffect( () => {
-		const recordShowEvent = () => {
+		if ( isAgencyPartner && ! isDismissed && isJetpackSource ) {
 			dispatch( recordTracksEvent( 'jetpack_dashboard_agency_checkout_redirect_modal_show' ) );
-		};
-
-		if (
-			isAgencyPartner &&
-			! isDismissed &&
-			( productSourceFromUrl === 'jetpack-plans' ||
-				redirectURLPage === 'my-jetpack' ||
-				redirectURLPage === 'jetpack' )
-		) {
-			recordShowEvent();
 		}
-	}, [ isAgencyPartner, isDismissed, productSourceFromUrl, redirectURLPage, dispatch ] );
+		// We only want to run this once
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	// Show the banner only if the user is agency partner, has not dismissed the banner and
 	// is coming from the Jetpack Plans page or Jetpack page in WP.com
-	if (
-		! isAgencyPartner ||
-		isDismissed ||
-		! (
-			productSourceFromUrl === 'jetpack-plans' ||
-			redirectURLPage === 'my-jetpack' ||
-			redirectURLPage === 'jetpack'
-		)
-	) {
+	if ( ! isAgencyPartner || isDismissed || ! isJetpackSource ) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/index.tsx
@@ -37,6 +37,11 @@ export default function JetpackProRedirectModal( { redirectTo, productSourceFrom
 		dispatch( recordTracksEvent( 'jetpack_dashboard_agency_checkout_redirect_modal_redirect' ) );
 	};
 
+	// Function to record the event when the modal is displayed.
+	const recordShowEvent = () => {
+		dispatch( recordTracksEvent( 'jetpack_dashboard_agency_checkout_redirect_modal_show' ) );
+	};
+
 	// Features list of Agency/Pro Dashboard.
 	const features = [
 		translate( 'Up to 60% off our products and bundles.' ),
@@ -63,7 +68,7 @@ export default function JetpackProRedirectModal( { redirectTo, productSourceFrom
 		return null;
 	}
 
-	dispatch( recordTracksEvent( 'jetpack_dashboard_agency_checkout_redirect_modal_show' ) );
+	recordShowEvent();
 
 	return (
 		<Modal onRequestClose={ dismissAndRecordEvent } title="" className="jetpack-pro-redirect-modal">

--- a/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/jetpack-pro-redirect-modal/index.tsx
@@ -3,6 +3,7 @@ import { CheckoutCheckIcon } from '@automattic/composite-checkout';
 import { Modal } from '@wordpress/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -37,11 +38,6 @@ export default function JetpackProRedirectModal( { redirectTo, productSourceFrom
 		dispatch( recordTracksEvent( 'jetpack_dashboard_agency_checkout_redirect_modal_redirect' ) );
 	};
 
-	// Function to record the event when the modal is displayed.
-	const recordShowEvent = () => {
-		dispatch( recordTracksEvent( 'jetpack_dashboard_agency_checkout_redirect_modal_show' ) );
-	};
-
 	// Features list of Agency/Pro Dashboard.
 	const features = [
 		translate( 'Up to 60% off our products and bundles.' ),
@@ -53,6 +49,24 @@ export default function JetpackProRedirectModal( { redirectTo, productSourceFrom
 	const redirectURLPage = getQueryArg( redirectTo ?? '', 'page' );
 
 	const isAgencyPartner = useSelector( isAgencyUser );
+
+	// Function to record the event when the modal is displayed.
+	// It is in a separate useEffect to avoid unecessary re-renders.
+	useEffect( () => {
+		const recordShowEvent = () => {
+			dispatch( recordTracksEvent( 'jetpack_dashboard_agency_checkout_redirect_modal_show' ) );
+		};
+
+		if (
+			isAgencyPartner &&
+			! isDismissed &&
+			( productSourceFromUrl === 'jetpack-plans' ||
+				redirectURLPage === 'my-jetpack' ||
+				redirectURLPage === 'jetpack' )
+		) {
+			recordShowEvent();
+		}
+	}, [ isAgencyPartner, isDismissed, productSourceFromUrl, redirectURLPage, dispatch ] );
 
 	// Show the banner only if the user is agency partner, has not dismissed the banner and
 	// is coming from the Jetpack Plans page or Jetpack page in WP.com
@@ -67,8 +81,6 @@ export default function JetpackProRedirectModal( { redirectTo, productSourceFrom
 	) {
 		return null;
 	}
-
-	recordShowEvent();
 
 	return (
 		<Modal onRequestClose={ dismissAndRecordEvent } title="" className="jetpack-pro-redirect-modal">


### PR DESCRIPTION

Related to # https://app.asana.com/0/1202619025189113/1205194838884604/f

## Proposed Changes

* When an agency user adds a product from the normal checkout process to the cart, a modal shows letting them know they can get a better deal when they use their agency dashboard instead.
* This PR adds an additional tracks event that fires when the modal redirecting users to the dashboard is displayed
* The event is recorded as `jetpack_dashboard_agency_checkout_redirect_modal_show`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This change is in calypso, so use the Calypso Live link below, or load up this PR locally and yarn start to fire up calypso local
* You will need to be an agency partner for this to work
* Navagate to checkout with a product in the cart ie: /checkout/jetpack/jetpack_backup_t1_yearly?source=jetpack-plans
* Open the browser javascript console and run the command:` localStorage.debug = 'calypso:analytics'`
* Reload the page, and look for a tracks event in the console called `jetpack_dashboard_agency_checkout_redirect_modal_show`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
