### PR TITLE
Design Picker: Fix Button Shrinking and Menu Not Collapsing

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -24,12 +24,14 @@
 
 	.design-picker__filters {
 		display: flex;
+		justify-content: space-between;
 
 		.design-picker__category-filter {
-			flex: 1;
+			flex: 0.85;
 		}
 
 		.design-picker__design-your-own-button {
+			flex-shrink: 0;
 			height: 32px;
 			line-height: 14px;
 			margin-top: 9px;


### PR DESCRIPTION
## Proposed Changes

* Fix the "Design your own" button shrinking caused by the categories menu not collapsing when needed.

This is a tentative fix, as it's not clear to me what causes it.

The button gains a new `flex-shrink: 0` to prevent its shrinkage, which should be a non-controversial change.

The menu gains a smaller `flex-grow` value (from 1 to 0.85), which, in my tests, should be enough to correct the interplay with the button.
For some reason, anything above 0.85 is identical to 1.

The issue became visible earlier today, when we merged the new (much longer) category list.
This fix is really just a workaround, but I couldn't figure out how to make the menu collapse when needed. It's as if the calculations only happen at load and sometimes when resizing, but not always.

| Before | After |
|--------|--------|
| <img width="1262" alt="Screenshot 2023-08-10 at 16 00 01" src="https://github.com/Automattic/wp-calypso/assets/2070010/bccf1e82-6aa0-4fc5-bf98-8cddf84cb7f1"> | <img width="1262" alt="Screenshot 2023-08-10 at 16 00 04" src="https://github.com/Automattic/wp-calypso/assets/2070010/d38b3750-55f1-49da-a670-0b157c7fdc87"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Design Picker (`/setup/site-setup/designSetup?siteSlug={ SITE }`).
* Look at the category list and "Design your own" button.
* Resize the window.
* Ensure the button does not shrink.
* Ensure the list collapses when needed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
