### PR TITLE
Fix discover sites sidebar layout from breaking for long titles with no spaces.

### DIFF
--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -91,6 +91,8 @@
 	display: -webkit-box;
 	line-height: 18px;
 	overflow: hidden;
+	overflow-wrap: break-word;
+	max-width: 190px;
 	width: auto;
 	-webkit-line-clamp: 1;
 	-webkit-box-orient: vertical;


### PR DESCRIPTION
…ot break layout

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1691422622835399-slack-C03NLNTPZ2T

## Proposed Changes

* Adds a couple styles to the site-title section of these components to prevent the noted layout breakage.

Before

<img width="328" alt="Screenshot 2023-08-08 at 10 17 49 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/b1e209fc-a9a0-47a2-909c-f9f2c9b9e9f9">


After

<img width="290" alt="Screenshot 2023-08-08 at 10 18 00 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/00c156f9-0e88-4856-8c0e-cd70761d1c78">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the /discover reader page
* go to the sites sidebar, right-click an item and inspect the DOM.
* update the text of the site title to be very long without any spaces.
* verify the name is cut off with an ellipsis and layout is not broken.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?