### PR TITLE
GF Signup : Attempt 2 - Relaunch  the free/free experiment with some modal fixes and preloading

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
@@ -5,8 +5,9 @@ const useIsPlanUpsellEnabledOnFreeDomain = (
 	flowName?: string | null,
 	hasPaidDomain?: boolean
 ): DataResponse< boolean > => {
-	const ONBOARDING_EXPERIMENT = 'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal';
-	const ONBOARDING_PM_EXPERIMENT = 'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal';
+	const ONBOARDING_EXPERIMENT = 'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v2';
+	const ONBOARDING_PM_EXPERIMENT =
+		'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v2';
 	const relevantExperiment =
 		flowName === 'onboarding' ? ONBOARDING_EXPERIMENT : ONBOARDING_PM_EXPERIMENT;
 	const [ isLoading, experimentAssignment ] = useExperiment( relevantExperiment, {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -26,6 +26,7 @@ import {
 	getFixedDomainSearch,
 } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getSitePropertyDefaults } from 'calypso/lib/signup/site-properties';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
 import wpcom from 'calypso/lib/wp';
@@ -280,6 +281,17 @@ class DomainsStep extends Component {
 					productSlug: suggestion.product_slug,
 			  } )
 			: undefined;
+
+		/**
+		 * If we do not select a paid domain.
+		 * We want to pre load an experiment to show a plan upsell modal in the plans step
+		 */
+		if ( ! isPurchasingItem ) {
+			loadExperimentAssignment( 'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v2' );
+			loadExperimentAssignment(
+				'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v2'
+			);
+		}
 
 		suggestion && this.props.submitDomainStepSelection( suggestion, this.getAnalyticsSection() );
 


### PR DESCRIPTION
Related to
- https://github.com/Automattic/growth-foundations/issues/139
- https://github.com/Automattic/wp-calypso/pull/80108

## Proposed Changes 

* While the previous PR [#80108](https://github.com/Automattic/wp-calypso/pull/80108) shipped, we realised the exposure event configured on the experiment model was incorrect.
Discussion : pbxNRc-2Ri-p2#comment-4727   
* This relaunches the experiment with a brand new experiment model with the fixes. 
* We also preload the experiment a bit earlier to make sure the assignment happens a bit earlier.


## Testing Instructions
* Do a few confidence checks based on the test plan in https://github.com/Automattic/growth-foundations/issues/139

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
