### PR TITLE
Fix ScreenCategoryList storybook which was breaking `yarn storybook:start`

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.stories.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.stories.tsx
@@ -7,7 +7,7 @@ import ScreenCategoryList from './screen-category-list';
 /**
  * FIXME: This component should depend only on local `./style.scss`.
  */
-import './navigator-buttons/style.scss';
+import '@automattic/onboarding/src/navigator/navigator-buttons/style.scss';
 import './style.scss';
 
 export default {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

I was looking into using storybook for an upcoming project and noted `yarn storybook:start` wasn't working. The `ScreenCategoryList` story was trying to import a non-existent file.

## Proposed Changes

* Import the navigator button styles from the correct location.

I don't know what the correct fix should be long term. I feel like importing `ScreenCategoryList` should import whatever navigator button component it needs, and the navigator button would import the scss.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn storybook:start`
* Open `http://localhost:6006/?path=/story/client-landing-pattern-assembler-screencategorylist--add-pattern`
   * Before this showed an error on screen (which caused an error on the other stories too)
   * After you can now see the category menu

<img width="912" alt="CleanShot 2023-08-11 at 20 27 24@2x" src="https://github.com/Automattic/wp-calypso/assets/1500769/d7a1e9e3-268c-4003-875b-971fe9243215">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
