### PR TITLE
Migration trial: hide "Use the content-only import" option

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
@@ -7,8 +7,9 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { convertToFriendlyWebsiteName } from 'calypso/blocks/import/util';
-import { URL } from 'calypso/types';
+import useCheckEligibilityMigrationTrialPlan from 'calypso/data/plans/use-check-eligibility-migration-trial-plan';
 import ConfirmUpgradePlan from './../confirm-upgrade-plan';
+import type { URL } from 'calypso/types';
 
 interface Props {
 	sourceSiteSlug: string;
@@ -32,6 +33,10 @@ export const PreMigrationUpgradePlan: React.FunctionComponent< Props > = ( props
 		onContentOnlyClick,
 		isBusy,
 	} = props;
+	const { data: migrationTrialEligibility } = useCheckEligibilityMigrationTrialPlan(
+		targetSite.slug
+	);
+	const isEligibleForTrialPlan = migrationTrialEligibility?.eligible;
 
 	return (
 		<div

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
@@ -79,13 +79,15 @@ export const PreMigrationUpgradePlan: React.FunctionComponent< Props > = ( props
 						{ translate( 'Try it for free' ) }
 					</Button>
 				) }
-				<Button
-					borderless={ true }
-					className="action-buttons__borderless"
-					onClick={ onContentOnlyClick }
-				>
-					{ translate( 'Use the content-only import option' ) }
-				</Button>
+				{ ! isEligibleForTrialPlan && (
+					<Button
+						borderless={ true }
+						className="action-buttons__borderless"
+						onClick={ onContentOnlyClick }
+					>
+						{ translate( 'Use the content-only import option' ) }
+					</Button>
+				) }
 			</div>
 		</div>
 	);

--- a/client/data/plans/use-check-eligibility-migration-trial-plan.ts
+++ b/client/data/plans/use-check-eligibility-migration-trial-plan.ts
@@ -1,0 +1,25 @@
+import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import type { SiteSlug, SiteId } from 'calypso/types';
+
+interface Response {
+	blog_id: SiteId;
+	eligible: boolean;
+	message: string;
+}
+
+const useCheckEligibilityMigrationTrialPlan = (
+	siteSlug: SiteSlug
+): UseQueryResult< Response > => {
+	return useQuery( {
+		queryKey: [ 'check_eligibility_wp_bundle_migration_trial_monthly', siteSlug ],
+		queryFn: () =>
+			wpcom.req.get( {
+				path: `/sites/${ siteSlug }/hosting/trial/check-eligibility/${ PLAN_MIGRATION_TRIAL_MONTHLY }`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+	} );
+};
+
+export default useCheckEligibilityMigrationTrialPlan;


### PR DESCRIPTION
Closes #80426

## Proposed Changes

* Hide "Use the content-only import" option when user is eligible for trying trial plan

## Testing Instructions

* Go to `/setup/import-focused/importerWordpress?siteSlug={SITE_SLUG}&from={JN_SITE}&option=everything`
* If the logged-in user is eligible for trying trial, "content only" option should be hidden

<img width="741" alt="Screenshot 2023-08-10 at 17 08 27" src="https://github.com/Automattic/wp-calypso/assets/1241413/24d0868c-5314-4e1f-939d-25c10d2d882a">
<img width="765" alt="Screenshot 2023-08-10 at 13 23 49" src="https://github.com/Automattic/wp-calypso/assets/1241413/1959ea1a-f3bd-482e-a323-8c6eb31cca7f">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
