### PR TITLE
Hosting Metrics: Add loading spinner on bar and line charts

### DIFF
--- a/client/my-sites/site-monitoring/components/site-monitoring-bar-chart/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-bar-chart/index.tsx
@@ -4,7 +4,7 @@ import { translate } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
 import { LegendTooltip } from './legend-tooltip';
 
-interface Props extends Pick< UplotChartProps, 'data' | 'labels' > {
+interface Props extends Pick< UplotChartProps, 'data' | 'labels' | 'isLoading' > {
 	title: string;
 	tooltip?: string | React.ReactNode;
 	className?: string;

--- a/client/my-sites/site-monitoring/components/site-monitoring-bar-chart/use-metrics-bar-chart-data.ts
+++ b/client/my-sites/site-monitoring/components/site-monitoring-bar-chart/use-metrics-bar-chart-data.ts
@@ -70,7 +70,7 @@ export function useMetricsBarChartData( { siteId, timeRange }: UseMetricsBarChar
 	const { start, end } = timeRange;
 	const metric = 'requests_persec';
 	const dimension = 'http_status';
-	const { data } = useSiteMetricsQuery( siteId, {
+	const { data, isLoading } = useSiteMetricsQuery( siteId, {
 		start,
 		end,
 		metric,
@@ -79,8 +79,8 @@ export function useMetricsBarChartData( { siteId, timeRange }: UseMetricsBarChar
 
 	const secondsWindow = useSecondsWindow( timeRange );
 	const { dataForBarChart, labels } = useGroupByTime( data?.data?.periods || [], secondsWindow );
-
 	return {
+		isLoading,
 		data: [ STATUS_CODES.map( ( code ) => `HTTP ${ code }` ), ...dataForBarChart ] as [
 			string[],
 			...number[][]

--- a/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
@@ -2,6 +2,7 @@ import useResize from '@automattic/components/src/chart-uplot/hooks/use-resize';
 import useScaleGradient from '@automattic/components/src/chart-uplot/hooks/use-scale-gradient';
 import getGradientFill from '@automattic/components/src/chart-uplot/lib/get-gradient-fill';
 import getPeriodDateFormat from '@automattic/components/src/chart-uplot/lib/get-period-date-format';
+import { Spinner } from '@wordpress/components';
 import classnames from 'classnames';
 import { getLocaleSlug, numberFormat, useTranslate } from 'i18n-calypso';
 import { useMemo, useRef, useState } from 'react';
@@ -24,6 +25,7 @@ interface UplotChartProps {
 	legendContainer?: React.RefObject< HTMLDivElement >;
 	solidFill?: boolean;
 	period?: string;
+	isLoading?: boolean;
 }
 
 export function formatChatHour( date: Date ): string {
@@ -42,6 +44,7 @@ export const SiteMonitoringLineChart = ( {
 	options: propOptions,
 	solidFill = false,
 	period,
+	isLoading = false,
 }: UplotChartProps ) => {
 	const translate = useTranslate();
 	const uplot = useRef< uPlot | null >( null );
@@ -183,6 +186,7 @@ export const SiteMonitoringLineChart = ( {
 				) }
 			</header>
 			<div ref={ uplotContainer }>
+				{ isLoading && <Spinner /> }
 				<UplotReact
 					data={ data }
 					onCreate={ ( chart ) => ( uplot.current = chart ) }

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -44,7 +44,7 @@ export function useSiteMetricsData( timeRange: TimeRange, metric?: MetricsType )
 	// Use the custom hook for time range selection
 	const { start, end } = timeRange;
 
-	const { data } = useSiteMetricsQuery( siteId, {
+	const { data, isLoading } = useSiteMetricsQuery( siteId, {
 		start,
 		end,
 		metric: metric || 'requests_persec',
@@ -77,6 +77,7 @@ export function useSiteMetricsData( timeRange: TimeRange, metric?: MetricsType )
 
 	return {
 		formattedData,
+		isLoading,
 	};
 }
 
@@ -135,7 +136,7 @@ export const MetricsTab = () => {
 	const translate = useTranslate();
 	const timeRange = useTimeRange();
 	const { handleTimeRangeChange } = timeRange;
-	const { formattedData } = useSiteMetricsData( timeRange );
+	const { formattedData, isLoading: isLoadingLineChart } = useSiteMetricsData( timeRange );
 	const { formattedData: cacheHitMissFormattedData } = useAggregateSiteMetricsData(
 		timeRange,
 		'requests_persec',
@@ -165,6 +166,7 @@ export const MetricsTab = () => {
 					}
 				) }
 				data={ formattedData as uPlot.AlignedData }
+				isLoading={ isLoadingLineChart }
 			></SiteMonitoringLineChart>
 			<div className="site-monitoring__pie-charts">
 				<SiteMonitoringPieChart

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -49,6 +49,13 @@
 	border: 1px solid var(--studio-gray-5);
 	border-radius: 3px; /* stylelint-disable-line scales/radii */
 	background-color: var(--studio-white);
+	position: relative;
+
+	.components-spinner {
+		position: absolute;
+		top: calc(50% - 8px);
+		left: calc(50% - 8px);
+	}
 }
 
 .site-monitoring__chart-header {

--- a/packages/components/src/chart-uplot/bar.tsx
+++ b/packages/components/src/chart-uplot/bar.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from '@wordpress/components';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import uPlot from 'uplot';
 import UplotReact from 'uplot-react';
@@ -19,6 +20,7 @@ export interface UplotChartProps {
 	legendData: { fillColor: string; tooltip?: JSX.Element }[];
 	labels: string[];
 	options?: Partial< uPlot.Options >;
+	isLoading?: boolean;
 }
 
 export default function UplotBarChart( {
@@ -26,6 +28,7 @@ export default function UplotBarChart( {
 	labels,
 	legendData = [],
 	options: propOptions,
+	isLoading = false,
 }: UplotChartProps ) {
 	const uplot = useRef< uPlot | null >( null );
 	const uplotContainer = useRef< HTMLDivElement | null >( null );
@@ -119,6 +122,7 @@ export default function UplotBarChart( {
 
 	return (
 		<div className="calypso-uplot-chart-container" ref={ uplotContainer }>
+			{ isLoading && <Spinner className="calypso-uplot-chart-container__spinner" /> }
 			<UplotReact
 				data={ data as unknown as uPlot.AlignedData }
 				onCreate={ ( chart ) => ( uplot.current = chart ) }

--- a/packages/components/src/chart-uplot/style.scss
+++ b/packages/components/src/chart-uplot/style.scss
@@ -28,3 +28,13 @@
 		}
 	}
 }
+
+.calypso-uplot-chart-container {
+	position: relative;
+
+	.components-spinner {
+		position: absolute;
+		top: calc(50% - 8px - 60px);
+		left: calc(50% - 8px);
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/3356
- https://github.com/Automattic/dotcom-forge/issues/3391

## Proposed Changes

* Add spinner while loading 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the diff <a href="#slower-snippet">provided below</a> or set the network settings to 3G
* Navigate to `/site-monitoring/${siteSlug}`
* Scroll down
* Observe the new bar chart


<details id="slower-snippet">
<summary>Make request slower diff</summary>

```
diff --git a/client/my-sites/site-monitoring/use-metrics-query.ts b/client/my-sites/site-monitoring/use-metrics-query.ts
index 417a151dc8..6637f17290 100644
--- a/client/my-sites/site-monitoring/use-metrics-query.ts
+++ b/client/my-sites/site-monitoring/use-metrics-query.ts
@@ -52,15 +52,18 @@ export type MetricsType =
 	| 'response_bytes_average'
 	| 'response_time_average';
 
+const sleep = ( ms ) => new Promise( ( r ) => setTimeout( r, ms ) );
+
 export function useSiteMetricsQuery(
 	siteId: number | null | undefined,
 	params: SiteMetricsParams
 ) {
 	const queryResult = useQuery< SiteMetricsAPIResponse >( {
 		queryKey: buildQueryKey( siteId, params ),
-		queryFn: () => {
+		queryFn: async () => {
 			const path = `/sites/${ siteId }/hosting/metrics`;
-			return wpcom.req.get(
+			await sleep( 10000 );
+			return await wpcom.req.get(
 				{ path, apiNamespace: 'wpcom/v2' },
 				{
 					start: params.start,

```
</details>

## Screencast


https://github.com/Automattic/wp-calypso/assets/779993/417a279c-a0fa-48dd-8b3e-e8893c9bd690




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
