### PR TITLE
Assembler: Copy updates Aug 1

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -259,7 +259,7 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 		options.push( {
 			title: assemblerCtaData.title,
 			icon: addTemplate,
-			description: assemblerCtaData.subtitleLineTwo,
+			description: assemblerCtaData.subtitle,
 			onClick: () =>
 				recordTracksEvent( 'calypso_themeshowcase_more_options_design_homepage_click', {
 					site_plan: sitePlan,

--- a/client/components/themes-list/test/__snapshots__/index.jsx.snap
+++ b/client/components/themes-list/test/__snapshots__/index.jsx.snap
@@ -31,8 +31,6 @@ exports[`ThemesList should render a div with a className of "themes-list" 1`] = 
       <p
         class="pattern-assembler-cta__subtitle"
       >
-        Can’t find something you like?
-        <br />
         Jump right into the editor to design your homepage from scratch.
       </p>
       <button

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -80,7 +80,7 @@ const ScreenCategoryList = ( {
 								'Replace the selected pattern by choosing from the list of categories below.'
 						  )
 						: translate(
-								'Find the right section patterns for your homepage by exploring the categories below.'
+								'Find the section patterns for your homepage by exploring the categories below.'
 						  )
 				}
 				onBack={ onBack }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -148,7 +148,7 @@ const ScreenCategoryList = ( {
 						onDoneClick();
 					} }
 				>
-					{ translate( 'Save' ) }
+					{ translate( 'Save sections' ) }
 				</NavigatorBackButton>
 			</div>
 			<PatternListPanel

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -80,7 +80,7 @@ const ScreenCategoryList = ( {
 								'Replace the selected pattern by choosing from the list of categories below.'
 						  )
 						: translate(
-								'Find the right patterns for your homepage by exploring the pattern categories below.'
+								'Find the right section patterns for your homepage by exploring the categories below.'
 						  )
 				}
 				onBack={ onBack }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
@@ -31,7 +31,9 @@ const ScreenColorPalettes = ( {
 		<>
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Colors' ) } /> }
-				description={ translate( 'Discover your ideal color blend, from free to custom styles.' ) }
+				description={ translate(
+					'Find your perfect color style. Change the look and feel of your site in one click with our custom colors.'
+				) }
 				onBack={ onBack }
 			/>
 			<div className="screen-container__body">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
@@ -34,7 +34,7 @@ const ScreenFooter = ( {
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Add footer' ) } /> }
 				description={ translate(
-					'The footer sits at the bottom of the homepage and typically shows useful links and contact details.'
+					'The footer pattern sits at the bottom of your homepage and typically shows useful links and contact details.'
 				) }
 				onBack={ onBack }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
@@ -34,7 +34,7 @@ const ScreenFooter = ( {
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Add footer' ) } /> }
 				description={ translate(
-					'The footer pattern sits at the bottom of your homepage and typically shows useful links and contact details.'
+					'The footer pattern sits at the bottom of the homepage and typically shows useful links and contact details.'
 				) }
 				onBack={ onBack }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
@@ -34,7 +34,7 @@ const ScreenFooter = ( {
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Add footer' ) } /> }
 				description={ translate(
-					'Pick the footer that appears at the bottom of every page and shows useful links and contact information.'
+					'The footer sits at the bottom of the homepage and typically shows useful links and contact details.'
 				) }
 				onBack={ onBack }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
@@ -34,7 +34,7 @@ const ScreenHeader = ( {
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Add header' ) } /> }
 				description={ translate(
-					'Pick the header that appears at the top of every page and shows your site logo, title and navigation.'
+					'The header lives at the top area and typically shows your site logo, title, and navigation.'
 				) }
 				onBack={ onBack }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
@@ -34,7 +34,7 @@ const ScreenHeader = ( {
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Add header' ) } /> }
 				description={ translate(
-					'The header lives at the top area and typically shows your site logo, title, and navigation.'
+					'The header pattern lives at the top of your homepage and typically shows your site logo, title, and navigation.'
 				) }
 				onBack={ onBack }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -49,7 +49,7 @@ const ScreenMain = ( {
 	const { location } = useNavigator();
 	const isInitialLocation = location.isInitial && ! location.isBack;
 	const headerDescription = translate(
-		'Customize everything by first adding patterns and then choosing styles.'
+		'Create your homepage by first adding patterns and then choosing a color palette and font style.'
 	);
 
 	// Use the mousedown event to prevent either the button focusing or text selection
@@ -92,7 +92,7 @@ const ScreenMain = ( {
 	return (
 		<>
 			<NavigatorHeader
-				title={ <NavigatorTitle title={ translate( 'Design your own homepage' ) } /> }
+				title={ <NavigatorTitle title={ translate( 'Design your own' ) } /> }
 				description={ headerDescription }
 				hideBack
 			/>

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -7,8 +7,7 @@ import './style.scss';
 type PatternAssemblerCtaData = {
 	shouldGoToAssemblerStep: boolean;
 	title: string;
-	subtitleLineOne: string;
-	subtitleLineTwo: string;
+	subtitle: string;
 	buttonText: string;
 };
 
@@ -25,9 +24,10 @@ export function usePatternAssemblerCtaData(): PatternAssemblerCtaData {
 	return {
 		shouldGoToAssemblerStep,
 		title: translate( 'Design your own' ),
-		subtitleLineOne: translate( 'Can’t find something you like?' ),
-		subtitleLineTwo: shouldGoToAssemblerStep
-			? translate( 'Use our library of styles and patterns to build a homepage.' )
+		subtitle: shouldGoToAssemblerStep
+			? translate(
+					'Unleash your creativity in just three simple steps: add patterns, choose colors, and select fonts to design your perfect site.'
+			  )
 			: translate( 'Jump right into the editor to design your homepage from scratch.' ),
 		buttonText: shouldGoToAssemblerStep
 			? translate( 'Start designing' )
@@ -48,11 +48,7 @@ const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 				<img className="pattern-assembler-cta__image" src={ blankCanvasImage } alt="Blank Canvas" />
 			</div>
 			<h3 className="pattern-assembler-cta__title">{ data.title }</h3>
-			<p className="pattern-assembler-cta__subtitle">
-				{ data.subtitleLineOne }
-				<br />
-				{ data.subtitleLineTwo }
-			</p>
+			<p className="pattern-assembler-cta__subtitle">{ data.subtitle }</p>
 			<Button className="pattern-assembler-cta__button" onClick={ handleButtonClick } primary>
 				{ data.buttonText }
 			</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/80118

## Proposed Changes

- Update `Save` to `Save sections` on the categories screen
- Update CTA subtitle copy in large breakpoint
- Update header title and description copy on main screen
- Update description copy on 
  - Header screen **using a shorter version to avoid an orphan**
  - Sections screen **using a shorter version to avoid an orphan**
  - Footer screen
  - Colors screen

### Update CTA subtitle copy in large breakpoint

|BEFORE >= 960px|AFTER >= 960px |AFTER < 960px (No changes)|
|--|--|--|
|<img width="1710" alt="Screenshot 2566-08-07 at 14 37 09" src="https://github.com/Automattic/wp-calypso/assets/1881481/a47f0751-a6de-4737-8c73-a00955e8abd4">|<img width="1684" alt="Screenshot 2566-08-07 at 13 22 42" src="https://github.com/Automattic/wp-calypso/assets/1881481/b5c1e193-7403-4cca-a119-2418a62a5a16">|<img width="909" alt="Screenshot 2566-08-07 at 13 23 23" src="https://github.com/Automattic/wp-calypso/assets/1881481/0acb2486-7099-48ec-b4a4-b1d986c6acf0">|

### Update header title and description copy on the main screen

|BEFORE|AFTER >= 1280px |AFTER < 1280px|
|--|--|--|
|<img width="297" alt="Screenshot 2566-08-07 at 14 33 29" src="https://github.com/Automattic/wp-calypso/assets/1881481/0d8c8e9a-c95d-48d0-bbe4-10882d6bfe59">|<img width="339" alt="Screenshot 2566-08-07 at 13 42 23" src="https://github.com/Automattic/wp-calypso/assets/1881481/a4eba36b-154f-4f27-baf0-937e991379a2">|<img width="301" alt="Screenshot 2566-08-07 at 13 42 05" src="https://github.com/Automattic/wp-calypso/assets/1881481/267abb8b-1eb8-4881-b698-9c6964aed3c5">|

### Update description copy on Header screen

|BEFORE|AFTER >= 1280px |AFTER < 1280px|
|--|--|--|
|<img width="322" alt="Screenshot 2566-08-07 at 14 39 34" src="https://github.com/Automattic/wp-calypso/assets/1881481/d5ff551a-3ea9-4bbb-b4f9-e60659239ab1">|<img width="342" alt="Screenshot 2566-08-07 at 14 42 31" src="https://github.com/Automattic/wp-calypso/assets/1881481/cb02cb11-a231-43e5-8083-57ef816bcfde">|<img width="278" alt="Screenshot 2566-08-07 at 14 43 13" src="https://github.com/Automattic/wp-calypso/assets/1881481/4560d08d-9a20-4244-9db7-069cdea95070">|

Note that the words "of the homepage" are being replaced from the new copy with "area" to avoid the following orphan word. cc: @lucasmendes-design @autumnfjeld

<img width="341" alt="Screenshot 2566-08-07 at 13 48 05" src="https://github.com/Automattic/wp-calypso/assets/1881481/ca825cf8-e24b-4c53-aa6b-71de9b4778f5">


### Update description copy on Sections screen

|BEFORE|AFTER >= 1280px |AFTER < 1280px|
|--|--|--|
|<img width="343" alt="Screenshot 2566-08-07 at 14 39 45" src="https://github.com/Automattic/wp-calypso/assets/1881481/381f2826-5bea-4b11-b685-8e2c1abd2b63">|<img width="344" alt="Screenshot 2566-08-07 at 14 14 43" src="https://github.com/Automattic/wp-calypso/assets/1881481/707304a0-832a-41b7-a909-3506c281d406">|<img width="268" alt="Screenshot 2566-08-07 at 14 15 28" src="https://github.com/Automattic/wp-calypso/assets/1881481/75cb6aa0-02da-4501-8c37-3f13d99dcbca">|

Note that the word "right" is being removed from the new copy to avoid the following orphan word. cc: @lucasmendes-design @autumnfjeld

<img width="315" alt="Screenshot 2566-08-07 at 14 08 06" src="https://github.com/Automattic/wp-calypso/assets/1881481/117de5e8-2386-45de-a82c-c76ddc2fff2f">

### Update description copy on Footer screen

|BEFORE|AFTER >= 1280px |AFTER < 1280px|
|--|--|--|
|<img width="345" alt="Screenshot 2566-08-07 at 14 40 06" src="https://github.com/Automattic/wp-calypso/assets/1881481/b7f00db8-5c2a-415c-9569-34a6ea881661">|<img width="325" alt="Screenshot 2566-08-07 at 14 18 51" src="https://github.com/Automattic/wp-calypso/assets/1881481/a6d6437e-e8cb-499e-91e0-269a74be7259">|<img width="301" alt="Screenshot 2566-08-07 at 14 19 07" src="https://github.com/Automattic/wp-calypso/assets/1881481/73e22c7f-07a9-4c53-ae3f-d380b8abf6c5">|

### Update description copy on Colors screen

|BEFORE|AFTER >= 1280px |AFTER < 1280px|
|--|--|--|
|<img width="343" alt="Screenshot 2566-08-07 at 14 40 24" src="https://github.com/Automattic/wp-calypso/assets/1881481/e085fe65-6049-467b-92ac-94d4b5982fe7">|<img width="341" alt="Screenshot 2566-08-07 at 14 22 07" src="https://github.com/Automattic/wp-calypso/assets/1881481/a50941de-3c68-4bfc-9625-d10866367da0">|<img width="296" alt="Screenshot 2566-08-07 at 14 22 20" src="https://github.com/Automattic/wp-calypso/assets/1881481/3bd4c4b7-8bec-4c38-a405-c9b90896943d">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the Calypso Live link in the first comment below
* Create a new site, and continue until the Design picker screen
* Scroll to find the CTA `Design your own` and verify the copy updates when the window width is lower and greater than `960px` 
* Click `Start designing` and verify the copy updates on the main screen
* Resize the window to less than `1280px` to verify there isn‘t an orphan word in the last line. Repeat this verification for the following steps as well.
* Click `Header`
* Click `Footer`
* Click `Sections`
* Click `Colors`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
