### PR TITLE
Fix Jetpack Search pricing display in search results list

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/preinstalled-premium-plugin-browser-item-pricing.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/preinstalled-premium-plugin-browser-item-pricing.jsx
@@ -49,18 +49,24 @@ export default function PreinstalledPremiumPluginBrowserItemPricing( { plugin } 
 	return (
 		<div className="plugins-browser-item__pricing">
 			<PluginPrice plugin={ plugin } billingPeriod={ IntervalLength.MONTHLY }>
-				{ ( { isFetching, price, period } ) =>
-					isFetching ? (
-						<div className="plugins-browser-item__pricing-placeholder">...</div>
-					) : (
-						<PreinstalledPremiumPluginPriceDisplay
-							className="plugins-browser-item__period"
-							period={ period }
-							pluginSlug={ plugin.slug }
-							price={ price }
-						/>
-					)
-				}
+				{ ( { isFetching, price, period } ) => {
+					if ( isFetching ) {
+						return <div className="plugins-browser-item__pricing-placeholder">...</div>;
+					}
+
+					if ( price ) {
+						return (
+							<PreinstalledPremiumPluginPriceDisplay
+								className="plugins-browser-item__period"
+								period={ period }
+								pluginSlug={ plugin.slug }
+								price={ price }
+							/>
+						);
+					}
+
+					return <>{ translate( 'Free' ) }</>;
+				} }
 			</PluginPrice>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1691502894705739-slack-C02ME06LF

## Proposed Changes

* Add a case to display free pricing to the `PreinstalledPremiumPluginBrowserItemPricing` component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins` and search for Jetpack Search
* In the search results list, check that the plugin displays **Free** as price

| Before | After |
| ------ | ----- |
| <img width="424" alt="CleanShot 2023-08-08 at 18 05 51@2x" src="https://github.com/Automattic/wp-calypso/assets/11555574/eedb7059-c30c-47e7-8aea-b13da0495313"> | <img width="427" alt="CleanShot 2023-08-08 at 18 05 09@2x" src="https://github.com/Automattic/wp-calypso/assets/11555574/dba4c394-ddfe-4c69-82a4-ddf3a1c98561"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
