### PR TITLE
Upgraded Swiper lib

### DIFF
--- a/packages/design-carousel/package.json
+++ b/packages/design-carousel/package.json
@@ -34,7 +34,7 @@
 		"@automattic/onboarding": "workspace:^",
 		"@tanstack/react-query": "^4.29.1",
 		"classnames": "^2.3.1",
-		"swiper": "^4.5.1",
+		"swiper": "^10.1.0",
 		"tslib": "^2.3.0",
 		"utility-types": "^3.10.0",
 		"wpcom-proxy-request": "workspace:^"

--- a/packages/design-carousel/src/index.tsx
+++ b/packages/design-carousel/src/index.tsx
@@ -5,8 +5,12 @@ import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useRef } from 'react';
 import Swiper from 'swiper';
+import { Navigation, Keyboard, Mousewheel } from 'swiper/modules';
 import { Item } from './item';
-import 'swiper/dist/css/swiper.css';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/keyboard';
+import 'swiper/css/mousewheel';
 import type { Design } from '@automattic/design-picker/src/types';
 
 type DesignCarouselProps = {
@@ -32,7 +36,10 @@ export default function DesignCarousel( {
 			swiperInstance.current = new Swiper( '.swiper-container', {
 				autoHeight: true,
 				mousewheel: true,
-				keyboard: true,
+				keyboard: {
+					enabled: true,
+					onlyInViewport: false,
+				},
 				threshold: 5,
 				slideToClickedSlide: true,
 				slidesPerView: 'auto',
@@ -42,6 +49,7 @@ export default function DesignCarousel( {
 					prevEl: '.design-carousel__carousel-nav-button--back',
 					nextEl: '.design-carousel__carousel-nav-button--next',
 				},
+				modules: [ Navigation, Keyboard, Mousewheel ],
 			} );
 		}
 		return () => {

--- a/packages/design-carousel/src/index.tsx
+++ b/packages/design-carousel/src/index.tsx
@@ -34,6 +34,7 @@ export default function DesignCarousel( {
 	useEffect( () => {
 		if ( selectedDesigns ) {
 			swiperInstance.current = new Swiper( '.swiper-container', {
+				cssMode: true,
 				autoHeight: true,
 				mousewheel: true,
 				keyboard: {

--- a/packages/design-carousel/src/swiper.d.ts
+++ b/packages/design-carousel/src/swiper.d.ts
@@ -1,9 +1,0 @@
-declare module 'swiper' {
-	class Swiper {
-		activeIndex: number;
-		constructor( containerClass: string, options: unknown );
-		destroy(): void;
-	}
-
-	export default Swiper;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -631,7 +631,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     redux: ^4.2.1
-    swiper: ^4.5.1
+    swiper: ^10.1.0
     tslib: ^2.3.0
     typescript: ^5.1.6
     utility-types: ^3.10.0
@@ -13788,15 +13788,6 @@ __metadata:
     domelementtype: ^1.3.0
     entities: ^1.1.1
   checksum: bb710d0a49dbe7b1019e8bf314102495e8894b9da188d00187c0ac52939ded630bc5f9eacc97bfa462d535cd321c734c0b02fefd5e4d93162ab886dccc6666f3
-  languageName: node
-  linkType: hard
-
-"dom7@npm:^2.1.3":
-  version: 2.1.3
-  resolution: "dom7@npm:2.1.3"
-  dependencies:
-    ssr-window: ^1.0.1
-  checksum: 90d099314eede55214f8f8cc431a0551d2abb725dc00d2bc733ff0d8fbff51494efe31a06dbce16de0ff14d04992d00eb7f43bcf103286ea4cfd6f528a793b58
   languageName: node
   linkType: hard
 
@@ -27843,13 +27834,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ssr-window@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "ssr-window@npm:1.0.1"
-  checksum: 760d43afdebcf0a697185e7293e71ef30a7cae2917130718f029a16fbe7721a7299ecf9af981b281fb281eb0f320fd516fe5608c82058f8425e7ec2244adb359
-  languageName: node
-  linkType: hard
-
 "ssr-window@npm:^4.0.0, ssr-window@npm:^4.0.2":
   version: 4.0.2
   resolution: "ssr-window@npm:4.0.2"
@@ -28575,13 +28559,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"swiper@npm:^4.5.1":
-  version: 4.5.1
-  resolution: "swiper@npm:4.5.1"
-  dependencies:
-    dom7: ^2.1.3
-    ssr-window: ^1.0.1
-  checksum: 823a63cb3708edc1958f068756b77fae19b4d4ea873802c3642bd7ae4e37a6753540797dfe148bb2483da0c1d62ded06a9bfe4ba364ecc8be12f7bdaf5636591
+"swiper@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "swiper@npm:10.1.0"
+  checksum: 88bdb25c960f5fce81d7e09909338ca5ac3eb6f2f4b65924565d1f8fe47365f7d5eb7458694befe27f52a651db88dcddc14c4d85609d41e18aad1676a656599e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Related to p1691446658912179-slack-C0Q664T29

## Proposed Changes

* Upgrade Swiper lib to the new v10 (from v4) in the `design-carousel` package.

## Testing Instructions

* Create a new "link in bio" site.
* In the `patterns` step (`/setup/link-in-bio/patterns?siteSlug=<site-slug>`), check that the carousel is still working correctly with the keyboard arrows, mouse wheel, and the arrows on the screen.

![image](https://github.com/Automattic/wp-calypso/assets/3801502/eba04ee8-5467-44d2-8b9c-eaf84b3ff0fc)