### PR TITLE
Hosting metrics: receive `timeRange` as a parameter on data query hooks

### DIFF
--- a/client/my-sites/site-monitoring/main.tsx
+++ b/client/my-sites/site-monitoring/main.tsx
@@ -43,11 +43,11 @@ function useTimeRange() {
 	};
 }
 
-export function useSiteMetricsData( metric?: MetricsType ) {
+export function useSiteMetricsData( timeRange: TimeRange, metric?: MetricsType ) {
 	const siteId = useSelector( getSelectedSiteId );
 
 	// Use the custom hook for time range selection
-	const { start, end, handleTimeRangeChange } = useTimeRange();
+	const { start, end } = timeRange;
 
 	const { data } = useSiteMetricsQuery( siteId, {
 		start,
@@ -81,15 +81,18 @@ export function useSiteMetricsData( metric?: MetricsType ) {
 
 	return {
 		formattedData,
-		handleTimeRangeChange,
 	};
 }
 
-function useAggregateSiteMetricsData( metric?: MetricsType, dimension?: DimensionParams ) {
+function useAggregateSiteMetricsData(
+	timeRange: TimeRange,
+	metric?: MetricsType,
+	dimension?: DimensionParams
+) {
 	const siteId = useSelector( getSelectedSiteId );
 
 	// Use the custom hook for time range selection
-	const { start, end, handleTimeRangeChange } = useTimeRange();
+	const { start, end } = timeRange;
 
 	const { data } = useSiteMetricsQuery( siteId, {
 		start,
@@ -114,7 +117,6 @@ function useAggregateSiteMetricsData( metric?: MetricsType, dimension?: Dimensio
 
 	return {
 		formattedData,
-		handleTimeRangeChange,
 	};
 }
 
@@ -136,12 +138,15 @@ export function SiteMetrics() {
 	const { __ } = useI18n();
 	const titleHeader = __( 'Site Monitoring' );
 	const timeRange = useTimeRange();
-	const { formattedData, handleTimeRangeChange } = useSiteMetricsData();
+	const { handleTimeRangeChange } = timeRange;
+	const { formattedData } = useSiteMetricsData( timeRange );
 	const { formattedData: cacheHitMissFormattedData } = useAggregateSiteMetricsData(
+		timeRange,
 		'requests_persec',
 		'page_is_cached'
 	);
 	const { formattedData: phpVsStaticFormattedData } = useAggregateSiteMetricsData(
+		timeRange,
 		'requests_persec',
 		'page_renderer'
 	);

--- a/client/my-sites/site-monitoring/test/main.js
+++ b/client/my-sites/site-monitoring/test/main.js
@@ -7,6 +7,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
+import { calculateTimeRange } from '../components/time-range-picker';
 import { useSiteMetricsData } from '../main';
 import { useSiteMetricsQuery } from '../use-metrics-query';
 
@@ -33,6 +34,7 @@ const INITIAL_STATE = {
 const mockStore = configureStore();
 const store = mockStore( INITIAL_STATE );
 const queryClient = new QueryClient();
+const timeRange = calculateTimeRange( '24-hours' );
 
 describe( 'useSiteMetrics test', () => {
 	beforeAll( () => {
@@ -68,7 +70,7 @@ describe( 'useSiteMetrics test', () => {
 		);
 
 		// Call the useSiteMetricsData function directly within the test
-		const { result } = renderHook( () => useSiteMetricsData(), { wrapper } );
+		const { result } = renderHook( () => useSiteMetricsData( timeRange ), { wrapper } );
 
 		// Get the formattedData from the hook's result
 		const { formattedData } = result.current;
@@ -97,7 +99,7 @@ describe( 'useSiteMetrics test', () => {
 			</QueryClientProvider>
 		);
 
-		const { result } = renderHook( () => useSiteMetricsData(), { wrapper } );
+		const { result } = renderHook( () => useSiteMetricsData( timeRange ), { wrapper } );
 
 		const { formattedData } = result.current;
 
@@ -122,7 +124,7 @@ describe( 'useSiteMetrics test', () => {
 			</QueryClientProvider>
 		);
 
-		const { result } = renderHook( () => useSiteMetricsData(), { wrapper } );
+		const { result } = renderHook( () => useSiteMetricsData( timeRange ), { wrapper } );
 
 		const { formattedData } = result.current;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/3274
- https://github.com/Automattic/dotcom-forge/issues/3276
- https://github.com/Automattic/dotcom-forge/issues/3356

## Proposed Changes

* Before this PR each chart was calling to useTimeRange and the changes with the datePicker were isolated to each chart.
* In this PR I suggest passing timeRange as a parameter for each data query hook to share the state across the hooks.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access `/site-monitoring/${siteSlug}`
* Change the date picker
* Observe all the charts are updateing their data, not only the first line graph.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
