### PR TITLE
Hosting Metrics; Remove bold from legends

### DIFF
--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -117,6 +117,10 @@
 			display: none;
 		}
 
+		tr.u-series th {
+			font-weight: 400;
+		}
+
 		// Use increased specificity to override original uPlot styles.
 		> tr.u-series > th {
 			cursor: initial;
@@ -136,5 +140,11 @@
 				vertical-align: baseline;
 			}
 		}
+	}
+}
+
+.site-monitoring-bar-chart {
+	tr.u-series th {
+		font-weight: 400;
 	}
 }


### PR DESCRIPTION
## Proposed Changes

Removes the bold from the legends:

<img width="1291" alt="CleanShot 2023-08-09 at 13 37 59@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/b55a754d-0ea2-4dcb-b445-0aee33cc36a5">


## Testing Instructions

1. Navigate to `/site-monitoring/<site>` and verify the legends are no longer bolded.