### PR TITLE
Migration trial: Hide the 'Coming soon' badge if a site is under the migration trial plan

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -145,7 +145,7 @@ class Site extends Component {
 			'is-highlighted': this.props.isHighlighted,
 			'is-compact': this.props.compact,
 			'is-reskinned': this.props.isReskinned,
-			'is-migration-trial': this.props.isTrialSite,
+			'is-trial': this.props.isTrialSite,
 		} );
 
 		// We show public coming soon badge only when the site is not private.

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -12,12 +12,12 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import SiteIndicator from 'calypso/my-sites/site-indicator';
 import SitesMigrationTrialBadge from 'calypso/sites-dashboard/components/sites-migration-trial-badge';
 import SitesStagingBadge from 'calypso/sites-dashboard/components/sites-staging-badge';
-import { isMigrationTrialSite } from 'calypso/sites-dashboard/utils';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
+import { isTrialSite } from 'calypso/state/sites/plans/selectors';
 import {
 	getSite,
 	getSiteSlug,
@@ -145,7 +145,7 @@ class Site extends Component {
 			'is-highlighted': this.props.isHighlighted,
 			'is-compact': this.props.compact,
 			'is-reskinned': this.props.isReskinned,
-			'is-migration-trial': isMigrationTrialSite( site ),
+			'is-migration-trial': this.props.isTrialSite,
 		} );
 
 		// We show public coming soon badge only when the site is not private.
@@ -154,7 +154,7 @@ class Site extends Component {
 			! site.is_private &&
 			this.props.site.is_coming_soon &&
 			! isAtomicAndEditingToolkitDeactivated &&
-			! isMigrationTrialSite( site );
+			! this.props.isTrialSite;
 
 		// Cover the coming Soon v1 cases for sites still unlaunched and/or in Coming Soon private by default.
 		// isPrivateAndUnlaunched means it is an unlaunched coming soon v1 site
@@ -205,7 +205,7 @@ class Site extends Component {
 								{ translate( 'Staging' ) }
 							</SitesStagingBadge>
 						) }
