### PR TITLE
Jetpack Pro Dashboard: Add track event for upgrade popover view

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/not-available-badge/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/not-available-badge/index.tsx
@@ -28,6 +28,7 @@ export default function NotAvailableBadge() {
 				context={ wrapperRef.current }
 				isVisible={ showPopover }
 				position="bottom"
+				showDelay={ 300 }
 				className="not-available-badge__tooltip"
 			>
 				{ translate( 'One of the selected sites does not have a Basic plan.' ) }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/index.tsx
@@ -81,6 +81,7 @@ export default function UpgradePopover( {
 			context={ context }
 			isVisible={ isVisible }
 			position={ position }
+			showDelay={ 300 }
 			onShow={ handleOnShow }
 		>
 			<h2 className="upgrade-popover__heading">{ translate( 'Maximise uptime' ) }</h2>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/index.tsx
@@ -66,6 +66,10 @@ export default function UpgradePopover( {
 		showLicenseInfo( 'monitor' );
 	};
 
+	const handleOnShow = () => {
+		recordEvent( 'downtime_monitoring_upgrade_popover_view' );
+	};
+
 	// Don't show the popover if the user has dismissed it
 	if ( isDismissed ) {
 		return null;
@@ -77,6 +81,7 @@ export default function UpgradePopover( {
 			context={ context }
 			isVisible={ isVisible }
 			position={ position }
+			onShow={ handleOnShow }
 		>
 			<h2 className="upgrade-popover__heading">{ translate( 'Maximise uptime' ) }</h2>
 			{ dismissibleWithPreference && (


### PR DESCRIPTION
Related to 1204992567518369-as-1205254213084100

## Proposed Changes

This PR 

- adds tracking events when the upgrade popover is viewed.
- adds a delay to the popover(Upgrade & Not Available) so that it is not shown immediately when moving the cursor on it. 

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/track-event-for-upgrade-popover-view` and `yarn start-jetpack-cloud` or use the Jetpack Cloud link
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Open the dev tool, go to the network tab, and apply the filters - `jetpack-cloud-development` as search and select `Img` filters.

<img width="739" alt="Screenshot 2023-01-19 at 12 43 57 PM" src="https://user-images.githubusercontent.com/10586875/213378720-624de9b6-dc14-489e-a9a2-d7f04cfa478c.png">

5. Perform the below actions and verify that the API call to track the event is made with the right action names on large and small screen devices

`L: Large screen(>1280px)`
`S: Small Screen(<1280px)`

------

<img width="462" alt="Screenshot 2023-08-03 at 11 02 20 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/03ef3834-edf7-4c4d-ae74-9fb04c1aef4c">

####  View the upgrade popover

Event name: 

L: calypso_jetpack_agency_dashboard_downtime_monitoring_upgrade_popover_view_large_screen
S: calypso_jetpack_agency_dashboard_downtime_monitoring_upgrade_popover_view_small_screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
