### PR TITLE
Launchpad: Paid newsletter task opens modal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -248,13 +248,11 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 				/>
 				{ showPlansModal && site?.ID && (
 					<RecurringPaymentsPlanAddEditModal
-						// This spread syntax for props is needed to
-						// resolve an odd IntrinsicAttributes TS error
-						{ ...{
-							closeDialog: () => setShowPlansModal( false ),
-							product: { subscribe_as_site_subscriber: true },
-							siteId: site.ID,
-						} }
+						closeDialog={ () => setShowPlansModal( false ) }
+						product={ { subscribe_as_site_subscriber: true } }
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
+						siteId={ site.ID }
 					/>
 				) }
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -250,7 +250,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 				{ showPlansModal && (
 					<RecurringPaymentsPlanAddEditModal
 						closeDialog={ () => setShowPlansModal( false ) }
-						product={ null }
+						product={ { subscribe_as_site_subscriber: true } }
 					/>
 				) }
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -251,7 +251,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 						closeDialog={ () => setShowPlansModal( false ) }
 						product={ { subscribe_as_site_subscriber: true } }
 						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-						// @ts-ignore
+						// @ts-ignore - Underlying component is JS class component with props supplied by connect() and mapstatetoprops.
 						siteId={ site.ID }
 					/>
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -251,6 +251,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 					<RecurringPaymentsPlanAddEditModal
 						closeDialog={ () => setShowPlansModal( false ) }
 						product={ { subscribe_as_site_subscriber: true } }
+						siteId={ site?.ID }
 					/>
 				) }
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -106,15 +106,15 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 			submit,
 			globalStylesInUse && shouldLimitGlobalStyles,
 			globalStylesInPersonalPlan ? PLAN_PERSONAL : PLAN_PREMIUM,
+			setShowPlansModal,
+			queryClient,
 			goToStep,
 			flow,
 			isEmailVerified,
 			checklistStatuses,
 			getPlanCartItem(),
 			getDomainCartItem(),
-			stripeConnectUrl,
-			setShowPlansModal,
-			queryClient
+			stripeConnectUrl
 		);
 
 	const currentTask = enhancedTasks?.filter( ( task ) => task.completed ).length;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -3,6 +3,7 @@ import { Badge, Gridicon, CircularProgressBar } from '@automattic/components';
 import { OnboardSelect, useLaunchpad } from '@automattic/data-stores';
 import { Launchpad } from '@automattic/launchpad';
 import { isBlogOnboardingFlow, isNewsletterFlow } from '@automattic/onboarding';
+import { useQueryClient } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
 import { useRef, useState, useEffect } from '@wordpress/element';
 import { Icon, copy } from '@wordpress/icons';
@@ -67,6 +68,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 	const [ stripeConnectUrl, setStripeConnectUrl ] = useState< string >( '' );
 
 	const [ showPlansModal, setShowPlansModal ] = useState( false );
+	const queryClient = useQueryClient();
 
 	const { globalStylesInUse, shouldLimitGlobalStyles, globalStylesInPersonalPlan } =
 		useSiteGlobalStylesStatus( site?.ID );
@@ -112,7 +114,8 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 			getPlanCartItem(),
 			getDomainCartItem(),
 			stripeConnectUrl,
-			setShowPlansModal
+			setShowPlansModal,
+			queryClient
 		);
 
 	const currentTask = enhancedTasks?.filter( ( task ) => task.completed ).length;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -66,7 +66,6 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 	const clipboardButtonEl = useRef< HTMLButtonElement >( null );
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const [ stripeConnectUrl, setStripeConnectUrl ] = useState< string >( '' );
-
 	const [ showPlansModal, setShowPlansModal ] = useState( false );
 	const queryClient = useQueryClient();
 
@@ -247,11 +246,15 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 					taskFilter={ () => enhancedTasks || [] }
 					makeLastTaskPrimaryAction={ true }
 				/>
