### PR TITLE
Launchpad: Changed css selector to fix rule priority

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -258,7 +258,7 @@
 	fill: var(--studio-green-50);
 }
 
-.launchpad__domain-upgrade-badge {
+.badge.launchpad__domain-upgrade-badge {
 	margin-left: auto;
 	background-color: var(--studio-blue-5);
 	color: var(--studio-blue-80);


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/79820

## Proposed Changes

*This PR fixed the launchpad badge on the full screen Launchpad

Before:
![image](https://github.com/Automattic/wp-calypso/assets/3801502/a5b51e3d-7e6d-45a7-9578-5d20db1d1ce5)

After:
![image](https://github.com/Automattic/wp-calypso/assets/3801502/b43b3ac3-2eee-4ebd-a49b-17012427ed87)

## Testing Instructions

* Create a new site with `/start`
* You will be taken to the fullscreen Launchpad
* Check the badge styles
