### PR TITLE
Checkout: Remove CheckoutStepGroup step number hash in URL

### DIFF
--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -352,9 +352,6 @@ function CheckoutStepGroupWrapper( {
 		} );
 	}, [ store ] );
 
-	// Change the step if the url changes
-	useChangeStepNumberForUrl( store.actions.setActiveStepNumber );
-
 	// WordPress.com checkout session activity.
 	const classNames = joinClasses( [
 		'composite-checkout',
@@ -432,7 +429,6 @@ export const CheckoutStep = ( {
 				paymentMethodId: activePaymentMethod?.id ?? '',
 			} );
 			if ( nextStepNumber ) {
-				saveStepNumberToUrl( nextStepNumber );
 				setActiveStepNumber( nextStepNumber );
 			}
 		}
@@ -1039,77 +1035,6 @@ Stepper.propTypes = {
 	isComplete: PropTypes.bool,
 	isActive: PropTypes.bool,
 };
-
-function saveStepNumberToUrl( stepNumber: number ) {
-	if ( ! window?.history || ! window?.location ) {
-		return;
-	}
-	const newHash = stepNumber > 1 ? `#step${ stepNumber }` : '';
-	if ( window.location.hash === newHash ) {
-		return;
-	}
-	const newUrl = window.location.hash
-		? window.location.href.replace( window.location.hash, newHash )
-		: window.location.href + newHash;
-	debug( 'updating url to', newUrl );
-	// We've seen this call to replaceState fail sometimes when the current URL
-	// is somehow different ("A history state object with URL
-	// 'https://wordpress.com/checkout/example.com#step2' cannot be created
-	// in a document with origin 'https://wordpress.com' and URL
-	// 'https://www.username@wordpress.com/checkout/example.com'.") so we
-	// wrap this in try/catch. It's not critical that the step number is saved to
-	// the URL.
-	try {
-		window.history.replaceState( null, '', newUrl );
-	} catch ( error ) {
-		debug( 'changing the url failed' );
-		return;
-	}
-	// Modifying history does not trigger a hashchange event which is what
-	// composite-checkout uses to change its current step, so we must fire one
-	// manually.
-	//
-	// We use try/catch because we support IE11 and that browser does not include
-	// HashChange.
-	try {
-		const event = new HashChangeEvent( 'hashchange' );
-		window.dispatchEvent( event );
-	} catch ( error ) {
-		debug( 'hashchange firing failed' );
-	}
-}
-
-function getStepNumberFromUrl() {
-	const hashValue = window.location?.hash;
-	if ( hashValue?.startsWith?.( '#step' ) ) {
-		const parts = hashValue.split( '#step' );
-		const stepNumber = parts.length > 1 ? parts[ 1 ] : '1';
-		return parseInt( stepNumber, 10 );
-	}
-	return 1;
-}
-
-function useChangeStepNumberForUrl( setActiveStepNumber: ( stepNumber: number ) => void ) {
-	// If there is a step number on page load, remove it
-	useEffect( () => {
-		const newStepNumber = getStepNumberFromUrl();
-		if ( newStepNumber ) {
-			saveStepNumberToUrl( 1 );
-		}
-	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
-
-	useEffect( () => {
-		let isSubscribed = true;
-		window.addEventListener?.( 'hashchange', () => {
-			const newStepNumber = getStepNumberFromUrl();
-			debug( 'step number in url changed to', newStepNumber );
-			isSubscribed && setActiveStepNumber( newStepNumber );
-		} );
-		return () => {
-			isSubscribed = false;
-		};
-	}, [ setActiveStepNumber ] );
-}
 
 export function CheckoutStepGroup( {
 	children,


### PR DESCRIPTION
When we first implemented the rebuilt checkout experience, the idea was that the components provided by the `@automattic/composite-checkout` package would take care of all aspects of the checkout form and flow with very few customizations. However, it soon became clear that this was not possible and over the years the package has been refactored to be a set of more general purpose building blocks.

One of these blocks is the multi-step form provided by `CheckoutStepGroup`. This form was designed to use the URL hash as the state for its active step so that the browser's back and forward buttons would allow changing steps without requiring clicks. For most of the time that the new checkout has existed, however, there have been only two steps (billing info and payment method), making the URL hash feature fairly unimportant. In addition, the first step is often auto-completed when checkout loads. 

Furthermore, because `CheckoutStepGroup` is sometimes embedded in non-checkout pages, this hash behavior can cause awkward effects and requires unpleasant hacks to work around. It's entirely possible for a form to include multiple `CheckoutStepGroup` components, and in that case we'd run into some awkward situations.

## Proposed Changes

In this PR we remove the `#stepX` URL hash used by checkout to simplify the API of `CheckoutStepGroup`.

## Testing Instructions

- Add a product to your cart and visit checkout.
- Verify that switching between steps works as expected and is unchanged from before this PR.