### PR TITLE
Revert "Fix theme details crash"

### DIFF
--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -9,6 +9,7 @@ import {
 	mergeBaseAndUserConfigs,
 	withExperimentalBlockEditorProvider,
 } from '../../gutenberg-bridge';
+import { useRegisterCoreBlocks } from '../../hooks';
 import GlobalStylesVariationPreview from './preview';
 import type { GlobalStylesObject } from '../../types';
 import './style.scss';
@@ -108,6 +109,7 @@ const GlobalStylesVariations = ( {
 	displayFreeLabel = true,
 	globalStylesInPersonalPlan,
 }: GlobalStylesVariationsProps ) => {
+	const isRegisteredCoreBlocks = useRegisterCoreBlocks();
 	const premiumStylesDescription = globalStylesInPersonalPlan
 		? translate(
 				'Unlock custom styles and tons of other features with the Personal plan, or try them out now for free.'
@@ -145,6 +147,10 @@ const GlobalStylesVariations = ( {
 	);
 
 	const headerText = splitDefaultVariation ? translate( 'Default Style' ) : translate( 'Styles' );
+
+	if ( ! isRegisteredCoreBlocks ) {
+		return null;
+	}
 
 	return (
 		<GlobalStylesContext.Provider value={ { base: baseGlobalStyles } }>


### PR DESCRIPTION
Reverts Automattic/wp-calypso#80375

We found out that only Zaino theme crashes the theme details page so we have delisted it and will investigate what's happening with its blocks and styles.