-				{ showPlansModal && (
+				{ showPlansModal && site?.ID && (
 					<RecurringPaymentsPlanAddEditModal
-						closeDialog={ () => setShowPlansModal( false ) }
-						product={ { subscribe_as_site_subscriber: true } }
-						siteId={ site?.ID }
+						// This spread syntax for props is needed to
+						// resolve an odd IntrinsicAttributes TS error
+						{ ...{
+							closeDialog: () => setShowPlansModal( false ),
+							product: { subscribe_as_site_subscriber: true },
+							siteId: site.ID,
+						} }
 					/>
 				) }
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -14,6 +14,7 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import wpcom from 'calypso/lib/wp';
+import RecurringPaymentsPlanAddEditModal from 'calypso/my-sites/earn/memberships/add-edit-plan-modal';
 import { useSelector } from 'calypso/state';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
@@ -65,6 +66,8 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const [ stripeConnectUrl, setStripeConnectUrl ] = useState< string >( '' );
 
+	const [ showPlansModal, setShowPlansModal ] = useState( false );
+
 	const { globalStylesInUse, shouldLimitGlobalStyles, globalStylesInPersonalPlan } =
 		useSiteGlobalStylesStatus( site?.ID );
 
@@ -108,7 +111,8 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 			checklistStatuses,
 			getPlanCartItem(),
 			getDomainCartItem(),
-			stripeConnectUrl
+			stripeConnectUrl,
+			setShowPlansModal
 		);
 
 	const currentTask = enhancedTasks?.filter( ( task ) => task.completed ).length;
@@ -240,6 +244,12 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 					taskFilter={ () => enhancedTasks || [] }
 					makeLastTaskPrimaryAction={ true }
 				/>
+				{ showPlansModal && (
+					<RecurringPaymentsPlanAddEditModal
+						closeDialog={ () => setShowPlansModal( false ) }
+						product={ null }
+					/>
+				) }
 			</div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -484,3 +484,29 @@
 		display: none;
 	}
 }
