### PR TITLE
Jetpack Pro Dashboard: show column info icon only if the feature flag is enabled

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -132,7 +132,7 @@ export default function ToggleActivateMonitoring( {
 						) as string
 					}
 				>
-					{ smsLimitReached ? (
+					{ isPaidTierEnabled && smsLimitReached ? (
 						<img src={ alertIcon } alt={ translate( 'Alert' ) } />
 					) : (
 						<img src={ clockIcon } alt={ translate( 'Current Schedule' ) } />

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -9,7 +9,6 @@ import SitesOverviewContext from '../context';
 import SiteBulkSelect from '../site-bulk-select';
 import SiteSort from '../site-sort';
 import SiteTableRow from '../site-table-row';
-import { getProductSlugFromProductType } from '../utils';
 import type { SiteData, SiteColumns } from '../types';
 
 interface Props {
@@ -60,7 +59,7 @@ const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableEle
 										<span className={ classNames( index === 0 && 'site-table-site-title' ) }>
 											{ column.title }
 
-											{ !! getProductSlugFromProductType( column.key ) && (
+											{ column.showInfo && (
 												<Icon
 													className="site-table__tooltip-icon"
 													size={ 16 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -10,6 +10,7 @@ export type SiteColumns = Array< {
 	className?: string;
 	isExpandable?: boolean;
 	isSortable?: boolean;
+	showInfo?: boolean;
 } >;
 
 export type AllowedStatusTypes =

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -24,6 +24,9 @@ import type {
 const INITIAL_UNIX_EPOCH = '1970-01-01 00:00:00';
 
 const isBoostEnabled = config.isEnabled( 'jetpack/pro-dashboard-jetpack-boost' );
+const isDowntimeMonitoringPaidTierEnabled = config.isEnabled(
+	'jetpack/pro-dashboard-monitor-paid-tier'
+);
 
 // Mapping the columns to the site data keys
 export const siteColumnKeyMap: { [ key: string ]: string } = {
@@ -37,6 +40,7 @@ const boostColumn: SiteColumns = isBoostEnabled
 				title: translate( 'Boost' ),
 				className: 'width-fit-content',
 				isExpandable: true,
+				showInfo: true,
 			},
 	  ]
 	: [];
@@ -59,17 +63,20 @@ export const siteColumns: SiteColumns = [
 		title: translate( 'Backup' ),
 		className: 'fixed-site-column',
 		isExpandable: true,
+		showInfo: true,
 	},
 	{
 		key: 'scan',
 		title: translate( 'Scan' ),
 		className: 'fixed-site-column',
+		showInfo: true,
 	},
 	{
 		key: 'monitor',
 		title: translate( 'Monitor' ),
 		className: 'min-width-100px',
 		isExpandable: true,
+		showInfo: isDowntimeMonitoringPaidTierEnabled,
 	},
 	{
 		key: 'plugin',


### PR DESCRIPTION
Related to 1204992567518369-as-1205228995198266

## Proposed Changes

This PR 

- Fixes an issue where the monitor column info icon is shown in production even when the feature is not enabled.
- Fixes an issue where the monitor column warning icon is shown when the SMS limit is reached in production, even when the feature is not enabled.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/show-info-key-to-dashboard-columns and `yarn start-jetpack-cloud` or use the Jetpack Cloud link
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Append the URL with `?flags=-jetpack/pro-dashboard-monitor-paid-tier`
4. Verify that the monitor column doesn't show the info icon 
5. Also, verify that the warning icon is not shown. Only checking the code is enough here, as it is not really available in production. We should show this icon only if the feature is enabled.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="978" alt="Screenshot 2023-08-08 at 11 46 12 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2dc16d49-bfc4-4879-aa41-8368513db81f">

</td>
<td>
<img width="978" alt="Screenshot 2023-08-08 at 11 45 56 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/10411af0-6cd7-48c8-a038-46bc1e236ec3">
</tr>
</table>





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
