### PR TITLE
Display images for posts and campaigns as same as possible

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -59,7 +59,7 @@ export default function CampaignItem( props: Props ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 
 	const safeUrl = safeImageUrl( content_config.imageUrl );
-	const adCreativeUrl = safeUrl && resizeImageUrl( safeUrl, { h: 80 }, 0 );
+	const adCreativeUrl = safeUrl && resizeImageUrl( safeUrl, 108, 0 );
 
 	const { totalBudget, totalBudgetLeft, campaignDays } = useMemo(
 		() => getCampaignBudgetData( budget_cents, start_date, end_date, spent_budget_cents ),
@@ -126,9 +126,10 @@ export default function CampaignItem( props: Props ) {
 				<div className="campaign-item__data-row">
 					<div className="promote-post-i2__campaign-item-wrapper">
 						{ adCreativeUrl && (
-							<div className="campaign-item__header-image">
-								<img src={ adCreativeUrl } alt="" />
-							</div>
+							<div
+								className="campaign-item__header-image"
+								style={ { backgroundImage: `url(${ adCreativeUrl })` } }
+							></div>
 						) }
 						<div className="campaign-item__title-row">
 							<div className="campaign-item__title">{ name }</div>

--- a/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
@@ -148,18 +148,17 @@ $font-sf-pro-text: "SF Pro Text", $sans;
 	}
 
 	.campaign-item__header-image {
-		height: 78px;
-		margin-right: 16px;
-		min-width: 108px;
-		width: 108px; // TODO: adjust height and width for mobile devices as well.
-
-		img,
+		&,
 		&-skeleton {
 			background-color: #f5f5f5;
+			background-repeat: no-repeat;
+			background-position: 50% 50%;
+			background-size: cover;
 			border: 1px solid #eee;
 			border-radius: 4px;
 			display: block;
 			height: 78px;
+			margin-right: 16px;
 			min-width: 108px;
 			width: 108px; // TODO: adjust height and width for mobile devices as well.
 		}

--- a/client/my-sites/promote-post-i2/components/post-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/post-item/index.tsx
@@ -21,7 +21,7 @@ export default function PostItem( { post }: { post: BlazablePost } ) {
 
 	// API can return "false" as a featured image URL
 	const safeUrl = 'string' === typeof post?.featured_image && safeImageUrl( post.featured_image );
-	const featuredImage = safeUrl && resizeImageUrl( safeUrl, { h: 80 }, 0 );
+	const featuredImage = safeUrl && resizeImageUrl( safeUrl, 108, 0 );
 
 	const postDate = (
 		<RelativeTime date={ post.date } showTooltip={ true } tooltipTitle={ __( 'Published date' ) } />

--- a/client/my-sites/promote-post-i2/components/post-item/style.scss
+++ b/client/my-sites/promote-post-i2/components/post-item/style.scss
@@ -126,6 +126,7 @@ body.is-section-promote-post-i2 {
 		}
 	}
 
+	// TODO: Reorder styles
 	.post-item__post-thumbnail-wrapper {
 		display: block;
 		position: relative;
@@ -136,6 +137,7 @@ body.is-section-promote-post-i2 {
 		border: 1px solid #eee;
 		border-radius: 4px;
 		overflow: hidden;
+		background-position: 50% 50%;
 		background-size: cover;
 		background-repeat: no-repeat;
 

--- a/client/my-sites/promote-post-i2/components/post-item/style.scss
+++ b/client/my-sites/promote-post-i2/components/post-item/style.scss
@@ -126,20 +126,19 @@ body.is-section-promote-post-i2 {
 		}
 	}
 
-	// TODO: Reorder styles
 	.post-item__post-thumbnail-wrapper {
-		display: block;
-		position: relative;
-		height: 78px;
-		width: 108px;
-		min-width: 108px;
 		align-self: stretch;
+		background-position: 50% 50%;
+		background-repeat: no-repeat;
+		background-size: cover;
 		border: 1px solid #eee;
 		border-radius: 4px;
+		display: block;
+		height: 78px;
+		min-width: 108px;
 		overflow: hidden;
-		background-position: 50% 50%;
-		background-size: cover;
-		background-repeat: no-repeat;
+		position: relative;
+		width: 108px;
 
 		&_no-image {
 			align-items: center;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [SELFSERVE-679](https://jira.tumblr.net/browse/SELFSERVE-679).

There were several cases when after creating a campaign, an image for a campaign was shrunk (in comparison to the original image in post).

Here're the changes of an image from creating a post to creating a campaign:
- When an image was added to a post as a Featured Image, it **holds its original proportions** (I've tested the cases of `1:1`, `2:1`, and `1:2`; the rest of cases might be placed in one of theses groups)
- During campaign creation a campaign and image is changing to `320x250`, so proportion is different and might be almost `6:5`, also DSP crops and image, so the original image from the post and what campaign has are different things
- Then we have the Dashboard where we show images in `108x78` boxes, so now proportion is `18:13`

Another thing to consider is using Photon (`https://i0.wp.com/`) for image resizing and zoom.

## Proposed Changes
To overcome this discrepancy in how initial and processed images look I suggest

* Use width of 108px for resize (eventually the size is doubled for better quality),
* Position image to center (`50% 50%`) with CSS,
* For posts and campaigns use div's background image instead of img tag to have the same CSS settings.

The image below depicts the difference between trunk and this branch for both posts and campaigns:
<img width="1259" alt="sample-screen-shot" src="https://github.com/Automattic/wp-calypso/assets/115007291/7cdb7eb8-6d0c-46a4-90ed-0fc883aa8ced">

The positioning to center should make images for Posts look nicer. The slight change for campaigns also centers images to mimic what we have for posts. Despite I can't make images the same (because for campaigns we rely on the changed images stored in DSP DB), the look alike and it might be considered and an improvement.

## Testing Instructions
- Checkout this branch locally and run local Calypso
- (You **don't need** tunnel local DSP via WPCOM sandbox)
- Adjust your sources to show image skeletons as a preloading indicator like this:
  - Adjust [this line](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/promote-post-i2/components/campaigns-list/index.tsx#L95) and [that line](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/promote-post-i2/components/posts-list/index.tsx#L97) to become `isFetchingPageResults={ true || isFetching }`
- Get images of different proportions (I used `1:1`, `2:1`, and `1:2`), you can use the following links of grab those images:
  - [1:1](https://picsum.photos/800/800)
  - [2:1](https://picsum.photos/800/400)
  - [1:2](https://picsum.photos/400/800)
- Make sure your have posts with those images featured
- Create campaigns (you can either use express flow or click "Make changes" and crop images
- Open both posts and campaigns tabs and see whether images look as expected.
- Then, scroll to the bottom for both Posts and Campaings
- Make sure that skeletons look good

(Posts)  
![posts-skeleton](https://github.com/Automattic/wp-calypso/assets/115007291/1e51bab5-1a8a-4a36-be14-c306b34a415f)

(Campaigns)
![campaigns-skeleton](https://github.com/Automattic/wp-calypso/assets/115007291/7d0ac92d-1372-4760-bbd5-b792b878a0bf)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
