### PR TITLE
Hosting Metrics: Add a background color to each chart

### DIFF
--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -46,6 +46,7 @@
 	padding: 24px;
 	border: 1px solid var(--studio-gray-5);
 	border-radius: 3px; /* stylelint-disable-line scales/radii */
+	background-color: var(--studio-white);
 }
 
 .site-monitoring__chart-header {


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/3276
See https://github.com/Automattic/dotcom-forge/issues/3274
See https://github.com/Automattic/dotcom-forge/issues/3356

## Proposed Changes

White looks better:

<img width="1394" alt="image" src="https://github.com/Automattic/wp-calypso/assets/36432/b623699f-cea7-4076-b174-b735074d804f">

## Testing Instructions

1. Navigate to `/site-monitoring/<site>` and breath a sigh of relief.