### PR TITLE
(SPT)(Patterns)(e2e) Fix empty `aria-label` in block pattern item

### DIFF
--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -43,7 +43,7 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 	// Parse patterns blocks and memoize them.
 	getFormattedPatternsByPatternSlugs = memoize( ( patterns: PatternDefinition[] ) => {
 		const blocksByPatternSlugs = patterns.reduce(
-			( prev, { name, description = '', html, pattern_meta } ) => {
+			( prev, { name, title = '', description = '', html, pattern_meta } ) => {
 				// The default value is from https://github.com/Automattic/wp-calypso/blob/d22976d8250fb4479d5677f5434742878fbd0ef3/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php#L115
 				const viewportWidth = pattern_meta?.viewport_width
 					? Number( pattern_meta.viewport_width )
@@ -51,8 +51,8 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 
 				prev[ name ] = {
 					name,
-					// Keep showing the description as before instead of the title
-					title: description,
+					// A lot of patterns don't have a description, so we fallback to the title if it's blank
+					title: description || title,
 					blocks: html
 						? parseBlocks( replacePlaceholders( html, this.props.siteInformation ) )
 						: [],


### PR DESCRIPTION
## Proposed Changes

Attempt to fix https://github.com/Automattic/wp-calypso/issues/80461.

#### How?

Fallback to title if a pattern description is falsey when building the list of patterns by slug. 

#### Why?

The problem is that for some reason, many patterns don't have a description - we're not sure what caused that or if it was like this for a while - to confirm this, you could check the patterns data that are fetched from the server, by evaluating `window.starterPageTemplatesConfig` in the browser console from within the wp-admin frame.

So, here, only the description was being used when reducing/transforming the array have slug keys: https://github.com/Automattic/wp-calypso/blob/trunk/packages/page-pattern-modal/src/components/page-pattern-modal.tsx#L55

And when it reached this part in GB, many got an empty string: https://github.com/WordPress/gutenberg/blame/trunk/packages/block-editor/src/components/block-patterns-list/index.js#L85

And this caused this locator to fail in our Calypso Gutenberg E2Es because it relies on the `aria-label` matching the corresponding label (in the specific failure that led us to discover this issue, it was the `About me` pattern):

https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts#L47

Since `About me` wasn't found, the test timed out and failed.

## Testing Instructions

We can't just run tests from this branch as the changes are in ETK! Most pragmatic way to make sure the changes work is to:

1. Build and sync this custom ETK version by going to `wp-calypso/apps/editing-toolkit` and running `yarn dev --sync`
2. Open your sandboxed WPCOM site and create a new page, wait for the STP. Find the `About me` pattern, right click on it and inspect -- you should see the `aria-label` is now correctly `About me`.

This was found as part of the 16.4.0 upgrade process in WPCOM. See: p1691635564130849-slack-CBTN58FTJ