### PR TITLE
Education Center: Fix mobile margin top

### DIFF
--- a/apps/happy-blocks/block-library/education-header/style.scss
+++ b/apps/happy-blocks/block-library/education-header/style.scss
@@ -215,6 +215,17 @@ body.archive {
 				}
 			}
 		}
+
+		&.is-webinars,
+		&.is-courses {
+			.happy-blocks-global-header-site__title__wrapper {
+				@media ( max-width: $breakpoint-mobile ) {
+					margin-top: 0;
+				}
+			}
+		}
+
+
 		.happy-blocks-search__inside-wrapper {
 			input {
 				background-color: var(--studio-gray-0);


### PR DESCRIPTION
This PR fixes the Courses and Webinars header (the margin top property)


| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/52076348/bb9aaf06-2684-4b26-b397-720da86333e7)  | ![image](https://github.com/Automattic/wp-calypso/assets/52076348/4921f736-fc16-459b-8d7a-497c69dcb448) |


