### PR TITLE
Happy blocks: Match header spacing on learn homepage

### DIFF
--- a/apps/happy-blocks/block-library/education-header/style.scss
+++ b/apps/happy-blocks/block-library/education-header/style.scss
@@ -172,10 +172,11 @@ body.archive {
 	&.happy-blocks-header {
 		&.is-learn {
 			margin-top: 120px;
-			margin-bottom: 70px;
+			margin-bottom: 6px;
 
 			@media ( max-width: $breakpoint-mobile ) {
-				margin: 56px 0;
+				margin-top: 56px;
+				margin-bottom: 8px;
 			}
 
 			.happy-blocks-global-header-site__title {
@@ -184,6 +185,9 @@ body.archive {
 
 				.happy-blocks-global-header-site__title__wrapper {
 					margin-bottom: 32px;
+					@media ( max-width: $breakpoint-mobile ) {
+						margin-top: 0;
+					}
 				}
 
 				h1 {


### PR DESCRIPTION
Related to #80278

## Proposed Changes

Fix spacing on Educational Header used on `Learn homepage` to match the [designs](IceKRdz5qlPYwuqzu6pBgF-fi-4357%3A91911)

## Testing Instructions

- Pull this branch
- Navigate to `apps/happy-blocks and run yarn dev --sync`
- Run wpsupport3 theme and navigate to [learn](https://learncft.wordpress.com/)
- Compare the header spacing against the design