### PR TITLE
Domain Management i1: Creates initial `<DomainsTable>` component

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -16,6 +16,7 @@ storybookConfig.previewHead = ( head ) => `
 	${ head }
 	<script>
 		window.configData = ${ JSON.stringify( configData ) };
+		window.__i18n_text_domain__ = 'default';
 	</script>
 `;
 

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -7,6 +7,7 @@ const storybookConfig = storybookDefaultConfig( {
 		'../client/**/*.stories.{js,jsx,ts,tsx}',
 		'../packages/design-picker/src/**/*.stories.{ts,tsx}',
 		'../packages/components/src/**/*.stories.{js,jsx,ts,tsx}',
+		'../packages/domains-table/src/**/*.stories.{js,jsx,ts,tsx}',
 	],
 } );
 

--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -70,6 +70,7 @@ class DomainManagementData extends Component {
 
 export function UsePresalesChat() {
 	usePresalesChat( 'wpcom', true, true );
+	return null;
 }
 
 export default connect( ( state ) => {

--- a/client/my-sites/domains/domain-management/components/domain-header/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain-header/index.tsx
@@ -12,7 +12,7 @@ type NavigationItem = {
 
 type DomainHeaderProps = {
 	items: Array< NavigationItem >;
-	mobileItem: NavigationItem;
+	mobileItem?: NavigationItem;
 	buttons?: Array< ReactNode > | null;
 	mobileButtons?: Array< ReactNode > | null;
 	titleOverride?: ReactNode | null;

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from 'page';
 import DomainManagementData from 'calypso/components/data/domain-management';
 import { isFreeUrlDomainName } from 'calypso/lib/domains/utils';
@@ -44,14 +45,25 @@ export default {
 	},
 
 	domainManagementListAllSites( pageContext, next ) {
-		pageContext.primary = (
-			<DomainManagementData
-				analyticsPath={ domainManagementRoot() }
-				analyticsTitle="Domain Management > All Domains"
-				component={ DomainManagement.AllDomains }
-				context={ pageContext }
-			/>
-		);
+		if ( isEnabled( 'domains/management' ) ) {
+			pageContext.primary = (
+				<>
+					<DomainManagement.BulkAllDomains
+						analyticsPath={ domainManagementRoot() }
+						analyticsTitle="Domain Management > All Domains"
+					/>
+				</>
+			);
+		} else {
+			pageContext.primary = (
+				<DomainManagementData
+					analyticsPath={ domainManagementRoot() }
+					analyticsTitle="Domain Management > All Domains"
+					component={ DomainManagement.AllDomains }
+					context={ pageContext }
+				/>
+			);
+		}
 		next();
 	},
 

--- a/client/my-sites/domains/domain-management/index.jsx
+++ b/client/my-sites/domains/domain-management/index.jsx
@@ -1,4 +1,5 @@
 import AllDomains from 'calypso/my-sites/domains/domain-management/list/all-domains';
+import BulkAllDomains from 'calypso/my-sites/domains/domain-management/list/bulk-all-domains';
 import SiteDomains from 'calypso/my-sites/domains/domain-management/list/site-domains';
 import ContactsPrivacy from './contacts-privacy';
 import AddDnsRecord from './dns/add-dns-record';
@@ -30,4 +31,5 @@ export default {
 	TransferPage,
 	TransferDomainToOtherSite,
 	TransferDomainToOtherUser,
+	BulkAllDomains,
 };

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -1,0 +1,55 @@
+import { DomainsTable, useDomainsTable } from '@automattic/domains-table';
+import { useTranslate } from 'i18n-calypso';
+import { UsePresalesChat } from 'calypso/components/data/domain-management';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import Main from 'calypso/components/main';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import DomainHeader from '../components/domain-header';
+import OptionsDomainButton from './options-domain-button';
+
+interface BulkAllDomainsProps {
+	analyticsPath: string;
+	analyticsTitle: string;
+}
+
+export default function BulkAllDomains( props: BulkAllDomainsProps ) {
+	const { domains } = useDomainsTable();
+	const translate = useTranslate();
+
+	const item = {
+		label: translate( 'All Domains' ),
+		subtitle: translate(
+			'Manage all your domains. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+			{
+				components: {
+					learnMoreLink: <InlineSupportLink supportContext="domains" showIcon={ false } />,
+				},
+			}
+		),
+		helpBubble: translate(
+			'Manage all your domains. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+			{
+				components: {
+					learnMoreLink: <InlineSupportLink supportContext="domains" showIcon={ false } />,
+				},
+			}
+		),
+	};
+
+	const buttons = [
+		<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions allDomainsList />,
+	];
+
+	return (
+		<>
+			<PageViewTracker path={ props.analyticsPath } title={ props.analyticsTitle } />
+			<Main wideLayout>
+				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
+				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
+				<DomainsTable domains={ domains } />
+			</Main>
+			<UsePresalesChat />
+		</>
+	);
+}

--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,7 @@
 		"@automattic/design-picker": "workspace:^",
 		"@automattic/design-preview": "workspace:^",
 		"@automattic/domain-picker": "workspace:^",
+		"@automattic/domains-table": "workspace:^",
 		"@automattic/explat-client": "workspace:^",
 		"@automattic/explat-client-react-helpers": "workspace:^",
 		"@automattic/format-currency": "workspace:^",

--- a/packages/data-stores/CHANGELOG.md
+++ b/packages/data-stores/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- New `useAllDomainsQuery` which fetches all the current user's domains
+
 ### Breaking changes
 
 - Remove custom query and mutation hooks (based on `@tanstack/query`) from `support-queries/*`. These are moved to `@automattic/help-center`.

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -21,6 +21,7 @@ export * from './domain-suggestions/types';
 export * from './plans/types';
 export * from './user/types';
 export * from './queries/use-launchpad';
+export * from './queries/use-all-domains-query';
 
 const { SubscriptionManager } = Reader;
 

--- a/packages/data-stores/src/queries/use-all-domains-query.ts
+++ b/packages/data-stores/src/queries/use-all-domains-query.ts
@@ -1,0 +1,29 @@
+import { UseQueryOptions, useQuery } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+
+// The data returned by the /all-domains endpoint only includes the basic data
+// related to a domain.
+export interface PartialDomainData {
+	domain: string;
+	blog_id: number;
+	type: 'mapping' | 'wpcom';
+	is_wpcom_staging_domain: boolean;
+	has_registration: boolean;
+	registration_date: string;
+	expiry: string;
+	wpcom_domain: boolean;
+	current_user_is_owner: boolean;
+}
+
+export interface AllDomainsQueryFnData {
+	domains: PartialDomainData[];
+}
+
+export function useAllDomainsQuery( options: UseQueryOptions< AllDomainsQueryFnData > = {} ) {
+	return useQuery( {
+		queryKey: [ 'all-domains' ],
+		queryFn: () =>
+			wpcomRequest< AllDomainsQueryFnData >( { path: '/all-domains', apiVersion: '1.1' } ),
+		...options,
+	} );
+}

--- a/packages/domains-table/jest.config.js
+++ b/packages/domains-table/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
+	setupFilesAfterEnv: [
+		'@testing-library/jest-dom/extend-expect',
+		'@automattic/calypso-build/jest/mocks/match-media',
+	],
+	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
+};

--- a/packages/domains-table/package.json
+++ b/packages/domains-table/package.json
@@ -1,0 +1,61 @@
+{
+	"name": "@automattic/domains-table",
+	"version": "1.0.0",
+	"description": "Component and hooks for displaying users domains in a table.",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.ts",
+	"sideEffects": [
+		"*.css",
+		"*.scss"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/domains-table"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": "https://github.com/Automattic/wp-calypso/issues",
+	"types": "dist/types",
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch"
+	},
+	"dependencies": {
+		"@automattic/calypso-config": "workspace:^",
+		"@automattic/components": "workspace:^",
+		"@automattic/typography": "workspace:^",
+		"@automattic/viewport": "workspace:^",
+		"@tanstack/react-query": "^4.29.1",
+		"@wordpress/components": "^25.4.0",
+		"@wordpress/react-i18n": "^3.36.0",
+		"classnames": "^2.3.1",
+		"react-intersection-observer": "^9.4.3"
+	},
+	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"@testing-library/jest-dom": "^5.17.0",
+		"@testing-library/react": "^14.0.0",
+		"jest": "^29.6.1",
+		"postcss": "^8.4.5",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"typescript": "^5.1.6",
+		"webpack": "^5.68.0"
+	},
+	"peerDependencies": {
+		"@wordpress/data": "^9.8.0",
+		"@wordpress/i18n": "^4.38.0",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0"
+	},
+	"private": true
+}

--- a/packages/domains-table/package.json
+++ b/packages/domains-table/package.json
@@ -31,6 +31,7 @@
 	"dependencies": {
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/components": "workspace:^",
+		"@automattic/data-stores": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@automattic/viewport": "workspace:^",
 		"@tanstack/react-query": "^4.29.1",

--- a/packages/domains-table/src/domains-table/index.stories.tsx
+++ b/packages/domains-table/src/domains-table/index.stories.tsx
@@ -1,0 +1,22 @@
+import { Meta } from '@storybook/react';
+import { DomainsTable } from './index';
+
+export default {
+	title: 'packages/domains-table/DomainsTable',
+	component: DomainsTable,
+	parameters: {
+		viewport: {
+			defaultViewport: 'LARGE',
+		},
+	},
+} as Meta;
+
+const defaultArgs = {
+	domains: [ { domain: 'example1.com' }, { domain: 'example2.com' }, { domain: 'example3.com' } ],
+};
+
+const storyDefaults = {
+	args: defaultArgs,
+};
+
+export const TableWithRows = { ...storyDefaults };

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -1,0 +1,28 @@
+import { useI18n } from '@wordpress/react-i18n';
+import type { BasicDomainData } from '../types';
+import './style.scss';
+
+interface DomainsTableProps {
+	domains: BasicDomainData[];
+}
+
+export function DomainsTable( { domains }: DomainsTableProps ) {
+	const { __ } = useI18n();
+
+	return (
+		<table className="domains-table">
+			<thead>
+				<tr>
+					<th>{ __( 'Domain', __i18n_text_domain__ ) }</th>
+				</tr>
+			</thead>
+			<tbody>
+				{ domains.map( ( { domain } ) => (
+					<tr key={ domain }>
+						<td>{ domain }</td>
+					</tr>
+				) ) }
+			</tbody>
+		</table>
+	);
+}

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -3,11 +3,15 @@ import type { BasicDomainData } from '../types';
 import './style.scss';
 
 interface DomainsTableProps {
-	domains: BasicDomainData[];
+	domains: BasicDomainData[] | undefined;
 }
 
 export function DomainsTable( { domains }: DomainsTableProps ) {
 	const { __ } = useI18n();
+
+	if ( ! domains ) {
+		return null;
+	}
 
 	return (
 		<table className="domains-table">

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -1,0 +1,27 @@
+@import "@automattic/typography/styles/variables";
+
+.domains-table {
+	th {
+		padding-bottom: 16px;
+		border-bottom: 1px solid #f0f0f0;
+
+		color: var(--studio-gray-60);
+		font-size: $font-body-small;
+		font-style: normal;
+		font-weight: 500;
+		line-height: 20px;
+	}
+
+	td {
+		padding: 20px 0;
+		border-bottom: 1px solid var(--studio-gray-5);
+		height: 44px;
+		vertical-align: middle;
+
+		color: var(--studio-gray-100);
+		font-size: $font-body;
+		font-style: normal;
+		font-weight: 500;
+		line-height: 24px;
+	}
+}

--- a/packages/domains-table/src/index.ts
+++ b/packages/domains-table/src/index.ts
@@ -1,1 +1,2 @@
 export { DomainsTable } from './domains-table';
+export { useDomainsTable } from './use-domains-table';

--- a/packages/domains-table/src/index.ts
+++ b/packages/domains-table/src/index.ts
@@ -1,0 +1,1 @@
+export { DomainsTable } from './domains-table';

--- a/packages/domains-table/src/type-declarations.d.ts
+++ b/packages/domains-table/src/type-declarations.d.ts
@@ -1,0 +1,1 @@
+declare const __i18n_text_domain__: string;

--- a/packages/domains-table/src/types.ts
+++ b/packages/domains-table/src/types.ts
@@ -1,0 +1,11 @@
+export interface BasicDomainData {
+	domain: string;
+	blog_id: number;
+	type: 'mapping' | 'wpcom';
+	is_wpcom_staging_domain: boolean;
+	has_registration: boolean;
+	registration_date: string;
+	expiry: string;
+	wpcom_domain: boolean;
+	current_user_is_owner: boolean;
+}

--- a/packages/domains-table/src/use-domains-table.ts
+++ b/packages/domains-table/src/use-domains-table.ts
@@ -1,0 +1,30 @@
+import { useAllDomainsQuery, AllDomainsQueryFnData } from '@automattic/data-stores';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import type { UseQueryOptions } from '@tanstack/react-query';
+
+const EMPTY_STATE = Object.freeze( {} );
+
+export function useDomainsTable( queryOptions: UseQueryOptions< AllDomainsQueryFnData > = {} ) {
+	const { capabilities, sites } = useSelector( ( state: any ) => ( {
+		capabilities: state?.currentUser?.capabilities || EMPTY_STATE,
+		sites: state?.sites?.items || EMPTY_STATE,
+	} ) );
+
+	const { data: allDomains, ...queryResult } = useAllDomainsQuery( queryOptions );
+
+	const filteredDomains = useMemo( () => {
+		const sitesUserCanManage = new Set(
+			Object.keys( sites ).filter(
+				( siteId ) => capabilities[ siteId ]?.[ 'manage_options' ] || false
+			)
+		);
+
+		return allDomains?.domains.filter(
+			( domain ) =>
+				domain.type !== 'wpcom' && sitesUserCanManage.has( domain.blog_id.toString( 10 ) )
+		);
+	}, [ allDomains, capabilities, sites ] );
+
+	return { ...queryResult, domains: filteredDomains };
+}

--- a/packages/domains-table/tsconfig-cjs.json
+++ b/packages/domains-table/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/domains-table/tsconfig.json
+++ b/packages/domains-table/tsconfig.json
@@ -11,6 +11,7 @@
 	"references": [
 		{ "path": "../calypso-config" },
 		{ "path": "../components" },
+		{ "path": "../data-stores" },
 		{ "path": "../viewport" }
 	]
 }

--- a/packages/domains-table/tsconfig.json
+++ b/packages/domains-table/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src",
+		"types": []
+	},
+	"include": [ "src", "src/*.json" ],
+	"exclude": [ "**/__tests__/*", "**/__mocks__/*", "**/*.stories.tsx" ],
+	"references": [
+		{ "path": "../calypso-config" },
+		{ "path": "../components" },
+		{ "path": "../viewport" }
+	]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -22,6 +22,7 @@
 		{ "path": "./design-picker" },
 		{ "path": "./design-preview" },
 		{ "path": "./domain-picker" },
+		{ "path": "./domains-table" },
 		{ "path": "./explat-client" },
 		{ "path": "./explat-client-react-helpers" },
 		{ "path": "./format-currency" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -771,6 +771,7 @@ __metadata:
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
+    "@automattic/data-stores": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@automattic/viewport": "workspace:^"
     "@tanstack/react-query": ^4.29.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -763,6 +763,37 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/domains-table@workspace:^, @automattic/domains-table@workspace:packages/domains-table":
+  version: 0.0.0-use.local
+  resolution: "@automattic/domains-table@workspace:packages/domains-table"
+  dependencies:
+    "@automattic/calypso-build": "workspace:^"
+    "@automattic/calypso-config": "workspace:^"
+    "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/components": "workspace:^"
+    "@automattic/typography": "workspace:^"
+    "@automattic/viewport": "workspace:^"
+    "@tanstack/react-query": ^4.29.1
+    "@testing-library/jest-dom": ^5.17.0
+    "@testing-library/react": ^14.0.0
+    "@wordpress/components": ^25.4.0
+    "@wordpress/react-i18n": ^3.36.0
+    classnames: ^2.3.1
+    jest: ^29.6.1
+    postcss: ^8.4.5
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    react-intersection-observer: ^9.4.3
+    typescript: ^5.1.6
+    webpack: ^5.68.0
+  peerDependencies:
+    "@wordpress/data": ^9.8.0
+    "@wordpress/i18n": ^4.38.0
+    react: ^18.2.0
+    react-dom: ^18.2.0
+  languageName: unknown
+  linkType: soft
+
 "@automattic/effective-module-tree@workspace:packages/effective-module-tree":
   version: 0.0.0-use.local
   resolution: "@automattic/effective-module-tree@workspace:packages/effective-module-tree"
@@ -11095,6 +11126,7 @@ __metadata:
     "@automattic/design-picker": "workspace:^"
     "@automattic/design-preview": "workspace:^"
     "@automattic/domain-picker": "workspace:^"
+    "@automattic/domains-table": "workspace:^"
     "@automattic/explat-client": "workspace:^"
     "@automattic/explat-client-react-helpers": "workspace:^"
     "@automattic/format-currency": "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/dotcom-forge#3414

## Proposed Changes

* Creates the initial `<DomainsTable>` component with a single column
* Fetches data using a `useBasicDomainDataQuery` hook
* Adds component to a `@automattic/domains-table` package so we can develop it in a portable way
* Create a basic storybook for the component which should also help us with portability
* Render the new table at `/domains/manage` if the feature flag is enabled.

![CleanShot 2023-08-14 at 17 28 28@2x](https://github.com/Automattic/wp-calypso/assets/1500769/52932e30-ac12-4f24-ba04-e681237fcdcd)

<img width="1441" alt="CleanShot 2023-08-14 at 17 29 52@2x" src="https://github.com/Automattic/wp-calypso/assets/1500769/fa61836f-6f28-4f66-9de4-602f68eae7d8">

_Some notes:_

The hook is called "basic domain data" because it fetches just enough to render the rows. Each row will fetch more detailed data when it's scrolled into view. This is because there could be 1000 rows.

The query hook implements existing Calypso behaviour by filtering `*.wordpress.com` domains and domains the user doesn't have permission to manage out of the table. It's currently doing this by assuming it will have access to redux data. This isn't 100% portable though. I think it's fine for now because we should eventually filter out the unwanted domains on the server side https://github.com/Automattic/dotcom-forge/issues/3434

The page header (the header and "Add a domain" button) aren't in the `@automattic/domains-table` package. I think this header is specific to the existing Calypso domains UI. If we added `<DomainsTable>` as a new tab to `/sites` then I think the header would be different. I think it's just the filtering and table rows that's going to be shared.

It's a biggish diff. You should be able to review each commit independently if that helps.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test in Calypso using the feature flag http://calypso.localhost:3000/domains/manage?flags=domains/management
* Test in storybook by running `yarn storybook:start` (your browser will open storybook automatically)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
