### PR TITLE
Fix design picker crash

### DIFF
--- a/packages/global-styles/src/components/global-styles-provider/index.tsx
+++ b/packages/global-styles/src/components/global-styles-provider/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback } from 'react';
 import { DEFAULT_GLOBAL_STYLES } from '../../constants';
 import { GlobalStylesContext, mergeBaseAndUserConfigs } from '../../gutenberg-bridge';
-import { useGetGlobalStylesBaseConfig, useRegisterCoreBlocks } from '../../hooks';
+import { useGetGlobalStylesBaseConfig } from '../../hooks';
 import type { GlobalStylesObject, SetConfig, SetConfigCallback } from '../../types';
 
 const cleanEmptyObject = < T extends Record< string, unknown > >( object: T | unknown ) => {
@@ -85,9 +85,8 @@ interface Props {
 
 const GlobalStylesProvider = ( { siteId, stylesheet, children, placeholder = null }: Props ) => {
 	const context = useGlobalStylesContext( siteId, stylesheet );
-	const isBlocksRegistered = useRegisterCoreBlocks();
 
-	if ( ! context.isReady || ! isBlocksRegistered ) {
+	if ( ! context.isReady ) {
 		return placeholder;
 	}
 	return (


### PR DESCRIPTION
## Proposed Changes

Follow-up to https://github.com/Automattic/wp-calypso/pull/80375.

Fixes the same crash but in the design picker.

This might introduce a regression somewhere, but I guess it's better than having the page to crash?

## Testing Instructions

- Use the Calypso live link below.
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>`.
- Select the Zaino theme.
- Make sure the page doesn't crash.