### PR TITLE
Migration Trial: Change the space limit to 50GB

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/hooks/use-unsupported-trial-feature-list.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/hooks/use-unsupported-trial-feature-list.ts
@@ -7,7 +7,7 @@ export default function useUnsupportedTrialFeatureList() {
 		__( 'Your site will be unpublished' ),
 		__( 'No custom domains' ),
 		__( 'No SSH or SFTP access' ),
-		__( 'Limit of 200GB' ),
+		__( 'Limit of 50GB' ),
 		__( 'Limit of 100 subscribers' ),
 	];
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/dotcom-forge#3400

## Proposed Changes

* Change the wording of limit space to 50GB for migration trial limitation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare a simple site and navigate to `http://calypso.localhost:3000/setup/import-focused/migrationTrial?siteSlug={target_site}&from={source_site}&option=everything. See if it shows limit of 50GB on the screen. 

![Screen Shot 2023-08-10 at 11 13 54 AM](https://github.com/Automattic/wp-calypso/assets/4074459/ea84b078-34bc-4bb5-8b8f-8007376d1b33)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
