### PR TITLE
Fix reader search stream rendering blank for single feed result

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -128,7 +128,11 @@ class SearchStream extends React.Component {
 		const segmentedControlClass = wideDisplay
 			? 'search-stream__sort-picker is-wide'
 			: 'search-stream__sort-picker';
-		const hidePostsAndSites = this.state.feeds && this.state.feeds?.length === 1;
+		// Hide posts and sites if the only result has no feed ID. This happens when searching for a
+		// specific site to add to your feed. Originally added in
+		// https://github.com/Automattic/wp-calypso/pull/78555.
+		const hidePostsAndSites =
+			this.state.feeds && this.state.feeds?.length === 1 && ! this.state.feeds[ 0 ].feed_ID;
 
 		let searchPlaceholderText = this.props.searchPlaceholderText;
 		if ( ! searchPlaceholderText ) {

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -128,8 +128,8 @@ class SearchStream extends React.Component {
 		const segmentedControlClass = wideDisplay
 			? 'search-stream__sort-picker is-wide'
 			: 'search-stream__sort-picker';
-		// Hide posts and sites if the only result has no feed ID. This happens when searching for a
-		// specific site to add to your feed. Originally added in
+		// Hide posts and sites if the only result has no feed ID. This can happen when searching
+		// for a specific site to add a rss to your feed. Originally added in
 		// https://github.com/Automattic/wp-calypso/pull/78555.
 		const hidePostsAndSites =
 			this.state.feeds && this.state.feeds?.length === 1 && ! this.state.feeds[ 0 ].feed_ID;


### PR DESCRIPTION
…levant feeds

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1691485293410249-slack-C03NLNTPZ2T

## Proposed Changes

* In https://github.com/Automattic/wp-calypso/pull/78555, a check was added to hide posts and sites. This was intended to only hide these for the case noted in that PR, where we are searching for a specific site to add an rss feed and rendering a search result for that. When these results do not have feed_IDs, showing post/site results stayed in the empty/loading states and this seems to be why they were hidden.
*  However, this did not check anything beyond the number of feed results present and assumed 1 feed result meant we should hide the post/site results. Thus we now have a bug where other search results are hidden if they result in only 1 feed. * In this PR we fix the above by checking the `feed_ID` property in this conditional so that valid feeds are still rendered when expected.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the reader search stream
* input the username from the slack thread linked above (generally, input a search query that will result in only one feed - this username is an easy example)
* verify you see results for posts and sites
* also search individual sites as laid out in instructions on https://github.com/Automattic/wp-calypso/pull/78555
* verify the result is shown but the posts and sites columns are hidden if there is no feed to render.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?