### PR TITLE
Domain Redirect: Fix clean input & isSecure

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-redirect-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-redirect-card.tsx
@@ -161,6 +161,7 @@ const DomainRedirectCard = ( props: DomainRedirectCardProps & PropsFromRedux ) =
 					! isValidUrl ||
 					isFetching ||
 					isUpdating ||
+					targetUrl === '' ||
 					( target === targetUrl && ( redirect?.isSecure ? 'https' : 'http' ) === protocol )
 				}
 			>

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -128,6 +128,8 @@
 }
 
 .domain-redirect-card__fields {
+	margin-bottom: 0 !important;
+
 	.form-text-input-with-affixes__prefix {
 		padding: 0;
 		border: 0;
@@ -136,6 +138,11 @@
 			border-right: 0;
 		}
 	}
+}
+
+.domain-redirect-card__error-field {
+	margin-bottom: 0;
+	height: 35px;
 }
 
 .ownership-verification-card {

--- a/client/state/domains/domain-redirects/actions.js
+++ b/client/state/domains/domain-redirects/actions.js
@@ -30,7 +30,7 @@ export const fetchDomainRedirect = ( domain ) => ( dispatch ) => {
 				targetHost: target_host,
 				targetPath: target_path,
 				forwardPaths: forward_paths,
-				is_secure: is_secure ? true : false,
+				isSecure: is_secure !== '0' ? true : false,
 			} );
 		},
 		( error ) => {

--- a/client/state/domains/domain-redirects/reducer.js
+++ b/client/state/domains/domain-redirects/reducer.js
@@ -20,12 +20,13 @@ function updateStateForDomain( state, domain, data ) {
 
 export const initialStateForDomain = {
 	isFetching: false,
+	isFetched: false,
 	isUpdating: false,
 	notice: null,
 	targetHost: null,
 	targetPath: null,
 	forwardPaths: false,
-	secure: true,
+	isSecure: true,
 };
 
 export default function reducer( state = {}, action ) {
@@ -45,11 +46,12 @@ export default function reducer( state = {}, action ) {
 		case DOMAINS_REDIRECT_FETCH_COMPLETED:
 			state = updateStateForDomain( state, action.domain, {
 				isFetching: false,
+				isFetched: true,
 				notice: null,
 				targetHost: action.targetHost,
 				targetPath: action.targetPath,
 				forwardPaths: action.forwardPaths,
-				secure: action.secure,
+				isSecure: action.isSecure,
 			} );
 			break;
 
@@ -79,7 +81,7 @@ export default function reducer( state = {}, action ) {
 				targetHost: action.targetHost,
 				targetPath: action.targetPath,
 				forwardPaths: action.forwardPaths,
-				secure: action.secure,
+				isSecure: action.isSecure,
 			} );
 			break;
 


### PR DESCRIPTION
Slack discussion: p1691690400381799/1691679395.931639-slack-CKZHG0QC

## Proposed Changes

We fixed an issue when removing all the input text & disable the `Update` button after saving.

## Testing Instructions

* Edit a domain
* Go to Redirect Domain section
* Enter a domain into the redirect input
* Save it
* After saving it, the button should be disabled.
* Remove the text you entered on the redirection.
* It should let you remove all the text


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
