### PR TITLE
Logged Out Theme Showcase: Fix Pricing Dropdown Font Size

### DIFF
--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -170,7 +170,6 @@
 			.select-dropdown__header {
 				border-width: 0;
 				color: #575d63;
-				font-size: 1rem;
 				line-height: 1.5;
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Restore the LoTS pricing dropdown font size to the default `.875rem`,

| Before | After |
|--------|--------|
| <img width="490" alt="Screenshot 2023-08-10 at 11 25 03" src="https://github.com/Automattic/wp-calypso/assets/2070010/7a9833da-214d-49cc-b3bf-74544ace9889"> | <img width="490" alt="Screenshot 2023-08-10 at 11 25 00" src="https://github.com/Automattic/wp-calypso/assets/2070010/f11d32a3-750c-4447-8ef0-04745cae1f42"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Logged Out Theme Showcase at https://wordpress.com/themes (logged-out, obviously).
* Look at the "View: All" dropdown, and ensure the font size is 0.875rem.
