### PR TITLE
Renovate tweaks

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,7 +19,7 @@ on:
           - lookup
           - extract
   schedule:
-    # Run every 15 minutes:
+    # Run every 30 minutes:
     - cron: '0,30 * * * *'
   pull_request:
     paths:

--- a/renovate.json5
+++ b/renovate.json5
@@ -12,6 +12,8 @@
 		{
 			matchDepNames: [ 'node' ],
 			prPriority: 2,
+			// This gets published with broader Node support, so we'll update it when needed.
+			ignorePaths: [ 'packages/eslint-plugin-wpcalypso' ]
 		},
 		{
 			extends: [ 'monorepo:react', ':widenPeerDependencies' ],


### PR DESCRIPTION
A couple of small adjustments to Renovate:
1. Avoid updating engines for one published package which should probably have broader node support.
2. fix typo in a comment