### PR TITLE
On billing interval change, replace history instead of pushing

### DIFF
--- a/client/lib/query-args/index.ts
+++ b/client/lib/query-args/index.ts
@@ -34,12 +34,17 @@ function getRelativeUrlWithParameters(
  *    } --> '/read/search'
  *
  * @param queryArgs search object
+ * @param redirect boolean if set to true, the history will be replaced instead of pushed
  * Every object key will be created in the URL
  */
-export function setQueryArgs( queryArgs: object ) {
+export function setQueryArgs( queryArgs: object, redirect = false ) {
 	const searchWithoutBaseURL = getRelativeUrlWithParameters( queryArgs, true );
 
-	page( searchWithoutBaseURL );
+	if ( redirect ) {
+		page.redirect( searchWithoutBaseURL );
+	} else {
+		page( searchWithoutBaseURL );
+	}
 }
 
 /**

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -148,7 +148,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 
 	const onIntervalSwitcherChange = useCallback(
 		( interval ) => {
-			setQueryArgs( { interval: interval?.toLowerCase() } );
+			setQueryArgs( { interval: interval?.toLowerCase() }, true );
 			dispatch( setBillingInterval( interval ) );
 		},
 		[ dispatch ]


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #80437

## Proposed Changes

* Adds an option to the query-args lib to avoid pushing the navigation to history
* Uses the new option on the plugin details page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins`
* Select a paid plugin
* Toggle the billing interval switcher on the page a couple of times
* Navigate back to the plugins page via the breadcrumbs link on the top of the page
* View browser history, check that the plugin page is only added once 
  <img width="573" alt="CleanShot 2023-08-11 at 12 09 12@2x" src="https://github.com/Automattic/wp-calypso/assets/11555574/d135396b-1745-47c7-b990-b070dceaa5c6">

#### Recording

https://github.com/Automattic/wp-calypso/assets/11555574/a157cc7a-81f6-456c-8705-88735e5d3940


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
