### PR TITLE
Plans: Refactor indirect checkout product card with new URLs

### DIFF
--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -174,8 +174,6 @@ export const INDIRECT_CHECKOUT_PRODUCT_STATS_PWYW_YEARLY = (): SelectorProduct =
 		items: [],
 	},
 	hidePrice: true,
-	// TODO: Refactor the checkout URL.
-	externalUrl: '/stats/purchase/{siteSlug}?from=calypso-plans',
 
 	// The Stats PWYW product in the Plans grid is shown as `Stats` but also referred to `Stats (Personal)`,
 	// which aligns with the naming in packages/calypso-products/src/translations.tsx.
@@ -190,6 +188,9 @@ export const INDIRECT_CHECKOUT_PRODUCT_STATS_PWYW_YEARLY = (): SelectorProduct =
 		comment:
 			'Used to describe price of Jetpack Stats, which can be either a pay-what-you-want product or fixed price product. In the future, it can also be a metered product.',
 	} ),
+
+	moreAboutUrl: 'https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing',
+	indirectCheckoutUrl: '/stats/purchase/{siteSlug}?from=calypso-plans',
 } );
 
 // TODO: We'll need to internationalize currencies like we did for the purchase page.

--- a/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
+++ b/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
@@ -155,9 +155,8 @@ export const getPurchaseURLCallback =
 		}
 
 		// Visit the indirect checkout URL to determine the purchasable product on another page.
-		// TODO: Use the checkout URL and product page URL respectively to alternate the externalUrl.
 		if ( INDIRECT_CHECKOUT_PRODUCTS_LIST.includes( product.productSlug ) ) {
-			return product.externalUrl?.replace( '{siteSlug}', siteSlug ) || '';
+			return product.indirectCheckoutUrl?.replace( '{siteSlug}', siteSlug ) || '';
 		}
 
 		let url;

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -42,11 +42,10 @@ import { UseStoreItemInfoProps } from '../types';
 import { useShoppingCartTracker } from './use-shopping-cart-tracker';
 const getIsDeprecated = ( item: SelectorProduct ) => Boolean( item.legacy );
 
-// TODO: Refactor indirect checkout products checking since they have only similar behaviors to external products but are different.
 const getIsExternal = ( item: SelectorProduct ) =>
-	EXTERNAL_PRODUCTS_LIST.includes( item.productSlug ) ||
-	INDIRECT_CHECKOUT_PRODUCTS_LIST.includes( item.productSlug );
+	EXTERNAL_PRODUCTS_LIST.includes( item.productSlug );
 
+// Indirect checkout products have more checkout flows, such as selecting plans on another page before being directed to the cart.
 const getIsIndirectCheckout = ( item: SelectorProduct ) =>
 	INDIRECT_CHECKOUT_PRODUCTS_LIST.includes( item.productSlug );
 

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -89,8 +89,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 								<MoreInfoLink
 									onClick={ onClickMoreInfoFactory( item ) }
 									item={ item }
-									isExternal={ isExternal }
-									externalLink={ isIndirectCheckout ? getCheckoutURL( item ) : '' }
+									isLinkExternal={ isExternal || isIndirectCheckout }
 								/>
 							) }
 						</>
@@ -113,10 +112,10 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 					// Go to the checkout page for all products when they click on the 'GET' CTA,
 					// except for Jetpack Social when it isn't owned or included in an active plan,
 					// in which case we open a modal.
-					const ctaHref =
-						isSocialProduct && ! isIncludedInPlanOrSuperseded
-							? `#${ item.productSlug }`
-							: getCheckoutURL( item );
+					let ctaHref = getCheckoutURL( item );
+					if ( isSocialProduct && ! isIncludedInPlanOrSuperseded ) {
+						ctaHref = `#${ item.productSlug }`;
+					}
 
 					const onClickCta = isSocialProduct
 						? onClickMoreInfoFactory( item )
@@ -132,7 +131,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 								description={ description }
 								icon={ <img alt="" src={ getProductIcon( { productSlug: item.productSlug } ) } /> }
 								isCtaDisabled={ isCtaDisabled }
-								isCtaExternal={ isExternal && ! isIndirectCheckout }
+								isCtaExternal={ isExternal }
 								onClickCta={ onClickCta }
 								isProductInCart={ isProductInCart }
 								price={ price }

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
@@ -78,7 +78,7 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 					const moreInfoLink = ! hideMoreInfoLink ? (
 						<MoreInfoLink
 							item={ item }
-							isExternal={ isExternal }
+							isLinkExternal={ isExternal }
 							onClick={ onClickMoreInfoFactory( item ) }
 						/>
 					) : null;

--- a/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/more-info-link/index.tsx
@@ -7,17 +7,16 @@ import './style.scss';
 export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( {
 	item,
 	onClick,
-	isExternal,
-	externalLink,
+	isLinkExternal,
 } ) => {
 	const translate = useTranslate();
 
-	// TODO: Refactor the external link with indirect checkout logic.
-	const isExternalLink = ( isExternal && item.externalUrl ) || !! externalLink;
+	// Open the link with new tab for `externalUrl` and `moreAboutUrl`.
+	const isOpeningNewTab = isLinkExternal && ( item.externalUrl || item.moreAboutUrl );
 
-	const href = isExternalLink ? externalLink || item.externalUrl : `#${ item.productSlug }`;
+	const href = isOpeningNewTab ? item.externalUrl || item.moreAboutUrl : `#${ item.productSlug }`;
 
-	const target = isExternalLink ? '_blank' : undefined;
+	const target = isOpeningNewTab ? '_blank' : undefined;
 
 	return (
 		<Button className="more-info-link" onClick={ onClick } href={ href } target={ target } plain>
@@ -25,7 +24,7 @@ export const MoreInfoLink: React.FC< MoreInfoLinkProps > = ( {
 				components: { productName: <>{ item.shortName }</> },
 			} ) }
 
-			{ isExternalLink && <Gridicon icon="external" size={ 16 } /> }
+			{ isOpeningNewTab && <Gridicon icon="external" size={ 16 } /> }
 		</Button>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -108,8 +108,7 @@ export type SimpleItemCardProps = Omit< FeaturedItemCardProps, 'hero' > & {
 export type MoreInfoLinkProps = {
 	item: SelectorProduct;
 	onClick?: VoidFunction;
-	isExternal?: boolean;
-	externalLink?: string;
+	isLinkExternal?: boolean;
 };
 
 export type PricingBreakdownProps = {

--- a/client/my-sites/plans/jetpack-plans/types.ts
+++ b/client/my-sites/plans/jetpack-plans/types.ts
@@ -141,6 +141,8 @@ export interface SelectorProduct extends SelectorProductCost {
 	faqs?: Array< FAQ >;
 	recommendedFor?: Array< JetpackTag >;
 	forceNoYearlyUpgrade?: boolean;
+	moreAboutUrl?: string;
+	indirectCheckoutUrl?: string;
 }
 
 export type SiteProduct = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79879 

## Proposed Changes

* Introduce new URLs `moreAboutUrl` and `indirectCheckoutUrl` for showing indirect checkout product cards.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the change with the Calypso Live link.
* Navigate to the `Plans` page: `/plans/{jetpack-site-slug}`.
* Ensure the `Get` button and `More about xxx` link of all product cards work as previously.
* Purchase any of Stats products.
* Back to the `Plans page`.
* Ensure the `Manage Subscription` button navigates to the purchase details page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
