### PR TITLE
Substack importer: improved "next step" styles

### DIFF
--- a/client/my-sites/importer/importer-action-buttons/action-button.scss
+++ b/client/my-sites/importer/importer-action-buttons/action-button.scss
@@ -5,6 +5,10 @@
 	margin-bottom: 1em;
 	flex-direction: row;
 
+	&.is-justify-content-center {
+		justify-content: center;
+	}
+
 	.importer-action-buttons__action-button {
 		margin-right: 0.75em;
 	}

--- a/client/my-sites/importer/importer-action-buttons/container.jsx
+++ b/client/my-sites/importer/importer-action-buttons/container.jsx
@@ -1,5 +1,15 @@
-const ImporterActionButtonContainer = ( { children } ) =>
-	children ? <div className="importer-action-buttons__container">{ children }</div> : null;
+import classnames from 'classnames';
+
+const ImporterActionButtonContainer = ( { justifyContentCenter = false, children } ) =>
+	children ? (
+		<div
+			className={ classnames( 'importer-action-buttons__container', {
+				'is-justify-content-center': justifyContentCenter,
+			} ) }
+		>
+			{ children }
+		</div>
+	) : null;
 
 ImporterActionButtonContainer.displayName = 'ImporterActionButtonContainer';
 

--- a/client/my-sites/importer/importer-action-buttons/done-button.jsx
+++ b/client/my-sites/importer/importer-action-buttons/done-button.jsx
@@ -31,6 +31,7 @@ export class DoneButton extends PureComponent {
 		this.props.recordTracksEvent( 'calypso_importer_main_done_clicked', {
 			blog_id: siteId,
 			importer_id: type,
+			action: 'view-site',
 		} );
 
 		const destination = '/view/' + ( siteSlug || '' );

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -2,16 +2,19 @@ import { ProgressBar, Spinner } from '@automattic/components';
 import classNames from 'classnames';
 import { numberFormat, localize } from 'i18n-calypso';
 import { omit } from 'lodash';
+import page from 'page';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
+import ImporterActionButton from 'calypso/my-sites/importer/importer-action-buttons/action-button';
 import BusyImportingButton from 'calypso/my-sites/importer/importer-action-buttons/busy-importing-button';
 import ImporterCloseButton from 'calypso/my-sites/importer/importer-action-buttons/close-button';
 import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-action-buttons/container';
 import ImporterDoneButton from 'calypso/my-sites/importer/importer-action-buttons/done-button';
-import { loadTrackingTool } from 'calypso/state/analytics/actions';
+import { loadTrackingTool, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { mapAuthor, startImporting } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import AuthorMappingPane from './author-mapping-pane';
 
 import './importing-pane.scss';
@@ -121,25 +124,8 @@ export class ImportingPane extends PureComponent {
 		return this.props.translate( 'Processing your file. Please wait a few moments.' );
 	};
 
-	getSuccessText = ( sourceType ) => {
-		const successText = this.props.translate( 'Success! Your content has been imported.' );
-
-		if ( sourceType === 'Substack' ) {
-			return (
-				<>
-					{ successText }
-					<br />
-					<br />
-					{ this.props.translate( 'To migrate your readers, {{a}}go to subscribers{{/a}}.', {
-						components: {
-							a: <a href={ `/subscribers/${ this.props.site.slug }#add-subscribers` } />,
-						},
-					} ) }
-				</>
-			);
-		}
-
-		return successText;
+	getSuccessText = () => {
+		return this.props.translate( 'Success! Your content has been imported.' );
 	};
 
 	getImportMessage = ( numResources ) => {
@@ -202,7 +188,26 @@ export class ImportingPane extends PureComponent {
 	handleOnMap = ( source, target ) =>
 		this.props.mapAuthor( this.props.importerStatus.importerId, source, target );
 
-	renderActionButtons = () => {
+	onClickViewPosts = () => {
+		console.log( 'onClickViewPosts', this.props ); // eslint-disable-line no-console
+		this.props.recordTracksEvent( 'calypso_importer_main_done_clicked', {
+			importer_id: this.props.importerStatus.type,
+			action: 'view-posts',
+		} );
+
+		page( `/posts/${ this.props.siteSlug || '' }` );
+	};
+
+	onClickImportSubscribers = () => {
+		console.log( 'onClickImportSubscribers', this.props ); // eslint-disable-line no-console
+		this.props.recordTracksEvent( 'calypso_importer_main_done_clicked', {
+			importer_id: this.props.importerStatus.type,
+			action: 'add-subscribers',
+		} );
+		page( `/subscribers/${ this.props.siteSlug || '' }#add-subscribers` );
+	};
+
+	renderActionButtons = ( sourceType ) => {
 		if ( this.isProcessing() || this.isMapping() ) {
 			// We either don't want to show buttons while processing
 			// or, in the case of `isMapping`, we let another component (author-mapping-pane)
@@ -216,6 +221,21 @@ export class ImportingPane extends PureComponent {
 		const isError = this.isError();
 		const showFallbackButton = isError || ( ! isImporting && ! isFinished );
 
+		// After Substack importer we nudge to view posts or
+		if ( sourceType === 'Substack' && isFinished ) {
+			return (
+				<ImporterActionButtonContainer justifyContentCenter>
+					<ImporterActionButton onClick={ this.onClickImportSubscribers } primary>
+						{ this.props.translate( 'Import Substack subscribers' ) }
+					</ImporterActionButton>
+					<ImporterActionButton onClick={ this.onClickViewPosts }>
+						{ this.props.translate( 'View imported content' ) }
+					</ImporterActionButton>
+				</ImporterActionButtonContainer>
+			);
+		}
+
+		// Other importers nudge to view the site
 		return (
 			<ImporterActionButtonContainer>
 				{ isImporting && <BusyImportingButton /> }
@@ -253,7 +273,7 @@ export class ImportingPane extends PureComponent {
 
 		if ( this.isFinished() ) {
 			percentComplete = 100;
-			statusMessage = this.getSuccessText( sourceType );
+			statusMessage = this.getSuccessText();
 		}
 
 		if ( this.isImporting() && hasProgressInfo( progress ) ) {
@@ -294,14 +314,20 @@ export class ImportingPane extends PureComponent {
 				<div>
 					<p className="importer__status-message">{ statusMessage }</p>
 				</div>
-				{ this.renderActionButtons() }
+				{ this.renderActionButtons( sourceType ) }
 			</div>
 		);
 	}
 }
 
-export default connect( null, {
-	loadTrackingTool,
-	mapAuthor,
-	startImporting,
-} )( localize( ImportingPane ) );
+export default connect(
+	( state ) => ( {
+		siteSlug: getSelectedSiteSlug( state ),
+	} ),
+	{
+		loadTrackingTool,
+		mapAuthor,
+		recordTracksEvent,
+		startImporting,
+	}
+)( localize( ImportingPane ) );

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -189,7 +189,6 @@ export class ImportingPane extends PureComponent {
 		this.props.mapAuthor( this.props.importerStatus.importerId, source, target );
 
 	onClickViewPosts = () => {
-		console.log( 'onClickViewPosts', this.props ); // eslint-disable-line no-console
 		this.props.recordTracksEvent( 'calypso_importer_main_done_clicked', {
 			importer_id: this.props.importerStatus.type,
 			action: 'view-posts',
@@ -199,7 +198,6 @@ export class ImportingPane extends PureComponent {
 	};
 
 	onClickImportSubscribers = () => {
-		console.log( 'onClickImportSubscribers', this.props ); // eslint-disable-line no-console
 		this.props.recordTracksEvent( 'calypso_importer_main_done_clicked', {
 			importer_id: this.props.importerStatus.type,
 			action: 'add-subscribers',

--- a/client/my-sites/importer/importing-pane.scss
+++ b/client/my-sites/importer/importing-pane.scss
@@ -35,4 +35,5 @@
 	font-size: $font-body-small;
 	color: var(--color-text-subtle);
 	text-align: center;
+	margin: 3em 0;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80364

## Proposed Changes

* Add new CTAs after Substack importer completes (view posts & add subscribers).
* Add padding around status message
* Add "action" prop to Tracks event to differentiate between buttons

<img width="867" alt="Screenshot" src="https://github.com/Automattic/wp-calypso/assets/87168/4cc6a8d9-c246-4b7e-a3a6-0a629090ec13">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go Tools → Import → Substack on localhost or while proxied
* Add Substack import file, complete import
* At the end, observe buttons
* Test other importers, buttons aren't affected
* Check Tracks event — it should now have `action` prop

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
