### PR TITLE
Stats Improvement: Add focus highlight/style to the dual choice popover

### DIFF
--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -220,6 +220,9 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 			box-sizing: border-box;
 			border-radius: 5px; // stylelint-disable-line scales/radii
 		}
+		button:focus {
+			box-shadow: 0 0 0 2px var(--color-primary-light);
+		}
 	}
 
 	// Modules settings popover


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78217

## Proposed Changes

* Adds a focus ring to the dual choice popover options
* Note: this does not address the fact that the settings icon comes at an unusual location in the accessibility focus flow. That will be addressed in a followup PR

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* * Visit any stats page. Check the on-focus view of the dual choice popover options on the right side of the navigation bar. 

| Before (on focus)  | After (on focus) |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/30754158/7e5acf36-b7ff-4a97-b7b1-aa63a603e5c5) | ![image](https://github.com/Automattic/wp-calypso/assets/30754158/eacd451d-271e-4a73-99b1-b3f8d6e1cfe4)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
