### PR TITLE
GF Signup: Remove free and enterprise plans and add free plan as a link in the subtitle in onboarding-pm flow

### DIFF
--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -102,6 +102,7 @@ export type PlansIntent =
 	| 'plans-jetpack-app'
 	| 'plans-import'
 	| 'plans-woocommerce'
+	| 'plans-paid-media'
 	| 'plans-default-wpcom'
 	| 'plans-business-trial'
 	| 'default';
@@ -183,6 +184,9 @@ const usePlanTypesWithIntent = ( {
 			break;
 		case 'plans-jetpack-app':
 			planTypes = [ TYPE_PERSONAL, TYPE_PREMIUM ];
+			break;
+		case 'plans-paid-media':
+			planTypes = [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
 		case 'plans-default-wpcom':
 			planTypes = [

--- a/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
@@ -5,9 +5,9 @@ const useIsPlanUpsellEnabledOnFreeDomain = (
 	flowName?: string | null,
 	hasPaidDomain?: boolean
 ): DataResponse< boolean > => {
-	const ONBOARDING_EXPERIMENT = 'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v2';
+	const ONBOARDING_EXPERIMENT = 'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3';
 	const ONBOARDING_PM_EXPERIMENT =
-		'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v2';
+		'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3';
 	const relevantExperiment =
 		flowName === 'onboarding' ? ONBOARDING_EXPERIMENT : ONBOARDING_PM_EXPERIMENT;
 	const [ isLoading, experimentAssignment ] = useExperiment( relevantExperiment, {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -11,10 +11,11 @@ import {
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
+import styled from '@emotion/styled';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useLayoutEffect, useState } from '@wordpress/element';
 import classNames from 'classnames';
-import { localize, useTranslate } from 'i18n-calypso';
+import { localize, useTranslate, translate } from 'i18n-calypso';
 import page from 'page';
 import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
@@ -67,6 +68,20 @@ import type { IAppState } from 'calypso/state/types';
 import './style.scss';
 
 const SPOTLIGHT_ENABLED_INTENTS = [ 'plans-default-wpcom' ];
+
+const FreePlanSubHeader = styled.p`
+	margin: -32px 0 40px 0;
+	color: var( --studio-gray-60 );
+	font-size: 1rem;
+	text-align: center;
+	button.is-borderless {
+		font-weight: 500;
+		color: var( --studio-gray-90 );
+		text-decoration: underline;
+		font-size: 16px;
+		padding: 0;
+	}
+`;
 
 export interface PlansFeaturesMainProps {
 	siteId?: number | null;
@@ -625,6 +640,18 @@ const PlansFeaturesMain = ( {
 							},
 						} ) }
 				/>
+			) }
+			{ hideFreePlan && (
+				<FreePlanSubHeader>
+					{ translate(
+						`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
+						{
+							components: {
+								link: <Button onClick={ () => handleUpgradeClick() } borderless />,
+							},
+						}
+					) }
+				</FreePlanSubHeader>
 			) }
 			{ isDisplayingPlansNeededForFeature() && <SecondaryFormattedHeader siteSlug={ siteSlug } /> }
 			{ ! intentFromSiteMeta.processing && (

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -641,7 +641,7 @@ const PlansFeaturesMain = ( {
 						} ) }
 				/>
 			) }
-			{ hideFreePlan && (
+			{ intent === 'plans-paid-media' && (
 				<FreePlanSubHeader>
 					{ translate(
 						`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -107,12 +107,36 @@ export interface PlansFeaturesMainProps {
 	withDiscount?: string;
 	discountEndDate?: Date;
 	hidePlansFeatureComparison?: boolean;
-	hideFreePlan?: boolean; // to be deprecated
-	hidePersonalPlan?: boolean; // to be deprecated
-	hidePremiumPlan?: boolean; // to be deprecated
-	hideBusinessPlan?: boolean; // to be deprecated
-	hideEcommercePlan?: boolean; // to be deprecated
-	hideEnterprisePlan?: boolean; // to be deprecated
+
+	/**
+	 * @deprecated use intent mechanism instead
+	 */
+	hideFreePlan?: boolean;
+
+	/**
+	 * @deprecated use intent mechanism instead
+	 */
+	hidePersonalPlan?: boolean;
+
+	/**
+	 * @deprecated use intent mechanism instead
+	 */
+	hidePremiumPlan?: boolean;
+
+	/**
+	 * @deprecated use intent mechanism instead
+	 */
+	hideBusinessPlan?: boolean;
+
+	/**
+	 * @deprecated use intent mechanism instead
+	 */
+	hideEcommercePlan?: boolean;
+
+	/**
+	 * @deprecated use intent mechanism instead
+	 */
+	hideEnterprisePlan?: boolean;
 	isStepperUpgradeFlow?: boolean;
 	isLaunchPage?: boolean | null;
 	isReskinned?: boolean;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -81,6 +81,9 @@ const FreePlanSubHeader = styled.p`
 		font-size: 16px;
 		padding: 0;
 	}
+	@media ( max-width: 960px ) {
+		margin-top: -16px;
+	}
 `;
 
 export interface PlansFeaturesMainProps {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -258,6 +258,7 @@ export function generateSteps( {
 			fulfilledStepCallback: isPlanFulfilled,
 			props: {
 				showBiennialToggle: true,
+				hideFreePlan: true,
 			},
 		},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -259,6 +259,7 @@ export function generateSteps( {
 			props: {
 				showBiennialToggle: true,
 				hideFreePlan: true,
+				hideEnterprisePlan: true,
 			},
 		},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -258,8 +258,12 @@ export function generateSteps( {
 			fulfilledStepCallback: isPlanFulfilled,
 			props: {
 				showBiennialToggle: true,
-				hideFreePlan: true,
-				hideEnterprisePlan: true,
+				/**
+				 * This intent is geared towards customizations related to the paid media flow
+				 * Current customizations are as follows
+				 * - Show only Personal, Premium, Business, and eCommerce plans (Hide free, enterprise)
+				 */
+				intent: 'plans-paid-media',
 			},
 		},
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -287,9 +287,9 @@ class DomainsStep extends Component {
 		 * We want to pre load an experiment to show a plan upsell modal in the plans step
 		 */
 		if ( ! isPurchasingItem ) {
-			loadExperimentAssignment( 'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v2' );
+			loadExperimentAssignment( 'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3' );
 			loadExperimentAssignment(
-				'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v2'
+				'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3'
 			);
 		}
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -335,6 +335,7 @@ PlansStep.propTypes = {
 		'plans-plugins',
 		'plans-jetpack-app',
 		'plans-import',
+		'plans-paid-media',
 		'default',
 	] ),
 };

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -15,10 +15,7 @@ import Notice from 'calypso/components/notice';
 import { getTld, isSubdomain } from 'calypso/lib/domains';
 import { buildUpgradeFunction } from 'calypso/lib/signup/step-actions';
 import wp from 'calypso/lib/wp';
-import PlansComparison, {
-	isEligibleForProPlan,
-	isStarterPlanEnabled,
-} from 'calypso/my-sites/plans-comparison';
+import PlansComparison, { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { ExperimentalIntervalTypeToggle } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -214,30 +211,20 @@ export class PlansStep extends Component {
 	}
 
 	getSubHeaderText() {
-		const { eligibleForProPlan, hideFreePlan, locale, translate, useEmailOnboardingSubheader } =
-			this.props;
+		const { hideFreePlan, translate, useEmailOnboardingSubheader } = this.props;
 
 		const freePlanButton = (
 			<Button onClick={ () => buildUpgradeFunction( this.props, null ) } borderless />
 		);
 
-		if ( eligibleForProPlan ) {
-			if ( isStarterPlanEnabled() ) {
-				return hideFreePlan
-					? translate( 'Try risk-free with a 14-day money-back guarantee.' )
-					: translate(
-							'Try risk-free with a 14-day money-back guarantee or {{link}}start with a free site{{/link}}.',
-							{ components: { link: freePlanButton } }
-					  );
-			}
-
-			return 'en' === locale ||
-				i18n.hasTranslation( 'he WordPress Pro plan comes with a 14-day money back guarantee' )
-				? translate( 'The WordPress Pro plan comes with a 14-day money back guarantee' )
-				: translate( 'The WordPress Pro plan comes with a 14-day full money back guarantee' );
+		if ( hideFreePlan ) {
+			return translate(
+				`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
+				{ components: { link: freePlanButton } }
+			);
 		}
 
-		if ( useEmailOnboardingSubheader && ! hideFreePlan ) {
+		if ( useEmailOnboardingSubheader ) {
 			return translate(
 				'Add more features to your professional website with a plan. Or {{link}}start with email and a free site{{/link}}.',
 				{ components: { link: freePlanButton } }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -211,18 +211,11 @@ export class PlansStep extends Component {
 	}
 
 	getSubHeaderText() {
-		const { hideFreePlan, translate, useEmailOnboardingSubheader } = this.props;
+		const { translate, useEmailOnboardingSubheader } = this.props;
 
 		const freePlanButton = (
 			<Button onClick={ () => buildUpgradeFunction( this.props, null ) } borderless />
 		);
-
-		if ( hideFreePlan ) {
-			return translate(
-				`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
-				{ components: { link: freePlanButton } }
-			);
-		}
 
 		if ( useEmailOnboardingSubheader ) {
 			return translate(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#Fixes : Automattic/growth-foundations#166

## Proposed Changes
* Changes done targeting the `onboarding-pm` flow only
* Remove free and enterprise plans
* Add a subtitle to the plans page with the free plan link
* Toggle should be 1y/2y (Already shipped?)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/onboarding-pm`
* Make it to the `plans-pm` step
* The plans step should look like below.

![image](https://github.com/Automattic/wp-calypso/assets/3422709/33920bf6-1380-4c18-a325-bd60193bcb00)


### Modal Test Cases
- Select a .blog domain in the domains step and make sure a plan upsell modal is shown when the free plan button is clicked
- Assign yourself to treatment on 21344-explat-experiment, 
     - select a free domains on  the domains step and make sure a different plan upsell modal is shown
     - skip domain selection make sure the same modal is shown as above
     - For more details on testing check #80108

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
