### PR TITLE
Fix the missing ol tag on /plugins list

### DIFF
--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -112,41 +112,43 @@ const PluginsBrowserList = ( {
 
 	return (
 		<div className="plugins-browser-list">
-			{ ! noHeader && ( title || subtitle || resultCount || browseAllLink ) && (
-				<PluginsResultsHeader
-					title={ title }
-					subtitle={ subtitle }
-					resultCount={ resultCount }
-					browseAllLink={ browseAllLink }
-					listName={ listName }
-				/>
-			) }
-			{ listName === 'paid' && (
-				<AsyncLoad
-					require="calypso/blocks/jitm"
-					template="spotlight"
-					placeholder={ null }
-					messagePath="calypso:plugins:spotlight"
-				/>
-			) }
-			{ listType === 'search' && (
-				<AsyncLoad
-					require="calypso/blocks/jitm"
-					template="spotlight"
-					jitmPlaceholder={ SpotlightPlaceholder }
-					messagePath="calypso:plugins:search"
-					searchQuery={ search }
-				/>
-			) }
-			{ listType === 'browse' && (
-				<AsyncLoad
-					require="calypso/blocks/jitm"
-					template="spotlight"
-					jitmPlaceholder={ SpotlightPlaceholder }
-					messagePath={ `calypso:${ sectionJitmPath }:spotlight` }
-				/>
-			) }
-			<Card className="plugins-browser-list__elements">{ renderViews() }</Card>
+			<ol>
+				{ ! noHeader && ( title || subtitle || resultCount || browseAllLink ) && (
+					<PluginsResultsHeader
+						title={ title }
+						subtitle={ subtitle }
+						resultCount={ resultCount }
+						browseAllLink={ browseAllLink }
+						listName={ listName }
+					/>
+				) }
+				{ listName === 'paid' && (
+					<AsyncLoad
+						require="calypso/blocks/jitm"
+						template="spotlight"
+						placeholder={ null }
+						messagePath="calypso:plugins:spotlight"
+					/>
+				) }
+				{ listType === 'search' && (
+					<AsyncLoad
+						require="calypso/blocks/jitm"
+						template="spotlight"
+						jitmPlaceholder={ SpotlightPlaceholder }
+						messagePath="calypso:plugins:search"
+						searchQuery={ search }
+					/>
+				) }
+				{ listType === 'browse' && (
+					<AsyncLoad
+						require="calypso/blocks/jitm"
+						template="spotlight"
+						jitmPlaceholder={ SpotlightPlaceholder }
+						messagePath={ `calypso:${ sectionJitmPath }:spotlight` }
+					/>
+				) }
+				<Card className="plugins-browser-list__elements">{ renderViews() }</Card>
+			</ol>
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75598

## Proposed Changes

* Add a `<ol>` to the `<div className="plugins-browser-list"> `on /plugins so that accessibility devices like screen readers know when to expect the list to start and end.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The /plugins page should display as expected. This is how the plugins list was displayed before this change, it should continue to display this way:
![image](https://github.com/Automattic/wp-calypso/assets/11060356/af430959-9834-4dee-9cac-9df03c6894f7)

* An accessibility scan of that page with a browser plug-in like Axe DevTools should not find missing `<ol>` tags.
* Pre-release tests should pass.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
