### PR TITLE
BBE: update copy and hide categories on design picker step

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -388,8 +388,7 @@ export default function DesignPickerStep( props ) {
 			{ ...props }
 			className={ classnames( {
 				'design-picker__has-categories': showDesignPickerCategories,
-				'design-picker__sell-intent': 'sell' === intent,
-				'design-picker__hide-category-column': useDIFMThemes,
+				'design-picker__hide-category-column': useDIFMThemes || 'sell' === intent,
 			} ) }
 			{ ...headerProps }
 			stepContent={ renderDesignPicker() }

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -6,7 +6,7 @@ import DesignPicker, {
 	useCategorization,
 	useThemeDesignsQuery,
 } from '@automattic/design-picker';
-import { englishLocales } from '@automattic/i18n-utils';
+import { englishLocales, translationExists } from '@automattic/i18n-utils';
 import { shuffle } from '@automattic/js-utils';
 import { useViewportMatch } from '@wordpress/compose';
 import classnames from 'classnames';
@@ -42,6 +42,7 @@ export default function DesignPickerStep( props ) {
 		hideDesignTitle,
 		hideDescription,
 		hideBadge,
+		useDIFMThemes,
 		signupDependencies: dependencies,
 	} = props;
 
@@ -58,10 +59,9 @@ export default function DesignPickerStep( props ) {
 	const [ selectedDesign, setSelectedDesign ] = useState( null );
 	const scrollTop = useRef( 0 );
 
-	const isDIFMStoreFlow = 'do-it-for-me-store' === props.flowName;
-
 	const getThemeFilters = () => {
-		if ( props.useDIFMThemes ) {
+		if ( useDIFMThemes ) {
+			const isDIFMStoreFlow = 'do-it-for-me-store' === props.flowName;
 			return isDIFMStoreFlow ? 'do-it-for-me-store' : 'do-it-for-me';
 		}
 
@@ -305,6 +305,10 @@ export default function DesignPickerStep( props ) {
 			);
 		}
 
+		if ( useDIFMThemes && translationExists( 'Select a theme to suggest a style.' ) ) {
+			return translate( 'Select a theme to suggest a style.' );
+		}
+
 		const text = translate( 'Choose a starting theme. You can change it later.' );
 
 		if ( englishLocales.includes( translate.localeSlug ) ) {
@@ -384,7 +388,8 @@ export default function DesignPickerStep( props ) {
 			{ ...props }
 			className={ classnames( {
 				'design-picker__has-categories': showDesignPickerCategories,
-				'design-picker__sell-intent': 'sell' === intent || isDIFMStoreFlow,
+				'design-picker__sell-intent': 'sell' === intent,
+				'design-picker__hide-category-column': useDIFMThemes,
 			} ) }
 			{ ...headerProps }
 			stepContent={ renderDesignPicker() }

--- a/client/signup/steps/design-picker/let-us-choose.tsx
+++ b/client/signup/steps/design-picker/let-us-choose.tsx
@@ -1,3 +1,4 @@
+import { translationExists } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -49,13 +50,17 @@ const LetUsChoose = ( { flowName, designs, onSelect }: Props ) => {
 		} );
 	}
 
+	const title = translationExists(
+		"Can't decide? No problem, we can create the perfect design for your site!"
+	)
+		? translate( "Can't decide? No problem, we can create the perfect design for your site!" )
+		: translate(
+				"Can't decide? No problem, our experts can choose the perfect design for your site!"
+		  );
+
 	return (
 		<LetUsChooseContainer>
-			<div>
-				{ translate(
-					"Can't decide? No problem, our experts can choose the perfect design for your site!"
-				) }
-			</div>
+			<div>{ title }</div>
 			<LetUsChooseButton variant="secondary" onClick={ onClick }>
 				{ translate( 'Let us choose' ) }
 			</LetUsChooseButton>

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -111,7 +111,6 @@
 }
 
 /* Hide categories from the sell intent */
-.design-picker__sell-intent,
 .design-picker__hide-category-column {
 	.design-picker-category-filter__sidebar,
 	.design-picker-category-filter__dropdown,

--- a/client/signup/steps/design-picker/style.scss
+++ b/client/signup/steps/design-picker/style.scss
@@ -111,7 +111,8 @@
 }
 
 /* Hide categories from the sell intent */
-.design-picker__sell-intent {
+.design-picker__sell-intent,
+.design-picker__hide-category-column {
 	.design-picker-category-filter__sidebar,
 	.design-picker-category-filter__dropdown,
 	.design-picker__category-heading-0 {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdh1Xd-2hj-p2

## Proposed Changes

These changes are visible in the design picker step only in the BBE (formerly DIFM) flow.
* Hide the categories column based on `useDIFMThemes` prop.
* Change the subheader text, and show the new text only if the translation exists.
* Change the "Let us choose" text and show the new text only if the translation exists.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`.
* Go through the flow till you reach the design picker step.
* Confirm that the subheader text has been updated.
* Confirm that the "Let us choose" text has been updated.
* Confirm that the category list is not visible.

<img width="643" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/6ecd7582-e22c-4741-90cf-a0fa8e01b697">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?