### PR TITLE
Jetpack Pro Dashboard: record track events for monitor paid plan changes

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/index.tsx
@@ -3,6 +3,7 @@ import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useContext } from 'react';
+import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
 import SitesOverviewContext from '../../sites-overview/context';
 import DashboardDataContext from '../../sites-overview/dashboard-data-context';
 import './style.scss';
@@ -11,7 +12,8 @@ export default function UpgradeLink( { isInline = false } ) {
 	const translate = useTranslate();
 	const { showLicenseInfo } = useContext( SitesOverviewContext );
 
-	const { products } = useContext( DashboardDataContext );
+	const { products, isLargeScreen } = useContext( DashboardDataContext );
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, isLargeScreen );
 
 	const monthlyProduct = products.find(
 		( product ) => product.slug === 'jetpack-monitor' && product.price_interval === 'month'
@@ -20,7 +22,7 @@ export default function UpgradeLink( { isInline = false } ) {
 	const price = monthlyProduct && formatCurrency( monthlyProduct.amount, monthlyProduct.currency );
 
 	const handleOnClick = () => {
-		// TODO: Add event tracking here
+		recordEvent( 'downtime_monitoring_upgrade_link_click' );
 		showLicenseInfo( 'monitor' );
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/index.tsx
@@ -8,7 +8,9 @@ import {
 	getJetpackDashboardPreference as getPreference,
 } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
+import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
 import SitesOverviewContext from '../../sites-overview/context';
+import DashboardDataContext from '../../sites-overview/dashboard-data-context';
 import { PreferenceType } from '../../sites-overview/types';
 import './style.scss';
 
@@ -35,6 +37,9 @@ export default function UpgradePopover( {
 
 	const isDismissed = dismissibleWithPreference ? preference?.dismiss : false;
 
+	const { isLargeScreen } = useContext( DashboardDataContext );
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, isLargeScreen );
+
 	const savePreferenceType = useCallback(
 		( type: PreferenceType ) => {
 			dispatch( savePreference( tooltipPreference, { ...preference, [ type ]: true } ) );
@@ -52,12 +57,12 @@ export default function UpgradePopover( {
 
 	const handleClose = () => {
 		handleDismissPopover();
-		// TODO: Add event tracking here
+		recordEvent( 'downtime_monitoring_upgrade_popover_dismiss' );
 	};
 
 	const handleClickExplore = () => {
 		handleDismissPopover();
-		// TODO: Add event tracking here
+		recordEvent( 'downtime_monitoring_upgrade_popover_accept' );
 		showLicenseInfo( 'monitor' );
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-downtime-monitoring-upgrade-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-downtime-monitoring-upgrade-banner/index.tsx
@@ -4,6 +4,7 @@ import { useCallback, useContext, useEffect } from 'react';
 import CelebrationIcon from 'calypso/assets/images/jetpack/celebration-icon.svg';
 import Banner from 'calypso/components/banner';
 import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	JETPACK_DASHBOARD_DOWNTIME_MONITORING_UPGRADE_BANNER_PREFERENCE,
 	getJetpackDashboardPreference as getPreference,
@@ -41,7 +42,9 @@ export default function SiteDowntimeMonitoringUpgradeBanner() {
 	useEffect( () => {
 		if ( isDowntimeMonitoringPaidTierEnabled && ! isDismissed && ! viewDate ) {
 			savePreferenceType( 'view_date', Date.now() );
-			// TODO: We need to record event here
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_agency_dashboard_monitor_upgrade_banner_view' )
+			);
 		}
 		// We only want to run this once
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -51,10 +54,9 @@ export default function SiteDowntimeMonitoringUpgradeBanner() {
 		return null;
 	}
 
-	const dismissAndRecordEvent = () => {
+	const dismissAndRecordEvent = ( eventName: string ) => {
 		savePreferenceType( 'dismiss', true );
-
-		// TODO: We need to record event here
+		dispatch( recordTracksEvent( `calypso_jetpack_agency_dashboard_${ eventName }` ) );
 		showLicenseInfo( 'monitor' );
 	};
 
@@ -71,8 +73,8 @@ export default function SiteDowntimeMonitoringUpgradeBanner() {
 			callToAction={ translate( 'Explore' ) }
 			dismissWithoutSavingPreference
 			href="" // TODO: We will need to provide link to the info modal here
-			onClick={ () => dismissAndRecordEvent() }
-			onDismiss={ () => dismissAndRecordEvent() }
+			onClick={ () => dismissAndRecordEvent( 'monitor_upgrade_banner_accept' ) }
+			onDismiss={ () => dismissAndRecordEvent( 'monitor_upgrade_banner_dismiss' ) }
 		/>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-downtime-monitoring-upgrade-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-downtime-monitoring-upgrade-banner/index.tsx
@@ -72,7 +72,6 @@ export default function SiteDowntimeMonitoringUpgradeBanner() {
 			iconPath={ CelebrationIcon }
 			callToAction={ translate( 'Explore' ) }
 			dismissWithoutSavingPreference
-			href="" // TODO: We will need to provide link to the info modal here
 			onClick={ () => dismissAndRecordEvent( 'monitor_upgrade_banner_accept' ) }
 			onDismiss={ () => dismissAndRecordEvent( 'monitor_upgrade_banner_dismiss' ) }
 		/>


### PR DESCRIPTION
Related to 1204992567518369-as-1205014730250980

## Proposed Changes

This PR adds tracking events to the downtime monitor notification paid plan changes.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/dashboard-data-context` and `yarn start-jetpack-cloud` or use the Jetpack Cloud link
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Open the dev tool, go to the network tab, and apply the filters - `jetpack-cloud-development` as search and select `Img` filters.

<img width="739" alt="Screenshot 2023-01-19 at 12 43 57 PM" src="https://user-images.githubusercontent.com/10586875/213378720-624de9b6-dc14-489e-a9a2-d7f04cfa478c.png">

5. Perform the below actions and verify that the API call to track the event is made with the right action names on large and small screen devices

`L: Large screen(>1280px)`
`S: Small Screen(<1280px)`

------

<img width="1545" alt="Screenshot 2023-08-07 at 3 37 51 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ebc69065-4e72-4e41-9420-cb0fe2888b4a">

####  View the banner

Event name: 

calypso_jetpack_agency_dashboard_monitor_upgrade_banner_view

####  Click "Explore" on the banner (1)

Event name: 

calypso_jetpack_agency_dashboard_monitor_upgrade_banner_accept

#### Click X(dismiss) on the banner (2)

Event names

calypso_jetpack_agency_dashboard_monitor_upgrade_banner_dismiss

-----

<img width="235" alt="Screenshot 2023-08-07 at 3 38 00 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ee6c52e8-578d-4156-a7ca-3670c02bc94f">

#### Click X(dismiss) on the upgrade popover (3)

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_upgrade_popover_dismiss_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_upgrade_popover_dismiss_small_screen

#### Click "Explore" on the upgrade popover (4)

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_upgrade_popover_accept_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_upgrade_popover_accept_small_screen

------

<img width="449" alt="Screenshot 2023-08-07 at 3 39 35 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/153ed6a4-8a82-4faf-928a-38b64bdfb04a">

#### Click on any upgrade link (5)

Event names

L: calypso_jetpack_agency_dashboard_downtime_monitoring_upgrade_link_click_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_upgrade_link_click_small_screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
