### PR TITLE
Migration trial: Site dashboard: Remove renew CTA

### DIFF
--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -106,7 +106,7 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 
 	const isP2Site = site.options?.is_wpforteams_site;
 	const isWpcomStagingSite = isStagingSite( site );
-	const isTrialSite = isMigrationTrialSite( site );
+	const isMigrationTrialPlanSite = isMigrationTrialSite( site );
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 	const isECommerceTrialSite = site.plan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 
@@ -143,7 +143,10 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 						/>
 					</ThumbnailWrapper>
 					{ showSiteRenewLink && site.plan?.expired && (
-						<SitesGridActionRenew site={ site } hideRenewLink={ isECommerceTrialSite } />
+						<SitesGridActionRenew
+							site={ site }
+							hideRenewLink={ isECommerceTrialSite || isMigrationTrialPlanSite }
+						/>
 					) }
 				</>
 			}
@@ -157,7 +160,7 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 						<div className={ badges }>
 							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
 							{ isWpcomStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
-							{ isTrialSite && (
+							{ isMigrationTrialPlanSite && (
 								<SitesMigrationTrialBadge>{ __( 'Trial' ) }</SitesMigrationTrialBadge>
 							) }
 							{ getSiteLaunchStatus( site ) !== 'public' && (

--- a/client/sites-dashboard/components/sites-site-plan.tsx
+++ b/client/sites-dashboard/components/sites-site-plan.tsx
@@ -1,7 +1,7 @@
 import { PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import JetpackLogo from 'calypso/components/jetpack-logo';
-import { isNotAtomicJetpack } from '../utils';
+import { isNotAtomicJetpack, isMigrationTrialSite } from '../utils';
 import { PlanRenewNag } from './sites-plan-renew-nag';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
@@ -32,6 +32,7 @@ const STAGING_PLAN_LABEL = 'Staging';
 export const SitePlan = ( { site, userId }: SitePlanProps ) => {
 	const isWpcomStagingSite = site?.is_wpcom_staging_site ?? false;
 	const isECommerceTrialSite = site.plan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
+	const isMigrationTrialPlanSite = isMigrationTrialSite( site );
 
 	return (
 		<SitePlanContainer>
@@ -48,7 +49,7 @@ export const SitePlan = ( { site, userId }: SitePlanProps ) => {
 								plan={ site.plan }
 								isSiteOwner={ site?.site_owner === userId }
 								checkoutUrl={ `/checkout/${ site.slug }/${ site.plan?.product_slug }` }
-								hideRenewLink={ isECommerceTrialSite }
+								hideRenewLink={ isECommerceTrialSite || isMigrationTrialPlanSite }
 							/>
 						</PlanRenewNagContainer>
 					) : (


### PR DESCRIPTION
Closes #80307

## Proposed Changes

* Remove "Renew plan" CTA for Migration Trial plans

## Testing Instructions

* Go to `/sites` route
* Check if banner is without "Renew" CTA (the same approach as for the WOO Trial)

**Before:**
<img width="823" alt="Screenshot 2023-08-08 at 13 42 56" src="https://github.com/Automattic/wp-calypso/assets/1241413/d107e32f-4a8c-4c21-ab0d-228bedc6ca57">
**After:**
<img width="833" alt="Screenshot 2023-08-08 at 13 49 42" src="https://github.com/Automattic/wp-calypso/assets/1241413/177193da-e7d7-4f2c-8058-5415ce506c33">


**Before:**
<img width="428" alt="Screenshot 2023-08-08 at 13 50 54" src="https://github.com/Automattic/wp-calypso/assets/1241413/abecae13-afca-44a2-93cb-a813e21deff1">
**After:**
<img width="422" alt="Screenshot 2023-08-08 at 13 51 47" src="https://github.com/Automattic/wp-calypso/assets/1241413/bc40bd72-5976-46e0-92e1-9c49a3e512a8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
