### PR TITLE
Update just buy a domain copy

### DIFF
--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -1,6 +1,6 @@
 import { SelectItems } from '@automattic/onboarding';
 import { globe, addCard, layout } from '@wordpress/icons';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import { get, isEmpty } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -54,11 +54,16 @@ class SiteOrDomain extends Component {
 
 		const choices = [];
 
+		const buyADomainDescription =
+			i18n.getLocaleSlug() === 'en' || i18n.hasTranslation( 'Add a site later.' )
+				? translate( 'Add a site later.' )
+				: translate( 'Show a "coming soon" notice on your domain. Add a site later.' );
+
 		if ( isReskinned ) {
 			choices.push( {
 				key: 'domain',
 				title: buyADomainTitle,
-				description: translate( 'Add a site later.' ),
+				description: buyADomainDescription,
 				icon: globe,
 				value: 'domain',
 				actionText: translate( 'Get domain' ),
@@ -120,7 +125,7 @@ class SiteOrDomain extends Component {
 				type: 'domain',
 				label: buyADomainTitle,
 				image: <DomainImage />,
-				description: translate( 'Add a site later.' ),
+				description: buyADomainDescription,
 			} );
 		}
 

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -58,7 +58,7 @@ class SiteOrDomain extends Component {
 			choices.push( {
 				key: 'domain',
 				title: buyADomainTitle,
-				description: translate( 'Show a "coming soon" notice on your domain. Add a site later.' ),
+				description: translate( 'Add a site later.' ),
 				icon: globe,
 				value: 'domain',
 				actionText: translate( 'Get domain' ),
@@ -120,7 +120,7 @@ class SiteOrDomain extends Component {
 				type: 'domain',
 				label: buyADomainTitle,
 				image: <DomainImage />,
-				description: translate( 'Show a "coming soon" notice on your domain. Add a site later.' ),
+				description: translate( 'Add a site later.' ),
 			} );
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3379

## Proposed Changes

* This PR updates language on "Just buy a domain" option in regular signup flow from "Show a "coming soon" notice on your domain. Add a site later." to "Add a site later."

Before | After
--|--
![just-buy-before](https://github.com/Automattic/wp-calypso/assets/140841/5327f8f2-bfe7-4bd8-9af8-299332d67a42)  | ![just-buy-after](https://github.com/Automattic/wp-calypso/assets/140841/ea811ce5-e48d-4563-bbcb-d0f2dded2ade)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/start/domain/site-or-domain
* Select a domain
* See the new copy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
