### PR TITLE
Design-first: fix design your own button alignment

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -34,6 +34,11 @@
 			line-height: 14px;
 			margin-top: 9px;
 		}
+
+		.design-picker__design-your-own-button-without-categories {
+			margin-left: auto;
+			margin-top: -60px;
+		}
 	}
 
 	.design-picker__grid,

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -235,7 +235,9 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 				) }
 				{ assemblerCtaData.shouldGoToAssemblerStep && (
 					<Button
-						className="design-picker__design-your-own-button"
+						className={ classnames( 'design-picker__design-your-own-button', {
+							'design-picker__design-your-own-button-without-categories': ! hasCategories,
+						} ) }
 						onClick={ () => onClickDesignYourOwnTopButton( DEFAULT_ASSEMBLER_DESIGN ) }
 					>
 						{ assemblerCtaData.title }


### PR DESCRIPTION
Related to p1691153743683259-slack-C048CUFRGFQ

## Proposed Changes

In the "design-first" flow, we don't show categories in the Design Picker. See:

- #77568

This PR fixes the alignment of the "Design your own" button so that it still shows nicely under such behavior:

|Before|After|
|-|-|
|<img width="943" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/069a8e92-ecf6-4fd2-b6ee-da6c58fb5b61">|<img width="943" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/86f207fa-7ea6-4046-9dc6-1d0e2b52da2d">|

## Testing Instructions

1. Go to `/setup/update-design/designSetup?siteSlug=<SITE_SLUG>&flowToReturnTo=design-first`
2. Ensure that the the Design your own button aligns with the subtitle.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
