### PR TITLE
Update calypso jetpack masterbar to pull wpcom data

### DIFF
--- a/client/data/jetpack/use-jetpack-masterbar-data-query.ts
+++ b/client/data/jetpack/use-jetpack-masterbar-data-query.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+export type MenuItem = {
+	id: string;
+	menu_order: number;
+	label: string;
+	tagline: string;
+	href: string;
+	items: { [ key: number ]: MenuItem };
+};
+
+type MasterbarData = {
+	sections: { [ key: number ]: MenuItem };
+	bundles: MenuItem;
+};
+
+const useJetpackMasterbarDataQuery = (): UseQueryResult< MasterbarData > => {
+	const queryKey = [ 'jetpack-masterbar-data' ];
+
+	return useQuery( {
+		queryKey,
+		queryFn: async () =>
+			wpcom.req.get( {
+				path: `/jetpack-marketing/jetpack-menu`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		refetchOnWindowFocus: false,
+	} );
+};
+
+export default useJetpackMasterbarDataQuery;

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -181,9 +181,11 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 																									</span>
 																									{ label }
 																								</span>
-																								<span className="header__submenu-tagline">
-																									{ tagline }
-																								</span>
+																								{ tagline && (
+																									<span className="header__submenu-tagline">
+																										{ tagline }
+																									</span>
+																								) }
 																							</ExternalLink>
 																							<ul className="header__submenu-links-list">
 																								{ Array.from( Object.values( items ) )
@@ -198,9 +200,11 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 																												<span className="header__submenu-label">
 																													{ label }
 																												</span>
-																												<span className="header__submenu-tagline">
-																													{ tagline }
-																												</span>
+																												{ tagline && (
+																													<span className="header__submenu-tagline">
+																														{ tagline }
+																													</span>
+																												) }
 																											</ExternalLink>
 																										</li>
 																									) ) }
@@ -232,9 +236,11 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 																										<span className="header__submenu-label">
 																											{ label }
 																										</span>
-																										<span className="header__submenu-tagline">
-																											{ tagline }
-																										</span>
+																										{ tagline && (
+																											<span className="header__submenu-tagline">
+																												{ tagline }
+																											</span>
+																										) }
 																									</ExternalLink>
 																								</li>
 																							) ) }

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -88,6 +88,39 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 		} );
 	}, [] );
 
+	const toggleMenuItem = ( btn: HTMLAnchorElement, menu: HTMLUListElement ) => {
+		const expanded = btn.getAttribute( 'aria-expanded' ) === 'true' || false;
+		btn.setAttribute( 'aria-expanded', String( ! expanded ) );
+
+		menu.hidden = ! menu.hidden;
+	};
+
+	const collapseExpandedMenu = () => {
+		const expandedBtn = document.querySelector(
+			'.js-menu-btn[aria-expanded="true"]'
+		) as HTMLAnchorElement;
+
+		if ( expandedBtn ) {
+			const menu = expandedBtn?.parentNode?.querySelector( 'js-menu' ) as HTMLUListElement;
+
+			if ( menu ) {
+				toggleMenuItem( expandedBtn, menu );
+			}
+		}
+	};
+
+	const onMenuBtnClick = ( e: React.MouseEvent< HTMLAnchorElement > ) => {
+		e.preventDefault();
+		const btn = e.currentTarget;
+		const menu = btn.parentNode?.querySelector( '.js-menu' ) as HTMLUListElement;
+
+		if ( btn.getAttribute( 'aria-expanded' ) === 'false' ) {
+			collapseExpandedMenu();
+		}
+
+		toggleMenuItem( btn, menu );
+	};
+
 	useSubmenuBtn();
 	useUserMenu();
 	useMobileBtn();
@@ -150,7 +183,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 																href && href !== '#' ? localizeUrl( href, locale ) : `#${ id }`
 															}
 															aria-expanded={ hasChildren ? false : undefined }
-															onClick={ href && href !== '#' ? onLinkClick : undefined }
+															onClick={ href && href !== '#' ? onLinkClick : onMenuBtnClick }
 														>
 															{ label }
 															{ hasChildren && <Gridicon icon="chevron-down" size={ 18 } /> }

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import Gravatar from 'calypso/components/gravatar';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import useJetpackMasterbarDataQuery from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
 import JetpackSaleBanner from 'calypso/jetpack-cloud/sections/pricing/sale-banner';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
@@ -21,6 +22,7 @@ import CloudCart from './cloud-cart';
 import useMobileBtn from './use-mobile-btn';
 import useSubmenuBtn from './use-submenu-btn';
 import useUserMenu from './use-user-menu';
+import type { MenuItem } from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
 
 import './style.scss';
 
@@ -44,133 +46,12 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 	const jetpackSaleCoupon = useSelector( getJetpackSaleCoupon );
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const user = useSelector( getCurrentUser );
+	const { data: menuData, status: menuDataStatus } = useJetpackMasterbarDataQuery();
 
