### PR TITLE
Revert "Fix design picker crash"

### DIFF
--- a/packages/global-styles/src/components/global-styles-provider/index.tsx
+++ b/packages/global-styles/src/components/global-styles-provider/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback } from 'react';
 import { DEFAULT_GLOBAL_STYLES } from '../../constants';
 import { GlobalStylesContext, mergeBaseAndUserConfigs } from '../../gutenberg-bridge';
-import { useGetGlobalStylesBaseConfig } from '../../hooks';
+import { useGetGlobalStylesBaseConfig, useRegisterCoreBlocks } from '../../hooks';
 import type { GlobalStylesObject, SetConfig, SetConfigCallback } from '../../types';
 
 const cleanEmptyObject = < T extends Record< string, unknown > >( object: T | unknown ) => {
@@ -85,8 +85,9 @@ interface Props {
 
 const GlobalStylesProvider = ( { siteId, stylesheet, children, placeholder = null }: Props ) => {
 	const context = useGlobalStylesContext( siteId, stylesheet );
+	const isBlocksRegistered = useRegisterCoreBlocks();
 
-	if ( ! context.isReady ) {
+	if ( ! context.isReady || ! isBlocksRegistered ) {
 		return placeholder;
 	}
 	return (


### PR DESCRIPTION
Reverts Automattic/wp-calypso#80384

We found out that only Zaino theme crashes the design picker so we have delisted it and will investigate what's happening with its blocks and styles.