### PR TITLE
Privacy: add AI bot toggle

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -408,121 +408,137 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 
 		return (
-			<FormFieldset>
-				{ ! isNonAtomicJetpackSite &&
-					! isWPForTeamsSite &&
-					! isAtomicAndEditingToolkitDeactivated && (
+			<>
+				<FormFieldset>
+					{ ! isNonAtomicJetpackSite &&
+						! isWPForTeamsSite &&
+						! isAtomicAndEditingToolkitDeactivated && (
+							<>
+								{ shouldShowPremiumStylesNotice && this.advancedCustomizationNotice() }
+								<FormLabel className={ comingSoonFormLabelClasses }>
+									<FormRadio
+										name="blog_public"
+										value="0"
+										checked={ isAnyComingSoonEnabled }
+										onChange={ () =>
+											this.handleVisibilityOptionChange( {
+												blog_public: 0,
+												wpcom_coming_soon: 0,
+												wpcom_public_coming_soon: 1,
+											} )
+										}
+										disabled={ isComingSoonDisabled }
+										onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+										label={ translate( 'Coming Soon' ) }
+									/>
+								</FormLabel>
+								<FormSettingExplanation>
+									{ translate(
+										'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
+									) }
+								</FormSettingExplanation>
+								{ showPreviewLink && (
+									<div className="site-settings__visibility-label is-checkbox">
+										<SitePreviewLink
+											siteUrl={ site.URL }
+											siteId={ siteId }
+											disabled={ ! isAnyComingSoonEnabled || isSavingSettings }
+											forceOff={ ! isAnyComingSoonEnabled }
+											source="privacy-settings"
+										/>
+									</div>
+								) }
+							</>
+						) }
+					{ isWpcomStagingSite && (
 						<>
-							{ shouldShowPremiumStylesNotice && this.advancedCustomizationNotice() }
-							<FormLabel className={ comingSoonFormLabelClasses }>
-								<FormRadio
+							<PublicFormRadio />
+							<FormSettingExplanation>
+								{ translate(
+									'Your site is visible to everyone, but search engines are discouraged from indexing staging sites.'
+								) }
+							</FormSettingExplanation>
+						</>
+					) }
+					{ ! isNonAtomicJetpackSite && ! isWpcomStagingSite && <PublicFormRadio /> }
+					{ ! isWpcomStagingSite && (
+						<>
+							<FormSettingExplanation>
+								{ translate( 'Your site is visible to everyone.' ) }
+							</FormSettingExplanation>
+							<FormLabel className="site-settings__visibility-label is-checkbox is-hidden">
+								<FormInputCheckbox
 									name="blog_public"
 									value="0"
-									checked={ isAnyComingSoonEnabled }
+									checked={
+										( wpcomPublicComingSoon && blogPublic === 0 && isComingSoonDisabled ) ||
+										( 0 === blogPublic && ! wpcomPublicComingSoon )
+									}
 									onChange={ () =>
 										this.handleVisibilityOptionChange( {
-											blog_public: 0,
+											blog_public:
+												wpcomPublicComingSoon || blogPublic === -1 || blogPublic === 1 ? 0 : 1,
 											wpcom_coming_soon: 0,
-											wpcom_public_coming_soon: 1,
+											wpcom_public_coming_soon: 0,
 										} )
 									}
-									disabled={ isComingSoonDisabled }
+									disabled={ isRequestingSettings }
 									onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-									label={ translate( 'Coming Soon' ) }
+								/>
+								<span>{ translate( 'Discourage search engines from indexing this site' ) }</span>
+								<FormSettingExplanation>
+									{ translate(
+										'This option does not block access to your site — it is up to search engines to honor your request.'
+									) }
+								</FormSettingExplanation>
+							</FormLabel>
+						</>
+					) }
+					{ ! isNonAtomicJetpackSite && (
+						<>
+							<FormLabel className="site-settings__visibility-label is-private">
+								<FormRadio
+									name="blog_public"
+									value="-1"
+									checked={
+										( -1 === blogPublic && ! wpcomComingSoon && ! isPrivateAndUnlaunched ) ||
+										( wpcomComingSoon && isAtomicAndEditingToolkitDeactivated )
+									}
+									onChange={ () =>
+										this.handleVisibilityOptionChange( {
+											blog_public: -1,
+											wpcom_coming_soon: 0,
+											wpcom_public_coming_soon: 0,
+										} )
+									}
+									disabled={ isRequestingSettings }
+									onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+									label={ translate( 'Private' ) }
 								/>
 							</FormLabel>
 							<FormSettingExplanation>
 								{ translate(
-									'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
+									'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
 								) }
 							</FormSettingExplanation>
-							{ showPreviewLink && (
-								<div className="site-settings__visibility-label is-checkbox">
-									<SitePreviewLink
-										siteUrl={ site.URL }
-										siteId={ siteId }
-										disabled={ ! isAnyComingSoonEnabled || isSavingSettings }
-										forceOff={ ! isAnyComingSoonEnabled }
-										source="privacy-settings"
-									/>
-								</div>
-							) }
 						</>
 					) }
-				{ isWpcomStagingSite && (
-					<>
-						<PublicFormRadio />
-						<FormSettingExplanation>
-							{ translate(
-								'Your site is visible to everyone, but search engines are discouraged from indexing staging sites.'
-							) }
-						</FormSettingExplanation>
-					</>
-				) }
-				{ ! isNonAtomicJetpackSite && ! isWpcomStagingSite && <PublicFormRadio /> }
-				{ ! isWpcomStagingSite && (
-					<>
-						<FormSettingExplanation>
-							{ translate( 'Your site is visible to everyone.' ) }
-						</FormSettingExplanation>
-						<FormLabel className="site-settings__visibility-label is-checkbox is-hidden">
-							<FormInputCheckbox
-								name="blog_public"
-								value="0"
-								checked={
-									( wpcomPublicComingSoon && blogPublic === 0 && isComingSoonDisabled ) ||
-									( 0 === blogPublic && ! wpcomPublicComingSoon )
-								}
-								onChange={ () =>
-									this.handleVisibilityOptionChange( {
-										blog_public:
-											wpcomPublicComingSoon || blogPublic === -1 || blogPublic === 1 ? 0 : 1,
-										wpcom_coming_soon: 0,
-										wpcom_public_coming_soon: 0,
-									} )
-								}
-								disabled={ isRequestingSettings }
-								onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-							/>
-							<span>{ translate( 'Discourage search engines from indexing this site' ) }</span>
-							<FormSettingExplanation>
-								{ translate(
-									'This option does not block access to your site — it is up to search engines to honor your request.'
-								) }
-							</FormSettingExplanation>
-						</FormLabel>
-					</>
-				) }
-				{ ! isNonAtomicJetpackSite && (
-					<>
-						<FormLabel className="site-settings__visibility-label is-private">
-							<FormRadio
-								name="blog_public"
-								value="-1"
-								checked={
-									( -1 === blogPublic && ! wpcomComingSoon && ! isPrivateAndUnlaunched ) ||
-									( wpcomComingSoon && isAtomicAndEditingToolkitDeactivated )
-								}
-								onChange={ () =>
-									this.handleVisibilityOptionChange( {
-										blog_public: -1,
-										wpcom_coming_soon: 0,
-										wpcom_public_coming_soon: 0,
-									} )
-								}
-								disabled={ isRequestingSettings }
-								onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-								label={ translate( 'Private' ) }
-							/>
-						</FormLabel>
-						<FormSettingExplanation>
-							{ translate(
-								'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
-							) }
-						</FormSettingExplanation>
-					</>
-				) }
-			</FormFieldset>
+				</FormFieldset>
+				<FormFieldset>
+					<ToggleControl
+						disabled={ isRequestingSettings || isSavingSettings }
+						className="site-settings__gifting-toggle"
+						label={ translate( 'Allow AI bots to index your public content' ) }
+						checked={ fields.wpcom_ai_permission }
+						onChange={ this.props.handleToggle( 'wpcom_ai_permission' ) }
+					/>
+					<FormSettingExplanation>
+						{ translate(
+							'AI bots can crawl public internet sites and use the content to train their algorithms. WordPress.com never gives or sells your data without your explicit permission.'
+						) }
+					</FormSettingExplanation>
+				</FormFieldset>
+			</>
 		);
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Came up at p1691776194523999-slack-C029GN3KD

**WIP**, just visual toggle without backend or anything else for now. To merge, perhaps put this behind a feature flag first. ;-)

Need less clunky copy, explaining it in simple, yet technical terms. Should probably use language like "Disencourage" since we can't stop malicious AI bots who don't respect `robots.txt`.

<img width="761" alt="Screenshot 2023-08-11 at 21 33 43" src="https://github.com/Automattic/wp-calypso/assets/87168/952e0b4c-a980-4495-91df-dcaf0579d18c">


## Proposed Changes

* Add a toggle to disable AI bots from indexing your site. Disabled by default.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Settings → Privacy
* Check `your-site.com/robots.txt`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
