### PR TITLE
Hosting Metrics: Tweak donut charts for mobile

### DIFF
--- a/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/style.scss
+++ b/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/style.scss
@@ -2,6 +2,7 @@
 	.pie-chart__chart-drawing {
 		height: 250px;
 		width: 250px;
+		max-width: none;
 	}
 	.site-monitoring__chart-container {
 		position: relative;

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -1,4 +1,6 @@
 @import "uplot/dist/uPlot.min.css";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .site-monitoring {
 	position: relative;
@@ -64,8 +66,12 @@
 .site-monitoring__pie-charts {
 	display: flex;
 	gap: 16px;
+	flex-direction: column;
 	.site-monitoring__chart {
 		flex-grow: 1;
+	}
+	@include break-large {
+		flex-direction: row;
 	}
 	.pie-chart__chart-drawing-empty {
 		fill: var(--studio-gray-5);


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/3276
Fixes https://github.com/Automattic/dotcom-forge/issues/3435

## Proposed Changes

Makes donut charts responsive on mobile and prevents resizing.

https://github.com/Automattic/wp-calypso/assets/36432/31619dfb-5cea-4fcc-bd11-20d1b06beec9

## Testing Instructions

1. Navigate to `/site-monitoring/<site>`.
2. Resize the page in your browser and make sure everything looks good on mobile.