-						{ isMigrationTrialSite( site ) && (
+						{ this.props.isTrialSite && (
 							<SitesMigrationTrialBadge className="site__badge" secondary>
 								{ translate( 'Trial' ) }
 							</SitesMigrationTrialBadge>
@@ -265,6 +265,7 @@ function mapStateToProps( state, ownProps ) {
 		isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
 		isSiteP2: isSiteWPForTeams( state, siteId ),
 		isP2Hub: isSiteP2Hub( state, siteId ),
+		isTrialSite: isTrialSite( state, siteId ),
 		isAtomicAndEditingToolkitDeactivated:
 			isAtomicSite( state, siteId ) &&
 			getSiteOption( state, siteId, 'editing_toolkit_is_active' ) === false,

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -151,7 +151,10 @@ class Site extends Component {
 		// We show public coming soon badge only when the site is not private.
 		// Check for `! site.is_private` to ensure two Coming Soon badges don't appear while we introduce public coming soon.
 		const shouldShowPublicComingSoonSiteBadge =
-			! site.is_private && this.props.site.is_coming_soon && ! isAtomicAndEditingToolkitDeactivated;
+			! site.is_private &&
+			this.props.site.is_coming_soon &&
+			! isAtomicAndEditingToolkitDeactivated &&
+			! isMigrationTrialSite( site );
 
 		// Cover the coming Soon v1 cases for sites still unlaunched and/or in Coming Soon private by default.
 		// isPrivateAndUnlaunched means it is an unlaunched coming soon v1 site

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -160,12 +160,14 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 						<div className={ badges }>
 							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
 							{ isWpcomStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
-							{ isMigrationTrialPlanSite && (
+							{ ( isMigrationTrialPlanSite || isECommerceTrialSite ) && (
 								<SitesMigrationTrialBadge>{ __( 'Trial' ) }</SitesMigrationTrialBadge>
 							) }
-							{ getSiteLaunchStatus( site ) !== 'public' && ! isMigrationTrialPlanSite && (
-								<SitesLaunchStatusBadge>{ translatedStatus }</SitesLaunchStatusBadge>
-							) }
+							{ getSiteLaunchStatus( site ) !== 'public' &&
+								! isMigrationTrialPlanSite &&
+								! isECommerceTrialSite && (
+									<SitesLaunchStatusBadge>{ translatedStatus }</SitesLaunchStatusBadge>
+								) }
 							<EllipsisMenuContainer>
 								{ inView && <SitesEllipsisMenu className={ ellipsis } site={ site } /> }
 							</EllipsisMenuContainer>

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -1,4 +1,3 @@
-import { PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { useSiteLaunchStatusLabel, getSiteLaunchStatus } from '@automattic/sites';
 import { css } from '@emotion/css';
@@ -8,7 +7,9 @@ import { memo } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 import SitesMigrationTrialBadge from 'calypso/sites-dashboard/components/sites-migration-trial-badge';
-import { displaySiteUrl, getDashboardUrl, isMigrationTrialSite, isStagingSite } from '../utils';
+import { useSelector } from 'calypso/state';
+import { isTrialSite } from 'calypso/state/sites/plans/selectors';
+import { displaySiteUrl, getDashboardUrl, isStagingSite } from '../utils';
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
 import { SitesGridActionRenew } from './sites-grid-action-renew';
 import { SitesGridTile } from './sites-grid-tile';
@@ -106,9 +107,8 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 
 	const isP2Site = site.options?.is_wpforteams_site;
 	const isWpcomStagingSite = isStagingSite( site );
-	const isMigrationTrialPlanSite = isMigrationTrialSite( site );
 	const translatedStatus = useSiteLaunchStatusLabel( site );
-	const isECommerceTrialSite = site.plan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
+	const isTrialSitePlan = useSelector( ( state ) => isTrialSite( state, site.ID ) );
 
 	const { ref, inView } = useInView( { triggerOnce: true } );
 
@@ -143,10 +143,7 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 						/>
 					</ThumbnailWrapper>
 					{ showSiteRenewLink && site.plan?.expired && (
-						<SitesGridActionRenew
-							site={ site }
-							hideRenewLink={ isECommerceTrialSite || isMigrationTrialPlanSite }
-						/>
+						<SitesGridActionRenew site={ site } hideRenewLink={ isTrialSitePlan } />
 					) }
 				</>
 			}
@@ -160,14 +157,12 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 						<div className={ badges }>
 							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
 							{ isWpcomStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
-							{ ( isMigrationTrialPlanSite || isECommerceTrialSite ) && (
+							{ isTrialSitePlan && (
 								<SitesMigrationTrialBadge>{ __( 'Trial' ) }</SitesMigrationTrialBadge>
 							) }
-							{ getSiteLaunchStatus( site ) !== 'public' &&
-								! isMigrationTrialPlanSite &&
-								! isECommerceTrialSite && (
-									<SitesLaunchStatusBadge>{ translatedStatus }</SitesLaunchStatusBadge>
-								) }
+							{ getSiteLaunchStatus( site ) !== 'public' && ! isTrialSitePlan && (
+								<SitesLaunchStatusBadge>{ translatedStatus }</SitesLaunchStatusBadge>
+							) }
 							<EllipsisMenuContainer>
 								{ inView && <SitesEllipsisMenu className={ ellipsis } site={ site } /> }
 							</EllipsisMenuContainer>

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -163,7 +163,7 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 							{ isMigrationTrialPlanSite && (
 								<SitesMigrationTrialBadge>{ __( 'Trial' ) }</SitesMigrationTrialBadge>
 							) }
-							{ getSiteLaunchStatus( site ) !== 'public' && (
+							{ getSiteLaunchStatus( site ) !== 'public' && ! isMigrationTrialPlanSite && (
 								<SitesLaunchStatusBadge>{ translatedStatus }</SitesLaunchStatusBadge>
 							) }
 							<EllipsisMenuContainer>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -11,15 +11,9 @@ import TimeSince from 'calypso/components/time-since';
 import SitesMigrationTrialBadge from 'calypso/sites-dashboard/components/sites-migration-trial-badge';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { isTrialSite } from 'calypso/state/sites/plans/selectors';
 import { hasSiteStatsQueryFailed } from 'calypso/state/stats/lists/selectors';
-import {
-	displaySiteUrl,
-	getDashboardUrl,
-	isECommerceTrialSite,
-	isMigrationTrialSite,
-	isStagingSite,
-	MEDIA_QUERIES,
-} from '../utils';
+import { displaySiteUrl, getDashboardUrl, isStagingSite, MEDIA_QUERIES } from '../utils';
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
 import SitesP2Badge from './sites-p2-badge';
 import { SiteItemThumbnail } from './sites-site-item-thumbnail';
@@ -149,7 +143,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 
 	const isP2Site = site.options?.is_wpforteams_site;
 	const isWpcomStagingSite = isStagingSite( site );
-	const isTrialSite = isMigrationTrialSite( site ) || isECommerceTrialSite( site );
+	const isTrialSitePlan = useSelector( ( state ) => isTrialSite( state, site.ID ) );
 
 	const hasStatsLoadingError = useSelector( ( state ) => {
 		const siteId = site.ID;
@@ -185,7 +179,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 							</SiteName>
 							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
 							{ isWpcomStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
-							{ isTrialSite && (
+							{ isTrialSitePlan && (
 								<SitesMigrationTrialBadge>{ __( 'Trial' ) }</SitesMigrationTrialBadge>
 							) }
 						</ListTileTitle>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -15,6 +15,7 @@ import { hasSiteStatsQueryFailed } from 'calypso/state/stats/lists/selectors';
 import {
 	displaySiteUrl,
 	getDashboardUrl,
+	isECommerceTrialSite,
 	isMigrationTrialSite,
 	isStagingSite,
 	MEDIA_QUERIES,
@@ -148,7 +149,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 
 	const isP2Site = site.options?.is_wpforteams_site;
 	const isWpcomStagingSite = isStagingSite( site );
-	const isTrialSite = isMigrationTrialSite( site );
+	const isTrialSite = isMigrationTrialSite( site ) || isECommerceTrialSite( site );
 
 	const hasStatsLoadingError = useSelector( ( state ) => {
 		const siteId = site.ID;

--- a/client/sites-dashboard/components/test/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/test/sites-grid-item.tsx
@@ -26,6 +26,11 @@ jest.mock( 'calypso/sites-dashboard/hooks/use-check-site-transfer-status.tsx', (
 	useCheckSiteTransferStatus: jest.fn(),
 } ) );
 
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useSelector: jest.fn(),
+} ) );
+
 describe( '<SitesGridItem>', () => {
 	beforeEach( () => {
 		( useCheckSiteTransferStatus as jest.Mock ).mockReturnValue( {

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -1,4 +1,7 @@
-import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import {
+	PLAN_MIGRATION_TRIAL_MONTHLY,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+} from '@automattic/calypso-products';
 import { SiteExcerptNetworkData } from 'calypso/data/sites/site-excerpt-types';
 
 export const TRACK_SOURCE_NAME = 'sites-dashboard';
@@ -53,6 +56,10 @@ export const isStagingSite = ( site: SiteExcerptNetworkData | undefined ) => {
 
 export const isMigrationTrialSite = ( site: SiteExcerptNetworkData ) => {
 	return site?.plan?.product_slug === PLAN_MIGRATION_TRIAL_MONTHLY;
+};
+
+export const isECommerceTrialSite = ( site: SiteExcerptNetworkData ) => {
+	return site?.plan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 };
 
 export const SMALL_MEDIA_QUERY = 'screen and ( max-width: 600px )';


### PR DESCRIPTION
Closes #80323
Closes #80324

## Proposed Changes

* Add a Trial badge for the eCommerce trial site
* Hide the Coming soon badge if the site is under the Trial plan

## Testing Instructions
* Go to the `/sites` route and check the labels
* Follow the screenshots

**Before:**
<img width="275" alt="Screenshot 2023-08-09 at 16 21 08" src="https://github.com/Automattic/wp-calypso/assets/1241413/2c8817f3-8388-4e78-aa4b-032c4774be52">

**After:**
<img width="275" alt="Screenshot 2023-08-09 at 16 21 34" src="https://github.com/Automattic/wp-calypso/assets/1241413/76f41b91-9e73-4c5e-aa02-d5a6902c7c9f">

**Before (ECommerce trial):**
<img width="419" alt="Screenshot 2023-08-09 at 17 01 48" src="https://github.com/Automattic/wp-calypso/assets/1241413/85b72cfb-06e4-46fc-af2f-afffe7a1b57c">
**After:**
<img width="418" alt="Screenshot 2023-08-09 at 17 01 54" src="https://github.com/Automattic/wp-calypso/assets/1241413/682c56dd-d4c1-4c9f-a9e0-ceb6a3c7488b">

**Before (ECommerce trial):**
<img width="467" alt="Screenshot 2023-08-09 at 17 04 39" src="https://github.com/Automattic/wp-calypso/assets/1241413/7d20e966-5ff8-4109-a2e9-cf6925846284">
**After:**
<img width="461" alt="Screenshot 2023-08-09 at 17 04 48" src="https://github.com/Automattic/wp-calypso/assets/1241413/590eb94e-9bb5-488d-9d95-1b2de8ca49ce">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
