### PR TITLE
Adds a test URL for the promote post widget

### DIFF
--- a/apps/blaze-dashboard/webpack.config.js
+++ b/apps/blaze-dashboard/webpack.config.js
@@ -112,6 +112,7 @@ module.exports = {
 							'features',
 							'dsp_stripe_pub_key',
 							'dsp_widget_js_src',
+							'dsp_widget_js_test_src',
 							'client_slug',
 							'hotjar_enabled',
 						],

--- a/client/lib/mobile-app/index.js
+++ b/client/lib/mobile-app/index.js
@@ -30,7 +30,7 @@ const deviceUnknown = {
 export function getMobileDeviceInfo() {
 	try {
 		const userAgent = navigator.userAgent.toLowerCase();
-		const regex = /w[pc]-(android|iphone|ios)\/(\d+.\d+)/;
+		const regex = /w[pc]-(android|iphone|ios)\/(\d+(.[0-9a-z-]+)*)/;
 		const match = userAgent.match( regex );
 
 		if ( ! match ) {

--- a/client/lib/mobile-app/test/index.js
+++ b/client/lib/mobile-app/test/index.js
@@ -103,4 +103,13 @@ describe( 'getMobileDeviceInfo', () => {
 
 		expect( getMobileDeviceInfo() ).toStrictEqual( { device: 'unknown', version: 'unknown' } );
 	} );
+
+	test( 'should return the correct version for a release candidate', () => {
+		global.navigator = {
+			userAgent:
+				'Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36 wc-android/22.9.rc-1',
+		};
+
+		expect( getMobileDeviceInfo() ).toMatchObject( { version: '22.9.rc-1' } );
+	} );
 } );

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -56,16 +56,26 @@ declare global {
 	}
 }
 
+const shouldUseTestWidgetURL = () => getMobileDeviceInfo()?.version === '22.9.blaze';
+
+const getWidgetDSPJSURL = () => {
+	let dspWidgetJS: string = shouldUseTestWidgetURL()
+		? config( 'dsp_widget_js_test_src' )
+		: config( 'dsp_widget_js_src' );
+
+	if ( config.isEnabled( 'promote-post/widget-i2' ) ) {
+		dspWidgetJS = dspWidgetJS.replace( '/promote/', '/promote-v2/' );
+	}
+	return dspWidgetJS;
+};
+
 export async function loadDSPWidgetJS(): Promise< void > {
 	// check if already loaded
 	if ( window.BlazePress ) {
 		return;
 	}
-	let dspWidgetJS: string = config( 'dsp_widget_js_src' );
-	if ( config.isEnabled( 'promote-post/widget-i2' ) ) {
-		dspWidgetJS = dspWidgetJS.replace( '/promote/', '/promote-v2/' );
-	}
-	const src = dspWidgetJS + '?ver=' + Math.round( Date.now() / ( 1000 * 60 * 60 ) );
+
+	const src = `${ getWidgetDSPJSURL() }?ver=${ Math.round( Date.now() / ( 1000 * 60 * 60 ) ) }`;
 	await loadScript( src );
 	// Load the strings so that translations get associated with the module and loaded properly.
 	// The module will assign the placeholder component to `window.BlazePress.strings` as a side-effect,

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -33,6 +33,7 @@
 	"livechat_support_locales": [ "en", "en-gb" ],
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
+	"dsp_widget_js_test_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": false,
 	"zendesk_presales_chat_key_akismet": false,

--- a/config/development.json
+++ b/config/development.json
@@ -23,6 +23,7 @@
 	"facebook_api_key": "249643311490",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
+	"dsp_widget_js_test_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",

--- a/config/production.json
+++ b/config/production.json
@@ -13,6 +13,7 @@
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"dsp_widget_js_test_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",

--- a/config/stage.json
+++ b/config/stage.json
@@ -11,6 +11,7 @@
 	"facebook_api_key": "249643311490",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
+	"dsp_widget_js_test_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -11,6 +11,7 @@
 	"facebook_api_key": "249643311490",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
+	"dsp_widget_js_test_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",


### PR DESCRIPTION
We have a bug in the Jetpack mobile app for android when we use the new DSP widget URL.
This PR adds the possibility of using a different URL for a specific app version to help us debug the problem.,

## Proposed Changes

* Adds a new config prop for the test URL using this name: `dsp_widget_js_test_src`
* Changes the logic so we load from that test URL if the Jetpack App version is `22.9.blaze` (This version is not used by any client)

## Testing Instructions

### Test that Web still works as expected

* Open the Live preview and navigate to Tools->Advertising
* Click on the promote button
* Verify that the DSP create campaign widget loads correctly

### Test for an app using version `22.9.blaze`
Right now, except in production, the props `dsp_widget_js_src` and `dsp_widget_js_test_src` points to the same URL. 
You will need to checkout this branch locally and change the value of `dsp_widget_js_test_src` in the developer config file to any other URL (e.g. `https://widgets.wp.com/promote/widget.js`).

* Create a mobile device using this user agent (or change your browser user-agent): 
`Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36 wp-android/22.9.blaze`
* Refresh the page
* Open your Browser network tab and filter by `widget.js`
* Click on the Promote button
* Verify that the widget load correctly using the `dsp_widget_js_test_src` URL for the `widget.js` file


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
