### PR TITLE
Update domains UI of the table

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -1,18 +1,25 @@
 @import "@automattic/onboarding/styles/mixins";
+@import "@wordpress/base-styles/colors";
 
 .domain-row {
 	position: relative;
 	display: block;
 	padding: 16px;
-	border-bottom: 1px solid var(--studio-gray-5);
-	font-size: $font-body-extra-small;
-	color: var(--studio-gray-50);
 	flex-wrap: wrap;
+	border-bottom: 1px solid $gray-100;
+	font-size: $font-body-extra-small;
+	color: var(--studio-gray-60);
+	line-height: 20px;
+	letter-spacing: -0.15px;
+	font-family: "SF Pro Text", $sans;
 
 	@include break-large {
 		display: flex;
+		flex-direction: column;
 		align-items: flex-start;
-		padding: 20px 0;
+		gap: 12px;
+		align-self: stretch;
+		padding: 24px 0;
 	}
 
 	/* div. for increased specificity */
@@ -72,10 +79,10 @@
 }
 
 .domain-row__mobile-container {
-	flex: 233 233 0;
 	display: flex;
-	flex-basis: 100%;
-	max-width: 100%;
+	justify-content: space-between;
+	align-items: flex-start;
+	align-self: stretch;
 }
 
 .domain-row__mobile-container2 {
@@ -190,9 +197,12 @@
 	flex: 1;
 
 	@include break-large {
-		flex: 83 83 0;
-		font-size: $font-body-small;
-		padding-top: 2px;
+		display: flex;
+		width: 280px;
+		flex-direction: column;
+		justify-content: center;
+		align-items: flex-start;
+		flex: none;
 	}
 
 	.domain-row__domain-name {
@@ -201,13 +211,14 @@
 		font-weight: 500;
 
 		button {
-			color: var(--studio-gray-90);
+			color: var(--studio-gray-100);
 			cursor: pointer;
+			font-family: "SF Pro Text", $sans;
+			font-size: $font-body;
+			font-style: normal;
 			font-weight: 500;
-			text-overflow: ellipsis;
-			overflow: hidden;
-			white-space: nowrap;
-			max-width: 100%;
+			line-height: 24px; /* 150% */
+			letter-spacing: -0.32px;
 
 			&:hover {
 				color: var(--color-link);
@@ -226,6 +237,9 @@
 	.domain-row__domain-type-text {
 		display: none;
 		font-size: $font-body-extra-small;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 20px;
 
 		@include break-large {
 			display: block;
@@ -237,21 +251,21 @@
 	display: none;
 
 	@include break-large {
-		flex: 70 70 0;
-		display: block;
+		display: flex;
+		width: 200px;
 		align-items: center;
-		padding-top: 2px;
+		gap: 2px;
 		font-size: $font-body-small;
 	}
 
 	a {
-		color: var(--studio-gray-50);
+		color: var(--studio-gray-60);
 
 		svg {
 			width: 18px;
 			height: 18px;
 			vertical-align: text-bottom;
-			fill: var(--studio-gray-50);
+			fill: var(--studio-gray-60);
 		}
 
 		&:hover {
@@ -267,10 +281,10 @@
 	display: none;
 
 	@include break-large {
-		flex: 40 40 0;
-		display: block;
+		display: flex;
+		width: 100px;
 		align-items: center;
-		padding-top: 2px;
+		gap: 2px;
 		font-size: $font-body-small;
 	}
 
@@ -285,10 +299,10 @@
 	margin-left: 16px;
 
 	@include break-large {
-		flex: 50 50 0;
-		margin: 0;
-		padding-top: 2px;
-		display: inline;
+		display: flex;
+		width: 140px;
+		align-items: center;
+		gap: 2px;
 		font-size: $font-body-small;
 	}
 }
@@ -307,6 +321,11 @@
 
 	@include break-large {
 		display: flex;
+		width: 80px;
+		align-items: center;
+		gap: 2px;
+		flex: none;
+		font-size: $font-body-small;
 
 		.components-base-control__field {
 			margin: 4px 0;
@@ -319,8 +338,12 @@
 	flex: 30 30 0;
 
 	@include break-large {
-		display: block;
-		padding-top: 2px;
+		display: flex;
+		width: 140px;
+		align-items: center;
+		gap: 2px;
+		font-size: $font-body-small;
+		flex: none;
 	}
 
 	a {
@@ -334,10 +357,12 @@
 
 .domain-row__action-cell {
 	margin-left: 10px;
-	height: 42px;
 
 	.ellipsis-menu {
 		margin: 0 auto;
+		button {
+			color: var(--studio-gray-50);
+		}
 	}
 
 	.ellipsis-menu__toggle {
@@ -347,8 +372,11 @@
 
 	@include break-large {
 		display: flex;
-		flex: 20 20 0;
-		margin: 0;
+		width: 50px;
+		flex-direction: column;
+		justify-content: center;
+		align-items: flex-end;
+		gap: 10px;
 	}
 }
 

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -14,11 +14,6 @@
 	font-family: "SF Pro Text", $sans;
 
 	@include break-large {
-		display: flex;
-		flex-direction: column;
-		align-items: flex-start;
-		gap: 12px;
-		align-self: stretch;
 		padding: 24px 0;
 	}
 
@@ -202,7 +197,7 @@
 		flex-direction: column;
 		justify-content: center;
 		align-items: flex-start;
-		flex: none;
+		flex: initial;
 	}
 
 	.domain-row__domain-name {
@@ -324,7 +319,7 @@
 		width: 80px;
 		align-items: center;
 		gap: 2px;
-		flex: none;
+		flex: initial;
 		font-size: $font-body-small;
 
 		.components-base-control__field {
@@ -343,7 +338,7 @@
 		align-items: center;
 		gap: 2px;
 		font-size: $font-body-small;
-		flex: none;
+		flex: initial;
 	}
 
 	a {

--- a/client/my-sites/domains/domain-management/list/domains-table-header.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table-header.jsx
@@ -1,5 +1,5 @@
 import { Button, CompactCard } from '@automattic/components';
-import { Icon, arrowDown, arrowUp } from '@wordpress/icons';
+import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -63,7 +63,7 @@ class DomainsTableHeader extends PureComponent {
 		const isActiveColumn = sortKey === column.name;
 		const columnSortOrder = isActiveColumn ? sortOrder : column.initialSortOrder;
 
-		return <Icon icon={ columnSortOrder === 1 ? arrowDown : arrowUp } size={ 16 } />;
+		return <Icon icon={ columnSortOrder === 1 ? chevronDown : chevronUp } size={ 16 } />;
 	}
 
 	getSingleSortOption( column, sortOrder ) {

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -1,6 +1,8 @@
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
+@import "@automattic/typography/styles/fonts";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/colors";
 
 .breadcrumbs {
 	svg.options-domain-button__add.gridicon {
@@ -200,18 +202,17 @@
 .domain-table-header {
 	display: flex;
 	justify-content: space-between;
-	padding: 8px 0;
+	padding: 8px 0 16px;
 	font-size: $font-body-small;
-	font-weight: 600;
-	color: var(--color-neutral-50);
-
-	border-bottom: 1px solid var(--color-neutral-5);
-	@include break-large {
-		border-bottom: 1px solid var(--color-neutral-20);
-	}
+	font-weight: 500;
+	color: var(--color-neutral-60);
+	border-bottom: 1px solid $gray-100;
 
 	.button-plain {
+		font-family: "SF Pro Text", $sans;
 		text-align: left;
+		line-height: 20px;
+		letter-spacing: -0.15px;
 
 		&:focus {
 			outline: thin dotted;
@@ -269,13 +270,22 @@
 	flex: 10 10 0;
 }
 .list__domain-cell {
-	flex: 83 83 0;
+	display: flex;
+	width: 280px;
+	align-items: center;
+	gap: 2px;
 }
 .list__site-cell {
-	flex: 70 70 0;
+	display: flex;
+	width: 200px;
+	align-items: center;
+	gap: 2px;
 }
 .list__status-cell {
-	flex: 40 40 0;
+	display: flex;
+	width: 100px;
+	align-items: center;
+	gap: 2px;
 	&__bubble {
 		display: flex;
 		width: 20px;
@@ -291,17 +301,28 @@
 	}
 }
 .list__registered-until-cell {
-	flex: 50 50 0;
+	display: flex;
+	width: 140px;
+	align-items: center;
+	gap: 2px;
 }
 .list__auto-renew-cell {
-	flex: 40 40 0;
+	display: flex;
+	width: 80px;
+	align-items: center;
+	gap: 2px;
 }
 .list__email-cell {
-	flex: 30 30 0;
+	display: flex;
+	width: 140px;
+	align-items: center;
+	gap: 2px;
 }
 .list__action-cell {
-	justify-content: center;
-	flex: 20 20 0;
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
+	gap: 2px;
 }
 
 .domain-management__all-domains-section {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3354

## Proposed Changes

Update domains list UI table to match Figma
P2: p9Jlb4-8vd-p2
Figma: mbuq4o5QxohQpBU9YoexXo-fi-1188_54349

## Testing Instructions

* Go to /domains/manage/all
* Check the table to match Figma
* Check on mobile
* Check also on `/domains/manage/YOUR_DOMAIN` (using a site with at least one domain)
* Check on mobile

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
