### PR TITLE
Importers: add file-too-large error and tracking

### DIFF
--- a/client/blocks/importer/wordpress/types.ts
+++ b/client/blocks/importer/wordpress/types.ts
@@ -16,3 +16,7 @@ export enum MigrationStatus {
 export enum WPImportError {
 	WPRESS_FILE_IS_NOT_SUPPORTED = 'wpress-file-is-not-supported',
 }
+
+export enum FileTooLarge {
+	FILE_TOO_LARGE = 'file-too-large',
+}

--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -3,7 +3,7 @@ import { localize } from 'i18n-calypso';
 import Page from 'page';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
-import { WPImportError } from 'calypso/blocks/importer/wordpress/types';
+import { WPImportError, FileTooLarge } from 'calypso/blocks/importer/wordpress/types';
 import Notice from 'calypso/components/notice';
 import { addQueryArgs } from 'calypso/lib/route';
 
@@ -91,6 +91,17 @@ class ImporterError extends PureComponent {
 						ei: (
 							<Button className="importer__error-pane is-link" onClick={ this.everythingImport } />
 						),
+						cs: <Button className="importer__error-pane is-link" onClick={ this.contactSupport } />,
+					},
+				}
+			);
+		}
+
+		if ( this.props.code === FileTooLarge.FILE_TOO_LARGE ) {
+			return this.props.translate(
+				'The file you are importing is too large. {{cs}}Please contact support to continue{{/cs}}.',
+				{
+					components: {
 						cs: <Button className="importer__error-pane is-link" onClick={ this.contactSupport } />,
 					},
 				}

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -95,7 +95,17 @@ class SectionImport extends Component {
 	handleStateChanges = () => {
 		this.props.siteImports.map( ( importItem ) => {
 			const { importerState, type: importerId } = importItem;
-			this.trackImporterStateChange( importerState, importerId );
+			let eventProps = {};
+
+			// Log more info about upload failures
+			if ( importerState === appStates.UPLOAD_FAILURE ) {
+				eventProps = {
+					error_code: importItem.errorData.code,
+					error_type: importItem.errorData.type,
+				};
+			}
+
+			this.trackImporterStateChange( importerState, importerId, eventProps );
 		} );
 	};
 
@@ -105,7 +115,7 @@ class SectionImport extends Component {
 			.forEach( ( x ) => this.props.cancelImport( x.site.ID, x.importerId ) );
 	};
 
-	trackImporterStateChange = memoizeLast( ( importerState, importerId ) => {
+	trackImporterStateChange = memoizeLast( ( importerState, importerId, eventProps = {} ) => {
 		const stateToEventNameMap = {
 			[ appStates.READY_FOR_UPLOAD ]: 'calypso_importer_view',
 			[ appStates.UPLOADING ]: 'calypso_importer_upload_start',
@@ -119,6 +129,7 @@ class SectionImport extends Component {
 		if ( stateToEventNameMap[ importerState ] ) {
 			this.props.recordTracksEvent( stateToEventNameMap[ importerState ], {
 				importer_id: importerId,
+				...eventProps,
 			} );
 		}
 	} );

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -5,7 +5,7 @@ import { truncate } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { WPImportError } from 'calypso/blocks/importer/wordpress/types';
+import { WPImportError, FileTooLarge } from 'calypso/blocks/importer/wordpress/types';
 import DropZone from 'calypso/components/drop-zone';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -14,7 +14,7 @@ import ImporterActionButton from 'calypso/my-sites/importer/importer-action-butt
 import ImporterCloseButton from 'calypso/my-sites/importer/importer-action-buttons/close-button';
 import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-action-buttons/container';
 import { startMappingAuthors, startUpload, failPreUpload } from 'calypso/state/imports/actions';
-import { appStates } from 'calypso/state/imports/constants';
+import { appStates, MAX_FILE_SIZE } from 'calypso/state/imports/constants';
 import {
 	getUploadFilename,
 	getUploadPercentComplete,
@@ -141,6 +141,12 @@ export class UploadingPane extends PureComponent {
 				'',
 				WPImportError.WPRESS_FILE_IS_NOT_SUPPORTED
 			);
+			return;
+		}
+
+		// Fail fast if a user tries to upload a too big file
+		if ( file.size > MAX_FILE_SIZE ) {
+			this.props.failPreUpload( importerStatus.importerId, '', FileTooLarge.FILE_TOO_LARGE );
 			return;
 		}
 

--- a/client/state/imports/constants.js
+++ b/client/state/imports/constants.js
@@ -17,4 +17,4 @@ export const appStates = Object.freeze( {
 	IMPORT_CLEAR: 'importer-clear',
 } );
 
-export const MAX_FILE_SIZE = 100000; // 100mb
+export const MAX_FILE_SIZE = 104857000; // In bytes. The file limit is 100mb, but we leave 600 bytes for headers and other meta that are sent.

--- a/client/state/imports/constants.js
+++ b/client/state/imports/constants.js
@@ -16,3 +16,5 @@ export const appStates = Object.freeze( {
 	UPLOADING: 'importer-uploading',
 	IMPORT_CLEAR: 'importer-clear',
 } );
+
+export const MAX_FILE_SIZE = 100000; // 100mb


### PR DESCRIPTION


## Proposed Changes

* Check filesize in clientside before attempting to upload, so that we don't waste time if the file is too large anyway.
* Fail with clear error message and next step.
* Add props to tracks event for all upload failures, so that we can see more what's going on.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try upload too big `.zip` file, try different importers.
* Note error

    <img width="779" alt="Screenshot 2023-08-04 at 22 48 22" src="https://github.com/Automattic/wp-calypso/assets/87168/94ff77f6-7237-4c2b-9e34-7beecefb021e">

* Note tracks event (you can debug tracks e.g. by typing `localStorage.debug="calypso:analytics"` in console and refreshing.

    <img width="753" alt="Screenshot 2023-08-04 at 22 47 14" src="https://github.com/Automattic/wp-calypso/assets/87168/c2c8c9e7-8764-494d-9af5-c5ffd1549ac3">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
