### PR TITLE
Update AI Assistant pricing card features

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -981,7 +981,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 	];
 	const aiAssistantIncludesInfo = [
 		translate( 'Prompt-based content generation' ),
-		translate( 'Text, table,list, and form generation' ),
+		translate( 'Text, table, list, and form generation' ),
 		translate( 'Adaptive tone adjustment' ),
 		translate( 'Superior spelling and grammar correction' ),
 		translate( 'Title and summary generation' ),

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -981,10 +981,11 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 	];
 	const aiAssistantIncludesInfo = [
 		translate( 'Prompt-based content generation' ),
-		translate( 'Text, table, and list generation' ),
+		translate( 'Text, table,list, and form generation' ),
 		translate( 'Adaptive tone adjustment' ),
 		translate( 'Superior spelling and grammar correction' ),
 		translate( 'Title and summary generation' ),
+		translate( 'Get feedback about your post' ),
 	];
 
 	// WooCommerce Extensions


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1691756324347449-slack-C054LN8RNVA

## Proposed Changes

* This change updates the text on Jetpack AI product description to have consistent title case and grammar. Available on https://cloud.jetpack.com/pricing
* 
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch locally 
* Start calypso and the Jetpack Cloud environment with `yarn start-jetpack-cloud`
* Navigate to http://jetpack.cloud.localhost:3001/pricing
* Confirm that you see the "AI Assistant" and click on "More about AI"
* Confirm that the text is updated
* Check that the copy looks correct and makes sense
* The list should include "Get feedback about your post"




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?