### PR TITLE
Update copy for transaction fee feature under Business and Commerce plans

### DIFF
--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -276,6 +276,9 @@ import {
 	FEATURE_PAYMENT_TRANSACTION_FEES_4,
 	FEATURE_PAYMENT_TRANSACTION_FEES_2,
 	FEATURE_PAYMENT_TRANSACTION_FEES_0,
+	FEATURE_PAYMENT_TRANSACTION_FEES_0_WOO,
+	FEATURE_PAYMENT_TRANSACTION_FEES_0_ALL,
+	FEATURE_PAYMENT_TRANSACTION_FEES_2_REGULAR,
 	FEATURE_PREMIUM_STORE_THEMES,
 	FEATURE_STORE_DESIGN,
 	FEATURE_UNLIMITED_PRODUCTS,
@@ -1745,6 +1748,38 @@ export const FEATURES_LIST: FeatureList = {
 		getDescription: () =>
 			i18n.translate( 'Credit card fees are applied in addition to commission fees for payments.' ),
 		getAlternativeTitle: () => '0%',
+		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
+	},
+	[ FEATURE_PAYMENT_TRANSACTION_FEES_0_WOO ]: {
+		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_0_WOO,
+		getTitle: () =>
+			i18n.translate( '%(commission)d%% transaction fee for WooCommerce payment features', {
+				args: { commission: 0 },
+			} ),
+		getDescription: () =>
+			i18n.translate( 'Credit card fees are applied in addition to commission fees for payments.' ),
+		getAlternativeTitle: () => '0%',
+	},
+	[ FEATURE_PAYMENT_TRANSACTION_FEES_0_ALL ]: {
+		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_0_ALL,
+		getTitle: () =>
+			i18n.translate( '%(commission)d%% transaction fee for all payment features', {
+				args: { commission: 0 },
+			} ),
+		getDescription: () =>
+			i18n.translate( 'Credit card fees are applied in addition to commission fees for payments.' ),
+		getAlternativeTitle: () => '0%',
+		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
+	},
+	[ FEATURE_PAYMENT_TRANSACTION_FEES_2_REGULAR ]: {
+		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_2_REGULAR,
+		getTitle: () =>
+			i18n.translate( '%(commission)d%% transaction fee for regular payment features', {
+				args: { commission: 2 },
+			} ),
+		getDescription: () =>
+			i18n.translate( 'Credit card fees are applied in addition to commission fees for payments.' ),
+		getAlternativeTitle: () => '2%',
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_50GB_STORAGE_ADD_ON ]: {

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -302,6 +302,9 @@ export const FEATURE_PAYMENT_TRANSACTION_FEES_8 = 'payment-transaction-fees-8';
 export const FEATURE_PAYMENT_TRANSACTION_FEES_4 = 'payment-transaction-fees-4';
 export const FEATURE_PAYMENT_TRANSACTION_FEES_2 = 'payment-transaction-fees-2';
 export const FEATURE_PAYMENT_TRANSACTION_FEES_0 = 'payment-transaction-fees-0';
+export const FEATURE_PAYMENT_TRANSACTION_FEES_0_WOO = 'payment-transaction-fees-0-woo';
+export const FEATURE_PAYMENT_TRANSACTION_FEES_0_ALL = 'payment-transaction-fees-0-all';
+export const FEATURE_PAYMENT_TRANSACTION_FEES_2_REGULAR = 'payment-transaction-fees-2-regular';
 export const FEATURE_GROUP_PAYMENT_TRANSACTION_FEES = 'payment-transaction-fees-group';
 export const FEATURE_THE_READER = 'the-reader';
 

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -413,6 +413,9 @@ import {
 	PLAN_MIGRATION_TRIAL_MONTHLY,
 	FEATURE_PAYMENT_BUTTONS_JP,
 	FEATURE_PAYPAL_JP,
+	FEATURE_PAYMENT_TRANSACTION_FEES_0_ALL,
+	FEATURE_PAYMENT_TRANSACTION_FEES_2_REGULAR,
+	FEATURE_PAYMENT_TRANSACTION_FEES_0_WOO,
 } from './constants';
 import type {
 	BillingTerm,
@@ -1032,7 +1035,10 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_STREAMLINED_CHECKOUT,
 		FEATURE_SELL_60_COUNTRIES,
 		FEATURE_SHIPPING_INTEGRATIONS,
-		FEATURE_PAYMENT_TRANSACTION_FEES_0,
+		i18n.hasTranslation( '%(commission)d%% transaction fee for all payment features' ) ||
+		[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
+			? FEATURE_PAYMENT_TRANSACTION_FEES_0_ALL
+			: FEATURE_PAYMENT_TRANSACTION_FEES_0,
 	],
 	get2023PricingGridSignupJetpackFeatures: () => [],
 	get2023PricingGridSignupStorageOptions: ( showLegacyStorageFeature, isCurrentPlan ) => {
@@ -1619,7 +1625,13 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_SITE_STAGING_SITES,
 		FEATURE_WP_UPDATES,
 		FEATURE_MULTI_SITE,
-		FEATURE_PAYMENT_TRANSACTION_FEES_2,
+		...( ( i18n.hasTranslation(
+			'%(commission)d%% transaction fee for WooCommerce payment features'
+		) &&
+			i18n.hasTranslation( '%(commission)d%% transaction fee for regular payment features' ) ) ||
+		[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
+			? [ FEATURE_PAYMENT_TRANSACTION_FEES_0_WOO, FEATURE_PAYMENT_TRANSACTION_FEES_2_REGULAR ]
+			: [ FEATURE_PAYMENT_TRANSACTION_FEES_2 ] ),
 	],
 	get2023PricingGridSignupJetpackFeatures: () => [
 		FEATURE_REALTIME_BACKUPS_JP,


### PR DESCRIPTION
## Proposed Changes

More info: p1691054228911529?
thread_ts=1689907028.495739-slack-C029GN3KD

WPCOM equivalent: D118573-code

This changes the copy for the transaction fee feature for Business and Commerce plans to be more specific:
**Business**
- 2% transaction fee for regular payment features
- 0% transaction fee for WooCommerce payment features

**Commerce**
- 0% transaction fee for all payment features

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/start/plans` and `/plans/{SITE_ID}` in an English locale
* You should see the changed transaction fee feature copy under the Business and Commerce plans

<img width="360" alt="Screenshot 2023-08-10 at 12 02 51" src="https://github.com/Automattic/wp-calypso/assets/2749938/83d940a1-6042-46aa-98f0-06145c9ed862">
<img width="360" alt="Screenshot 2023-08-10 at 12 02 14" src="https://github.com/Automattic/wp-calypso/assets/2749938/a43959fe-df9f-4d58-a18c-522c6227637e">


* Switch account to non-English (untranslated) language
* Copy changes should not be visible
<img width="360" alt="Screenshot 2023-08-10 at 12 03 44" src="https://github.com/Automattic/wp-calypso/assets/2749938/b6cc8f46-046b-4670-a3e7-42f2365f46bc">
<img width="360" alt="Screenshot 2023-08-10 at 12 03 32" src="https://github.com/Automattic/wp-calypso/assets/2749938/a7dd6f40-ab34-4098-8ed3-becea2ee1f59">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
