### PR TITLE
Stats: Add better empty state copy to traffic page

### DIFF
--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -1,4 +1,9 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
+
+// No need to localize this URL, since it's used as the prefix for other localized URLs.
+// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+const SUPPORT_URL = 'https://wordpress.com/support/stats/';
 
 export default function () {
 	const statsStrings = {};
@@ -7,9 +12,16 @@ export default function () {
 		title: translate( 'Posts & pages', { context: 'Stats: title of module' } ),
 		item: translate( 'Title', { context: 'Stats: module row header for post title.' } ),
 		value: translate( 'Views', { context: 'Stats: module row header for number of post views.' } ),
-		empty: translate( 'No posts or pages viewed', {
-			context: 'Stats: Info box label when the Posts & Pages module is empty',
-		} ),
+		empty: translate(
+			'Your most popular {{link}}posts and pages{{/link}} will display here once you begin to get some visitors.',
+			{
+				comment: '{{link}} links to support documentation.',
+				components: {
+					link: <a href={ localizeUrl( `${ SUPPORT_URL }#posts-amp-pages` ) } />,
+				},
+				context: 'Stats: Info box label when the Posts & Pages module is empty',
+			}
+		),
 	};
 
 	statsStrings.referrers = {
@@ -18,9 +30,16 @@ export default function () {
 		value: translate( 'Views', {
 			context: 'Stats: module row header for number of post views by referrer.',
 		} ),
-		empty: translate( 'No referrers recorded', {
-			context: 'Stats: Info box label when the Referrers module is empty',
-		} ),
+		empty: translate(
+			"We'll show you which websites are {{link}}referring visitors{{/link}} to your site.",
+			{
+				comment: '{{link}} links to support documentation.',
+				components: {
+					link: <a href={ localizeUrl( `${ SUPPORT_URL }#referrers` ) } />,
+				},
+				context: 'Stats: Info box label when the Referrers module is empty',
+			}
+		),
 	};
 
 	statsStrings.clicks = {
@@ -29,7 +48,11 @@ export default function () {
 		value: translate( 'Clicks', {
 			context: 'Stats: module row header for number of clicks on a given link in a post.',
 		} ),
-		empty: translate( 'No clicks recorded', {
+		empty: translate( 'Your most {{link}}clicked external links{{/link}} will display here.', {
+			comment: '{{link}} links to support documentation.',
+			components: {
+				link: <a href={ localizeUrl( `${ SUPPORT_URL }#clicks` ) } />,
+			},
 			context: 'Stats: Info box label when the Clicks module is empty',
 		} ),
 	};
@@ -40,9 +63,16 @@ export default function () {
 		value: translate( 'Views', {
 			context: 'Stats: module row header for number of views from a country.',
 		} ),
-		empty: translate( 'No countries recorded', {
-			context: 'Stats: Info box label when the Countries module is empty',
-		} ),
+		empty: translate(
+			'Stats on visitors and {{link}}their viewing location{{/link}} will make its way here.',
+			{
+				comment: '{{link}} links to support documentation.',
+				components: {
+					link: <a href={ localizeUrl( `${ SUPPORT_URL }#countries` ) } />,
+				},
+				context: 'Stats: Info box label when the Countries module is empty',
+			}
+		),
 	};
 
 	statsStrings.search = {
@@ -53,7 +83,11 @@ export default function () {
 		value: translate( 'Views', {
 			context: 'Stats: module row header for views of a given search in search terms.',
 		} ),
-		empty: translate( 'No search terms recorded', {
+		empty: translate( 'See {{link}}terms that visitors search{{/link}} to find your site, here. ', {
+			comment: '{{link}} links to support documentation.',
+			components: {
+				link: <a href={ localizeUrl( `${ SUPPORT_URL }#search-terms` ) } />,
+			},
 			context: 'Stats: Info box label when the Search Terms module is empty',
 		} ),
 	};
@@ -64,7 +98,11 @@ export default function () {
 		value: translate( 'Views', {
 			context: 'Stats: module row header for number of views per author.',
 		} ),
-		empty: translate( 'No posts or pages viewed', {
+		empty: translate( '{{link}}Traffic that authors have generated{{/link}} will show here.', {
+			comment: '{{link}} links to support documentation.',
+			components: {
+				link: <a href={ localizeUrl( `${ SUPPORT_URL }#authors` ) } />,
+			},
 			context: 'Stats: Info box label when the Authors module is empty',
 		} ),
 	};
@@ -75,7 +113,11 @@ export default function () {
 		value: translate( 'Views', {
 			context: 'Stats: module row header for number of views per video.',
 		} ),
-		empty: translate( 'No videos viewed', {
+		empty: translate( 'Your most viewed {{link}}video stats{{/link}} will show up here.', {
+			comment: '{{link}} links to support documentation.',
+			components: {
+				link: <a href={ localizeUrl( `${ SUPPORT_URL }#videos` ) } />,
+			},
 			context: 'Stats: Info box label when the Videos module is empty',
 		} ),
 	};
@@ -86,7 +128,11 @@ export default function () {
 		value: translate( 'downloads', {
 			context: 'Stats: module row header for number of downloads per file.',
 		} ),
-		empty: translate( 'No files downloaded', {
+		empty: translate( 'Stats from any {{link}}downloaded files{{/link}} will display here.', {
+			comment: '{{link}} links to support documentation.',
+			components: {
+				link: <a href={ localizeUrl( `${ SUPPORT_URL }#file-downloads` ) } />,
+			},
 			context: 'Stats: Info box label when the file downloads module is empty',
 		} ),
 	};
@@ -117,7 +163,11 @@ export default function () {
 		title: translate( 'Emails', { context: 'Stats: title of module' } ),
 		item: translate( 'Title', { context: 'Stats: module row header for post title.' } ),
 		value: translate( 'Opens', { context: 'Stats: module row header for number of email opens.' } ),
-		empty: translate( 'No email opens', {
+		empty: translate( 'Stats from {{link}}your emails{{/link}} will display here.', {
+			comment: '{{link}} links to support documentation.',
+			components: {
+				link: <a href={ localizeUrl( `${ SUPPORT_URL }#emails` ) } />,
+			},
 			context: 'Stats: Info box label when the Email Open module is empty',
 		} ),
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Partially addresses #80465

## Proposed Changes

Before|After
-|-
![SCR-20230810-j7b-2](https://github.com/Automattic/wp-calypso/assets/4044428/a06391cf-ab50-4b25-941e-227e14717224)|![SCR-20230810-j7b-3](https://github.com/Automattic/wp-calypso/assets/4044428/60170990-a42c-4cb8-8fff-5b0bdb467364)

* Replaced existing copy with newer copy incorporating links to our support documentation. Uses designs proposed in p1HpG7-iTh-p2 by @jeffgolenski.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Stats using the live branch of this PR. Select a site with no traffic.
* Ensure that every link goes to the appropriate section of the support documentation.
* Ensure that every link is correctly localized to the interface language you've selected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?