### PR TITLE
Hosting metrics: add tooltips to bar chart legend

### DIFF
--- a/client/my-sites/site-monitoring/components/site-monitoring-bar-chart/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-bar-chart/index.tsx
@@ -1,8 +1,10 @@
 import UplotBarChart, { UplotChartProps } from '@automattic/components/src/chart-uplot/bar';
 import classnames from 'classnames';
+import { translate } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
+import { LegendTooltip } from './legend-tooltip';
 
-interface Props extends UplotChartProps {
+interface Props extends Pick< UplotChartProps, 'data' | 'labels' > {
 	title: string;
 	tooltip?: string | React.ReactNode;
 	className?: string;
@@ -14,6 +16,63 @@ export const SiteMonitoringBarChart = ( { title, tooltip, className, ...rest }: 
 		classes.push( className );
 	}
 	const isValidData = rest.data?.[ 0 ]?.length > 0;
+	const legendData = [
+		// 200
+		{
+			fillColor: '#68B3E8',
+			tooltip: (
+				<LegendTooltip title={ translate( 'OK' ) }>
+					{ translate(
+						'The HTTP 200 OK success status response code indicates that the request has succeeded.'
+					) }
+				</LegendTooltip>
+			),
+		},
+		// 401
+		{
+			fillColor: '#A7AAAD',
+			tooltip: (
+				<LegendTooltip title={ translate( 'Unauthorized Response' ) }>
+					{ translate(
+						'The client request has not been completed because it lacks valid authentication credentials for the requested resource.'
+					) }
+				</LegendTooltip>
+			),
+		},
+		// 400
+		{
+			fillColor: '#F2D76B',
+			tooltip: (
+				<LegendTooltip title={ translate( 'Bad Request' ) }>
+					{ translate(
+						'The server cannot or will not process the request due to something that is perceived to be a client error (for example, malformed request syntax, invalid request message framing, or deceptive request routing).'
+					) }
+				</LegendTooltip>
+			),
+		},
+		// 404
+		{
+			fillColor: '#09B585',
+			tooltip: (
+				<LegendTooltip title={ translate( 'Not Found' ) }>
+					{ translate(
+						'The server cannot find the requested resource. Links that lead to a 404 page are often called broken or dead links.'
+					) }
+				</LegendTooltip>
+			),
+		},
+		// 500
+		{
+			fillColor: '#F283AA',
+			tooltip: (
+				<LegendTooltip title={ translate( 'Internal Server Error' ) }>
+					{ translate(
+						'The server encountered an unexpected condition that prevented it from fulfilling the request.'
+					) }
+				</LegendTooltip>
+			),
+		},
+	];
 	return (
 		<div className={ classnames( classes ) }>
 			<header className="site-monitoring__chart-header">
@@ -22,7 +81,7 @@ export const SiteMonitoringBarChart = ( { title, tooltip, className, ...rest }: 
 					<InfoPopover className="site-monitoring__chart-tooltip">{ tooltip }</InfoPopover>
 				) }
 			</header>
-			{ isValidData && <UplotBarChart { ...rest } /> }
+			{ isValidData && <UplotBarChart { ...rest } legendData={ legendData } /> }
 		</div>
 	);
 };

--- a/client/my-sites/site-monitoring/components/site-monitoring-bar-chart/legend-tooltip.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-bar-chart/legend-tooltip.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+
+const Root = styled.div( {
+	fontSize: 14,
+	maxWidth: 350,
+	padding: 16,
+	textAlign: 'left',
+	color: 'var(--color-neutral-50)',
+} );
+
+const Title = styled.div( {
+	fontWeight: 600,
+} );
+
+export function LegendTooltip( {
+	title,
+	children,
+}: {
+	title?: string;
+	children?: React.ReactNode;
+} ) {
+	return (
+		<Root>
+			{ title && <Title>{ title }</Title> }
+			<div>{ children }</div>
+		</Root>
+	);
+}

--- a/client/my-sites/site-monitoring/components/site-monitoring-bar-chart/use-metrics-bar-chart-data.ts
+++ b/client/my-sites/site-monitoring/components/site-monitoring-bar-chart/use-metrics-bar-chart-data.ts
@@ -4,7 +4,6 @@ import { TimeRange } from '../../metrics-tab';
 import { PeriodData, useSiteMetricsQuery } from '../../use-metrics-query';
 
 const STATUS_CODES = [ 200, 401, 400, 404, 500 ];
