### PR TITLE
Presales Chat: Add it back to checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -37,7 +37,6 @@ import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
-import { usePresalesChat } from 'calypso/lib/presales-chat';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
@@ -359,8 +358,6 @@ function CheckoutSummaryFeaturesList( props: {
 	const hasDomainTransferProduct = responseCart.products.some( ( product ) =>
 		isDomainTransfer( product )
 	);
-
-	usePresalesChat( 'wpcom', hasDomainTransferProduct );
 
 	return (
 		<CheckoutSummaryFeaturesListWrapper>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -42,6 +42,7 @@ import {
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
 import { areVatDetailsSame } from 'calypso/me/purchases/vat-info/are-vat-details-same';
 import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
 import { CheckoutOrderBanner } from 'calypso/my-sites/checkout/composite-checkout/components/checkout-order-banner';
@@ -240,6 +241,7 @@ export default function WPCheckout( {
 	const couponFieldStateProps = useCouponFieldState( applyCoupon );
 	const total = useTotal();
 	const reduxDispatch = useReduxDispatch();
+	usePresalesChat( 'wpcom', true, true );
 
 	const areThereDomainProductsInCart =
 		hasDomainRegistration( responseCart ) || hasTransferProduct( responseCart );


### PR DESCRIPTION
Context: p1691533584935889-slack-C02FMH4G8

Presales chat has been refactored to use `usePresalesChat`, and that is not being called by most checkout flows.

This PR adds it back to checkout.

![image](https://github.com/Automattic/wp-calypso/assets/52076348/b883a8ed-ac39-4031-914f-8732638c821e)


## Testing
1. Live link
2. Visit checkout and check that the presales chat appears
3. Try to reach checkout in various ways