### PR TITLE
Fix theme details crash

### DIFF
--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -9,7 +9,6 @@ import {
 	mergeBaseAndUserConfigs,
 	withExperimentalBlockEditorProvider,
 } from '../../gutenberg-bridge';
-import { useRegisterCoreBlocks } from '../../hooks';
 import GlobalStylesVariationPreview from './preview';
 import type { GlobalStylesObject } from '../../types';
 import './style.scss';
@@ -109,7 +108,6 @@ const GlobalStylesVariations = ( {
 	displayFreeLabel = true,
 	globalStylesInPersonalPlan,
 }: GlobalStylesVariationsProps ) => {
-	const isRegisteredCoreBlocks = useRegisterCoreBlocks();
 	const premiumStylesDescription = globalStylesInPersonalPlan
 		? translate(
 				'Unlock custom styles and tons of other features with the Personal plan, or try them out now for free.'
@@ -147,10 +145,6 @@ const GlobalStylesVariations = ( {
 	);
 
 	const headerText = splitDefaultVariation ? translate( 'Default Style' ) : translate( 'Styles' );
-
-	if ( ! isRegisteredCoreBlocks ) {
-		return null;
-	}
 
 	return (
 		<GlobalStylesContext.Provider value={ { base: baseGlobalStyles } }>


### PR DESCRIPTION
## Proposed Changes

Fixes a crash in the theme details page reported in p1691576959289179-slack-C02FMH4G8.

Kudos to @miksansegundo for the investigation.

This probably introduces a regression, but I guess it's better than having the page to crash?

## Testing Instructions

- Use the Calypso live link below.
- Go to `/theme/zaino`.
- Make sure the page doesn't crash.