### PR TITLE
Hosting Metrics: Transform pie chart into donut chart and add loading state

### DIFF
--- a/client/components/pie-chart/README.md
+++ b/client/components/pie-chart/README.md
@@ -10,6 +10,7 @@ This component renders a dataset as a pie chart. A separate `PieChartLegend` sub
   - **description** - (optional) (String) A longer description of the datum
 - **title** — (optional) (String | Function) Title for the chart. If it is a function it will be called with the arguments
   `translate` and `dataTotal`. This is used to create titles that reference the data total
+- **donut** - (optional) (Boolean) Make it a donut chart instead of a pie chart.
 
 ## Usage
 

--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -37,6 +37,7 @@ function transformData( data ) {
 class PieChart extends Component {
 	static propTypes = {
 		data: PropTypes.arrayOf( DataType ).isRequired,
+		donut: PropTypes.bool,
 		translate: PropTypes.func.isRequired,
 		title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.func ] ),
 	};
@@ -79,7 +80,7 @@ class PieChart extends Component {
 	}
 
 	render() {
-		const { title, translate } = this.props;
+		const { title, translate, donut } = this.props;
 		const { dataTotal } = this.state;
 
 		return (
@@ -91,6 +92,14 @@ class PieChart extends Component {
 				>
 					<g transform={ `translate(${ SVG_SIZE / 2 }, ${ SVG_SIZE / 2 })` }>
 						{ dataTotal > 0 ? this.renderPieChart() : this.renderEmptyChart() }
+						{ dataTotal > 0 && donut && (
+							<circle
+								cx={ 0 }
+								cy={ 0 }
+								r={ SVG_SIZE / 4 }
+								className="pie-chart__chart-drawing-donut-hole"
+							/>
+						) }
 					</g>
 				</svg>
 

--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -10,7 +10,7 @@ import './style.scss';
 const SVG_SIZE = 300;
 const NUM_COLOR_SECTIONS = 3;
 
-function transformData( data ) {
+function transformData( data, donut = false ) {
 	const sortedData = sortBy( data, ( datum ) => datum.value )
 		.reverse()
 		.map( ( datum, index ) => ( {
@@ -23,7 +23,7 @@ function transformData( data ) {
 		.value( ( datum ) => datum.value )( sortedData );
 
 	const arcGen = d3Arc()
-		.innerRadius( 0 )
+		.innerRadius( donut ? SVG_SIZE / 4 : 0 )
 		.outerRadius( SVG_SIZE / 2 );
 
 	const paths = arcs.map( ( arc ) => arcGen( arc ) );
@@ -52,7 +52,7 @@ class PieChart extends Component {
 			return {
 				data: nextProps.data,
 				dataTotal: nextProps.data.reduce( ( sum, { value } ) => sum + value, 0 ),
-				transformedData: transformData( nextProps.data ),
+				transformedData: transformData( nextProps.data, nextProps.donut ),
 			};
 		}
 
@@ -80,7 +80,7 @@ class PieChart extends Component {
 	}
 
 	render() {
-		const { title, translate, donut } = this.props;
+		const { title, translate } = this.props;
 		const { dataTotal } = this.state;
 
 		return (
@@ -92,14 +92,6 @@ class PieChart extends Component {
 				>
 					<g transform={ `translate(${ SVG_SIZE / 2 }, ${ SVG_SIZE / 2 })` }>
 						{ dataTotal > 0 ? this.renderPieChart() : this.renderEmptyChart() }
-						{ dataTotal > 0 && donut && (
-							<circle
-								cx={ 0 }
-								cy={ 0 }
-								r={ SVG_SIZE / 4 }
-								className="pie-chart__chart-drawing-donut-hole"
-							/>
-						) }
 					</g>
 				</svg>
 

--- a/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/index.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from '@wordpress/components';
 import classnames from 'classnames';
 import PieChart from 'calypso/components/pie-chart';
 import PieChartLegend from 'calypso/components/pie-chart/legend';
@@ -21,7 +22,10 @@ export const SiteMonitoringPieChart = ( { title, className, data }: Props ) => {
 			<header className="site-monitoring__chart-header">
 				<h2 className="site-monitoring__chart-title">{ title }</h2>
 			</header>
-			<PieChart data={ data } />
+			<div className="site-monitoring__chart-container">
+				{ ! data.length ? <Spinner /> : null }
+				<PieChart data={ data } donut />
+			</div>
 			<PieChartLegend data={ data } onlyPercent />
 		</div>
 	);

--- a/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/style.scss
+++ b/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/style.scss
@@ -3,6 +3,19 @@
 		height: 250px;
 		width: 250px;
 	}
+	.site-monitoring__chart-container {
+		position: relative;
+		.components-spinner {
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			transform: translate(-50%, -50%);
+			z-index: 1;
+			height: 20px;
+			width: 20px;
+			margin: 0;
+		}
+	}
 	.pie-chart__legend {
 		margin-top: 24px;
 		flex-direction: row;

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -67,6 +67,9 @@
 	.site-monitoring__chart {
 		flex-grow: 1;
 	}
+	.pie-chart__chart-drawing-empty {
+		fill: var(--studio-gray-5);
+	}
 }
 
 .site-monitoring-cache-pie-chart {


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/3276

## Proposed Changes

Transforms the pie chart into a donut chart and adds a loading state:

https://github.com/Automattic/wp-calypso/assets/36432/271563de-3cc1-473f-9883-16abeb02fca5

## Testing Instructions

1. Navigate to `/site-monitoring/<site>`.
2. Verify the pie charts appear as expected.