### PR TITLE
Jetpack Error UX: Show error banner on General and Reading settings

### DIFF
--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -6,8 +6,11 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
+import isJetpackConnectionProblem from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import JetpackDevModeNotice from './jetpack-dev-mode-notice';
 import SiteSettingsNavigation from './navigation';
@@ -15,10 +18,18 @@ import GeneralSettings from './section-general';
 
 import './style.scss';
 
-const SiteSettingsComponent = ( { siteId, translate } ) => {
+const SiteSettingsComponent = ( {
+	isJetpack,
+	isPossibleJetpackConnectionProblem,
+	siteId,
+	translate,
+} ) => {
 	return (
 		<Main className="site-settings">
 			<ScreenOptionsTab wpAdminPath="options-general.php" />
+			{ isJetpack && isPossibleJetpackConnectionProblem && (
+				<JetpackConnectionHealthBanner siteId={ siteId } />
+			) }
 			<DocumentHead title={ translate( 'General Settings' ) } />
 			<QueryProductsList />
 			<QuerySitePurchases siteId={ siteId } />
@@ -45,6 +56,11 @@ SiteSettingsComponent.propTypes = {
 	siteId: PropTypes.number,
 };
 
-export default connect( ( state ) => ( {
-	siteId: getSelectedSiteId( state ),
-} ) )( localize( SiteSettingsComponent ) );
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		siteId,
+		isJetpack: isJetpackSite( state, siteId ),
+		isPossibleJetpackConnectionProblem: isJetpackConnectionProblem( state, siteId ),
+	};
+} )( localize( SiteSettingsComponent ) );

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -3,8 +3,11 @@ import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
+import { useSelector } from 'calypso/state';
+import isJetpackConnectionProblem from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSiteUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import { IAppState } from 'calypso/state/types';
@@ -178,6 +181,11 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 
 const ReadingSettings = () => {
 	const translate = useTranslate();
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isPossibleJetpackConnectionProblem = useSelector( ( state ) =>
+		isJetpackConnectionProblem( state, siteId as number )
+	);
 
 	if ( ! isEnabled ) {
 		return null;
@@ -186,6 +194,9 @@ const ReadingSettings = () => {
 	return (
 		<Main className="site-settings site-settings__reading-settings">
 			<ScreenOptionsTab wpAdminPath="options-reading.php" />
+			{ isJetpack && isPossibleJetpackConnectionProblem && siteId && (
+				<JetpackConnectionHealthBanner siteId={ siteId } />
+			) }
 			<DocumentHead title={ translate( 'Reading Settings' ) } />
 			<FormattedHeader brandFont headerText={ translate( 'Reading Settings' ) } align="left" />
 			<ReadingSettingsForm />


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/3394

## Proposed Changes

Shows an error notice on the General and Reading settings pages when Jetpack is unable to connect to the site:

<img width="1001" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/70a242b9-a497-4923-8a8e-47fe96bb0905">

<img width="1021" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/2972d789-8751-485f-a3e9-676f222317d0">

Triggering logic was introduced in https://github.com/Automattic/wp-calypso/pull/79965

## Testing Instructions

1. Create a new Business site and take it Atomic.
2. Add some PHP code to `~/htdocs/wp-content/mu-plugins/local.php` that causes a fatal error.
3. Navigate to General Settings in Calypso.
4. Verify the notice appears as expected.
5. Fix your fatal error.
6. Reload the General Settings view.
7. Verify the notice no longer appears.