### PR TITLE
Happy blocks: Separate support content links for reusability

### DIFF
--- a/apps/happy-blocks/block-library/support-content-footer/index.php
+++ b/apps/happy-blocks/block-library/support-content-footer/index.php
@@ -11,6 +11,25 @@ if ( ! isset( $args ) ) {
 	$args = array();
 }
 
+ob_start();
+require_once WP_CONTENT_DIR . '/a8c-plugins/happy-blocks/block-library/support-content-links/index.php';
+$support_content_links_html = ob_get_clean();
+
+$support_content_links_allowed_tags = array(
+	'a' => array(
+		'href'   => array(),
+		'target' => array(),
+		'rel'    => array(),
+	),
+	'p' => array(),
+	'div' => array(
+		'class' => array(),
+	)
+);
+
+$support_content_links_html_output = wp_kses( $support_content_links_html, $support_content_links_allowed_tags );
+
+
 $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-library/support-content-footer/build/assets';
 ?>
 
@@ -76,28 +95,11 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 		</div>
 	</div>
 	<div class="support-content-links-subscribe">
-		<div class="support-content-links">
-			<p>
-				<?php esc_html_e( 'Questions?', 'happy-blocks' ); ?>
-				<a href="<?php echo esc_url( 'https://wordpress.com/help/contact/' ); ?>" target="_blank" rel="noreferrer noopener">
-					<?php esc_html_e( 'Contact our Happiness Engineers.', 'happy-blocks' ); ?>
-				</a>
-			</p>
-			<p>
-				<?php esc_html_e( 'Self-hosted WordPress site?', 'happy-blocks' ); ?>
-				<a href="<?php echo esc_url( 'http://wordpress.org/support' ); ?>" target="_blank" rel="noreferrer noopener">
-					<?php esc_html_e( 'Find support here.', 'happy-blocks' ); ?>
-				</a>
-			</p>
-			<p>
-				<?php esc_html_e( 'New to WordPress.com? ', 'happy-blocks' ); ?>
-				<a href="<?php echo esc_url( 'https://wordpress.com/support/start/' ); ?>" target="_blank" rel="noreferrer noopener">
-					<?php esc_html_e( 'Find your perfect-fit plan here.', 'happy-blocks' ); ?>
-				</a>
-			</p>
-		</div>
+		<?php
+			echo $support_content_links_html_output;
+		?>
 		<div class="support-content-subscribe">
-			<p><?php esc_html_e( 'Get the latest learning in your inbox::', 'happy-blocks' ); ?></p>
+			<p><?php esc_html_e( 'Get the latest learning in your inbox:', 'happy-blocks' ); ?></p>
 			<form action="https://subscribe.wordpress.com" method="post" accept-charset="utf-8" data-blog="<?php echo get_current_blog_id(); ?>" data-post_access_level="everybody" id="subscribe-blog">
 				<input class="support-content-subscribe-email" required="required" type="email" name="email" placeholder="<?php esc_html_e( 'Type your email', 'happy-blocks' ); ?>"  id="subscribe-field">
 				<input type="hidden" name="action" value="subscribe">

--- a/apps/happy-blocks/block-library/support-content-footer/index.php
+++ b/apps/happy-blocks/block-library/support-content-footer/index.php
@@ -11,25 +11,6 @@ if ( ! isset( $args ) ) {
 	$args = array();
 }
 
-ob_start();
-require_once WP_CONTENT_DIR . '/a8c-plugins/happy-blocks/block-library/support-content-links/index.php';
-$support_content_links_html = ob_get_clean();
-
-$support_content_links_allowed_tags = array(
-	'a' => array(
-		'href'   => array(),
-		'target' => array(),
-		'rel'    => array(),
-	),
-	'p' => array(),
-	'div' => array(
-		'class' => array(),
-	)
-);
-
-$support_content_links_html_output = wp_kses( $support_content_links_html, $support_content_links_allowed_tags );
-
-
 $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-library/support-content-footer/build/assets';
 ?>
 
@@ -96,7 +77,7 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 	</div>
 	<div class="support-content-links-subscribe">
 		<?php
-			echo $support_content_links_html_output;
+			require WP_CONTENT_DIR . '/a8c-plugins/happy-blocks/block-library/support-content-links/index.php';
 		?>
 		<div class="support-content-subscribe">
 			<p><?php esc_html_e( 'Get the latest learning in your inbox:', 'happy-blocks' ); ?></p>

