### PR TITLE
Newsletter Categories: Add optimistic update to unmark newsletter mutations

### DIFF
--- a/client/data/newsletter-categories/test/use-unmark-as-newsletter-category-mutation.test.tsx
+++ b/client/data/newsletter-categories/test/use-unmark-as-newsletter-category-mutation.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, act } from '@testing-library/react-hooks';
 import React from 'react';
 import request from 'wpcom-proxy-request';
+import { NewsletterCategories } from '../types';
 import useUnmarkAsNewsletterCategoryMutation from '../use-unmark-as-newsletter-category-mutation';
 
 jest.mock( 'wpcom-proxy-request', () => jest.fn() );
@@ -117,5 +118,70 @@ describe( 'useUnmarkAsNewsletterCategoryMutation', () => {
 		);
 
 		console.error = consoleError;
+	} );
+
+	it( 'should update optimistically newsletter categories cache', async () => {
+		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( {
+			success: true,
+		} );
+
+		const mockedNewsletterCategories = [
+			{
+				id: 200,
+				count: 15,
+				description: 'Fascinating art styles',
+				link: 'https://mocksite.wordpress.com/category/art-styles/',
+				name: 'Creative Expressions',
+				slug: 'creative-expressions',
+				taxonomy: 'category',
+				parent: 0,
+				meta: [ { key: 'theme', value: 'imagination' } ],
+				_links: {},
+			},
+			{
+				id: 10,
+				count: 7,
+				description: 'Exploring the unknown',
+				link: 'https://mocksite.wordpress.com/category/adventures/',
+				name: 'Adventures Beyond',
+				slug: 'adventures-beyond',
+				taxonomy: 'category',
+				parent: 0,
+				meta: [ { key: 'discovery', value: 'thrills' } ],
+				_links: {},
+			},
+		];
+
+		queryClient.setQueryData( [ 'newsletter-categories', siteId ], {
+			newsletterCategories: mockedNewsletterCategories,
+		} );
+
+		const { result } = renderHook( () => useUnmarkAsNewsletterCategoryMutation( siteId ), {
+			wrapper,
+		} );
+
+		await act( async () => {
+			await result.current.mutateAsync( 200 );
+		} );
+
+		const updatedData = queryClient.getQueryData< NewsletterCategories >( [
+			'newsletter-categories',
+			siteId,
+		] );
+
+		expect( updatedData?.newsletterCategories ).toEqual( [
+			{
+				id: 10,
+				count: 7,
+				description: 'Exploring the unknown',
+				link: 'https://mocksite.wordpress.com/category/adventures/',
+				name: 'Adventures Beyond',
+				slug: 'adventures-beyond',
+				taxonomy: 'category',
+				parent: 0,
+				meta: [ { key: 'discovery', value: 'thrills' } ],
+				_links: {},
+			},
+		] );
 	} );
 } );


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/80443

## Proposed Changes

This PR introduces several changes:
- adds optimistic updates to the mutation to unmark a category as a newsletter category.
- adds a test to test that optimistic update.

## Testing Instructions

Run the tests with `yarn test-client --watch client/data/newsletter-categories/test/use-unmark-as-newsletter-category-mutation.test.tsx` and verify all of them are green.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
