### PR TITLE
Stepper Framework: Fix calypso_signup_complete event isn't fired when navigating to wp-admin

### DIFF
--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -45,23 +45,26 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 		const hasPaidDomainItem =
 			( selectedDomain && ! selectedDomain.is_free ) || !! domainProductSlug;
 
-		recordSignupComplete( {
-			flow,
-			siteId,
-			isNewUser,
-			hasCartItems,
-			isNew7DUserSite,
-			theme,
-			intent: flow,
-			startingPoint: flow,
-			isBlankCanvas: theme?.includes( 'blank-canvas' ),
-			planProductSlug,
-			domainProductSlug,
-			isMapping:
-				hasPaidDomainItem && domainCartItem ? isDomainMapping( domainCartItem ) : undefined,
-			isTransfer:
-				hasPaidDomainItem && domainCartItem ? isDomainTransfer( domainCartItem ) : undefined,
-			signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.NOT_SET,
-		} );
+		recordSignupComplete(
+			{
+				flow,
+				siteId,
+				isNewUser,
+				hasCartItems,
+				isNew7DUserSite,
+				theme,
+				intent: flow,
+				startingPoint: flow,
+				isBlankCanvas: theme?.includes( 'blank-canvas' ),
+				planProductSlug,
+				domainProductSlug,
+				isMapping:
+					hasPaidDomainItem && domainCartItem ? isDomainMapping( domainCartItem ) : undefined,
+				isTransfer:
+					hasPaidDomainItem && domainCartItem ? isDomainTransfer( domainCartItem ) : undefined,
+				signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.NOT_SET,
+			},
+			true
+		);
 	}, [ domainCartItem, flow, planCartItem, selectedDomain, siteCount, siteId, theme ] );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78092

## Proposed Changes

* Resolved the issue that the `calypso_signup_complete` isn't fired when finishing the Assembler step. The reason is the default behavior is to queue the `calypso_signup_complete` event utils you land on the next page (the page view event gets fired). However, the destination of the Assembler step is the Site Editor, so that event won't be triggered. If you go back to the dashboard, you will see the event is fired at that time.
* Hence, this PR is trying to fire the event immediately to avoid this issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/with-theme-assembler?siteSlug=<your_site>
* Finish the Assembler screen
* Ensure the `calypso_signup_complete` event is fired

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
