### PR TITLE
Add Jetpack Stats title and description to licensing portal

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
@@ -218,6 +218,8 @@ export function useProductDescription( productSlug: string ): {
 					'Powerful marketing automation for WooCommerce - grow your store and make more money.'
 				);
 				break;
+			case 'jetpack-stats':
+				description = translate( 'Powerful analytics to help you understand your audience.' );
 		}
 
 		return {

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -184,6 +184,9 @@ export function getProductTitle( product: string ): string {
 		return 'AI Assistant';
 	}
 
+	if ( 'Jetpack Stats (Commercial license)' === product ) {
+		return 'Stats';
+	}
 	return product.replace( /(?:Jetpack\s|[)(])/gi, '' );
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Overrides the Jetpack Stats product name and descriptions for referencing simply as "Stats" instead of "Stats Commercial license"

## Testing Instructions

* Use a partner key with billing scheme 871
* Go to http://jetpack.cloud.localhost:3000/partner-portal/issue-license
* There should be the "Stats" product
* Check if the "more information" modal text is proper.

![image](https://github.com/Automattic/wp-calypso/assets/5550190/aaea3a12-8642-42e6-9fe1-96812f377102)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
