### PR TITLE
Newsletter Categories: Add react-query to fetch all categories

### DIFF
--- a/client/data/newsletter-categories/index.ts
+++ b/client/data/newsletter-categories/index.ts
@@ -1,0 +1,4 @@
+export { default as useCategoriesQuery } from './use-categories-query';
+export { default as useNewsletterCategoriesQuery } from './use-newsletter-categories-query';
+export { default as useMarkAsNewsletterCategoryMutation } from './use-mark-as-newsletter-category-mutation';
+export { default as useUnmarkAsNewsletterCategoryMutation } from './use-unmark-as-newsletter-category-mutation';

--- a/client/data/newsletter-categories/test/use-categories-query.test.tsx
+++ b/client/data/newsletter-categories/test/use-categories-query.test.tsx
@@ -66,7 +66,7 @@ describe( 'useCategoriesQuery', () => {
 
 		const { result } = renderHook( () => useCategoriesQuery( { blogId: 123 } ), { wrapper } );
 
-		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		await waitFor( () => expect( result.current.isFetched ).toBe( true ) );
 
 		expect( result.current.data ).toEqual( mockResponse );
 	} );
@@ -76,7 +76,7 @@ describe( 'useCategoriesQuery', () => {
 
 		const { result } = renderHook( () => useCategoriesQuery( { blogId: 123 } ), { wrapper } );
 
-		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		await waitFor( () => expect( result.current.isFetched ).toBe( true ) );
 
 		expect( result.current.data ).toEqual( [] );
 	} );

--- a/client/data/newsletter-categories/test/use-categories-query.test.tsx
+++ b/client/data/newsletter-categories/test/use-categories-query.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import request from 'wpcom-proxy-request';
+import useCategoriesQuery from '../use-categories-query';
+
+const mockResponse = [
+	{
+		id: 177,
+		count: 0,
+		description: '',
+		link: 'https://mocksite.wordpress.com/category/art/',
+		name: 'Art',
+		slug: 'art',
+		taxonomy: 'category',
+		parent: 0,
+		meta: [],
+		_links: {},
+	},
+	{
+		id: 1,
+		count: 4,
+		description: '',
+		link: 'https://mocksite.wordpress.com/category/uncategorized/',
+		name: 'Uncategorized',
+		slug: 'uncategorized',
+		taxonomy: 'category',
+		parent: 0,
+		meta: [],
+		_links: {},
+	},
+];
+
+jest.mock( 'wpcom-proxy-request', () => jest.fn() );
+
+describe( 'useCategoriesQuery', () => {
+	let queryClient: QueryClient;
+	let wrapper: any;
+
+	beforeEach( () => {
+		( request as jest.MockedFunction< typeof request > ).mockReset();
+
+		queryClient = new QueryClient( {
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		} );
+
+		wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should return expected data when successful', async () => {
+		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( mockResponse );
+
+		const { result } = renderHook( () => useCategoriesQuery( { blogId: 123 } ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( result.current.data ).toEqual( mockResponse );
+	} );
+
+	it( 'should handle empty response', async () => {
+		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( [] );
+
+		const { result } = renderHook( () => useCategoriesQuery( { blogId: 123 } ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( result.current.data ).toEqual( [] );
+	} );
+} );

--- a/client/data/newsletter-categories/test/use-categories-query.test.tsx
+++ b/client/data/newsletter-categories/test/use-categories-query.test.tsx
@@ -61,7 +61,7 @@ describe( 'useCategoriesQuery', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'shouldcall request with the right parameters', async () => {
+	it( 'should call request with the right parameters', async () => {
 		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( mockResponse );
 
 		const { result } = renderHook( () => useCategoriesQuery( 123 ), { wrapper } );

--- a/client/data/newsletter-categories/test/use-categories-query.test.tsx
+++ b/client/data/newsletter-categories/test/use-categories-query.test.tsx
@@ -61,6 +61,20 @@ describe( 'useCategoriesQuery', () => {
 		jest.clearAllMocks();
 	} );
 
+	it( 'shouldcall request with the right parameters', async () => {
+		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( mockResponse );
+
+		const { result } = renderHook( () => useCategoriesQuery( 123 ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isFetched ).toBe( true ) );
+
+		expect( request ).toHaveBeenCalledWith( {
+			path: `/sites/123/categories`,
+			apiVersion: '2',
+			apiNamespace: 'wp/v2',
+		} );
+	} );
+
 	it( 'should return expected data when successful', async () => {
 		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( mockResponse );
 

--- a/client/data/newsletter-categories/test/use-categories-query.test.tsx
+++ b/client/data/newsletter-categories/test/use-categories-query.test.tsx
@@ -64,7 +64,7 @@ describe( 'useCategoriesQuery', () => {
 	it( 'should return expected data when successful', async () => {
 		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( mockResponse );
 
-		const { result } = renderHook( () => useCategoriesQuery( { blogId: 123 } ), { wrapper } );
+		const { result } = renderHook( () => useCategoriesQuery( 123 ), { wrapper } );
 
 		await waitFor( () => expect( result.current.isFetched ).toBe( true ) );
 
@@ -74,7 +74,7 @@ describe( 'useCategoriesQuery', () => {
 	it( 'should handle empty response', async () => {
 		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( [] );
 
-		const { result } = renderHook( () => useCategoriesQuery( { blogId: 123 } ), { wrapper } );
+		const { result } = renderHook( () => useCategoriesQuery( 123 ), { wrapper } );
 
 		await waitFor( () => expect( result.current.isFetched ).toBe( true ) );
 

--- a/client/data/newsletter-categories/types.ts
+++ b/client/data/newsletter-categories/types.ts
@@ -1,3 +1,16 @@
+export type Category = {
+	id: number;
+	count: number;
+	description: string;
+	link: string;
+	name: string;
+	slug: string;
+	taxonomy: string;
+	parent: number;
+	meta: any;
+	_links: any;
+};
+
 export type NewsletterCategories = {
 	newsletterCategories: NewsletterCategory[];
 };

--- a/client/data/newsletter-categories/use-categories-query.tsx
+++ b/client/data/newsletter-categories/use-categories-query.tsx
@@ -1,0 +1,19 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import request from 'wpcom-proxy-request';
+import type { Category } from './types';
+
+const useCategoriesQuery = ( blogId?: number ): UseQueryResult< Category[] > => {
+	return useQuery( {
+		queryKey: [ 'categories', blogId ],
+		queryFn: () =>
+			request< Category[] >( {
+				path: `/sites/${ blogId }/categories`,
+				apiVersion: '2',
+				apiNamespace: 'wp/v2',
+			} ),
+		initialData: [],
+		enabled: !! blogId,
+	} );
+};
+
+export default useCategoriesQuery;


### PR DESCRIPTION
Closes #80305

## Proposed Changes

* Adds the `useCategoriesQuery` query. This calls the `wp/v2` `/sites/<siteid>categories` endpoint
* Introduces the `Category` type
* While loading, and without data present in the cache, the query will return an empty array.
* This also creates named exports the current queries/mutations inside `index.ts`, similar to how we did this in previous projects.

## Testing Instructions

- Run the unit tests: `yarn test-client client/data/newsletter-categories/test/use-categories-query.test.tsx`
- Test the query manually:

Import it somewhere, I did this inside `client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx`, but you can do it basically anywhere where you have access to the site id.

```ts
import { useCategoriesQuery } from '../../../../../client/data/newsletter-categories/';

...

// inside the component
	const { data } = useCategoriesQuery( siteId );
	console.log(data);
```

You should see the categories being logged to the console.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
