### PR TITLE
Hosting onboarding: use 'Migrate a site' as the flow-switching CTA

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
@@ -167,7 +167,7 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 				stepName="site-options"
 				backLabelText={ __( 'Back' ) }
 				goBack={ goBack }
-				skipLabelText={ __( 'Import a site' ) }
+				skipLabelText={ __( 'Migrate a site' ) }
 				goNext={ () => window.location.assign( '/setup/import-hosted-site' ) }
 				isHorizontalLayout
 				formattedHeader={


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/79988.

## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/79988, we cross-linked the new hosted site and import hosted site flows through a new "Import a site" link at the top-right corner of the "Create a site" flow.

This direction is correct, but the wording is inconsistent with the `/hosting` page term and the `/sites?hosting-flow=true` bifurcation:

| `/hosting` | `/sites?hosting-flow=true` |
| ---------- | --------------------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/a2b5882e-b865-4b6f-a7ca-7eccd3ba1098) | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/27243417-765b-4154-8b7f-12169422385d) |

As you can see above, both places use "Migrate your site", so we shouldn't say "Import a site" in the "Create a site" flow:

| trunk | this PR |
| ------ | ------ |
| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/c5623673-e0ea-43e6-92fa-8268468b1c2a) | ![Screenshot 2023-08-07 at 22 27 22](https://github.com/Automattic/wp-calypso/assets/26530524/a25d3a55-946f-476f-a041-83f7e4f200f2) |

## Testing Instructions

Open `/setup/new-hosted-site` and observe "Migrate a site" as the link at the top-right corner of the page. Clicking it should send the user to `/setup/import-hosted-site`.
