### PR TITLE
Bug Triage: add workflow to automatically apply the `[Status] Stale` label for issues closed with a keyword.

### DIFF
--- a/.github/workflows/apply-stale-closure-label.yml
+++ b/.github/workflows/apply-stale-closure-label.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set Last Comment
         id: get_last_comment
         run: |
-          last_comment=$( echo '${{ steps.get_all_comments.outputs.data }}' | jq -r '.[-1].body' )
+          last_comment=$( echo '${{ steps.get_all_comments.outputs.data }}' | tr -d '[:cntrl:]' | jq -r '.[-1].body' )
           echo comment=$last_comment >> $GITHUB_OUTPUT
 
       - name: Add [Closed] Stale label

--- a/.github/workflows/apply-stale-closure-label.yml
+++ b/.github/workflows/apply-stale-closure-label.yml
@@ -11,15 +11,15 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Get comments
+      - name: Get all comments on issue
         uses: octokit/request-action@v2.x
-        id: get_comments
+        id: get_all_comments
         with:
           route: GET /repos/${{github.repository}}/issues/${{ github.event.issue.number }}/comments
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set Last Comment
+      - name: Identify last comment
         id: get_last_comment
         run: |
           last_comment=$( echo '${{ steps.get_all_comments.outputs.data }}' | tr -d '[:cntrl:]' | jq -r '.[-1].body' )

--- a/.github/workflows/apply-stale-closure-label.yml
+++ b/.github/workflows/apply-stale-closure-label.yml
@@ -1,0 +1,33 @@
+name: Add [Closed] Stale label to closed issues
+
+on:
+  issues:
+    types: closed
+
+jobs:
+  add_label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Get comments
+        uses: octokit/request-action@v2.x
+        id: get_comments
+        with:
+          route: GET /repos/${{github.repository}}/issues/${{ github.event.issue.number }}/comments
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Last Comment
+        id: get_last_comment
+        run: |
+          last_comment=$( echo '${{ steps.get_all_comments.outputs.data }}' | jq -r '.[-1].body' )
+          echo comment=$last_comment >> $GITHUB_OUTPUT
+
+      - name: Add [Closed] Stale label
+        id: add_closed_stale_label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: contains( steps.get_last_comment.outputs.comment, 'Since this issue has been inactive for quite some time, KitKat has made the decision to close it.' )
+        with:
+          labels: [Closed] Stale


### PR DESCRIPTION
Context: p1691054833018099-slack-CQD1HH4MA

## Proposed Changes

This PR adds a GitHub workflow to automatically add the label (shown above) to issues that KitKat closes with the agreed-upon predef.

The aim for this workflow is to make sure we appropriately label issues closed under this Stale issue effort for future reporting purposes.

## Testing Instructions

Cannot be tested until merged and running.

That said, I have tested a near-identical copy of the workflow in another repository to make sure it works.
Example issue: https://github.com/Automattic/wp-calypso-test-results/issues/23
Workflow: https://github.com/Automattic/wp-calypso-test-results/blob/trunk/.github/workflows/label.yml

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
