### PR TITLE
Plans Billing Timeframe: Revert translated strings

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -69,9 +69,9 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 	if ( discountedPriceFullTermText ) {
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
 			return translate(
-				'per month, %(discountedPriceFullTermText)s for the first year, Excl. Taxes',
+				'per month, %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes',
 				{
-					args: { discountedPriceFullTermText },
+					args: { fullTermDiscountedPriceText: discountedPriceFullTermText },
 					comment: 'Excl. Taxes is short for excluding taxes',
 				}
 			);
@@ -79,9 +79,9 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 
 		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
 			return translate(
-				'per month, %(discountedPriceFullTermText)s for the first two years, Excl. Taxes',
+				'per month, %(fullTermDiscountedPriceText)s for the first two years, Excl. Taxes',
 				{
-					args: { discountedPriceFullTermText },
+					args: { fullTermDiscountedPriceText: discountedPriceFullTermText },
 					comment: 'Excl. Taxes is short for excluding taxes',
 				}
 			);
@@ -89,39 +89,33 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 
 		if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
 			return translate(
-				'per month, %(discountedPriceFullTermText)s for the first three years, Excl. Taxes',
+				'per month, %(fullTermDiscountedPriceText)s for the first three years, Excl. Taxes',
 				{
-					args: { discountedPriceFullTermText },
+					args: { fullTermDiscountedPriceText: discountedPriceFullTermText },
 					comment: 'Excl. Taxes is short for excluding taxes',
 				}
 			);
 		}
 	} else if ( originalPriceFullTermText ) {
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, %(originalPriceFullTermText)s billed annually, Excl. Taxes', {
-				args: { originalPriceFullTermText },
+			return translate( 'per month, %(rawPrice)s billed annually, Excl. Taxes', {
+				args: { rawPrice: originalPriceFullTermText },
 				comment: 'Excl. Taxes is short for excluding taxes',
 			} );
 		}
 
 		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
-			return translate(
-				'per month, %(originalPriceFullTermText)s billed every two years, Excl. TaxesText',
-				{
-					args: { originalPriceFullTermText },
-					comment: 'Excl. Taxes is short for excluding taxes',
-				}
-			);
+			return translate( 'per month, %(rawPrice)s billed every two years, Excl. Taxes', {
+				args: { rawPrice: originalPriceFullTermText },
+				comment: 'Excl. Taxes is short for excluding taxes',
+			} );
 		}
 
 		if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
-			return translate(
-				'per month, %(originalPriceFullTermText)s billed every three years, Excl. TaxesText',
-				{
-					args: { originalPriceFullTermText },
-					comment: 'Excl. Taxes is short for excluding taxes',
-				}
-			);
+			return translate( 'per month, %(rawPrice)s billed every three years, Excl. Taxes', {
+				args: { rawPrice: originalPriceFullTermText },
+				comment: 'Excl. Taxes is short for excluding taxes',
+			} );
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79733

## Proposed Changes

* This reverts the translated strings changed in #79733 as changing the interpolated variable names also changes the translation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The Translate job and the `String Freeze` workflow should confirm that the strings are present in existing translations.
* Change account language to any non-EN language.
* Go to `/start/plans`.
* Check the billing timeframe for 1M and 1Y plans by using the term toggle
<img width="1479" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/e49bc7f0-b13e-4b33-939a-30b64258c69a">
<img width="1477" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/29c602ff-50ab-4919-8be6-f09fd4e0ff6c">

* Go to `/start/onboarding-pm/plans`.
* Check the billing timeframe for 2Y plans by using the term toggle
<img width="1448" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/b1a5912c-bf5b-405e-bf2f-eccd19163764">

* If you have a site with a 3Y plan, check the timeframe on the `/plans` page:
<img width="1160" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/fba39a30-a46d-4a08-a3e6-b068dbd2111c">







## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
