### PR TITLE
Paid Stats: Fix celebartion leaking to site type selecting step

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -69,6 +69,9 @@ const ProductCard = ( {
 	const personalLabel = translate( 'Personal site' );
 	const commercialLabel = translate( 'Commercial site' );
 	const selectedTypeLabel = siteType === TYPE_PERSONAL ? personalLabel : commercialLabel;
+	const showCelebration =
+		wizardStep === SCREEN_PURCHASE &&
+		( siteType === TYPE_COMMERCIAL || subscriptionValue >= uiImageCelebrationTier );
 
 	const setPersonalSite = () => {
 		recordTracksEvent( `calypso_stats_personal_plan_selected` );
@@ -211,12 +214,8 @@ const ProductCard = ( {
 					<div className={ `${ COMPONENT_CLASS_NAME }__card-inner--right` }>
 						<StatsPurchaseSVG
 							isFree={ siteType === TYPE_PERSONAL && subscriptionValue === 0 }
-							hasHighlight={
-								siteType === TYPE_COMMERCIAL || subscriptionValue >= uiImageCelebrationTier
-							}
-							extraMessage={
-								siteType === TYPE_COMMERCIAL || subscriptionValue >= uiImageCelebrationTier
-							}
+							hasHighlight={ showCelebration }
+							extraMessage={ showCelebration }
 						/>
 						<div className={ `${ COMPONENT_CLASS_NAME }__card-inner--right-background` }>
 							<img src={ statsPurchaseBackgroundSVG } alt="Blurred background" />


### PR DESCRIPTION
Related to #80469 

## Proposed Changes

Celebration effects should only be shown for the second step, the pricing confirmation step. In the site type selecting step, the celebration effects should always be hidden.

This is a regression caused by the refactoring of #79815.

## Testing Instructions

* Open Calypso Live Branch
* Open `/stats/purchase/:siteSlug`
* Choose `Commercial site`
* Ensure you see the celebration effects
* Click `⓵Commercial site`
* Ensure the effects are gone

| Site Type Selection | Commercial / Personal > 80% |
| --- | ----------- |
| <img width="250" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/a9a4d2ea-75b5-46ff-9194-a4eda63ee949"> | <img width="250" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/8a840612-e58c-4cdc-8664-5edc0bd73b65"> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
