### PR TITLE
Add a route for Stats purchase page without site

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -116,7 +116,7 @@ class Sites extends Component {
 				path = translate( 'Activity' );
 				break;
 			case 'stats':
-				path = translate( 'Insights' );
+				path = translate( 'Stats' );
 				break;
 			case 'plans':
 				path = translate( 'Plans' );

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -50,12 +50,12 @@ export default function () {
 	// Stat Overview Page
 	statsPage( `/stats/:period(${ validPeriods })`, overview );
 
-	statsPage( '/stats/insights', sites );
-
 	// Stat Purchase Page
+	statsPage( '/stats/purchase', sites );
 	statsPage( '/stats/purchase/:site', purchase );
 
 	// Stat Insights Page
+	statsPage( '/stats/insights', sites );
 	statsPage( '/stats/insights/:site', insights );
 
 	// Stat Subscribers Page (do not confuse with people/subscribers/)


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Adds a new route `/stats/purchase` so users can visit that page without specifying the site beforehand. The goal is to be able to point users to that page, and let them select which site they are going to purchase Stats for. This is going to be used on Jetpack.com, to let users go to the PWYW page
* Updates the site selection title for Stats from "Insights" to "Stats"

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit wordpress.com/stats/purchase and confirm that you are redirected to `/stats/day`, instead of being able to select a site
* Open the Calypso live link for this PR
* Go to /stats/purchase on Calypso live
* Confirm that you now see the site selection screen
* Click to choose a site, make sure you're redirected to /stats/purchase/:site with the site you've just chosen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
