### PR TITLE
(GB)(E2E)(Automation) Fix redundant E2E Slack failure messages when builds pass

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -140,7 +140,7 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 
 			exec {
 				name = "Post Failure Message to Slack"
-				executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+				executionMode = BuildStep.ExecutionMode.RUN_ONLY_ON_FAILURE
 				path = "./bin/post-threaded-slack-message.sh"
 				arguments = "%GB_E2E_ANNOUNCEMENT_SLACK_CHANNEL_ID% %GB_E2E_ANNOUNCEMENT_THREAD_TS% \"The $buildName failed! Could you have a look? @kitkat-team @calypso-platform-team! <%teamcity.serverUrl%/viewLog.html?buildId=%teamcity.build.id%|View build>\" %GB_E2E_ANNOUNCEMENT_SLACK_API_TOKEN%"
 			}


### PR DESCRIPTION
## Proposed Changes

Follow-up to: https://github.com/Automattic/wp-calypso/pull/79893

Change the `executionMode` of the failure step to `RUN_ONLY_ON_FAILURE` to make sure it runs only if the build (entirely) fails. According to Jetbrains, `RUN_ON_FAILURE` will run when any tests fail, so that's why we get redundant notifications due to flaky tests failing and then passing after a retry (which means a failure *and* a success message, which is confusing).

## Testing Instructions

1. Verify there are no Kotlin syntax or compilation errors locally -- use `mvn compile` for that (or IDEA if you have it correctly setup)
2. Checks should pass
