### PR TITLE
Substack importer: release

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -44,6 +44,7 @@
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/unified": true,
+		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/api-cache": true,

--- a/config/production.json
+++ b/config/production.json
@@ -51,6 +51,7 @@
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/unified": true,
+		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"is_running_in_jetpack_site": false,
 		"jetpack/agency-dashboard": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of https://github.com/Automattic/wp-calypso/issues/80364

Can be merged once CFT is done.

Adds "subscriber importing" into Substack importing in lightweight way, simply linking into existing "add subscribers" modal.

<img width="844" alt="Screenshot 2023-08-08 at 16 55 52" src="https://github.com/Automattic/wp-calypso/assets/87168/a3545746-979e-4027-b279-37225a106c12">

## Proposed Changes

* Enable feature flag in all environments

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Tools → Import → Substack
* Try import Substack file, it should work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
