### PR TITLE
Fix broken highlight

### DIFF
--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -588,7 +588,7 @@ body.is-section-signup.is-white-signup,
 			padding: 0 19px 24px 20px;
 
 			@include plans-2023-break-small {
-				padding-bottom: 0;
+				padding-bottom: 16px;
 			}
 
 			.plan-features-2023-grid__vip-price {

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -588,7 +588,7 @@ body.is-section-signup.is-white-signup,
 			padding: 0 19px 24px 20px;
 
 			@include plans-2023-break-small {
-				padding-bottom: 16px;
+				padding-bottom: 24px;
 			}
 
 			.plan-features-2023-grid__vip-price {

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -442,6 +442,9 @@ $mobile-card-max-width: 440px;
 
 				&.plan-features-2023-grid__header-billing-info {
 					padding-bottom: 32px;
+					@include plans-2023-break-small {
+						padding-bottom: 32px;
+					}
 				}
 
 				&.popular-plan-parent-class .plan-features-2023-grid__popular-badge {
@@ -588,7 +591,7 @@ body.is-section-signup.is-white-signup,
 			padding: 0 19px 24px 20px;
 
 			@include plans-2023-break-small {
-				padding-bottom: 24px;
+				padding-bottom: 0;
 			}
 
 			.plan-features-2023-grid__vip-price {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -61,7 +61,7 @@ import type { IAppState } from 'calypso/state/types';
 
 import './style.scss';
 
-const SPOTLIGHT_VISIBLE_PLANS_COUNT = 6;
+const SPOTLIGHT_ENABLED_INTENTS = [ 'plans-default-wpcom' ];
 
 export interface PlansFeaturesMainProps {
 	siteId?: number | null;
@@ -494,8 +494,17 @@ const PlansFeaturesMain = ( {
 	};
 
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
-	const isSpotlightOnCurrentPlanAllowed =
-		Object.keys( visiblePlans ).length === SPOTLIGHT_VISIBLE_PLANS_COUNT;
+
+	/**
+	 * The spotlight in smaller grids looks broken.
+	 * So for now we only allow the spotlight in the default grid plans grid where we display all 6 plans.
+	 * In order to accommodate this for other variations with lesser number of plans the design needs to be reworked.
+	 * Or else the intent needs to be explicitly allow the spotlight to be shown in this relevant intent.
+	 * Eventually once the spotlight card is made responsive this flag can be removed.
+	 * Check : https://github.com/Automattic/wp-calypso/pull/80232 for more details.
+	 */
+	const isSpotlightOnCurrentPlanAllowed = SPOTLIGHT_ENABLED_INTENTS.includes( intent );
+
 	return (
 		<div
 			className={ classNames( 'plans-features-main', 'is-pricing-grid-2023-plans-features-main' ) }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -61,6 +61,8 @@ import type { IAppState } from 'calypso/state/types';
 
 import './style.scss';
 
+const SPOTLIGHT_VISIBLE_PLANS_COUNT = 6;
+
 export interface PlansFeaturesMainProps {
 	siteId?: number | null;
 	intent?: PlansIntent | null;
@@ -449,6 +451,7 @@ const PlansFeaturesMain = ( {
 			hideBusinessPlan,
 			hideEcommercePlan,
 		} ) || null;
+
 	// merge/update default plans with plans with intent
 	const gridPlanRecords = {
 		...defaultPlanRecords,
@@ -491,7 +494,8 @@ const PlansFeaturesMain = ( {
 	};
 
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
-
+	const isSpotlightOnCurrentPlanAllowed =
+		Object.keys( visiblePlans ).length === SPOTLIGHT_VISIBLE_PLANS_COUNT;
 	return (
 		<div
 			className={ classNames( 'plans-features-main', 'is-pricing-grid-2023-plans-features-main' ) }
@@ -591,7 +595,7 @@ const PlansFeaturesMain = ( {
 						intent={ intent }
 						isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
 						showLegacyStorageFeature={ showLegacyStorageFeature }
-						isSpotlightOnCurrentPlan={ isSpotlightOnCurrentPlan }
+						isSpotlightOnCurrentPlan={ isSpotlightOnCurrentPlanAllowed && isSpotlightOnCurrentPlan }
 						showUpgradeableStorage={ showUpgradeableStorage }
 					/>
 				</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


### Bug Details
* Discussion -  p1691156435766389-slack-C029GN3KD
* The plans shown in the home page looks broken for smaller number of plans
* The bottom padding of the plan highlight is missing in all number of plans

### Proposed Changes

- Fix the bottom padding of the plan spotlight
- Only show the spotlight when there are only 5 plans


|  Before |  After  |
|---|---|
|  ![image](https://github.com/Automattic/wp-calypso/assets/3422709/5659ea76-419e-4f31-bb26-e123b626ce0f) |   ![image](https://github.com/Automattic/wp-calypso/assets/3422709/984a37a7-aa25-4810-9510-4bdadd529a6b) |



## Testing Instructions

### Hide Spotlight on Lesser number of Plans
- Go through the newsletter flow `/setup/newsletter` 
- complete the flow
- Skip the dashboard
- Go to the `/plans` page
- Make sure the spotlight is hidden
- 
### Fix Bottom Padding
- Go through the onboarding flow`/start`
- On the goals screen `skip the dashboard`
- On the launch pad `Skip for now`
- Go to the `/plans` page 
- Make sure the plans spotlight is visible and the padding bottom is not missing on it.


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
