### PR TITLE
Checkout: Update AdditionalTermsOfServiceInCart to clarify logic

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -1,7 +1,7 @@
-import { localizeUrl, useLocale } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { TermsOfServiceRecord, useShoppingCart } from '@automattic/shopping-cart';
 import debugFactory from 'debug';
-import i18n, { useTranslate, TranslateResult } from 'i18n-calypso';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
 import moment from 'moment';
 import { EDIT_PAYMENT_DETAILS } from 'calypso/lib/url/support';
 import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
@@ -15,7 +15,6 @@ const debug = debugFactory( 'calypso:composite-checkout:additional-terms-of-serv
 
 export default function AdditionalTermsOfServiceInCart() {
 	const translate = useTranslate();
-	const locale = useLocale();
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const siteSlug = useSelector( getSelectedSiteSlug );
@@ -30,7 +29,6 @@ export default function AdditionalTermsOfServiceInCart() {
 				const message = getMessageForTermsOfServiceRecord(
 					termsOfServiceRecord,
 					translate,
-					locale,
 					siteSlug
 				);
 
@@ -47,7 +45,6 @@ export default function AdditionalTermsOfServiceInCart() {
 function getMessageForTermsOfServiceRecord(
 	termsOfServiceRecord: TermsOfServiceRecord,
 	translate: ReturnType< typeof useTranslate >,
-	locale: string,
 	siteSlug: string | null
 ): TranslateResult {
 	const { args = {} } = termsOfServiceRecord;
@@ -61,21 +58,11 @@ function getMessageForTermsOfServiceRecord(
 				return '';
 			}
 			if (
-				( locale === 'en' ||
-					i18n.hasTranslation(
-						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription {{/manageSubscriptionLink}} at any time.'
-					) ) &&
 				args.subscription_start_date &&
 				args.subscription_expiry_date &&
 				args.subscription_auto_renew_date
 			) {
-				if (
-					args.is_renewal_price_prorated &&
-					( locale === 'en' ||
-						i18n.hasTranslation(
-							'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.'
-						) )
-				) {
+				if ( args.is_renewal_price_prorated ) {
 					return translate(
 						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
 						{
@@ -165,21 +152,11 @@ function getMessageForTermsOfServiceRecord(
 				return '';
 			}
 			if (
-				( locale === 'en' ||
-					i18n.hasTranslation(
-						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.'
-					) ) &&
 				args.subscription_start_date &&
 				args.subscription_expiry_date &&
 				args.subscription_auto_renew_date
 			) {
-				if (
-					args.is_renewal_price_prorated &&
-					( locale === 'en' ||
-						i18n.hasTranslation(
-							'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.'
-						) )
-				) {
+				if ( args.is_renewal_price_prorated ) {
 					return translate(
 						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
 						{

--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -47,7 +47,10 @@ function getMessageForTermsOfServiceRecordPayPal(
 	translate: ReturnType< typeof useTranslate >,
 	siteSlug: string | null
 ): TranslateResult {
-	const { args = {} } = termsOfServiceRecord;
+	const args = termsOfServiceRecord.args;
+	if ( ! args ) {
+		return '';
+	}
 	if ( ! args.email || ! args.product_name || ! args.renewal_price ) {
 		debug(
 			`Malformed terms of service args with code: ${ termsOfServiceRecord.code }`,
@@ -148,7 +151,10 @@ function getMessageForTermsOfServiceRecordCard(
 	translate: ReturnType< typeof useTranslate >,
 	siteSlug: string | null
 ): TranslateResult {
-	const { args = {} } = termsOfServiceRecord;
+	const args = termsOfServiceRecord.args;
+	if ( ! args ) {
+		return '';
+	}
 	if ( ! args.card_type || ! args.card_last_4 || ! args.product_name || ! args.renewal_price ) {
 		debug(
 			`Malformed terms of service args with code: ${ termsOfServiceRecord.code }`,
@@ -252,7 +258,10 @@ function getMessageForTermsOfServiceRecordUnknown(
 	translate: ReturnType< typeof useTranslate >,
 	siteSlug: string | null
 ): TranslateResult {
-	const { args = {} } = termsOfServiceRecord;
+	const args = termsOfServiceRecord.args;
+	if ( ! args ) {
+		return '';
+	}
 	if (
 		args.subscription_start_date &&
 		args.subscription_expiry_date &&

--- a/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/additional-terms-of-service-in-cart.tsx
@@ -42,277 +42,38 @@ export default function AdditionalTermsOfServiceInCart() {
 	);
 }
 
-function getMessageForTermsOfServiceRecord(
+function getMessageForTermsOfServiceRecordPayPal(
 	termsOfServiceRecord: TermsOfServiceRecord,
 	translate: ReturnType< typeof useTranslate >,
 	siteSlug: string | null
 ): TranslateResult {
 	const { args = {} } = termsOfServiceRecord;
-	switch ( termsOfServiceRecord.code ) {
-		case 'terms_for_bundled_trial_auto_renewal_paypal':
-			if ( ! args.email || ! args.product_name || ! args.renewal_price ) {
-				debug(
-					`Malformed terms of service args with code: ${ termsOfServiceRecord.code }`,
-					termsOfServiceRecord
-				);
-				return '';
-			}
-			if (
-				args.subscription_start_date &&
-				args.subscription_expiry_date &&
-				args.subscription_auto_renew_date
-			) {
-				if ( args.is_renewal_price_prorated ) {
-					return translate(
-						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
-						{
-							args: {
-								startDate: moment( args.subscription_start_date ).format( 'll' ),
-								endDate: moment( args.subscription_expiry_date ).format( 'll' ),
-								renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
-								email: args.email,
-								renewalPrice: args.renewal_price,
-								regularPrice: args.regular_renewal_price,
-								numberOfDays: args.subscription_pre_renew_reminder_days || 7,
-							},
-							components: {
-								updatePaymentMethodLink: (
-									<a
-										href={ localizeUrl( EDIT_PAYMENT_DETAILS ) }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-								manageSubscriptionLink: (
-									<a
-										href={ `/purchases/subscriptions/${ siteSlug }` }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
-						}
-					);
-				}
-				return translate(
-					'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
-					{
-						args: {
-							startDate: moment( args.subscription_start_date ).format( 'll' ),
-							endDate: moment( args.subscription_expiry_date ).format( 'll' ),
-							renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
-							email: args.email,
-							renewalPrice: args.renewal_price,
-							numberOfDays: args.subscription_pre_renew_reminder_days || 7,
-						},
-						components: {
-							updatePaymentMethodLink: (
-								<a
-									href={ localizeUrl( EDIT_PAYMENT_DETAILS ) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-							manageSubscriptionLink: (
-								<a
-									href={ `/purchases/subscriptions/${ siteSlug }` }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					}
-				);
-			}
+	if ( ! args.email || ! args.product_name || ! args.renewal_price ) {
+		debug(
+			`Malformed terms of service args with code: ${ termsOfServiceRecord.code }`,
+			termsOfServiceRecord
+		);
+		return '';
+	}
+	if (
+		args.subscription_start_date &&
+		args.subscription_expiry_date &&
+		args.subscription_auto_renew_date
+	) {
+		if ( args.is_renewal_price_prorated ) {
 			return translate(
-				'At the end of the promotional period we will begin charging your PayPal account (%(email)s) the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}',
+				'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
 				{
 					args: {
-						email: args.email,
-						productName: args.product_name,
-						renewalPrice: args.renewal_price,
-					},
-					components: {
-						link: (
-							<a
-								href={ `/purchases/subscriptions/${ siteSlug }` }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-					},
-				}
-			);
-		case 'terms_for_bundled_trial_auto_renewal_credit_card':
-			if ( ! args.card_type || ! args.card_last_4 || ! args.product_name || ! args.renewal_price ) {
-				debug(
-					`Malformed terms of service args with code: ${ termsOfServiceRecord.code }`,
-					termsOfServiceRecord
-				);
-				return '';
-			}
-			if (
-				args.subscription_start_date &&
-				args.subscription_expiry_date &&
-				args.subscription_auto_renew_date
-			) {
-				if ( args.is_renewal_price_prorated ) {
-					return translate(
-						'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
-						{
-							args: {
-								startDate: moment( args.subscription_start_date ).format( 'll' ),
-								endDate: moment( args.subscription_expiry_date ).format( 'll' ),
-								renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
-								cardType: args.card_type,
-								cardLast4: args.card_last_4,
-								renewalPrice: args.renewal_price,
-								regularPrice: args.regular_renewal_price,
-								numberOfDays: args.subscription_pre_renew_reminder_days || 7,
-							},
-							components: {
-								updatePaymentMethodLink: (
-									<a
-										href={ localizeUrl( EDIT_PAYMENT_DETAILS ) }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-								manageSubscriptionLink: (
-									<a
-										href={ `/purchases/subscriptions/${ siteSlug }` }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
-						}
-					);
-				}
-				return translate(
-					'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (%(cardType)s ****%(cardLast4)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription {{/manageSubscriptionLink}} at any time.',
-					{
-						args: {
-							startDate: moment( args.subscription_start_date ).format( 'll' ),
-							endDate: moment( args.subscription_expiry_date ).format( 'll' ),
-							renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
-							cardType: args.card_type,
-							cardLast4: args.card_last_4,
-							renewalPrice: args.renewal_price,
-							numberOfDays: args.subscription_pre_renew_reminder_days || 7,
-						},
-						components: {
-							updatePaymentMethodLink: (
-								<a
-									href={ localizeUrl( EDIT_PAYMENT_DETAILS ) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-							manageSubscriptionLink: (
-								<a
-									href={ `/purchases/subscriptions/${ siteSlug }` }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					}
-				);
-			}
-			return translate(
-				'At the end of the promotional period we will begin charging your %(cardType)s card ending in %(cardLast4)s the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}',
-				{
-					args: {
-						cardType: args.card_type,
-						cardLast4: args.card_last_4,
-						productName: args.product_name,
-						renewalPrice: args.renewal_price,
-					},
-					components: {
-						link: (
-							<a
-								href={ `/purchases/subscriptions/${ siteSlug }` }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-					},
-				}
-			);
-		case 'terms_for_bundled_trial_unknown_payment_method': {
-			if (
-				args.subscription_start_date &&
-				args.subscription_expiry_date &&
-				args.subscription_auto_renew_date
-			) {
-				if ( args.is_renewal_price_prorated ) {
-					const proratedRenewalArgs = {
-						args: {
-							endDate: moment( args.subscription_expiry_date ).format( 'll' ),
-							numberOfDays: args.subscription_pre_renew_reminder_days || 7,
-							productName: args.product_name,
-							regularPrice: args.regular_renewal_price,
-							renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
-							renewalPrice: args.renewal_price,
-							startDate: moment( args.subscription_start_date ).format( 'll' ),
-						},
-						components: {
-							manageSubscriptionLink: (
-								<a
-									href={ `/purchases/subscriptions/${ siteSlug }` }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-							updatePaymentMethodLink: (
-								<a
-									href={ localizeUrl( EDIT_PAYMENT_DETAILS ) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					};
-
-					if ( args.product_meta && args.product_meta !== '' ) {
-						return translate(
-							'The promotional period for your %(productName)s subscription for %(domainName)s lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the reduced price of %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
-							{
-								args: {
-									...proratedRenewalArgs.args,
-									domainName: args.product_meta,
-								},
-								components: {
-									...proratedRenewalArgs.components,
-								},
-							}
-						);
-					}
-
-					return translate(
-						'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the reduced price of %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
-						proratedRenewalArgs
-					);
-				}
-
-				const standardRenewalArgs = {
-					args: {
-						endDate: moment( args.subscription_expiry_date ).format( 'll' ),
-						numberOfDays: args.subscription_pre_renew_reminder_days || 7,
-						productName: args.product_name,
-						renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
-						renewalPrice: args.renewal_price,
 						startDate: moment( args.subscription_start_date ).format( 'll' ),
+						endDate: moment( args.subscription_expiry_date ).format( 'll' ),
+						renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
+						email: args.email,
+						renewalPrice: args.renewal_price,
+						regularPrice: args.regular_renewal_price,
+						numberOfDays: args.subscription_pre_renew_reminder_days || 7,
 					},
 					components: {
-						manageSubscriptionLink: (
-							<a
-								href={ `/purchases/subscriptions/${ siteSlug }` }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
 						updatePaymentMethodLink: (
 							<a
 								href={ localizeUrl( EDIT_PAYMENT_DETAILS ) }
@@ -320,39 +81,205 @@ function getMessageForTermsOfServiceRecord(
 								rel="noopener noreferrer"
 							/>
 						),
+						manageSubscriptionLink: (
+							<a
+								href={ `/purchases/subscriptions/${ siteSlug }` }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
 					},
-				};
-
-				if ( args.product_meta && args.product_meta !== '' ) {
-					return translate(
-						'The promotional period for your %(productName)s subscription for %(domainName)s lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
-						{
-							args: {
-								...standardRenewalArgs.args,
-								domainName: args.product_meta,
-							},
-							components: {
-								...standardRenewalArgs.components,
-							},
-						}
-					);
 				}
-
-				return translate(
-					'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
-					standardRenewalArgs
-				);
-			}
-
-			const defaultRenewalArgs = {
+			);
+		}
+		return translate(
+			'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
+			{
 				args: {
-					productName: args.product_name,
+					startDate: moment( args.subscription_start_date ).format( 'll' ),
+					endDate: moment( args.subscription_expiry_date ).format( 'll' ),
+					renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
+					email: args.email,
 					renewalPrice: args.renewal_price,
+					numberOfDays: args.subscription_pre_renew_reminder_days || 7,
 				},
 				components: {
-					link: (
+					updatePaymentMethodLink: (
+						<a
+							href={ localizeUrl( EDIT_PAYMENT_DETAILS ) }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					manageSubscriptionLink: (
 						<a
 							href={ `/purchases/subscriptions/${ siteSlug }` }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			}
+		);
+	}
+	return translate(
+		'At the end of the promotional period we will begin charging your PayPal account (%(email)s) the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}',
+		{
+			args: {
+				email: args.email,
+				productName: args.product_name,
+				renewalPrice: args.renewal_price,
+			},
+			components: {
+				link: (
+					<a
+						href={ `/purchases/subscriptions/${ siteSlug }` }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			},
+		}
+	);
+}
+
+function getMessageForTermsOfServiceRecordCard(
+	termsOfServiceRecord: TermsOfServiceRecord,
+	translate: ReturnType< typeof useTranslate >,
+	siteSlug: string | null
+): TranslateResult {
+	const { args = {} } = termsOfServiceRecord;
+	if ( ! args.card_type || ! args.card_last_4 || ! args.product_name || ! args.renewal_price ) {
+		debug(
+			`Malformed terms of service args with code: ${ termsOfServiceRecord.code }`,
+			termsOfServiceRecord
+		);
+		return '';
+	}
+	if (
+		args.subscription_start_date &&
+		args.subscription_expiry_date &&
+		args.subscription_auto_renew_date
+	) {
+		if ( args.is_renewal_price_prorated ) {
+			return translate(
+				'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
+				{
+					args: {
+						startDate: moment( args.subscription_start_date ).format( 'll' ),
+						endDate: moment( args.subscription_expiry_date ).format( 'll' ),
+						renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
+						cardType: args.card_type,
+						cardLast4: args.card_last_4,
+						renewalPrice: args.renewal_price,
+						regularPrice: args.regular_renewal_price,
+						numberOfDays: args.subscription_pre_renew_reminder_days || 7,
+					},
+					components: {
+						updatePaymentMethodLink: (
+							<a
+								href={ localizeUrl( EDIT_PAYMENT_DETAILS ) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+						manageSubscriptionLink: (
+							<a
+								href={ `/purchases/subscriptions/${ siteSlug }` }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+				}
+			);
+		}
+		return translate(
+			'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (%(cardType)s ****%(cardLast4)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription {{/manageSubscriptionLink}} at any time.',
+			{
+				args: {
+					startDate: moment( args.subscription_start_date ).format( 'll' ),
+					endDate: moment( args.subscription_expiry_date ).format( 'll' ),
+					renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
+					cardType: args.card_type,
+					cardLast4: args.card_last_4,
+					renewalPrice: args.renewal_price,
+					numberOfDays: args.subscription_pre_renew_reminder_days || 7,
+				},
+				components: {
+					updatePaymentMethodLink: (
+						<a
+							href={ localizeUrl( EDIT_PAYMENT_DETAILS ) }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					manageSubscriptionLink: (
+						<a
+							href={ `/purchases/subscriptions/${ siteSlug }` }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			}
+		);
+	}
+	return translate(
+		'At the end of the promotional period we will begin charging your %(cardType)s card ending in %(cardLast4)s the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}',
+		{
+			args: {
+				cardType: args.card_type,
+				cardLast4: args.card_last_4,
+				productName: args.product_name,
+				renewalPrice: args.renewal_price,
+			},
+			components: {
+				link: (
+					<a
+						href={ `/purchases/subscriptions/${ siteSlug }` }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			},
+		}
+	);
+}
+
+function getMessageForTermsOfServiceRecordUnknown(
+	termsOfServiceRecord: TermsOfServiceRecord,
+	translate: ReturnType< typeof useTranslate >,
+	siteSlug: string | null
+): TranslateResult {
+	const { args = {} } = termsOfServiceRecord;
+	if (
+		args.subscription_start_date &&
+		args.subscription_expiry_date &&
+		args.subscription_auto_renew_date
+	) {
+		if ( args.is_renewal_price_prorated ) {
+			const proratedRenewalArgs = {
+				args: {
+					endDate: moment( args.subscription_expiry_date ).format( 'll' ),
+					numberOfDays: args.subscription_pre_renew_reminder_days || 7,
+					productName: args.product_name,
+					regularPrice: args.regular_renewal_price,
+					renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
+					renewalPrice: args.renewal_price,
+					startDate: moment( args.subscription_start_date ).format( 'll' ),
+				},
+				components: {
+					manageSubscriptionLink: (
+						<a
+							href={ `/purchases/subscriptions/${ siteSlug }` }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					updatePaymentMethodLink: (
+						<a
+							href={ localizeUrl( EDIT_PAYMENT_DETAILS ) }
 							target="_blank"
 							rel="noopener noreferrer"
 						/>
@@ -362,24 +289,122 @@ function getMessageForTermsOfServiceRecord(
 
 			if ( args.product_meta && args.product_meta !== '' ) {
 				return translate(
-					'At the end of the promotional period your %(productName)s subscription for %(domainName)s will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
+					'The promotional period for your %(productName)s subscription for %(domainName)s lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the reduced price of %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
 					{
 						args: {
-							...defaultRenewalArgs.args,
+							...proratedRenewalArgs.args,
 							domainName: args.product_meta,
 						},
 						components: {
-							...defaultRenewalArgs.components,
+							...proratedRenewalArgs.components,
 						},
 					}
 				);
 			}
 
 			return translate(
-				'At the end of the promotional period your %(productName)s subscription will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
-				defaultRenewalArgs
+				'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the reduced price of %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
+				proratedRenewalArgs
 			);
 		}
+
+		const standardRenewalArgs = {
+			args: {
+				endDate: moment( args.subscription_expiry_date ).format( 'll' ),
+				numberOfDays: args.subscription_pre_renew_reminder_days || 7,
+				productName: args.product_name,
+				renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
+				renewalPrice: args.renewal_price,
+				startDate: moment( args.subscription_start_date ).format( 'll' ),
+			},
+			components: {
+				manageSubscriptionLink: (
+					<a
+						href={ `/purchases/subscriptions/${ siteSlug }` }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+				updatePaymentMethodLink: (
+					<a
+						href={ localizeUrl( EDIT_PAYMENT_DETAILS ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			},
+		};
+
+		if ( args.product_meta && args.product_meta !== '' ) {
+			return translate(
+				'The promotional period for your %(productName)s subscription for %(domainName)s lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
+				{
+					args: {
+						...standardRenewalArgs.args,
+						domainName: args.product_meta,
+					},
+					components: {
+						...standardRenewalArgs.components,
+					},
+				}
+			);
+		}
+
+		return translate(
+			'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will attempt to renew your subscription at the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
+			standardRenewalArgs
+		);
+	}
+
+	const defaultRenewalArgs = {
+		args: {
+			productName: args.product_name,
+			renewalPrice: args.renewal_price,
+		},
+		components: {
+			link: (
+				<a
+					href={ `/purchases/subscriptions/${ siteSlug }` }
+					target="_blank"
+					rel="noopener noreferrer"
+				/>
+			),
+		},
+	};
+
+	if ( args.product_meta && args.product_meta !== '' ) {
+		return translate(
+			'At the end of the promotional period your %(productName)s subscription for %(domainName)s will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
+			{
+				args: {
+					...defaultRenewalArgs.args,
+					domainName: args.product_meta,
+				},
+				components: {
+					...defaultRenewalArgs.components,
+				},
+			}
+		);
+	}
+
+	return translate(
+		'At the end of the promotional period your %(productName)s subscription will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
+		defaultRenewalArgs
+	);
+}
+
+function getMessageForTermsOfServiceRecord(
+	termsOfServiceRecord: TermsOfServiceRecord,
+	translate: ReturnType< typeof useTranslate >,
+	siteSlug: string | null
+): TranslateResult {
+	switch ( termsOfServiceRecord.code ) {
+		case 'terms_for_bundled_trial_auto_renewal_paypal':
+			return getMessageForTermsOfServiceRecordPayPal( termsOfServiceRecord, translate, siteSlug );
+		case 'terms_for_bundled_trial_auto_renewal_credit_card':
+			return getMessageForTermsOfServiceRecordCard( termsOfServiceRecord, translate, siteSlug );
+		case 'terms_for_bundled_trial_unknown_payment_method':
+			return getMessageForTermsOfServiceRecordUnknown( termsOfServiceRecord, translate, siteSlug );
 		default:
 			debug(
 				`Unknown terms of service code: ${ termsOfServiceRecord.code }`,

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -672,15 +672,15 @@ export type FrDomainContactExtraDetails = {
 export interface TermsOfServiceRecord {
 	key: string;
 	code: string;
-	args?: TermsOfServiceRecordArgs;
+	args?: TermsOfServiceRecordArgsBase | TermsOfServiceRecordArgsRenewal;
 }
 
-export interface TermsOfServiceRecordArgs {
+export interface TermsOfServiceRecordArgsBase {
 	subscription_start_date: string;
-	subscription_expiry_date: string;
-	subscription_auto_renew_date: string;
-	subscription_pre_renew_reminder_days: string;
-	subscription_pre_renew_reminders_count: number;
+	subscription_expiry_date?: string;
+	subscription_auto_renew_date?: string;
+	subscription_pre_renew_reminder_days?: string;
+	subscription_pre_renew_reminders_count?: number;
 	product_meta: string;
 	product_name: string;
 	renewal_price: string;
@@ -689,4 +689,11 @@ export interface TermsOfServiceRecordArgs {
 	email?: string;
 	card_type?: string;
 	card_last_4?: string;
+}
+
+export interface TermsOfServiceRecordArgsRenewal extends TermsOfServiceRecordArgsBase {
+	subscription_expiry_date: string;
+	subscription_auto_renew_date: string;
+	subscription_pre_renew_reminder_days: string;
+	subscription_pre_renew_reminders_count: number;
 }

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -672,5 +672,21 @@ export type FrDomainContactExtraDetails = {
 export interface TermsOfServiceRecord {
 	key: string;
 	code: string;
-	args?: Record< string, string >;
+	args?: TermsOfServiceRecordArgs;
+}
+
+export interface TermsOfServiceRecordArgs {
+	subscription_start_date: string;
+	subscription_expiry_date: string;
+	subscription_auto_renew_date: string;
+	subscription_pre_renew_reminder_days: string;
+	subscription_pre_renew_reminders_count: number;
+	product_meta: string;
+	product_name: string;
+	renewal_price: string;
+	is_renewal_price_prorated: boolean;
+	regular_renewal_price: string;
+	email?: string;
+	card_type?: string;
+	card_last_4?: string;
 }


### PR DESCRIPTION
## Proposed Changes

The `AdditionalTermsOfServiceInCart` component uses data from the shopping cart endpoint to determine what data to display. However, the data it relies upon is typed as `Record<string, string>` which is not very specific, and makes it hard to follow some of that component's logic. In addition, the component itself has some very big functions.

In this PR we specify the actual types of the data and split up the functions used by the component to be more clear. This should not change any actual behavior.

Related to D118518-code and https://github.com/Automattic/payments-shilling/issues/1850

Screenshot of the TOS section of checkout:

<img width="604" alt="Screenshot 2023-08-09 at 3 29 32 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/34b36725-c94b-4437-806e-bd09cd871882">


## Testing Instructions

**NOTE**: reviewing the code of this diff is better done commit-by-commit due to the nature of these changes. Otherwise it will look like a jumble.

Testing this is a little tricky. Probably the best way is to see the testing instructions of D118518-code