### PR TITLE
Hosting Metrics: Improve resize and labels on  bar chart

### DIFF
--- a/client/my-sites/site-monitoring/components/site-monitoring-bar-chart/use-metrics-bar-chart-data.ts
+++ b/client/my-sites/site-monitoring/components/site-monitoring-bar-chart/use-metrics-bar-chart-data.ts
@@ -1,3 +1,4 @@
+import { getLocaleSlug } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { TimeRange } from '../../main';
 import { PeriodData, useSiteMetricsQuery } from '../../use-metrics-query';
@@ -49,6 +50,23 @@ function useGroupByTime( periods: PeriodData[], secondsWindow: number ) {
 	}, [ periods, secondsWindow ] );
 }
 
+function getLongDate( date: Date, locale: string ): string {
+	const formatter = new Intl.DateTimeFormat( locale, {
+		day: 'numeric',
+		month: 'long',
+	} );
+	return formatter.format( date );
+}
+
+function getShortDate( date: Date, locale: string ): string {
+	const formatter = new Intl.DateTimeFormat( locale, {
+		hour: '2-digit',
+		minute: '2-digit',
+		hour12: false,
+	} );
+	return formatter.format( date );
+}
+
 export function useMetricsBarChartData( { siteId, timeRange }: UseMetricsBarChartDataParams ) {
 	const { start, end } = timeRange;
 	const metric = 'requests_persec';
@@ -68,7 +86,14 @@ export function useMetricsBarChartData( { siteId, timeRange }: UseMetricsBarChar
 			string[],
 			...number[][]
 		],
-		labels: labels.map( ( timeSeconds ) => new Date( timeSeconds * 1000 ).toLocaleTimeString() ),
+		labels: labels.map( ( timeSeconds ) => {
+			const date = new Date( timeSeconds * 1000 );
+			const locale = getLocaleSlug() || 'en';
+			if ( secondsWindow < 24 * 3600 ) {
+				return getShortDate( date, locale );
+			}
+			return getLongDate( date, locale );
+		} ),
 		fillColors: FILL_COLORS,
 	};
 }

--- a/packages/components/src/chart-uplot/bar.tsx
+++ b/packages/components/src/chart-uplot/bar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import uPlot from 'uplot';
 import UplotReact from 'uplot-react';
 import useResize from './hooks/use-resize';
@@ -30,12 +30,13 @@ export default function UplotBarChart( {
 	options: propOptions,
 }: UplotChartProps ) {
 	const uplot = useRef< uPlot | null >( null );
-	const uplotContainer = useRef( null );
+	const uplotContainer = useRef< HTMLDivElement | null >( null );
+	const [ chartDimensions, setChartDimensions ] = useState( DEFAULT_DIMENSIONS );
 
 	const options: uPlot.Options = useMemo( () => {
 		const defaultOptions: uPlot.Options = {
 			class: 'calypso-uplot-bar-chart',
-			...DEFAULT_DIMENSIONS,
+			...chartDimensions,
 			axes: [
 				{},
 				{
@@ -71,9 +72,19 @@ export default function UplotBarChart( {
 			...defaultOptions,
 			...( typeof propOptions === 'object' ? propOptions : {} ),
 		};
-	}, [ data, fillColors, labels, legendContainer, propOptions ] );
+	}, [ chartDimensions, data, fillColors, labels, legendContainer, propOptions ] );
 
 	useResize( uplot, uplotContainer );
+
+	useEffect( () => {
+		// Need extra check for container resize due to `seriesBarsPlugin`
+		if ( uplotContainer.current ) {
+			const { width, height } = uplotContainer.current.getBoundingClientRect();
+			if ( width !== chartDimensions.width || height !== chartDimensions.height ) {
+				setChartDimensions( { width, height } );
+			}
+		}
+	}, [ chartDimensions, data ] );
 
 	return (
 		<div className="calypso-uplot-chart-container" ref={ uplotContainer }>

--- a/packages/components/src/chart-uplot/bar.tsx
+++ b/packages/components/src/chart-uplot/bar.tsx
@@ -45,13 +45,10 @@ export default function UplotBarChart( {
 				},
 			],
 			padding: [ null, 0, null, 0 ],
-			series: [
-				{},
-				...( data[ 0 ].map( ( label, i ) => ( {
-					label,
-					fill: fillColors[ i ],
-				} ) ) as uPlot.Series[] ),
-			],
+			series: data[ 0 ].map( ( label, i ) => ( {
+				label,
+				fill: fillColors[ i ],
+			} ) ) as uPlot.Series[],
 			plugins: [
 				seriesBarsPlugin( {
 					labels: () => labels,

--- a/packages/components/src/chart-uplot/uplot-plugins/multi-bars.ts
+++ b/packages/components/src/chart-uplot/uplot-plugins/multi-bars.ts
@@ -324,13 +324,11 @@ export default function seriesBarsPlugin(
 				ticks: { show: false },
 				side: ori === 0 ? 2 : 3,
 			} );
-
+			opts.series = [ {}, ...opts.series ];
 			opts.series.forEach( ( s, i ) => {
 				if ( i > 0 ) {
 					uPlot.assign( s, {
 						width: 0,
-						// pxAlign: false,
-						// stroke: 'rgba(255,0,0,0)',
 						paths: drawBars,
 						points: {
 							show: false, // drawPoints,

--- a/packages/components/src/chart-uplot/uplot-plugins/multi-bars.ts
+++ b/packages/components/src/chart-uplot/uplot-plugins/multi-bars.ts
@@ -300,7 +300,7 @@ export default function seriesBarsPlugin(
 					const splits: any[] = [];
 
 					distr(
-						u.data.length + 1,
+						u.data?.[ 1 ]?.length,
 						groupWidth,
 						groupDistr,
 						null,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/dotcom-forge/issues/3356

## Proposed Changes

* Improve resize and center labels on x-axis

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/site-monitoring/${siteSlug}`
* Scroll down
* Observe the bar chart works as expected
* Resize the browser
* Observe the bar chart is resized as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
