### PR TITLE
SiteStatusContent: slugify site URL in Activity Log link

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getActionEventName } from '../utils';
@@ -75,7 +76,7 @@ export default function SiteActions( { isLargeScreen = false, site, siteError }:
 						</PopoverMenuItem>
 						<PopoverMenuItem
 							onClick={ () => handleClickMenuItem( 'view_activity' ) }
-							href={ `/activity-log/${ siteUrl }` }
+							href={ `/activity-log/${ urlToSlug( siteUrl ) }` }
 							className="site-actions__menu-item"
 						>
 							{ translate( 'View activity' ) }
@@ -86,14 +87,14 @@ export default function SiteActions( { isLargeScreen = false, site, siteError }:
 					<>
 						<PopoverMenuItem
 							onClick={ () => handleClickMenuItem( 'clone_site' ) }
-							href={ `/backup/${ siteUrl }/clone` }
+							href={ `/backup/${ urlToSlug( siteUrl ) }/clone` }
 							className="site-actions__menu-item"
 						>
 							{ translate( 'Copy this site' ) }
 						</PopoverMenuItem>
 						<PopoverMenuItem
 							onClick={ () => handleClickMenuItem( 'site_settings' ) }
-							href={ `/settings/${ siteUrl }` }
+							href={ `/settings/${ urlToSlug( siteUrl ) }` }
 							className="site-actions__menu-item"
 						>
 							{ translate( 'Site settings' ) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-error-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-error-content.tsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -25,7 +26,7 @@ export default function SiteErrorContent( { siteUrl }: { siteUrl: string } ) {
 			<a
 				onClick={ handleClickFixNow }
 				className="sites-overview__error-message-link"
-				href={ `/settings/disconnect-site/${ siteUrl }?type=down` }
+				href={ `/settings/disconnect-site/${ urlToSlug( siteUrl ) }?type=down` }
 			>
 				{ translate( 'Fix now' ) }
 			</a>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -91,7 +91,7 @@ const BackupStorageContent = ( {
 			<div className="site-expanded-content__card-footer">
 				<Button
 					onClick={ () => trackEvent( 'expandable_block_activity_log_click' ) }
-					href={ `/activity-log/${ siteUrl }` }
+					href={ `/activity-log/${ urlToSlug( siteUrl ) }` }
 					className="site-expanded-content__card-button"
 					compact
 				>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -6,6 +6,7 @@ import { translate } from 'i18n-calypso';
 import page from 'page';
 import { useRef, useState, useMemo, useContext } from 'react';
 import Tooltip from 'calypso/components/tooltip';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectLicense, unselectLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
@@ -169,7 +170,7 @@ export default function SiteStatusContent( {
 						className="sites-overview__row-text"
 						borderless
 						compact
-						href={ `/activity-log/${ siteUrl }` }
+						href={ `/activity-log/${ urlToSlug( siteUrl ) }` }
 					>
 						{ siteUrl }
 						<SiteBackupStaging siteId={ siteId } />

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -9,6 +9,7 @@ import nock from 'nock';
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { siteColumns } from '../../utils';
 import SiteTable from '../index';
 import type { SiteData } from '../../types';
@@ -145,16 +146,16 @@ describe( '<SiteTable>', () => {
 		);
 
 		const backupEle = getByTestId( `row-${ blogId }-backup` );
-		expect( backupEle.getAttribute( 'href' ) ).toEqual( `/backup/${ siteUrl }` );
+		expect( backupEle.getAttribute( 'href' ) ).toEqual( `/backup/${ urlToSlug( siteUrl ) }` );
 		expect( getByText( /failed/i ) ).toBeInTheDocument();
 
 		const scanEle = getByTestId( `row-${ blogId }-scan` );
-		expect( scanEle.getAttribute( 'href' ) ).toEqual( `/scan/${ siteUrl }` );
+		expect( scanEle.getAttribute( 'href' ) ).toEqual( `/scan/${ urlToSlug( siteUrl ) }` );
 		expect( getByText( `${ scanThreats } Threats` ) ).toBeInTheDocument();
 
 		const pluginEle = getByTestId( `row-${ blogId }-plugin` );
 		expect( pluginEle.getAttribute( 'href' ) ).toEqual(
-			`https://wordpress.com/plugins/updates/${ siteUrl }`
+			`https://wordpress.com/plugins/updates/${ urlToSlug( siteUrl ) }`
 		);
 		expect( getByText( `${ pluginUpdates.length } Available` ) ).toBeInTheDocument();
 	} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/site-error-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/site-error-content.tsx
@@ -5,6 +5,7 @@
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
 import SiteErrorContent from '../site-error-content';
 
 describe( '<SiteErrorContent>', () => {
@@ -24,7 +25,7 @@ describe( '<SiteErrorContent>', () => {
 		const [ fixNow ] = container.getElementsByClassName( 'sites-overview__error-message-link' );
 		expect( fixNow ).toHaveProperty(
 			'href',
-			`https://example.com/settings/disconnect-site/${ siteUrl }?type=down`
+			`https://example.com/settings/disconnect-site/${ urlToSlug( siteUrl ) }?type=down`
 		);
 	} );
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/site-status-content.jsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/site-status-content.jsx
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import SiteStatusContent from '../site-status-content';
+
+jest.mock( 'react', () => ( {
+	...jest.requireActual( 'react' ),
+	useContext: jest.fn().mockReturnValue( {} ),
+} ) );
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useSelector: jest.fn().mockReturnValue( () => null ),
+	useDispatch: jest.fn().mockReturnValue( () => {} ),
+} ) );
+jest.mock( '../site-set-favorite' );
+
+describe( 'SiteStatusContent', () => {
+	it( 'renders the correct Activity Log link for sites with a path component', () => {
+		const SITE_URL = 'https://mycoolsite.example/wordpress';
+
+		const props = {
+			rows: {
+				site: {
+					value: {
+						url: SITE_URL,
+					},
+				},
+				monitor: {
+					error: {},
+				},
+				scan: {
+					threats: 0,
+				},
+				plugin: {
+					updates: 0,
+				},
+				backup: {},
+			},
+			type: 'site',
+			isLargeScreen: true,
+			siteError: false,
+		};
+
+		render( <SiteStatusContent { ...props } /> );
+		const button = screen.getByText( SITE_URL, { role: 'button' } );
+		const href = button.getAttribute( 'href' );
+		expect( href ).toBe( '/activity-log/mycoolsite.example::wordpress' );
+	} );
+} );


### PR DESCRIPTION
This pull request fixes an incorrect linking behavior on the Agency Dashboard for sites inside nested paths (e.g., `myawesomesite.com/wordpress`), which were erroneously directed to a non-existent page (e.g., `/activity-log/myawesomesite.com/wordpress`).

Resolves `1202619025189113-as-1205175816509628`.

## Proposed Changes

* Wrap `siteUrl` inside a call to `urlToSlug` when building button `href`s in the site table's **Site** column.
* Add unit test coverage for **Site** column links in the Dashboard's site table, to ensure they point to the correct slug-ified Activity Log URLs.

## Testing Instructions

*NOTE: If you're an Automattician and need to create a site that lives inside a nested path, use Jurassic Ninja. Be sure to select the option for "Launch Multisite on subdirs"!*

* Before starting, ensure you have access to an account that has at least one site that exists inside a nested path, and that this account can see the Agency Dashboard.
* In your testing environment with this pull request applied, visit `/dashboard` in Jetpack Cloud.
* Find a site in the table that exists inside a nested path, and click its name.
* Verify you're sent to that site's Activity Log, and not an error page.
* Inspect code changes and unit test cases to ensure they make sense and test the proper lines of code.

### Reference screenshots

#### Error condition

![image](https://github.com/Automattic/wp-calypso/assets/670067/c2508e02-9f0a-4767-b399-18dc23dc651a)

#### Corrected

<img width="868" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/77c89c96-708b-4e43-aef1-5af8d6289b50">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1205175816509628