### PR TITLE
Newsletter Categories: Updated Newsletter query keys, plus tests

### DIFF
--- a/client/data/newsletter-categories/test/use-mark-as-newsletter-category-mutation.test.tsx
+++ b/client/data/newsletter-categories/test/use-mark-as-newsletter-category-mutation.test.tsx
@@ -69,7 +69,7 @@ describe( 'useMarkAsNewsletterCategoryMutation', () => {
 			await result.current.mutateAsync( categoryId );
 		} );
 
-		expect( invalidateQueriesSpy ).toHaveBeenCalledWith( [ `newsletter-categories-123` ] );
+		expect( invalidateQueriesSpy ).toHaveBeenCalledWith( [ 'newsletter-categories', 123 ] );
 	} );
 
 	it( 'should throw an error when ID is missing', async () => {

--- a/client/data/newsletter-categories/test/use-newsletter-categories-query.test.tsx
+++ b/client/data/newsletter-categories/test/use-newsletter-categories-query.test.tsx
@@ -42,7 +42,7 @@ describe( 'useNewsletterCategories', () => {
 			],
 		} );
 
-		const { result } = renderHook( () => useNewsletterCategories( { blogId: 123 } ), { wrapper } );
+		const { result } = renderHook( () => useNewsletterCategories( { siteId: 123 } ), { wrapper } );
 
 		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 
@@ -59,10 +59,28 @@ describe( 'useNewsletterCategories', () => {
 			newsletter_categories: [],
 		} );
 
-		const { result } = renderHook( () => useNewsletterCategories( { blogId: 123 } ), { wrapper } );
+		const { result } = renderHook( () => useNewsletterCategories( { siteId: 123 } ), { wrapper } );
 
 		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 
 		expect( result.current.data ).toEqual( { newsletterCategories: [] } );
+	} );
+
+	it( 'should call request with correct arguments', async () => {
+		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( {
+			success: true,
+		} );
+
+		renderHook( () => useNewsletterCategories( { siteId: 123 } ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( request ).toHaveBeenCalled() );
+
+		expect( request ).toHaveBeenCalledWith( {
+			path: `/sites/123/newsletter-categories`,
+			apiVersion: '2',
+			apiNamespace: 'wpcom/v2',
+		} );
 	} );
 } );

--- a/client/data/newsletter-categories/test/use-subscriber-newsletter-categories-query.test.tsx
+++ b/client/data/newsletter-categories/test/use-subscriber-newsletter-categories-query.test.tsx
@@ -56,7 +56,7 @@ describe( 'useSubscriberNewsletterCategories', () => {
 			],
 		} );
 
