### PR TITLE
BackupBrowser: Layout header for Granular download/restore

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
@@ -36,12 +36,7 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
 		<div className="file-browser-header">
 			{ ! showCheckboxes && (
 				<div className="file-browser-header__select">
-					<Button
-						className="file-browser-header__select-button"
-						onClick={ onSelectClick }
-						secondary
-						compact
-					>
+					<Button className="file-browser-header__select-button" onClick={ onSelectClick } compact>
 						{ translate( 'Select' ) }
 					</Button>
 					<div className="file-browser-header__select-info">
@@ -63,7 +58,6 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
 					<Button
 						className="file-browser-header__download-button"
 						onClick={ onDownloadClick }
-						secondary
 						compact
 						disabled={ currentlySelected === 0 }
 					>
@@ -72,7 +66,7 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
 					<Button
 						className="file-browser-header__restore-button"
 						onClick={ onRestoreClick }
-						secondary
+						primary
 						compact
 						disabled={ currentlySelected === 0 }
 					>

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
@@ -1,16 +1,22 @@
-import { Button } from '@wordpress/components';
-import { close } from '@wordpress/icons';
+import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
+import BulkSelect from 'calypso/components/bulk-select';
 
 interface FileBrowserHeaderProps {
 	setShowCheckboxes: ( enabled: boolean ) => void;
 	showCheckboxes: boolean;
+	currentlySelected: number;
+	totalElements: number;
+	onToggleAll: ( checkedState?: boolean ) => void;
 }
 
 const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
 	setShowCheckboxes,
 	showCheckboxes,
+	currentlySelected,
+	totalElements,
+	onToggleAll,
 } ) => {
 	const translate = useTranslate();
 	const onSelectClick = () => {
@@ -19,25 +25,68 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
 	const onCancelClick = () => {
 		setShowCheckboxes( false );
 	};
+	const onDownloadClick = () => {
+		alert( 'Not yet implemented' );
+	};
+	const onRestoreClick = () => {
+		alert( 'Not yet implemented' );
+	};
 
 	return (
 		<div className="file-browser-header">
 			{ ! showCheckboxes && (
-				<Button
-					className="file-browser-header__select-button"
-					onClick={ onSelectClick }
-					variant="secondary"
-				>
-					{ translate( 'Select' ) }
-				</Button>
+				<div className="file-browser-header__select">
+					<Button
+						className="file-browser-header__select-button"
+						onClick={ onSelectClick }
+						secondary
+						compact
+					>
+						{ translate( 'Select' ) }
+					</Button>
+					<div className="file-browser-header__select-info">
+						{ translate( 'Select individual files to restore or download' ) }
+					</div>
+				</div>
 			) }
 			{ showCheckboxes && (
-				<Button
-					className="file-browser-header__cancel-button"
-					icon={ close }
-					onClick={ onCancelClick }
-					variant="secondary"
-				/>
+				<div className="file-browser-header__selecting">
+					<BulkSelect
+						className="file-browser-header__bulk-select"
+						totalElements={ totalElements }
+						selectedElements={ currentlySelected }
+						onToggle={ onToggleAll }
+					/>
+					<div className="file-browser-header__selecting-info">
+						{ translate( 'files selected' ) }
+					</div>
+					<Button
+						className="file-browser-header__download-button"
+						onClick={ onDownloadClick }
+						secondary
+						compact
+						disabled={ currentlySelected === 0 }
+					>
+						{ translate( 'Download files' ) }
+					</Button>
+					<Button
+						className="file-browser-header__restore-button"
+						onClick={ onRestoreClick }
+						secondary
+						compact
+						disabled={ currentlySelected === 0 }
+					>
+						{ translate( 'Restore files' ) }
+					</Button>
+					<Button
+						className="file-browser-header__cancel-button"
+						onClick={ onCancelClick }
+						borderless
+						compact
+					>
+						<Gridicon icon="cross" />
+					</Button>
+				</div>
 			) }
 		</div>
 	);

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
@@ -1,4 +1,6 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
+import { Icon } from '@wordpress/components';
+import { close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import BulkSelect from 'calypso/components/bulk-select';
@@ -78,7 +80,7 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
 						borderless
 						compact
 					>
-						<Gridicon icon="cross" />
+						<Icon icon={ close } />
 					</Button>
 				</div>
 			) }

--- a/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
@@ -17,7 +17,7 @@ const FileBrowser: FunctionComponent< FileBrowserProps > = ( { siteId, rewindId 
 	// Temporary values and logic for laying out header
 	const [ currentlySelected, setCurrentlySelected ] = useState< number >( 0 );
 	const totalElements = 10;
-	const onToggleAll = ( checkedState ) => {
+	const onToggleAll = ( checkedState?: boolean ) => {
 		if ( checkedState ) {
 			setCurrentlySelected( totalElements );
 		} else {

--- a/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
@@ -14,6 +14,17 @@ const FileBrowser: FunctionComponent< FileBrowserProps > = ( { siteId, rewindId 
 	const [ activeNodePath, setActiveNodePath ] = useState< string >( '' );
 	const [ showCheckboxes, setShowCheckboxes ] = useState< boolean >( false );
 
+	// Temporary values and logic for laying out header
+	const [ currentlySelected, setCurrentlySelected ] = useState< number >( 0 );
+	const totalElements = 10;
+	const onToggleAll = ( checkedState ) => {
+		if ( checkedState ) {
+			setCurrentlySelected( totalElements );
+		} else {
+			setCurrentlySelected( 0 );
+		}
+	};
+
 	const handleClick = ( path: string ) => {
 		setActiveNodePath( path );
 	};
@@ -32,6 +43,9 @@ const FileBrowser: FunctionComponent< FileBrowserProps > = ( { siteId, rewindId 
 				<FileBrowserHeader
 					showCheckboxes={ showCheckboxes }
 					setShowCheckboxes={ setShowCheckboxes }
+					currentlySelected={ currentlySelected }
+					totalElements={ totalElements }
+					onToggleAll={ onToggleAll }
 				/>
 			) }
 			<FileBrowserNode

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -223,6 +223,9 @@
 				font-size: $font-body-extra-small;
 				padding: 6px 0;
 			}
+			.file-browser-header__cancel-button {
+				padding: 0;
+			}
 			.button {
 				margin-left: 8px;
 				color: #000;

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -226,6 +226,12 @@
 			.button {
 				margin-left: 8px;
 				color: #000;
+				&.is-primary {
+					&:disabled {
+						color: #000;
+					}
+					color: #fff;
+				}
 			}
 		}
 	}

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -38,7 +38,6 @@
 	&__body {
 		border-top: 1px solid var(--studio-gray-5);
 		overflow-x: auto;
-		padding-top: 30px;
 		padding-bottom: 14px;
 	}
 
@@ -49,6 +48,7 @@
 
 		&.is-root {
 			margin-left: 0;
+			padding-top: 30px;
 		}
 
 		&.wordpress > .file-card .file-card__actions {
@@ -193,6 +193,40 @@
 	}
 
 	.file-browser-header {
-		text-align: end;
+		padding: 13px 0;
+		.file-browser-header__select {
+			display: flex;
+			justify-content: space-between;
+
+			.file-browser-header__select-button {
+				color: #000;
+			}
+
+			.file-browser-header__select-info {
+				margin: auto 0;
+				font-size: $font-body-extra-small;
+			}
+		}
+		.file-browser-header__selecting {
+			display: flex;
+
+			.bulk-select {
+				padding: 6px 0;
+			}
+			.count {
+				border: none;
+				font-weight: 400;
+				padding-top: 2px;
+			}
+			.file-browser-header__selecting-info {
+				flex-grow: 1;
+				font-size: $font-body-extra-small;
+				padding: 6px 0;
+			}
+			.button {
+				margin-left: 8px;
+				color: #000;
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Layout for the granular restore / download header
* Adds a BulkSelect box, which we may be able to utilize but may need to change based on how it works with the final item selection logic.

## Known Issues
* This doesn't disable the buttons in the Backup Status card above the header, which means when files are selected we'll have two primary buttons.  That update will come in another PR.
* The logic for the toggle all select button is temporary just to be able to validate the UI interactions
* The download buttons throw an alert as they are not yet implemented

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load up the backup browser for any site and backup.
* If using a live branch, append `flags=jetpack/backup-granular` to the url to enable the feature
* Ensure the header matches the i1 designs for Granular Restores  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
