### PR TITLE
Revert "Subscribe Modal: Temporarily remove edit link "

### DIFF
--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -1,6 +1,11 @@
 import { ToggleControl } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 export const SUBSCRIBE_MODAL_OPTION = 'sm_enabled';
 
@@ -24,6 +29,20 @@ export const SubscribeModalSetting = ( {
 	disabled,
 }: SubscribeModalSettingProps ) => {
 	const translate = useTranslate();
+	const selectedSite = useSelector( getSelectedSite );
+	const siteEditorUrl = useSelector( ( state: object ) =>
+		getSiteEditorUrl( state, selectedSite?.ID || null )
+	);
+	const themeSlug = useSelector( ( state ) =>
+		getSiteOption( state, selectedSite?.ID, 'theme_slug' )
+	);
+	const subscribeModalEditorUrl = themeSlug
+		? addQueryArgs( siteEditorUrl, {
+				postType: 'wp_template_part',
+				postId: `${ themeSlug }//subscribe-modal`,
+				canvas: 'edit',
+		  } )
+		: siteEditorUrl;
 
 	return (
 		<>
@@ -40,10 +59,20 @@ export const SubscribeModalSetting = ( {
 			<FormSettingExplanation>
 				{ isModalToggleHelpTranslated
 					? translate(
-							'Grow your subscriber list by enabling a pop-up modal with a subscribe form. This will show as readers scroll.'
+							'Grow your subscriber list by enabling a pop-up modal with a subscribe form. This will show as readers scroll. {{link}}Edit the modal{{/link}}.',
+							{
+								components: {
+									link: <a href={ subscribeModalEditorUrl } target="_blank" rel="noreferrer" />,
+								},
+							}
 					  )
 					: translate(
-							'Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll.'
+							'Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll. {{link}}Edit the modal{{/link}}.',
+							{
+								components: {
+									link: <a href={ subscribeModalEditorUrl } target="_blank" rel="noreferrer" />,
+								},
+							}
 					  ) }
 			</FormSettingExplanation>
 		</>

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -3,7 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
-import { useSiteOption } from 'calypso/state/sites/hooks';
 import { SubscriptionOptions } from '../settings-reading/main';
 import { EmailsTextSetting } from './EmailsTextSetting';
 import { ExcerptSetting } from './ExcerptSetting';
@@ -36,8 +35,6 @@ export const NewsletterSettingsSection = ( {
 	savedSubscriptionOptions,
 	updateFields,
 }: NewsletterSettingsSectionProps ) => {
-	const siteIntent = useSiteOption( 'site_intent' );
-	const isNewsletterSite = siteIntent === 'newsletter';
 	const translate = useTranslate();
 	const {
 		wpcom_featured_image_in_email,
@@ -80,15 +77,13 @@ export const NewsletterSettingsSection = ( {
 					disabled={ disabled }
 				/>
 			</Card>
-			{ isNewsletterSite && (
-				<Card className="site-settings__card">
-					<SubscribeModalSetting
-						value={ sm_enabled }
-						handleToggle={ handleToggle }
-						disabled={ disabled }
-					/>
-				</Card>
-			) }
+			<Card className="site-settings__card">
+				<SubscribeModalSetting
+					value={ sm_enabled }
+					handleToggle={ handleToggle }
+					disabled={ disabled }
+				/>
+			</Card>
 			<Card className="site-settings__card">
 				<ExcerptSetting
 					value={ wpcom_subscription_emails_use_excerpt }


### PR DESCRIPTION
Now that WP.com runs Gutenberg 16.4 and the bug with API (soon) fixed, we can add back the editing link again.

I'm also including small copy changes, and using "ExternalLink" component which adds the little square to the link, making it clearer we'll open a new tab.

- Mention "popup" more instead of "modal". Feedback from Team 51 and HEs that "popup"is more common term.
- Mention "preview" in the edit link, because people do want to know how they can see it; feedback from Núria.
- Add "external link" icon because it opens in new tab, so this makes it clear and not a surprise.

Reverts Automattic/wp-calypso#80297

**In production without the link:**

<img width="792" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/199ad6a2-e705-4cd0-aa92-626ec0f029f9">

**Before copy changes:**

<img width="786" alt="Screenshot 2023-08-11 at 16 37 33" src="https://github.com/Automattic/wp-calypso/assets/87168/a77bbb1b-f11b-42b9-af55-0af1702c050c">

**After copy changes:**

<img width="769" alt="Screenshot 2023-08-11 at 17 08 32" src="https://github.com/Automattic/wp-calypso/assets/87168/fc5a3f63-4694-47dd-ae55-678fb6f60407">
