### PR TITLE
Stats Improvement: Update focus ring styling to be consistent

### DIFF
--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -83,8 +83,7 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 		cursor: pointer;
 
 		&:focus {
-			outline: 2px solid #3057dc;
-			border-radius: 2px;
+			box-shadow: 0 0 0 2px var(--color-primary-light);
 		}
 
 		svg {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR updates the focus ring styling around the highlight setting to match the focus style of the rest of the page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit any stats page. Check the on-focus view of the dual choice popover options on the right side of the navigation bar. Check that the focus style matches the rest of the page. 

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/30754158/a8e855d9-d7f7-4fed-821a-859915f223bf) | ![image](https://github.com/Automattic/wp-calypso/assets/30754158/7b193491-1098-4402-a60a-82fa2e38b9c5)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
