### PR TITLE
Fix Theme Details Crash - Zaino - Use style blocks default in base global styles context

### DIFF
--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -3,7 +3,7 @@ import { ENTER } from '@wordpress/keycodes';
 import classnames from 'classnames';
 import { translate, TranslateResult } from 'i18n-calypso';
 import { useMemo, useContext } from 'react';
-import { DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from '../../constants';
+import { DEFAULT_GLOBAL_STYLES_VARIATION_SLUG, DEFAULT_GLOBAL_STYLES } from '../../constants';
 import {
 	GlobalStylesContext,
 	mergeBaseAndUserConfigs,
@@ -48,10 +48,11 @@ const GlobalStylesVariation = ( {
 	const context = useMemo( () => {
 		const { inline_css: globalStylesVariationInlineCss = '' } = globalStylesVariation;
 		const baseInlineCss = base.inline_css || '';
+		const baseStyles = base.styles || DEFAULT_GLOBAL_STYLES.styles;
 		return {
 			user: globalStylesVariation,
 			base,
-			merged: mergeBaseAndUserConfigs( base, globalStylesVariation ),
+			merged: mergeBaseAndUserConfigs( { ...base, styles: baseStyles }, globalStylesVariation ),
 			inline_css: baseInlineCss + globalStylesVariationInlineCss,
 		};
 	}, [ globalStylesVariation, base ] );

--- a/packages/global-styles/src/constants.ts
+++ b/packages/global-styles/src/constants.ts
@@ -12,5 +12,7 @@ export const SYSTEM_FONT_SLUG = 'system-font';
 
 export const DEFAULT_GLOBAL_STYLES = {
 	settings: {},
-	styles: {},
+	styles: {
+		blocks: {},
+	},
 };

--- a/packages/global-styles/src/types.ts
+++ b/packages/global-styles/src/types.ts
@@ -49,6 +49,9 @@ export interface GlobalStylesObject {
 			};
 		};
 		typography?: Typography;
+		blocks?: {
+			[ key: string ]: unknown;
+		};
 	};
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/80413 https://github.com/Automattic/wp-calypso/pull/80414

## Proposed Changes

* Fix Theme Details Crash with Zaino theme
* Use style blocks default in base global styles context

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Using the Calypso live link in the comment above
* Access Zaino theme detail `wordpress.com/theme/zaino/{ YOUR SITE }`
* Verify the page is not blank, it doesn't crash 

|BEFORE|AFTER|
|--|--|
|<img width="1268" alt="Screenshot 2566-08-10 at 14 35 50" src="https://github.com/Automattic/wp-calypso/assets/1881481/6a3d768c-8815-4456-8b11-39fdfd1df251">|<img width="1268" alt="Screenshot 2566-08-10 at 14 36 21" src="https://github.com/Automattic/wp-calypso/assets/1881481/0e639553-3cd5-432c-bdfe-33cb94cda00c">| 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
