### PR TITLE
Design Picker: Fix calypso_signup_select_design event doesn't include colors & fonts

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -14,14 +14,25 @@ export function recordPreviewedDesign( {
 	intent,
 	design,
 	styleVariation,
+	colorVariation,
+	fontVariation,
 }: {
 	flow: string | null;
 	intent: string;
 	design: Design;
 	styleVariation?: StyleVariation;
+	colorVariation?: GlobalStylesObject | null;
+	fontVariation?: GlobalStylesObject | null;
 } ) {
 	recordTracksEvent( 'calypso_signup_design_preview_select', {
-		...getDesignEventProps( { flow, intent, design, styleVariation } ),
+		...getDesignEventProps( {
+			flow,
+			intent,
+			design,
+			styleVariation,
+			colorVariation,
+			fontVariation,
+		} ),
 		...getDesignTypeProps( design ),
 		...getVirtualDesignProps( design ),
 	} );
@@ -32,12 +43,16 @@ export function recordSelectedDesign( {
 	intent,
 	design,
 	styleVariation,
+	colorVariation,
+	fontVariation,
 	optionalProps,
 }: {
 	flow: string | null;
 	intent: string;
 	design?: Design;
 	styleVariation?: StyleVariation;
+	colorVariation?: GlobalStylesObject | null;
+	fontVariation?: GlobalStylesObject | null;
 	optionalProps?: object;
 } ) {
 	recordTracksEvent( 'calypso_signup_design_type_submit', {
@@ -49,7 +64,14 @@ export function recordSelectedDesign( {
 
 	if ( design ) {
 		recordTracksEvent( 'calypso_signup_select_design', {
-			...getDesignEventProps( { flow, intent, design, styleVariation } ),
+			...getDesignEventProps( {
+				flow,
+				intent,
+				design,
+				styleVariation,
+				colorVariation,
+				fontVariation,
+			} ),
 			...getDesignTypeProps( design ),
 			...getVirtualDesignProps( design ),
 			...optionalProps,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -562,6 +562,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				intent,
 				design: _selectedDesign,
 				styleVariation: selectedStyleVariation,
+				colorVariation: selectedColorVariation,
+				fontVariation: selectedFontVariation,
 				optionalProps,
 			} );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Added following properties to the `calypso_signup_select_design` event for the metrics
  * color_variation_title
  * color_variation_type
  * font_variation_title
  * font_variation_type

![Screenshot 2023-08-07 at 1 13 20 PM](https://github.com/Automattic/wp-calypso/assets/13596067/c1e60ea4-7d12-435d-b11f-14f799d4bd06)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Continue to the Design Picker
* Preview a design without the style variations
* Select Colors & Fonts
* Continue
* Ensure you can see the `calypso_signup_select_design` event with those properties

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
