### PR TITLE
Stats: Append checkoutBackUrl to the Stats purchase checkout link

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -42,12 +42,16 @@ const getCheckoutBackUrl = ( {
 	siteSlug: string;
 	adminUrl?: string;
 } ) => {
+	// TODO: Enumerate all possible values of `from` parameter.
 	const isFromWPAdmin = from.startsWith( 'jetpack' );
 	const isFromMyJetpack = from === 'jetpack-my-jetpack';
+	const isFromPlansPage = from === 'calypso-plans';
 
 	// Use full URL even though redirecting on Calypso.
 	if ( ! isFromWPAdmin ) {
-		return window.location.origin + `/stats/day/${ siteSlug }`;
+		return window.location.origin + isFromPlansPage
+			? `/plans/${ siteSlug }`
+			: `/stats/day/${ siteSlug }`;
 	}
 
 	const checkoutBackPath = isFromMyJetpack ? 'admin.php?page=my-jetpack' : 'admin.php?page=stats';

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -49,9 +49,10 @@ const getCheckoutBackUrl = ( {
 
 	// Use full URL even though redirecting on Calypso.
 	if ( ! isFromWPAdmin ) {
-		return window.location.origin + isFromPlansPage
-			? `/plans/${ siteSlug }`
-			: `/stats/day/${ siteSlug }`;
+		return (
+			window.location.origin +
+			( isFromPlansPage ? `/plans/${ siteSlug }` : `/stats/day/${ siteSlug }` )
+		);
 	}
 
 	const checkoutBackPath = isFromMyJetpack ? 'admin.php?page=my-jetpack' : 'admin.php?page=stats';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80257 

## Proposed Changes

* Prepare `checkoutBackUrl` for the checkout link to redirect back to the previous page when the checkout is canceled.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Calypso Stats
* Spin up the change with the Live Calypso link.
* Navigate to the Stats > `Traffic` page of your Jetpack site.
* Click the `Upgrade my Stats` button on the upsell notice.
* Ensure the page is directed to the Stats purchase page.
* Checkout with any of Stats products.
* Click the `Remove from cart` action on the checkout page.
* Ensure the redirection after canceling checkout is back to the Calypso Stats page, where you start the flow.

#### Calypso Plans
* Navigate to the Plans page of your Jetpack site on Calypso: `/plans/{jetpack-site-slug}`.
* Click the `Get` button on the Stats product card.
* Ensure the page is directed to the Stats purchase page.
* Checkout with any of Stats products.
* Click the `Remove from cart` action on the checkout page.
* Ensure the redirection after canceling checkout is back to the Plans page, where you start the flow.

#### Odyssey Stats
* Spin up the change with the local Jetpack site.
* Navigate to the Stats > `Traffic` page.
* Click the `Upgrade my Stats` button on the upsell notice.
* Ensure the page is directed to the Stats purchase page.
* Checkout with any of Stats products.
* Click the `Remove from cart` action on the checkout page.
* Ensure the redirection after canceling checkout is back to the Odyssey Stats page, where you start the flow.

#### My Jetpack
* Navigate to the My Jetpack page of your Jetpack site.
* Click the `Upgrade` button on the Stats product card.
* Ensure the page is directed to the Stats purchase page.
* Checkout with any of Stats products.
* Click the `Remove from cart` action on the checkout page.
* Ensure the redirection after canceling checkout is back to the My Jetpack page, where you start the flow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
