### PR TITLE
Subscription Management: Update Add Site modal

### DIFF
--- a/client/landing/subscriptions/components/add-sites-button/add-sites-button.tsx
+++ b/client/landing/subscriptions/components/add-sites-button/add-sites-button.tsx
@@ -1,9 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import './styles.scss';
 import { AddSitesModal } from 'calypso/landing/subscriptions/components/add-sites-modal';
+import './styles.scss';
 
 const AddSitesButton = () => {
 	const translate = useTranslate();
@@ -20,7 +20,8 @@ const AddSitesButton = () => {
 				className="subscriptions-add-sites__button"
 				onClick={ () => setIsAddSitesModalVisible( true ) }
 			>
-				{ translate( 'Add sites' ) }
+				<Gridicon className="subscriptions-add-sites__button-icon" icon="plus" size={ 24 } />
+				<span className="subscriptions-add-sites__button-text">{ translate( 'Add a site' ) }</span>
 			</Button>
 			<AddSitesModal
 				showModal={ isAddSitesModalVisible }

--- a/client/landing/subscriptions/components/add-sites-button/styles.scss
+++ b/client/landing/subscriptions/components/add-sites-button/styles.scss
@@ -1,3 +1,22 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .subscriptions-add-sites__button {
 	margin-top: 12px;
+
+	.subscriptions-add-sites__button-icon {
+		display: none;
+	}
+
+	@media (max-width: $break-medium) {
+		.subscriptions-add-sites__button-text {
+			display: none;
+		}
+
+		.subscriptions-add-sites__button-icon {
+			display: block;
+			margin-top: 0;
+			margin-right: 0 !important;
+			top: 0;
+		}
+	}
 }

--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -1,26 +1,29 @@
-import { FormInputValidation } from '@automattic/components';
+import { Button, FormInputValidation } from '@automattic/components';
+import { SubscriptionManager } from '@automattic/data-stores';
 import { TextControl } from '@wordpress/components';
 import { check, Icon } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import './styles.scss';
 
 type AddSitesFormProps = {
-	recordTracksEvent: ( eventName: string, eventProperties?: Record< string, unknown > ) => void;
-	onClose: () => void;
 	onAddFinished: () => void;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const AddSitesForm = ( { recordTracksEvent, onClose, onAddFinished }: AddSitesFormProps ) => {
+const AddSitesForm = ( { onAddFinished }: AddSitesFormProps ) => {
 	const translate = useTranslate();
 	const [ inputValue, setInputValue ] = useState( '' );
 	const [ inputFieldError, setInputFieldError ] = useState< string | null >( null );
 	const [ isValidUrl, setIsValidUrl ] = useState( false );
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const [ isUploading, setIsUploading ] = useState( false );
+	const dispatch = useDispatch();
+
+	const { mutate: subscribe, isLoading: subscribing } =
+		SubscriptionManager.useSiteSubscribeMutation();
 
 	const validateInputValue = useCallback(
 		( url: string, showError = false ) => {
@@ -47,30 +50,66 @@ const AddSitesForm = ( { recordTracksEvent, onClose, onAddFinished }: AddSitesFo
 			setInputValue( value );
 			validateInputValue( value );
 		},
-		[ inputFieldError, validateInputValue ]
+		[ validateInputValue ]
 	);
+
+	const onAddSite = useCallback( () => {
+		if ( isValidUrl ) {
+			subscribe(
+				{ url: inputValue },
+				{
+					onSuccess: () => {
+						dispatch(
+							successNotice(
+								translate( 'You have successfully subscribed to %s.', {
+									args: [ inputValue ],
+									comment: 'URL of the site that the user has subscribed to.',
+								} )
+							)
+						);
+						onAddFinished();
+					},
+					onError: () => {
+						dispatch(
+							errorNotice(
+								translate( 'There was an error when trying to subscribe to %s.', {
+									args: [ inputValue ],
+									comment: 'URL of the site that the user tried to subscribe to.',
+								} )
+							)
+						);
+					},
+				}
+			);
+		}
+	}, [ dispatch, inputValue, isValidUrl, onAddFinished, subscribe, translate ] );
 
 	return (
 		<div className="subscriptions-add-sites__form--container">
-			<label className="subscriptions-add-sites__form-label-url">
-				<strong>{ translate( 'Address' ) }</strong>
-			</label>
-
 			<TextControl
 				className={ classnames(
 					'subscriptions-add-sites__form-input',
 					inputFieldError ? 'is-error' : ''
 				) }
-				disabled={ isUploading }
+				disabled={ subscribing }
 				placeholder={ translate( 'https://www.site.com' ) }
 				value={ inputValue }
 				type="url"
 				onChange={ onTextFieldChange }
-				help={ isValidUrl ? <Icon icon={ check } /> : undefined }
+				help={ isValidUrl ? <Icon icon={ check } data-testid="check-icon" /> : undefined }
 				onBlur={ () => validateInputValue( inputValue, true ) }
 			/>
 
 			{ inputFieldError ? <FormInputValidation isError={ true } text={ inputFieldError } /> : null }
+
+			<Button
+				primary
+				className="subscriptions-add-sites__save-button"
+				disabled={ ! inputValue || !! inputFieldError || subscribing }
+				onClick={ onAddSite }
+			>
+				{ translate( 'Add site' ) }
+			</Button>
 		</div>
 	);
 };

--- a/client/landing/subscriptions/components/add-sites-form/styles.scss
+++ b/client/landing/subscriptions/components/add-sites-form/styles.scss
@@ -1,11 +1,7 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .subscriptions-add-sites__form--container {
-	label {
-		display: block;
-		width: 100%;
-		font-size: rem(14px);
-		line-height: rem(20px);
-		font-weight: 500;
-	}
+	min-width: 515px;
 
 	.components-base-control.is-error input {
 		border-color: var(--color-error);
@@ -16,7 +12,7 @@
 	}
 
 	.components-base-control__field {
-		margin: rem(6px) auto;
+		margin-bottom: 16px;
 	}
 
 	.components-text-control__input {
@@ -55,5 +51,13 @@
 		svg {
 			fill: var(--color-success-50);
 		}
+	}
+
+	.subscriptions-add-sites__save-button {
+		float: right;
+	}
+
+	@media (max-width: $break-small) {
+		min-width: initial;
 	}
 }

--- a/client/landing/subscriptions/components/add-sites-form/styles.scss
+++ b/client/landing/subscriptions/components/add-sites-form/styles.scss
@@ -15,6 +15,10 @@
 		margin-bottom: 16px;
 	}
 
+	.is-error .components-base-control__field {
+		margin-bottom: 6px;
+	}
+
 	.components-text-control__input {
 		border-color: var(--studio-gray-10);
 		border-radius: 4px;

--- a/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
@@ -2,19 +2,24 @@
  * @jest-environment jsdom
  */
 
-import { render, fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
+import React from 'react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import AddSitesForm from '../add-sites-form';
+
+jest.mock( 'calypso/state/notices/actions', () => ( {
+	successNotice: jest.fn(),
+	errorNotice: jest.fn(),
+} ) );
 
 describe( 'AddSitesForm', () => {
 	const mockProps = {
-		recordTracksEvent: jest.fn(),
-		onClose: jest.fn(),
 		onAddFinished: jest.fn(),
 	};
 
 	test( 'displays an error message with invalid URL', () => {
-		render( <AddSitesForm { ...mockProps } /> );
-		const input = document.querySelector( '.subscriptions-add-sites__form-input input' );
+		renderWithProvider( <AddSitesForm { ...mockProps } /> );
+		const input = screen.getByRole( 'textbox' );
 
 		fireEvent.change( input, {
 			target: { value: 'not-a-url' },
@@ -26,8 +31,8 @@ describe( 'AddSitesForm', () => {
 	} );
 
 	test( 'does not display an error message with valid URL', () => {
-		render( <AddSitesForm { ...mockProps } /> );
-		const input = document.querySelector( '.subscriptions-add-sites__form-input input' );
+		renderWithProvider( <AddSitesForm { ...mockProps } /> );
+		const input = screen.getByRole( 'textbox' );
 
 		fireEvent.change( input, {
 			target: { value: 'https://www.valid-url.com' },
@@ -39,8 +44,8 @@ describe( 'AddSitesForm', () => {
 	} );
 
 	test( 'does not display an error message when input field is empty and blurred', () => {
-		render( <AddSitesForm { ...mockProps } /> );
-		const input = document.querySelector( '.subscriptions-add-sites__form-input input' );
+		renderWithProvider( <AddSitesForm { ...mockProps } /> );
+		const input = screen.getByRole( 'textbox' );
 
 		fireEvent.change( input, {
 			target: { value: '' },
@@ -51,9 +56,9 @@ describe( 'AddSitesForm', () => {
 		expect( screen.queryByText( 'Please enter a valid URL' ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'displays an SVG when a valid URL is entered', () => {
-		render( <AddSitesForm { ...mockProps } /> );
-		const input = document.querySelector( '.subscriptions-add-sites__form-input input' );
+	test( 'displays a check icon when a valid URL is entered', () => {
+		renderWithProvider( <AddSitesForm { ...mockProps } /> );
+		const input = screen.getByRole( 'textbox' );
 
 		fireEvent.change( input, {
 			target: { value: 'https://www.valid-url.com' },
@@ -61,8 +66,21 @@ describe( 'AddSitesForm', () => {
 
 		fireEvent.blur( input );
 
-		const checkIcon = document.querySelector( '.components-base-control__help' );
+		const checkIcon = screen.getByTestId( 'check-icon' );
 		expect( checkIcon ).toBeInTheDocument();
-		expect( checkIcon.innerHTML ).toContain( 'svg' );
+	} );
+
+	test( 'disables the Add site button when an invalid URL is entered', () => {
+		renderWithProvider( <AddSitesForm { ...mockProps } /> );
+		const input = screen.getByRole( 'textbox' );
+		const addButton = screen.getByRole( 'button', { name: 'Add site' } );
+
+		fireEvent.change( input, {
+			target: { value: 'not-a-url' },
+		} );
+
+		fireEvent.blur( input );
+
+		expect( addButton ).toBeDisabled();
 	} );
 } );

--- a/client/landing/subscriptions/components/add-sites-modal/add-sites-modal.tsx
+++ b/client/landing/subscriptions/components/add-sites-modal/add-sites-modal.tsx
@@ -1,7 +1,7 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { AddSitesForm } from 'calypso/landing/subscriptions/components/add-sites-form';
+import './styles.scss';
 
 type AddSitesModalProps = {
 	showModal: boolean;
@@ -12,7 +12,7 @@ type AddSitesModalProps = {
 const AddSitesModal = ( { showModal, onClose, onAddFinished }: AddSitesModalProps ) => {
 	const translate = useTranslate();
 
-	const modalTitle = translate( 'Add sites', {
+	const modalTitle = translate( 'Add a site', {
 		context: 'Modal title',
 	} );
 
@@ -26,11 +26,11 @@ const AddSitesModal = ( { showModal, onClose, onAddFinished }: AddSitesModalProp
 			onRequestClose={ onClose }
 			overlayClassName="add-sites-modal"
 		>
-			<AddSitesForm
-				recordTracksEvent={ recordTracksEvent }
-				onClose={ onClose }
-				onAddFinished={ onAddFinished }
-			/>
+			<p className="add-sites-modal__subtitle">
+				{ translate( 'Subscribe to sites, newsletters, and RSS feeds.' ) }
+			</p>
+
+			<AddSitesForm onAddFinished={ onAddFinished } />
 		</Modal>
 	);
 };

--- a/client/landing/subscriptions/components/add-sites-modal/styles.scss
+++ b/client/landing/subscriptions/components/add-sites-modal/styles.scss
@@ -1,0 +1,16 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
+
+.add-sites-modal {
+	.components-modal__content {
+		margin-top: 60px;
+	}
+
+	.add-sites-modal__subtitle {
+		color: $studio-gray-50;
+		font-size: $font-body-small;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 20px;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/79236
Closes https://github.com/Automattic/wp-calypso/issues/79237

## Proposed Changes

* Update CTA button and modal layout to match the latest Figma changes
* Add submit button on form
* Display success and error notices
* Add tests

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/read/subscriptions?flags=subscription-management-add-sites-modal
* Click on the "Add a site" button, and you should see the modal
* Add an invalid URL, and you should see an error message
* Add a valid URL, and you should see a validation check
* Click on "Add site"
* Check if a confirmation notice is displayed
* Check if you were subscribed to the site

<img width="592" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/7234263d-b50d-483e-a4c0-b04bbcabad8d">

<img width="592" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/66bba451-b33e-4092-aedd-0d2be7281e8e">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
