### PR TITLE
Stats Improvement: Add focus highlight/style on the global settings icon

### DIFF
--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -19,6 +19,7 @@
 
 		.page-modules-settings-action:focus {
 			box-shadow: 0 0 0 2px var(--color-primary-light);
+			z-index: 0; //fix for left box-shadow being cut off
 		}
 	}
 

--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -18,8 +18,7 @@
 		}
 
 		.page-modules-settings-action:focus {
-			border-radius: 2px;
-			box-shadow: 0 0 0 3px var(--color-primary-light);
+			box-shadow: 0 0 0 2px var(--color-primary-light);
 		}
 	}
 

--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -16,6 +16,11 @@
 			height: 24px;
 			cursor: pointer;
 		}
+
+		.page-modules-settings-action:focus {
+			border-radius: 2px;
+			box-shadow: 0 0 0 3px var(--color-primary-light);
+		}
 	}
 
 	.section-nav__panel {


### PR DESCRIPTION
fixes #78218

## Proposed Changes

* Adds a focus ring to the global settings icon

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit any stats page. Check the on-focus view of the global settings icon on the right side of the navigation bar. 

| Before (on focus)  | After (on focus) |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/30754158/1ac90a5d-fa42-4aa4-8477-c9d7a322a434)  | ![image](https://github.com/Automattic/wp-calypso/assets/30754158/0540d0c5-d31e-4402-97ae-e6af5738b05e)  |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
