### PR TITLE
Launchpad: Conditionally disable paid newsletter task

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -95,6 +95,10 @@ export function getEnhancedTasks(
 
 	const shouldDisplayWarning = displayGlobalStylesWarning || isVideoPressFlowWithUnsupportedPlan;
 
+	const isStripeConnected = Boolean(
+		tasks?.find( ( task ) => task.id === 'set_up_payments' )?.completed
+	);
+
 	tasks &&
 		tasks.map( ( task ) => {
 			let taskData = {};
@@ -476,6 +480,7 @@ export function getEnhancedTasks(
 					break;
 				case 'newsletter_plan_created':
 					taskData = {
+						disabled: ! isStripeConnected,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(


### PR DESCRIPTION
## Proposed Changes

This PR disables the `Create paid newsletter` until Stripe is connected. Without the Stripe connection, you can't create a plan. Once Stripe is connected, the `Create paid newsletter` task is enabled. 

## Testing Instructions

1) Checkout this branch, start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro, and be sure to choose the 'Paid' option.
2) Continue to Launchpad and confirm that the `Create paid newsletter` task is initially disabled.
3) Complete the `Set up payments` task.
   - You may want to add `define( 'USE_STORE_SANDBOX', true );`. This will ensure you don't have to actually setup stripe. You can add it to wp-content/mu-plugins/0-sandbox.php. Be sure to sandbox public-api.wordpress.com and the domain of your test site.
   - Click 'Set up payments', then click the Stripe connection button. Either set up Stripe or click the 'Skip' button if you've added the constant above.
   - Return to Launchpad. Coming back from stripe, your domain was likely reset to wordpress.com. When you get back to Launchpad, replace `https://wordpress.com` with `http://calypso.localhost:3000/` to ensure you are running this branch. 
4) Confirm `Set up payments` is now complete and `Create paid newsletter` is now enabled. In some cases, especially when sandboxed, there may be a small delay while the backend request is made and state updates.