-		const { result } = renderHook( () => useSubscriberNewsletterCategories( { blogId: 123 } ), {
+		const { result } = renderHook( () => useSubscriberNewsletterCategories( { siteId: 123 } ), {
 			wrapper,
 		} );
 
@@ -89,12 +89,30 @@ describe( 'useSubscriberNewsletterCategories', () => {
 			newsletter_categories: [],
 		} );
 
-		const { result } = renderHook( () => useSubscriberNewsletterCategories( { blogId: 123 } ), {
+		const { result } = renderHook( () => useSubscriberNewsletterCategories( { siteId: 123 } ), {
 			wrapper,
 		} );
 
 		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 
 		expect( result.current.data ).toEqual( { newsletterCategories: [] } );
+	} );
+
+	it( 'should call request with correct arguments', async () => {
+		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( {
+			success: true,
+		} );
+
+		renderHook( () => useSubscriberNewsletterCategories( { siteId: 123 } ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( request ).toHaveBeenCalled() );
+
+		expect( request ).toHaveBeenCalledWith( {
+			path: `/sites/123/newsletter-categories/subscriptions`,
+			apiVersion: '2',
+			apiNamespace: 'wpcom/v2',
+		} );
 	} );
 } );

--- a/client/data/newsletter-categories/test/use-unmark-as-newsletter-category-mutation.test.tsx
+++ b/client/data/newsletter-categories/test/use-unmark-as-newsletter-category-mutation.test.tsx
@@ -69,7 +69,7 @@ describe( 'useUnmarkAsNewsletterCategoryMutation', () => {
 			await result.current.mutateAsync( categoryId );
 		} );
 
-		expect( invalidateQueriesSpy ).toHaveBeenCalledWith( [ `newsletter-categories-123` ] );
+		expect( invalidateQueriesSpy ).toHaveBeenCalledWith( [ 'newsletter-categories', 123 ] );
 	} );
 
 	it( 'should throw an error when ID is missing', async () => {

--- a/client/data/newsletter-categories/use-mark-as-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-mark-as-newsletter-category-mutation.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import request from 'wpcom-proxy-request';
+import { getNewsletterCategoriesKey } from './use-newsletter-categories-query';
 
 type MarkAsNewsletterCategoryResponse = {
 	success: boolean;
@@ -7,7 +8,7 @@ type MarkAsNewsletterCategoryResponse = {
 
 const useMarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 	const queryClient = useQueryClient();
-	const cacheKey = [ `newsletter-categories-${ siteId }` ];
+	const cacheKey = getNewsletterCategoriesKey( siteId );
 	return useMutation( {
 		mutationFn: async ( id: number ) => {
 			if ( ! id ) {

--- a/client/data/newsletter-categories/use-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-newsletter-categories-query.tsx
@@ -3,7 +3,7 @@ import request from 'wpcom-proxy-request';
 import { NewsletterCategories, NewsletterCategory } from './types';
 
 type NewsletterCategoryQueryProps = {
-	blogId?: number;
+	siteId?: string | number;
 };
 
 type NewsletterCategoryResponse = {
@@ -16,18 +16,23 @@ const convertNewsletterCategoryResponse = (
 	return { newsletterCategories: response.newsletter_categories };
 };
 
+export const getNewsletterCategoriesKey = ( siteId?: string | number ) => [
+	`newsletter-categories`,
+	siteId,
+];
+
 const useNewsletterCategories = ( {
-	blogId,
+	siteId,
 }: NewsletterCategoryQueryProps ): UseQueryResult< NewsletterCategories > => {
 	return useQuery( {
-		queryKey: [ `newsletter-categories-${ blogId }` ],
+		queryKey: getNewsletterCategoriesKey( siteId ),
 		queryFn: () =>
 			request< NewsletterCategoryResponse >( {
-				path: `/sites/${ blogId }/newsletter-categories`,
+				path: `/sites/${ siteId }/newsletter-categories`,
 				apiVersion: '2',
 				apiNamespace: 'wpcom/v2',
 			} ).then( convertNewsletterCategoryResponse ),
-		enabled: !! blogId,
+		enabled: !! siteId,
 	} );
 };
 

--- a/client/data/newsletter-categories/use-subscriber-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-subscriber-newsletter-categories-query.tsx
@@ -3,12 +3,17 @@ import request from 'wpcom-proxy-request';
 import { NewsletterCategories, NewsletterCategory } from './types';
 
 type NewsletterCategoryQueryProps = {
-	blogId: number;
+	siteId: number;
 };
 
 type NewsletterCategoryResponse = {
 	newsletter_categories: NewsletterCategory[];
 };
+
+export const getSubscriberNewsletterCategoriesKey = ( siteId?: string | number ) => [
+	`newsletter-categories`,
+	siteId,
+];
 
 const convertNewsletterCategoryResponse = (
 	response: NewsletterCategoryResponse
@@ -17,17 +22,17 @@ const convertNewsletterCategoryResponse = (
 };
 
 const useSubscriberNewsletterCategories = ( {
-	blogId,
+	siteId,
 }: NewsletterCategoryQueryProps ): UseQueryResult< NewsletterCategories > => {
 	return useQuery( {
-		queryKey: [ `newsletter-categories-${ blogId }` ],
+		queryKey: getSubscriberNewsletterCategoriesKey( siteId ),
 		queryFn: () =>
 			request< NewsletterCategoryResponse >( {
-				path: `/sites/${ blogId }/newsletter-categories/subscriptions`,
+				path: `/sites/${ siteId }/newsletter-categories/subscriptions`,
 				apiVersion: '2',
 				apiNamespace: 'wpcom/v2',
 			} ).then( convertNewsletterCategoryResponse ),
-		enabled: !! blogId,
+		enabled: !! siteId,
 	} );
 };
 

--- a/client/data/newsletter-categories/use-unmark-as-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-unmark-as-newsletter-category-mutation.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import request from 'wpcom-proxy-request';
+import { getNewsletterCategoriesKey } from './use-newsletter-categories-query';
 
 type UnmarkAsNewsletterCategoryResponse = {
 	success: boolean;
@@ -7,7 +8,7 @@ type UnmarkAsNewsletterCategoryResponse = {
 
 const useUnmarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 	const queryClient = useQueryClient();
-	const cacheKey = [ `newsletter-categories-${ siteId }` ];
+	const cacheKey = getNewsletterCategoriesKey( siteId );
 
 	return useMutation( {
 		mutationFn: async ( id: number ) => {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/80368

## Proposed Changes

In this PR I updated the query Keys of the Newsletter Categories queries as suggested in this comment: https://github.com/Automattic/wp-calypso/pull/80143#discussion_r1286015089

I also changed `blogId` to `siteId` for consistency between the queries and the mutations.

The tests were updated for these new changes, plus I added one more test for the queries regarding the parameters of the request.

## Testing Instructions

To test these changes, you should run the test for all the files modified in this PR. These are the commands:

`yarn test-client client/data/newsletter-categories/test/use-mark-as-newsletter-category-mutation.test.tsx`
`yarn test-client client/data/newsletter-categories/test/use-newsletter-categories-query.test.tsx`
`yarn test-client client/data/newsletter-categories/test/use-subscriber-newsletter-categories-query.test.tsx`
`yarn test-client client/data/newsletter-categories/test/use-unmark-as-newsletter-category-mutation.test.tsx`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
