### PR TITLE
Substack importer: update docs ID

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -117,7 +117,7 @@ const contextLinks = {
 	},
 	'importers-substack': {
 		link: 'https://wordpress.com/support/import/import-from-substack/',
-		post_id: 87696,
+		post_id: 257527,
 	},
 	'importers-wix': {
 		link: 'https://wordpress.com/support/import/import-from-wix/',

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -1,3 +1,6 @@
+// Links are localized at InlineSupportLink during render
+/* eslint-disable wpcalypso/i18n-unlocalized-url */
+
 const contextLinks = {
 	'account-settings': {
 		link: 'https://wordpress.com/support/account-settings/',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80364

Internal ref 2064-GH-en.support-docs-content

Since the doc isn't public yet, it won't actually load:

<img width="1802" alt="Screenshot 2023-08-12 at 22 33 13" src="https://github.com/Automattic/wp-calypso/assets/87168/07ff62a5-0a56-44d8-8ee9-3a5d0acc347c">


## Proposed Changes

* Switch Substack ID from Squarespace doc to Substack doc


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The doc isn't public yet so nothing to test. The whole importer is behind a feature flag, actually.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
