### PR TITLE
Fix: Check for the presence of a user id before loading the user.

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -218,7 +218,7 @@ const utils = () => {
 const configureReduxStore = ( currentUser, reduxStore ) => {
 	debug( 'Executing Calypso configure Redux store.' );
 
-	if ( currentUser ) {
+	if ( currentUser && currentUser.ID ) {
 		// Set current user in Redux store
 		reduxStore.dispatch( setCurrentUser( currentUser ) );
 	}

--- a/client/landing/login/common.js
+++ b/client/landing/login/common.js
@@ -55,7 +55,7 @@ export function setupContextMiddleware() {
 export const configureReduxStore = ( currentUser, reduxStore ) => {
 	debug( 'Executing Calypso configure Redux store.' );
 
-	if ( currentUser ) {
+	if ( currentUser && currentUser.ID ) {
 		// Set current user in Redux store
 		reduxStore.dispatch( setCurrentUser( currentUser ) );
 	}


### PR DESCRIPTION
## Proposed Changes

@yansern and me noticed that when landing on wordpress.com/start with a subkey cookie set you get a white screen of death.

I couldn't reproduce locally, but by adding a breakpoint I could see it occurred when receiving the user object in Redux.

![image](https://github.com/Automattic/wp-calypso/assets/528287/c2aa2338-2e57-4818-9aa6-89259493ac8b)

The user object only consisted of a `subscriptionManagementSubkey`, so it's not a user. This PR adds a check for a user's ID before passing it to `CURRENT_USER_RECEIVE`. Keeping this as draft for now, will finish up next week.


## Testing Instructions

On Calypso live:

- Verify that the `/start` URL works with a subkey set (`document.cookie = 'subkey=xxx'`)
- Verify other paths
- Verify subscription management still loads when using a valid subkey

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
