### PR TITLE
Hosting Metrics: Fix line charts after API changes

### DIFF
--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -48,10 +48,11 @@ export function useSiteMetricsData( timeRange: TimeRange, metric?: MetricsType )
 		end,
 		metric: metric || 'requests_persec',
 	} );
+
 	// Function to get the dimension value for a specific key and period
 	const getDimensionValue = ( period: PeriodData ) => {
-		if ( Array.isArray( period?.dimension ) ) {
-			// If the dimension is an array, return 0
+		if ( typeof period?.dimension === 'object' && Object.keys( period.dimension ).length === 0 ) {
+			// If the dimension is an empty object, return 0
 			return 0;
 		} else if ( typeof period?.dimension === 'object' ) {
 			// If the dimension is an object, try to find and return the dimension value

--- a/client/my-sites/site-monitoring/test/main.js
+++ b/client/my-sites/site-monitoring/test/main.js
@@ -58,7 +58,7 @@ describe( 'useSiteMetrics test', () => {
 	it( 'should return formattedData for the case with an empty array for dimension', () => {
 		useSiteMetricsQuery.mockReturnValueOnce( {
 			data: {
-				data: { periods: [ { timestamp: 1685577600, dimension: [] } ] },
+				data: { periods: [ { timestamp: 1685577600, dimension: {} } ] },
 			},
 		} );
 
@@ -112,7 +112,7 @@ describe( 'useSiteMetrics test', () => {
 				data: {
 					periods: [
 						{ timestamp: 1685577600, dimension: { 'example.com': 0.0030000000000000005 } },
-						{ timestamp: 1685577800, dimension: [] },
+						{ timestamp: 1685577800, dimension: {} },
 					],
 				},
 			},

--- a/client/my-sites/site-monitoring/use-metrics-query.ts
+++ b/client/my-sites/site-monitoring/use-metrics-query.ts
@@ -11,7 +11,7 @@ export type SiteMetricsAPIResponse = {
 
 export type PeriodData = {
 	timestamp: number;
-	dimension: [] | { [ key: string ]: number };
+	dimension: { [ key: string ]: number };
 };
 
 export type MetaData = {


### PR DESCRIPTION
Related to #https://github.com/Automattic/dotcom-forge/issues/3274

## Proposed Changes

This PR adapts the code for the line chart for requests per minute and average response time to the newest API changes that broke the chart display.

Before (chart is not being properly displayed):


<img width="780" alt="Screenshot 2023-08-09 at 8 53 48 AM" src="https://github.com/Automattic/wp-calypso/assets/25575134/77fef6c5-e838-463c-bb06-89791a747ba1">

After:

<img width="801" alt="Screenshot 2023-08-09 at 8 54 19 AM" src="https://github.com/Automattic/wp-calypso/assets/25575134/99c817f5-992d-4495-9310-a39602d01363">

## Testing Instructions

* Navigate with Calypso Live link to `site-monitoring/{yourAtomicSite}?page=metrics`
* Confirm that the chart blue line displays as expected

If you would like to confirm that the tests are working:

* Pull the changes from this branch locally 
* Run `yarn test-client -- client/my-sites/site-monitoring/test/main.js`
* Confirm that all three tests passed successfully 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