--- a/apps/happy-blocks/block-library/support-content-links/includes.php
+++ b/apps/happy-blocks/block-library/support-content-links/includes.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Title: Support content links
+ * Slug: happy-blocks/support-content-links
+ * Categories: support
+ *
+ * @package happy-blocks
+ */
+
+if ( ! function_exists( 'happy_blocks_get_support_content_links_asset' ) ) {
+	/**
+	 * Find the URL of the asset file from happy-blocks.
+	 *
+	 * @param file $file The file name.
+	 */
+	function happy_blocks_get_support_content_links_asset( $file ) {
+		return array(
+			'path'    => "https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-library/support-content-links/build/$file",
+			'version' => filemtime( __DIR__ . "/build/$file" ),
+		);
+	}
+}
+
+$happy_blocks_header_js  = happy_blocks_get_support_content_links_asset( 'view.js' );
+$happy_blocks_header_css = happy_blocks_get_support_content_links_asset( is_rtl() ? 'view.rtl.css' : 'view.css' );
+
+wp_enqueue_style( 'wpsupport3-happy-blocks-support-content-links-style', $happy_blocks_header_css['path'], array(), $happy_blocks_header_css['version'] );
+wp_enqueue_script( 'wpsupport3-happy-blocks-support-content-links-script', $happy_blocks_header_js['path'], array(), $happy_blocks_header_js['version'], true );

--- a/apps/happy-blocks/block-library/support-content-links/index.js
+++ b/apps/happy-blocks/block-library/support-content-links/index.js
@@ -1,0 +1,1 @@
+// This is needed for the build.

--- a/apps/happy-blocks/block-library/support-content-links/index.php
+++ b/apps/happy-blocks/block-library/support-content-links/index.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Title: Support content links
+ * Slug: happy-blocks/support-content-links
+ * Categories: support
+ *
+ * @package happy-blocks
+ */
+
+?>
+<div class="support-content-links">
+	<p>
+		<?php esc_html_e( 'Questions?', 'happy-blocks' ); ?>
+		<a href="<?php echo esc_url( 'https://wordpress.com/help/contact/' ); ?>" target="_blank" rel="noreferrer noopener">
+			<?php esc_html_e( 'Contact our Happiness Engineers.', 'happy-blocks' ); ?>
+		</a>
+	</p>
+	<p>
+		<?php esc_html_e( 'Self-hosted WordPress site?', 'happy-blocks' ); ?>
+		<a href="<?php echo esc_url( 'http://wordpress.org/support' ); ?>" target="_blank" rel="noreferrer noopener">
+			<?php esc_html_e( 'Find support here.', 'happy-blocks' ); ?>
+		</a>
+	</p>
+	<p>
+		<?php esc_html_e( 'New to WordPress.com? ', 'happy-blocks' ); ?>
+		<a href="<?php echo esc_url( 'https://wordpress.com/support/start/' ); ?>" target="_blank" rel="noreferrer noopener">
+			<?php esc_html_e( 'Find your perfect-fit plan here.', 'happy-blocks' ); ?>
+		</a>
+	</p>
+</div>

--- a/apps/happy-blocks/block-library/support-content-links/style.scss
+++ b/apps/happy-blocks/block-library/support-content-links/style.scss
@@ -1,0 +1,6 @@
+.support-content-links {
+	p {
+		font-size: 1rem;
+		line-height: 24px;
+	}
+}

--- a/apps/happy-blocks/block-library/support-content-links/view.js
+++ b/apps/happy-blocks/block-library/support-content-links/view.js
@@ -1,0 +1,1 @@
+import './style.scss';

--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -18,6 +18,7 @@
 		"build:universal-footer": "calypso-build --env block='universal-footer'",
 		"build:support-content-footer": "calypso-build --env block='support-content-footer'",
 		"build:education-header": "calypso-build --env block='education-header'",
+		"build:support-content-links": "calypso-build --env block='support-content-links'",
 		"build-translations-manifest": "yarn run build-calypso-strings && node bin/build-translations-manifest.js",
 		"clean": "rm -r release-files block-library/*/build || true",
 		"dev": "yarn run calypso-apps-builder --localPath / --remotePath /home/wpcom/public_html/wp-content/a8c-plugins/happy-blocks"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wpsupport3/pull/508

## Proposed Changes

* Separates support content links from `support-content-footer` block to reuse in wpsupport3 course lesson page.

![image](https://github.com/Automattic/wpsupport3/assets/10482592/26c97cf1-f5ce-42cc-b376-e8708a330eac)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and the [wpsupport3 PR](https://github.com/Automattic/wpsupport3/pull/508)
* Navigate to a course lesson page (`/courses/create-your-site/create-a-wordpress-com-account-and-site/`)
* Verify the support content links appear at the bottom of the inner content (middle of the screen).
* Verify the support content links still appear in other areas such as the homepage (`https://learncft.wordpress.com/`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
