### PR TITLE
Checkout: Add error message to transaction failed logs

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -115,6 +115,7 @@ export default async function existingCardProcessor(
 			reduxDispatch(
 				recordTracksEvent( 'calypso_checkout_card_transaction_failed', {
 					payment_intent_id: paymentIntentId ?? '',
+					error: error.message,
 				} )
 			);
 			logStashEvent(
@@ -122,6 +123,7 @@ export default async function existingCardProcessor(
 				{
 					payment_intent_id: paymentIntentId ?? '',
 					tags: [ `payment_intent_id:${ paymentIntentId }` ],
+					error: error.message,
 				},
 				'info'
 			);

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -113,13 +113,13 @@ export default async function existingCardProcessor(
 		.catch( ( error ) => {
 			debug( 'transaction failed' );
 			reduxDispatch(
-				recordTracksEvent( 'calypso_checkout_card_transaction_failed', {
+				recordTracksEvent( 'calypso_checkout_existing_card_transaction_failed', {
 					payment_intent_id: paymentIntentId ?? '',
 					error: error.message,
 				} )
 			);
 			logStashEvent(
-				'calypso_checkout_card_transaction_failed',
+				'calypso_checkout_existing_card_transaction_failed',
 				{
 					payment_intent_id: paymentIntentId ?? '',
 					tags: [ `payment_intent_id:${ paymentIntentId }` ],

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -166,11 +166,13 @@ async function stripeCardProcessor(
 			reduxDispatch(
 				recordTracksEvent( 'calypso_checkout_card_transaction_failed', {
 					payment_intent_id: paymentIntentId ?? '',
+					error: error.message,
 				} )
 			);
 			logStashEvent( 'calypso_checkout_card_transaction_failed', {
 				payment_intent_id: paymentIntentId ?? '',
 				tags: [ `payment_intent_id:${ paymentIntentId }` ],
+				error: error.message,
 			} );
 
 			// Errors here are "expected" errors, meaning that they (hopefully) come

--- a/client/my-sites/checkout/composite-checkout/lib/web-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/web-pay-processor.ts
@@ -88,7 +88,7 @@ export default async function webPayProcessor(
 					error: error.message,
 				} )
 			);
-			logStashEvent( 'calypso_checkout__transaction_failed', {
+			logStashEvent( 'calypso_checkout_web_pay_transaction_failed', {
 				payment_intent_id: paymentIntentId ?? '',
 				tags: [ `payment_intent_id:${ paymentIntentId }` ],
 				error: error.message,

--- a/client/my-sites/checkout/composite-checkout/lib/web-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/web-pay-processor.ts
@@ -85,11 +85,13 @@ export default async function webPayProcessor(
 			transactionOptions.reduxDispatch(
 				recordTracksEvent( 'calypso_checkout_web_pay_transaction_failed', {
 					payment_intent_id: paymentIntentId ?? '',
+					error: error.message,
 				} )
 			);
 			logStashEvent( 'calypso_checkout__transaction_failed', {
 				payment_intent_id: paymentIntentId ?? '',
 				tags: [ `payment_intent_id:${ paymentIntentId }` ],
+				error: error.message,
 			} );
 
 			// Errors here are "expected" errors, meaning that they (hopefully) come


### PR DESCRIPTION
## Proposed Changes

We have special logs when the `catch` block of the transactions endpoint is triggered to record that the failure happened. However, these logs do not actually record the error (the error is recorded in other places but seeking them out is often difficult if looking for a payment intent ID and not a user).

In this PR we add the error message to the logs also.

## Testing Instructions

None should be needed.