### PR TITLE
Hosting Metrics: Tweak line chart

### DIFF
--- a/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
@@ -27,14 +27,14 @@ export function formatChatHour( date: Date ): string {
 	return `${ hours }:${ minutes }`;
 }
 
-export default function UplotChartMetrics( {
+export const SiteMonitoringLineChart = ( {
 	data,
 	fillColor = 'rgba(48, 87, 220, 0.4)',
 	legendContainer,
 	options: propOptions,
 	solidFill = false,
 	period,
-}: UplotChartProps ) {
+}: UplotChartProps ) => {
 	const translate = useTranslate();
 	const uplot = useRef< uPlot | null >( null );
 	const uplotContainer = useRef( null );
@@ -170,4 +170,4 @@ export default function UplotChartMetrics( {
 			/>
 		</div>
 	);
-}
+};

--- a/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
@@ -2,6 +2,7 @@ import useResize from '@automattic/components/src/chart-uplot/hooks/use-resize';
 import useScaleGradient from '@automattic/components/src/chart-uplot/hooks/use-scale-gradient';
 import getGradientFill from '@automattic/components/src/chart-uplot/lib/get-gradient-fill';
 import getPeriodDateFormat from '@automattic/components/src/chart-uplot/lib/get-period-date-format';
+import classnames from 'classnames';
 import { getLocaleSlug, numberFormat, useTranslate } from 'i18n-calypso';
 import { useMemo, useRef, useState } from 'react';
 import uPlot from 'uplot';
@@ -13,6 +14,8 @@ const DEFAULT_DIMENSIONS = {
 };
 
 interface UplotChartProps {
+	title?: string;
+	className?: string;
 	data: uPlot.AlignedData;
 	fillColor?: string;
 	options?: Partial< uPlot.Options >;
@@ -28,6 +31,8 @@ export function formatChatHour( date: Date ): string {
 }
 
 export const SiteMonitoringLineChart = ( {
+	title,
+	className,
 	data,
 	fillColor = 'rgba(48, 87, 220, 0.4)',
 	legendContainer,
@@ -161,13 +166,23 @@ export const SiteMonitoringLineChart = ( {
 
 	useResize( uplot, uplotContainer );
 
+	const classes = [ 'site-monitoring-line-chart', 'site-monitoring__chart' ];
+	if ( className ) {
+		classes.push( className );
+	}
+
 	return (
-		<div className="calypso-uplot-chart-container" ref={ uplotContainer }>
-			<UplotReact
-				data={ data }
-				onCreate={ ( chart ) => ( uplot.current = chart ) }
-				options={ options }
-			/>
+		<div className={ classnames( classes ) }>
+			<header className="site-monitoring__chart-header">
+				<h2 className="site-monitoring__chart-title">{ title }</h2>
+			</header>
+			<div ref={ uplotContainer }>
+				<UplotReact
+					data={ data }
+					onCreate={ ( chart ) => ( uplot.current = chart ) }
+					options={ options }
+				/>
+			</div>
 		</div>
 	);
 };

--- a/client/my-sites/site-monitoring/main.tsx
+++ b/client/my-sites/site-monitoring/main.tsx
@@ -164,6 +164,7 @@ export function SiteMetrics() {
 			></FormattedHeader>
 			<TimeDateChartControls onTimeRangeChange={ handleTimeRangeChange }></TimeDateChartControls>
 			<SiteMonitoringLineChart
+				title={ __( 'Requests per minute & average response time' ) }
 				data={ formattedData as uPlot.AlignedData }
 			></SiteMonitoringLineChart>
 			<div className="site-monitoring__pie-charts">

--- a/client/my-sites/site-monitoring/main.tsx
+++ b/client/my-sites/site-monitoring/main.tsx
@@ -7,9 +7,9 @@ import Main from 'calypso/components/main';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { SiteMonitoringBarChart } from './components/site-monitoring-bar-chart';
 import { useMetricsBarChartData } from './components/site-monitoring-bar-chart/use-metrics-bar-chart-data';
+import { SiteMonitoringLineChart } from './components/site-monitoring-line-chart';
 import { SiteMonitoringPieChart } from './components/site-monitoring-pie-chart';
 import { calculateTimeRange, TimeDateChartControls } from './components/time-range-picker';
-import UplotChartMetrics from './metrics-chart';
 import { MetricsType, DimensionParams, PeriodData, useSiteMetricsQuery } from './use-metrics-query';
 
 import './style.scss';
@@ -163,7 +163,9 @@ export function SiteMetrics() {
 				className="site-monitoring__formatted-header"
 			></FormattedHeader>
 			<TimeDateChartControls onTimeRangeChange={ handleTimeRangeChange }></TimeDateChartControls>
-			<UplotChartMetrics data={ formattedData as uPlot.AlignedData }></UplotChartMetrics>
+			<SiteMonitoringLineChart
+				data={ formattedData as uPlot.AlignedData }
+			></SiteMonitoringLineChart>
 			<div className="site-monitoring__pie-charts">
 				<SiteMonitoringPieChart
 					title="Cache hit/miss"

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -96,7 +96,3 @@
 		}
 	}
 }
-
-.uplot {
-	border: 1px solid var(--studio-gray-5);
-}


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/3274

## Proposed Changes

* Moves the line chart to `components/site-monitoring-line-chart/index.tsx`
* Reuses classes and adds a title to the element.

<img width="1359" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/c7a9723d-f0e7-4119-8651-6b4b4b9fcfd0">

## Testing Instructions

1. Navigate to `/site-monitoring/<site>`.
2. See the page appear as expected.