### PR TITLE
Jetpack Pro Dashboard: add "isLargeScreen" to DashboardDataContext to avoid prop drilling

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context.ts
@@ -10,6 +10,7 @@ const DashboardDataContext = createContext< DashboardDataContextInterface >( {
 		},
 	},
 	products: [],
+	isLargeScreen: true,
 } );
 
 export default DashboardDataContext;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -31,6 +31,7 @@ import DashboardBanners from './dashboard-banners';
 import DashboardDataContext from './dashboard-data-context';
 import SiteAddLicenseNotification from './site-add-license-notification';
 import SiteContent from './site-content';
+import useDashboardShowLargeScreen from './site-content/use-dashboard-show-large-screen';
 import SiteContentHeader from './site-content-header';
 import SiteSearchFilterContainer from './site-search-filter-container/SiteSearchFilterContainer';
 import { getProductSlugFromProductType } from './utils';
@@ -46,6 +47,9 @@ export default function SitesOverview() {
 	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
 
 	const containerRef = createRef< any >();
+	const siteTableRef = createRef< HTMLTableElement >();
+
+	const showLargeScreen = useDashboardShowLargeScreen( siteTableRef, containerRef );
 
 	const selectedLicenses = useSelector( getSelectedLicenses );
 	const selectedLicensesSiteId = useSelector( getSelectedLicensesSiteId );
@@ -341,6 +345,7 @@ export default function SitesOverview() {
 										},
 									},
 									products: products ?? [],
+									isLargeScreen: showLargeScreen,
 								} }
 							>
 								<>
@@ -350,7 +355,7 @@ export default function SitesOverview() {
 										isLoading={ isLoading }
 										currentPage={ currentPage }
 										isFavoritesTab={ isFavoritesTab }
-										ref={ containerRef }
+										ref={ siteTableRef }
 									/>
 								</>
 							</DashboardDataContext.Provider>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -2,7 +2,7 @@ import { Card } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useContext, forwardRef, createRef, useMemo } from 'react';
+import { useContext, forwardRef, useMemo } from 'react';
 import Pagination from 'calypso/components/pagination';
 import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
@@ -16,7 +16,6 @@ import SiteCard from '../site-card';
 import SiteSort from '../site-sort';
 import SiteTable from '../site-table';
 import { formatSites, getProductSlugFromProductType, siteColumns } from '../utils';
-import useDashboardShowLargeScreen from './use-dashboard-show-large-screen';
 import './style.scss';
 
 const addPageArgs = ( pageNumber: number ) => {
@@ -39,8 +38,8 @@ const SiteContent = ( { data, isLoading, currentPage, isFavoritesTab }: Props, r
 
 	const { isBulkManagementActive, currentLicenseInfo, hideLicenseInfo } =
 		useContext( SitesOverviewContext );
-	const { products } = useContext( DashboardDataContext );
 
+	const { products, isLargeScreen } = useContext( DashboardDataContext );
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, ! isMobile );
 
 	const sites = formatSites( data?.sites );
@@ -48,10 +47,6 @@ const SiteContent = ( { data, isLoading, currentPage, isFavoritesTab }: Props, r
 	const handlePageClick = ( pageNumber: number ) => {
 		addPageArgs( pageNumber );
 	};
-
-	const siteTableRef = createRef< HTMLTableElement >();
-
-	const isLargeScreen = useDashboardShowLargeScreen( siteTableRef, ref );
 
 	const firstColumn = siteColumns[ 0 ];
 
@@ -91,12 +86,7 @@ const SiteContent = ( { data, isLoading, currentPage, isFavoritesTab }: Props, r
 		<>
 			{ isLargeScreen ? (
 				<div className="site-content__large-screen-view">
-					<SiteTable
-						ref={ siteTableRef }
-						isLoading={ isLoading }
-						columns={ siteColumns }
-						items={ sites }
-					/>
+					<SiteTable ref={ ref } isLoading={ isLoading } columns={ siteColumns } items={ sites } />
 				</div>
 			) : (
 				<div className="site-content__small-screen-view">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -218,6 +218,7 @@ export interface DashboardDataContextInterface {
 		refetchIfFailed: () => void;
 	};
 	products: APIProductFamilyProduct[];
+	isLargeScreen: boolean;
 }
 
 export type AgencyDashboardFilterOption =


### PR DESCRIPTION
Related to 1202619025189113-as-1205210125061127

## Proposed Changes

This PR

- Moves the `useDashboardShowLargeScreen` hook invocation to the parent component.
- Adds `isLargeScreen` in the `DashboardDataContext` to avoid prop drilling.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/dashboard-data-context` and `yarn start-jetpack-cloud` or use the Jetpack Cloud link
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Visit https://wordpress.com/me/account and change the language to `Deutsch` so that texts appear longer
4. Now visit the dashboard > Refresh the page > Verify the UI switches to a small screen view after 1280px(Basically any screen width greater than 1280px because any screen width lesser than 1280px is small screen view) 

<img width="1043" alt="Screenshot 2023-08-07 at 12 12 45 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e45dbd4e-9165-49ae-a1e5-ac80de2a739f">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React, or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
