### PR TITLE
Subscription Management: Fix validation and add tracks event on Add Sites modal

### DIFF
--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -64,15 +64,14 @@ const AddSitesForm = ( { onAddFinished }: AddSitesFormProps ) => {
 						if ( data?.info === 'already_subscribed' ) {
 							showWarningNotice( inputValue );
 						} else {
-					onSuccess: () => {
-						dispatch(
-							successNotice(
-								translate( 'You have successfully subscribed to %s.', {
-									args: [ inputValue ],
-									comment: 'URL of the site that the user has subscribed to.',
-								} )
-							)
-						);
+							if ( data?.subscription?.blog_ID ) {
+								recordSiteSubscribed( {
+									blog_id: data?.subscription?.blog_ID,
+									url: inputValue,
+									source: SOURCE_SUBSCRIPTIONS_ADD_SITES_MODAL,
+								} );
+							}
+
 							showSuccessNotice( inputValue );
 						}
 						onAddFinished();

--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -19,27 +19,28 @@ const AddSitesForm = ( { onAddFinished }: AddSitesFormProps ) => {
 	const translate = useTranslate();
 	const [ inputValue, setInputValue ] = useState( '' );
 	const [ inputFieldError, setInputFieldError ] = useState< string | null >( null );
-	const [ isValidUrl, setIsValidUrl ] = useState( false );
-	const dispatch = useDispatch();
+	const [ isValidInput, setIsValidInput ] = useState( false );
 
 	const { mutate: subscribe, isLoading: subscribing } =
 		SubscriptionManager.useSiteSubscribeMutation();
 
 	const validateInputValue = useCallback(
 		( url: string, showError = false ) => {
+			// If the input is empty, we don't want to show an error message
 			if ( url.length === 0 ) {
-				setIsValidUrl( false );
+				setIsValidInput( false );
 				setInputFieldError( null );
 				return;
 			}
-			if ( ! CAPTURE_URL_RGX.test( url ) ) {
-				setIsValidUrl( false );
+
+			if ( isValidUrl( url ) ) {
+				setInputFieldError( null );
+				setIsValidInput( true );
+			} else {
+				setIsValidInput( false );
 				if ( showError ) {
 					setInputFieldError( translate( 'Please enter a valid URL' ) );
 				}
-			} else {
-				setInputFieldError( null );
-				setIsValidUrl( true );
 			}
 		},
 		[ translate ]
@@ -54,7 +55,7 @@ const AddSitesForm = ( { onAddFinished }: AddSitesFormProps ) => {
 	);
 
 	const onAddSite = useCallback( () => {
-		if ( isValidUrl ) {
+		if ( isValidInput ) {
 			subscribe(
 				{ url: inputValue },
 				{
@@ -96,7 +97,7 @@ const AddSitesForm = ( { onAddFinished }: AddSitesFormProps ) => {
 				value={ inputValue }
 				type="url"
 				onChange={ onTextFieldChange }
-				help={ isValidUrl ? <Icon icon={ check } data-testid="check-icon" /> : undefined }
+				help={ isValidInput ? <Icon icon={ check } data-testid="check-icon" /> : undefined }
 				onBlur={ () => validateInputValue( inputValue, true ) }
 			/>
 

--- a/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
@@ -5,12 +5,19 @@
 import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import {
+	SubscriptionManagerContextProvider,
+	SubscriptionsPortal,
+} from '../../subscription-manager-context';
 import AddSitesForm from '../add-sites-form';
 
-jest.mock( 'calypso/state/notices/actions', () => ( {
-	successNotice: jest.fn(),
-	errorNotice: jest.fn(),
-} ) );
+const renderWithContextProvider = ( component: React.ReactNode ) => {
+	return renderWithProvider(
+		<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Subscriptions }>
+			{ component }
+		</SubscriptionManagerContextProvider>
+	);
+};
 
 describe( 'AddSitesForm', () => {
 	const mockProps = {
@@ -18,7 +25,7 @@ describe( 'AddSitesForm', () => {
 	};
 
 	test( 'displays an error message with invalid URL', () => {
-		renderWithProvider( <AddSitesForm { ...mockProps } /> );
+		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
 		const input = screen.getByRole( 'textbox' );
 
 		fireEvent.change( input, {
@@ -31,7 +38,7 @@ describe( 'AddSitesForm', () => {
 	} );
 
 	test( 'does not display an error message with valid URL', () => {
-		renderWithProvider( <AddSitesForm { ...mockProps } /> );
+		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
 		const input = screen.getByRole( 'textbox' );
 
 		fireEvent.change( input, {
@@ -44,7 +51,7 @@ describe( 'AddSitesForm', () => {
 	} );
 
 	test( 'does not display an error message when input field is empty and blurred', () => {
-		renderWithProvider( <AddSitesForm { ...mockProps } /> );
+		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
 		const input = screen.getByRole( 'textbox' );
 
 		fireEvent.change( input, {
@@ -57,7 +64,7 @@ describe( 'AddSitesForm', () => {
 	} );
 
 	test( 'displays a check icon when a valid URL is entered', () => {
-		renderWithProvider( <AddSitesForm { ...mockProps } /> );
+		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
 		const input = screen.getByRole( 'textbox' );
 
 		fireEvent.change( input, {
@@ -71,12 +78,26 @@ describe( 'AddSitesForm', () => {
 	} );
 
 	test( 'disables the Add site button when an invalid URL is entered', () => {
-		renderWithProvider( <AddSitesForm { ...mockProps } /> );
+		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
 		const input = screen.getByRole( 'textbox' );
 		const addButton = screen.getByRole( 'button', { name: 'Add site' } );
 
 		fireEvent.change( input, {
 			target: { value: 'not-a-url' },
+		} );
+
+		fireEvent.blur( input );
+
+		expect( addButton ).toBeDisabled();
+	} );
+
+	test( 'disables the Add site button when a URL without protocol is entered', () => {
+		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
+		const input = screen.getByRole( 'textbox' );
+		const addButton = screen.getByRole( 'button', { name: 'Add site' } );
+
+		fireEvent.change( input, {
+			target: { value: 'www.valid-url.com' },
 		} );
 
 		fireEvent.blur( input );

--- a/client/landing/subscriptions/helpers/index.ts
+++ b/client/landing/subscriptions/helpers/index.ts
@@ -1,4 +1,5 @@
 import { getQueryArgs } from '@wordpress/url';
+import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
 import type { Option } from 'calypso/landing/subscriptions/components/sort-controls';
 
 export const getOptionLabel = < T >( options: Option< T >[], value: T ) =>
@@ -7,4 +8,14 @@ export const getOptionLabel = < T >( options: Option< T >[], value: T ) =>
 export const getUrlQuerySearchTerm = () => {
 	const { s: urlQuerySearchTerm } = getQueryArgs( window.location.href );
 	return urlQuerySearchTerm as string;
+};
+
+export const isValidUrl = ( url: string ) => {
+	try {
+		// eslint-disable-next-line no-new
+		new URL( url );
+		return CAPTURE_URL_RGX.test( url );
+	} catch ( e ) {
+		return false;
+	}
 };

--- a/client/landing/subscriptions/hooks/index.ts
+++ b/client/landing/subscriptions/hooks/index.ts
@@ -3,3 +3,4 @@ export { default as useSearch } from './use-search';
 export { default as useSubheaderText } from './use-subheader-text';
 export { default as useSiteSubscriptionsFilterOptions } from './use-site-subscriptions-filter-options';
 export { default as useSubscribersFilterOptions } from './use-subscribers-filter-options';
+export { default as useAddSitesModalNotices } from './use-add-sites-modal-notices';

--- a/client/landing/subscriptions/hooks/use-add-sites-modal-notices.ts
+++ b/client/landing/subscriptions/hooks/use-add-sites-modal-notices.ts
@@ -1,0 +1,59 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { errorNotice, successNotice, warningNotice } from 'calypso/state/notices/actions';
+
+const useAddSitesModalNotices = () => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const showErrorNotice = useCallback(
+		( url: string ) => {
+			dispatch(
+				errorNotice(
+					translate( 'There was an error when trying to subscribe to %s.', {
+						args: [ url ],
+						comment: 'URL of the site that the user tried to subscribe to.',
+					} )
+				)
+			);
+		},
+		[ dispatch, translate ]
+	);
+
+	const showSuccessNotice = useCallback(
+		( url: string ) => {
+			dispatch(
+				successNotice(
+					translate( 'You have successfully subscribed to %s.', {
+						args: [ url ],
+						comment: 'URL of the site that the user successfully subscribed to.',
+					} )
+				)
+			);
+		},
+		[ dispatch, translate ]
+	);
+
+	const showWarningNotice = useCallback(
+		( url: string ) => {
+			dispatch(
+				warningNotice(
+					translate( 'You are already subscribed to %s.', {
+						args: [ url ],
+						comment: 'URL of the site that the user is already subscribed to.',
+					} )
+				)
+			);
+		},
+		[ dispatch, translate ]
+	);
+
+	return {
+		showErrorNotice,
+		showSuccessNotice,
+		showWarningNotice,
+	};
+};
+
+export default useAddSitesModalNotices;

--- a/client/landing/subscriptions/tracks/constants.ts
+++ b/client/landing/subscriptions/tracks/constants.ts
@@ -2,3 +2,4 @@ export const SOURCE_SUBSCRIPTIONS_SITE_LIST = 'subscriptions-site-list';
 export const SOURCE_SUBSCRIPTIONS_UNSUBSCRIBED_NOTICE = 'subscriptions-unsubscribed-notice';
 export const SOURCE_SUBSCRIPTIONS_SEARCH_RECOMMENDATION_LIST =
 	'subscriptions-search-recommendation-list';
+export const SOURCE_SUBSCRIPTIONS_ADD_SITES_MODAL = 'subscriptions-add-sites-modal';

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -126,7 +126,7 @@
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,
-		"subscription-management-add-sites-modal": false,
+		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,

--- a/config/production.json
+++ b/config/production.json
@@ -154,7 +154,7 @@
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,
-		"subscription-management-add-sites-modal": false,
+		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -147,7 +147,7 @@
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,
-		"subscription-management-add-sites-modal": false,
+		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -160,7 +160,7 @@
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,
-		"subscription-management-add-sites-modal": false,
+		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -14,6 +14,7 @@ type SubscribeParams = {
 };
 
 type SubscribeResponse = {
+	info?: string;
 	success?: boolean;
 	subscribed?: boolean;
 	subscription?: {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/80434
Closes https://github.com/Automattic/wp-calypso/issues/80435
Closes https://github.com/Automattic/wp-calypso/issues/80459

## Proposed Changes

* Fix URL validation
* Add tracks event when subscribing
* Display warning when the user has already subscribed to a site
* Enable feature flag

## Testing Instructions

1. Apply this PR to your local
2. Run tests `yarn test-client client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx`
3. Go to http://calypso.localhost:3000/read/subscriptions
4. Click on "Add a site"
5. Enter a site without the protocol, it should display a validation error
6. Enter a site that you are already subscribed to, click on "Add site", and  you should see a warning notice
7. Enter a valid site (that you are not subscribed yet), click on "Add site", and verify if the event was recorded on tracks

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
