### PR TITLE
Update Congrats page footer for P2 plus plans

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/Footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/Footer.tsx
@@ -1,7 +1,7 @@
 import { isP2Plus } from '@automattic/calypso-products';
 import { isBulkDomainTransfer } from '../../utils';
 import BulkDomainTransferFooter from './footer/BulkDomainTransferFooter';
-import P2PlanFooter from './footer/P2PlanFooter';
+import P2PlusPlanFooter from './footer/P2PlusPlanFooter';
 import PlanFooter from './footer/PlanFooter';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
@@ -11,7 +11,7 @@ const Footer = ( { purchases }: { purchases: ReceiptPurchase[] } ) => {
 	}
 
 	if ( purchases.some( isP2Plus ) ) {
-		return <P2PlanFooter />;
+		return <P2PlusPlanFooter />;
 	}
 
 	return <PlanFooter />;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/Footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/Footer.tsx
@@ -1,11 +1,17 @@
+import { isP2Plus } from '@automattic/calypso-products';
 import { isBulkDomainTransfer } from '../../utils';
 import BulkDomainTransferFooter from './footer/BulkDomainTransferFooter';
+import P2PlanFooter from './footer/P2PlanFooter';
 import PlanFooter from './footer/PlanFooter';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
 const Footer = ( { purchases }: { purchases: ReceiptPurchase[] } ) => {
 	if ( isBulkDomainTransfer( purchases ) ) {
 		return <BulkDomainTransferFooter />;
+	}
+
+	if ( purchases.some( isP2Plus ) ) {
+		return <P2PlanFooter />;
 	}
 
 	return <PlanFooter />;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/P2PlanFooter.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/P2PlanFooter.tsx
@@ -1,0 +1,37 @@
+import { translate } from 'i18n-calypso';
+import PurchaseDetail from 'calypso/components/purchase-detail';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSelector } from 'calypso/state';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const P2PlanFooter = () => {
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+
+	return (
+		<div>
+			<PurchaseDetail
+				title={ translate( 'Go further, together' ) }
+				description={ translate(
+					'Invite people to the P2 to create a fully interactive work environment and start getting better results.'
+				) }
+				buttonText={ translate( 'Add members' ) }
+				href={ `/people/new/${ siteSlug }` }
+				onClick={ () => recordTracksEvent( 'calypso_plan_thank_you_add_members_click' ) }
+			/>
+
+			<PurchaseDetail
+				title={ translate( 'Everything you need to know' ) }
+				description={ translate(
+					'Explore our support guides and find an answer to every question.'
+				) }
+				buttonText={ translate( 'Explore support resources' ) }
+				href="/support"
+				onClick={ () => recordTracksEvent( 'calypso_plan_thank_you_support_click' ) }
+			/>
+		</div>
+	);
+};
+
+export default P2PlanFooter;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/P2PlusPlanFooter.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/P2PlusPlanFooter.tsx
@@ -5,7 +5,7 @@ import { useSelector } from 'calypso/state';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-const P2PlanFooter = () => {
+const P2PlusPlanFooter = () => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
@@ -34,4 +34,4 @@ const P2PlanFooter = () => {
 	);
 };
 
-export default P2PlanFooter;
+export default P2PlusPlanFooter;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3405

## Proposed Changes

* Since the P2s don't have the themes in their sidebar menu, we're changing it to something more relevant

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/02291ad8-7bbc-4ec7-833a-adffff8cd91b">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/c92933b4-ae5a-406e-ad83-c6b8ab9718e4">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a P2 plus plan
* Test for screen sizes
* See if tracks event `calypso_plan_thank_you_add_members_click` is logged

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?