### PR TITLE
Happy Blocks: Support global content border color 

### DIFF
--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -30,7 +30,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 	}
 
 	.support-content-cta {
-		border-bottom: 1px solid var(--studio-gray-5);
+		border-bottom: 1px solid var(--studio-gray-0);
 		display: flex;
 		margin-bottom: 2rem;
 		font-size: 1.25rem;


### PR DESCRIPTION
“Your site, built for you” border bottom is too dark. Should by F6F7F7 (gray-0?)

## Before

![image](https://github.com/Automattic/wp-calypso/assets/52076348/97ea613a-e2c7-4227-b63f-a9987f4b7b89)


## After

![image](https://github.com/Automattic/wp-calypso/assets/52076348/eeb95bd5-b808-4cf6-b258-450c633f28c4)

## Testing

1. Checkout and sync happy blocks
2. Visit https://learncft.wordpress.com/webinars/ and check the bottom for the border