### PR TITLE
Substack importer: improve heading copy for subscribers

### DIFF
--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -169,7 +169,7 @@ function getConfig( {
 						},
 					}
 				) }{ ' ' }
-				{ translate( 'To migrate your readers, {{a}}go to subscribers{{/a}}.', {
+				{ translate( 'To import your subscribers, go to {{a}}subscribers page{{/a}}.', {
 					components: {
 						a: <a href={ `/subscribers/${ siteSlug }#add-subscribers` } />,
 					},

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -219,17 +219,21 @@ function getConfig( {
 		type: 'file',
 		title: 'Squarespace',
 		icon: 'squarespace',
-		description: translate(
-			'Import posts, pages, comments, tags, and images from a %(importerName)s export file to {{b}}%(siteTitle)s{{/b}}.',
-			{
-				args: {
-					importerName: 'Squarespace',
-					siteTitle,
-				},
-				components: {
-					b: <strong />,
-				},
-			}
+		description: (
+			<p>
+				{ translate(
+					'Import posts, pages, comments, tags, and images from a %(importerName)s export file to {{b}}%(siteTitle)s{{/b}}.',
+					{
+						args: {
+							importerName: 'Squarespace',
+							siteTitle,
+						},
+						components: {
+							b: <strong />,
+						},
+					}
+				) }
+			</p>
 		),
 		uploadDescription: translate(
 			'A %(importerName)s export file is an XML file ' +

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -47,14 +47,18 @@ function getConfig( {
 		type: 'file',
 		title: 'WordPress',
 		icon: 'wordpress',
-		description: translate(
-			'Import posts, pages, and media from a WordPress export\u00A0file to {{b}}%(siteTitle)s{{/b}}.',
-			{
-				args: { siteTitle },
-				components: {
-					b: <strong />,
-				},
-			}
+		description: (
+			<p>
+				{ translate(
+					'Import posts, pages, and media from a WordPress export\u00A0file to {{b}}%(siteTitle)s{{/b}}.',
+					{
+						args: { siteTitle },
+						components: {
+							b: <strong />,
+						},
+					}
+				) }
+			</p>
 		),
 		uploadDescription: translate(
 			'A WordPress export is ' +
@@ -81,17 +85,21 @@ function getConfig( {
 		type: 'file',
 		title: 'Blogger',
 		icon: 'blogger-alt',
-		description: translate(
-			'Import posts, pages, comments, tags, and images from a %(importerName)s export file to {{b}}%(siteTitle)s{{/b}}.',
-			{
-				args: {
-					importerName: 'Blogger',
-					siteTitle,
-				},
-				components: {
-					b: <strong />,
-				},
-			}
+		description: (
+			<p>
+				{ translate(
+					'Import posts, pages, comments, tags, and images from a %(importerName)s export file to {{b}}%(siteTitle)s{{/b}}.',
+					{
+						args: {
+							importerName: 'Blogger',
+							siteTitle,
+						},
+						components: {
+							b: <strong />,
+						},
+					}
+				) }
+			</p>
 		),
 		uploadDescription: translate(
 			'A %(importerName)s export file is an XML file ' +
@@ -119,15 +127,19 @@ function getConfig( {
 		type: 'file',
 		title: 'Medium',
 		icon: 'medium',
-		description: translate(
-			'Import posts, tags, images, and videos ' +
-				'from a Medium export file to {{b}}%(siteTitle)s{{/b}}.',
-			{
-				args: { siteTitle },
-				components: {
-					b: <strong />,
-				},
-			}
+		description: (
+			<p>
+				{ translate(
+					'Import posts, tags, images, and videos ' +
+						'from a Medium export file to {{b}}%(siteTitle)s{{/b}}.',
+					{
+						args: { siteTitle },
+						components: {
+							b: <strong />,
+						},
+					}
+				) }
+			</p>
 		),
 		uploadDescription: translate(
 			'A %(importerName)s export file is a ZIP ' +
@@ -157,23 +169,26 @@ function getConfig( {
 		icon: 'substack',
 		description: (
 			<>
-				{ translate(
-					'Import posts and images, podcasts and public comments from a %(importerName)s export file to {{b}}%(siteTitle)s{{/b}}.',
-					{
-						args: {
-							importerName: 'Substack',
-							siteTitle,
-						},
+				<p>
+					{ translate(
+						'Import posts and images, podcasts and public comments from a Substack export file to {{b}}%(siteTitle)s{{/b}}.',
+						{
+							args: {
+								siteTitle,
+							},
+							components: {
+								b: <strong />,
+							},
+						}
+					) }
+				</p>
+				<p>
+					{ translate( 'To import your subscribers, go to {{a}}subscribers page{{/a}}.', {
 						components: {
-							b: <strong />,
+							a: <a href={ `/subscribers/${ siteSlug }#add-subscribers` } />,
 						},
-					}
-				) }{ ' ' }
-				{ translate( 'To import your subscribers, go to {{a}}subscribers page{{/a}}.', {
-					components: {
-						a: <a href={ `/subscribers/${ siteSlug }#add-subscribers` } />,
-					},
-				} ) }
+					} ) }
+				</p>
 			</>
 		),
 		uploadDescription: (
@@ -242,14 +257,18 @@ function getConfig( {
 		type: 'url',
 		title: 'Wix',
 		icon: 'wix',
-		description: translate(
-			'Import posts, pages, and media from your Wix.com site to {{b}}%(siteTitle)s{{/b}}.',
-			{
-				args: { siteTitle },
-				components: {
-					b: <strong />,
-				},
-			}
+		description: (
+			<p>
+				{ translate(
+					'Import posts, pages, and media from your Wix.com site to {{b}}%(siteTitle)s{{/b}}.',
+					{
+						args: { siteTitle },
+						components: {
+							b: <strong />,
+						},
+					}
+				) }
+			</p>
 		),
 		uploadDescription: translate( 'Enter the URL of your Wix site. ' + '{{supportLink/}}', {
 			components: {

--- a/client/my-sites/importer/importer-header/index.jsx
+++ b/client/my-sites/importer/importer-header/index.jsx
@@ -41,7 +41,7 @@ class ImporterHeader extends PureComponent {
 				<ImporterLogo icon={ icon } />
 				<div className="importer-header__service-info">
 					<h1 className="importer-header__service-title">{ title }</h1>
-					{ ! showStart && <p>{ description }</p> }
+					{ ! showStart && description }
 				</div>
 			</header>
 		);

--- a/client/my-sites/importer/importer-header/style.scss
+++ b/client/my-sites/importer/importer-header/style.scss
@@ -1,6 +1,17 @@
 .importer-header {
 	border-bottom: 1px solid var(--color-border-subtle);
+	display: flex;
+	flex-flow: row nowrap;
 	margin-bottom: 1.25em;
+	gap: 1em;
+
+	@include breakpoint-deprecated( ">960px" ) {
+		gap: 1.75em;
+	}
+
+	.logo {
+		flex-basis: auto;
+	}
 }
 
 .importer-header__is-start {
@@ -15,18 +26,13 @@
 	}
 }
 
-.importer-header__service-info {
-	margin-left: 3.75em;
-
-	p {
-		margin-bottom: 1em;
-	}
+.importer-header__service-info p {
+	margin-bottom: 1em;
 }
 
 .importer-header__service-title {
 	font-size: $font-title-small;
 	color: var(--color-text-subtle);
-	clear: none;
 
 	@include breakpoint-deprecated( "<660px" ) {
 		line-height: 1;

--- a/client/my-sites/importer/importer-logo.scss
+++ b/client/my-sites/importer/importer-logo.scss
@@ -1,10 +1,9 @@
 .importer__service-icon {
 	box-sizing: border-box;
-	float: left;
+	min-width: 40px;
 	width: 40px;
 	height: 40px;
 	padding: 2px;
-	margin-right: 1em;
 
 	background-color: var(--color-neutral-70);
 	fill: var(--color-text-inverted);
@@ -36,9 +35,9 @@
 	}
 
 	@include breakpoint-deprecated( ">960px" ) {
+		min-width: 56px;
 		width: 56px;
 		height: 56px;
 		padding: 4px;
-		margin-right: 1.5em;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80364

## Proposed Changes

- Update copy in the header for importing subscribers.
- Improve styling for long text.
- Make it possible to have multiple `p` tags in the importer description.


Previously, longer text, which can be caused for example by translations, don't flow nicely:

<img width="700" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/5ffb2df7-2e29-4b7f-893e-8991049e5150">

With this change, longer texts float well:

<img width="700" alt="Screenshot 2023-08-14 at 15 36 10" src="https://github.com/Automattic/wp-calypso/assets/87168/e5d026ce-995b-45de-b599-0137166bcac2">


<img width="300" alt="Screenshot 2023-08-14 at 15 36 00" src="https://github.com/Automattic/wp-calypso/assets/87168/45f4ba5f-e30a-4335-a61a-77b261a746e1">


## Testing Instructions

* Tools → Import → Substack
* Observe heading, link works. Styling works nicely across different screen sizes from mobile to desktop.
* Test also that the list works well on mobile/desktop

    <img width="400" alt="Screenshot 2023-08-14 at 15 36 22" src="https://github.com/Automattic/wp-calypso/assets/87168/7afd44b1-0fc0-4691-9c22-74387eb88306">
    <img width="200" alt="Screenshot 2023-08-14 at 15 36 29" src="https://github.com/Automattic/wp-calypso/assets/87168/c9723caa-cbad-406b-a803-32db6661a1d4">

* Check that other importer descriptions work well.

    <img width="400" alt="Screenshot 2023-08-14 at 15 37 20" src="https://github.com/Automattic/wp-calypso/assets/87168/75b60519-28be-4506-ae27-e69c0279f216">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
