### PR TITLE
Jetpack Error UX: Show error banner on Comments, Media, Pages

### DIFF
--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -6,12 +6,15 @@ import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { preventWidows } from 'calypso/lib/formatting';
+import isJetpackConnectionProblem from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteId } from 'calypso/state/sites/selectors';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import CommentList from './comment-list';
 import { NEWEST_FIRST } from './constants';
 
@@ -45,6 +48,8 @@ export class CommentsManagement extends Component {
 		const {
 			analyticsPath,
 			changePage,
+			isJetpack,
+			isPossibleJetpackConnectionProblem,
 			page,
 			postId,
 			showCommentList,
@@ -60,6 +65,9 @@ export class CommentsManagement extends Component {
 			<Main className="comments" wideLayout>
 				<ScreenOptionsTab wpAdminPath="edit-comments.php" />
 				<PageViewTracker path={ analyticsPath } title="Comments" />
+				{ isJetpack && isPossibleJetpackConnectionProblem && (
+					<JetpackConnectionHealthBanner siteId={ siteId } />
+				) }
 				<DocumentHead title={ translate( 'Comments' ) } />
 				{ ! showPermissionError && (
 					<FormattedHeader
@@ -115,6 +123,8 @@ const mapStateToProps = ( state, { siteFragment } ) => {
 	const showCommentList = ! showPermissionError;
 
 	return {
+		isJetpack: isJetpackSite( state, siteId ),
+		isPossibleJetpackConnectionProblem: isJetpackConnectionProblem( state, siteId ),
 		siteId,
 		showCommentList,
 		showPermissionError,

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -9,6 +9,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryMedia from 'calypso/components/data/query-media';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Notice from 'calypso/components/notice';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import { withEditMedia } from 'calypso/data/media/use-edit-media-mutation';
@@ -20,11 +21,13 @@ import searchUrl from 'calypso/lib/search-url';
 import MediaLibrary from 'calypso/my-sites/media-library';
 import { EditorMediaModalDetail } from 'calypso/post-editor/media-modal/detail';
 import EditorMediaModalDialog from 'calypso/post-editor/media-modal/dialog';
+import isJetpackConnectionProblem from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
 import { selectMediaItems, changeMediaSource, clearSite } from 'calypso/state/media/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getMediaItem from 'calypso/state/selectors/get-media-item';
 import getMediaLibrarySelectedItems from 'calypso/state/selectors/get-media-library-selected-items';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -351,13 +354,24 @@ class Media extends Component {
 	};
 
 	render() {
-		const { selectedSite: site, mediaId, previousRoute, translate } = this.props;
+		const {
+			selectedSite: site,
+			mediaId,
+			previousRoute,
+			translate,
+			siteId,
+			isJetpack,
+			isPossibleJetpackConnectionProblem,
+		} = this.props;
 
 		return (
 			<div ref={ this.containerRef } className="main main-column media" role="main">
 				<ScreenOptionsTab wpAdminPath="upload.php" />
 				{ mediaId && site && site.ID && <QueryMedia siteId={ site.ID } mediaId={ mediaId } /> }
 				<PageViewTracker path={ this.getAnalyticsPath() } title="Media" />
+				{ isJetpack && isPossibleJetpackConnectionProblem && (
+					<JetpackConnectionHealthBanner siteId={ siteId } />
+				) }
 				<DocumentHead title={ translate( 'Media' ) } />
 				<FormattedHeader
 					brandFont
@@ -453,9 +467,12 @@ const mapStateToProps = ( state, { mediaId } ) => {
 	const siteId = getSelectedSiteId( state );
 
 	return {
+		siteId,
 		selectedSite: getSelectedSite( state ),
 		previousRoute: getPreviousRoute( state ),
 		currentRoute: getCurrentRoute( state ),
+		isJetpack: isJetpackSite( state, siteId ),
+		isPossibleJetpackConnectionProblem: isJetpackConnectionProblem( state, siteId ),
 		media: getMediaItem( state, siteId, mediaId ),
 		selectedItems: getMediaLibrarySelectedItems( state, siteId ),
 	};

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -8,6 +8,7 @@ import SitePreview from 'calypso/blocks/site-preview';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -15,8 +16,10 @@ import { Experiment } from 'calypso/lib/explat';
 import { mapPostStatus } from 'calypso/lib/route';
 import urlSearch from 'calypso/lib/url-search';
 import PostTypeFilter from 'calypso/my-sites/post-type-filter';
+import isJetpackConnectionProblem from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
 import { getPostTypeLabel } from 'calypso/state/post-types/selectors';
 import { POST_STATUSES } from 'calypso/state/posts/constants';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PageList from './page-list';
 
@@ -60,7 +63,16 @@ class PagesMain extends Component {
 	}
 
 	render() {
-		const { siteId, search, status, translate, queryType, author } = this.props;
+		const {
+			isJetpack,
+			isPossibleJetpackConnectionProblem,
+			siteId,
+			search,
+			status,
+			translate,
+			queryType,
+			author,
+		} = this.props;
 		const postStatus = mapPostStatus( status );
 		/* Check if All Sites Mode */
 		const isAllSites = siteId ? 1 : 0;
@@ -85,6 +97,9 @@ class PagesMain extends Component {
 			<Main wideLayout classname="pages">
 				<ScreenOptionsTab wpAdminPath="edit.php?post_type=page" />
 				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />
+				{ isJetpack && isPossibleJetpackConnectionProblem && (
+					<JetpackConnectionHealthBanner siteId={ siteId } />
+				) }
 				<DocumentHead title={ translate( 'Pages' ) } />
 				<SitePreview />
 				<FormattedHeader
@@ -159,6 +174,8 @@ const mapState = ( state ) => {
 		searchPagesPlaceholder,
 		queryType,
 		siteId,
+		isJetpack: isJetpackSite( state, siteId ),
+		isPossibleJetpackConnectionProblem: isJetpackConnectionProblem( state, siteId ),
 	};
 };
 


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/3394

## Proposed Changes

Shows an error notice on the Comments, Media, and Pages lists when Jetpack is unable to connect to the site:

<img width="1283" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/90614876-5dbc-4400-8820-a9924bb44512">

<img width="1285" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/fd190629-d303-4985-90e5-6ca5e8ba55f2">

<img width="1283" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/d725f587-0a0c-401b-b65b-825da5375d11">

Triggering logic was introduced in https://github.com/Automattic/wp-calypso/pull/79965

## Testing Instructions

1. Create a new Business site and take it Atomic.
2. Add some PHP code to `~/htdocs/wp-content/mu-plugins/local.php` that causes a fatal error.
3. Navigate to Comments in Calypso.
4. Verify the notice appears as expected.
5. Fix your fatal error.
6. Reload the Comments view.
7. Verify the notice no longer appears.