### PR TITLE
Theme showcase: Reset query page after changing category

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -442,7 +442,8 @@ class ThemesSelectionWithPage extends React.Component {
 			nextProps.search !== this.props.search ||
 			nextProps.tier !== this.props.tier ||
 			nextProps.filter !== this.props.filter ||
-			nextProps.vertical !== this.props.vertical
+			nextProps.vertical !== this.props.vertical ||
+			nextProps.tabFilter !== this.props.tabFilter
 		) {
 			this.resetPage();
 		}


### PR DESCRIPTION
## Proposed Changes

Fixes a bug that was causing the themes query to use the last page of the previously active category.

## Testing Instructions

- Open the Calypso live link below in a incognito window
- Observe the requests in the network tab of the browser devtools
- Go to `/themes`
- Make sure there are requests for `page=1` and `page=2`.
- Make sure you see all curated themes.
- Switch to All.
- Make sure there are requests for `page=1` and `page=2`.
- Make sure you see the same curated themes followed by all non-curated themes.
- Reload the browser while in the All category.
- Switch to Recommended.
- Make sure there are requests for `page=1` and `page=2`.
- Make sure you see all curated themes.