### PR TITLE
Jetpack Pro Dashboard: hide the monitor upgrade banner if the feature flag is not enabled

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-banners/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-banners/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import showBanner from 'calypso/jetpack-cloud/sections/utils/show-banner';
 import { useSelector } from 'calypso/state';
 import {
@@ -26,6 +27,7 @@ export default function DashboardBanners() {
 				getPreference( state, downtimeMonitoringUpgradeBannerPreferenceName )
 			),
 			showDays: 7,
+			hideBanner: ! isEnabled( 'jetpack/pro-dashboard-monitor-paid-tier' ),
 		},
 		{
 			component: () => <SiteSurveyBanner isDashboardView />,


### PR DESCRIPTION
Related to 1202619025189113-as-1205237269610193

## Proposed Changes

This PR fixes an issue that was causing the site survey banner not to display when the monitor upgrade banner was hidden using a feature flag.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/dashboard-banners-to-show-correctly` and `yarn start-jetpack-cloud` or open the Jetpack Cloud live link. 
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Reset all the banners if you have already cleared them, as mentioned below.
4. Try clearing the first banner(Welcome Banner), verify the next one appears(Downtime Monitoring Upgrade Banner), clear this also, and verify the next banner appears(Dashboard Survey Banner) > Close the survey banner and verify no banner is now shown.
5. Reset the banners again, as mentioned below.
6. Now append the URL with `?flags=-jetpack/pro-dashboard-monitor-paid-tier` to disable the feature flag.
7. Try clearing the first banner(Welcome Banner), verify the next one appears(Dashboard Survey Banner) instead of Downtime Monitoring Upgrade Banner 
8. Close the survey banner and verify no banner is now shown.

**How to reset the banner?**

1. On the Jetpack page at the bottom right. Hover on the debug icon and click preferences. Look for **jetpack-dashboard-agency-program-downtime-monitoring-upgrade-banner-preference** and clear it by clicking the **X** button.

<img width="1174" alt="Screen Shot 2023-07-12 at 4 57 50 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/aeb0af42-c99b-409f-a652-fb2fb207b97b">

2. Do the same for **jetpack-dashboard-welcome-banner-preference-home-page** & **jetpack-dashboard-agency-program-survey-banner-preference**.

3. This should reset the banner and will show up again on the Dashboard screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
