### PR TITLE
Plans 2023: Tune/cleanup GridPlan a little

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -29,7 +29,6 @@ type PlanFeaturesActionsButtonProps = {
 	canUserPurchasePlan?: boolean | null;
 	className: string;
 	currentSitePlanSlug?: string | null;
-	current: boolean;
 	freePlan: boolean;
 	manageHref: string;
 	isPopular?: boolean;
@@ -176,7 +175,6 @@ const LoggedInPlansFeatureActionButton = ( {
 	planTitle,
 	handleUpgradeButtonClick,
 	planSlug,
-	current,
 	manageHref,
 	canUserPurchasePlan,
 	currentSitePlanSlug,
@@ -192,7 +190,6 @@ const LoggedInPlansFeatureActionButton = ( {
 	planTitle: TranslateResult;
 	handleUpgradeButtonClick: () => void;
 	planSlug: string;
-	current?: boolean;
 	manageHref?: string;
 	canUserPurchasePlan?: boolean | null;
 	currentSitePlanSlug?: string | null;
@@ -201,6 +198,8 @@ const LoggedInPlansFeatureActionButton = ( {
 	planActionOverrides?: PlanActionOverrides;
 } ) => {
 	const translate = useTranslate();
+	const { gridPlansIndex } = usePlansGridContext();
+	const { current } = gridPlansIndex[ planSlug ];
 	const currentPlanBillPeriod = useSelector( ( state ) => {
 		return currentSitePlanSlug ? getPlanBillPeriod( state, currentSitePlanSlug ) : null;
 	} );
@@ -339,7 +338,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	canUserPurchasePlan,
 	className,
 	currentSitePlanSlug,
-	current = false,
 	freePlan = false,
 	manageHref,
 	isInSignup,
@@ -358,15 +356,15 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
 	const { gridPlansIndex } = usePlansGridContext();
+	const {
+		planTitle,
+		current,
+		pricing: { currencyCode, originalPrice, discountedPrice },
+	} = gridPlansIndex[ planSlug ];
 
 	const classes = classNames( 'plan-features-2023-grid__actions-button', className, {
 		'is-current-plan': current,
 	} );
-
-	const {
-		planTitle,
-		pricing: { currencyCode, originalPrice, discountedPrice },
-	} = gridPlansIndex[ planSlug ];
 
 	const handleUpgradeButtonClick = () => {
 		if ( ! freePlan ) {
@@ -466,7 +464,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			availableForPurchase={ availableForPurchase }
 			classes={ classes }
 			handleUpgradeButtonClick={ handleUpgradeButtonClick }
-			current={ current }
 			manageHref={ manageHref }
 			canUserPurchasePlan={ canUserPurchasePlan }
 			currentSitePlanSlug={ currentSitePlanSlug }

--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -36,7 +36,6 @@ type PlanFeaturesActionsButtonProps = {
 	isInSignup?: boolean;
 	isLaunchPage?: boolean | null;
 	onUpgradeClick: () => void;
-	planTitle: TranslateResult;
 	planSlug: PlanSlug;
 	flowName?: string | null;
 	buttonText?: string;
@@ -346,7 +345,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	isInSignup,
 	isLaunchPage,
 	onUpgradeClick,
-	planTitle,
 	planSlug,
 	flowName,
 	buttonText,
@@ -366,6 +364,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	} );
 
 	const {
+		planTitle,
 		pricing: { currencyCode, originalPrice, discountedPrice },
 	} = gridPlansIndex[ planSlug ];
 

--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -11,7 +11,7 @@ import {
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import styled from '@emotion/styled';
-import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../grid-context';
 
 function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
@@ -132,7 +132,6 @@ const DiscountPromotion = styled.div`
 
 interface Props {
 	planSlug: PlanSlug;
-	billingTimeframe: TranslateResult;
 }
 
 const PlanFeatures2023GridBillingTimeframe = ( { planSlug }: Props ) => {

--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -135,10 +135,10 @@ interface Props {
 	billingTimeframe: TranslateResult;
 }
 
-const PlanFeatures2023GridBillingTimeframe = ( { planSlug, billingTimeframe }: Props ) => {
+const PlanFeatures2023GridBillingTimeframe = ( { planSlug }: Props ) => {
 	const translate = useTranslate();
 	const { gridPlansIndex } = usePlansGridContext();
-	const { isMonthlyPlan } = gridPlansIndex[ planSlug ];
+	const { isMonthlyPlan, billingTimeframe } = gridPlansIndex[ planSlug ];
 	const perMonthDescription = usePerMonthDescription( { planSlug } );
 	const description = perMonthDescription || billingTimeframe;
 

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -458,7 +458,6 @@ const PlanComparisonGridHeaderCell = ( {
 				isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planSlug ) }
 				isInSignup={ isInSignup }
 				isLaunchPage={ isLaunchPage }
-				planTitle={ gridPlan.planConstantObj.getTitle() }
 				planSlug={ planSlug }
 				flowName={ flowName }
 				selectedSiteSlug={ selectedSiteSlug }

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -442,10 +442,7 @@ const PlanComparisonGridHeaderCell = ( {
 				siteId={ siteId }
 			/>
 			<div className="plan-comparison-grid__billing-info">
-				<PlanFeatures2023GridBillingTimeframe
-					planSlug={ planSlug }
-					billingTimeframe={ gridPlan.planConstantObj.getBillingTimeFrame() }
-				/>
+				<PlanFeatures2023GridBillingTimeframe planSlug={ planSlug } />
 			</div>
 			<PlanFeatures2023GridActions
 				currentSitePlanSlug={ currentSitePlanSlug }

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -412,7 +412,7 @@ const PlanComparisonGridHeaderCell = ( {
 						className="plan-comparison-grid__title-select"
 						value={ planSlug }
 					>
-						{ displayedGridPlans.map( ( { planSlug: otherPlan, planConstantObj } ) => {
+						{ displayedGridPlans.map( ( { planSlug: otherPlan, planTitle } ) => {
 							const isVisiblePlan = visibleGridPlans.find(
 								( { planSlug } ) => planSlug === otherPlan
 							);
@@ -423,14 +423,14 @@ const PlanComparisonGridHeaderCell = ( {
 
 							return (
 								<option key={ otherPlan } value={ otherPlan }>
-									{ planConstantObj.getTitle() }
+									{ planTitle }
 								</option>
 							);
 						} ) }
 					</select>
 				) }
 				<h4 className="plan-comparison-grid__title">
-					<span>{ gridPlan.planConstantObj.getTitle() }</span>
+					<span>{ gridPlan.planTitle }</span>
 					{ showPlanSelect && <DropdownIcon /> }
 				</h4>
 			</PlanSelector>

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -448,7 +448,6 @@ const PlanComparisonGridHeaderCell = ( {
 				currentSitePlanSlug={ currentSitePlanSlug }
 				manageHref={ manageHref }
 				canUserPurchasePlan={ canUserPurchasePlan }
-				current={ gridPlan.current ?? false }
 				availableForPurchase={ gridPlan.availableForPurchase }
 				className={ getPlanClass( planSlug ) }
 				freePlan={ isFreePlan( planSlug ) }

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -19,7 +19,6 @@ import {
 	type FeatureList,
 	type PlanSlug,
 	type FeatureObject,
-	type FilteredPlan,
 	type StorageOption,
 } from '@automattic/calypso-products';
 import useHighlightLabels from './use-highlight-labels';
@@ -74,7 +73,6 @@ export type UsePricingMetaForGridPlans = ( {
 export type GridPlan = {
 	planSlug: PlanSlug;
 	isVisible: boolean;
-	planConstantObj: FilteredPlan;
 	features: {
 		wpcomFeatures: TransformedFeatureObject[];
 		jetpackFeatures: TransformedFeatureObject[];
@@ -295,7 +293,6 @@ const useGridPlans = ( {
 		return {
 			planSlug,
 			isVisible: planSlugsForIntent.includes( planSlug ),
-			planConstantObj,
 			tagline,
 			availableForPurchase,
 			productNameShort,

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -85,6 +85,7 @@ export type GridPlan = {
 	availableForPurchase: boolean;
 	productNameShort?: string | null;
 	planTitle: TranslateResult;
+	billingTimeframe?: TranslateResult | null;
 	current?: boolean;
 	isMonthlyPlan?: boolean;
 	cartItemForPlan?: {
@@ -299,6 +300,7 @@ const useGridPlans = ( {
 			availableForPurchase,
 			productNameShort,
 			planTitle: planConstantObj.getTitle?.() ?? '',
+			billingTimeframe: planConstantObj.getBillingTimeFrame?.(),
 			current: sitePlanSlug === planSlug,
 			isMonthlyPlan,
 			cartItemForPlan,

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -25,6 +25,7 @@ import {
 import useHighlightLabels from './use-highlight-labels';
 import usePlansFromTypes from './use-plans-from-types';
 import type { PricedAPIPlan } from '@automattic/data-stores';
+import type { TranslateResult } from 'i18n-calypso';
 
 // TODO clk: move to plans data store
 export type TransformedFeatureObject = FeatureObject & {
@@ -83,6 +84,7 @@ export type GridPlan = {
 	tagline: string;
 	availableForPurchase: boolean;
 	productNameShort?: string | null;
+	planTitle: TranslateResult;
 	current?: boolean;
 	isMonthlyPlan?: boolean;
 	cartItemForPlan?: {
@@ -296,6 +298,7 @@ const useGridPlans = ( {
 			tagline,
 			availableForPurchase,
 			productNameShort,
+			planTitle: planConstantObj.getTitle?.() ?? '',
 			current: sitePlanSlug === planSlug,
 			isMonthlyPlan,
 			cartItemForPlan,

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -566,7 +566,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			isLargeCurrency,
 		} = this.props;
 
-		return renderedGridPlans.map( ( { planSlug, current, availableForPurchase } ) => {
+		return renderedGridPlans.map( ( { planSlug, availableForPurchase } ) => {
 			const classes = classNames(
 				'plan-features-2023-grid__table-item',
 				'is-top-buttons',
@@ -603,7 +603,6 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 						onUpgradeClick={ () => this.handleUpgradeClick( planSlug ) }
 						planSlug={ planSlug }
 						flowName={ flowName }
-						current={ current ?? false }
 						currentSitePlanSlug={ currentSitePlanSlug }
 						selectedSiteSlug={ selectedSiteSlug }
 						buttonText={ buttonText }

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -467,7 +467,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 	}
 
 	renderBillingTimeframe( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		return renderedGridPlans.map( ( { planConstantObj, planSlug } ) => {
+		return renderedGridPlans.map( ( { planSlug } ) => {
 			const classes = classNames(
 				'plan-features-2023-grid__table-item',
 				'plan-features-2023-grid__header-billing-info'
@@ -475,10 +475,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 
 			return (
 				<Container className={ classes } isTableCell={ options?.isTableCell } key={ planSlug }>
-					<PlanFeatures2023GridBillingTimeframe
-						planSlug={ planSlug }
-						billingTimeframe={ planConstantObj.getBillingTimeFrame() }
-					/>
+					<PlanFeatures2023GridBillingTimeframe planSlug={ planSlug } />
 				</Container>
 			);
 		} );

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -502,7 +502,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 	}
 
 	renderPlanHeaders( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		return renderedGridPlans.map( ( { planSlug, planConstantObj } ) => {
+		return renderedGridPlans.map( ( { planSlug, planTitle } ) => {
 			const headerClasses = classNames(
 				'plan-features-2023-grid__header',
 				getPlanClass( planSlug )
@@ -515,9 +515,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 					isTableCell={ options?.isTableCell }
 				>
 					<header className={ headerClasses }>
-						<h4 className="plan-features-2023-grid__header-title">
-							{ planConstantObj.getTitle() }
-						</h4>
+						<h4 className="plan-features-2023-grid__header-title">{ planTitle }</h4>
 					</header>
 				</Container>
 			);

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -571,59 +571,56 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			isLargeCurrency,
 		} = this.props;
 
-		return renderedGridPlans.map(
-			( { planSlug, planConstantObj, current, availableForPurchase } ) => {
-				const classes = classNames(
-					'plan-features-2023-grid__table-item',
-					'is-top-buttons',
-					'is-bottom-aligned'
-				);
+		return renderedGridPlans.map( ( { planSlug, current, availableForPurchase } ) => {
+			const classes = classNames(
+				'plan-features-2023-grid__table-item',
+				'is-top-buttons',
+				'is-bottom-aligned'
+			);
 
-				// Leaving it `undefined` makes it use the default label
-				let buttonText;
+			// Leaving it `undefined` makes it use the default label
+			let buttonText;
 
-				if (
-					isWooExpressMediumPlan( planSlug ) &&
-					! isWooExpressMediumPlan( currentSitePlanSlug || '' )
-				) {
-					buttonText = translate( 'Get Performance', { textOnly: true } );
-				} else if (
-					isWooExpressSmallPlan( planSlug ) &&
-					! isWooExpressSmallPlan( currentSitePlanSlug || '' )
-				) {
-					buttonText = translate( 'Get Essential', { textOnly: true } );
-				}
-
-				return (
-					<Container key={ planSlug } className={ classes } isTableCell={ options?.isTableCell }>
-						<PlanFeatures2023GridActions
-							manageHref={ manageHref }
-							canUserPurchasePlan={ canUserPurchasePlan }
-							availableForPurchase={ availableForPurchase }
-							className={ getPlanClass( planSlug ) }
-							freePlan={ isFreePlan( planSlug ) }
-							isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planSlug ) }
-							isWooExpressPlusPlan={ isWooExpressPlusPlan( planSlug ) }
-							isInSignup={ isInSignup }
-							isLaunchPage={ isLaunchPage }
-							onUpgradeClick={ () => this.handleUpgradeClick( planSlug ) }
-							planTitle={ planConstantObj.getTitle() }
-							planSlug={ planSlug }
-							flowName={ flowName }
-							current={ current ?? false }
-							currentSitePlanSlug={ currentSitePlanSlug }
-							selectedSiteSlug={ selectedSiteSlug }
-							buttonText={ buttonText }
-							planActionOverrides={ planActionOverrides }
-							showMonthlyPrice={ true }
-							siteId={ siteId }
-							isStuck={ options?.isStuck || false }
-							isLargeCurrency={ isLargeCurrency }
-						/>
-					</Container>
-				);
+			if (
+				isWooExpressMediumPlan( planSlug ) &&
+				! isWooExpressMediumPlan( currentSitePlanSlug || '' )
+			) {
+				buttonText = translate( 'Get Performance', { textOnly: true } );
+			} else if (
+				isWooExpressSmallPlan( planSlug ) &&
+				! isWooExpressSmallPlan( currentSitePlanSlug || '' )
+			) {
+				buttonText = translate( 'Get Essential', { textOnly: true } );
 			}
-		);
+
+			return (
+				<Container key={ planSlug } className={ classes } isTableCell={ options?.isTableCell }>
+					<PlanFeatures2023GridActions
+						manageHref={ manageHref }
+						canUserPurchasePlan={ canUserPurchasePlan }
+						availableForPurchase={ availableForPurchase }
+						className={ getPlanClass( planSlug ) }
+						freePlan={ isFreePlan( planSlug ) }
+						isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planSlug ) }
+						isWooExpressPlusPlan={ isWooExpressPlusPlan( planSlug ) }
+						isInSignup={ isInSignup }
+						isLaunchPage={ isLaunchPage }
+						onUpgradeClick={ () => this.handleUpgradeClick( planSlug ) }
+						planSlug={ planSlug }
+						flowName={ flowName }
+						current={ current ?? false }
+						currentSitePlanSlug={ currentSitePlanSlug }
+						selectedSiteSlug={ selectedSiteSlug }
+						buttonText={ buttonText }
+						planActionOverrides={ planActionOverrides }
+						showMonthlyPrice={ true }
+						siteId={ siteId }
+						isStuck={ options?.isStuck || false }
+						isLargeCurrency={ isLargeCurrency }
+					/>
+				</Container>
+			);
+		} );
 	}
 
 	maybeRenderRefundNotice( gridPlan: GridPlan[], options?: PlanRowOptions ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Some cleanup for the most part:
- moves the default billing-timeframe and plan title as properties on the GridPlan
- no need for `planConstantObj` on the GridPlan (will probably make it easier to mock down the line)
- one case of `current` passed through props when already retrievable from GridPlan object

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* General sanity check on `/plans` page
* Titles render correctly
* Billing timeframes shown under plan prices render correctly
* Current plan highlighted properly (either in Spotlight and/or "your plan" highlight label)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
