### PR TITLE
[Only Chrome] Assembler - Fix orphans and widows in header and description with text-wrap: balance

### DIFF
--- a/packages/onboarding/src/navigator/navigator-header/style.scss
+++ b/packages/onboarding/src/navigator/navigator-header/style.scss
@@ -14,6 +14,7 @@
 .navigator-header__heading {
 	margin-bottom: 8px;
 	color: var(--color-neutral-100);
+	text-wrap: balance;
 
 	h2 {
 		font-family: Recoleta, sans-serif;
@@ -40,4 +41,5 @@
 	letter-spacing: -0.15px;
 	color: var(--color-neutral-60);
 	margin: 0;
+	text-wrap: balance;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related https://github.com/Automattic/wp-calypso/pull/80271

## Proposed Changes

* Added the CSS feature `text-wrap: balance` to the header and description texts to[ balance the words](https://developer.chrome.com/blog/css-text-wrap-balance/) and prevent [widows and orphans](https://en.wikipedia.org/wiki/Widows_and_orphans).

|BEFORE|AFTER|
|--|--|
|<img width="311" alt="Screenshot 2566-08-08 at 16 29 12" src="https://github.com/Automattic/wp-calypso/assets/1881481/041ed31f-9097-4ede-88f9-37efb05ff58e">|<img width="274" alt="Screenshot 2566-08-08 at 16 29 23" src="https://github.com/Automattic/wp-calypso/assets/1881481/17905c26-885e-4ab5-a9a7-462c0d49ca7a">|

|BEFORE|AFTER|
|--|--|
|<img width="309" alt="Screenshot 2566-08-08 at 16 31 00" src="https://github.com/Automattic/wp-calypso/assets/1881481/b8e7e611-652c-427b-919c-476e944d21d7">|<img width="256" alt="Screenshot 2566-08-08 at 16 30 14" src="https://github.com/Automattic/wp-calypso/assets/1881481/b56e6512-dfa4-4ff9-b1d3-7e279a22e18b">|

It's only partially supported on Chrome but we can expect others to follow because it's part of the [standard CSS4](https://www.w3.org/TR/css-text-4/#text-wrap).

<img width="807" alt="Screenshot 2566-08-08 at 16 20 19" src="https://github.com/Automattic/wp-calypso/assets/1881481/288d6b3c-952b-467b-a9bc-348d344a37a8">

Read more about [text-wrap](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }`
* Verify the balance of the description text
* Navigate to other steps to verify the descriptions
* Reduce the window size to `< 1280px` to verify the text when the sidebar width is reduced



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
