### PR TITLE
Fix design setup step reliance on siteSlug

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/domain-upsell.ts
@@ -7,6 +7,7 @@ import {
 	DOMAIN_UPSELL_FLOW,
 } from 'calypso/../packages/onboarding/src';
 import { useQuery } from '../hooks/use-query';
+import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
 import DomainsStep from './internals/steps-repository/domains';
@@ -30,6 +31,7 @@ const domainUpsell: Flow = {
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = useQuery().get( 'flowToReturnTo' );
 		const siteSlug = useSiteSlug();
+		const siteId = useSiteIdParam();
 		const { getDomainCartItem, getPlanCartItem } = useSelect(
 			( select ) => ( {
 				getDomainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem,
@@ -56,9 +58,12 @@ const domainUpsell: Flow = {
 				case 'domains':
 					if ( providedDependencies?.deferDomainSelection ) {
 						try {
-							await updateLaunchpadSettings( siteSlug, {
-								checklist_statuses: { domain_upsell_deferred: true },
-							} );
+							const siteIdentifier = siteSlug || siteId;
+							if ( siteIdentifier ) {
+								await updateLaunchpadSettings( siteIdentifier, {
+									checklist_statuses: { domain_upsell_deferred: true },
+								} );
+							}
 						} catch ( error ) {}
 
 						return window.location.assign( returnUrl );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -488,9 +488,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	async function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
 		setSelectedDesign( _selectedDesign );
 
-		await updateLaunchpadSettings( siteSlug, {
-			checklist_statuses: { design_completed: true },
-		} );
+		if ( siteSlugOrId ) {
+			await updateLaunchpadSettings( siteSlugOrId, {
+				checklist_statuses: { design_completed: true },
+			} );
+		}
 
 		if ( siteSlugOrId && _selectedDesign ) {
 			const positionIndex = designs.findIndex(

--- a/client/my-sites/customer-home/components/share-site-modal.tsx
+++ b/client/my-sites/customer-home/components/share-site-modal.tsx
@@ -23,9 +23,11 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 
 	const copyHandler = async () => {
 		navigator.clipboard.writeText( `https://${ site?.slug }` );
-		await updateLaunchpadSettings( site?.slug || null, {
-			checklist_statuses: { share_site: true },
-		} );
+		if ( site?.slug ) {
+			await updateLaunchpadSettings( site?.slug, {
+				checklist_statuses: { share_site: true },
+			} );
+		}
 		queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );
 		setClipboardCopied( true );
 		setTimeout( () => setClipboardCopied( false ), 3000 );

--- a/client/my-sites/customer-home/components/share-site-modal.tsx
+++ b/client/my-sites/customer-home/components/share-site-modal.tsx
@@ -24,7 +24,7 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 	const copyHandler = async () => {
 		navigator.clipboard.writeText( `https://${ site?.slug }` );
 		if ( site?.slug ) {
-			await updateLaunchpadSettings( site?.slug, {
+			await updateLaunchpadSettings( site.slug, {
 				checklist_statuses: { share_site: true },
 			} );
 		}

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -86,7 +86,7 @@ export const useLaunchpad = (
 };
 
 export const updateLaunchpadSettings = (
-	siteSlug: string | null,
+	siteSlug: string | number,
 	settings: LaunchpadUpdateSettings = {}
 ) => {
 	const slug = encodeURIComponent( siteSlug as string );


### PR DESCRIPTION
Follow up for https://github.com/Automattic/wp-calypso/pull/80112.

The design setup step is currently broken in the sign up flow.

Sadly, TS could have easily caught this bug, but the function was mistyped, it allowed null as a `siteSlug`, even though it is guaranteed to break the network request. 

## Proposed Changes

Now the function only accepts string or number, and whoever consumes it, we'll have to ensure that they have a valid site ID or slug.

To reproduce
1. you can visit this URL: /setup/site-setup/designSetup?siteId=YOUR_SIMPLE_SITE_ID&notice=purchase-success&theme=loudness&font_variation_title=Space+Mono+%2B+Roboto
2. Click continue, it will fail silently.

## Testing Instructions

Visit the same link but using the Calypso live.
