### PR TITLE
Remove wp redux routine from redux group in renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -24,6 +24,7 @@
 			groupName: 'redux-related packages',
 			matchPackagePatterns: [ 'redux' ],
 			matchPackageNames: [ 'react-redux' ],
+			excludePackageNames: [ '@wordpress/redux-routine' ],
 			prPriority: 2,
 		},
 		{


### PR DESCRIPTION
Removes `@wordpress/redux-routine` from the redux group in Renovate. It was added because the group matches anything including `redux`