### PR TITLE
Fix ThankYou page for P2+ purchase

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -14,6 +14,7 @@ import {
 	isGSuiteOrExtraLicenseOrGoogleWorkspace,
 	isGSuiteOrGoogleWorkspace,
 	isJetpackPlan,
+	isP2Plus,
 	isPersonal,
 	isPlan,
 	isPremium,
@@ -819,6 +820,10 @@ export class CheckoutThankYou extends Component<
 		if ( purchases.some( isChargeback ) ) {
 			return [ 'chargeback-details', purchases.find( isChargeback ) ];
 		}
+		if ( purchases.some( isP2Plus ) ) {
+			return [ 'p2-plus-details', purchases.find( isP2Plus ) ];
+		}
+
 		return [];
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3404

## Proposed Changes

* ThankYou page was blank due to `primaryPurchase` passed in was blank
* Add P2 Plus plan to `primaryPurchase`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a P2 workspace
* Go to `/plans/:siteSlug`
* Upgrade to P2+
* ThankYou page should be there

![congrats p2](https://github.com/Automattic/wp-calypso/assets/6586048/f1f2d781-ba27-4705-8c83-407c26a218fa)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?