### PR TITLE
Remove Jetpack Search from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,9 +80,6 @@
 /client/lib/explat @Automattic/experimentation-platform
 /packages/explat-* @Automattic/experimentation-platform
 
-# Jetpack Search
-/client/my-sites/jetpack-search @Automattic/jetpack-search
-
 # TeamCity configuration
 /.teamcity @Automattic/team-calypso-platform
 


### PR DESCRIPTION
## Proposed Changes

As discussed in https://github.com/Automattic/wp-calypso/pull/51380#issuecomment-1672391511, the Jetpack Search team no longer exists on Github. This PR removes its entry from the CODEOWNERS file.

## Testing Instructions

Make sure the CODEOWNERS file is valid. You can verify this on the 'Files changed' view: https://github.com/Automattic/wp-calypso/pull/80464/files.
<img width="408" alt="Screenshot 2023-08-11 at 9 48 11 AM" src="https://github.com/Automattic/wp-calypso/assets/17325/f07334e9-7e61-4b9b-9493-1f2d7c6da9f4">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
