### PR TITLE
Stats: Show one notice at a time

### DIFF
--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -82,7 +82,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 				<DoYouLoveJetpackStatsNotice siteId={ siteId } hasFreeStats={ hasFreeStats } />
 			) }
 			{ /* If we add more notice, we'll need to refator the logic with logic similar in `use-notice-visibility-query` */ }
-			{ ! showDoYouLoveJetpackStatsNotice && isOdysseyStats && (
+			{ ! showDoYouLoveJetpackStatsNotice && hasLoadedPurchases && isOdysseyStats && (
 				<>
 					<OptOutNotice siteId={ siteId } />
 					<FeedbackNotice siteId={ siteId } />

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -74,8 +74,12 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 			{ showDoYouLoveJetpackStatsNotice && (
 				<DoYouLoveJetpackStatsNotice siteId={ siteId } hasFreeStats={ hasFreeStats } />
 			) }
-			{ isOdysseyStats && <OptOutNotice siteId={ siteId } /> }
-			{ isOdysseyStats && <FeedbackNotice siteId={ siteId } /> }
+			{ ! showDoYouLoveJetpackStatsNotice && isOdysseyStats && (
+				<>
+					<OptOutNotice siteId={ siteId } />
+					<FeedbackNotice siteId={ siteId } />
+				</>
+			) }
 		</>
 	);
 };

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -3,6 +3,7 @@ import page from 'page';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import version_compare from 'calypso/lib/version-compare';
+import useNoticeVisibilityQuery from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
@@ -49,6 +50,11 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 	// TODO: Display error messages on the notice.
 	const { hasLoadedPurchases } = usePurchasesToUpdateSiteProducts( isOdysseyStats, siteId );
 
+	const { data: isDoYouLoveJetpackStatsVisible } = useNoticeVisibilityQuery(
+		siteId,
+		'do_you_love_jetpack_stats'
+	);
+
 	// Gate notices for WPCOM sites behind a flag.
 	const showUpgradeNoticeForWpcomSites =
 		config.isEnabled( 'stats/paid-wpcom-stats' ) &&
@@ -62,6 +68,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 		config.isEnabled( 'stats/paid-stats' ) && isSiteJetpackNotAtomic;
 
 	const showDoYouLoveJetpackStatsNotice =
+		isDoYouLoveJetpackStatsVisible &&
 		( showUpgradeNoticeOnOdyssey ||
 			showUpgradeNoticeForJetpackNotAtomic ||
 			showUpgradeNoticeForWpcomSites ) &&

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -74,6 +74,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 			{ showDoYouLoveJetpackStatsNotice && (
 				<DoYouLoveJetpackStatsNotice siteId={ siteId } hasFreeStats={ hasFreeStats } />
 			) }
+			{ /* If we add more notice, we'll need to refator the logic with logic similar in `use-notice-visibility-query` */ }
 			{ ! showDoYouLoveJetpackStatsNotice && isOdysseyStats && (
 				<>
 					<OptOutNotice siteId={ siteId } />


### PR DESCRIPTION
Related to p1691682134078089-slack-C01264051NE

## Proposed Changes

The PR proposes to hide other banners if purchase notice will be shown. We'll refactor the notices in follow up PRs to make the logic clearer.

## Testing Instructions
* Delete site option with wpsh from your sandbox
```
wpsh
switch_to_blog($yourSiteId);
var_dump(delete_option('stats_dashboard_options'));
``` 
* It might need a couple of minutes for the cache to expire
* Checkout branch `update/show-one-notice-per-time`
* Build Odyssey Stats `STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
* Build your local Jetpack if necessary `jetpack build plugins/jetpack`
* Delete `stats_options` in you LOCAL database `wp_options` with 
```
DELETE FROM wp_options WHERE `wp_options`.`option_name` = 'stats_options'
```
* Open `/wp-admin/admin.php?page=stats` on your local instance
* Ensure you see the upgrade notice
* Refresh several times
* Ensure you still only see the upgrade notice (not showing a second one: the survey notice)

Optional steps:
* Switch to trunk
* Ensure you see two notices

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
