### PR TITLE
Jetpack Cloud Sites Overview: add tests for new buttons

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
@@ -47,7 +47,6 @@ describe( '<SitesOverview>', () => {
 		filter: { issueTypes: [], showOnlyFavorites: false },
 		selectedSites: [],
 		sort: { field: 'url', direction: 'asc' },
-		isLargeScreen: true,
 	};
 
 	const queryClient = new QueryClient();

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
@@ -25,7 +25,11 @@ describe( '<SitesOverview>', () => {
 	const initialState = {
 		sites: {},
 		partnerPortal: { partner: {} },
-		agencyDashboard: {},
+		agencyDashboard: {
+			selectedLicenses: {
+				licenses: [ 'test' ],
+			},
+		},
 		ui: {},
 		documentHead: {},
 		currentUser: {
@@ -43,7 +47,6 @@ describe( '<SitesOverview>', () => {
 		filter: { issueTypes: [], showOnlyFavorites: false },
 		selectedSites: [],
 		sort: { field: 'url', direction: 'asc' },
-		selectedLicensesCount: 0,
 		isLargeScreen: true,
 	};
 
@@ -141,7 +144,20 @@ describe( '<SitesOverview>', () => {
 		await act( () => promise );
 	} );
 
-	test( 'Show the add site and issue license buttons', async () => {
+	test( 'Do not show the Add X Licenses button when license count is 0', async () => {
+		initialState.agencyDashboard.selectedLicenses.licenses = [];
+		setData();
+
+		const { queryByText } = render( <Wrapper context={ context } /> );
+
+		const addLicensesButton = queryByText( 'Add 1 license' );
+		expect( addLicensesButton ).not.toBeInTheDocument();
+
+		//reset the license count
+		initialState.agencyDashboard.selectedLicenses.licenses = [ 'test' ];
+	} );
+
+	test( 'Show the add site and issue license buttons on mobile', async () => {
 		setData();
 
 		const { getAllByText } = render( <Wrapper context={ context } /> );
@@ -150,22 +166,14 @@ describe( '<SitesOverview>', () => {
 		const [ issueLicenseButton ] = getAllByText( 'Issue License' );
 		expect( addSiteButton ).toBeInTheDocument();
 		expect( issueLicenseButton ).toBeInTheDocument();
-
-		const promise = Promise.resolve();
-		await act( () => promise );
 	} );
 
-	test( 'Hide the add site and issue license buttons', async () => {
+	test( 'Show the Add x Licenses button on mobile', async () => {
 		setData();
-		context.selectedLicensesCount = 1;
+
 		const { getAllByText } = render( <Wrapper context={ context } /> );
 
-		const [ addSiteButton ] = getAllByText( 'Add New Site' );
-		const [ issueLicenseButton ] = getAllByText( 'Issue License' );
-		expect( addSiteButton ).not.toBeInTheDocument();
-		expect( issueLicenseButton ).not.toBeInTheDocument();
-
-		const promise = Promise.resolve();
-		await act( () => promise );
+		const [ issueLicenseButton ] = getAllByText( 'Issue 1 license' );
+		expect( issueLicenseButton ).toBeInTheDocument();
 	} );
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
@@ -34,7 +34,7 @@ describe( '<SitesOverview>', () => {
 		partnerPortal: { partner: {} },
 		agencyDashboard: {
 			selectedLicenses: {
-				licenses: [ 'test' ],
+				licenses: [ '' ],
 			},
 		},
 		ui: {},
@@ -84,6 +84,11 @@ describe( '<SitesOverview>', () => {
 		];
 		queryClient.setQueryData( queryKey, data );
 	};
+
+	beforeEach( () => {
+		//some tests manipulate the store, so we need to reset it
+		initialState.agencyDashboard.selectedLicenses.licenses = [];
+	} );
 
 	test( 'Show the correct empty state message when there are no sites and no applied filters in All tab', async () => {
 		setData();
@@ -151,32 +156,12 @@ describe( '<SitesOverview>', () => {
 	} );
 
 	test( 'Do not show the Add X Licenses button when license count is 0', async () => {
-		initialState.agencyDashboard.selectedLicenses.licenses = [];
 		setData();
 
 		const { queryByText } = render( <Wrapper context={ context } /> );
 
 		const addLicensesButton = queryByText( 'Add 1 license' );
 		expect( addLicensesButton ).not.toBeInTheDocument();
-
-		//reset the license count
-		initialState.agencyDashboard.selectedLicenses.licenses = [ 'test' ];
-	} );
-
-	test( 'do not show the add site and issue license buttons on large screen if licenseCount is 1', async () => {
-		setData();
-
-		mockedIsWithinBreakpoint.mockReturnValue( true );
-
-		const { queryByText } = render( <Wrapper context={ context } /> );
-
-		const addSiteButton = queryByText( 'Add New Site' );
-		const issueLicenseButton = queryByText( 'Issue 1 license' );
-		expect( addSiteButton ).not.toBeInTheDocument();
-		expect( issueLicenseButton ).toBeInTheDocument();
-
-		// set screen back to mobile for rest of tests
-		mockedIsWithinBreakpoint.mockReturnValue( false );
 	} );
 
 	test( 'Show the add site and issue license buttons', async () => {
@@ -190,12 +175,32 @@ describe( '<SitesOverview>', () => {
 		expect( issueLicenseButton ).toBeInTheDocument();
 	} );
 
-	test( 'Show the Add x Licenses button on mobile', async () => {
+	test( 'Show the Add x Licenses button when a license is selected', async () => {
+		initialState.agencyDashboard.selectedLicenses.licenses = [ 'test' ];
 		setData();
 
 		const { getAllByText } = render( <Wrapper context={ context } /> );
 
 		const [ issueLicenseButton ] = getAllByText( 'Issue 1 license' );
 		expect( issueLicenseButton ).toBeInTheDocument();
+	} );
+
+	// the default view for tests is mobile, widescreen buttons behave a bit differently
+	test( 'Swap the issue x buttons and add site/add new license buttons on large screen when a license is selected', async () => {
+		initialState.agencyDashboard.selectedLicenses.licenses = [ 'test' ];
+		setData();
+
+		//set screen to widescreen for this test
+		mockedIsWithinBreakpoint.mockReturnValue( true );
+
+		const { queryByText } = render( <Wrapper context={ context } /> );
+
+		const addSiteButton = queryByText( 'Add New Site' );
+		const issueLicenseButton = queryByText( 'Issue 1 license' );
+		expect( addSiteButton ).not.toBeInTheDocument();
+		expect( issueLicenseButton ).toBeInTheDocument();
+
+		// set screen back to mobile for rest of tests
+		mockedIsWithinBreakpoint.mockReturnValue( false );
 	} );
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
@@ -43,6 +43,8 @@ describe( '<SitesOverview>', () => {
 		filter: { issueTypes: [], showOnlyFavorites: false },
 		selectedSites: [],
 		sort: { field: 'url', direction: 'asc' },
+		selectedLicensesCount: 0,
+		isLargeScreen: true,
 	};
 
 	const queryClient = new QueryClient();
@@ -134,6 +136,34 @@ describe( '<SitesOverview>', () => {
 
 		const [ emptyStateMessage ] = getAllByText( "You don't have any favorites yet." );
 		expect( emptyStateMessage ).toBeInTheDocument();
+
+		const promise = Promise.resolve();
+		await act( () => promise );
+	} );
+
+	test( 'Show the add site and issue license buttons', async () => {
+		setData();
+
+		const { getAllByText } = render( <Wrapper context={ context } /> );
+
+		const [ addSiteButton ] = getAllByText( 'Add New Site' );
+		const [ issueLicenseButton ] = getAllByText( 'Issue License' );
+		expect( addSiteButton ).toBeInTheDocument();
+		expect( issueLicenseButton ).toBeInTheDocument();
+
+		const promise = Promise.resolve();
+		await act( () => promise );
+	} );
+
+	test( 'Hide the add site and issue license buttons', async () => {
+		setData();
+		context.selectedLicensesCount = 1;
+		const { getAllByText } = render( <Wrapper context={ context } /> );
+
+		const [ addSiteButton ] = getAllByText( 'Add New Site' );
+		const [ issueLicenseButton ] = getAllByText( 'Issue License' );
+		expect( addSiteButton ).not.toBeInTheDocument();
+		expect( issueLicenseButton ).not.toBeInTheDocument();
 
 		const promise = Promise.resolve();
 		await act( () => promise );


### PR DESCRIPTION


Related to # N/A

## Proposed Changes

* This PR adds tests to the Sites Overview in relation to #79736 which added new buttons
* There are a few conditions for when the buttons should and should not show
* On small screens the buttons should always show, and the add x licenses button should also show if there is a selected license to add
* On large screens, the buttons should show when there is no selected license and be replaced by the add x licenses button when there are selected licenses

## Testing Instructions

* Apply this PR locally
* run `yarn run test-client client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx`
* Ensure all the tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
