### PR TITLE
Domains: Add "Create site" button/flow to domain-only sites

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
@@ -13,8 +13,8 @@ import {
 } from 'calypso/my-sites/checkout/checkout-thank-you/domains/types';
 import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
 import { useDispatch, useSelector } from 'calypso/state';
+import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import { useSiteOption } from 'calypso/state/sites/hooks';
-import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 import { hideMasterbar, showMasterbar } from 'calypso/state/ui/masterbar-visibility/actions';
 
 import './style.scss';
@@ -46,8 +46,9 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 	const launchpadScreen = useSiteOption( 'launchpad_screen' );
 	const redirectTo = isLaunchpadIntentBuildEnabled ? 'home' : 'setup';
 	const siteIntent = useSiteOption( 'site_intent' );
-	const isDomainOnlySiteOption = useSelector( ( state ) =>
-		Boolean( getSiteOption( state, selectedSiteId, 'is_domain_only' ) )
+	const isDomainOnlySiteOption = useSelector(
+		( state ) =>
+			selectedSiteId !== undefined && Boolean( isDomainOnlySite( state, selectedSiteId ) )
 	);
 	const thankYouProps = useMemo< DomainThankYouProps >( () => {
 		const propsGetter = domainThankYouContent[ type ];

--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
@@ -14,7 +14,7 @@ import {
 import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { useSiteOption } from 'calypso/state/sites/hooks';
-import { getSiteBySlug } from 'calypso/state/sites/selectors';
+import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 import { hideMasterbar, showMasterbar } from 'calypso/state/ui/masterbar-visibility/actions';
 
 import './style.scss';
@@ -27,6 +27,7 @@ interface DomainThankYouContainerProps {
 	selectedSiteSlug: string;
 	type: DomainThankYouType;
 	isDomainOnly: boolean;
+	selectedSiteId?: number;
 }
 
 const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
@@ -37,6 +38,7 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 	hideProfessionalEmailStep,
 	type,
 	isDomainOnly,
+	selectedSiteId,
 } ) => {
 	const {
 		data: { is_enabled: isLaunchpadIntentBuildEnabled },
@@ -44,7 +46,9 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 	const launchpadScreen = useSiteOption( 'launchpad_screen' );
 	const redirectTo = isLaunchpadIntentBuildEnabled ? 'home' : 'setup';
 	const siteIntent = useSiteOption( 'site_intent' );
-	const selectedSite = useSelector( ( state ) => getSiteBySlug( state, selectedSiteSlug ) );
+	const isDomainOnlySiteOption = useSelector( ( state ) =>
+		Boolean( getSiteOption( state, selectedSiteId, 'is_domain_only' ) )
+	);
 	const thankYouProps = useMemo< DomainThankYouProps >( () => {
 		const propsGetter = domainThankYouContent[ type ];
 		return propsGetter( {
@@ -56,8 +60,8 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 			siteIntent,
 			launchpadScreen,
 			redirectTo,
-			isDomainOnly,
-			selectedSiteId: selectedSite?.ID,
+			isDomainOnly: isDomainOnly && isDomainOnlySiteOption,
+			selectedSiteId,
 		} );
 	}, [
 		type,
@@ -70,7 +74,8 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 		launchpadScreen,
 		redirectTo,
 		isDomainOnly,
-		selectedSite,
+		selectedSiteId,
+		isDomainOnlySiteOption,
 	] );
 	const dispatch = useDispatch();
 	const isLaunchpadEnabled = launchpadScreen === 'full';

--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
@@ -25,6 +25,7 @@ interface DomainThankYouContainerProps {
 	hideProfessionalEmailStep: boolean;
 	selectedSiteSlug: string;
 	type: DomainThankYouType;
+	isDomainOnly: boolean;
 }
 
 const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
@@ -34,6 +35,7 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 	selectedSiteSlug,
 	hideProfessionalEmailStep,
 	type,
+	isDomainOnly,
 } ) => {
 	const {
 		data: { is_enabled: isLaunchpadIntentBuildEnabled },

--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
@@ -12,8 +12,9 @@ import {
 	DomainThankYouType,
 } from 'calypso/my-sites/checkout/checkout-thank-you/domains/types';
 import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { useSiteOption } from 'calypso/state/sites/hooks';
+import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { hideMasterbar, showMasterbar } from 'calypso/state/ui/masterbar-visibility/actions';
 
 import './style.scss';
@@ -43,6 +44,7 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 	const launchpadScreen = useSiteOption( 'launchpad_screen' );
 	const redirectTo = isLaunchpadIntentBuildEnabled ? 'home' : 'setup';
 	const siteIntent = useSiteOption( 'site_intent' );
+	const selectedSite = useSelector( ( state ) => getSiteBySlug( state, selectedSiteSlug ) );
 	const thankYouProps = useMemo< DomainThankYouProps >( () => {
 		const propsGetter = domainThankYouContent[ type ];
 		return propsGetter( {
@@ -54,6 +56,8 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 			siteIntent,
 			launchpadScreen,
 			redirectTo,
+			isDomainOnly,
+			selectedSiteId: selectedSite?.ID,
 		} );
 	}, [
 		type,
@@ -65,6 +69,8 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 		siteIntent,
 		launchpadScreen,
 		redirectTo,
+		isDomainOnly,
+		selectedSite,
 	] );
 	const dispatch = useDispatch();
 	const isLaunchpadEnabled = launchpadScreen === 'full';

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -21,6 +21,8 @@ const domainRegistrationThankYouProps = ( {
 	siteIntent,
 	launchpadScreen,
 	redirectTo,
+	isDomainOnly,
+	selectedSiteId,
 }: DomainThankYouParams ): DomainThankYouProps => {
 	const professionalEmail = buildDomainStepForProfessionalEmail(
 		{
@@ -49,7 +51,7 @@ const domainRegistrationThankYouProps = ( {
 		stepDescription: translate( 'Choose a theme, customize and launch your site.' ),
 		stepCta: (
 			<FullWidthButton
-				href={ createSiteFromDomainOnly( domain, null ) }
+				href={ createSiteFromDomainOnly( domain, selectedSiteId ) }
 				busy={ false }
 				disabled={ false }
 			>
@@ -92,7 +94,7 @@ const domainRegistrationThankYouProps = ( {
 					? [ launchpadNextSteps ]
 					: [
 							...( professionalEmail ? [ professionalEmail ] : [] ),
-							...( ! selectedSiteSlug ? [ createSiteStep ] : [] ),
+							...( isDomainOnly && selectedSiteId ? [ createSiteStep ] : [] ),
 							viewDomainsStep,
 					  ],
 			},

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -5,7 +5,7 @@ import {
 	buildDomainStepForLaunchpadNextSteps,
 	buildDomainStepForProfessionalEmail,
 } from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index';
-import { domainManagementList } from 'calypso/my-sites/domains/paths';
+import { domainManagementList, createSiteFromDomainOnly } from 'calypso/my-sites/domains/paths';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import type {
 	DomainThankYouParams,
@@ -43,6 +43,21 @@ const domainRegistrationThankYouProps = ( {
 		true
 	);
 
+	const createSiteStep = {
+		stepKey: 'domain_registration_whats_next_create-site',
+		stepTitle: translate( 'Add a site' ),
+		stepDescription: translate( 'Choose a theme, customize and launch your site.' ),
+		stepCta: (
+			<FullWidthButton
+				href={ createSiteFromDomainOnly( domain, null ) }
+				busy={ false }
+				disabled={ false }
+			>
+				{ translate( 'Create a site' ) }
+			</FullWidthButton>
+		),
+	};
+
 	const viewDomainsStep = {
 		stepKey: 'domain_registration_whats_next_view_domains',
 		stepTitle: selectedSiteSlug
@@ -75,7 +90,11 @@ const domainRegistrationThankYouProps = ( {
 				sectionTitle: translate( 'What’s next?' ),
 				nextSteps: launchpadNextSteps
 					? [ launchpadNextSteps ]
-					: [ ...( professionalEmail ? [ professionalEmail ] : [] ), viewDomainsStep ],
+					: [
+							...( professionalEmail ? [ professionalEmail ] : [] ),
+							...( ! selectedSiteSlug ? [ createSiteStep ] : [] ),
+							viewDomainsStep,
+					  ],
 			},
 		],
 		thankYouImage: {

--- a/client/my-sites/checkout/checkout-thank-you/domains/types.ts
+++ b/client/my-sites/checkout/checkout-thank-you/domains/types.ts
@@ -15,6 +15,8 @@ export type DomainThankYouParams = {
 	hideProfessionalEmailStep: boolean;
 	launchpadScreen: ReturnType< typeof useSiteOption >;
 	selectedSiteSlug: string;
+	selectedSiteId?: number;
+	isDomainOnly: boolean;
 	siteIntent: ReturnType< typeof useSiteOption >;
 	redirectTo: 'home' | 'setup';
 };

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -71,6 +71,7 @@ import { getReceiptById } from 'calypso/state/receipts/selectors';
 import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
 import getCheckoutUpgradeIntent from 'calypso/state/selectors/get-checkout-upgrade-intent';
 import getCustomizeOrEditFrontPageUrl from 'calypso/state/selectors/get-customize-or-edit-front-page-url';
+import { requestSite } from 'calypso/state/sites/actions';
 import { fetchSitePlans, refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { getPlansBySite } from 'calypso/state/sites/plans/selectors';
 import { getSiteHomeUrl, getSiteSlug, getSite } from 'calypso/state/sites/selectors';
@@ -167,6 +168,7 @@ export interface CheckoutThankYouConnectedProps {
 		purchased?: boolean,
 		keepCurrentHomepage?: boolean
 	) => void;
+	requestSite: ( siteSlug: string ) => SiteDetails | null;
 }
 
 interface CheckoutThankYouState {
@@ -638,14 +640,15 @@ export class CheckoutThankYou extends Component<
 			);
 
 			const emailFallback = email ? email : this.props.user?.email ?? '';
-
+			const siteSlug = this.props.domainOnlySiteFlow ? domainName : this.props.selectedSiteSlug;
 			return (
 				<DomainThankYou
 					domain={ domainName ?? '' }
 					email={ professionalEmailPurchase ? professionalEmailPurchase.meta : emailFallback }
 					hasProfessionalEmail={ wasTitanEmailProduct }
 					hideProfessionalEmailStep={ wasGSuiteOrGoogleWorkspace || wasDomainOnly }
-					selectedSiteSlug={ this.props.selectedSiteSlug ?? '' }
+					selectedSiteSlug={ siteSlug ?? '' }
+					isDomainOnly={ this.props.domainOnlySiteFlow }
 					type={ purchaseType as DomainThankYouType }
 				/>
 			);
@@ -949,6 +952,7 @@ export default connect(
 		refreshSitePlans,
 		recordStartTransferClickInThankYou,
 		requestThenActivate,
+		requestSite,
 	}
 )( localize( CheckoutThankYou ) );
 

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -71,7 +71,6 @@ import { getReceiptById } from 'calypso/state/receipts/selectors';
 import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
 import getCheckoutUpgradeIntent from 'calypso/state/selectors/get-checkout-upgrade-intent';
 import getCustomizeOrEditFrontPageUrl from 'calypso/state/selectors/get-customize-or-edit-front-page-url';
-import { requestSite } from 'calypso/state/sites/actions';
 import { fetchSitePlans, refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { getPlansBySite } from 'calypso/state/sites/plans/selectors';
 import { getSiteHomeUrl, getSiteSlug, getSite } from 'calypso/state/sites/selectors';
@@ -168,7 +167,6 @@ export interface CheckoutThankYouConnectedProps {
 		purchased?: boolean,
 		keepCurrentHomepage?: boolean
 	) => void;
-	requestSite: ( siteSlug: string ) => SiteDetails | null;
 }
 
 interface CheckoutThankYouState {
@@ -952,7 +950,6 @@ export default connect(
 		refreshSitePlans,
 		recordStartTransferClickInThankYou,
 		requestThenActivate,
-		requestSite,
 	}
 )( localize( CheckoutThankYou ) );
 

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -222,7 +222,10 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 				: upsellType;
 
 		// There is no `siteId` if we're purchasing a domain-only site, so we pass the site slug to the query component instead.
-		const siteId = upsellType === PROFESSIONAL_EMAIL_UPSELL ? upgradeItem : selectedSiteId;
+		const siteId =
+			upsellType === PROFESSIONAL_EMAIL_UPSELL
+				? upgradeItem
+				: parseInt( String( selectedSiteId ), 10 );
 		return (
 			<Main
 				className={ classnames( styleClass, {
@@ -232,7 +235,9 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 				<QueryPaymentCountries />
 				<QuerySites siteId={ siteId } />
 				{ ! hasProductsList && <QueryProductsList /> }
-				{ ! hasSitePlans && <QuerySitePlans siteId={ parseInt( String( siteId ), 10 ) } /> }
+				{ ! hasSitePlans && typeof siteId === 'number' && ! isNaN( siteId ) && (
+					<QuerySitePlans siteId={ siteId } />
+				) }
 				{ this.renderContent() }
 				{ this.state.showPurchaseModal && this.renderPurchaseModal() }
 				{ this.preloadIconsForPurchaseModal() }

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -215,12 +215,14 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 	};
 
 	render() {
-		const { selectedSiteId, hasProductsList, hasSitePlans, upsellType } = this.props;
+		const { selectedSiteId, hasProductsList, hasSitePlans, upsellType, upgradeItem } = this.props;
 		const styleClass =
 			BUSINESS_PLAN_UPGRADE_UPSELL === upsellType
 				? 'business-plan-upgrade-upsell-new-design'
 				: upsellType;
 
+		// There is no `siteId` if we're purchasing a domain-only site, so we pass the site slug to the query component instead.
+		const siteId = upsellType === PROFESSIONAL_EMAIL_UPSELL ? upgradeItem : selectedSiteId;
 		return (
 			<Main
 				className={ classnames( styleClass, {
@@ -228,9 +230,9 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 				} ) }
 			>
 				<QueryPaymentCountries />
-				<QuerySites siteId={ selectedSiteId } />
+				<QuerySites siteId={ siteId } />
 				{ ! hasProductsList && <QueryProductsList /> }
-				{ ! hasSitePlans && <QuerySitePlans siteId={ parseInt( String( selectedSiteId ), 10 ) } /> }
+				{ ! hasSitePlans && <QuerySitePlans siteId={ parseInt( String( siteId ), 10 ) } /> }
 				{ this.renderContent() }
 				{ this.state.showPurchaseModal && this.renderPurchaseModal() }
 				{ this.preloadIconsForPurchaseModal() }

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -5,9 +5,10 @@ import { connect } from 'react-redux';
 import Illustration from 'calypso/assets/images/domains/domain.svg';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import EmptyContent from 'calypso/components/empty-content';
+import { canCurrentUserCreateSiteFromDomainOnly } from 'calypso/lib/domains';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
 import { hasTitanMailWithUs } from 'calypso/lib/titan';
-import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
+import { domainManagementEdit, createSiteFromDomainOnly } from 'calypso/my-sites/domains/paths';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -36,6 +37,8 @@ const DomainOnly = ( {
 
 	const hasEmailWithUs = hasGSuiteWithUs( primaryDomain ) || hasTitanMailWithUs( primaryDomain );
 	const domainName = primaryDomain.name;
+	const canCreateSite = canCurrentUserCreateSiteFromDomainOnly( primaryDomain );
+	const createSiteUrl = createSiteFromDomainOnly( slug, siteId );
 
 	const recordEmailClick = () => {
 		const tracksName = hasEmailWithUs
@@ -50,8 +53,14 @@ const DomainOnly = ( {
 		<div>
 			<EmptyContent
 				title={ translate( '%(domainName)s is ready when you are.', { args: { domainName } } ) }
-				action={ translate( 'Manage domain' ) }
-				actionURL={ domainManagementEdit( slug, domainName, currentRoute ) }
+				line={
+					canCreateSite &&
+					translate( 'Start a site now to unlock everything WordPress.com can offer.' )
+				}
+				action={ canCreateSite && translate( 'Create site' ) }
+				actionURL={ canCreateSite && createSiteUrl }
+				secondaryAction={ translate( 'Manage domain' ) }
+				secondaryActionURL={ domainManagementEdit( slug, domainName, currentRoute ) }
 				illustration={ Illustration }
 			>
 				<Button

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -1,5 +1,5 @@
 import { Badge, Button, Spinner } from '@automattic/components';
-import { Icon, home, info, redo } from '@wordpress/icons';
+import { Icon, home, info, redo, plus } from '@wordpress/icons';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
@@ -31,6 +31,7 @@ import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
 import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-toggle';
 import TransferConnectedDomainNudge from 'calypso/my-sites/domains/domain-management/components/transfer-connected-domain-nudge';
 import {
+	createSiteFromDomainOnly,
 	domainManagementDns,
 	domainManagementEditContactInfo,
 	domainUseMyDomain,
@@ -422,6 +423,12 @@ class DomainRow extends PureComponent {
 						>
 							<Icon icon={ redo } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
 							{ translate( 'Transfer to WordPress.com' ) }
+						</PopoverMenuItem>
+					) }
+					{ site.options?.is_domain_only && domain.type !== domainTypes.TRANSFER && (
+						<PopoverMenuItem href={ createSiteFromDomainOnly( site.slug, site.siteId ) }>
+							<Icon icon={ plus } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
+							{ translate( 'Create site' ) }
 						</PopoverMenuItem>
 					) }
 				</EllipsisMenu>

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -426,7 +426,7 @@ class DomainRow extends PureComponent {
 						</PopoverMenuItem>
 					) }
 					{ site.options?.is_domain_only && domain.type !== domainTypes.TRANSFER && (
-						<PopoverMenuItem href={ createSiteFromDomainOnly( site.slug, site.siteId ) }>
+						<PopoverMenuItem href={ createSiteFromDomainOnly( site.slug, site.ID ) }>
 							<Icon icon={ plus } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
 							{ translate( 'Create site' ) }
 						</PopoverMenuItem>

--- a/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
@@ -1,7 +1,10 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { domainManagementTransferToOtherSite } from 'calypso/my-sites/domains/paths';
+import {
+	createSiteFromDomainOnly,
+	domainManagementTransferToOtherSite,
+} from 'calypso/my-sites/domains/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { IAppState } from 'calypso/state/types';
 import type { DomainOnlyConnectCardProps } from './types';
@@ -18,6 +21,10 @@ const DomainOnlyConnectCard = ( props: DomainOnlyConnectCardProps ) => {
 				<p>{ translate( 'Your domain is not associated with a WordPress.com site.' ) }</p>
 			</div>
 			<div className="domain-only-connect__card-button-container">
+				<Button href={ createSiteFromDomainOnly( selectedDomainName, selectedSite.ID ) } primary>
+					{ translate( 'Create a site' ) }
+				</Button>
+
 				<Button
 					href={ domainManagementTransferToOtherSite(
 						selectedSite.slug,

--- a/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
@@ -18,11 +18,15 @@ const DomainOnlyConnectCard = ( props: DomainOnlyConnectCardProps ) => {
 	return (
 		<div className="domain-only-connect__card">
 			<div className="domain-only-connect__card-content">
-				<p>{ translate( 'Your domain is not associated with a WordPress.com site.' ) }</p>
+				<p>
+					{ translate(
+						'This domain is not associated to any site. Would you like to create one?'
+					) }
+				</p>
 			</div>
 			<div className="domain-only-connect__card-button-container">
 				<Button href={ createSiteFromDomainOnly( selectedDomainName, selectedSite.ID ) } primary>
-					{ translate( 'Create a site' ) }
+					{ translate( 'Add a new site' ) }
 				</Button>
 
 				<Button

--- a/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
@@ -13,7 +13,7 @@ import './style.scss';
 
 const DomainOnlyConnectCard = ( props: DomainOnlyConnectCardProps ) => {
 	const translate = useTranslate();
-	const { selectedSite, selectedDomainName, currentRoute } = props;
+	const { selectedSite, selectedDomainName, currentRoute, hasConnectableSites } = props;
 
 	return (
 		<div className="domain-only-connect__card">
@@ -29,15 +29,17 @@ const DomainOnlyConnectCard = ( props: DomainOnlyConnectCardProps ) => {
 					{ translate( 'Add a new site' ) }
 				</Button>
 
-				<Button
-					href={ domainManagementTransferToOtherSite(
-						selectedSite.slug,
-						selectedDomainName,
-						currentRoute
-					) }
-				>
-					{ translate( 'Connect to an existing site' ) }
-				</Button>
+				{ hasConnectableSites && (
+					<Button
+						href={ domainManagementTransferToOtherSite(
+							selectedSite.slug,
+							selectedDomainName,
+							currentRoute
+						) }
+					>
+						{ translate( 'Connect to an existing site' ) }
+					</Button>
+				) }
 			</div>
 		</div>
 	);

--- a/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/types.ts
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/types.ts
@@ -2,6 +2,7 @@ import type { SiteDetails } from '@automattic/data-stores';
 export type DomainOnlyConnectCardPassedProps = {
 	selectedSite: SiteDetails;
 	selectedDomainName: string;
+	hasConnectableSites: boolean;
 };
 
 export type DomainOnlyConnectCardConnectedProps = {

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -151,7 +151,6 @@ const Settings = ( {
 	const renderStatusSection = () => {
 		if (
 			! ( domain && selectedSite?.options?.is_domain_only ) ||
-			! hasConnectableSites ||
 			domain.type === domainTypes.TRANSFER
 		) {
 			return null;
@@ -163,7 +162,11 @@ const Settings = ( {
 				key="status"
 				expanded
 			>
-				<DomainOnlyConnectCard selectedDomainName={ domain.domain } selectedSite={ selectedSite } />
+				<DomainOnlyConnectCard
+					selectedDomainName={ domain.domain }
+					selectedSite={ selectedSite }
+					hasConnectableSites={ hasConnectableSites }
+				/>
 			</Accordion>
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -159,7 +159,7 @@ const Settings = ( {
 
 		return (
 			<Accordion
-				title={ translate( 'Connect a WordPress.com site', { textOnly: true } ) }
+				title={ translate( 'Create a WordPress.com site', { textOnly: true } ) }
 				key="status"
 				expanded
 			>


### PR DESCRIPTION
Related to #79395, #80250, https://github.com/Automattic/dotcom-forge/issues/3174.

## Proposed Changes

Adds back the "Create site" button for domain-only sites, enabling customers to convert a domain-only site into a regular one.

## Preview

### Post checkout page (`Thank you` page)
![image](https://github.com/Automattic/wp-calypso/assets/18705930/8baf366c-e1af-49d2-bde8-aed92176859c)

### Management page
![image](https://github.com/Automattic/wp-calypso/assets/18705930/c1f34546-66eb-4721-b061-daf7228dcad6)

### Management page for a new user

![image](https://github.com/Automattic/wp-calypso/assets/18705930/54247e50-54d0-4add-8dfb-d1cc6905e766)

Notice that we don't show the `Connect to an existing site` button in this one since the user still doesn't have sites to which the domain can be connected.

### Domain management list

![image](https://github.com/Automattic/wp-calypso/assets/18705930/1d184973-9fd7-406a-b274-9fea802af9c2)

---

## Testing Instructions

- Analyze the code statically;
- Ensure all unit tests are passing;
- Confirm that all references to the "Create site" button were added back:
  - Try purchasing a domain for a domain-only site and ensure that the button is displayed on the post-checkout page;
  - Go to a domain-only management page (`/domains/manage/:site`) and ensure that the button is displayed in one of the page's sections;
  - ~Ensure that on the "All domains" page, there's no upsell card with the "Create site" button~ Removed in #79310.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
