### PR TITLE
Updates test app version for DSP widget URL

### DIFF
--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -56,7 +56,7 @@ declare global {
 	}
 }
 
-const shouldUseTestWidgetURL = () => getMobileDeviceInfo()?.version === '22.9.blaze';
+const shouldUseTestWidgetURL = () => getMobileDeviceInfo()?.version === '23.0-rc-1';
 
 const getWidgetDSPJSURL = () => {
 	let dspWidgetJS: string = shouldUseTestWidgetURL()
@@ -86,7 +86,7 @@ export async function loadDSPWidgetJS(): Promise< void > {
 const shouldHideGoToCampaignButton = () => {
 	// App versions higher or equal than 22.9.rc-1 should hide the button
 	const deviceInfo = getMobileDeviceInfo();
-	return versionCompare( deviceInfo?.version, '22.9.rc-1', '>=' );
+	return versionCompare( deviceInfo?.version, '22.9-rc-1', '>=' );
 };
 
 const getWidgetOptions = () => {

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -84,7 +84,7 @@ export async function loadDSPWidgetJS(): Promise< void > {
 }
 
 const shouldHideGoToCampaignButton = () => {
-	// App versions higher or equal than 22.9.rc-1 should hide the button
+	// App versions higher or equal than 22.9-rc-1 should hide the button
 	const deviceInfo = getMobileDeviceInfo();
 	return versionCompare( deviceInfo?.version, '22.9-rc-1', '>=' );
 };


### PR DESCRIPTION
We are testing an error in the Jetpack Android app related to the change in the DSP widget URL.
We are now open the testing for the next release candidate version.

## Proposed Changes

* Change the Test app version to `23.0-rc-1`. All beta users will be able to load the DSP widget from the new URL.

## Testing Instructions
Right now, except in production, the props dsp_widget_js_src and dsp_widget_js_test_src points to the same URL.
You will need to checkout this branch locally and change the value of dsp_widget_js_test_src in the developer config file to any other URL (e.g. https://widgets.wp.com/promote/widget.js).

* Open the Live preview and navigate to Tools->Advertising
* Create a mobile device using this user agent (or change your browser user-agent):
`Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36 wp-android/23.0-rc-1`
* Refresh the page
* Open your Browser network tab and filter by widget.js
* Click on the Promote button
* Verify that the widget load correctly using the dsp_widget_js_test_src URL for the widget.js file

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
