### PR TITLE
Launchpads: add "migrate content" task

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -236,6 +236,15 @@ export function getEnhancedTasks(
 						},
 					};
 					break;
+				case 'migrate_content':
+					taskData = {
+						disabled: mustVerifyEmailBeforePosting || false,
+						actionDispatch: () => {
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
+							window.location.assign( `/import/${ siteSlug }` );
+						},
+					};
+					break;
 				case 'first_post_published':
 					taskData = {
 						disabled:

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -3,6 +3,7 @@ import {
 	planHasFeature,
 	FEATURE_STYLE_CUSTOMIZATION,
 } from '@automattic/calypso-products';
+import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import {
 	isBlogOnboardingFlow,
@@ -99,6 +100,14 @@ export function getEnhancedTasks(
 	const isStripeConnected = Boolean(
 		tasks?.find( ( task ) => task.id === 'set_up_payments' )?.completed
 	);
+
+	const completeMigrateContentTask = async () => {
+		if ( siteSlug ) {
+			await updateLaunchpadSettings( siteSlug, {
+				checklist_statuses: { migrate_content: true },
+			} );
+		}
+	};
 
 	tasks &&
 		tasks.map( ( task ) => {
@@ -241,6 +250,11 @@ export function getEnhancedTasks(
 						disabled: mustVerifyEmailBeforePosting || false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
+
+							// Mark task done
+							completeMigrateContentTask();
+
+							// Go to importers
 							window.location.assign( `/import/${ siteSlug }` );
 						},
 					};


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/80364

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Requires pairing with Jetpack PR https://github.com/Automattic/jetpack/pull/32357

Since the task simply links to "importers" page, it'll work well for anyone coming from anywhere — WordPress, Medium, etc.

Simply clicking the task completes it.

[Next up we also add Substack importer](https://github.com/Automattic/wp-calypso/issues/80364).

## Proposed Changes

* Add "migrate content" task handling



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply https://github.com/Automattic/jetpack/pull/32357 in your sandbox
* Create a Newsletter with "import" goal via [/setup/newsletter](https://wordpress.com/setup/newsletter)
* See that you get the migrate content task when checking import goal, and otherwise you don't get it.
* See that you get linked to importers and task gets marked as done.
* You can add `?flags=importers/substack` to URL at importers page to see and test Substack importer as well.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
