### PR TITLE
EducationHeader: decrease search input height

### DIFF
--- a/apps/happy-blocks/block-library/education-header/style.scss
+++ b/apps/happy-blocks/block-library/education-header/style.scss
@@ -117,7 +117,7 @@ body.archive {
 			border-style: none;
 			border-radius: 4px;
 			width: 366px;
-			height: 56px;
+			height: 55px;
 
 			&,
 			&::placeholder {

--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -16,6 +16,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 	p {
 		font-size: 1rem;
 		line-height: 24px;
+		margin-top: 4px;
 	}
 
 	h4 {
@@ -116,6 +117,13 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 		display: flex;
 		justify-content: space-between;
 		margin-top: 3rem;
+
+		p,
+		form {
+			margin-bottom: 8px;
+			margin-top: 0;
+		}
+
 
 		.support-content-subscribe-disclaimer {
 			color: var(--studio-gray-60);


### PR DESCRIPTION
## Proposed Changes

* Decrease the search input height by 1px in our education header, according to a design request
* Fix spacing in the support footer according to the designs



## Testing Instructions
- Checkout this branch
- Sync the happyblocks to your sandbox
- Check the learn site for the changes

- Search should have 55px height
- Each paragraph in the support footer should be spaced accordingly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
