### PR TITLE
[Odie][Experiment] Slide in odie on plans page when compare plans button is visible

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -124,6 +124,7 @@ export type PlanFeatures2023GridProps = {
 	showUpgradeableStorage: boolean; // feature flag used to show the storage add-on dropdown
 	stickyRowOffset: number;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
+	showOdie?: () => void;
 };
 
 type PlanFeatures2023GridConnectedProps = {
@@ -224,6 +225,9 @@ export class PlanFeatures2023Grid extends Component<
 	PlanFeatures2023GridType,
 	PlanFeatures2023GridState
 > {
+	observer: IntersectionObserver | null = null;
+	buttonRef: React.RefObject< HTMLButtonElement > = createRef< HTMLButtonElement >();
+
 	state: PlanFeatures2023GridState = {
 		showPlansComparisonGrid: false,
 		selectedStorage: {},
@@ -235,6 +239,25 @@ export class PlanFeatures2023Grid extends Component<
 		// TODO clk: move these to PlansFeaturesMain (after Woo plans migrate)
 		this.props.recordTracksEvent( 'calypso_wp_plans_test_view' );
 		retargetViewPlans();
+
+		this.observer = new IntersectionObserver( ( entries ) => {
+			entries.forEach( ( entry ) => {
+				if ( entry.isIntersecting ) {
+					this.props.showOdie?.();
+					this.observer?.disconnect();
+				}
+			} );
+		} );
+
+		if ( this.buttonRef.current ) {
+			this.observer.observe( this.buttonRef.current );
+		}
+	}
+
+	componentWillUnmount() {
+		if ( this.observer ) {
+			this.observer.disconnect();
+		}
 	}
 
 	toggleShowPlansComparisonGrid = () => {
@@ -906,7 +929,7 @@ export class PlanFeatures2023Grid extends Component<
 				</div>
 				{ ! hidePlansFeatureComparison && (
 					<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
-						<Button onClick={ this.toggleShowPlansComparisonGrid }>
+						<Button onClick={ this.toggleShowPlansComparisonGrid } ref={ this.buttonRef }>
 							{ this.state.showPlansComparisonGrid
 								? translate( 'Hide comparison' )
 								: translate( 'Compare plans' ) }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -29,6 +29,7 @@ import usePlanFeaturesForGridPlans from 'calypso/my-sites/plan-features-2023-gri
 import useRestructuredPlanFeaturesForComparisonGrid from 'calypso/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-restructured-plan-features-for-comparison-grid';
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
 import PlanTypeSelector from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
+import { useOdieAssistantContext } from 'calypso/odie/context';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
@@ -119,6 +120,7 @@ type OnboardingPricingGrid2023Props = PlansFeaturesMainProps & {
 	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >;
 	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >;
 	isGlobalStylesOnPersonal?: boolean;
+	showOdie?: () => void;
 };
 
 const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
@@ -167,6 +169,7 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 		isSpotlightOnCurrentPlan,
 		showUpgradeableStorage,
 		isGlobalStylesOnPersonal,
+		showOdie,
 	} = props;
 	const translate = useTranslate();
 	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
@@ -271,6 +274,7 @@ const OnboardingPricingGrid2023 = ( props: OnboardingPricingGrid2023Props ) => {
 			require="calypso/my-sites/plan-features-2023-grid"
 			{ ...asyncProps }
 			planTypeSelectorProps={ planTypeSelectorProps }
+			showOdie={ showOdie }
 		/>
 	);
 
@@ -358,6 +362,8 @@ const PlansFeaturesMain = ( {
 	if ( _customerType === 'personal' && userCanUpgradeToPersonalPlan ) {
 		_customerType = 'business';
 	}
+
+	const { setIsVisible } = useOdieAssistantContext();
 
 	const isDisplayingPlansNeededForFeature = () => {
 		if (
@@ -658,6 +664,7 @@ const PlansFeaturesMain = ( {
 						isSpotlightOnCurrentPlan={ isSpotlightOnCurrentPlanAllowed && isSpotlightOnCurrentPlan }
 						showUpgradeableStorage={ showUpgradeableStorage }
 						isGlobalStylesOnPersonal={ globalStylesInPersonalPlan }
+						showOdie={ () => setIsVisible( true ) }
 					/>
 				</>
 			) }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -363,7 +363,7 @@ const PlansFeaturesMain = ( {
 		_customerType = 'business';
 	}
 
-	const { setIsVisible } = useOdieAssistantContext();
+	const { isVisible, setIsVisible, trackEvent } = useOdieAssistantContext();
 
 	const isDisplayingPlansNeededForFeature = () => {
 		if (
@@ -664,7 +664,15 @@ const PlansFeaturesMain = ( {
 						isSpotlightOnCurrentPlan={ isSpotlightOnCurrentPlanAllowed && isSpotlightOnCurrentPlan }
 						showUpgradeableStorage={ showUpgradeableStorage }
 						isGlobalStylesOnPersonal={ globalStylesInPersonalPlan }
-						showOdie={ () => setIsVisible( true ) }
+						showOdie={ () => {
+							if ( ! isVisible ) {
+								trackEvent( 'calypso_odie_chat_toggle_visibility', {
+									visibility: true,
+									trigger: 'scroll',
+								} );
+								setIsVisible( true );
+							}
+						} }
 					/>
 				</>
 			) }

--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -1,7 +1,8 @@
 import config from '@automattic/calypso-config';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { useExperiment } from 'calypso/lib/explat';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import OdieAssistant from '..';
 import { getOdieInitialPrompt } from './initial-prompts';
@@ -38,6 +39,7 @@ interface OdieAssistantContextInterface {
 	setIsNudging: ( isNudging: boolean ) => void;
 	setIsVisible: ( isVisible: boolean ) => void;
 	setIsLoading: ( isLoading: boolean ) => void;
+	trackEvent: ( event: string, properties?: Record< string, unknown > ) => void;
 }
 
 const defaultContextInterfaceValues = {
@@ -56,6 +58,7 @@ const defaultContextInterfaceValues = {
 	setIsNudging: noop,
 	setIsVisible: noop,
 	setIsLoading: noop,
+	trackEvent: noop,
 };
 
 // Create a default new context
@@ -76,6 +79,7 @@ const OdieAssistantProvider = ( {
 	sectionName: OdieAllowedSectionNames;
 	children: ReactNode;
 } ) => {
+	const dispatch = useDispatch();
 	const [ , experimentAssignment ] = useExperiment( 'calypso_plans_wapuu_sales_agent_v0' );
 	const odieIsEnabled =
 		config.isEnabled( 'odie' ) ||
@@ -102,6 +106,10 @@ const OdieAssistantProvider = ( {
 			messages: [ { content: getOdieInitialPrompt( sectionName ), role: 'bot', type: 'message' } ],
 		} );
 	}, [ sectionName, siteId ] );
+
+	const trackEvent = ( event: string, properties?: Record< string, unknown > ) => {
+		dispatch( recordTracksEvent( event, properties ) );
+	};
 
 	const addMessage = ( message: Message ) => {
 		setMessages( ( prevMessages ) => {
@@ -141,6 +149,7 @@ const OdieAssistantProvider = ( {
 				setIsLoading,
 				setIsNudging,
 				setIsVisible,
+				trackEvent,
 			} }
 		>
 			{ children }

--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -80,7 +80,7 @@ const OdieAssistantProvider = ( {
 	children: ReactNode;
 } ) => {
 	const dispatch = useDispatch();
-	const [ , experimentAssignment ] = useExperiment( 'calypso_plans_wapuu_sales_agent_v0' );
+	const [ , experimentAssignment ] = useExperiment( 'calypso_plans_wapuu_sales_agent_v1' );
 	const odieIsEnabled =
 		config.isEnabled( 'odie' ) ||
 		( experimentAssignment?.variationName === 'treatment' &&


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/ai-services/issues/230

## Proposed Changes

Slide in Odie when Compare plan button is visible.

## Testing Instructions

Be proxied

1. Go to plans page
2. Amend `?flags=odie` to the url
3. Assert that Odie appears
4. Scroll to the bottom and assert that Odie slides in

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
