### PR TITLE
Importers: add filesize range to error tracks event

### DIFF
--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -60,6 +60,30 @@ const importerComponents = {
 const getImporterTypeForEngine = ( engine ) => `importer-type-${ engine }`;
 
 /**
+ * Turns filesize into a range divided by 100MB, so that we dont'need to track specific filesizes in Tracks.
+ *
+ * For example:
+ * 0mb   = 0—100MB (1 chunk)
+ * 85mb   = 0—100MB (1 chunk)
+ * 100mb  = 100—200MB (2 chunks)
+ * 110mb  = 100—200MB (2 chunks)
+ * 350mb  = 300—400MB (4 chunks)
+ */
+const bytesToFilesizeRange = ( bytes ) => {
+	const megabytes = parseInt( bytes / ( 1024 * 1024 ) );
+	const maxChunk = 100;
+
+	// How many full chunks can fit into our megabytes?
+	const chunks = Math.floor( megabytes / maxChunk );
+
+	const min = chunks * 100;
+	const max = min + maxChunk;
+
+	// Range of mbs where the filesize fits
+	return `${ min }—${ max }MB`;
+};
+
+/**
  * The minimum version of the Jetpack plugin required to use the Jetpack Importer API.
  */
 const JETPACK_IMPORT_MIN_PLUGIN_VERSION = '12.1';
@@ -102,6 +126,9 @@ class SectionImport extends Component {
 				eventProps = {
 					error_code: importItem.errorData.code,
 					error_type: importItem.errorData.type,
+					filesize_range: importItem.file?.size
+						? bytesToFilesizeRange( importItem.file.size )
+						: null,
 				};
 			}
 

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -139,14 +139,15 @@ export class UploadingPane extends PureComponent {
 			this.props.failPreUpload(
 				importerStatus.importerId,
 				'',
-				WPImportError.WPRESS_FILE_IS_NOT_SUPPORTED
+				WPImportError.WPRESS_FILE_IS_NOT_SUPPORTED,
+				file
 			);
 			return;
 		}
 
 		// Fail fast if a user tries to upload a too big file
 		if ( file.size > MAX_FILE_SIZE ) {
-			this.props.failPreUpload( importerStatus.importerId, '', FileTooLarge.FILE_TOO_LARGE );
+			this.props.failPreUpload( importerStatus.importerId, '', FileTooLarge.FILE_TOO_LARGE, file );
 			return;
 		}
 

--- a/client/state/imports/actions.js
+++ b/client/state/imports/actions.js
@@ -257,9 +257,10 @@ export const startUpload =
 			} );
 	};
 
-export const failPreUpload = ( importerId, message, code ) => ( {
+export const failPreUpload = ( importerId, message, code, file ) => ( {
 	type: IMPORTS_PRE_UPLOAD_FAILED,
 	importerId,
 	error: message,
 	errorCode: code,
+	file,
 } );

--- a/client/state/imports/reducer.js
+++ b/client/state/imports/reducer.js
@@ -58,6 +58,7 @@ function importerStatus( state = {}, action ) {
 					...state[ action.importerId ],
 					importerState: appStates.UPLOAD_FAILURE,
 					errorData: { type: 'preUploadError', description: action.error, code: action.errorCode },
+					file: action.file,
 				},
 			};
 


### PR DESCRIPTION
A follow up to https://github.com/Automattic/wp-calypso/pull/80242

Adds filesize range to Tracks event to track "file too large" more closely.

## Proposed Changes

* Add file-size range (in 100mbs) to the Tracks event.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In calypso you can see tracks events e.g. by entering `localStorage.debug="calypso:analytics"` in console and reloading.
* Go `/importers` and pick one.
* Upload too big file. Observe the event has the range correctly:

<img width="753" alt="Screenshot 2023-08-10 at 11 20 53" src="https://github.com/Automattic/wp-calypso/assets/87168/d69a203b-6979-40f7-ab22-6f29ce223056">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
