### PR TITLE
E2E: extend timeout when selecting from template modal in the editor.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
+++ b/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
@@ -25,15 +25,18 @@ export class EditorTemplateModalComponent {
 	 * Select a template category from the sidebar of options.
 	 *
 	 * @param {TemplateCategory} category Name of the category to select.
+	 * @param {number} timeout Timeout for the action.
 	 */
-	async selectTemplateCategory( category: TemplateCategory ): Promise< void > {
+	async selectTemplateCategory( category: TemplateCategory, timeout: number ): Promise< void > {
 		const editorParent = await this.editor.parent();
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
 			await editorParent
 				.locator( '.page-pattern-modal__mobile-category-dropdown' )
-				.selectOption( category.toLowerCase() );
+				.selectOption( category.toLowerCase(), { timeout: timeout } );
 		} else {
-			await editorParent.getByRole( 'menuitem', { name: category, exact: true } ).click();
+			await editorParent
+				.getByRole( 'menuitem', { name: category, exact: true } )
+				.click( { timeout: timeout } );
 		}
 	}
 
@@ -41,10 +44,13 @@ export class EditorTemplateModalComponent {
 	 * Select a template from the grid of options.
 	 *
 	 * @param {string} label Label for the template (the string underneath the preview).
+	 * @param {number} timeout Timeout for the action.
 	 */
-	async selectTemplate( label: string ): Promise< void > {
+	async selectTemplate( label: string, timeout: number ): Promise< void > {
 		const editorParent = await this.editor.parent();
-		await editorParent.getByRole( 'option', { name: label, exact: true } ).click();
+		await editorParent
+			.getByRole( 'option', { name: label, exact: true } )
+			.click( { timeout: timeout } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -167,18 +167,28 @@ export class EditorPage {
 	 * Select a template category from the sidebar of options.
 	 *
 	 * @param {TemplateCategory} category Name of the category to select.
+	 * @param param1 Keyed object parameter.
+	 * @param {number} param1.timeout Timeout to apply.
 	 */
-	async selectTemplateCategory( category: TemplateCategory ) {
-		return await this.editorTemplateModalComponent.selectTemplateCategory( category );
+	async selectTemplateCategory(
+		category: TemplateCategory,
+		{ timeout = envVariables.TIMEOUT }: { timeout?: number } = {}
+	) {
+		return await this.editorTemplateModalComponent.selectTemplateCategory( category, timeout );
 	}
 
 	/**
 	 * Select a template from the grid of options.
 	 *
 	 * @param {string} label Label for the template (the string underneath the preview).
+	 * @param param1 Keyed object parameter.
+	 * @param {number} param1.timeout Timeout to apply.
 	 */
-	async selectTemplate( label: string ) {
-		return await this.editorTemplateModalComponent.selectTemplate( label );
+	async selectTemplate(
+		label: string,
+		{ timeout = envVariables.TIMEOUT }: { timeout?: number } = {}
+	) {
+		return await this.editorTemplateModalComponent.selectTemplate( label, timeout );
 	}
 
 	/**

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -58,8 +58,9 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 	it( 'Select page template', async function () {
 		editorPage = new EditorPage( page );
-		await editorPage.selectTemplateCategory( 'About' );
-		await editorPage.selectTemplate( 'About me' );
+		// Allow some time for CPU and/or network to catch up.
+		await editorPage.selectTemplateCategory( 'About', { timeout: 20 * 1000 } );
+		await editorPage.selectTemplate( 'About me', { timeout: 15 * 1000 } );
 	} );
 
 	it( 'Template content loads into editor', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/80543.

## Proposed Changes

This PR adds custom timeout override for methods involved in the selection of templates, which is shown when starting a new Page.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E Simple production (desktop)
  - [x] Gutenberg E2E Simple production (mobile)

![image](https://github.com/Automattic/wp-calypso/assets/6549265/dad37b2f-103a-4b64-b033-9e2b1e00697c)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
