### PR TITLE
Fix: Add Stats Yearly to indirect checkout map

### DIFF
--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -41,12 +41,12 @@ import {
 	JETPACK_SECURITY_T1_PLANS,
 	JETPACK_SECURITY_T2_PLANS,
 	JETPACK_COMPLETE_PLANS,
+	PRODUCT_JETPACK_STATS_YEARLY,
 	PRODUCT_JETPACK_STATS_MONTHLY,
 	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
 	PRODUCT_JETPACK_STATS_FREE,
 } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
-import { PRODUCT_JETPACK_STATS_YEARLY } from './../../../../packages/calypso-products/src/constants/jetpack';
 import buildCardFeaturesFromItem from './build-card-features-from-item';
 import type { SelectorProduct } from './types';
 import type { JetpackPlanSlug, JetpackPurchasableItemSlug } from '@automattic/calypso-products';

--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -46,6 +46,7 @@ import {
 	PRODUCT_JETPACK_STATS_FREE,
 } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
+import { PRODUCT_JETPACK_STATS_YEARLY } from './../../../../packages/calypso-products/src/constants/jetpack';
 import buildCardFeaturesFromItem from './build-card-features-from-item';
 import type { SelectorProduct } from './types';
 import type { JetpackPlanSlug, JetpackPurchasableItemSlug } from '@automattic/calypso-products';
@@ -204,6 +205,19 @@ export const INDIRECT_CHECKOUT_PRODUCT_STATS = (): SelectorProduct => ( {
 	productSlug: PRODUCT_JETPACK_STATS_MONTHLY,
 	costProductSlug: PRODUCT_JETPACK_STATS_MONTHLY,
 	term: TERM_MONTHLY,
+	displayTerm: TERM_MONTHLY,
+	monthlyProductSlug: PRODUCT_JETPACK_STATS_MONTHLY,
+	displayPrice: STATS_COMMERCIAL_PRICE,
+	displayCurrency: STATS_COMMERCIAL_CURRENCY,
+} );
+
+export const INDIRECT_CHECKOUT_PRODUCT_STATS_YEARLY = (): SelectorProduct => ( {
+	...INDIRECT_CHECKOUT_PRODUCT_STATS_PWYW_YEARLY(),
+	displayName: translate( 'Stats (Commercial)' ),
+	shortName: translate( 'Stats (Commercial)' ),
+	productSlug: PRODUCT_JETPACK_STATS_YEARLY,
+	costProductSlug: PRODUCT_JETPACK_STATS_YEARLY,
+	term: TERM_ANNUALLY,
 	displayTerm: TERM_ANNUALLY,
 	monthlyProductSlug: PRODUCT_JETPACK_STATS_MONTHLY,
 	displayPrice: STATS_COMMERCIAL_PRICE,
@@ -221,6 +235,7 @@ export const INDIRECT_CHECKOUT_PRODUCT_STATS_FREE = (): SelectorProduct => ( {
 
 // List of products showcased in the Plans grid but not sold via checkout URL directly.
 export const INDIRECT_CHECKOUT_PRODUCTS_LIST = [
+	PRODUCT_JETPACK_STATS_YEARLY,
 	PRODUCT_JETPACK_STATS_MONTHLY,
 	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
 	PRODUCT_JETPACK_STATS_FREE,
@@ -228,6 +243,7 @@ export const INDIRECT_CHECKOUT_PRODUCTS_LIST = [
 
 // Indirect checkout Product slugs to SelectorProduct.
 export const INDIRECT_CHECKOUT_PRODUCTS_SLUG_MAP: Record< string, () => SelectorProduct > = {
+	[ PRODUCT_JETPACK_STATS_YEARLY ]: INDIRECT_CHECKOUT_PRODUCT_STATS_YEARLY,
 	[ PRODUCT_JETPACK_STATS_MONTHLY ]: INDIRECT_CHECKOUT_PRODUCT_STATS,
 	[ PRODUCT_JETPACK_STATS_PWYW_YEARLY ]: INDIRECT_CHECKOUT_PRODUCT_STATS_PWYW_YEARLY,
 	[ PRODUCT_JETPACK_STATS_FREE ]: INDIRECT_CHECKOUT_PRODUCT_STATS_FREE,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add Stats Yearly to indirect checkout description map, so places referencing it can get the product description. At the moment, the only place is the Jetpack Complete lightbox

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Jetpack Cloud live link
* Visit /pricing#jetpack_complete
* Confirm that Stats in the "Products included" list has a title
* Confirm it matches the screenshot below

<img width="1092" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5714212/1be17c01-1837-4c63-bc09-c48f1ea08b8a">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
