### PR TITLE
Hosting Metrics: Prevent multiple re-renders of charts on page load

### DIFF
--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -25,13 +25,10 @@ function useTimeRange() {
 		setSelectedTimeRange( timeRange );
 	};
 
-	// Call the `calculateTimeRange` function with the default selected option
-	const defaultTimeRange = calculateTimeRange( '24-hours' );
-
 	// Calculate the startTime and endTime using useMemo to memoize the result
 	const { start, end } = useMemo( () => {
-		return selectedTimeRange || defaultTimeRange;
-	}, [ defaultTimeRange, selectedTimeRange ] );
+		return selectedTimeRange || calculateTimeRange( '24-hours' );
+	}, [ selectedTimeRange ] );
 
 	return {
 		start,


### PR DESCRIPTION
## Proposed Changes

Moves `const defaultTimeRange = calculateTimeRange( '24-hours' )` inside of `useMemo()` to prevent new default `start` and `end` values from being generated when the `<MetricsTab />` component is re-mounted.

It became possible for the `<MetricsTab />` component to easily be re-mounted in https://github.com/Automattic/wp-calypso/pull/80316, which exposed this issue.

From https://github.com/Automattic/wp-calypso/commit/bb0d95d50b856217e9bfbaca43de4e533bc0ec9f#diff-a56207c057bcffa3a78bcced9e9b99878eaadeded3594679c44141c44b64f0baR19-R25

## Testing Instructions

1. Navigate to `/site-monitoring/<site>`.
2. Verify the charts don't flicker while the page is loading.