### PR TITLE
Jetpack Error UX: Add message for DNS health error

### DIFF
--- a/client/components/jetpack/connection-health/constants.js
+++ b/client/components/jetpack/connection-health/constants.js
@@ -1,1 +1,2 @@
+export const UNKNOWN_ERROR = 'unknown_error';
 export const DNS_ERROR = 'dns_error';

--- a/client/components/jetpack/connection-health/constants.js
+++ b/client/components/jetpack/connection-health/constants.js
@@ -1,0 +1,1 @@
+export const DNS_ERROR = 'dns_error';

--- a/client/components/jetpack/connection-health/error-notice.tsx
+++ b/client/components/jetpack/connection-health/error-notice.tsx
@@ -22,7 +22,7 @@ export const ErrorNotice = ( {
 	const handleJetpackConnectionHealthLinkClick = () => {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_connection_health_issue_click', {
-				type: eventType,
+				error_type: eventType,
 			} )
 		);
 	};
@@ -31,7 +31,7 @@ export const ErrorNotice = ( {
 		<>
 			<TrackComponentView
 				eventName="calypso_jetpack_connection_health_issue_view"
-				eventProperties={ { type: eventType } }
+				eventProperties={ { error_type: eventType } }
 			/>
 			<Notice status="is-error" showDismiss={ false } text={ errorText }>
 				<NoticeAction

--- a/client/components/jetpack/connection-health/error-notice.tsx
+++ b/client/components/jetpack/connection-health/error-notice.tsx
@@ -16,6 +16,7 @@ interface Props {
 export const ErrorNotice = ( {
 	eventViewName,
 	eventClickName,
+	eventType,
 	errorText,
 	noticeActionHref,
 	noticeActionText,

--- a/client/components/jetpack/connection-health/error-notice.tsx
+++ b/client/components/jetpack/connection-health/error-notice.tsx
@@ -1,0 +1,47 @@
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+interface Props {
+	eventViewName: string;
+	eventClickName: string;
+	eventType: string;
+	errorText: string;
+	noticeActionHref: string;
+	noticeActionText: string;
+}
+
+export const ErrorNotice = ( {
+	eventViewName,
+	eventClickName,
+	errorText,
+	noticeActionHref,
+	noticeActionText,
+}: Props ) => {
+	const dispatch = useDispatch();
+
+	const handleJetpackConnectionHealthLinkClick = () => {
+		dispatch(
+			recordTracksEvent( eventClickName, {
+				type: eventType,
+			} )
+		);
+	};
+
+	return (
+		<>
+			<TrackComponentView eventName={ eventViewName } eventProperties={ { type: eventType } } />
+			<Notice status="is-error" showDismiss={ false } text={ errorText }>
+				<NoticeAction
+					href={ noticeActionHref }
+					external
+					onClick={ handleJetpackConnectionHealthLinkClick }
+				>
+					{ noticeActionText }
+				</NoticeAction>
+			</Notice>
+		</>
+	);
+};

--- a/client/components/jetpack/connection-health/error-notice.tsx
+++ b/client/components/jetpack/connection-health/error-notice.tsx
@@ -5,8 +5,6 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 interface Props {
-	eventViewName: string;
-	eventClickName: string;
 	eventType: string;
 	errorText: string;
 	noticeActionHref: string;
@@ -14,8 +12,6 @@ interface Props {
 }
 
 export const ErrorNotice = ( {
-	eventViewName,
-	eventClickName,
 	eventType,
 	errorText,
 	noticeActionHref,
@@ -25,7 +21,7 @@ export const ErrorNotice = ( {
 
 	const handleJetpackConnectionHealthLinkClick = () => {
 		dispatch(
-			recordTracksEvent( eventClickName, {
+			recordTracksEvent( 'calypso_jetpack_connection_health_issue_click', {
 				type: eventType,
 			} )
 		);
@@ -33,7 +29,10 @@ export const ErrorNotice = ( {
 
 	return (
 		<>
-			<TrackComponentView eventName={ eventViewName } eventProperties={ { type: eventType } } />
+			<TrackComponentView
+				eventName="calypso_jetpack_connection_health_issue_view"
+				eventProperties={ { type: eventType } }
+			/>
 			<Notice status="is-error" showDismiss={ false } text={ errorText }>
 				<NoticeAction
 					href={ noticeActionHref }

--- a/client/components/jetpack/connection-health/error-notice.tsx
+++ b/client/components/jetpack/connection-health/error-notice.tsx
@@ -5,14 +5,14 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 interface Props {
-	eventType: string;
+	errorType: string;
 	errorText: string;
 	noticeActionHref: string;
 	noticeActionText: string;
 }
 
 export const ErrorNotice = ( {
-	eventType,
+	errorType,
 	errorText,
 	noticeActionHref,
 	noticeActionText,
@@ -22,7 +22,7 @@ export const ErrorNotice = ( {
 	const handleJetpackConnectionHealthLinkClick = () => {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_connection_health_issue_click', {
-				error_type: eventType,
+				error_type: errorType,
 			} )
 		);
 	};
@@ -31,7 +31,7 @@ export const ErrorNotice = ( {
 		<>
 			<TrackComponentView
 				eventName="calypso_jetpack_connection_health_issue_view"
-				eventProperties={ { error_type: eventType } }
+				eventProperties={ { error_type: errorType } }
 			/>
 			<Notice status="is-error" showDismiss={ false } text={ errorText }>
 				<NoticeAction

--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -1,7 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import { DNS_ERROR } from './constants';
+import { DNS_ERROR, UNKNOWN_ERROR } from './constants';
 import { ErrorNotice } from './error-notice';
 import { useCheckJetpackConnectionHealth } from './use-check-jetpack-connection-health';
 
@@ -33,7 +33,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 	if ( jetpackConnectionHealth?.error === DNS_ERROR ) {
 		return (
 			<ErrorNotice
-				errorType="dns"
+				errorType={ DNS_ERROR }
 				errorText={ translate(
 					"Your domain is not properly set up to point to your site. Reset your domain's A records in the Domains section to fix this."
 				) }
@@ -47,7 +47,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 
 	return (
 		<ErrorNotice
-			errorType="default"
+			errorType={ UNKNOWN_ERROR }
 			errorText={ translate( 'Jetpack is unable to communicate with your site.' ) }
 			noticeActionHref={ localizeUrl(
 				'https://wordpress.com/support/why-is-my-site-down/#theres-an-issue-with-your-sites-jetpack-connection'

--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { DNS_ERROR } from './constants';
 import { ErrorNotice } from './error-notice';
 import { useCheckJetpackConnectionHealth } from './use-check-jetpack-connection-health';
 
@@ -32,7 +33,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 		return;
 	}
 
-	if ( jetpackConnectionHealth?.error === 'dns_error' ) {
+	if ( jetpackConnectionHealth?.error === DNS_ERROR ) {
 		return (
 			<ErrorNotice
 				eventViewName="calypso_jetpack_connection_health_issue_view"

--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -1,6 +1,8 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { ErrorNotice } from './error-notice';
 import { useCheckJetpackConnectionHealth } from './use-check-jetpack-connection-health';
 
@@ -10,6 +12,7 @@ interface Props {
 
 export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 	const translate = useTranslate();
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
 	const [ isErrorCheckJetpackConnectionHealth, setIsErrorCheckJetpackConnectionHealth ] =
 		useState( false );
@@ -27,6 +30,21 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 		jetpackConnectionHealth?.is_healthy
 	) {
 		return;
+	}
+
+	if ( jetpackConnectionHealth?.error === 'dns_error' ) {
+		return (
+			<ErrorNotice
+				eventViewName="calypso_jetpack_connection_health_issue_view"
+				eventClickName="calypso_jetpack_connection_health_issue_click"
+				eventType="dns"
+				errorText={ translate(
+					"Your domain is not properly set up to point to your site. Reset your domain's A records in the Domains section to fix this."
+				) }
+				noticeActionHref={ `/domains/manage/${ siteSlug }` }
+				noticeActionText={ translate( 'Manage domain' ) }
+			/>
+		);
 	}
 
 	return (

--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -36,8 +36,6 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 	if ( jetpackConnectionHealth?.error === DNS_ERROR ) {
 		return (
 			<ErrorNotice
-				eventViewName="calypso_jetpack_connection_health_issue_view"
-				eventClickName="calypso_jetpack_connection_health_issue_click"
 				eventType="dns"
 				errorText={ translate(
 					"Your domain is not properly set up to point to your site. Reset your domain's A records in the Domains section to fix this."
@@ -50,8 +48,6 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 
 	return (
 		<ErrorNotice
-			eventViewName="calypso_jetpack_connection_health_issue_view"
-			eventClickName="calypso_jetpack_connection_health_issue_click"
 			eventType="default"
 			errorText={ translate( 'Jetpack is unable to communicate with your site.' ) }
 			noticeActionHref={ localizeUrl(

--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -1,8 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { DNS_ERROR } from './constants';
 import { ErrorNotice } from './error-notice';
 import { useCheckJetpackConnectionHealth } from './use-check-jetpack-connection-health';
@@ -13,7 +11,6 @@ interface Props {
 
 export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 	const translate = useTranslate();
-	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
 	const [ isErrorCheckJetpackConnectionHealth, setIsErrorCheckJetpackConnectionHealth ] =
 		useState( false );
@@ -40,8 +37,10 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 				errorText={ translate(
 					"Your domain is not properly set up to point to your site. Reset your domain's A records in the Domains section to fix this."
 				) }
-				noticeActionHref={ `/domains/manage/${ siteSlug }` }
-				noticeActionText={ translate( 'Manage domain' ) }
+				noticeActionHref={ localizeUrl(
+					'https://wordpress.com/support/why-is-my-site-down/#theres-an-issue-with-your-domain-name'
+				) }
+				noticeActionText={ translate( 'Learn how to fix' ) }
 			/>
 		);
 	}

--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -1,11 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import Notice from 'calypso/components/notice';
-import NoticeAction from 'calypso/components/notice/notice-action';
-import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import { useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { ErrorNotice } from './error-notice';
 import { useCheckJetpackConnectionHealth } from './use-check-jetpack-connection-health';
 
 interface Props {
@@ -14,7 +10,6 @@ interface Props {
 
 export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 
 	const [ isErrorCheckJetpackConnectionHealth, setIsErrorCheckJetpackConnectionHealth ] =
 		useState( false );
@@ -26,14 +21,6 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 			},
 		} );
 
-	const handleJetpackConnectionHealthLinkClick = () => {
-		dispatch(
-			recordTracksEvent( 'calypso_jetpack_connection_health_issue_click', {
-				error_type: 'default',
-			} )
-		);
-	};
-
 	if (
 		isLoadingJetpackConnectionHealth ||
 		isErrorCheckJetpackConnectionHealth ||
@@ -43,26 +30,15 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 	}
 
 	return (
-		<>
-			<TrackComponentView
-				eventName="calypso_jetpack_connection_health_issue_view"
-				eventProperties={ { error_type: 'default' } }
-			/>
-			<Notice
-				status="is-error"
-				showDismiss={ false }
-				text={ translate( 'Jetpack is unable to communicate with your site.' ) }
-			>
-				<NoticeAction
-					href={ localizeUrl(
-						'https://wordpress.com/support/why-is-my-site-down/#theres-an-issue-with-your-sites-jetpack-connection'
-					) }
-					external
-					onClick={ handleJetpackConnectionHealthLinkClick }
-				>
-					{ translate( 'Learn how to fix' ) }
-				</NoticeAction>
-			</Notice>
-		</>
+		<ErrorNotice
+			eventViewName="calypso_jetpack_connection_health_issue_view"
+			eventClickName="calypso_jetpack_connection_health_issue_click"
+			eventType="default"
+			errorText={ translate( 'Jetpack is unable to communicate with your site.' ) }
+			noticeActionHref={ localizeUrl(
+				'https://wordpress.com/support/why-is-my-site-down/#theres-an-issue-with-your-sites-jetpack-connection'
+			) }
+			noticeActionText={ translate( 'Learn how to fix' ) }
+		/>
 	);
 };

--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -36,7 +36,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 	if ( jetpackConnectionHealth?.error === DNS_ERROR ) {
 		return (
 			<ErrorNotice
-				eventType="dns"
+				errorType="dns"
 				errorText={ translate(
 					"Your domain is not properly set up to point to your site. Reset your domain's A records in the Domains section to fix this."
 				) }
@@ -48,7 +48,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 
 	return (
 		<ErrorNotice
-			eventType="default"
+			errorType="default"
 			errorText={ translate( 'Jetpack is unable to communicate with your site.' ) }
 			noticeActionHref={ localizeUrl(
 				'https://wordpress.com/support/why-is-my-site-down/#theres-an-issue-with-your-sites-jetpack-connection'

--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -35,7 +35,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 			<ErrorNotice
 				errorType={ DNS_ERROR }
 				errorText={ translate(
-					"Your domain is not properly set up to point to your site. Reset your domain's A records in the Domains section to fix this."
+					"Jetpack is unable to connect to your domain. Please update your domain's DNS records so they're pointed properly to your site."
 				) }
 				noticeActionHref={ localizeUrl(
 					'https://wordpress.com/support/why-is-my-site-down/#theres-an-issue-with-your-domain-name'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3302

## Proposed Changes

In this PR, I propose to add a Jetpack connection error message for DNS error.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply D118236-code to your sandbox
2. Create an Atomic site with a Business plan and activate hosting features
3. Add a custom domain for the site, and make it primary
4. Point domain to valid external name servers which don’t serve this domain
5. Wait 5 minutes to let it propagate
6. Load the Posts page for the site and confirm that error is displayed

<img width="1369" alt="Screenshot 2023-08-07 at 14 37 40" src="https://github.com/Automattic/wp-calypso/assets/727413/311d4fb6-fd25-4549-8015-72343c4ef5b1">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
