### PR TITLE
Open nameservers section in domain settings with query params

### DIFF
--- a/client/components/domains/accordion/index.tsx
+++ b/client/components/domains/accordion/index.tsx
@@ -11,6 +11,7 @@ const Accordion = ( {
 	children,
 	isPlaceholder,
 	expanded = false,
+	onClose,
 }: AccordionProps ) => {
 	const classes = classNames( {
 		'is-placeholder': isPlaceholder,
@@ -44,6 +45,7 @@ const Accordion = ( {
 						<Icon icon={ chevronUp } viewBox="6 4 12 14" size={ 16 } />
 					</button>
 				}
+				onClose={ onClose }
 			>
 				{ children }
 			</FoldableCard>

--- a/client/components/domains/accordion/types.ts
+++ b/client/components/domains/accordion/types.ts
@@ -5,6 +5,7 @@ export type AccordionProps = {
 	title: string;
 	subtitle?: string | React.ReactNode;
 	expanded?: boolean;
+	onClose?: () => void;
 
 	isPlaceholder?: boolean;
 };

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -495,7 +495,7 @@ export function resolveDomainStatus(
 							a: (
 								<a
 									href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute, {
-										dns: true,
+										nameservers: true,
 									} ) }
 								/>
 							),
@@ -511,7 +511,7 @@ export function resolveDomainStatus(
 							a: (
 								<a
 									href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute, {
-										dns: true,
+										nameservers: true,
 									} ) }
 								/>
 							),

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -494,7 +494,9 @@ export function resolveDomainStatus(
 							strong: <strong />,
 							a: (
 								<a
-									href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute ) }
+									href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute, {
+										dns: true,
+									} ) }
 								/>
 							),
 						},
@@ -508,7 +510,9 @@ export function resolveDomainStatus(
 							strong: <strong />,
 							a: (
 								<a
-									href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute ) }
+									href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute, {
+										dns: true,
+									} ) }
 								/>
 							),
 						},

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,7 +1,9 @@
 import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useEffect } from '@wordpress/element';