-const FILL_COLORS = [ '#68B3E8', '#A7AAAD', '#F2D76B', '#09B585', '#F283AA' ];
 
 interface UseMetricsBarChartDataParams {
 	siteId: number | null;
@@ -94,6 +93,5 @@ export function useMetricsBarChartData( { siteId, timeRange }: UseMetricsBarChar
 			}
 			return getLongDate( date, locale );
 		} ),
-		fillColors: FILL_COLORS,
 	};
 }

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -108,29 +108,33 @@
 	margin: 0 0 1.5rem;
 }
 
-.u-legend {
-	color: var(--studio-gray-100);
+.site-monitoring-line-chart {
+	.u-legend {
+		color: var(--studio-gray-100);
 
-	// Disable rendering first u-marker, which is for "Date" and is empty.
-	> .u-series:first-child > th > .u-marker {
-		display: none;
-	}
-
-	// Use increased specificity to override original uPlot styles.
-	> tr.u-series > th {
-		cursor: initial;
-
-		&::after {
-			vertical-align: baseline;
+		// Disable rendering first u-marker, which is for "Date" and is empty.
+		> .u-series:first-child > th > .u-marker {
+			display: none;
 		}
-		> .u-marker {
-			// Nudge marker down to align with text.
-			margin-top: -2px;
-			// Make the marker round.
-			border-radius: 100%;
-		}
-		> .u-label {
-			vertical-align: baseline;
+
+		// Use increased specificity to override original uPlot styles.
+		> tr.u-series > th {
+			cursor: initial;
+
+			&::after {
+				vertical-align: baseline;
+			}
+
+			> .u-marker {
+				// Nudge marker down to align with text.
+				margin-top: -2px;
+				// Make the marker round.
+				border-radius: 100%;
+			}
+
+			> .u-label {
+				vertical-align: baseline;
+			}
 		}
 	}
 }

--- a/packages/components/src/chart-uplot/bar.tsx
+++ b/packages/components/src/chart-uplot/bar.tsx
@@ -3,7 +3,6 @@ import uPlot from 'uplot';
 import UplotReact from 'uplot-react';
 import useResize from './hooks/use-resize';
 import seriesBarsPlugin from './uplot-plugins/multi-bars';
-// import seriesBarsPlugin from './uplot-plugins/series-bars-plugins';
 
 // NOTE: Do not include this component in the package entry bundle.
 //       Doing so will cause tests of the consumer package to break due to uPlot's reliance on matchMedia.

--- a/packages/components/src/chart-uplot/bar.tsx
+++ b/packages/components/src/chart-uplot/bar.tsx
@@ -1,7 +1,7 @@
-import { Popover } from '@automattic/components';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import uPlot from 'uplot';
 import UplotReact from 'uplot-react';
+import Popover from '../popover';
 import useResize from './hooks/use-resize';
 import seriesBarsPlugin from './uplot-plugins/multi-bars';
 

--- a/packages/components/src/chart-uplot/bar.tsx
+++ b/packages/components/src/chart-uplot/bar.tsx
@@ -16,7 +16,7 @@ const DEFAULT_DIMENSIONS = {
 
 export interface UplotChartProps {
 	data: [ string[], ...number[][] ];
-	fillColors: string[];
+	legendData: { fillColor: string; tooltip?: JSX.Element }[];
 	labels: string[];
 	options?: Partial< uPlot.Options >;
 }
@@ -24,7 +24,7 @@ export interface UplotChartProps {
 export default function UplotBarChart( {
 	data,
 	labels,
-	fillColors = [],
+	legendData = [],
 	options: propOptions,
 }: UplotChartProps ) {
 	const uplot = useRef< uPlot | null >( null );
@@ -47,7 +47,7 @@ export default function UplotBarChart( {
 			padding: [ null, 0, null, 0 ],
 			series: data[ 0 ].map( ( label, i ) => ( {
 				label,
-				fill: fillColors[ i ],
+				fill: legendData[ i ].fillColor,
 			} ) ) as uPlot.Series[],
 			plugins: [
 				seriesBarsPlugin( {
@@ -66,7 +66,7 @@ export default function UplotBarChart( {
 			...defaultOptions,
 			...( typeof propOptions === 'object' ? propOptions : {} ),
 		};
-	}, [ chartDimensions, data, fillColors, labels, propOptions ] );
+	}, [ chartDimensions, data, labels, legendData, propOptions ] );
 
 	useResize( uplot, uplotContainer );
 
@@ -114,6 +114,8 @@ export default function UplotBarChart( {
 			legendEl.removeEventListener( 'mouseout', onMouseLeaveListener );
 		};
 	}, [ legendEl ] );
+	const tooltipContent = legendData?.[ legendVisibleIndex ]?.tooltip;
+	const tooltipContext = legendEl?.children[ legendVisibleIndex ];
 
 	return (
 		<div className="calypso-uplot-chart-container" ref={ uplotContainer }>
@@ -122,9 +124,9 @@ export default function UplotBarChart( {
 				onCreate={ ( chart ) => ( uplot.current = chart ) }
 				options={ options }
 			/>
-			{ legendVisibleIndex >= 0 && legendEl?.children[ legendVisibleIndex ] && (
-				<Popover isVisible context={ legendEl.children[ legendVisibleIndex ] } position="top">
-					{ fillColors[ legendVisibleIndex ] }
+			{ tooltipContent && tooltipContext && (
+				<Popover isVisible context={ tooltipContext } position="top">
+					{ tooltipContent }
 				</Popover>
 			) }
 		</div>

--- a/packages/components/src/chart-uplot/stories/index.stories.tsx
+++ b/packages/components/src/chart-uplot/stories/index.stories.tsx
@@ -55,13 +55,31 @@ const barChartData: [ string[], ...number[][] ] = [
 ];
 
 const barChartLabels = [ '12:00', '13:00', '14:00', '15:00', '16:00', '17:00', '18:00' ];
+const legendData = [
+	{
+		fillColor: '#68B3E8',
+		tooltip: <span>Tooltip content for HTTP 200</span>,
+	},
+	{
+		fillColor: '#A7AAAD',
+		tooltip: <span>Tooltip content for HTTP 401</span>,
+	},
+	{
+		fillColor: '#F2D76B',
+		tooltip: <span>Tooltip content for HTTP 400</span>,
+	},
+	{
+		fillColor: '#09B585',
+		tooltip: <span>Tooltip content for HTTP 404</span>,
+	},
+	{
+		fillColor: '#F283AA',
+		tooltip: <span>Tooltip content for HTTP 500</span>,
+	},
+];
 
 export const BarChartUplot = () => {
 	return (
-		<UplotBarChart
-			data={ barChartData }
-			labels={ barChartLabels }
-			fillColors={ [ '#68B3E8', '#A7AAAD', '#F2D76B', '#09B585', '#F283AA' ] }
-		/>
+		<UplotBarChart data={ barChartData } labels={ barChartLabels } legendData={ legendData } />
 	);
 };

--- a/packages/components/src/chart-uplot/style.scss
+++ b/packages/components/src/chart-uplot/style.scss
@@ -1,28 +1,30 @@
 @import "uplot/dist/uPlot.min.css";
 
-.u-legend {
-	color: var(--studio-gray-100);
+.uplot:not(.calypso-uplot-bar-chart) {
+	.u-legend {
+		color: var(--studio-gray-100);
 
-	// Disable rendering first u-marker, which is for "Date" and is empty.
-	> .u-series:first-child > th > .u-marker {
-		display: none;
-	}
-
-	// Use increased specificity to override original uPlot styles.
-	> tr.u-series > th {
-		cursor: initial;
-
-		&::after {
-			vertical-align: baseline;
+		// Disable rendering first u-marker, which is for "Date" and is empty.
+		> .u-series:first-child > th > .u-marker {
+			display: none;
 		}
-		> .u-marker {
-			// Nudge marker down to align with text.
-			margin-top: -2px;
-			// Make the marker round.
-			border-radius: 100%;
-		}
-		> .u-label {
-			vertical-align: baseline;
+
+		// Use increased specificity to override original uPlot styles.
+		> tr.u-series > th {
+			cursor: initial;
+
+			&::after {
+				vertical-align: baseline;
+			}
+			> .u-marker {
+				// Nudge marker down to align with text.
+				margin-top: -2px;
+				// Make the marker round.
+				border-radius: 100%;
+			}
+			> .u-label {
+				vertical-align: baseline;
+			}
 		}
 	}
 }


### PR DESCRIPTION


See https://github.com/Automattic/dotcom-forge/issues/3356

## Proposed Changes

* Improve the legend for Bar Charts and add Tooltips with description.
* Limit the legend re-styling on the line chart.
* The texts of the tooltips are extracted from MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/site-monitoring/${siteSlug}`
* Scroll down
* Observe the new tooltips on the bar chart

## Screenshot
![tooltip-bar-chart](https://github.com/Automattic/wp-calypso/assets/779993/b8321107-685d-4616-b96d-059593c8bba6)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
