### PR TITLE
composite-checkout: Extract FormStatusProvider to own component and state

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -723,7 +723,6 @@ export default function CheckoutMain( {
 				onPaymentError={ handlePaymentError }
 				onPaymentRedirect={ handlePaymentRedirect }
 				onPageLoadError={ onPageLoadError }
-				onStepChanged={ handleStepChanged }
 				onPaymentMethodChanged={ handlePaymentMethodChanged }
 				paymentMethods={ paymentMethods }
 				paymentProcessors={ paymentProcessors }
@@ -736,6 +735,7 @@ export default function CheckoutMain( {
 					loadingContent={
 						<CheckoutLoadingPlaceholder checkoutLoadingConditions={ checkoutLoadingConditions } />
 					}
+					onStepChanged={ handleStepChanged }
 					customizedPreviousPath={ customizedPreviousPath }
 					isRemovingProductFromCart={ isRemovingProductFromCart }
 					areThereErrors={ areThereErrors }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -79,7 +79,10 @@ import WPCheckoutOrderSummary from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
 import WPContactFormSummary from './wp-contact-form-summary';
 import type { OnChangeItemVariant } from './item-variation-picker';
-import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
+import type {
+	CheckoutPageErrorCallback,
+	StepChangedCallback,
+} from '@automattic/composite-checkout';
 import type { RemoveProductFromCart, MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { CountryListItem } from '@automattic/wpcom-checkout';
 import type { ReactNode } from 'react';
@@ -211,9 +214,11 @@ export default function WPCheckout( {
 	isInitialCartLoading,
 	customizedPreviousPath,
 	loadingContent,
+	onStepChanged,
 }: {
 	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
 	changeSelection: OnChangeItemVariant;
+	onStepChanged?: StepChangedCallback;
 	countriesList: CountryListItem[];
 	createUserAndSiteBeforeTransaction: boolean;
 	infoMessage?: JSX.Element;
@@ -427,7 +432,7 @@ export default function WPCheckout( {
 			<WPCheckoutMainContent>
 				<CheckoutOrderBanner />
 				<WPCheckoutTitle>{ translate( 'Checkout' ) }</WPCheckoutTitle>
-				<CheckoutStepGroup loadingContent={ loadingContent }>
+				<CheckoutStepGroup loadingContent={ loadingContent } onStepChanged={ onStepChanged }>
 					<PerformanceTrackerStop />
 					{ infoMessage }
 					<CheckoutStepBody

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -122,7 +122,6 @@ It has the following props.
 - `onPaymentRedirect?: ({paymentMethodId: string | null, transactionLastResponse: unknown }) => null`. A function to call for redirect payment methods when payment begins to redirect. Passed the current payment method id and the transaction response as set by the payment processor function.
 - `onPaymentError?: ({paymentMethodId: string | null, transactionError: string | null }) => null`. A function to call for payment methods when payment is not successful.
 - `onPageLoadError?: ( errorType: string, error: Error, errorData?: Record< string, string | number | undefined > ) => void`. A function to call when an internal error boundary triggered.
-- `onStepChanged?: ({ stepNumber: number | null; previousStepNumber: number; paymentMethodId: string }) => void`. A function to call when the active checkout step is changed.
 - `onPaymentMethodChanged?: (method: string) => void`. A function to call when the active payment method is changed. The argument will be the method's id.
 - `paymentMethods: object[]`. An array of [Payment Method objects](#payment-methods). Can be disabled by [useTogglePaymentMethod](#useTogglePaymentMethod).
 - `paymentProcessors: object`. A key-value map of payment processor functions (see [Payment Methods](#payment-methods)).
@@ -206,6 +205,7 @@ Available props:
 - `areStepsActive?: boolean`. A boolean you can set to explicitly disable all the steps in the group.
 - `stepAreaHeader?: ReactNode`. A slot for additional components that can be injected at the top of the step group.
 - `loadingContent: ReactNode`. A component that will be displayed while checkout is loading. The default is [LoadingContent](#LoadingContent).
+- `onStepChanged?: ({ stepNumber: number | null; previousStepNumber: number; paymentMethodId: string }) => void`. A function to call when the active checkout step is changed.
 - `store?: CheckoutStepGroupStore`. A way to inject a data store for the step group created by [createCheckoutStepGroupStore](#createCheckoutStepGroupStore). If not provided, a store will be created automatically.
 
 ### CheckoutSubmitButton

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -15,6 +15,7 @@ import {
 } from '../lib/validation';
 import { LineItem, CheckoutProviderProps, FormStatus, TransactionStatus } from '../types';
 import CheckoutErrorBoundary from './checkout-error-boundary';
+import { FormStatusProvider } from './form-status-provider';
 import TransactionStatusHandler from './transaction-status-handler';
 import type { CheckoutContextInterface } from '../lib/checkout-context';
 import type {
@@ -87,10 +88,7 @@ export function CheckoutProvider( {
 		setPaymentMethodId
 	);
 
-	const [ formStatus, setFormStatus ] = useFormStatusManager(
-		Boolean( isLoading ),
-		Boolean( isValidating )
-	);
+	const formStatusManager = useFormStatusManager( Boolean( isLoading ), Boolean( isValidating ) );
 	const transactionStatusManager = useTransactionStatusManager();
 	const { transactionLastResponse, transactionStatus, transactionError } = transactionStatusManager;
 
@@ -98,7 +96,7 @@ export function CheckoutProvider( {
 		onPaymentComplete,
 		onPaymentRedirect,
 		onPaymentError,
-		formStatus,
+		formStatus: formStatusManager.formStatus,
 		transactionError,
 		transactionStatus,
 		paymentMethodId,
@@ -112,8 +110,6 @@ export function CheckoutProvider( {
 			setDisabledPaymentMethodIds,
 			paymentMethodId,
 			setPaymentMethodId,
-			formStatus,
-			setFormStatus,
 			transactionStatusManager,
 			paymentProcessors,
 			onPageLoadError,
@@ -121,11 +117,9 @@ export function CheckoutProvider( {
 			onPaymentMethodChanged,
 		} ),
 		[
-			formStatus,
 			paymentMethodId,
 			paymentMethods,
 			disabledPaymentMethodIds,
-			setFormStatus,
 			transactionStatusManager,
 			paymentProcessors,
 			onPageLoadError,
@@ -147,10 +141,12 @@ export function CheckoutProvider( {
 			<CheckoutProviderPropValidator propsToValidate={ propsToValidate } />
 			<ThemeProvider theme={ theme || defaultTheme }>
 				<LineItemsProvider items={ items } total={ total }>
-					<CheckoutContext.Provider value={ value }>
-						<TransactionStatusHandler redirectToUrl={ redirectToUrl } />
-						{ children }
-					</CheckoutContext.Provider>
+					<FormStatusProvider formStatusManager={ formStatusManager }>
+						<CheckoutContext.Provider value={ value }>
+							<TransactionStatusHandler redirectToUrl={ redirectToUrl } />
+							{ children }
+						</CheckoutContext.Provider>
+					</FormStatusProvider>
 				</LineItemsProvider>
 			</ThemeProvider>
 		</CheckoutErrorBoundary>

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -40,7 +40,6 @@ export function CheckoutProvider( {
 	onPaymentRedirect,
 	onPaymentError,
 	onPageLoadError,
-	onStepChanged,
 	onPaymentMethodChanged,
 	redirectToUrl,
 	theme,
@@ -113,7 +112,6 @@ export function CheckoutProvider( {
 			transactionStatusManager,
 			paymentProcessors,
 			onPageLoadError,
-			onStepChanged,
 			onPaymentMethodChanged,
 		} ),
 		[
@@ -123,7 +121,6 @@ export function CheckoutProvider( {
 			transactionStatusManager,
 			paymentProcessors,
 			onPageLoadError,
-			onStepChanged,
 			onPaymentMethodChanged,
 		]
 	);

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -17,11 +17,11 @@ import { LineItem, CheckoutProviderProps, FormStatus, TransactionStatus } from '
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import { FormStatusProvider } from './form-status-provider';
 import TransactionStatusHandler from './transaction-status-handler';
-import type { CheckoutContextInterface } from '../lib/checkout-context';
 import type {
 	PaymentEventCallback,
 	PaymentErrorCallback,
 	PaymentProcessorResponseData,
+	CheckoutContextInterface,
 } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout-provider' );

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -355,17 +355,17 @@ function CheckoutStepGroupWrapper( {
 		} );
 	}, [ store ] );
 
-	const [ previousStepNumber, setPreviousStepNumber ] = useState( store.state.activeStepNumber );
+	const previousStepNumber = useRef( store.state.activeStepNumber );
 	const activePaymentMethod = usePaymentMethod();
 	// Call the `onStepChanged` callback when a step changes.
 	useEffect( () => {
-		if ( store.state.activeStepNumber !== previousStepNumber ) {
+		if ( store.state.activeStepNumber !== previousStepNumber.current ) {
 			onStepChanged?.( {
 				stepNumber: store.state.activeStepNumber,
-				previousStepNumber: previousStepNumber,
+				previousStepNumber: previousStepNumber.current,
 				paymentMethodId: activePaymentMethod?.id ?? '',
 			} );
-			setPreviousStepNumber( store.state.activeStepNumber );
+			previousStepNumber.current = store.state.activeStepNumber;
 		}
 		// We only want to run this when the step changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -551,7 +551,7 @@ export const SubmitFooterWrapper = styled.div`
 	}
 `;
 
-export function CheckoutStepArea( {
+function CheckoutStepArea( {
 	children,
 	className,
 }: PropsWithChildren< {

--- a/packages/composite-checkout/src/components/form-status-provider.tsx
+++ b/packages/composite-checkout/src/components/form-status-provider.tsx
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import { FormStatusContext } from '../lib/form-status-context';
+import type { FormStatusManager, FormStatusContextInterface } from '../types';
+import type { ReactNode } from 'react';
+
+/**
+ * This component provides the context necessary to render a
+ * `CheckoutStepGroup` form and/or other forms that want to use the same
+ * active/busy state.
+ *
+ * The required `formStatusManager` prop can be created by calling the
+ * `useFormStatusManager` hook.
+ *
+ * This provider supplies a form status state that can be accessed with
+ * `useFormStatus` and will always be in one of the following states:
+ *
+ * - `FormStatus.LOADING`
+ * - `FormStatus.READY`
+ * - `FormStatus.VALIDATING`
+ * - `FormStatus.SUBMITTING`
+ * - `FormStatus.COMPLETE`
+ *
+ * You can change the current form status by using the `setFormStatus` function
+ * returned by the `useFormStatus` hook.
+ *
+ * You may wrap several `CheckoutStepGroup` instances inside this provider if
+ * they want them to share the same form status.
+ */
+export function FormStatusProvider( {
+	formStatusManager,
+	children,
+}: {
+	formStatusManager: FormStatusManager;
+	children: ReactNode;
+} ) {
+	const value: FormStatusContextInterface = useMemo(
+		() => formStatusManager,
+		[ formStatusManager ]
+	);
+	return <FormStatusContext.Provider value={ value }>{ children }</FormStatusContext.Provider>;
+}

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -2,7 +2,6 @@ import { createContext } from 'react';
 import {
 	StepChangedCallback,
 	CheckoutPageErrorCallback,
-	FormStatus,
 	PaymentMethod,
 	PaymentProcessorProp,
 	TransactionStatusManager,
@@ -15,8 +14,6 @@ export interface CheckoutContextInterface {
 	setDisabledPaymentMethodIds: ( methods: string[] ) => void;
 	paymentMethodId: string | null;
 	setPaymentMethodId: ( id: string ) => void;
-	formStatus: FormStatus;
-	setFormStatus: ( newStatus: FormStatus ) => void;
 	transactionStatusManager: TransactionStatusManager | null;
 	paymentProcessors: PaymentProcessorProp;
 	onPageLoadError?: CheckoutPageErrorCallback;
@@ -30,8 +27,6 @@ const defaultCheckoutContext: CheckoutContextInterface = {
 	setDisabledPaymentMethodIds: noop,
 	paymentMethodId: null,
 	setPaymentMethodId: noop,
-	formStatus: FormStatus.LOADING,
-	setFormStatus: noop,
 	transactionStatusManager: null,
 	paymentProcessors: {},
 };

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -1,25 +1,5 @@
 import { createContext } from 'react';
-import {
-	StepChangedCallback,
-	CheckoutPageErrorCallback,
-	PaymentMethod,
-	PaymentProcessorProp,
-	TransactionStatusManager,
-	PaymentMethodChangedCallback,
-} from '../types';
-
-export interface CheckoutContextInterface {
-	allPaymentMethods: PaymentMethod[];
-	disabledPaymentMethodIds: string[];
-	setDisabledPaymentMethodIds: ( methods: string[] ) => void;
-	paymentMethodId: string | null;
-	setPaymentMethodId: ( id: string ) => void;
-	transactionStatusManager: TransactionStatusManager | null;
-	paymentProcessors: PaymentProcessorProp;
-	onPageLoadError?: CheckoutPageErrorCallback;
-	onStepChanged?: StepChangedCallback;
-	onPaymentMethodChanged?: PaymentMethodChangedCallback;
-}
+import { CheckoutContextInterface } from '../types';
 
 const defaultCheckoutContext: CheckoutContextInterface = {
 	allPaymentMethods: [],

--- a/packages/composite-checkout/src/lib/form-status-context.ts
+++ b/packages/composite-checkout/src/lib/form-status-context.ts
@@ -1,0 +1,12 @@
+import { createContext } from 'react';
+import { FormStatus, FormStatusContextInterface } from '../types';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function noop(): void {}
+
+const defaultFormStatusContext: FormStatusContextInterface = {
+	formStatus: FormStatus.LOADING,
+	setFormStatus: noop,
+};
+
+export const FormStatusContext = createContext( defaultFormStatusContext );

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -98,7 +98,15 @@ export interface FormStatusController extends FormStatusState {
 
 export type FormStatusSetter = ( newStatus: FormStatus ) => void;
 
-export type FormStatusManager = [ FormStatus, FormStatusSetter ];
+export type FormStatusManager = {
+	formStatus: FormStatus;
+	setFormStatus: FormStatusSetter;
+};
+
+export interface FormStatusContextInterface {
+	formStatus: FormStatus;
+	setFormStatus: ( newStatus: FormStatus ) => void;
+}
 
 export type ReactStandardAction< T = string, P = unknown > = P extends void
 	? {

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -108,6 +108,19 @@ export interface FormStatusContextInterface {
 	setFormStatus: ( newStatus: FormStatus ) => void;
 }
 
+export interface CheckoutContextInterface {
+	allPaymentMethods: PaymentMethod[];
+	disabledPaymentMethodIds: string[];
+	setDisabledPaymentMethodIds: ( methods: string[] ) => void;
+	paymentMethodId: string | null;
+	setPaymentMethodId: ( id: string ) => void;
+	transactionStatusManager: TransactionStatusManager | null;
+	paymentProcessors: PaymentProcessorProp;
+	onPageLoadError?: CheckoutPageErrorCallback;
+	onStepChanged?: StepChangedCallback;
+	onPaymentMethodChanged?: PaymentMethodChangedCallback;
+}
+
 export type ReactStandardAction< T = string, P = unknown > = P extends void
 	? {
 			type: T;

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -117,7 +117,6 @@ export interface CheckoutContextInterface {
 	transactionStatusManager: TransactionStatusManager | null;
 	paymentProcessors: PaymentProcessorProp;
 	onPageLoadError?: CheckoutPageErrorCallback;
-	onStepChanged?: StepChangedCallback;
 	onPaymentMethodChanged?: PaymentMethodChangedCallback;
 }
 


### PR DESCRIPTION
The `@automattic/composite-checkout` package has gone through many variations as calypso's checkout was refactored to use it as a replacement to the original calypso checkout experience. As a result, its `CheckoutProvider` wrapper component is something of a ["god object"](https://en.wikipedia.org/wiki/God_object), containing state for many different parts of the systems that the package makes available. In recent refactors, the primary systems have become more clear: the package contains:

- A form UI which allows for multiple steps and various busy and loading states.
- A transaction processing system with customizable functionality for different payment methods.
- An API for payment method UI elements including validation and customizable submit buttons.
- A number of UI primitives like input fields, buttons, layout helpers, and icons.

There's no real reason why these pieces cannot be used independently. However, the way that the pieces are intertwined and their dependence on the single provider makes it difficult to do.

## Proposed Changes

In this PR we refactor the form status state (the overall state of the form: loading, ready, validating, submitting, or complete) to move it into its own provider, `FormStatusProvider`. In order to not change the API of the package too much (yet), this PR leaves the new provider inside the `CheckoutProvider` for now but in the future this change will make it easier to split up the provider into its component parts.

## Testing Instructions

Automated tests should cover most things. We can check that the functionality is preserved by viewing calypso checkout and clicking through the steps, verifying that the form enters a "loading" state when loading, then is editable, then enters a "validating" state when the billing information is validated, and finally that it enters a "submitting" state when the payment button is clicked.

As this PR also moves the `onStepChange` function into a different location, we should also verify that the Tracks events are still fired when a step changes. You can do this by writing `localStorage.setItem('debug', 'calypso:analytics')` in your browser's devtools and then reloading the page. You should see `calypso_checkout_composite_step_changed` with the `step` property every time a step changes (`step` will be the new step), and `calypso_checkout_composite_first_step_complete` when the first step is completed.