### PR TITLE
Jetpack Pro Dashboard: add UI test cases for downtime monitoring changes(contact-list components)

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/test/contact-list-item.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/test/contact-list-item.tsx
@@ -1,0 +1,161 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import ContactListItem from '../item';
+
+describe( 'ContactListItem', () => {
+	const mockedEmailItem = {
+		email: 'test@test.com',
+		name: 'test',
+		verified: true,
+		isDefault: true,
+	};
+	const mockedPhoneItem = {
+		name: 'test',
+		countryCode: 'AF',
+		countryNumericCode: '+93',
+		phoneNumber: '774405234',
+		phoneNumberFull: '+93774405234',
+		verified: true,
+	};
+
+	const initialState = {};
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'should render the default contact', () => {
+		const mockedOnAction = jest.fn();
+		const mockedRecordEvent = jest.fn();
+		render(
+			<ContactListItem
+				item={ mockedEmailItem }
+				onAction={ mockedOnAction }
+				recordEvent={ mockedRecordEvent }
+				type="email"
+			/>,
+			{
+				wrapper: Wrapper,
+			}
+		);
+		expect( screen.queryByRole( 'button', { name: /more actions/i } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should render the verified contact', () => {
+		const mockedOnAction = jest.fn();
+		const mockedRecordEvent = jest.fn();
+		render(
+			<ContactListItem
+				item={ mockedPhoneItem }
+				onAction={ mockedOnAction }
+				recordEvent={ mockedRecordEvent }
+				showVerifiedBadge
+				type="sms"
+			/>,
+			{
+				wrapper: Wrapper,
+			}
+		);
+
+		expect( screen.getByText( /verified/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render the unverified contact', () => {
+		const mockedOnAction = jest.fn();
+		const mockedRecordEvent = jest.fn();
+		render(
+			<ContactListItem
+				item={ { ...mockedEmailItem, isDefault: false, verified: false } }
+				onAction={ mockedOnAction }
+				recordEvent={ mockedRecordEvent }
+				type="email"
+			/>,
+			{
+				wrapper: Wrapper,
+			}
+		);
+		expect( screen.getByText( /pending/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render contact actions when a contact is verified', () => {
+		const mockedOnAction = jest.fn();
+		const mockedRecordEvent = jest.fn();
+		render(
+			<ContactListItem
+				item={ mockedPhoneItem }
+				onAction={ mockedOnAction }
+				recordEvent={ mockedRecordEvent }
+				showVerifiedBadge
+				type="sms"
+			/>,
+			{
+				wrapper: Wrapper,
+			}
+		);
+
+		const moreActionButton = screen.getByRole( 'button', { name: /more actions/i } );
+		expect( moreActionButton ).toBeInTheDocument();
+
+		fireEvent.click( moreActionButton );
+
+		expect( screen.queryByRole( 'menuitem', { name: /verify/i } ) ).not.toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'menuitem', { name: /edit/i } ) );
+		expect( mockedOnAction ).toHaveBeenCalledWith( mockedPhoneItem, 'edit' );
+		expect( mockedRecordEvent ).toHaveBeenCalledWith(
+			'downtime_monitoring_phone_number_edit_click'
+		);
+
+		fireEvent.click( moreActionButton );
+		fireEvent.click( screen.getByRole( 'menuitem', { name: /remove/i } ) );
+		expect( mockedOnAction ).toHaveBeenCalledWith( mockedPhoneItem, 'remove' );
+		expect( mockedRecordEvent ).toHaveBeenCalledWith(
+			'downtime_monitoring_phone_number_remove_click'
+		);
+	} );
+
+	it( 'should render contact actions when a contact is not verified', () => {
+		const mockedOnAction = jest.fn();
+		const mockedRecordEvent = jest.fn();
+		const emailItem = { ...mockedEmailItem, verified: false, isDefault: false };
+		render(
+			<ContactListItem
+				item={ emailItem }
+				onAction={ mockedOnAction }
+				recordEvent={ mockedRecordEvent }
+				showVerifiedBadge
+				type="email"
+			/>,
+			{
+				wrapper: Wrapper,
+			}
+		);
+
+		const moreActionButton = screen.getByRole( 'button', { name: /more actions/i } );
+		expect( moreActionButton ).toBeInTheDocument();
+
+		fireEvent.click( moreActionButton );
+
+		expect( screen.getByRole( 'menuitem', { name: /edit/i } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'menuitem', { name: /remove/i } ) ).toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'menuitem', { name: /verify/i } ) );
+		expect( mockedOnAction ).toHaveBeenCalledWith( emailItem, 'verify' );
+		expect( mockedRecordEvent ).toHaveBeenCalledWith(
+			'downtime_monitoring_email_address_verify_click'
+		);
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/test/contact-list.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/test/contact-list.tsx
@@ -1,0 +1,144 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import DashboardDataContext from '../../../sites-overview/dashboard-data-context';
+import ContactList from '../index';
+
+describe( 'ContactList', () => {
+	const mockedEmailItems = [
+		{
+			email: 'test@test.com',
+			name: 'test',
+			verified: true,
+			isDefault: true,
+		},
+	];
+	const mockedPhoneItems = [
+		{
+			name: 'test',
+			countryCode: 'AF',
+			countryNumericCode: '+93',
+			phoneNumber: '774405234',
+			phoneNumberFull: '+93774405234',
+			verified: true,
+		},
+	];
+
+	const dashboardContextValue = {
+		verifiedContacts: {
+			emails: [],
+			phoneNumbers: [],
+			refetchIfFailed: jest.fn(),
+		},
+		products: [
+			{
+				name: 'Jetpack Monitor',
+				slug: 'jetpack-monitor',
+				product_id: 123,
+				currency: 'USD',
+				amount: 1,
+				price_interval: 'month',
+				family_slug: 'jetpack-monitor',
+			},
+		],
+		isLargeScreen: true,
+	};
+
+	const initialState = {};
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'should render the add email button', () => {
+		const mockedOnAction = jest.fn();
+		const mockedRecordEvent = jest.fn();
+		render(
+			<ContactList
+				onAction={ mockedOnAction }
+				type="email"
+				items={ mockedEmailItems }
+				recordEvent={ mockedRecordEvent }
+			/>,
+			{
+				wrapper: Wrapper,
+			}
+		);
+
+		const addButton = screen.getByRole( 'button', { name: /add email address/i } );
+		expect( addButton ).toBeInTheDocument();
+
+		fireEvent.click( addButton );
+		expect( mockedOnAction ).toHaveBeenCalledTimes( 1 );
+		expect( mockedRecordEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should show the upgrade path for email', () => {
+		const mockedOnAction = jest.fn();
+		render(
+			<DashboardDataContext.Provider value={ dashboardContextValue }>
+				<ContactList
+					restriction="upgrade_required"
+					onAction={ mockedOnAction }
+					type="email"
+					items={ mockedEmailItems }
+				/>
+				,
+			</DashboardDataContext.Provider>,
+
+			{
+				wrapper: Wrapper,
+			}
+		);
+
+		expect( screen.getByRole( 'button', { name: /add email address/i } ) ).toHaveAttribute(
+			'disabled'
+		);
+
+		const upgradeBadge = screen.getByRole( 'button', { name: 'Upgrade' } );
+		expect( upgradeBadge ).toBeInTheDocument();
+
+		const upgradeLink = screen.getByRole( 'button', { name: 'Upgrade ($1.00/m)' } );
+		expect( upgradeLink ).toBeInTheDocument();
+
+		expect(
+			screen.getByText( /multiple email recipients is part of the basic plan./i )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render the add phone number button', () => {
+		const mockedOnAction = jest.fn();
+		render( <ContactList onAction={ mockedOnAction } type="sms" items={ [] } />, {
+			wrapper: Wrapper,
+		} );
+
+		const addButton = screen.getByRole( 'button', { name: /Add phone number/i } );
+		expect( addButton ).toBeInTheDocument();
+		fireEvent.click( addButton );
+		expect( mockedOnAction ).toHaveBeenCalledTimes( 1 );
+
+		expect( screen.getByText( /you need at least one phone number/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'should not render the add phone number button if there is one contact added', () => {
+		const mockedOnAction = jest.fn();
+		render( <ContactList onAction={ mockedOnAction } type="sms" items={ mockedPhoneItems } />, {
+			wrapper: Wrapper,
+		} );
+
+		expect( screen.queryByRole( 'button', { name: /Add phone number/i } ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /you need at least one phone number/i ) ).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Related to 1202619025189113-as-1205254271742829

#### Proposed Changes

This PR adds test cases to the /contact-list components added as a part of the downtime monitoring changes.

#### Testing Instructions

- Run `git checkout add/test-cases-for-downtime-monitoring-changes-2 && git pull`
- Run `yarn run test-client client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/test/` to run the tests.
- Verify the tests are passing and code changes make sense


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
