### PR TITLE
Checkout: Add email support to feature list when purchasing email products

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -3,9 +3,11 @@ import {
 	getYearlyPlanByMonthly,
 	isDomainProduct,
 	isDomainTransfer,
+	isGoogleWorkspace,
 	isMonthly,
 	isNoAds,
 	isPlan,
+	isTitanMail,
 	isWpComBusinessPlan,
 	isWpComEcommercePlan,
 	isWpComPersonalPlan,
@@ -328,6 +330,10 @@ function CheckoutSummaryFeaturesList( props: {
 		( product ) => isDomainProduct( product ) || isDomainTransfer( product )
 	);
 
+	const hasEmailInCart = responseCart.products.some(
+		( product ) => isGoogleWorkspace( product ) || isTitanMail( product )
+	);
+
 	// Check for domains
 	const domains = responseCart.products.filter(
 		( product ) => isDomainProduct( product ) || isDomainTransfer( product )
@@ -401,6 +407,13 @@ function CheckoutSummaryFeaturesList( props: {
 						{ translate( 'Private domain registration and SSL certificate included for free' ) }
 					</CheckoutSummaryFeaturesListItem>
 				</>
+			) }
+
+			{ ! hasPlanInCart && hasEmailInCart && (
+				<CheckoutSummaryFeaturesListItem>
+					<WPCheckoutCheckIcon id="features-list-support-email" />
+					{ translate( '24/7 support via email' ) }
+				</CheckoutSummaryFeaturesListItem>
 			) }
 
 			{ ( ! hasPlanInCart || hasDomainTransferProduct ) && (


### PR DESCRIPTION
There is currently no summary feature list displayed in checkout when purchasing only Professional Email at first. Surfaced in this conversation: p1691134420750029-slack-C01TJT42PMM. 

A refund policy is displayed for Google Workspace, but not for Professional Email with free trial because the user doesn't pay to trial the product.

To mitigate this, we are adding `24/7 support via email` to the feature list when an email product is in the cart and a plan isn't.

## Proposed Changes

* Display the email support feature when an email product is detected to be in the cart and a plan isn't in the cart

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test multiple scenarios:

* Add just Professional Email (for an existing domain) to the cart
* Add a new domain and Professional Email to the cart
* Add at least a premium plan and Professional Email (for an existing domain) to the cart
* Add at least a premium plan, new domain and Professional Email to the cart
* Run the previous scenarios for Google Workspace as well

In each case, confirm that:
- The added feature list is only displayed when a plan is not in the cart

## Screenshots

*With an active plan*
<img width="1119" alt="Screenshot 2023-08-11 at 6 46 01 AM" src="https://github.com/Automattic/wp-calypso/assets/277661/876c8d5c-2ee3-4e65-9354-407b1aa69303">

*Without a plan*
<img width="1118" alt="Screenshot 2023-08-11 at 6 41 12 AM" src="https://github.com/Automattic/wp-calypso/assets/277661/3a5dcfd8-9b35-4c0e-9071-18ba16cfbce1">

*With a domain in cart*
<img width="1131" alt="Screenshot 2023-08-11 at 6 38 38 AM" src="https://github.com/Automattic/wp-calypso/assets/277661/2306da2c-53bf-4621-a600-907e17eef8ff">

*With a plan in cart*
<img width="1124" alt="Screenshot 2023-08-11 at 6 37 18 AM" src="https://github.com/Automattic/wp-calypso/assets/277661/9eb7e840-1619-41e2-8cce-482d01f4d144">

## Pre-merge Checklist


<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?