### PR TITLE
Add WooCommerce origin in blazepress and fix calypso origin

### DIFF
--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -3,7 +3,7 @@ import { loadScript } from '@automattic/load-script';
 import { __ } from '@wordpress/i18n';
 import { translate } from 'i18n-calypso/types';
 import { getHotjarSiteSettings, mayWeLoadHotJarScript } from 'calypso/lib/analytics/hotjar';
-import { getMobileDeviceInfo, isWpMobileApp } from 'calypso/lib/mobile-app';
+import { getMobileDeviceInfo, isWcMobileApp, isWpMobileApp } from 'calypso/lib/mobile-app';
 import versionCompare from 'calypso/lib/version-compare';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
@@ -169,11 +169,13 @@ export async function showDSP(
  * @param {string} entryPoint - A slug describing the entry point.
  */
 export function recordDSPEntryPoint( entryPoint: string ) {
-	let origin = 'wpcom';
+	let origin = 'calypso';
 	if ( config.isEnabled( 'is_running_in_jetpack_site' ) ) {
 		origin = 'jetpack';
 	} else if ( isWpMobileApp() ) {
 		origin = 'wp-mobile-app';
+	} else if ( isWcMobileApp() ) {
+		origin = 'wc-mobile-app';
 	}
 
 	const eventProps = {


### PR DESCRIPTION
Related to #

## Proposed Changes
We require to add and fix some of the origins we're sending in the DSP. I've found this method that registers in tracks

- Fix origin in Blazepress: from `wpcom` to `calypso`
- Add new origin: WooCommerce, based on the user agent using the same strategy used in Jetpack app

Testing the calypso endpoint: To fire this event you just need to open the widget. I haven't managed to get a tracks live in staging. Supossedly they should appear 15mins after they're fired. 
Testing the WooCommerce app would be difficult since we don't have the full suite for test. Reviewing code is OK. 
## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
