### PR TITLE
Substack importer: link to subscriber importing

### DIFF
--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -27,12 +27,18 @@ interface ImporterConfigMap {
 }
 
 interface ImporterConfigArgs {
-	siteTitle?: string;
 	isAtomic?: boolean;
 	isJetpack?: boolean;
+	siteSlug?: string;
+	siteTitle?: string;
 }
 
-function getConfig( { siteTitle = '', isAtomic = false, isJetpack = false } ): ImporterConfigMap {
+function getConfig( {
+	isAtomic = false,
+	isJetpack = false,
+	siteSlug = '',
+	siteTitle = '',
+} ): ImporterConfigMap {
 	let importerConfig: ImporterConfigMap = {};
 
 	importerConfig.wordpress = {
@@ -149,34 +155,36 @@ function getConfig( { siteTitle = '', isAtomic = false, isJetpack = false } ): I
 		type: 'file',
 		title: 'Substack',
 		icon: 'substack',
-		description: translate(
-			'Import posts and images, podcasts and public comments from a %(importerName)s export file to {{b}}%(siteTitle)s{{/b}}.',
-			{
-				args: {
-					importerName: 'Substack',
-					siteTitle,
-				},
-				components: {
-					b: <strong />,
-				},
-			}
+		description: (
+			<>
+				{ translate(
+					'Import posts and images, podcasts and public comments from a %(importerName)s export file to {{b}}%(siteTitle)s{{/b}}.',
+					{
+						args: {
+							importerName: 'Substack',
+							siteTitle,
+						},
+						components: {
+							b: <strong />,
+						},
+					}
+				) }{ ' ' }
+				{ translate( 'To migrate your readers, {{a}}go to subscribers{{/a}}.', {
+					components: {
+						a: <a href={ `/subscribers/${ siteSlug }#add-subscribers` } />,
+					},
+				} ) }
+			</>
 		),
-		uploadDescription: translate(
-			'A %(importerName)s export file is a ZIP file ' +
-				'containing a CSV file with all posts and individual HTML posts. ' +
-				'{{supportLink/}}',
-			{
-				args: {
-					importerName: 'Substack',
-				},
-				components: {
-					supportLink: (
-						<InlineSupportLink supportContext="importers-substack" showIcon={ false }>
-							{ translate( 'Need help exporting your content?' ) }
-						</InlineSupportLink>
-					),
-				},
-			}
+		uploadDescription: (
+			<>
+				{ translate(
+					'A Substack export file is a ZIP file containing a CSV file with all posts.'
+				) }{ ' ' }
+				<InlineSupportLink supportContext="importers-substack" showIcon={ false }>
+					{ translate( 'See how to get your export file.' ) }
+				</InlineSupportLink>
+			</>
 		),
 		optionalUrl: {
 			title: translate( 'Substack Newsletter URL' ),
@@ -270,7 +278,7 @@ function getConfig( { siteTitle = '', isAtomic = false, isJetpack = false } ): I
 	return importerConfig;
 }
 
-export function getImporters( args: ImporterConfigArgs = { siteTitle: '' } ) {
+export function getImporters( args: ImporterConfigArgs = { siteSlug: '', siteTitle: '' } ) {
 	const importerConfig = getConfig( args );
 
 	if ( ! config.isEnabled( 'importers/substack' ) ) {
@@ -282,7 +290,10 @@ export function getImporters( args: ImporterConfigArgs = { siteTitle: '' } ) {
 	return importers;
 }
 
-export function getImporterByKey( key: string, args: ImporterConfigArgs = { siteTitle: '' } ) {
+export function getImporterByKey(
+	key: string,
+	args: ImporterConfigArgs = { siteSlug: '', siteTitle: '' }
+) {
 	return filter( getImporters( args ), ( importer ) => importer.key === key )[ 0 ];
 }
 

--- a/client/my-sites/importer/importer-substack.jsx
+++ b/client/my-sites/importer/importer-substack.jsx
@@ -11,6 +11,7 @@ class ImporterSubstack extends PureComponent {
 		site: PropTypes.shape( {
 			title: PropTypes.string.isRequired,
 		} ).isRequired,
+		siteSlug: PropTypes.string.isRequired,
 		siteTitle: PropTypes.string.isRequired,
 		importerStatus: PropTypes.shape( {
 			importerState: PropTypes.string.isRequired,
@@ -24,6 +25,7 @@ class ImporterSubstack extends PureComponent {
 
 	render() {
 		const importerData = importerConfig( {
+			siteSlug: this.props.siteSlug,
 			siteTitle: this.props.siteTitle,
 		} ).substack;
 

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -98,6 +98,7 @@ export class ImportingPane extends PureComponent {
 			ID: PropTypes.number.isRequired,
 			name: PropTypes.string.isRequired,
 			single_user_site: PropTypes.bool.isRequired,
+			site_slug: PropTypes.bool.isRequired,
 		} ).isRequired,
 		sourceType: PropTypes.string.isRequired,
 	};
@@ -120,8 +121,25 @@ export class ImportingPane extends PureComponent {
 		return this.props.translate( 'Processing your file. Please wait a few moments.' );
 	};
 
-	getSuccessText = () => {
-		return this.props.translate( 'Success! Your content has been imported.' );
+	getSuccessText = ( sourceType ) => {
+		const successText = this.props.translate( 'Success! Your content has been imported.' );
+
+		if ( sourceType === 'Substack' ) {
+			return (
+				<>
+					{ successText }
+					<br />
+					<br />
+					{ this.props.translate( 'To migrate your readers, {{a}}go to subscribers{{/a}}.', {
+						components: {
+							a: <a href={ `/subscribers/${ this.props.site.slug }#add-subscribers` } />,
+						},
+					} ) }
+				</>
+			);
+		}
+
+		return successText;
 	};
 
 	getImportMessage = ( numResources ) => {
@@ -235,7 +253,7 @@ export class ImportingPane extends PureComponent {
 
 		if ( this.isFinished() ) {
 			percentComplete = 100;
-			statusMessage = this.getSuccessText();
+			statusMessage = this.getSuccessText( sourceType );
 		}
 
 		if ( this.isImporting() && hasProgressInfo( progress ) ) {

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -187,7 +187,7 @@ class SectionImport extends Component {
 	 * @returns {Array} A list of react elements for each enabled importer
 	 */
 	renderIdleImporters( importerState ) {
-		const { site, siteTitle } = this.props;
+		const { site, siteSlug, siteTitle } = this.props;
 		const importers = getImporters( {
 			isAtomic: site.options.is_wpcom_atomic,
 			isJetpack: site.jetpack,
@@ -209,6 +209,7 @@ class SectionImport extends Component {
 				<ImporterComponent
 					key={ engine }
 					site={ site }
+					siteSlug={ siteSlug }
 					siteTitle={ siteTitle }
 					importerStatus={ importerStatus }
 					isAtomic={ site.options.is_wpcom_atomic }
@@ -234,7 +235,7 @@ class SectionImport extends Component {
 	 * @returns {Array} Importer react elements for the active import jobs
 	 */
 	renderActiveImporters() {
-		const { fromSite, site, siteTitle, siteImports } = this.props;
+		const { fromSite, site, siteSlug, siteTitle, siteImports } = this.props;
 
 		return siteImports.map( ( importItem, idx ) => {
 			const importer = getImporterByKey( importItem.type );
@@ -250,6 +251,7 @@ class SectionImport extends Component {
 						key={ idx }
 						site={ site }
 						fromSite={ fromSite }
+						siteSlug={ siteSlug }
 						siteTitle={ siteTitle }
 						importerStatus={ importItem }
 					/>

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -3,7 +3,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import './style.scss';
@@ -17,6 +17,13 @@ const AddSubscribersModal = ( { siteId, siteTitle }: AddSubscribersModalProps ) 
 	const translate = useTranslate();
 	const { showAddSubscribersModal, setShowAddSubscribersModal, addSubscribersCallback } =
 		useSubscribersPage();
+
+	useEffect( () => {
+		// Open "add subscribers" modal by default via URL
+		if ( window.location.hash === '#add-subscribers' ) {
+			setShowAddSubscribersModal( true );
+		}
+	}, [] );
 
 	const modalTitle = translate( 'Add subscribers to %s', {
 		args: [ siteTitle ],


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of https://github.com/Automattic/wp-calypso/issues/80364

Adds "subscriber importing" into Substack importing in lightweight way, simply linking into existing "add subscribers" modal.

TODO: Needs more polish, improving copy, and some testing.

<img width="844" alt="Screenshot 2023-08-08 at 16 55 52" src="https://github.com/Automattic/wp-calypso/assets/87168/a3545746-979e-4027-b279-37225a106c12">

<img width="1008" alt="Screenshot 2023-08-08 at 23 13 16" src="https://github.com/Automattic/wp-calypso/assets/87168/2812d27d-0160-4b58-a484-6dd4b523d9f5">

<img width="925" alt="Screenshot 2023-08-08 at 22 41 30" src="https://github.com/Automattic/wp-calypso/assets/87168/cb8e67ce-597b-47fe-8aae-3192e14f52b6">

<img width="926" alt="Screenshot 2023-08-08 at 23 12 47" src="https://github.com/Automattic/wp-calypso/assets/87168/6118268e-6fe3-4d5b-8771-c2b150e2403e">

<img width="1550" alt="Screenshot 2023-08-08 at 23 52 40" src="https://github.com/Automattic/wp-calypso/assets/87168/776b5072-c102-45d4-813b-32ada73ee21f">


## Proposed Changes

* Add ability to open "add subscribers" modal via URL hash
* Link to said modal from Substack importer

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Tools → Import → Substack
* Observe link to add subscribers in the header. Clicking it should open the modal at subscriber management page.
* Import a substack file. At the end, below success message, follow the link to subscribers management page. The modal should open again.
* Visiting Subscribers management page on its own; modal shouldn't open

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
