### PR TITLE
Jetpack Pro Dashboard: Fix issue with Monitor modal showing up when dismissing upgrade banner.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-downtime-monitoring-upgrade-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-downtime-monitoring-upgrade-banner/index.tsx
@@ -54,10 +54,13 @@ export default function SiteDowntimeMonitoringUpgradeBanner() {
 		return null;
 	}
 
-	const dismissAndRecordEvent = ( eventName: string ) => {
+	const dismissAndRecordEvent = ( eventName: string, showInfoAfterDismiss = false ) => {
 		savePreferenceType( 'dismiss', true );
 		dispatch( recordTracksEvent( `calypso_jetpack_agency_dashboard_${ eventName }` ) );
-		showLicenseInfo( 'monitor' );
+
+		if ( showInfoAfterDismiss ) {
+			showLicenseInfo( 'monitor' );
+		}
 	};
 
 	return (
@@ -72,7 +75,7 @@ export default function SiteDowntimeMonitoringUpgradeBanner() {
 			iconPath={ CelebrationIcon }
 			callToAction={ translate( 'Explore' ) }
 			dismissWithoutSavingPreference
-			onClick={ () => dismissAndRecordEvent( 'monitor_upgrade_banner_accept' ) }
+			onClick={ () => dismissAndRecordEvent( 'monitor_upgrade_banner_accept', true ) }
 			onDismiss={ () => dismissAndRecordEvent( 'monitor_upgrade_banner_dismiss' ) }
 		/>
 	);


### PR DESCRIPTION
Related to 1202619025189113-as-1205254810113123

## Proposed Changes

* Update the Downtime monitoring upgrade banner so that when dismissed, it won't show the Monitor modal.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

*  Run `git checkout fix/downtime-monitoring-upgrade-banner-dismiss-bug` and `yarn start-jetpack-cloud` or open the Jetpack Cloud live link.
* Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
* Reset the Downtime Monitoring banner preference if you have dismissed this before. Please take a look at the instruction below.
* Refresh the dashboard page so the banner will show up then dismiss the banner by clicking the 'X' button.
* Confirm that the Monitor modal does not show up.
 
<img width="1379" alt="Screen Shot 2023-08-11 at 1 52 01 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/20bf81dd-b1ed-498c-bebc-673c9e222192">

* Reset the banner preference again, this time test the **Explore** button still works as expected by showing the Monitor modal.


**How to reset the banner?**

* On the Jetpack page at the bottom right. Hover on the debug icon and click preferences. Look for jetpack-dashboard-agency-program-downtime-monitoring-upgrade-banner-preference and clear it by clicking the X button.

<img src="https://user-images.githubusercontent.com/56598660/252915055-aeb0af42-c99b-409f-a652-fb2fb207b97b.png" />

This should reset the banner and will show up again on the Dashboard screen.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React, or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205254810113123