### PR TITLE
Jetpack Error UX: Rename `type` prop to `error_type`

### DIFF
--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -29,7 +29,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 	const handleJetpackConnectionHealthLinkClick = () => {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_connection_health_issue_click', {
-				type: 'default',
+				error_type: 'default',
 			} )
 		);
 	};
@@ -46,7 +46,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 		<>
 			<TrackComponentView
 				eventName="calypso_jetpack_connection_health_issue_view"
-				eventProperties={ { type: 'default' } }
+				eventProperties={ { error_type: 'default' } }
 			/>
 			<Notice
 				status="is-error"


### PR DESCRIPTION
From https://github.com/Automattic/wp-calypso/pull/79965

## Proposed Changes

Renames the `type` Tracks prop to `error_type` for clarity.

## Testing Instructions

1. Create a Business site in an erred Jetpack state.
2. Verify the correct error type is conveyed when the notice renders.