### PR TITLE
Jetpack Error UX: Show error banner on Users list when connection fails

### DIFF
--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -31,7 +31,7 @@ function SubscribersTeam( props: Props ) {
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
 	const isPossibleJetpackConnectionProblem = useSelector( ( state ) =>
-		isJetpackConnectionProblem( state, site?.ID )
+		isJetpackConnectionProblem( state, site?.ID as number )
 	);
 	const pendingInvites = useSelector( ( state ) =>
 		getPendingInvitesForSite( state, site?.ID as number )

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -2,6 +2,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import SectionNav from 'calypso/components/section-nav';
@@ -10,6 +11,8 @@ import useUsersQuery from 'calypso/data/users/use-users-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useSelector } from 'calypso/state';
 import { getPendingInvitesForSite } from 'calypso/state/invites/selectors';
+import isJetpackConnectionProblem from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PeopleSectionNavCompact from '../people-section-nav-compact';
 import Subscribers from '../subscribers';
@@ -26,6 +29,10 @@ function SubscribersTeam( props: Props ) {
 	const translate = useTranslate();
 	const { filter, search } = props;
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
+	const isPossibleJetpackConnectionProblem = useSelector( ( state ) =>
+		isJetpackConnectionProblem( state, site?.ID )
+	);
 	const pendingInvites = useSelector( ( state ) =>
 		getPendingInvitesForSite( state, site?.ID as number )
 	);
@@ -51,6 +58,9 @@ function SubscribersTeam( props: Props ) {
 	return (
 		<Main>
 			<ScreenOptionsTab wpAdminPath="users.php" />
+			{ isJetpack && isPossibleJetpackConnectionProblem && site?.ID && (
+				<JetpackConnectionHealthBanner siteId={ site.ID } />
+			) }
 			<FormattedHeader
 				brandFont
 				className="people__page-heading"

--- a/client/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js
+++ b/client/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js
@@ -3,11 +3,14 @@ import 'calypso/state/jetpack-connection-health/init';
 /**
  * Returns true if the current site has possible Jetpack connection problem
  *
- * @param  {Object}   state         Global state tree
- * @param  {number}   siteId        Site ID
- * @returns {?boolean}               Whether the current site can have connection problem
+ * @param  {Object}  state         Global state tree
+ * @param  {number}  siteId        Site ID
+ * @returns {?boolean}             Whether the current site can have connection problem
  */
 export default function isJetpackConnectionProblem( state, siteId ) {
+	if ( ! siteId ) {
+		return null;
+	}
 	const connection_data = state.jetpackConnectionHealth[ siteId ];
 
 	if ( ! connection_data ) {


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/3394

## Proposed Changes

Shows an error notice on the Users list when Jetpack is unable to connect to the site:

<img width="1288" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/ae30fe49-1fef-4a2f-bb1b-c005f0ed86bf">

Triggering logic was introduced in https://github.com/Automattic/wp-calypso/pull/79965

## Testing Instructions

1. Create a new Business site and take it Atomic.
2. Add some PHP code to `~/htdocs/wp-content/mu-plugins/local.php` that causes a fatal error.
3. Navigate to "All People" in Calypso.
4. Verify the notice appears as expected.
5. Fix your fatal error.
6. Reload the "All People" view.
7. Verify the notice no longer appears.