### PR TITLE
We now exclude the theme subjects that have less than 2 themes in them

### DIFF
--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -79,6 +79,7 @@ export function fetchThemeFilters( context, next ) {
 
 	wpcom.req
 		.get( '/theme-filters', {
+			min_themes_in_subject: 2,
 			apiVersion: '1.2',
 			locale: context.lang, // Note: undefined will be omitted by the query string builder.
 		} )

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -99,6 +99,7 @@ export function fetchThemeFilters( context, next ) {
 
 	wpcom.req
 		.get( '/theme-filters', {
+			min_themes_in_subject: 2,
 			apiVersion: '1.2',
 			locale: context.lang, // Note: undefined will be omitted by the query string builder.
 		} )

--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -9,13 +9,20 @@ import {
 	THEME_FILTERS_REQUEST_FAILURE,
 } from 'calypso/state/themes/action-types';
 
+const defaultThemeFiltersArguments = {
+	min_themes_in_subject: 2,
+};
+
 const fetchFilters = ( action ) =>
 	http(
 		{
 			method: 'GET',
 			apiVersion: '1.2',
 			path: '/theme-filters',
-			query: action.locale ? { locale: action.locale } : {},
+			query: {
+				...defaultThemeFiltersArguments,
+				...( action.locale ? { locale: action.locale } : {} ),
+			},
 		},
 		action
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3324

## Proposed Changes

* Added the `min_themes_in_subject` argument with a value of 2 to the API calls Calypso when we request the Theme Subjects in the Theme Showcase.

| Before | After |
| ------  | ----- |
|![Captura de Pantalla 2023-08-08 a las 15 34 15](https://github.com/Automattic/wp-calypso/assets/1989914/4bec36e7-d7bc-4a5d-b195-6cd523a51211)|![Captura de Pantalla 2023-08-08 a las 15 33 51](https://github.com/Automattic/wp-calypso/assets/1989914/f0a1e562-89bb-47c3-8717-dfb85cc0fed7)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live link
* Navigate to the LITS and check that only subjects with 2 or more themes are shown (Newsletter has 2 and shouldn't be shown)
* Navigate to the LOTS and check the same as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
