### PR TITLE
Use more specific path for renovate cache

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -48,6 +48,7 @@ env:
   cache_archive: renovate_cache.tar.gz
   # This is the dir renovate provides -- if we set our own, we run into permissions issues.
   cache_dir: /tmp/renovate/cache/renovate/repository
+  cache_key: gandalfs-renovate-cache
 
 jobs:
   renovate:
@@ -59,7 +60,7 @@ jobs:
         if: github.event.inputs.repoCache != 'disabled'
         continue-on-error: true
         with:
-          name: renovate-cache
+          name: ${{ env.cache_key }}
           path: cache-download
 
       - name: Extract renovate cache
@@ -107,7 +108,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: github.event.inputs.repoCache != 'disabled'
         with:
-          name: renovate-cache
+          name: ${{ env.cache_key }}
           path: ${{ env.cache_archive }}
           # Since this is created frequently, we don't need to keep it for long.
           retention-days: 1

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -47,7 +47,7 @@ env:
   RENOVATE_VERSION: 36.31.0
   cache_archive: renovate_cache.tar.gz
   # This is the dir renovate provides -- if we set our own, we run into permissions issues.
-  cache_dir: /tmp/renovate/cache/renovate
+  cache_dir: /tmp/renovate/cache/renovate/repository
 
 jobs:
   renovate:
@@ -83,8 +83,7 @@ jobs:
           # are different than the ones given after the cache is restored. We have to
           # change ownership to solve this.
           sudo chown -R runneradmin:root /tmp/renovate/
-          ls $cache_dir
-          ls $cache_dir/renovate-cache-v1
+          ls -R $cache_dir
 
       - uses: renovatebot/github-action@v39.0.1
         with:


### PR DESCRIPTION
Follow-up from #80397. Renovate maintainers said to use a more narrow directory for the cache (see https://github.com/renovatebot/renovate/discussions/23767#discussioncomment-6687901), which should help keep the cache parts of the operation more simple. That path is just `/repository` within the directory we were already caching.

I also added a cache key as a variable so that we can easily "bust the cache" when we don't want to start from the old cache.