### PR TITLE
Change an external link icon according to design

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -4,7 +4,6 @@ import {
 	Badge,
 	Button,
 	Dialog,
-	Gridicon,
 	HorizontalBarList,
 	HorizontalBarListItem,
 } from '@automattic/components';
@@ -57,6 +56,17 @@ const getPostIdFromURN = ( targetUrn: string ) => {
 		return splitted[ 4 ];
 	}
 };
+
+const getExternalLinkIcon = ( fillColor?: string ) => (
+	<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path
+			fill-rule="evenodd"
+			clip-rule="evenodd"
+			d="M9.93271 3.02436L12.4162 3.01314L8.1546 7.27477L8.8617 7.98188L13.1183 3.72526L13.0971 6.18673L14.0971 6.19534L14.1332 2.00537L9.92819 2.02437L9.93271 3.02436ZM4.66732 2.83349C3.6548 2.83349 2.83398 3.6543 2.83398 4.66682V11.3335C2.83398 12.346 3.6548 13.1668 4.66732 13.1668H11.334C12.3465 13.1668 13.1673 12.346 13.1673 11.3335V8.90756H12.1673V11.3335C12.1673 11.7937 11.7942 12.1668 11.334 12.1668H4.66732C4.20708 12.1668 3.83398 11.7937 3.83398 11.3335V4.66682C3.83398 4.20658 4.20708 3.83349 4.66732 3.83349H6.83398V2.83349H4.66732Z"
+			fill={ fillColor }
+		/>
+	</svg>
+);
 
 export default function CampaignItemDetails( props: Props ) {
 	const isRunningInJetpack = config.isEnabled( 'is_running_in_jetpack_site' );
@@ -527,7 +537,7 @@ export default function CampaignItemDetails( props: Props ) {
 													target="_blank"
 												>
 													{ clickUrl }
-													<Gridicon icon="external" size={ 16 } />
+													{ getExternalLinkIcon() }
 												</Button>
 											) : (
 												<FlexibleSkeleton />
@@ -648,7 +658,7 @@ export default function CampaignItemDetails( props: Props ) {
 								commented out until we get the link
 								<Button className="is-link campaign-item-details__support-effective-ad-doc">
 									{ translate( 'What makes an effective ad?' ) }
-									<Gridicon icon="external" size={ 16 } />
+									{ getExternalLinkIcon() }
 								</Button>*/ }
 
 								<InlineSupportLink
@@ -658,7 +668,7 @@ export default function CampaignItemDetails( props: Props ) {
 									showSupportModal={ ! isRunningInJetpack }
 								>
 									{ translate( 'View documentation' ) }
-									<Gridicon icon="external" size={ 16 } />
+									{ getExternalLinkIcon() }
 								</InlineSupportLink>
 								<div className="campaign-item-details__powered-by">
 									<span>{ translate( 'Blaze - Powered by Jetpack' ) }</span>

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -330,6 +330,7 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 		}
 
 		.campaign-item-details__ad-destination-url-link {
+			align-items: center;
 			color: var(--studio-gray-50);
 			display: flex;
 			flex-grow: 1;
@@ -340,6 +341,7 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 			word-break: break-word;
 			text-align: left;
 			svg {
+				fill: var(--studio-gray-50);
 				min-width: 20px;
 			}
 		}
@@ -484,8 +486,10 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				}
 
 				.inline-support-link__nowrap {
+					align-items: center;
+					display: flex;
+
 					svg {
-						vertical-align: text-top;
 						width: 16px;
 					}
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to SELFSERVE-618

## Proposed Changes
* Change external icon on the Campaign Detail page in Calypso according to [Figma](https://www.figma.com/file/uvh2KtY65b7hGBHI9exbJ1/BlazePress?type=design&node-id=7223-61220&mode=design&t=cW908MRx9xJSXR0t-0) design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch locally or use a live view link
- Open Tools > Advertising
- Open Campaign Details
- Scroll down a bit until you reach "Ad destination" sign
- Take a look on the external link icon next to the URL
- Ensure that it's the same as in Figma
- Next, check another section, "Support articles"
- Check that it uses the External Icon as in "Ad destination"

<img width="1289" alt="Screenshot 2023-08-09 at 13 52 16" src="https://github.com/Automattic/wp-calypso/assets/115007291/334855cf-1582-43e1-8021-143f628a4f8b">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