-	const sections = useMemo(
-		() => [
-			{
-				label: translate( 'Products' ),
-				id: 'products',
-				items: [
-					{
-						label: translate( 'Security', { context: 'Jetpack product name' } ),
-						tagline: translate( 'Protect your site' ),
-						href: `${ JETPACK_COM_BASE_URL }/features/security/`,
-						items: [
-							{
-								label: translate( 'VaultPress Backup' ),
-								tagline: translate( 'Save every change in real-time' ),
-								href: `${ JETPACK_COM_BASE_URL }/upgrade/backup/`,
-							},
-							{
-								label: translate( 'Scan' ),
-								tagline: translate( 'Stay one step ahead of threats' ),
-								href: `${ JETPACK_COM_BASE_URL }/upgrade/scan/`,
-							},
-							{
-								label: translate( 'Akismet Anti-spam' ),
-								tagline: translate( 'Stop comment and form spam' ),
-								href: `${ JETPACK_COM_BASE_URL }/upgrade/anti-spam/`,
-							},
-						],
-					},
-					{
-						label: translate( 'Performance' ),
-						tagline: translate( 'Speed up your site' ),
-						href: `${ JETPACK_COM_BASE_URL }/features/performance/`,
-						items: [
-							{
-								label: translate( 'Site Search' ),
-								tagline: translate( 'Help them find what they need' ),
-								href: `${ JETPACK_COM_BASE_URL }/upgrade/search/`,
-							},
-							{
-								label: translate( 'Boost' ),
-								tagline: translate( 'Instant speed and SEO' ),
-								href: `${ JETPACK_COM_BASE_URL }/boost/`,
-							},
-							{
-								label: translate( 'VideoPress' ),
-								tagline: translate( 'High-quality, ad-free video' ),
-								href: `${ JETPACK_COM_BASE_URL }/videopress/`,
-							},
-						],
-					},
-					{
-						label: translate( 'Growth' ),
-						tagline: translate( 'Grow your audience' ),
-						href: `${ JETPACK_COM_BASE_URL }/features/growth/`,
-						items: [
-							{
-								label: translate( 'AI Assistant', { context: 'Jetpack product name' } ),
-								tagline: translate( 'Write smarter, not harder' ),
-								href: `${ JETPACK_COM_BASE_URL }/ai/`,
-							},
-							{
-								label: translate( 'Stats', { context: 'Jetpack product name' } ),
-								tagline: translate( 'Simple, yet powerful analytics' ),
-								href: `${ JETPACK_COM_BASE_URL }/stats/`,
-							},
-							{
-								label: translate( 'Social', { context: 'Jetpack product name' } ),
-								tagline: translate( 'Write once, post everywhere' ),
-								href: `${ JETPACK_COM_BASE_URL }/social/`,
-							},
-							{
-								label: translate( 'CRM' ),
-								tagline: translate( 'Connect with your people' ),
-								href: 'https://jetpackcrm.com/?utm_medium=automattic_referred&utm_source=jpcom_header',
-							},
-							{
-								label: translate( 'Blaze' ),
-								tagline: translate( 'Advertise your best content' ),
-								href: `${ JETPACK_COM_BASE_URL }/blaze/`,
-							},
-							{
-								label: translate( 'Newsletter' ),
-								tagline: translate( 'Write once, reach all' ),
-								href: `${ JETPACK_COM_BASE_URL }/newsletter/`,
-							},
-						],
-					},
-				],
-			},
-			{
-				label: translate( 'Pricing' ),
-				href: `${ JETPACK_COM_BASE_URL }/pricing/`,
-			},
-			{
-				label: translate( 'Partners' ),
-				href: `${ JETPACK_COM_BASE_URL }/jetpack-partners/`,
-			},
-			{
-				label: translate( 'Support' ),
-				href: `${ JETPACK_COM_BASE_URL }/support/`,
-			},
-			{
-				label: translate( 'Blog' ),
-				href: `${ JETPACK_COM_BASE_URL }/blog/`,
-			},
-		],
-		[ translate ]
-	);
-	const bundles = useMemo(
-		() => ( {
-			label: translate( 'Bundles' ),
-			items: [
-				{
-					label: translate( 'Complete', { context: 'Jetpack plan name' } ),
-					tagline: translate( 'The ultimate toolkit' ),
-					href: `${ JETPACK_COM_BASE_URL }/complete/`,
-				},
-				{
-					label: translate( 'Security', { context: 'Jetpack product name' } ),
-					tagline: translate( 'Comprehensive site security' ),
-					href: `${ JETPACK_COM_BASE_URL }/features/security/`,
-				},
-			],
-		} ),
-		[ translate ]
-	);
+	const sortByMenuOrder = ( a: MenuItem, b: MenuItem ) => a.menu_order - b.menu_order;
+
+	const sections = menuData?.sections ? Array.from( Object.values( menuData.sections ) ) : null;
+	const bundles = menuData?.bundles ?? null;
 
 	const appsLink = {
 		categoryLabel: translate( 'Android and iOS' ),
@@ -216,212 +97,230 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 		<>
 			{ jetpackSaleCoupon && <JetpackSaleBanner coupon={ jetpackSaleCoupon } /> }
 
-			<div className="jpcom-masterbar">
-				<header className="header js-header force-opaque">
-					<div className="header__content-wrapper">
-						<div className="header__content-background-wrapper-sentinal" { ...outerDivProps }></div>
-						<div className={ classes }>
-							<nav className="header__content is-sticky">
-								<a className="header__skip" href={ `#${ MAIN_CONTENT_ID }` }>
-									{ translate( 'Skip to main content' ) }
-								</a>
-								<ExternalLink
-									className="header__home-link"
-									href={ localizeUrl( JETPACK_COM_BASE_URL, locale ) }
-									aria-label={ translate( 'Jetpack home' ) }
-									onClick={ () => recordTracksEvent( 'calypso_jetpack_nav_logo_click' ) }
-								>
-									<JetpackLogo full size={ 38 } />
-								</ExternalLink>
-								{ shouldShowCart && <CloudCart /> }
-								<a
-									className="header__mobile-btn mobile-btn js-mobile-btn"
-									href="#mobile-menu"
-									aria-expanded="false"
-								>
-									<span className="mobile-btn__icon" aria-hidden="true">
-										<span className="mobile-btn__inner"></span>
-									</span>
-									<span className="mobile-btn__label">{ translate( 'Menu' ) }</span>
-								</a>
-								<div className="header__nav-wrapper js-mobile-menu" id="mobile-menu">
-									<ul className="header__sections-list js-nav-list">
-										{ sections.map( ( { label, id, href, items } ) => {
-											const hasChildren = Array.isArray( items );
-											const Tag = hasChildren ? 'a' : ExternalLink;
+			{ menuDataStatus === 'success' ? (
+				<div className="jpcom-masterbar">
+					<header className="header js-header force-opaque">
+						<div className="header__content-wrapper">
+							<div
+								className="header__content-background-wrapper-sentinal"
+								{ ...outerDivProps }
+							></div>
+							<div className={ classes }>
+								<nav className="header__content is-sticky">
+									<a className="header__skip" href={ `#${ MAIN_CONTENT_ID }` }>
+										{ translate( 'Skip to main content' ) }
+									</a>
+									<ExternalLink
+										className="header__home-link"
+										href={ localizeUrl( JETPACK_COM_BASE_URL, locale ) }
+										aria-label={ translate( 'Jetpack home' ) }
+										onClick={ () => recordTracksEvent( 'calypso_jetpack_nav_logo_click' ) }
+									>
+										<JetpackLogo full size={ 38 } />
+									</ExternalLink>
+									{ shouldShowCart && <CloudCart /> }
+									<a
+										className="header__mobile-btn mobile-btn js-mobile-btn"
+										href="#mobile-menu"
+										aria-expanded="false"
+									>
+										<span className="mobile-btn__icon" aria-hidden="true">
+											<span className="mobile-btn__inner"></span>
+										</span>
+										<span className="mobile-btn__label">{ translate( 'Menu' ) }</span>
+									</a>
+									<div className="header__nav-wrapper js-mobile-menu" id="mobile-menu">
+										<ul className="header__sections-list js-nav-list">
+											{ sections &&
+												sections.sort( sortByMenuOrder ).map( ( { label, id, href, items } ) => {
+													const hasChildren = Object.keys( items ).length > 0;
+													const Tag = hasChildren ? 'a' : ExternalLink;
 
-											return (
-												<li
-													className={ classNames( {
-														'is-active':
-															pathname &&
-															href &&
-															new URL( trailingslashit( href ) ).pathname ===
-																trailingslashit( pathname ),
-													} ) }
-													key={ href || id }
-												>
-													<Tag
-														className={ hasChildren ? 'header__menu-btn js-menu-btn' : '' }
-														href={ href ? localizeUrl( href, locale ) : `#${ id }` }
-														aria-expanded={ hasChildren ? false : undefined }
-														onClick={ href ? onLinkClick : undefined }
-													>
-														{ label }
-														{ hasChildren && <Gridicon icon="chevron-down" size={ 18 } /> }
-													</Tag>
-													{ hasChildren && (
-														<div id={ id } className="header__submenu js-menu" tabIndex={ -1 }>
-															<div className="header__submenu-content">
-																<button className="header__back-btn js-menu-back">
-																	<Gridicon icon="chevron-left" size={ 18 } />
-																	{ translate( 'Back' ) }
-																</button>
-																<ul className="header__submenu-categories-list">
-																	{ items.map( ( { label, tagline, href, items } ) => (
-																		<li key={ href }>
-																			<ExternalLink
-																				className="header__submenu-category header__submenu-link"
-																				href={ localizeUrl( href, locale ) }
-																				onClick={ onLinkClick }
-																			>
-																				<span className="header__submenu-label">
-																					<span className="header__submenu-chevron">
-																						<Gridicon icon="chevron-right" size={ 18 } />
-																					</span>
-																					{ label }
-																				</span>
-																				<span className="header__submenu-tagline">{ tagline }</span>
-																			</ExternalLink>
-																			<ul className="header__submenu-links-list">
-																				{ items.map( ( { label, tagline, href } ) => (
-																					<li key={ href }>
+													return (
+														<li
+															className={ classNames( {
+																'is-active':
+																	pathname &&
+																	href &&
+																	href !== '#' &&
+																	new URL( trailingslashit( href ) ).pathname ===
+																		trailingslashit( pathname ),
+															} ) }
+															key={ href || id }
+														>
+															<Tag
+																className={ hasChildren ? 'header__menu-btn js-menu-btn' : '' }
+																href={ href ? localizeUrl( href, locale ) : `#${ id }` }
+																aria-expanded={ hasChildren ? false : undefined }
+																onClick={ href ? onLinkClick : undefined }
+															>
+																{ label }
+																{ hasChildren && <Gridicon icon="chevron-down" size={ 18 } /> }
+															</Tag>
+															{ hasChildren && (
+																<div id={ id } className="header__submenu js-menu" tabIndex={ -1 }>
+																	<div className="header__submenu-content">
+																		<button className="header__back-btn js-menu-back">
+																			<Gridicon icon="chevron-left" size={ 18 } />
+																			{ translate( 'Back' ) }
+																		</button>
+																		<ul className="header__submenu-categories-list">
+																			{ Array.from( Object.values( items ) )
+																				.sort( sortByMenuOrder )
+																				.map( ( { label, tagline, href, items } ) => {
+																					return (
+																						<li key={ href }>
+																							<ExternalLink
+																								className="header__submenu-category header__submenu-link"
+																								href={ localizeUrl( href, locale ) }
+																								onClick={ onLinkClick }
+																							>
+																								<span className="header__submenu-label">
+																									<span className="header__submenu-chevron">
+																										<Gridicon icon="chevron-right" size={ 18 } />
+																									</span>
+																									{ label }
+																								</span>
+																								<span className="header__submenu-tagline">
+																									{ tagline }
+																								</span>
+																							</ExternalLink>
+																							<ul className="header__submenu-links-list">
+																								{ Array.from( Object.values( items ) )
+																									.sort( sortByMenuOrder )
+																									.map( ( { label, tagline, href } ) => (
+																										<li key={ href }>
+																											<ExternalLink
+																												className="header__submenu-link"
+																												href={ localizeUrl( href, locale ) }
+																												onClick={ onLinkClick }
+																											>
+																												<span className="header__submenu-label">
+																													{ label }
+																												</span>
+																												<span className="header__submenu-tagline">
+																													{ tagline }
+																												</span>
+																											</ExternalLink>
+																										</li>
+																									) ) }
+																							</ul>
+																						</li>
+																					);
+																				} ) }
+																		</ul>
+
+																		<hr className="header__submenu-section-separator" />
+
+																		<div className="header__submenu-bottom-section">
+																			<div className="header__submenu-bundles">
+																				<p className="header__submenu-category-heading">
+																					{ bundles?.label }
+																				</p>
+
+																				<ul className="header__submenu-links-list">
+																					{ bundles &&
+																						Array.from( Object.values( bundles.items ) )
+																							.sort( sortByMenuOrder )
+																							.map( ( { label, tagline, href } ) => (
+																								<li key={ `bundles-${ href }` }>
+																									<ExternalLink
+																										className="header__submenu-link"
+																										href={ localizeUrl( href, locale ) }
+																										onClick={ onLinkClick }
+																									>
+																										<span className="header__submenu-label">
+																											{ label }
+																										</span>
+																										<span className="header__submenu-tagline">
+																											{ tagline }
+																										</span>
+																									</ExternalLink>
+																								</li>
+																							) ) }
+																				</ul>
+																			</div>
+																			<div className="header__submenu-apps-wrapper">
+																				<p className="header__submenu-category-heading">
+																					{ appsLink.categoryLabel }
+																				</p>
+
+																				<ul className="header__submenu-links-list">
+																					<li>
 																						<ExternalLink
 																							className="header__submenu-link"
-																							href={ localizeUrl( href, locale ) }
+																							href={ localizeUrl( appsLink.href, locale ) }
 																							onClick={ onLinkClick }
 																						>
 																							<span className="header__submenu-label">
-																								{ label }
+																								{ appsLink.label }
 																							</span>
 																							<span className="header__submenu-tagline">
-																								{ tagline }
+																								{ appsLink.tagline }
 																							</span>
 																						</ExternalLink>
 																					</li>
-																				) ) }
-																			</ul>
-																		</li>
-																	) ) }
-																</ul>
-
-																<hr className="header__submenu-section-separator" />
-
-																<div className="header__submenu-bottom-section">
-																	<div className="header__submenu-bundles">
-																		<p className="header__submenu-category-heading">
-																			{ bundles.label }
-																		</p>
-
-																		<ul className="header__submenu-links-list">
-																			{ bundles.items.map( ( { label, tagline, href } ) => {
-																				return (
-																					<li key={ `bundles-${ href }` }>
-																						<ExternalLink
-																							className="header__submenu-link"
-																							href={ localizeUrl( href, locale ) }
-																							onClick={ onLinkClick }
-																						>
-																							<span className="header__submenu-label">
-																								{ label }
-																							</span>
-																							<span className="header__submenu-tagline">
-																								{ tagline }
-																							</span>
-																						</ExternalLink>
-																					</li>
-																				);
-																			} ) }
-																		</ul>
-																	</div>
-																	<div className="header__submenu-apps-wrapper">
-																		<p className="header__submenu-category-heading">
-																			{ appsLink.categoryLabel }
-																		</p>
-
-																		<ul className="header__submenu-links-list">
-																			<li>
-																				<ExternalLink
-																					className="header__submenu-link"
-																					href={ localizeUrl( appsLink.href, locale ) }
-																					onClick={ onLinkClick }
-																				>
-																					<span className="header__submenu-label">
-																						{ appsLink.label }
-																					</span>
-																					<span className="header__submenu-tagline">
-																						{ appsLink.tagline }
-																					</span>
-																				</ExternalLink>
-																			</li>
-																		</ul>
+																				</ul>
+																			</div>
+																		</div>
 																	</div>
 																</div>
+															) }
+														</li>
+													);
+												} ) }
+										</ul>
+										{ shouldShowCart && <CloudCart /> }
+										<ul className="header__actions-list">
+											<li
+												className={ classNames( 'header__user-menu user-menu ', {
+													'is-logged-in': isLoggedIn,
+												} ) }
+											>
+												{ isLoggedIn ? (
+													<>
+														<a className="user-menu__btn js-user-menu-btn" href="#profile">
+															<Gravatar user={ user } className="user-menu__avatar" />
+														</a>
+														<div id="profile" className="user-menu__tooltip js-user-menu">
+															<div className="tooltip">
+																<span className="user-menu__greetings">
+																	{ translate( 'Hi, %s!', {
+																		args: user?.display_name || user?.username,
+																	} ) }
+																</span>
+																<ul className="user-menu__list">
+																	<li>
+																		<a
+																			className="js-manage-sites"
+																			href={ localizeUrl( '/', locale ) }
+																		>
+																			{ translate( 'Manage your sites' ) }
+																		</a>
+																	</li>
+																</ul>
 															</div>
 														</div>
-													) }
-												</li>
-											);
-										} ) }
-									</ul>
-									{ shouldShowCart && <CloudCart /> }
-									<ul className="header__actions-list">
-										<li
-											className={ classNames( 'header__user-menu user-menu ', {
-												'is-logged-in': isLoggedIn,
-											} ) }
-										>
-											{ isLoggedIn ? (
-												<>
-													<a className="user-menu__btn js-user-menu-btn" href="#profile">
-														<Gravatar user={ user } className="user-menu__avatar" />
+													</>
+												) : (
+													<a
+														className="header__action-link js-login"
+														href={ localizeUrl( '/login/', locale ) }
+													>
+														{ translate( 'Log in' ) }
 													</a>
-													<div id="profile" className="user-menu__tooltip js-user-menu">
-														<div className="tooltip">
-															<span className="user-menu__greetings">
-																{ translate( 'Hi, %s!', {
-																	args: user?.display_name || user?.username,
-																} ) }
-															</span>
-															<ul className="user-menu__list">
-																<li>
-																	<a
-																		className="js-manage-sites"
-																		href={ localizeUrl( '/', locale ) }
-																	>
-																		{ translate( 'Manage your sites' ) }
-																	</a>
-																</li>
-															</ul>
-														</div>
-													</div>
-												</>
-											) : (
-												<a
-													className="header__action-link js-login"
-													href={ localizeUrl( '/login/', locale ) }
-												>
-													{ translate( 'Log in' ) }
-												</a>
-											) }
-										</li>
-									</ul>
-								</div>
-							</nav>
+												) }
+											</li>
+										</ul>
+									</div>
+								</nav>
+							</div>
 						</div>
-					</div>
-				</header>
-			</div>
+					</header>
+				</div>
+			) : (
+				<></>
+			) }
 		</>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -163,7 +163,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 										{ menuDataStatus === 'success' && sections ? (
 											sections.sort( sortByMenuOrder ).map( ( { label, id, href, items } ) => {
 												const hasChildren = Object.keys( items ).length > 0;
-												const Tag = hasChildren ? 'a' : ExternalLink;
+												const MainMenuTag = hasChildren ? 'a' : ExternalLink;
 
 												return (
 													<li
@@ -177,7 +177,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 														} ) }
 														key={ href || id }
 													>
-														<Tag
+														<MainMenuTag
 															className={ hasChildren ? 'header__menu-btn js-menu-btn' : '' }
 															href={
 																href && href !== '#' ? localizeUrl( href, locale ) : `#${ id }`
@@ -187,7 +187,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 														>
 															{ label }
 															{ hasChildren && <Gridicon icon="chevron-down" size={ 18 } /> }
-														</Tag>
+														</MainMenuTag>
 														{ hasChildren && (
 															<div id={ id } className="header__submenu js-menu" tabIndex={ -1 }>
 																<div className="header__submenu-content">

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -146,9 +146,11 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 													>
 														<Tag
 															className={ hasChildren ? 'header__menu-btn js-menu-btn' : '' }
-															href={ href ? localizeUrl( href, locale ) : `#${ id }` }
+															href={
+																href && href !== '#' ? localizeUrl( href, locale ) : `#${ id }`
+															}
 															aria-expanded={ hasChildren ? false : undefined }
-															onClick={ href ? onLinkClick : undefined }
+															onClick={ href && href !== '#' ? onLinkClick : undefined }
 														>
 															{ label }
 															{ hasChildren && <Gridicon icon="chevron-down" size={ 18 } /> }

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -97,236 +97,232 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 		<>
 			{ jetpackSaleCoupon && <JetpackSaleBanner coupon={ jetpackSaleCoupon } /> }
 
-			{ menuDataStatus === 'success' ? (
-				<div className="jpcom-masterbar">
-					<header className="header js-header force-opaque">
-						<div className="header__content-wrapper">
-							<div
-								className="header__content-background-wrapper-sentinal"
-								{ ...outerDivProps }
-							></div>
-							<div className={ classes }>
-								<nav className="header__content is-sticky">
-									<a className="header__skip" href={ `#${ MAIN_CONTENT_ID }` }>
-										{ translate( 'Skip to main content' ) }
-									</a>
-									<ExternalLink
-										className="header__home-link"
-										href={ localizeUrl( JETPACK_COM_BASE_URL, locale ) }
-										aria-label={ translate( 'Jetpack home' ) }
-										onClick={ () => recordTracksEvent( 'calypso_jetpack_nav_logo_click' ) }
-									>
-										<JetpackLogo full size={ 38 } />
-									</ExternalLink>
-									{ shouldShowCart && <CloudCart /> }
-									<a
-										className="header__mobile-btn mobile-btn js-mobile-btn"
-										href="#mobile-menu"
-										aria-expanded="false"
-									>
-										<span className="mobile-btn__icon" aria-hidden="true">
-											<span className="mobile-btn__inner"></span>
-										</span>
-										<span className="mobile-btn__label">{ translate( 'Menu' ) }</span>
-									</a>
-									<div className="header__nav-wrapper js-mobile-menu" id="mobile-menu">
-										<ul className="header__sections-list js-nav-list">
-											{ sections &&
-												sections.sort( sortByMenuOrder ).map( ( { label, id, href, items } ) => {
-													const hasChildren = Object.keys( items ).length > 0;
-													const Tag = hasChildren ? 'a' : ExternalLink;
+			<div className="jpcom-masterbar">
+				<header className="header js-header force-opaque">
+					<div className="header__content-wrapper">
+						<div className="header__content-background-wrapper-sentinal" { ...outerDivProps }></div>
+						<div className={ classes }>
+							<nav className="header__content is-sticky">
+								<a className="header__skip" href={ `#${ MAIN_CONTENT_ID }` }>
+									{ translate( 'Skip to main content' ) }
+								</a>
+								<ExternalLink
+									className="header__home-link"
+									href={ localizeUrl( JETPACK_COM_BASE_URL, locale ) }
+									aria-label={ translate( 'Jetpack home' ) }
+									onClick={ () => recordTracksEvent( 'calypso_jetpack_nav_logo_click' ) }
+								>
+									<JetpackLogo full size={ 38 } />
+								</ExternalLink>
+								{ shouldShowCart && <CloudCart /> }
+								<a
+									className="header__mobile-btn mobile-btn js-mobile-btn"
+									href="#mobile-menu"
+									aria-expanded="false"
+								>
+									<span className="mobile-btn__icon" aria-hidden="true">
+										<span className="mobile-btn__inner"></span>
+									</span>
+									<span className="mobile-btn__label">{ translate( 'Menu' ) }</span>
+								</a>
+								<div className="header__nav-wrapper js-mobile-menu" id="mobile-menu">
+									<ul className="header__sections-list js-nav-list">
+										{ menuDataStatus === 'success' && sections ? (
+											sections.sort( sortByMenuOrder ).map( ( { label, id, href, items } ) => {
+												const hasChildren = Object.keys( items ).length > 0;
+												const Tag = hasChildren ? 'a' : ExternalLink;
 
-													return (
-														<li
-															className={ classNames( {
-																'is-active':
-																	pathname &&
-																	href &&
-																	href !== '#' &&
-																	new URL( trailingslashit( href ) ).pathname ===
-																		trailingslashit( pathname ),
-															} ) }
-															key={ href || id }
+												return (
+													<li
+														className={ classNames( {
+															'is-active':
+																pathname &&
+																href &&
+																href !== '#' &&
+																new URL( trailingslashit( href ) ).pathname ===
+																	trailingslashit( pathname ),
+														} ) }
+														key={ href || id }
+													>
+														<Tag
+															className={ hasChildren ? 'header__menu-btn js-menu-btn' : '' }
+															href={ href ? localizeUrl( href, locale ) : `#${ id }` }
+															aria-expanded={ hasChildren ? false : undefined }
+															onClick={ href ? onLinkClick : undefined }
 														>
-															<Tag
-																className={ hasChildren ? 'header__menu-btn js-menu-btn' : '' }
-																href={ href ? localizeUrl( href, locale ) : `#${ id }` }
-																aria-expanded={ hasChildren ? false : undefined }
-																onClick={ href ? onLinkClick : undefined }
-															>
-																{ label }
-																{ hasChildren && <Gridicon icon="chevron-down" size={ 18 } /> }
-															</Tag>
-															{ hasChildren && (
-																<div id={ id } className="header__submenu js-menu" tabIndex={ -1 }>
-																	<div className="header__submenu-content">
-																		<button className="header__back-btn js-menu-back">
-																			<Gridicon icon="chevron-left" size={ 18 } />
-																			{ translate( 'Back' ) }
-																		</button>
-																		<ul className="header__submenu-categories-list">
-																			{ Array.from( Object.values( items ) )
-																				.sort( sortByMenuOrder )
-																				.map( ( { label, tagline, href, items } ) => {
-																					return (
-																						<li key={ href }>
-																							<ExternalLink
-																								className="header__submenu-category header__submenu-link"
-																								href={ localizeUrl( href, locale ) }
-																								onClick={ onLinkClick }
-																							>
-																								<span className="header__submenu-label">
-																									<span className="header__submenu-chevron">
-																										<Gridicon icon="chevron-right" size={ 18 } />
-																									</span>
-																									{ label }
-																								</span>
-																								{ tagline && (
-																									<span className="header__submenu-tagline">
-																										{ tagline }
-																									</span>
-																								) }
-																							</ExternalLink>
-																							<ul className="header__submenu-links-list">
-																								{ Array.from( Object.values( items ) )
-																									.sort( sortByMenuOrder )
-																									.map( ( { label, tagline, href } ) => (
-																										<li key={ href }>
-																											<ExternalLink
-																												className="header__submenu-link"
-																												href={ localizeUrl( href, locale ) }
-																												onClick={ onLinkClick }
-																											>
-																												<span className="header__submenu-label">
-																													{ label }
-																												</span>
-																												{ tagline && (
-																													<span className="header__submenu-tagline">
-																														{ tagline }
-																													</span>
-																												) }
-																											</ExternalLink>
-																										</li>
-																									) ) }
-																							</ul>
-																						</li>
-																					);
-																				} ) }
-																		</ul>
-
-																		<hr className="header__submenu-section-separator" />
-
-																		<div className="header__submenu-bottom-section">
-																			<div className="header__submenu-bundles">
-																				<p className="header__submenu-category-heading">
-																					{ bundles?.label }
-																				</p>
-
-																				<ul className="header__submenu-links-list">
-																					{ bundles &&
-																						Array.from( Object.values( bundles.items ) )
-																							.sort( sortByMenuOrder )
-																							.map( ( { label, tagline, href } ) => (
-																								<li key={ `bundles-${ href }` }>
-																									<ExternalLink
-																										className="header__submenu-link"
-																										href={ localizeUrl( href, locale ) }
-																										onClick={ onLinkClick }
-																									>
-																										<span className="header__submenu-label">
-																											{ label }
-																										</span>
-																										{ tagline && (
-																											<span className="header__submenu-tagline">
-																												{ tagline }
-																											</span>
-																										) }
-																									</ExternalLink>
-																								</li>
-																							) ) }
-																				</ul>
-																			</div>
-																			<div className="header__submenu-apps-wrapper">
-																				<p className="header__submenu-category-heading">
-																					{ appsLink.categoryLabel }
-																				</p>
-
-																				<ul className="header__submenu-links-list">
-																					<li>
+															{ label }
+															{ hasChildren && <Gridicon icon="chevron-down" size={ 18 } /> }
+														</Tag>
+														{ hasChildren && (
+															<div id={ id } className="header__submenu js-menu" tabIndex={ -1 }>
+																<div className="header__submenu-content">
+																	<button className="header__back-btn js-menu-back">
+																		<Gridicon icon="chevron-left" size={ 18 } />
+																		{ translate( 'Back' ) }
+																	</button>
+																	<ul className="header__submenu-categories-list">
+																		{ Array.from( Object.values( items ) )
+																			.sort( sortByMenuOrder )
+																			.map( ( { label, tagline, href, items } ) => {
+																				return (
+																					<li key={ href }>
 																						<ExternalLink
-																							className="header__submenu-link"
-																							href={ localizeUrl( appsLink.href, locale ) }
+																							className="header__submenu-category header__submenu-link"
+																							href={ localizeUrl( href, locale ) }
 																							onClick={ onLinkClick }
 																						>
 																							<span className="header__submenu-label">
-																								{ appsLink.label }
+																								<span className="header__submenu-chevron">
+																									<Gridicon icon="chevron-right" size={ 18 } />
+																								</span>
+																								{ label }
 																							</span>
-																							<span className="header__submenu-tagline">
-																								{ appsLink.tagline }
-																							</span>
+																							{ tagline && (
+																								<span className="header__submenu-tagline">
+																									{ tagline }
+																								</span>
+																							) }
 																						</ExternalLink>
+																						<ul className="header__submenu-links-list">
+																							{ Array.from( Object.values( items ) )
+																								.sort( sortByMenuOrder )
+																								.map( ( { label, tagline, href } ) => (
+																									<li key={ href }>
+																										<ExternalLink
+																											className="header__submenu-link"
+																											href={ localizeUrl( href, locale ) }
+																											onClick={ onLinkClick }
+																										>
+																											<span className="header__submenu-label">
+																												{ label }
+																											</span>
+																											{ tagline && (
+																												<span className="header__submenu-tagline">
+																													{ tagline }
+																												</span>
+																											) }
+																										</ExternalLink>
+																									</li>
+																								) ) }
+																						</ul>
 																					</li>
-																				</ul>
-																			</div>
+																				);
+																			} ) }
+																	</ul>
+
+																	<hr className="header__submenu-section-separator" />
+
+																	<div className="header__submenu-bottom-section">
+																		<div className="header__submenu-bundles">
+																			<p className="header__submenu-category-heading">
+																				{ bundles?.label }
+																			</p>
+
+																			<ul className="header__submenu-links-list">
+																				{ bundles &&
+																					Array.from( Object.values( bundles.items ) )
+																						.sort( sortByMenuOrder )
+																						.map( ( { label, tagline, href } ) => (
+																							<li key={ `bundles-${ href }` }>
+																								<ExternalLink
+																									className="header__submenu-link"
+																									href={ localizeUrl( href, locale ) }
+																									onClick={ onLinkClick }
+																								>
+																									<span className="header__submenu-label">
+																										{ label }
+																									</span>
+																									{ tagline && (
+																										<span className="header__submenu-tagline">
+																											{ tagline }
+																										</span>
+																									) }
+																								</ExternalLink>
+																							</li>
+																						) ) }
+																			</ul>
+																		</div>
+																		<div className="header__submenu-apps-wrapper">
+																			<p className="header__submenu-category-heading">
+																				{ appsLink.categoryLabel }
+																			</p>
+
+																			<ul className="header__submenu-links-list">
+																				<li>
+																					<ExternalLink
+																						className="header__submenu-link"
+																						href={ localizeUrl( appsLink.href, locale ) }
+																						onClick={ onLinkClick }
+																					>
+																						<span className="header__submenu-label">
+																							{ appsLink.label }
+																						</span>
+																						<span className="header__submenu-tagline">
+																							{ appsLink.tagline }
+																						</span>
+																					</ExternalLink>
+																				</li>
+																			</ul>
 																		</div>
 																	</div>
 																</div>
-															) }
-														</li>
-													);
-												} ) }
-										</ul>
-										{ shouldShowCart && <CloudCart /> }
-										<ul className="header__actions-list">
-											<li
-												className={ classNames( 'header__user-menu user-menu ', {
-													'is-logged-in': isLoggedIn,
-												} ) }
-											>
-												{ isLoggedIn ? (
-													<>
-														<a className="user-menu__btn js-user-menu-btn" href="#profile">
-															<Gravatar user={ user } className="user-menu__avatar" />
-														</a>
-														<div id="profile" className="user-menu__tooltip js-user-menu">
-															<div className="tooltip">
-																<span className="user-menu__greetings">
-																	{ translate( 'Hi, %s!', {
-																		args: user?.display_name || user?.username,
-																	} ) }
-																</span>
-																<ul className="user-menu__list">
-																	<li>
-																		<a
-																			className="js-manage-sites"
-																			href={ localizeUrl( '/', locale ) }
-																		>
-																			{ translate( 'Manage your sites' ) }
-																		</a>
-																	</li>
-																</ul>
 															</div>
-														</div>
-													</>
-												) : (
-													<a
-														className="header__action-link js-login"
-														href={ localizeUrl( '/login/', locale ) }
-													>
-														{ translate( 'Log in' ) }
+														) }
+													</li>
+												);
+											} )
+										) : (
+											<></>
+										) }
+									</ul>
+									{ shouldShowCart && <CloudCart /> }
+									<ul className="header__actions-list">
+										<li
+											className={ classNames( 'header__user-menu user-menu ', {
+												'is-logged-in': isLoggedIn,
+											} ) }
+										>
+											{ isLoggedIn ? (
+												<>
+													<a className="user-menu__btn js-user-menu-btn" href="#profile">
+														<Gravatar user={ user } className="user-menu__avatar" />
 													</a>
-												) }
-											</li>
-										</ul>
-									</div>
-								</nav>
-							</div>
+													<div id="profile" className="user-menu__tooltip js-user-menu">
+														<div className="tooltip">
+															<span className="user-menu__greetings">
+																{ translate( 'Hi, %s!', {
+																	args: user?.display_name || user?.username,
+																} ) }
+															</span>
+															<ul className="user-menu__list">
+																<li>
+																	<a
+																		className="js-manage-sites"
+																		href={ localizeUrl( '/', locale ) }
+																	>
+																		{ translate( 'Manage your sites' ) }
+																	</a>
+																</li>
+															</ul>
+														</div>
+													</div>
+												</>
+											) : (
+												<a
+													className="header__action-link js-login"
+													href={ localizeUrl( '/login/', locale ) }
+												>
+													{ translate( 'Log in' ) }
+												</a>
+											) }
+										</li>
+									</ul>
+								</div>
+							</nav>
 						</div>
-					</header>
-				</div>
-			) : (
-				<></>
-			) }
+					</div>
+				</header>
+			</div>
 		</>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -992,6 +992,7 @@
 		background-color: transparent;
 		border: none;
 		font-size: 1rem;
+		cursor: pointer;
 	}
 	.header__back-btn:focus-visible {
 		border-radius: 2px;

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/use-submenu-btn.js
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/use-submenu-btn.js
@@ -4,6 +4,11 @@ import { getLastFocusableElement } from 'calypso/lib/dom/focus';
 /*
  * WARNING: script below is directly ported from
  * https://opengrok.a8c.com/source/xref/a8c/jetpackme-new/js/header.js
+ *
+ * A portion of this script has been ported to React to avoid an issue
+ * where the menu buttons were getting multiple event listeners attached.
+ *
+ * This entire script should probably be ported over eventually.
  */
 export default function useSubmenuBtn() {
 	useEffect( () => {

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/use-submenu-btn.js
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/use-submenu-btn.js
@@ -40,16 +40,6 @@ export default function useSubmenuBtn() {
 				toggleMenuItem( btn, menu );
 			};
 
-			btn.addEventListener( 'click', function ( e ) {
-				e.preventDefault();
-
-				if ( btn.getAttribute( 'aria-expanded' ) === 'false' ) {
-					collapseExpandedMenu();
-				}
-
-				toggle();
-			} );
-
 			menu.addEventListener( 'click', function ( e ) {
 				// If user clicks menu backdrop
 				if ( e.target === menu ) {


### PR DESCRIPTION
Related: https://github.com/Automattic/jetpack-roadmap/issues/99

## Proposed Changes

* There is a new API endpoint to query the Jetpack masterbar data
* This PR updates the masterbar to pull data from that API instead of having it set in a static array
* This also makes the tagline conditionally render because we will be removing them in the redesign

## Testing Instructions

1. Click on the Calypso live link and go to `/pricing`
2. In the network tab, make sure the `wpcom/v2/jetpack-marketing/jetpack-menu` is being called and the data is returned successfully
![image](https://github.com/Automattic/wp-calypso/assets/65001528/1dcd15d7-f0e5-4b7a-ad60-cd3fae390376)
3. Test out the menu to make sure it works exactly as it did before, there should be no differences between the previous version and this one
![image](https://github.com/Automattic/wp-calypso/assets/65001528/a508b47b-93ac-49c8-8e34-133b1fd1ff94)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
