### PR TITLE
Domain Redirects: Updated call to match backend API

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-redirect-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-redirect-card.tsx
@@ -154,7 +154,8 @@ const connector = connect(
 				( redirect?.targetHost ?? '_invalid_.domain' );
 			const url = new URL( path, origin );
 			if ( url.hostname !== '_invalid_.domain' ) {
-				targetUrl = url.hostname + url.pathname + url.search + url.hash;
+				targetUrl =
+					url.hostname + ( url.pathname === '/' ? '' : url.pathname ) + url.search + url.hash;
 			}
 		} catch ( e ) {
 			// ignore

--- a/client/state/domains/domain-redirects/actions.js
+++ b/client/state/domains/domain-redirects/actions.js
@@ -23,14 +23,14 @@ export const fetchDomainRedirect = ( domain ) => ( dispatch ) => {
 	dispatch( { type: DOMAINS_REDIRECT_FETCH, domain } );
 
 	wpcom.req.get( { path: '/sites/all/domain/' + domain + '/redirects' } ).then(
-		( { target_host, target_path, forward_paths, secure } ) => {
+		( { target_host, target_path, forward_paths, is_secure } ) => {
 			dispatch( {
 				type: DOMAINS_REDIRECT_FETCH_COMPLETED,
 				domain,
 				targetHost: target_host,
 				targetPath: target_path,
 				forwardPaths: forward_paths,
-				secure: secure ? true : false,
+				is_secure: is_secure ? true : false,
 			} );
 		},
 		( error ) => {
@@ -48,13 +48,19 @@ export const fetchDomainRedirect = ( domain ) => ( dispatch ) => {
 };
 
 export const updateDomainRedirect =
-	( domain, targetHost, targetPath, forwardPaths, secure ) => ( dispatch ) => {
+	( domain, targetHost, targetPath, forwardPaths, isSecure ) => ( dispatch ) => {
 		dispatch( { type: DOMAINS_REDIRECT_UPDATE, domain } );
 
 		return wpcom.req
 			.post(
 				{ path: '/sites/all/domain/' + domain + '/redirects' },
-				{ target_host: targetHost, target_path: targetPath, forward_paths: forwardPaths, secure }
+				{
+					target_host: targetHost,
+					target_path: targetPath,
+					is_secure: isSecure,
+					forward_paths: true, // Always permanent on v1
+					is_permanent: true, // Always permanent on v1
+				}
 			)
 			.then(
 				( data ) => {
@@ -65,7 +71,7 @@ export const updateDomainRedirect =
 							targetHost,
 							targetPath,
 							forwardPaths,
-							secure,
+							isSecure,
 							success: i18n.translate( 'The redirect settings were updated successfully.' ),
 						} );
 						return true;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Task-related: 3437-gh-Automattic/dotcom-forge

Please apply this patch to test it: D118535-code

TODO:

Fix issue when trying to save an option without changing content:

![image](https://github.com/Automattic/wp-calypso/assets/1044309/19ff3875-c099-48c3-9930-125f33db390a)



## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?