### PR TITLE
Jetpack Licensing: Fix WooCommerce min/max quantities description

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
@@ -203,7 +203,7 @@ export function useProductDescription( productSlug: string ): {
 					'Offer add-ons like gift wrapping, special messages, or other special options for your products.'
 				);
 				break;
-			case 'woocommerce-product-minxmax-quantities':
+			case 'woocommerce-minmax-quantities':
 				description = translate(
 					'Minimum and maximum quantity rules for products, orders, and categories.'
 				);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix WooCommerce Min/Max Quantities description not rendering on license issuing page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With an account with billing scheme 871;
* Go to https://jetpack.cloud.localhost:3000/partner-portal/issue-license
* You should see the product description

## Screenshots

|  Before | After  | 
|---|---|
|  ![image](https://github.com/Automattic/wp-calypso/assets/5550190/1c5c0735-6fbd-40ab-b012-1943d351107b) |  ![image](https://github.com/Automattic/wp-calypso/assets/5550190/d5da1135-8bcb-44e3-8b6f-403044717e58) | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
