### PR TITLE
Fixes the style of the admin notices in the Jetpack Blaze Dashboard

### DIFF
--- a/apps/blaze-dashboard/src/app.scss
+++ b/apps/blaze-dashboard/src/app.scss
@@ -7,17 +7,10 @@
 @import "./styles/typography.scss";
 
 .jp-blaze-dashboard {
-	.notice {
-		display: flex;
-		width: 100%;
+	.promote-post-notice {
 		margin: 0;
 		border: none;
 		box-shadow: none;
-
-		&.is-error:not(.is-reskinned) {
-			background: var(--color-neutral-80);
-			color: var(--color-text-inverted);
-		}
 	}
 
 	.promote-post-i2 {

--- a/apps/blaze-dashboard/src/app.scss
+++ b/apps/blaze-dashboard/src/app.scss
@@ -7,6 +7,19 @@
 @import "./styles/typography.scss";
 
 .jp-blaze-dashboard {
+	.notice {
+		display: flex;
+		width: 100%;
+		margin: 0;
+		border: none;
+		box-shadow: none;
+
+		&.is-error:not(.is-reskinned) {
+			background: var(--color-neutral-80);
+			color: var(--color-text-inverted);
+		}
+	}
+
 	.promote-post-i2 {
 		.jetpack-header {
 			padding: 0;

--- a/apps/blaze-dashboard/src/styles/wp-admin.scss
+++ b/apps/blaze-dashboard/src/styles/wp-admin.scss
@@ -28,11 +28,45 @@
 	box-sizing: border-box;
 }
 
-.notice {
-	display: inline-block;
+// Since the component `Notice` styles affect the WP Admin notice styles,
+// we need to restore by overriding them except for `.wpcomsh-notice` on Atomic sites.
+.notice:not(.wpcomsh-notice, .promote-post-notice) {
+	display: block;
 	width: auto;
-	background: #fff;
-	margin-left: 64px;
-	margin-bottom: 0;
-	color: #3c434a;
+	background: var(--studio-white);
+	color: var(--color-text);
+	font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	margin-left: 20px;
+	margin-bottom: 2px;
+
+	// Avoid overriding hidden notices.
+	&[aria-hidden="true"],
+	&.hidden {
+		display: none;
+	}
+
+	&.inline {
+		display: inline-block;
+	}
+
+	h2,
+	h3 {
+		color: var(--studio-gray-90);
+		font-size: 1.3em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		margin: 1em 0;
+		font-weight: 600;
+	}
+
+	p {
+		font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		line-height: 1.5;
+		margin: 0.5em 0;
+		padding: 2px;
+		color: var(--studio-gray-70);
+	}
+
+	code {
+		padding: 3px 5px 2px;
+		margin: 0 1px;
+	}
 }

--- a/apps/blaze-dashboard/src/styles/wp-admin.scss
+++ b/apps/blaze-dashboard/src/styles/wp-admin.scss
@@ -29,7 +29,10 @@
 }
 
 .notice {
-	margin: 0;
-	border: none;
-	box-shadow: none;
+	display: inline-block;
+	width: auto;
+	background: #fff;
+	margin-left: 64px;
+	margin-bottom: 0;
+	color: #3c434a;
 }

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -317,7 +317,7 @@ export default function CampaignItemDetails( props: Props ) {
 						showDismiss={ false }
 						status="is-error"
 						icon="notice-outline"
-						className="campaign-item-details__notice"
+						className="promote-post-notice campaign-item-details__notice"
 					>
 						{ translate(
 							'Your ad was not approved, please review our {{wpcomTos}}WordPress.com Terms{{/wpcomTos}} and {{advertisingTos}}Advertising Policy{{/advertisingTos}}.',

--- a/client/my-sites/promote-post-i2/components/campaign-item-page/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-page/index.tsx
@@ -34,7 +34,12 @@ export default function CampaignItemPage( props: Props ) {
 	if ( isError ) {
 		return (
 			<MainWrapper>
-				<Notice status="is-error" icon="mention" showDismiss={ false }>
+				<Notice
+					className="promote-post-notice"
+					status="is-error"
+					icon="mention"
+					showDismiss={ false }
+				>
 					{ noCampaignListMessage }
 				</Notice>
 			</MainWrapper>

--- a/client/my-sites/promote-post-i2/components/campaigns-list/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-list/index.tsx
@@ -58,7 +58,7 @@ export default function CampaignsList( props: Props ) {
 	if ( isError && hasLocalUser ) {
 		return (
 			<Notice
-				className="promote-post-i2__aux-wrapper"
+				className="promote-post-notice promote-post-i2__aux-wrapper"
 				status="is-error"
 				icon="mention"
 				showDismiss={ false }

--- a/client/my-sites/promote-post-i2/components/posts-list/index.tsx
+++ b/client/my-sites/promote-post-i2/components/posts-list/index.tsx
@@ -59,7 +59,7 @@ export default function PostsList( props: Props ) {
 	if ( isError && hasLocalUser ) {
 		return (
 			<Notice
-				className="promote-post-i2__aux-wrapper"
+				className="promote-post-notice promote-post-i2__aux-wrapper"
 				status="is-error"
 				icon="mention"
 				showDismiss={ false }


### PR DESCRIPTION
We have a style issue in ap-admin notices when the user is in the Jetpack Blaze Dashboard:

![Screenshot 2023-08-09 at 10 28 52](https://github.com/Automattic/wp-calypso/assets/1258162/4bfedaf1-440d-42da-9fdb-bf9c3f336c67)

There is a conflict between the Calypso notices that the Dashboard uses, and the one that are provided by the wp-admin page.

## Proposed Changes

I override the conflicting style at the root of the app, and then try to maintain consistency for all the notices that the dashboard uses inside the `.jp-blaze-dashboard` section.

**Final result:**
![Screenshot 2023-08-09 at 10 28 15](https://github.com/Automattic/wp-calypso/assets/1258162/c026c5d4-bff9-48c5-bbbe-2247898122e4)

## Testing Instructions
We have a guide with multiples way to test the dashboard here: PCYsg-SuD-p2
I will describe the local steps in the description, but feel free to use any of the other methods described on that guide.

Set up a [Jetpack development](https://href.li/?https://github.com/Automattic/jetpack/blob/trunk/docs/development-environment.md) environment.

1. Open a terminal and navigate to `/some-path-to/wp-calypso/apps/blaze-dashboard`
2. Execute: `BLAZE_DASHBOARD_PACKAGE_PATH=/some-path-to/jetpack/projects/packages/blaze yarn dev`
3. Open the site in your browser using a tunnel of your choice
4. Navigate to Tools->Advertising
5. Verify that the notices are displayed correctly. For example, you could install the plugin `Admin Notice` and create a test notice. Or, if your local is not updated to the last WordPress.com version, you should see the same notice as the screenshot in this PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
