### PR TITLE
GF Signup : Attempt 3 - Free free experiment with proper Eligbility

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -15,7 +15,7 @@ import styled from '@emotion/styled';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from '@wordpress/element';
 import classNames from 'classnames';
-import { localize, useTranslate, translate } from 'i18n-calypso';
+import { localize, useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useSelector } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
@@ -276,6 +276,8 @@ const PlansFeaturesMain = ( {
 		// It only applies to main onboarding flow and the paid media flow at the moment.
 		// Standardizing it or not is TBD; see Automattic/growth-foundations#63 and pdgrnI-2nV-p2#comment-4110 for relevant discussion.
 		if ( ! cartItemForPlan ) {
+			recordTracksEvent( 'calypso_signup_free_plan_click' );
+
 			/**
 			 * Delay showing modal until the experiments have loaded
 			 */

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -288,15 +288,17 @@ class DomainsStep extends Component {
 		 * We want to pre load an experiment to show a plan upsell modal in the plans step
 		 */
 		if ( ! isPurchasingItem ) {
-			loadExperimentAssignment( 'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3', {
-				isEligible: flowName === 'onboarding',
-			} );
-			loadExperimentAssignment(
-				'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3',
-				{
-					isEligible: flowName === 'onboarding-pm',
-				}
-			);
+			switch ( flowName ) {
+				case 'onboarding':
+					loadExperimentAssignment(
+						'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3'
+					);
+					break;
+				case 'onboarding-pm':
+					loadExperimentAssignment(
+						'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3'
+					);
+			}
 		}
 
 		suggestion && this.props.submitDomainStepSelection( suggestion, this.getAnalyticsSection() );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -258,6 +258,7 @@ class DomainsStep extends Component {
 	};
 
 	submitWithDomain = ( { googleAppsCartItem, shouldHideFreePlan = false, signupDomainOrigin } ) => {
+		const { flowName } = this.props;
 		const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();
 		const useThemeHeadstartItem = shouldUseThemeAnnotation
 			? { useThemeHeadstart: shouldUseThemeAnnotation }
@@ -287,9 +288,14 @@ class DomainsStep extends Component {
 		 * We want to pre load an experiment to show a plan upsell modal in the plans step
 		 */
 		if ( ! isPurchasingItem ) {
-			loadExperimentAssignment( 'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3' );
+			loadExperimentAssignment( 'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3', {
+				isEligible: flowName === 'onboarding',
+			} );
 			loadExperimentAssignment(
-				'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3'
+				'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3',
+				{
+					isEligible: flowName === 'onboarding-pm',
+				}
 			);
 		}
 


### PR DESCRIPTION
#Fixes Automattic/growth-foundations#139

Related to 
- Attempt 1 -  https://github.com/Automattic/wp-calypso/pull/80335 ( Stopped due to experiment model issue )
- Attempt 2 -  https://github.com/Automattic/wp-calypso/pull/80108 ( Stopped due to experiment code exclusion flag issue )

## Proposed Changes

- The exclusions in the previous PR was incorrect.
- Discussion : pbxNRc-2Ri-p2
- This relaunches the experiment with a brand new experiment model with the fixes included in code.
- The main fix is adding flow based conditions when preloading the experiment.

## Testing Instructions
* Do a few confidence checks based on the test plan in #80108

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
