### PR TITLE
Theme: Fix the live demo for not WP.com themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -341,7 +341,7 @@ class ThemeSheet extends Component {
 	}
 
 	previewAction = ( event, type ) => {
-		const { demoUrl, isExternallyManagedTheme } = this.props;
+		const { demoUrl, isExternallyManagedTheme, isWpcomTheme } = this.props;
 		if ( event.altKey || event.ctrlKey || event.metaKey || event.shiftKey ) {
 			return;
 		}
@@ -352,19 +352,19 @@ class ThemeSheet extends Component {
 			type,
 		} );
 
-		if ( isExternallyManagedTheme && demoUrl ) {
-			window.open( demoUrl, '_blank', 'noreferrer,noopener' );
-			return;
+		// The embed live demo works only for WP.com themes
+		if ( isWpcomTheme && ! isExternallyManagedTheme ) {
+			const { preview } = this.props.options;
+			this.props.setThemePreviewOptions(
+				this.props.themeId,
+				this.props.defaultOption,
+				this.props.secondaryOption,
+				this.getSelectedStyleVariation()
+			);
+			return preview.action( this.props.themeId );
 		}
 
-		const { preview } = this.props.options;
-		this.props.setThemePreviewOptions(
-			this.props.themeId,
-			this.props.defaultOption,
-			this.props.secondaryOption,
-			this.getSelectedStyleVariation()
-		);
-		return preview.action( this.props.themeId );
+		return window.open( demoUrl, '_blank', 'noreferrer,noopener' );
 	};
 
 	shouldRenderForStaging() {

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -260,7 +260,19 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 		label: translate( 'Live demo', {
 			comment: 'label for previewing the theme demo website',
 		} ),
-		action: themePreview,
+		action: ( themeId, siteId ) => {
+			return ( dispatch, getState ) => {
+				const state = getState();
+				if ( isWpcomTheme( state, themeId ) && ! isExternallyManagedTheme( state, themeId ) ) {
+					return dispatch( themePreview( themeId, siteId ) );
+				}
+				return window.open(
+					getThemeDemoUrl( state, themeId, siteId ),
+					'_blank',
+					'noreferrer,noopener'
+				);
+			};
+		},
 		hideForTheme: ( state, themeId, siteId ) => {
 			const demoUrl = getThemeDemoUrl( state, themeId, siteId );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71780

## Proposed Changes

* Fix the live demo doesn't work for themes not belonging to WP.com as
  1. The demo site doesn't have the `jetpack-iframe-embed` plugin, so we might not have enough information
  2. The ancestor (Calypso) violates the Content Security Policy of the 3rd party demo site
* Hence, open the live demo URL directly if the theme is not a WP.com theme or 3rd party theme
* Moreover, this PR also makes the behavior of the Live demo consistent between
  1. Theme Showcase
  2. The Live demo button on the Theme Details page
  3. The behavior when you click the preview on the Theme Details page 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase
* On the list screen, ensure the live demo works for free, premium, community, and partner themes
* Go to the theme details page, ensure the live demo works for those themes as well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