+import { removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { connect } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Accordion from 'calypso/components/domains/accordion';
@@ -74,6 +76,8 @@ const Settings = ( {
 }: SettingsPageProps ) => {
 	const translate = useTranslate();
 	const contactInformation = findRegistrantWhois( whoisData );
+
+	const queryParams = new URLSearchParams( window.location.search );
 
 	useEffect( () => {
 		if ( ! contactInformation ) {
@@ -309,10 +313,16 @@ const Settings = ( {
 			return null;
 		}
 
+		const onClose = () => {
+			page.redirect( window.location.pathname + removeQueryArgs( window.location.search, 'dns' ) );
+		};
+
 		return (
 			<Accordion
 				title={ translate( 'DNS records', { textOnly: true } ) }
 				subtitle={ translate( 'Connect your domain to other services', { textOnly: true } ) }
+				expanded={ queryParams.get( 'dns' ) === 'true' }
+				onClose={ onClose }
 			>
 				{ domain.canManageDnsRecords ? (
 					<DnsRecords

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -281,10 +281,18 @@ const Settings = ( {
 			return null;
 		}
 
+		const onClose = () => {
+			page.redirect(
+				window.location.pathname + removeQueryArgs( window.location.search, 'nameservers' )
+			);
+		};
+
 		return (
 			<Accordion
 				title={ translate( 'Name servers', { textOnly: true } ) }
 				subtitle={ getNameServerSectionSubtitle() }
+				expanded={ queryParams.get( 'nameservers' ) === 'true' }
+				onClose={ onClose }
 			>
 				{ domain.canManageNameServers ? (
 					<NameServersCard
@@ -313,16 +321,10 @@ const Settings = ( {
 			return null;
 		}
 
-		const onClose = () => {
-			page.redirect( window.location.pathname + removeQueryArgs( window.location.search, 'dns' ) );
-		};
-
 		return (
 			<Accordion
 				title={ translate( 'DNS records', { textOnly: true } ) }
 				subtitle={ translate( 'Connect your domain to other services', { textOnly: true } ) }
-				expanded={ queryParams.get( 'dns' ) === 'true' }
-				onClose={ onClose }
 			>
 				{ domain.canManageDnsRecords ? (
 					<DnsRecords

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -106,7 +106,7 @@ export function domainManagementList( siteName, relativeTo = null, isDomainOnlyS
  * @param {string} siteName
  * @param {string} domainName
  * @param {string?} relativeTo
- * @param {Object | null} expandSections Which accordion to expand automattically, e.g. { 'dns': true }
+ * @param {Object | null} expandSections Which accordion to expand automattically, e.g. { 'nameservers': true }
  */
 export function domainManagementEdit( siteName, domainName, relativeTo, expandSections = null ) {
 	return domainManagementEditBase( siteName, domainName, 'edit', relativeTo, expandSections );

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -108,7 +108,12 @@ export function domainManagementList( siteName, relativeTo = null, isDomainOnlyS
  * @param {string?} relativeTo
  * @param {Object | null} expandSections Which accordion to expand automattically, e.g. { 'nameservers': true }
  */
-export function domainManagementEdit( siteName, domainName, relativeTo, expandSections = null ) {
+export function domainManagementEdit(
+	siteName,
+	domainName,
+	relativeTo = null,
+	expandSections = null
+) {
 	return domainManagementEditBase( siteName, domainName, 'edit', relativeTo, expandSections );
 }
 

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -1,5 +1,6 @@
 import { filter } from 'lodash';
 import { stringify } from 'qs';
+import { addQueryArgs } from 'calypso/lib/url';
 import { isUnderEmailManagementAll } from 'calypso/my-sites/email/paths';
 
 function resolveRootPath( relativeTo = null ) {
@@ -16,7 +17,13 @@ function resolveRootPath( relativeTo = null ) {
 	return domainManagementRoot();
 }
 
-function domainManagementEditBase( siteName, domainName, slug, relativeTo = null ) {
+function domainManagementEditBase(
+	siteName,
+	domainName,
+	slug,
+	relativeTo = null,
+	queryArgs = null
+) {
 	slug = slug || 'edit';
 
 	// Encodes only real domain names and not parameter placeholders
@@ -26,7 +33,13 @@ function domainManagementEditBase( siteName, domainName, slug, relativeTo = null
 		domainName = encodeURIComponent( encodeURIComponent( domainName ) );
 	}
 
-	return resolveRootPath( relativeTo ) + '/' + domainName + '/' + slug + '/' + siteName;
+	const baseUrl = resolveRootPath( relativeTo ) + '/' + domainName + '/' + slug + '/' + siteName;
+
+	if ( queryArgs ) {
+		return addQueryArgs( queryArgs, baseUrl );
+	}
+
+	return baseUrl;
 }
 
 function domainManagementTransferBase(
@@ -89,8 +102,14 @@ export function domainManagementList( siteName, relativeTo = null, isDomainOnlyS
 	return domainManagementRoot() + '/' + siteName ?? '';
 }
 
-export function domainManagementEdit( siteName, domainName, relativeTo ) {
-	return domainManagementEditBase( siteName, domainName, 'edit', relativeTo );
+/**
+ * @param {string} siteName
+ * @param {string} domainName
+ * @param {string?} relativeTo
+ * @param {Object | null} expandSections Which accordion to expand automattically, e.g. { 'dns': true }
+ */
+export function domainManagementEdit( siteName, domainName, relativeTo, expandSections = null ) {
+	return domainManagementEditBase( siteName, domainName, 'edit', relativeTo, expandSections );
 }
 
 /**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3318

## Proposed Changes

* When a user clicks on the link, it will go to the domain settings page and expand the nameservers settings

![banner](https://github.com/Automattic/wp-calypso/assets/6586048/378e88ea-e72d-46a5-a981-445c6d8810ec)

* Opens the nameservers tab in the settings page

![ns](https://github.com/Automattic/wp-calypso/assets/6586048/549cc4a6-0926-40a0-b4e8-c4aa1d072569)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]  
> PreReq: a successfully transferred domain not using WP.com nameservers

* Go to `/domains/manage`
* Click on "point it to WordPress.com name servers."
* Should go to settings page with the nameservers tab open
* On the settings page, delete the query parameter from the URL and click "point it to WordPress.com name servers."

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
