### PR TITLE
Jetpack Portal: remove 'partner-portal-payment' feature flag (always on)

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/index.ts
+++ b/client/jetpack-cloud/sections/partner-portal/index.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
 import * as controller from './controller';
@@ -77,47 +76,45 @@ export default function () {
 	);
 
 	// Manage payment methods.
-	if ( config.isEnabled( 'jetpack/partner-portal-payment' ) ) {
-		page(
-			`/partner-portal/payment-methods`,
-			controller.requireAccessContext,
-			controller.requireTermsOfServiceConsentContext,
-			controller.requireSelectedPartnerKeyContext,
-			controller.paymentMethodListContext,
-			makeLayout,
-			clientRender
-		);
+	page(
+		`/partner-portal/payment-methods`,
+		controller.requireAccessContext,
+		controller.requireTermsOfServiceConsentContext,
+		controller.requireSelectedPartnerKeyContext,
+		controller.paymentMethodListContext,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			`/partner-portal/payment-methods/add`,
-			controller.requireAccessContext,
-			controller.requireTermsOfServiceConsentContext,
-			controller.requireSelectedPartnerKeyContext,
-			controller.paymentMethodAddContext,
-			makeLayout,
-			clientRender
-		);
+	page(
+		`/partner-portal/payment-methods/add`,
+		controller.requireAccessContext,
+		controller.requireTermsOfServiceConsentContext,
+		controller.requireSelectedPartnerKeyContext,
+		controller.paymentMethodAddContext,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			`/partner-portal/invoices`,
-			controller.requireAccessContext,
-			controller.requireTermsOfServiceConsentContext,
-			controller.requireSelectedPartnerKeyContext,
-			controller.invoicesDashboardContext,
-			makeLayout,
-			clientRender
-		);
+	page(
+		`/partner-portal/invoices`,
+		controller.requireAccessContext,
+		controller.requireTermsOfServiceConsentContext,
+		controller.requireSelectedPartnerKeyContext,
+		controller.invoicesDashboardContext,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			`/partner-portal/company-details`,
-			controller.requireAccessContext,
-			controller.requireTermsOfServiceConsentContext,
-			controller.requireSelectedPartnerKeyContext,
-			controller.companyDetailsDashboardContext,
-			makeLayout,
-			clientRender
-		);
-	}
+	page(
+		`/partner-portal/company-details`,
+		controller.requireAccessContext,
+		controller.requireTermsOfServiceConsentContext,
+		controller.requireSelectedPartnerKeyContext,
+		controller.companyDetailsDashboardContext,
+		makeLayout,
+		clientRender
+	);
 
 	// Pricing page
 	page(

--- a/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
@@ -30,8 +29,6 @@ const PartnerPortalSidebar: React.FC< Props > = ( { path } ) => {
 		[ dispatch ]
 	);
 
-	const arePaymentsEnabled = isEnabled( 'jetpack/partner-portal-payment' );
-
 	return (
 		<Sidebar className="sidebar__jetpack-cloud">
 			<SidebarRegion>
@@ -47,7 +44,7 @@ const PartnerPortalSidebar: React.FC< Props > = ( { path } ) => {
 					/>
 
 					<SidebarItem
-						customIcon={ <JetpackIcons icon={ arePaymentsEnabled ? 'money' : 'credit-card' } /> }
+						customIcon={ <JetpackIcons icon="money" /> }
 						label={ translate( 'Billing', {
 							comment: 'Jetpack sidebar navigation item',
 						} ) }
@@ -56,29 +53,25 @@ const PartnerPortalSidebar: React.FC< Props > = ( { path } ) => {
 						selected={ path === '/partner-portal/billing' }
 					/>
 
-					{ arePaymentsEnabled && (
-						<SidebarItem
-							customIcon={ <JetpackIcons icon="credit-card" /> }
-							label={ translate( 'Payment Methods', {
-								comment: 'Jeptack sidebar navigation item',
-							} ) }
-							link="/partner-portal/payment-methods"
-							onNavigate={ onNavigate( 'Jetpack Cloud / Partner Portal / Payment Methods' ) }
-							selected={ itemLinkMatches( '/partner-portal/payment-methods', path ) }
-						/>
-					) }
+					<SidebarItem
+						customIcon={ <JetpackIcons icon="credit-card" /> }
+						label={ translate( 'Payment Methods', {
+							comment: 'Jeptack sidebar navigation item',
+						} ) }
+						link="/partner-portal/payment-methods"
+						onNavigate={ onNavigate( 'Jetpack Cloud / Partner Portal / Payment Methods' ) }
+						selected={ itemLinkMatches( '/partner-portal/payment-methods', path ) }
+					/>
 
-					{ arePaymentsEnabled && (
-						<SidebarItem
-							customIcon={ <JetpackIcons icon="page" /> }
-							label={ translate( 'Invoices', {
-								comment: 'Jeptack sidebar navigation item',
-							} ) }
-							link="/partner-portal/invoices"
-							onNavigate={ onNavigate( 'Jetpack Cloud / Partner Portal / Invoices' ) }
-							selected={ itemLinkMatches( '/partner-portal/invoices', path ) }
-						/>
-					) }
+					<SidebarItem
+						customIcon={ <JetpackIcons icon="page" /> }
+						label={ translate( 'Invoices', {
+							comment: 'Jeptack sidebar navigation item',
+						} ) }
+						link="/partner-portal/invoices"
+						onNavigate={ onNavigate( 'Jetpack Cloud / Partner Portal / Invoices' ) }
+						selected={ itemLinkMatches( '/partner-portal/invoices', path ) }
+					/>
 
 					<SidebarItem
 						customIcon={ <JetpackIcons icon="prices" /> }
@@ -90,17 +83,15 @@ const PartnerPortalSidebar: React.FC< Props > = ( { path } ) => {
 						selected={ itemLinkMatches( '/partner-portal/prices', path ) }
 					/>
 
-					{ arePaymentsEnabled && (
-						<SidebarItem
-							customIcon={ <JetpackIcons icon="settings" /> }
-							label={ translate( 'Company Details', {
-								comment: 'Jeptack sidebar navigation item',
-							} ) }
-							link="/partner-portal/company-details"
-							onNavigate={ onNavigate( 'Jetpack Cloud / Partner Portal / Company Details' ) }
-							selected={ itemLinkMatches( '/partner-portal/company-details', path ) }
-						/>
-					) }
+					<SidebarItem
+						customIcon={ <JetpackIcons icon="settings" /> }
+						label={ translate( 'Company Details', {
+							comment: 'Jeptack sidebar navigation item',
+						} ) }
+						link="/partner-portal/company-details"
+						onNavigate={ onNavigate( 'Jetpack Cloud / Partner Portal / Company Details' ) }
+						selected={ itemLinkMatches( '/partner-portal/company-details', path ) }
+					/>
 				</SidebarMenu>
 			</SidebarRegion>
 		</Sidebar>

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -45,7 +45,6 @@
 		"jetpack/backup-retention-settings": true,
 		"jetpack/backup-granular": true,
 		"jetpack/golden-token": true,
-		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -38,7 +38,6 @@
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/golden-token": false,
-		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -41,7 +41,6 @@
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/golden-token": false,
-		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -41,7 +41,6 @@
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/golden-token": true,
-		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,


### PR DESCRIPTION
This pull request removes the `jetpack/partner-portal-payment` and updates affected components to behave as if this flag were always set to `true`.

Resolves `1202619025189113-as-1205140782121819`.

## Proposed Changes

* Remove calls to `config.isEnabled( 'jetpack/partner-portal-payment' )` in:
  * `PartnerPortalSidebar`
  * `partner-portal/index.ts` (client-side router for the Partner Portal)
* Remove references to `jetpack/partner-portal-payment` from all environment configuration `.json` files.

## Testing Instructions

* Verify that you're able to reach the following pages in the Jetpack Cloud Partner Portal:
  * Payment Methods (both viewing and adding)
  * Invoices
  * Company Details
* Verify you see the above-mentioned pages in the navigation sidebar.
* Verify the icon next to Billing looks like a dollar sign, instead of like a credit card. (Payment Methods should look like a credit card, though.)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205140782121819