### PR TITLE
Assembler: Remove LIB and Coming Soon categories

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -16,3 +16,37 @@ export const NAVIGATOR_PATHS = {
 };
 
 export const STYLES_PATHS = [ NAVIGATOR_PATHS.COLOR_PALETTES, NAVIGATOR_PATHS.FONT_PAIRINGS ];
+
+/* Category list of the patterns fetched via PTK API from Dotcompatterns
+ *
+ * The categories that are commented are not fetched because they
+ *  - are hidden intentionaly in the Assembler only
+ *  - don't exist in Dotcompatterns source site
+ */
+export const PATTERN_CATEGORIES = [
+	'about',
+	//'buttons', -- Not exist
+	//'banner', -- Not exist
+	//'query', -- Not exist
+	//'posts', -- Not exist
+	'blog',
+	'call-to-action',
+	//'columns', -- Not exist
+	//'coming-soon', -- Hidden
+	'contact',
+	'footer',
+	'forms',
+	'gallery',
+	'header',
+	//'link-in-bio', -- Hidden
+	//'media', -- Not exist
+	'newsletter',
+	'podcast',
+	'portfolio',
+	'quotes',
+	'services',
+	'store',
+	//'team', -- Not exist
+	'testimonials',
+	'text',
+];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -24,12 +24,13 @@ export const STYLES_PATHS = [ NAVIGATOR_PATHS.COLOR_PALETTES, NAVIGATOR_PATHS.FO
  *  - don't exist in Dotcompatterns source site
  */
 export const PATTERN_CATEGORIES = [
+	'featured', // Reused for "All" category
 	'about',
 	//'buttons', -- Not exist
 	//'banner', -- Not exist
 	//'query', -- Not exist
-	//'posts', -- Not exist
 	'blog',
+	'posts', // Reused as "Blog Posts"
 	'call-to-action',
 	//'columns', -- Not exist
 	//'coming-soon', -- Hidden

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
@@ -1,5 +1,6 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
+import { PATTERN_CATEGORIES } from '../constants';
 import type { Pattern } from '../types';
 
 const useDotcomPatterns = (
@@ -16,6 +17,7 @@ const useDotcomPatterns = (
 				query: new URLSearchParams( {
 					tags: 'pattern',
 					pattern_meta: 'is_web',
+					categories: PATTERN_CATEGORIES.join( ',' ),
 				} ).toString(),
 			} );
 		},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-patterns-map-by-category.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-patterns-map-by-category.ts
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useMemo } from 'react';
+import { PATTERN_CATEGORIES } from '../constants';
 import type { Pattern, Category } from '../types';
 
 const usePatternsMapByCategory = ( patterns: Pattern[], categories: Category[] ) => {
@@ -15,6 +16,10 @@ const usePatternsMapByCategory = ( patterns: Pattern[], categories: Category[] )
 				return;
 			}
 			Object.keys( pattern.categories ).forEach( ( category ) => {
+				if ( ! PATTERN_CATEGORIES.includes( category ) ) {
+					// Only show allowed categories
+					return;
+				}
 				if ( ! categoriesMap[ category ] ) {
 					categoriesMap[ category ] = [];
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/80231

## Proposed Changes
* Remove LIB and Coming Soon categories from the assembler
* Create an allowlist of categories shown in the assembler
  * This improves the performance because we only fetch patterns in the allowed categories
  * This improves the documentation of the hidden and existent categories

### Categories shown

|BEFORE|AFTER|
|--|--|
|16 Categories|14 Categories|
|<img width="343" alt="Screenshot 2566-08-07 at 11 54 25" src="https://github.com/Automattic/wp-calypso/assets/1881481/c7c3ced8-110b-46f7-8475-c1c83de3e6cf">|<img width="347" alt="Screenshot 2566-08-07 at 12 00 16" src="https://github.com/Automattic/wp-calypso/assets/1881481/a1cd6df8-7375-462c-994f-504964946e88">|

### PTK API Request to fetch patterns

|BEFORE|AFTER|
|--|--|
|All Patterns|Patterns in Allowed Categories|
|<img width="175" alt="Screenshot 2566-08-07 at 11 52 31" src="https://github.com/Automattic/wp-calypso/assets/1881481/1cc8fdf8-da61-4e44-84ba-cc3c0e710d38">|<img width="971" alt="Screenshot 2566-08-07 at 11 31 21" src="https://github.com/Automattic/wp-calypso/assets/1881481/75fbed00-035d-4214-8f74-466f921d24bc">|

### Patterns count

|BEFORE|AFTER|
|--|--|
|296 Patterns|268 Patterns|
|<img width="121" alt="Screenshot 2566-08-07 at 11 52 46" src="https://github.com/Automattic/wp-calypso/assets/1881481/13791212-da24-4ef1-b6f6-3e7ad86ea8f0">|<img width="120" alt="Screenshot 2566-08-07 at 11 53 24" src="https://github.com/Automattic/wp-calypso/assets/1881481/0fb2c551-37fe-4929-b9c5-0daf1fcebb1b">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the Calypso Live link in the first comment below
* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }`
* Click `Sections`
* Verify you don't see the categories "Link in Bio" and "Coming Soon"
* Verify you don't see patterns from the categories "Link in Bio" and "Coming Soon" in other categories, like in "All"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
