### PR TITLE
Design Picker: Query all themes (including Marketplace themes)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -317,7 +317,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	// ********** Logic for unlocking a selected premium design
 
-	useQueryThemes( 'wpcom', { tier: '-marketplace', number: 1000 } );
+	useQueryThemes( 'wpcom', { number: 1000 } );
 	useQuerySitePurchases( site ? site.ID : -1 );
 	useQuerySiteFeatures( [ site?.ID ] );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -317,7 +317,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	// ********** Logic for unlocking a selected premium design
 
-	useQueryThemes( 'wpcom', { number: 1000 } );
+	useQueryThemes( 'wpcom', {
+		number: 1000,
+		...( ! isEnabled( 'design-picker/query-marketplace-themes' ) ? { tier: '-marketplace' } : {} ),
+	} );
 	useQuerySitePurchases( site ? site.ID : -1 );
 	useQuerySiteFeatures( [ site?.ID ] );
 

--- a/config/development.json
+++ b/config/development.json
@@ -42,6 +42,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
+		"design-picker/query-marketplace-themes": true,
 		"desktop-promo": true,
 		"dev/auth-helper": true,
 		"dev/account-settings-helper": true,

--- a/config/production.json
+++ b/config/production.json
@@ -33,6 +33,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
+		"design-picker/query-marketplace-themes": false,
 		"desktop-promo": true,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -30,6 +30,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
+		"design-picker/query-marketplace-themes": true,
 		"desktop-promo": true,
 		"dev/preferences-helper": true,
 		"domains/gdpr-consent-page": true,

--- a/config/test.json
+++ b/config/test.json
@@ -33,6 +33,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
+		"design-picker/query-marketplace-themes": true,
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -30,6 +30,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
+		"design-picker/query-marketplace-themes": true,
 		"desktop-promo": true,
 		"dev/auth-helper": true,
 		"dev/account-settings-helper": true,


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2955

## Proposed Changes

Remove the filtering out of Marketplace themes, after this change all Themes should be retrieved to have the information available on the Onboarding section.

## Testing Instructions

* Apply the diff D118900-code to your sandbox and direct requests to the sandbox
* Go to the route `/setup/update-design/designSetup?siteSlug=:site`
* The Markeplace Themes (ex: Yuna, Olsen) should have the partner tag

![CleanShot 2023-08-10 at 13 30 49@2x](https://github.com/Automattic/wp-calypso/assets/5039531/c6a86451-c7cd-4f59-8cd2-65c88cf56197)

* Clear the browser cache
* Append this to the end of the URL to disable the feature flag: `&flags=-design-picker/query-marketplace-themes`
* Now you should not see the partners tag to the Marketplace themes
* This means the information was not queried and should be the default behavior in production for now.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
