### PR TITLE
Hosting Metrics: Fix space between each chart

### DIFF
--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -148,7 +148,7 @@ export const MetricsTab = () => {
 		timeRange,
 	} );
 	return (
-		<>
+		<div className="site-monitoring-metrics-tab">
 			<TimeDateChartControls onTimeRangeChange={ handleTimeRangeChange }></TimeDateChartControls>
 			<SiteMonitoringLineChart
 				title={ __( 'Requests per minute & average response time' ) }
@@ -176,6 +176,6 @@ export const MetricsTab = () => {
 				title={ __( 'Requests by HTTP Response Code' ) }
 				{ ...statusCodeRequestsProps }
 			/>
-		</>
+		</div>
 	);
 };

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -1,9 +1,6 @@
 @import "uplot/dist/uPlot.min.css";
 
 .site-monitoring {
-	display: flex;
-	flex-direction: column;
-	gap: 16px;
 	position: relative;
 
 	// The logging API doesn't allow us to jump directly to a page, so hide page buttons.
@@ -37,6 +34,12 @@
 		left: -33px;
 		z-index: -1;
 	}
+}
+
+.site-monitoring-metrics-tab {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
 }
 
 .site-monitoring__chart {


### PR DESCRIPTION
More fallout from https://github.com/Automattic/wp-calypso/pull/80316

## Proposed Changes

<img width="1395" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/7129d9df-c91d-4499-b2e2-ac5c5a2d656f">

## Testing Instructions

1. Navigate to `/site-monitoring/<site>` and verify everything appears as expected.