+
+// Fix small CSS with payment modal. Ideally, should
+// be resolved via css for payment modal component itself.
+// But that modal doesn't have its own css. The CSS is part
+// of the Earn > Memberships page.
+.memberships__dialog-sections-price {
+	display: flex;
+	justify-content: flex-start;
+	flex-direction: column;
+
+	@include break-medium {
+		flex-direction: row;
+	}
+}
+
+.memberships__dialog-sections-price-field-container {
+	display: flex;
+	flex-direction: column;
+	margin-bottom: 25px;
+
+	@include break-medium {
+		margin-bottom: 0;
+		margin-right: 35px;
+		max-width: 200px;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -45,15 +45,15 @@ export function getEnhancedTasks(
 	submit: NavigationControls[ 'submit' ],
 	displayGlobalStylesWarning: boolean,
 	globalStylesMinimumPlan: string,
+	setShowPlansModal: Dispatch< SetStateAction< boolean > >,
+	queryClient: QueryClient,
 	goToStep?: NavigationControls[ 'goToStep' ],
 	flow: string | null = '',
 	isEmailVerified = false,
 	checklistStatuses: LaunchpadStatuses = {},
 	planCartItem?: MinimalRequestCartProduct | null,
 	domainCartItem?: MinimalRequestCartProduct | null,
-	stripeConnectUrl?: string,
-	setShowPlansModal?: Dispatch< SetStateAction< boolean > >,
-	queryClient?: QueryClient
+	stripeConnectUrl?: string
 ) {
 	if ( ! tasks ) {
 		return [];
@@ -117,9 +117,7 @@ export function getEnhancedTasks(
 			await updateLaunchpadSettings( siteSlug, {
 				checklist_statuses: { newsletter_plan_created: true },
 			} );
-			if ( queryClient ) {
-				queryClient?.invalidateQueries( [ 'launchpad' ] );
-			}
+			queryClient?.invalidateQueries( [ 'launchpad' ] );
 		}
 	};
 
@@ -525,7 +523,7 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							completePaidNewsletterTask();
-							setShowPlansModal
+							site?.ID
 								? setShowPlansModal( true )
 								: window.location.assign(
 										`/earn/payments-plans/${ siteSlug }?launchpad=add-product#add-newsletter-payment-plan`

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -117,6 +117,9 @@ export function getEnhancedTasks(
 			await updateLaunchpadSettings( siteSlug, {
 				checklist_statuses: { newsletter_plan_created: true },
 			} );
+			if ( queryClient ) {
+				queryClient?.invalidateQueries( [ 'launchpad' ] );
+			}
 		}
 	};
 
@@ -522,9 +525,6 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							completePaidNewsletterTask();
-							if ( queryClient ) {
-								queryClient?.invalidateQueries( [ 'launchpad' ] );
-							}
 							setShowPlansModal
 								? setShowPlansModal( true )
 								: window.location.assign(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -18,6 +18,7 @@ import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
+import { Dispatch, SetStateAction } from 'react';
 import { PLANS_LIST } from 'calypso/../packages/calypso-products/src/plans-list';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import useCheckout from 'calypso/landing/stepper/hooks/use-checkout';
@@ -50,7 +51,8 @@ export function getEnhancedTasks(
 	checklistStatuses: LaunchpadStatuses = {},
 	planCartItem?: MinimalRequestCartProduct | null,
 	domainCartItem?: MinimalRequestCartProduct | null,
-	stripeConnectUrl?: string
+	stripeConnectUrl?: string,
+	setShowPlansModal?: Dispatch< SetStateAction< boolean > >
 ) {
 	if ( ! tasks ) {
 		return [];
@@ -510,9 +512,11 @@ export function getEnhancedTasks(
 						disabled: ! isStripeConnected,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.assign(
-								`/earn/payments-plans/${ siteSlug }?launchpad=add-product#add-newsletter-payment-plan`
-							);
+							setShowPlansModal
+								? setShowPlansModal( true )
+								: window.location.assign(
+										`/earn/payments-plans/${ siteSlug }?launchpad=add-product#add-newsletter-payment-plan`
+								  );
 						},
 					};
 					break;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -2,8 +2,13 @@
  * @jest-environment jsdom
  */
 import { PLAN_PREMIUM } from '@automattic/calypso-products';
+import { QueryClient } from '@tanstack/react-query';
 import { getEnhancedTasks } from '../task-helper';
 import { buildTask } from './lib/fixtures';
+
+const queryClient = new QueryClient( {
+	defaultOptions: {},
+} );
 
 describe( 'Task Helpers', () => {
 	describe( 'getEnhancedTasks', () => {
@@ -15,8 +20,18 @@ describe( 'Task Helpers', () => {
 					buildTask( { id: 'fake-task-3' } ),
 				];
 				expect(
-					// eslint-disable-next-line @typescript-eslint/no-empty-function
-					getEnhancedTasks( fakeTasks, 'fake.wordpress.com', null, () => {}, false, PLAN_PREMIUM )
+					getEnhancedTasks(
+						fakeTasks,
+						'fake.wordpress.com',
+						null,
+						// eslint-disable-next-line @typescript-eslint/no-empty-function
+						() => {},
+						false,
+						PLAN_PREMIUM,
+						// eslint-disable-next-line @typescript-eslint/no-empty-function
+						() => {},
+						queryClient
+					)
 				).toEqual( fakeTasks );
 			} );
 		} );
@@ -33,6 +48,9 @@ describe( 'Task Helpers', () => {
 						() => {},
 						false,
 						PLAN_PREMIUM,
+						// eslint-disable-next-line @typescript-eslint/no-empty-function
+						() => {},
+						queryClient,
 						// eslint-disable-next-line @typescript-eslint/no-empty-function
 						() => {},
 						'newsletter',
@@ -54,6 +72,9 @@ describe( 'Task Helpers', () => {
 						() => {},
 						false,
 						PLAN_PREMIUM,
+						// eslint-disable-next-line @typescript-eslint/no-empty-function
+						() => {},
+						queryClient,
 						// eslint-disable-next-line @typescript-eslint/no-empty-function
 						() => {},
 						'start-writing'

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -385,8 +385,8 @@ const RecurringPaymentsPlanAddEditModal = ( {
 };
 
 export default connect(
-	( state ) => ( {
-		siteId: getSelectedSiteId( state ),
+	( state, props ) => ( {
+		siteId: props.siteId || getSelectedSiteId( state ),
 		connectedAccountDefaultCurrency: getconnectedAccountDefaultCurrencyForSiteId(
 			state,
 			getSelectedSiteId( state )


### PR DESCRIPTION
## Proposed Changes

Update the `Create paid newsletter` task on Launchpad to directly open the Plans modal rather than redirect the user to the Earn page in the WordPress.com admin area.

<img width="1476" alt="paid newsletter modal" src="https://github.com/Automattic/wp-calypso/assets/21228350/666b2d04-7cb3-4316-8865-55d18fded791">

## Testing Instructions

1) Setup
   - Add `define( 'USE_STORE_SANDBOX', true );` to your sandbox. You can add it to wp-content/mu-plugins/0-sandbox.php. This will allow you to NOT have to fully set up stripe when sent to stripe.
   - Sandbox public-api.wordpress.com and the domain of your test site.
   - Checkout this calypso branch and run yarn or yarn start if needed.
   - Start a newsletter site at `http://calypso.localhost:3000/setup/newsletter/intro`. Be sure to choose the "Paid" option. And remember to sandbox this domain before clicking the stripe link if you've created a new site.
   - Click the `Set up payment method` link. You'll need this before you can add plans. It will take you to the Stripe connect page. If you've set the USE_STORE_SANDBOX constant, you should see a button near the top to Skip this Form. Click that and return to Launchpad.
   - When Stripe sends you back to WordPress, it will load wordpress.com rather than Calypso localhost for the domain. If needed, replace https://wordpress.com with http://calypso.localhost:3000/. 
   
2) Test the link
   - Click the `Create paid newsletter` link
   - Add a plan/product and click save. confirm the Modal closes and that the task now shows as complete on Launchpad. There may be a small delay on completion status.
   - Go to site's admin, to Tools > Earn, and confirm the new plan has been created there. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
