### PR TITLE
Live Preview: Coexist "Live preview" with "Demo site"

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -48,7 +48,7 @@ import ActivationModal from 'calypso/my-sites/themes/activation-modal';
 import { localizeThemesPath } from 'calypso/my-sites/themes/helpers';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import { connectOptions } from 'calypso/my-sites/themes/theme-options';
-import DemoSiteModal from 'calypso/my-sites/themes/theme-preview';
+import ThemePreview from 'calypso/my-sites/themes/theme-preview';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
@@ -1357,7 +1357,7 @@ class ThemeSheet extends Component {
 						</div>
 					) }
 				</div>
-				<DemoSiteModal belowToolbar={ previewUpsellBanner } />
+				<ThemePreview belowToolbar={ previewUpsellBanner } />
 				<PremiumGlobalStylesUpgradeModal
 					checkout={ this.onPremiumGlobalStylesUpgradeModalCheckout }
 					tryStyle={ this.onPremiumGlobalStylesUpgradeModalTryStyle }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -48,7 +48,7 @@ import ActivationModal from 'calypso/my-sites/themes/activation-modal';
 import { localizeThemesPath } from 'calypso/my-sites/themes/helpers';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import { connectOptions } from 'calypso/my-sites/themes/theme-options';
-import ThemePreview from 'calypso/my-sites/themes/theme-preview';
+import DemoSiteModal from 'calypso/my-sites/themes/theme-preview';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
@@ -87,6 +87,7 @@ import {
 	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
 	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
 	isThemeActivationSyncStarted as getIsThemeActivationSyncStarted,
+	getIsLivePreviewSupported,
 } from 'calypso/state/themes/selectors';
 import { getIsLoadingCart } from 'calypso/state/themes/selectors/get-is-loading-cart';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
@@ -469,16 +470,35 @@ class ThemeSheet extends Component {
 					} }
 					rel="noopener noreferrer"
 				>
+					{ this.shouldRenderPreviewButton() && (
+						<Button className="theme__sheet-preview-demo-site">
+							{ translate( 'Preview demo site' ) }
+						</Button>
+					) }
 					{ img }
 				</a>
 			);
 		}
 
