### PR TITLE
Subscribe Modal: Temporarily remove edit link 

### DIFF
--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -1,11 +1,6 @@
 import { ToggleControl } from '@wordpress/components';
-import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
-import { getSiteOption } from 'calypso/state/sites/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 export const SUBSCRIBE_MODAL_OPTION = 'sm_enabled';
 
@@ -21,20 +16,6 @@ export const SubscribeModalSetting = ( {
 	disabled,
 }: SubscribeModalSettingProps ) => {
 	const translate = useTranslate();
-	const selectedSite = useSelector( getSelectedSite );
-	const siteEditorUrl = useSelector( ( state: object ) =>
-		getSiteEditorUrl( state, selectedSite?.ID || null )
-	);
-	const themeSlug = useSelector( ( state ) =>
-		getSiteOption( state, selectedSite?.ID, 'theme_slug' )
-	);
-	const subscribeModalEditorUrl = themeSlug
-		? addQueryArgs( siteEditorUrl, {
-				postType: 'wp_template_part',
-				postId: `${ themeSlug }//subscribe-modal`,
-				canvas: 'edit',
-		  } )
-		: siteEditorUrl;
 
 	return (
 		<>
@@ -46,12 +27,7 @@ export const SubscribeModalSetting = ( {
 			/>
 			<FormSettingExplanation>
 				{ translate(
-					'Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll. {{link}}Edit the modal{{/link}}.',
-					{
-						components: {
-							link: <a href={ subscribeModalEditorUrl } target="_blank" rel="noreferrer" />,
-						},
-					}
+					'Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll.'
 				) }
 			</FormSettingExplanation>
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The Subscribe Modal is not showing in the site editor, and thus is not editable. We're resolving that. Until we fix it, this PR removes the edit link to that modal. 

<img width="784" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/4f68fbca-d6e8-4db4-afb5-8284175e6d96">


## Testing Instructions

Check out this branch and go to Settings > Reading > Newsletters. Find the "Enable subscriber modal" setting and confirm that the description underneath just says "Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll" with no link to edit the modal. 
