### PR TITLE
i18n on logged out /tags page

### DIFF
--- a/client/blocks/reader-post-card/tag-link.jsx
+++ b/client/blocks/reader-post-card/tag-link.jsx
@@ -1,3 +1,4 @@
+import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
@@ -30,10 +31,12 @@ class TagLink extends Component {
 
 	render() {
 		const { tag } = this.props;
+		const path = addLocaleToPathLocaleInFront( `/tag/${ encodeURIComponent( tag.slug ) }` );
+
 		return (
 			<span className="reader-post-card__tag">
 				<a
-					href={ '/tag/' + tag.slug }
+					href={ path }
 					className="reader-post-card__tag-link ignore-click"
 					onClick={ this.recordSingleTagClick }
 				>

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -76,6 +76,7 @@ export const ssrSetupLocale = ssrSetupLocaleMiddleware();
 /**
  * These functions are not used by Node. It is here to provide an APi compatible with `./index.web.js`
  */
+export const redirectLoggedInUrl = () => {};
 export const redirectInvalidLanguage = () => {};
 export const redirectLoggedOut = () => {};
 export const redirectLoggedOutToSignup = () => {};

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -1,5 +1,9 @@
 import config from '@automattic/calypso-config';
-import { getLanguage, getLanguageSlugs } from '@automattic/i18n-utils';
+import {
+	getLanguage,
+	getLanguageSlugs,
+	removeLocaleFromPathLocaleInFront,
+} from '@automattic/i18n-utils';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { translate } from 'i18n-calypso';
 import page from 'page';
@@ -209,5 +213,15 @@ export const notFound = ( context, next ) => {
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 
+	next();
+};
+
+export const redirectLoggedInUrl = ( context, next ) => {
+	if ( isUserLoggedIn( context.store.getState() ) ) {
+		const pathWithoutLocale = removeLocaleFromPathLocaleInFront( context.path );
+		if ( pathWithoutLocale !== context.path ) {
+			return page.redirect( pathWithoutLocale );
+		}
+	}
 	next();
 };

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -39,11 +39,7 @@ class MasterbarLoggedOut extends Component {
 	renderTagsItem() {
 		const { translate } = this.props;
 		const locale = getLocaleSlug();
-
-		let tagsUrl = '/tags';
-		if ( ! isDefaultLocale( locale ) ) {
-			tagsUrl = addLocaleToPathLocaleInFront( tagsUrl, locale );
-		}
+		const tagsUrl = addLocaleToPathLocaleInFront( '/tags', locale );
 
 		return (
 			<Item url={ tagsUrl }>
@@ -58,11 +54,7 @@ class MasterbarLoggedOut extends Component {
 	renderSearchItem() {
 		const { translate } = this.props;
 		const locale = getLocaleSlug();
-
-		let searchUrl = '/read/search';
-		if ( ! isDefaultLocale( locale ) ) {
-			searchUrl = addLocaleToPathLocaleInFront( searchUrl, locale );
-		}
+		const searchUrl = addLocaleToPathLocaleInFront( '/read/search', locale );
 
 		return (
 			<Item url={ searchUrl }>
@@ -77,11 +69,7 @@ class MasterbarLoggedOut extends Component {
 	renderDiscoverItem() {
 		const { translate } = this.props;
 		const locale = getLocaleSlug();
-
-		let discoverUrl = '/discover';
-		if ( ! isDefaultLocale( locale ) ) {
-			discoverUrl = addLocaleToPathLocaleInFront( discoverUrl, locale );
-		}
+		const discoverUrl = addLocaleToPathLocaleInFront( '/discover', locale );
 
 		return (
 			<Item url={ discoverUrl }>

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -38,8 +38,7 @@ class MasterbarLoggedOut extends Component {
 
 	renderTagsItem() {
 		const { translate } = this.props;
-		const locale = getLocaleSlug();
-		const tagsUrl = addLocaleToPathLocaleInFront( '/tags', locale );
+		const tagsUrl = addLocaleToPathLocaleInFront( '/tags' );
 
 		return (
 			<Item url={ tagsUrl }>
@@ -53,8 +52,7 @@ class MasterbarLoggedOut extends Component {
 
 	renderSearchItem() {
 		const { translate } = this.props;
-		const locale = getLocaleSlug();
-		const searchUrl = addLocaleToPathLocaleInFront( '/read/search', locale );
+		const searchUrl = addLocaleToPathLocaleInFront( '/read/search' );
 
 		return (
 			<Item url={ searchUrl }>
@@ -68,8 +66,7 @@ class MasterbarLoggedOut extends Component {
 
 	renderDiscoverItem() {
 		const { translate } = this.props;
-		const locale = getLocaleSlug();
-		const discoverUrl = addLocaleToPathLocaleInFront( '/discover', locale );
+		const discoverUrl = addLocaleToPathLocaleInFront( '/discover' );
 
 		return (
 			<Item url={ discoverUrl }>

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -38,13 +38,12 @@ class MasterbarLoggedOut extends Component {
 
 	renderTagsItem() {
 		const { translate } = this.props;
-		// const locale = getLocaleSlug();
+		const locale = getLocaleSlug();
 
-		const tagsUrl = '/tags';
-		// TODO - Enable locales for logged out tags page.
-		// if ( ! isDefaultLocale( locale ) ) {
-		// 	tagsUrl = addLocaleToPathLocaleInFront( tagsUrl, locale );
-		// }
+		let tagsUrl = '/tags';
+		if ( ! isDefaultLocale( locale ) ) {
+			tagsUrl = addLocaleToPathLocaleInFront( tagsUrl, locale );
+		}
 
 		return (
 			<Item url={ tagsUrl }>

--- a/client/reader/discover/index.js
+++ b/client/reader/discover/index.js
@@ -1,6 +1,11 @@
 import { getLanguageRouteParam, getAnyLanguageRouteParam } from '@automattic/i18n-utils';
 import page from 'page';
-import { makeLayout, redirectInvalidLanguage, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	redirectInvalidLanguage,
+	redirectLoggedInUrl,
+	render as clientRender,
+} from 'calypso/controller';
 import { setLocaleMiddleware } from 'calypso/controller/shared';
 import { sidebar, updateLastRoute } from 'calypso/reader/controller';
 import { discover } from './controller';
@@ -12,6 +17,7 @@ export default function () {
 
 	page(
 		[ '/discover', `/${ langParam }/discover` ],
+		redirectLoggedInUrl,
 		setLocaleMiddleware(),
 		updateLastRoute,
 		sidebar,

--- a/client/reader/search/index.js
+++ b/client/reader/search/index.js
@@ -1,10 +1,11 @@
-import {
-	getLanguageRouteParam,
-	getAnyLanguageRouteParam,
-	removeLocaleFromPathLocaleInFront,
-} from '@automattic/i18n-utils';
+import { getLanguageRouteParam, getAnyLanguageRouteParam } from '@automattic/i18n-utils';
 import page from 'page';
-import { makeLayout, redirectInvalidLanguage, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	redirectInvalidLanguage,
+	redirectLoggedInUrl,
+	render as clientRender,
+} from 'calypso/controller';
 import { setLocaleMiddleware } from 'calypso/controller/shared';
 import { sidebar, updateLastRoute } from 'calypso/reader/controller';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -14,16 +15,6 @@ import { search } from './controller';
 const fetchTrendingTagsIfLoggedOut = ( context, next ) => {
 	if ( ! isUserLoggedIn( context.store.getState() ) ) {
 		return fetchTrendingTags( context, next );
-	}
-	next();
-};
-
-const redirectLoggedInUrl = ( context, next ) => {
-	if ( isUserLoggedIn( context.store.getState() ) ) {
-		const pathWithoutLocale = removeLocaleFromPathLocaleInFront( context.path );
-		if ( pathWithoutLocale !== context.path ) {
-			return page.redirect( pathWithoutLocale );
-		}
 	}
 	next();
 };

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -1,5 +1,6 @@
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
+import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
@@ -55,6 +56,7 @@ const ReaderTagSidebar = ( { tag } ) => {
 	const relatedSitesLinks = relatedMetaByTag.data?.related_sites?.map( ( relatedSite ) => (
 		<ReaderListFollowingItem key={ relatedSite.feed_ID } follow={ relatedSite } path="/" />
 	) );
+	const tagsPageUrl = addLocaleToPathLocaleInFront( '/tags' );
 
 	return (
 		<>
@@ -80,7 +82,11 @@ const ReaderTagSidebar = ( { tag } ) => {
 					<div className="reader-post-card__tags">{ tagLinks }</div>
 				</div>
 			) }
-			<a className="reader-tag-sidebar-tags-page" href="/tags" onClick={ trackTagsPageLinkClick }>
+			<a
+				className="reader-tag-sidebar-tags-page"
+				href={ tagsPageUrl }
+				onClick={ trackTagsPageLinkClick }
+			>
 				{ translate( 'See all tags' ) }
 			</a>
 			{ relatedSitesLinks && (

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -6,6 +6,7 @@ import {
 	makeLayout,
 	redirectLoggedOutToSignup,
 	redirectInvalidLanguage,
+	redirectLoggedInUrl,
 	render as clientRender,
 } from 'calypso/controller';
 import { setLocaleMiddleware } from 'calypso/controller/shared';
@@ -36,6 +37,7 @@ export default function () {
 
 	page(
 		[ '/tag/:tag', `/${ langParam }/tag/:tag` ],
+		redirectLoggedInUrl,
 		setLocaleMiddleware(),
 		redirectToSignup,
 		updateLastRoute,

--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -1,3 +1,4 @@
+import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { debounce } from 'lodash';
@@ -31,16 +32,16 @@ const trackTagClick = ( slug: string ) => {
 	} );
 };
 
-const TagsColumn = ( props: TagsColProps ) => (
-	<div key={ props.slug }>
-		<a
-			href={ `/tag/${ encodeURIComponent( props.slug ) }` }
-			onClick={ trackTagClick.bind( null, props.slug ) }
-		>
-			<span className="alphabetic-tags__title">{ titlecase( props.title ) }</span>
-		</a>
-	</div>
-);
+const TagsColumn = ( props: TagsColProps ) => {
+	const path = addLocaleToPathLocaleInFront( `/tag/${ encodeURIComponent( props.slug ) }` );
+	return (
+		<div key={ props.slug }>
+			<a href={ path } onClick={ trackTagClick.bind( null, props.slug ) }>
+				<span className="alphabetic-tags__title">{ titlecase( props.title ) }</span>
+			</a>
+		</div>
+	);
+};
 
 const TagsRow = ( props: TagsRowProps ) => (
 	<div className="alphabetic-tags__row">

--- a/client/reader/tags/index.node.js
+++ b/client/reader/tags/index.node.js
@@ -1,6 +1,17 @@
-import { makeLayout } from 'calypso/controller';
+import { getLanguageRouteParam, getAnyLanguageRouteParam } from '@automattic/i18n-utils';
+import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import { tagsListing, fetchTrendingTags, fetchAlphabeticTags } from './controller';
 
 export default function ( router ) {
-	router( '/tags', fetchTrendingTags, fetchAlphabeticTags, tagsListing, makeLayout );
+	const langParam = getLanguageRouteParam();
+	const anyLangParam = getAnyLanguageRouteParam();
+
+	router(
+		[ '/tags', `/${ langParam }/tags`, `/${ anyLangParam }/tags` ],
+		ssrSetupLocale,
+		fetchTrendingTags,
+		fetchAlphabeticTags,
+		tagsListing,
+		makeLayout
+	);
 }

--- a/client/reader/tags/index.web.js
+++ b/client/reader/tags/index.web.js
@@ -1,10 +1,15 @@
+import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { setLocaleMiddleware } from 'calypso/controller/shared';
 import { sidebar } from '../controller';
 import { tagsListing, fetchTrendingTags, fetchAlphabeticTags } from './controller';
 
 export default function ( router ) {
+	const langParam = getLanguageRouteParam();
+
 	router(
-		'/tags',
+		[ '/tags', `/${ langParam }/tags` ],
+		setLocaleMiddleware(),
 		fetchTrendingTags,
 		fetchAlphabeticTags,
 		sidebar,

--- a/client/reader/tags/index.web.js
+++ b/client/reader/tags/index.web.js
@@ -1,5 +1,5 @@
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import { makeLayout, redirectLoggedInUrl, render as clientRender } from 'calypso/controller';
 import { setLocaleMiddleware } from 'calypso/controller/shared';
 import { sidebar } from '../controller';
 import { tagsListing, fetchTrendingTags, fetchAlphabeticTags } from './controller';
@@ -9,6 +9,7 @@ export default function ( router ) {
 
 	router(
 		[ '/tags', `/${ langParam }/tags` ],
+		redirectLoggedInUrl,
 		setLocaleMiddleware(),
 		fetchTrendingTags,
 		fetchAlphabeticTags,

--- a/client/reader/tags/trending-tags.tsx
+++ b/client/reader/tags/trending-tags.tsx
@@ -1,3 +1,5 @@
+import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
+import { getLocaleSlug } from 'i18n-calypso';
 import titlecase from 'to-title-case';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formatNumberCompact from 'calypso/lib/format-number-compact';
@@ -20,17 +22,18 @@ const trackTagClick = ( slug: string ) => {
 	} );
 };
 
-const TagRow = ( props: TagRowProps ) => (
-	<div className="trending-tags__column" key={ props.slug }>
-		<a
-			href={ `/tag/${ encodeURIComponent( props.slug ) }` }
-			onClick={ trackTagClick.bind( null, props.slug ) }
-		>
-			<span className="trending-tags__title">{ titlecase( props.title ) }</span>
-			<span className="trending-tags__count">{ formatNumberCompact( props.count ) }</span>
-		</a>
-	</div>
-);
+const TagRow = ( props: TagRowProps ) => {
+	const locale = getLocaleSlug();
+	const path = addLocaleToPathLocaleInFront( `/tag/${ encodeURIComponent( props.slug ) }`, locale );
+	return (
+		<div className="trending-tags__column" key={ props.slug }>
+			<a href={ path } onClick={ trackTagClick.bind( null, props.slug ) }>
+				<span className="trending-tags__title">{ titlecase( props.title ) }</span>
+				<span className="trending-tags__count">{ formatNumberCompact( props.count ) }</span>
+			</a>
+		</div>
+	);
+};
 
 export default function TrendingTags( { trendingTags }: TrendingTagsProps ) {
 	if ( ! trendingTags ) {

--- a/client/reader/tags/trending-tags.tsx
+++ b/client/reader/tags/trending-tags.tsx
@@ -1,5 +1,4 @@
 import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
-import { getLocaleSlug } from 'i18n-calypso';
 import titlecase from 'to-title-case';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formatNumberCompact from 'calypso/lib/format-number-compact';
@@ -23,8 +22,7 @@ const trackTagClick = ( slug: string ) => {
 };
 
 const TagRow = ( props: TagRowProps ) => {
-	const locale = getLocaleSlug();
-	const path = addLocaleToPathLocaleInFront( `/tag/${ encodeURIComponent( props.slug ) }`, locale );
+	const path = addLocaleToPathLocaleInFront( `/tag/${ encodeURIComponent( props.slug ) }` );
 	return (
 		<div className="trending-tags__column" key={ props.slug }>
 			<a href={ path } onClick={ trackTagClick.bind( null, props.slug ) }>

--- a/client/sections.js
+++ b/client/sections.js
@@ -348,7 +348,7 @@ const sections = [
 	},
 	{
 		name: 'reader',
-		paths: [ '/tags' ],
+		paths: [ '/tags', '/([a-z]{2,3}|[a-z]{2}-[a-z]{2})/tags' ],
 		module: 'calypso/reader/tags',
 		group: 'reader',
 		trackLoadPerformance: true,

--- a/packages/i18n-utils/src/test/utils.js
+++ b/packages/i18n-utils/src/test/utils.js
@@ -34,7 +34,7 @@ describe( '#addLocaleToPathLocaleInFront', () => {
 	test( 'should correctly return the real path when locale is at the beginning of the path', () => {
 		expect( addLocaleToPathLocaleInFront( '/en/themes', 'fr' ) ).toBe( '/fr/themes' );
 		expect( addLocaleToPathLocaleInFront( '/themes?thing=stuff', 'en' ) ).toBe(
-			'/en/themes?thing=stuff'
+			'/themes?thing=stuff'
 		);
 	} );
 } );

--- a/packages/i18n-utils/src/test/utils.js
+++ b/packages/i18n-utils/src/test/utils.js
@@ -4,7 +4,11 @@ import {
 	addLocaleToPathLocaleInFront,
 } from '../';
 
-jest.mock( '@automattic/calypso-config', () => ( {} ) );
+jest.mock( '@automattic/calypso-config', () => ( key ) => {
+	if ( 'i18n_default_locale_slug' === key ) {
+		return 'en';
+	}
+} );
 
 describe( '#getMappedLanguageSlug', () => {
 	test( 'should Norwegian `no` locale slug to `nb`.', () => {

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -247,10 +247,10 @@ export function isTranslatedIncompletely( locale: string ) {
  * Will replace existing locale slug, if present.
  *
  * @param path - original path
- * @param locale - locale slug (eg: 'fr')
  * @returns original path with new locale slug
  */
-export function addLocaleToPathLocaleInFront( path: string, locale: string | null ) {
+export function addLocaleToPathLocaleInFront( path: string ) {
+	const locale = getLocaleSlug();
 	const urlParts = getUrlParts( path );
 	const queryString = urlParts.search || '';
 	if ( ! locale || isDefaultLocale( locale ) ) {

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -247,16 +247,20 @@ export function isTranslatedIncompletely( locale: string ) {
  * Will replace existing locale slug, if present.
  *
  * @param path - original path
+ * @param locale - the locale to add to the path (Optional)
+ *
  * @returns original path with new locale slug
  */
-export function addLocaleToPathLocaleInFront( path: string ) {
-	const locale = getLocaleSlug();
+export function addLocaleToPathLocaleInFront( path: string, locale?: string ) {
+	const localeOrDefault = locale || getLocaleSlug();
 	const urlParts = getUrlParts( path );
 	const queryString = urlParts.search || '';
-	if ( ! locale || isDefaultLocale( locale ) ) {
+	if ( ! localeOrDefault || isDefaultLocale( localeOrDefault ) ) {
 		return path;
 	}
-	return `/${ locale }` + removeLocaleFromPathLocaleInFront( urlParts.pathname ) + queryString;
+	return (
+		`/${ localeOrDefault }` + removeLocaleFromPathLocaleInFront( urlParts.pathname ) + queryString
+	);
 }
 
 /**

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -250,10 +250,12 @@ export function isTranslatedIncompletely( locale: string ) {
  * @param locale - locale slug (eg: 'fr')
  * @returns original path with new locale slug
  */
-export function addLocaleToPathLocaleInFront( path: string, locale: string ) {
+export function addLocaleToPathLocaleInFront( path: string, locale: string | null ) {
 	const urlParts = getUrlParts( path );
 	const queryString = urlParts.search || '';
-
+	if ( ! locale || isDefaultLocale( locale ) ) {
+		return path;
+	}
 	return `/${ locale }` + removeLocaleFromPathLocaleInFront( urlParts.pathname ) + queryString;
 }
 


### PR DESCRIPTION
Follow up on https://github.com/Automattic/wp-calypso/pull/80302 as part of pe7F0s-148-p2.

This enables internationalization on the /tags page via routes such as `/:lang/tags` e.g. `/es/tags`

This route behaves slightly differently to the other reader routes because it supports server side rendering. Server side rendering is done in index.node.js with the `ssrSetupLocale` middleware. Another example of this can be seen in the `/themes` route.

The `ssrSetupLocale` middleware handles invalid language codes e.g. `/zzz/tags`, these will be redirected to the `/tags` page as expected.

Note that the alphabetic tag listing is still in English, this is because the list is hand curated.

### Testing instructions
In a logged out browser:
Go to `/es/tags`, the page should be translated.
Try an invalid language such as `/zzz/tags`. You should be redirected to `/tags`
Scroll to the bottom ofthe page and use the language switcher, you should switch to that language using the URL
