### PR TITLE
Jetpack Pro Dashboard:  add UI test cases for downtime monitoring changes(contact-editor components)

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/index.tsx
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import {
+	AllowedMonitorContactTypes,
+	AllowedMonitorContactActions,
+} from '../../../sites-overview/types';
+import ContactEditor from '../index';
+
+jest.mock( 'calypso/data/geo/use-geolocation-query', () => ( {
+	useGeoLocationQuery: () => ( {
+		isLoading: false,
+		data: {},
+	} ),
+} ) );
+
+describe( 'ContactEditor', () => {
+	const defaultProps = {
+		type: 'email' as AllowedMonitorContactTypes,
+		contacts: [],
+		setContacts: jest.fn(),
+		setVerifiedContact: jest.fn(),
+		recordEvent: jest.fn(),
+		onClose: jest.fn(),
+		sites: [],
+	};
+
+	const initialState = {};
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'should render email form', () => {
+		render( <ContactEditor { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+		expect( screen.getByText( /add new email address/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render sms form', () => {
+		const props = {
+			...defaultProps,
+			type: 'sms' as AllowedMonitorContactTypes,
+		};
+		render( <ContactEditor { ...props } />, {
+			wrapper: Wrapper,
+		} );
+		expect( screen.getByText( /add your phone number/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render remove email confirmation', () => {
+		const props = {
+			...defaultProps,
+			action: 'remove' as AllowedMonitorContactActions,
+		};
+		render( <ContactEditor { ...props } />, {
+			wrapper: Wrapper,
+		} );
+		expect( screen.getByText( /remove email/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render remove sms confirmation', () => {
+		const props = {
+			...defaultProps,
+			action: 'remove' as AllowedMonitorContactActions,
+			type: 'sms' as AllowedMonitorContactTypes,
+		};
+		render( <ContactEditor { ...props } />, {
+			wrapper: Wrapper,
+		} );
+		expect( screen.getByText( /remove phone number/i ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/remove.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/remove.tsx
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import RemoveContactForm from '../remove';
+
+jest.mock( 'calypso/data/geo/use-geolocation-query', () => ( {
+	useGeoLocationQuery: () => ( {
+		isLoading: false,
+		data: {},
+	} ),
+} ) );
+
+describe( 'RemoveContactForm', () => {
+	const initialState = {};
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	const onCancelMock = jest.fn();
+	const onRemoveMock = jest.fn();
+
+	it( 'should render remove email form', () => {
+		const contact = {
+			email: 'test@test.com',
+			name: 'test',
+			verified: true,
+		};
+
+		render(
+			<RemoveContactForm
+				contact={ contact }
+				onCancel={ onCancelMock }
+				onRemove={ onRemoveMock }
+				type="email"
+			/>,
+			{
+				wrapper: Wrapper,
+			}
+		);
+
+		expect( screen.getByText( 'test@test.com' ) ).toBeInTheDocument();
+
+		fireEvent.click( screen.getByText( /remove/i ) );
+		expect( onRemoveMock ).toHaveBeenCalled();
+
+		fireEvent.click( screen.getByText( /back/i ) );
+		expect( onCancelMock ).toHaveBeenCalled();
+	} );
+
+	it( 'should render remove sms form', () => {
+		const contact = {
+			name: 'test',
+			countryCode: 'AF',
+			countryNumericCode: '+93',
+			phoneNumber: '774405234',
+			phoneNumberFull: '+93774405234',
+			verified: true,
+		};
+
+		render(
+			<RemoveContactForm
+				contact={ contact }
+				onCancel={ onCancelMock }
+				onRemove={ onRemoveMock }
+				type="sms"
+			/>,
+			{
+				wrapper: Wrapper,
+			}
+		);
+
+		expect( screen.getByText( '+93774405234' ) ).toBeInTheDocument();
+
+		fireEvent.click( screen.getByText( /remove/i ) );
+		expect( onRemoveMock ).toHaveBeenCalled();
+
+		fireEvent.click( screen.getByText( /back/i ) );
+		expect( onCancelMock ).toHaveBeenCalled();
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/verify-email.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/verify-email.tsx
@@ -1,0 +1,249 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import DashboardDataContext from '../../../sites-overview/dashboard-data-context';
+import {
+	AllowedMonitorContactTypes,
+	AllowedMonitorContactActions,
+	StateMonitoringSettingsContact,
+} from '../../../sites-overview/types';
+import VerifyContactForm from '../verify';
+
+jest.mock( 'calypso/data/geo/use-geolocation-query', () => ( {
+	useGeoLocationQuery: () => ( {
+		isLoading: false,
+		data: {},
+	} ),
+} ) );
+
+describe( 'VerifyContactForm', () => {
+	beforeAll( () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.persist()
+			.post( '/wpcom/v2/jetpack-agency/contacts' )
+			.reply( 200 );
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/jetpack-agency/contacts/verify' )
+			.reply( 200 );
+	} );
+
+	afterAll( () => {
+		nock.cleanAll();
+	} );
+
+	const defaultProps = {
+		type: 'email' as AllowedMonitorContactTypes,
+		contacts: [],
+		setContacts: jest.fn(),
+		action: 'add' as AllowedMonitorContactActions,
+		setVerifiedContact: jest.fn(),
+		recordEvent: jest.fn(),
+		onClose: jest.fn(),
+		sites: [],
+	};
+
+	const dashboardContextValue = {
+		verifiedContacts: {
+			emails: [ 'test-verified@test.com' ],
+			phoneNumbers: [],
+			refetchIfFailed: jest.fn(),
+		},
+		products: [],
+		isLargeScreen: true,
+	};
+
+	const initialState = {};
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'should render add email address form', async () => {
+		const onAdd = jest.fn();
+		render( <VerifyContactForm onAdd={ onAdd } { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+
+		expect( screen.getByText( 'Name' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( /give this email a nickname for your personal reference/i )
+		).toBeInTheDocument();
+
+		expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( /We’ll send a code to verify your email address/i )
+		).toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: /back/i } ) );
+		expect( defaultProps.onClose ).toHaveBeenCalledTimes( 1 );
+
+		const verifyButton = screen.getByTestId( 'submit-verify-contact' );
+		expect( verifyButton ).toHaveTextContent( /verify/i );
+		expect( verifyButton ).toHaveAttribute( 'disabled' );
+	} );
+
+	it( 'should show invalid email address error', async () => {
+		const onAdd = jest.fn();
+		render( <VerifyContactForm onAdd={ onAdd } { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+
+		fireEvent.change( screen.getByLabelText( 'Name' ), {
+			target: { value: 'test' },
+		} );
+		fireEvent.change( screen.getByLabelText( 'Email' ), {
+			target: { value: 'testtest.com' },
+		} );
+
+		const verifyButton = screen.getByTestId( 'submit-verify-contact' );
+		fireEvent.click( verifyButton );
+		expect( screen.getByText( /please enter a valid email address/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'should add the email address if already verified', async () => {
+		const onAdd = jest.fn();
+		render(
+			<DashboardDataContext.Provider value={ dashboardContextValue }>
+				<VerifyContactForm onAdd={ onAdd } { ...defaultProps } />
+			</DashboardDataContext.Provider>,
+			{
+				wrapper: Wrapper,
+			}
+		);
+
+		fireEvent.change( screen.getByLabelText( 'Name' ), {
+			target: { value: 'test' },
+		} );
+		fireEvent.change( screen.getByLabelText( 'Email' ), {
+			target: { value: 'test-verified@test.com' },
+		} );
+
+		const verifyButton = screen.getByTestId( 'submit-verify-contact' );
+		fireEvent.click( verifyButton );
+		expect( onAdd ).toHaveBeenCalledWith(
+			{ email: 'test-verified@test.com', name: 'test' },
+			true,
+			'downtime_monitoring_email__already_verified'
+		);
+	} );
+
+	it( 'should should an error if the email address is already added', async () => {
+		const props = {
+			...defaultProps,
+			contacts: [
+				{
+					email: 'test@test.com',
+					name: 'test',
+					verified: true,
+				},
+			] as Array< StateMonitoringSettingsContact >,
+		};
+		const onAdd = jest.fn();
+		render( <VerifyContactForm onAdd={ onAdd } { ...props } />, {
+			wrapper: Wrapper,
+		} );
+
+		fireEvent.change( screen.getByLabelText( 'Name' ), {
+			target: { value: 'test' },
+		} );
+		fireEvent.change( screen.getByLabelText( 'Email' ), {
+			target: { value: 'test@test.com' },
+		} );
+
+		const verifyButton = screen.getByTestId( 'submit-verify-contact' );
+		fireEvent.click( verifyButton );
+		expect( screen.getByText( /this email address is already in use/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'should add the email address if later is clicked', async () => {
+		const onAdd = jest.fn();
+		render( <VerifyContactForm onAdd={ onAdd } { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+
+		const verifyButton = screen.getByTestId( 'submit-verify-contact' );
+
+		fireEvent.change( screen.getByLabelText( 'Name' ), {
+			target: { value: 'test' },
+		} );
+		fireEvent.change( screen.getByLabelText( 'Email' ), {
+			target: { value: 'test@test.com' },
+		} );
+
+		expect( verifyButton ).not.toHaveAttribute( 'disabled' );
+
+		fireEvent.click( verifyButton );
+		expect( verifyButton ).toHaveAttribute( 'disabled' );
+		// Wait for the API call to finish
+		await waitFor( () => {
+			expect( verifyButton ).not.toHaveAttribute( 'disabled' );
+		} );
+
+		const codeLabel = /please enter the code you received via email/i;
+		expect( screen.getByText( codeLabel ) ).toBeInTheDocument();
+
+		const saveLaterButton = screen.getByRole( 'button', { name: /later/i } );
+		expect( saveLaterButton ).toBeInTheDocument();
+		fireEvent.click( saveLaterButton );
+		expect( onAdd ).toHaveBeenCalledWith(
+			{ email: 'test@test.com', name: 'test' },
+			false,
+			'downtime_monitoring_verify_email_later'
+		);
+
+		const promise = Promise.resolve();
+		await act( () => promise );
+	} );
+
+	it( 'should verify the email address', async () => {
+		const onAdd = jest.fn();
+		render( <VerifyContactForm onAdd={ onAdd } { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+
+		fireEvent.change( screen.getByLabelText( 'Name' ), {
+			target: { value: 'test' },
+		} );
+		fireEvent.change( screen.getByLabelText( 'Email' ), {
+			target: { value: 'test@test.com' },
+		} );
+
+		const verifyButton = screen.getByTestId( 'submit-verify-contact' );
+		fireEvent.click( verifyButton );
+		// Wait for the API call to finish
+		await waitFor( () => {
+			expect( verifyButton ).not.toHaveAttribute( 'disabled' );
+		} );
+		expect( verifyButton ).toHaveAttribute( 'disabled' );
+
+		const codeLabel = /please enter the code you received via email/i;
+		fireEvent.change( screen.getByLabelText( codeLabel ), {
+			target: { value: '123456' },
+		} );
+
+		expect( verifyButton ).not.toHaveAttribute( 'disabled' );
+		fireEvent.click( verifyButton );
+		await waitFor( () => {
+			expect( onAdd ).toHaveBeenCalledWith(
+				{ email: 'test@test.com', name: 'test', verificationCode: '123456' },
+				true
+			);
+		} );
+
+		const promise = Promise.resolve();
+		await act( () => promise );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/verify-sms.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/verify-sms.tsx
@@ -1,0 +1,311 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import DashboardDataContext from '../../../sites-overview/dashboard-data-context';
+import {
+	AllowedMonitorContactTypes,
+	AllowedMonitorContactActions,
+	StateMonitoringSettingsContact,
+} from '../../../sites-overview/types';
+import VerifyContactForm from '../verify';
+
+jest.mock( 'calypso/data/geo/use-geolocation-query', () => ( {
+	useGeoLocationQuery: () => ( {
+		isLoading: false,
+		data: {},
+	} ),
+} ) );
+
+jest.mock( '../hooks', () => ( {
+	...jest.requireActual( '../hooks' ),
+	useGetSupportedSMSCountries: () => [
+		// Alphabetical order
+		{
+			code: 'AF',
+			name: 'Afghanistan',
+			numeric_code: '+93',
+			country_name: 'Afghanistan',
+		},
+		{
+			code: 'AL',
+			name: 'Albania',
+			numeric_code: '+355',
+			country_name: 'Albania',
+		},
+	],
+} ) );
+
+describe( 'VerifyContactForm', () => {
+	beforeAll( () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.persist()
+			.post( '/wpcom/v2/jetpack-agency/contacts' )
+			.reply( 200 );
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/jetpack-agency/contacts/verify' )
+			.reply( 200 );
+	} );
+
+	afterAll( () => {
+		nock.cleanAll();
+	} );
+
+	const defaultProps = {
+		type: 'sms' as AllowedMonitorContactTypes,
+		contacts: [],
+		setContacts: jest.fn(),
+		action: 'add' as AllowedMonitorContactActions,
+		setVerifiedContact: jest.fn(),
+		recordEvent: jest.fn(),
+		onClose: jest.fn(),
+		sites: [],
+	};
+
+	const dashboardContextValue = {
+		verifiedContacts: {
+			emails: [],
+			phoneNumbers: [ '+93774405234' ],
+			refetchIfFailed: jest.fn(),
+		},
+		products: [],
+		isLargeScreen: true,
+	};
+
+	const initialState = {};
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'should render add phone number form', async () => {
+		const onAdd = jest.fn();
+		render( <VerifyContactForm onAdd={ onAdd } { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+
+		expect( screen.getByText( 'Name' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( /give this number a nickname for your personal reference/i )
+		).toBeInTheDocument();
+
+		expect( screen.getByText( /country code/i ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Phone number' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( /We’ll send a code to verify your phone number/i )
+		).toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: /back/i } ) );
+		expect( defaultProps.onClose ).toHaveBeenCalledTimes( 1 );
+
+		const verifyButton = screen.getByTestId( 'submit-verify-contact' );
+
+		expect( verifyButton ).toHaveTextContent( /verify/i );
+		expect( verifyButton ).toHaveAttribute( 'disabled' );
+	} );
+
+	it( 'should show invalid phone number error', async () => {
+		const onAdd = jest.fn();
+		render( <VerifyContactForm onAdd={ onAdd } { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+
+		fireEvent.change( screen.getByLabelText( 'Name' ), {
+			target: { value: 'test' },
+		} );
+
+		fireEvent.click( screen.getByText( /afghanistan/i ) );
+		const selectElement = screen.getByTestId( 'country-code-select' );
+		fireEvent.change( selectElement, { target: { value: 'AF' } } );
+
+		const inputElement = screen.getByTestId( 'phone-number-input' );
+		fireEvent.change( inputElement, { target: { value: '77012222' } } );
+
+		const verifyButton = screen.getByTestId( 'submit-verify-contact' );
+		fireEvent.click( verifyButton );
+		expect(
+			screen.getByText( /that phone number does not appear to be valid/i )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should add the phone number if already verified', async () => {
+		const onAdd = jest.fn();
+		render(
+			<DashboardDataContext.Provider value={ dashboardContextValue }>
+				<VerifyContactForm onAdd={ onAdd } { ...defaultProps } />
+			</DashboardDataContext.Provider>,
+			{
+				wrapper: Wrapper,
+			}
+		);
+		fireEvent.change( screen.getByLabelText( 'Name' ), {
+			target: { value: 'test' },
+		} );
+
+		fireEvent.click( screen.getByText( /afghanistan/i ) );
+		const selectElement = screen.getByTestId( 'country-code-select' );
+		fireEvent.change( selectElement, { target: { value: 'AF' } } );
+
+		const inputElement = screen.getByTestId( 'phone-number-input' );
+		fireEvent.change( inputElement, { target: { value: '0774405234' } } );
+
+		const verifyButton = screen.getByTestId( 'submit-verify-contact' );
+		fireEvent.click( verifyButton );
+		expect( onAdd ).toHaveBeenCalledWith(
+			{
+				countryCode: 'AF',
+				countryNumericCode: '+93',
+				phoneNumber: '774405234',
+				phoneNumberFull: '+93774405234',
+				name: 'test',
+			},
+			true,
+			'downtime_monitoring_phone_number_already_verified'
+		);
+	} );
+
+	it( 'should should an error if the phone number is already added', async () => {
+		const props = {
+			...defaultProps,
+			contacts: [
+				{
+					name: 'test',
+					countryCode: 'AF',
+					phoneNumber: '774405234',
+					phoneNumberFull: '+93774405234',
+					verified: true,
+				},
+			] as Array< StateMonitoringSettingsContact >,
+		};
+		const onAdd = jest.fn();
+		render( <VerifyContactForm onAdd={ onAdd } { ...props } />, {
+			wrapper: Wrapper,
+		} );
+
+		fireEvent.change( screen.getByLabelText( 'Name' ), {
+			target: { value: 'test' },
+		} );
+
+		fireEvent.click( screen.getByText( /afghanistan/i ) );
+		const selectElement = screen.getByTestId( 'country-code-select' );
+		fireEvent.change( selectElement, { target: { value: 'AF' } } );
+
+		const inputElement = screen.getByTestId( 'phone-number-input' );
+		fireEvent.change( inputElement, { target: { value: '0774405234' } } );
+
+		const verifyButton = screen.getByTestId( 'submit-verify-contact' );
+		fireEvent.click( verifyButton );
+		expect( screen.getByText( /this phone number is already in use/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'should add the phone number if later is clicked', async () => {
+		const onAdd = jest.fn();
+		render( <VerifyContactForm onAdd={ onAdd } { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+
+		fireEvent.change( screen.getByLabelText( 'Name' ), {
+			target: { value: 'test' },
+		} );
+
+		fireEvent.click( screen.getByText( /afghanistan/i ) );
+		const selectElement = screen.getByTestId( 'country-code-select' );
+		fireEvent.change( selectElement, { target: { value: 'AF' } } );
+
+		const inputElement = screen.getByTestId( 'phone-number-input' );
+		fireEvent.change( inputElement, { target: { value: '0774405234' } } );
+
+		const verifyButton = screen.getByTestId( 'submit-verify-contact' );
+		expect( verifyButton ).not.toHaveAttribute( 'disabled' );
+		fireEvent.click( verifyButton );
+		expect( verifyButton ).toHaveAttribute( 'disabled' );
+		// Wait for the API call to finish
+		await waitFor( () => {
+			expect( verifyButton ).not.toHaveAttribute( 'disabled' );
+		} );
+
+		const codeLabel = /please enter the code you received via sms/i;
+		expect( screen.getByText( codeLabel ) ).toBeInTheDocument();
+
+		const saveLaterButton = screen.getByRole( 'button', { name: /later/i } );
+		expect( saveLaterButton ).toBeInTheDocument();
+		fireEvent.click( saveLaterButton );
+		expect( onAdd ).toHaveBeenCalledWith(
+			{
+				countryCode: 'AF',
+				countryNumericCode: '+93',
+				phoneNumber: '774405234',
+				phoneNumberFull: '+93774405234',
+				name: 'test',
+			},
+			false,
+			'downtime_monitoring_verify_phone_number_later'
+		);
+
+		const promise = Promise.resolve();
+		await act( () => promise );
+	} );
+
+	it( 'should verify the phone number', async () => {
+		const onAdd = jest.fn();
+		render( <VerifyContactForm onAdd={ onAdd } { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+
+		fireEvent.change( screen.getByLabelText( 'Name' ), {
+			target: { value: 'test' },
+		} );
+
+		fireEvent.click( screen.getByText( /afghanistan/i ) );
+		const selectElement = screen.getByTestId( 'country-code-select' );
+		fireEvent.change( selectElement, { target: { value: 'AF' } } );
+
+		const inputElement = screen.getByTestId( 'phone-number-input' );
+		fireEvent.change( inputElement, { target: { value: '0774405234' } } );
+
+		const verifyButton = screen.getByTestId( 'submit-verify-contact' );
+		fireEvent.click( verifyButton );
+		// Wait for the API call to finish
+		await waitFor( () => {
+			expect( verifyButton ).not.toHaveAttribute( 'disabled' );
+		} );
+
+		expect( verifyButton ).toHaveAttribute( 'disabled' );
+
+		const codeLabel = /please enter the code you received via sms/i;
+		fireEvent.change( screen.getByLabelText( codeLabel ), {
+			target: { value: '123456' },
+		} );
+
+		expect( verifyButton ).not.toHaveAttribute( 'disabled' );
+		fireEvent.click( verifyButton );
+		await waitFor( () => {
+			expect( onAdd ).toHaveBeenCalledWith(
+				{
+					countryCode: 'AF',
+					countryNumericCode: '+93',
+					phoneNumber: '774405234',
+					phoneNumberFull: '+93774405234',
+					name: 'test',
+					verificationCode: '123456',
+				},
+				true
+			);
+		} );
+
+		const promise = Promise.resolve();
+		await act( () => promise );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/verify.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/verify.tsx
@@ -448,6 +448,12 @@ export default function VerifyContactForm( {
 						noCountryList && <QuerySmsCountries />
 					}
 					<FormPhoneInput
+						countrySelectProps={ {
+							'data-testid': 'country-code-select',
+						} }
+						phoneInputProps={ {
+							'data-testid': 'phone-number-input',
+						} }
 						isDisabled={ noCountryList || showCodeVerification }
 						countriesList={ countriesList }
 						initialCountryCode={ contactInfo.countryCode }
@@ -493,6 +499,7 @@ export default function VerifyContactForm( {
 					{ showCodeVerification ? translate( 'Later' ) : translate( 'Back' ) }
 				</Button>
 				<Button
+					data-testid="submit-verify-contact"
 					disabled={
 						! isCompleteContactInfo( type, contactInfo, showCodeVerification ) ||
 						isSubmittingVerificationCode ||


### PR DESCRIPTION
Related to 1202619025189113-as-1205248018119129

#### Proposed Changes

This PR adds test cases to the /contact-editor components added as a part of the downtime monitoring changes.

#### Testing Instructions

- Run `git checkout add/test-cases-for-downtime-monitoring-changes && git pull`
- Run `yarn run test-client client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/` to run the tests.
- Verify the tests are passing and code changes make sense


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
