### PR TITLE
Convert Live Preview related code into TypeScript

### DIFF
--- a/client/my-sites/theme/live-preview-button/index.tsx
+++ b/client/my-sites/theme/live-preview-button/index.tsx
@@ -1,14 +1,20 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { FC } from 'react';
 import { useSelector } from 'calypso/state';
 import { getIsLivePreviewSupported, getLivePreviewUrl } from 'calypso/state/themes/selectors';
+
+interface Props {
+	themeId: string;
+	siteId: number;
+}
 
 /**
  * Live Preview leveraging Gutenberg's Block Theme Previews
  *
  * @see pbxlJb-3Uv-p2
  */
-export const LivePreviewButton = ( { themeId, siteId } ) => {
+export const LivePreviewButton: FC< Props > = ( { themeId, siteId } ) => {
 	const translate = useTranslate();
 	const isLivePreviewSupported = useSelector( ( state ) =>
 		getIsLivePreviewSupported( state, themeId, siteId )

--- a/client/state/themes/selectors/get-is-live-preview-supported.ts
+++ b/client/state/themes/selectors/get-is-live-preview-supported.ts
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isSimpleSite } from 'calypso/state/sites/selectors';
+import { AppState } from 'calypso/types';
 import {
 	isWporgTheme,
 	isThemeActive,
@@ -62,7 +63,7 @@ const NOT_COMPATIBLE_THEMES = [
 	'winkel',
 ];
 
-const isNotCompatibleThemes = ( themeId ) => {
+const isNotCompatibleThemes = ( themeId: string ) => {
 	return NOT_COMPATIBLE_THEMES.includes( themeId );
 };
 
@@ -82,7 +83,7 @@ const isNotCompatibleThemes = ( themeId ) => {
  *
  * @see pbxlJb-3Uv-p2
  */
-export const getIsLivePreviewSupported = ( state, themeId, siteId ) => {
+export const getIsLivePreviewSupported = ( state: AppState, themeId: string, siteId: number ) => {
 	if ( ! config.isEnabled( 'themes/block-theme-previews' ) ) {
 		return false;
 	}
@@ -125,7 +126,8 @@ export const getIsLivePreviewSupported = ( state, themeId, siteId ) => {
 		 * Disable Live Preview for 3rd party themes, as Block Theme Previews need a theme installed.
 		 * Note that BTP works on Atomic sites if a theme is installed.
 		 */
-		if ( isExternallyManagedTheme( state, themeId ) || isWporgTheme( state, themeId ) ) {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		if ( isExternallyManagedTheme( state, themeId ) || isWporgTheme( state, themeId as any ) ) {
 			return false;
 		}
 

--- a/client/state/themes/selectors/get-is-live-preview-supported.ts
+++ b/client/state/themes/selectors/get-is-live-preview-supported.ts
@@ -126,8 +126,7 @@ export const getIsLivePreviewSupported = ( state: AppState, themeId: string, sit
 		 * Disable Live Preview for 3rd party themes, as Block Theme Previews need a theme installed.
 		 * Note that BTP works on Atomic sites if a theme is installed.
 		 */
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		if ( isExternallyManagedTheme( state, themeId ) || isWporgTheme( state, themeId as any ) ) {
+		if ( isExternallyManagedTheme( state, themeId ) || isWporgTheme( state, themeId ) ) {
 			return false;
 		}
 

--- a/client/state/themes/selectors/get-live-preview-url.ts
+++ b/client/state/themes/selectors/get-live-preview-url.ts
@@ -2,11 +2,12 @@ import config from '@automattic/calypso-config';
 import { addQueryArgs } from 'calypso/lib/route';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { getTheme } from './';
+import { AppState } from 'calypso/types';
+import { getTheme } from '.';
 
 const QUERY_NAME = 'wp_theme_preview';
 
-export const getLivePreviewUrl = ( state, themeId, siteId ) => {
+export const getLivePreviewUrl = ( state: AppState, themeId: string, siteId: number ) => {
 	if ( ! config.isEnabled( 'themes/block-theme-previews' ) ) {
 		return undefined;
 	}

--- a/client/state/themes/selectors/is-wporg-theme.js
+++ b/client/state/themes/selectors/is-wporg-theme.js
@@ -6,7 +6,7 @@ import 'calypso/state/themes/init';
  * Whether a theme is present in the WordPress.org Theme Directory
  *
  * @param  {Object}  state   Global state tree
- * @param  {number}  themeId Theme ID
+ * @param  {string}  themeId Theme ID
  * @returns {boolean}         Whether theme is in WP.org theme directory
  */
 export function isWporgTheme( state, themeId ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80089, https://github.com/Automattic/wp-calypso/issues/79219, https://github.com/Automattic/wp-calypso/issues/79218

## Proposed Changes

* Convert Live Preview related code into TS!

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
i
- Go to the Theme Showcase page.
- Click three-dot on a free theme.
- See if clicking the "Live Preview" option redirects you to the Site Editor (Block Theme Previews).

ii
- Go to the Theme Detail page of a free theme.
- See if clicking the "Live Preview" option redirects you to the Site Editor (Block Theme Previews).


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
