### PR TITLE
Hosting Metrics: Fix color on cache chart

### DIFF
--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -50,7 +50,7 @@
 .site-monitoring-cache-pie-chart {
 	.pie-chart__chart-section-0,
 	.pie-chart__legend-sample-0 {
-		fill: #a7e8d3;
+		fill: #bae0f9;
 
 	}
 	.pie-chart__chart-section-1,


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/3276

## Proposed Changes

Needs to be blue, not green:

<img width="1370" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/d06639b4-8b28-4854-9121-1dd3eddef18c">


## Testing Instructions

1. Navigate to `/site-monitoring/<site>`.
2. Verify the cache hit/miss chart appears as expected.