-		return <div className="theme__sheet-screenshot">{ img }</div>;
+		return (
+			<div className="theme__sheet-screenshot">
+				{ this.shouldRenderPreviewButton() && (
+					<Button
+						className="theme__sheet-preview-demo-site"
+						onClick={ ( e ) => {
+							this.previewAction( e, 'link' );
+						} }
+					>
+						{ translate( 'Preview demo site' ) }
+					</Button>
+				) }
+				{ img }
+			</div>
+		);
 	}
 
 	renderWebPreview = () => {
-		const { locale, siteSlug, stylesheet, styleVariations, themeId } = this.props;
+		const { locale, siteSlug, stylesheet, styleVariations, themeId, translate } = this.props;
 		const baseStyleVariation = styleVariations.find( ( style ) =>
 			isDefaultGlobalStylesVariationSlug( style.slug )
 		);
@@ -499,6 +519,16 @@ class ThemeSheet extends Component {
 
 		return (
 			<div className="theme__sheet-web-preview">
+				{ this.shouldRenderPreviewButton() && (
+					<Button
+						className="theme__sheet-preview-demo-site"
+						onClick={ ( e ) => {
+							this.previewAction( e, 'link' );
+						} }
+					>
+						{ translate( 'Preview demo site' ) }
+					</Button>
+				) }
 				<ThemeWebPreview
 					url={ url }
 					inlineCss={ baseStyleVariationInlineCss + selectedStyleVariationInlineCss }
@@ -540,6 +570,7 @@ class ThemeSheet extends Component {
 		const {
 			author,
 			isLoggedIn,
+			isLivePreviewSupported,
 			isWPForTeamsSite,
 			name,
 			retired,
@@ -575,14 +606,14 @@ class ThemeSheet extends Component {
 								? this.renderUnlockStyleButton()
 								: this.renderButton() ) }
 						<LivePreviewButton siteId={ siteId } themeId={ themeId } />
-						{ this.shouldRenderPreviewButton() && (
+						{ this.shouldRenderPreviewButton() && ! isLivePreviewSupported && (
 							<Button
 								onClick={ ( e ) => {
 									this.previewAction( e, 'link' );
 								} }
 							>
-								{ translate( 'Open live demo', {
-									context: 'Individual theme live preview button',
+								{ translate( 'Demo site', {
+									context: 'The button to open the demo site of individual theme',
 								} ) }
 							</Button>
 						) }
@@ -1326,7 +1357,7 @@ class ThemeSheet extends Component {
 						</div>
 					) }
 				</div>
-				<ThemePreview belowToolbar={ previewUpsellBanner } />
+				<DemoSiteModal belowToolbar={ previewUpsellBanner } />
 				<PremiumGlobalStylesUpgradeModal
 					checkout={ this.onPremiumGlobalStylesUpgradeModalCheckout }
 					tryStyle={ this.onPremiumGlobalStylesUpgradeModalTryStyle }
@@ -1464,6 +1495,8 @@ export default connect(
 		const isMarketplaceThemeSubscribed =
 			isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, theme?.id, siteId );
 
+		const isLivePreviewSupported = getIsLivePreviewSupported( state, themeId, siteId );
+
 		return {
 			...theme,
 			themeId,
@@ -1506,6 +1539,7 @@ export default connect(
 			isLoading,
 			isMarketplaceThemeSubscribed,
 			isThemeActivationSyncStarted: getIsThemeActivationSyncStarted( state, siteId, themeId ),
+			isLivePreviewSupported,
 		};
 	},
 	{

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -1,6 +1,7 @@
 @import "@automattic/onboarding/styles/mixins";
 
 $theme-sheet-content-max-width: 1462px;
+$button-border: 4px;
 
 .is-section-theme {
 	&.theme-default.color-scheme {
@@ -198,7 +199,7 @@ $theme-sheet-content-max-width: 1462px;
 		}
 
 		.button {
-			border-radius: 4px;
+			border-radius: $button-border;
 
 			@include breakpoint-deprecated( "<960px" ) {
 				width: 100%;
@@ -341,11 +342,10 @@ $theme-sheet-content-max-width: 1462px;
 .theme__sheet-web-preview {
 	$iframe-viewport-height: 1040px;
 	$iframe-viewport-height-scaled: calc($iframe-viewport-height / 2);
-
 	min-height: $iframe-viewport-height-scaled;
-	pointer-events: none;
 
 	.theme-preview__frame-wrapper {
+		pointer-events: none;
 		@include breakpoint-deprecated( ">960px" ) {
 			max-height: calc(100vh - var(--masterbar-height));
 
@@ -359,6 +359,12 @@ $theme-sheet-content-max-width: 1462px;
 			}
 		}
 	}
+	&:hover,
+	&:focus {
+		.theme-preview__frame-wrapper {
+			opacity: 0.8;
+		}
+	}
 
 	.theme-preview__container {
 		position: relative;
@@ -366,6 +372,21 @@ $theme-sheet-content-max-width: 1462px;
 
 	.theme-preview__frame {
 		transform: none !important;
+	}
+}
+
+.theme__sheet-screenshot {
+	&:hover,
+	&:focus {
+		.theme__sheet-img {
+			opacity: 0.8;
+		}
+	}
+}
+
+@keyframes theme__sheet-preview-demo-site {
+	0% {
+		transform: translate(-50%, 10px);
 	}
 }
 
@@ -383,6 +404,14 @@ $theme-sheet-content-max-width: 1462px;
 	transition: all 200ms ease-in-out;
 	width: 98%;
 	z-index: 1;
+
+	&:hover,
+	&:focus {
+		.theme__sheet-preview-demo-site {
+			opacity: 1;
+			animation: theme__sheet-preview-demo-site 150ms ease-in-out;
+		}
+	}
 
 	@include breakpoint-deprecated( "<960px" ) {
 		border-radius: 0;
@@ -416,6 +445,18 @@ $theme-sheet-content-max-width: 1462px;
 				0 0 0 1px var(--color-neutral-light),
 				0 2px 10px 0 rgba(var(--color-neutral-dark-rgb), 0.5);
 		}
+	}
+}
+
+.theme__sheet-preview-demo-site {
+	opacity: 0;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	z-index: 1;
+	transform: translate(-50%, 0);
+	&.button {
+		border-radius: $button-border;
 	}
 }
 
@@ -648,7 +689,7 @@ $theme-sheet-content-max-width: 1462px;
 		display: inline-block;
 		position: relative;
 		background-color: var(--color-neutral-5);
-		border-radius: 4px;
+		border-radius: $button-border;
 		color: var(--color-neutral-80);
 		margin: 0;
 		padding: 2px 10px;
@@ -772,7 +813,7 @@ $theme-sheet-content-max-width: 1462px;
 	&.theme__page-upsell-banner {
 		background-color: #f0f7fc;
 		border: 0;
-		border-radius: 4px;
+		border-radius: $button-border;
 		box-shadow: none;
 		margin-bottom: 24px;
 		padding: 24px 30px;

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -257,7 +257,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 	};
 
 	const preview = {
-		label: translate( 'Live demo', {
+		label: translate( 'Demo site', {
 			comment: 'label for previewing the theme demo website',
 		} ),
 		action: ( themeId, siteId ) => {
@@ -274,9 +274,10 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			};
 		},
 		hideForTheme: ( state, themeId, siteId ) => {
-			const demoUrl = getThemeDemoUrl( state, themeId, siteId );
-
-			return ! demoUrl;
+			return (
+				getIsLivePreviewSupported( state, themeId, siteId ) ||
+				! getThemeDemoUrl( state, themeId, siteId )
+			);
 		},
 	};
 

--- a/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
@@ -3,7 +3,7 @@ import { PreviewComponent } from '../components';
 
 const selectors = {
 	// Preview
-	demoButton: 'button:text("Open live demo")',
+	demoButton: 'button:text("Demo site")',
 
 	// Main body
 	activateDesignButton: 'button:text("Activate this design")',

--- a/packages/calypso-e2e/src/lib/pages/themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-page.ts
@@ -103,7 +103,7 @@ export class ThemesPage {
 	 */
 	async clickPopoverItem(
 		selectedTheme: ElementHandle,
-		action: 'Live Demo' | 'Activate' | 'Info' | 'Support'
+		action: 'Demo site' | 'Activate' | 'Info' | 'Support'
 	): Promise< void > {
 		const popoverButton = await selectedTheme.waitForSelector( selectors.popoverButton );
 		await popoverButton.click();

--- a/test/e2e/specs/appearance/theme__popover-preview.ts
+++ b/test/e2e/specs/appearance/theme__popover-preview.ts
@@ -52,9 +52,9 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), function () {
 		await themesPage.search( themeName );
 	} );
 
-	it( `Select ${ themeName } and click on Live Demo popover item`, async function () {
+	it( `Select ${ themeName } and click on Demo site popover item`, async function () {
 		const selectedTheme = await themesPage.select( themeName );
-		await themesPage.clickPopoverItem( selectedTheme, 'Live Demo' );
+		await themesPage.clickPopoverItem( selectedTheme, 'Demo site' );
 	} );
 
 	it( 'Preview theme', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80134
https://github.com/Automattic/wp-calypso/pull/80310

## Proposed Changes

Coexist "Live preview" with "Demo site" while avoiding the users' confusion. See https://github.com/Automattic/wp-calypso/issues/80134 and pbxlJb-3Uv-p2#comment-2868 for more detailed UI conversations.

This PR covers the following scenarios;

| on the Theme Card three dots menu |  |
|--------|--------|
| For themes that have Live Preview functionality, show `Live preview` | <img width="384" alt="Screen Shot 2023-08-14 at 15 23 20" src="https://github.com/Automattic/wp-calypso/assets/5287479/d31dd168-b98c-4662-a9e8-c3ff693e90ff"> |
| For other themes (that has [demo site URL](https://github.com/Automattic/wp-calypso/blob/e52e53e82f9a9a51eb6c8673ec8d5c62031756fa/client/state/themes/selectors/get-theme-demo-url.js#L13)), show `Demo site` | <img width="384" alt="Screen Shot 2023-08-14 at 15 24 09" src="https://github.com/Automattic/wp-calypso/assets/5287479/53c09181-29c7-4333-b38a-a5c93b307b64"> | 

| on Theme Detail view |  |
|--------|--------|
| Show the `Preview demo site` button by hovering over the right side column preview | [![Image from Gyazo](https://i.gyazo.com/af9d1eaab977bcf9a2f947b0714a4ee7.gif)](https://gyazo.com/af9d1eaab977bcf9a2f947b0714a4ee7) |
| Show `Demo site` as a button for themes that do NOT have the Live Preview functionality | [![Image from Gyazo](https://i.gyazo.com/2680981a17d77b6c8e090433bb03d14d.gif)](https://gyazo.com/2680981a17d77b6c8e090433bb03d14d) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Theme Card three dots menu

- Go to the Theme Showcase page
- Find the "Live preview" option on the Theme Card three dots menu
	- For themes that have Live Preview functionality, show `Live preview` 
	- For other themes, show `Demo site` 

Theme Detail page 

- Go to the Theme Detail page 
- Find the "Live preview" button 
	- Show the `Preview demo site` button by hovering over the right side column preview
	- Show `Demo site` as a button for themes that do NOT have the Live Preview functionality

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
