### PR TITLE
Partner Portal: Update page layout to handle wider screens.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/layout/body.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/layout/body.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+type Props = {
+	children: ReactNode;
+};
+
+export default function LayoutBody( { children }: Props ) {
+	return (
+		<div className="partner-portal-layout__body">
+			<div className="partner-portal-layout__body-wrapper">{ children }</div>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/layout/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/layout/index.tsx
@@ -17,7 +17,7 @@ export default function Layout( { children, className, title, wide = false }: Pr
 	return (
 		<Main
 			className={ classNames( 'partner-portal-layout', className ) }
-			fullWidthLayout={ wide } // Our 'wide' here means maximum of 1500px.
+			fullWidthLayout={ wide }
 			wideLayout={ ! wide } // When we set to full width, we want to set this to false.
 		>
 			<DocumentHead title={ title } />

--- a/client/jetpack-cloud/sections/partner-portal/layout/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/layout/index.tsx
@@ -11,12 +11,21 @@ type Props = {
 	className?: string;
 	title: ReactNode;
 	wide?: boolean;
+	withBorder?: boolean;
 };
 
-export default function Layout( { children, className, title, wide = false }: Props ) {
+export default function Layout( {
+	children,
+	className,
+	title,
+	wide = false,
+	withBorder = false,
+}: Props ) {
 	return (
 		<Main
-			className={ classNames( 'partner-portal-layout', className ) }
+			className={ classNames( 'partner-portal-layout', className, {
+				'is-with-border': withBorder,
+			} ) }
 			fullWidthLayout={ wide }
 			wideLayout={ ! wide } // When we set to full width, we want to set this to false.
 		>

--- a/client/jetpack-cloud/sections/partner-portal/layout/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/layout/style.scss
@@ -4,29 +4,17 @@
 
 .partner-portal-layout__container {
 	max-width: 100%;
+	min-height: calc(100vh - 123px);
+	display: flex;
+	flex-direction: column;
 	margin: auto;
 	padding: 0;
 }
 
-.partner-portal-layout__top {
-	&:not(.is-borderless) {
-		margin-block-end: 16px;
-	}
-
-	@include breakpoint-deprecated( ">660px" ) {
-		// We need these negative margin values because we want to make the container full-width,
-		// but our element is inside a limited-width parent.
-		margin-inline: -73px;
-		padding-inline: 73px;
-
-		&:not(.is-borderless) {
-			border-bottom: 1px solid var(--color-primary-5);
-		}
-	}
-}
-
 .partner-portal-layout__body {
-	padding: 0;
+	padding: 16px 0;
+	margin-block-end: -32px;
+	flex: 1 1 100%;
 }
 
 .partner-portal-layout__top,
@@ -40,6 +28,13 @@
 	&-wrapper > * {
 		max-width: 1500px;
 		margin-inline: auto !important;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		// We need these negative margin values because we want to make the container full-width,
+		// but our element is inside a limited-width parent.
+		margin-inline: -73px;
+		padding-inline: 73px;
 	}
 }
 
@@ -70,5 +65,17 @@
 
 	a.button {
 		margin-left: auto;
+	}
+}
+
+.main.partner-portal-layout.is-with-border {
+	@include breakpoint-deprecated( ">660px" ) {
+		.partner-portal-layout__top {
+			border-bottom: 1px solid var(--color-primary-5);
+		}
+
+		.partner-portal-layout__body {
+			background: rgba(255, 255, 255, 0.5);
+		}
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/layout/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/layout/style.scss
@@ -32,7 +32,7 @@
 	@include breakpoint-deprecated( ">660px" ) {
 		// We need these negative margin values because we want to make the container full-width,
 		// but our element is inside a limited-width parent.
-		margin-inline: -73px;
+		margin-inline-start: -73px;
 		padding-inline: 73px;
 	}
 }
@@ -69,7 +69,7 @@
 
 .main.partner-portal-layout.is-with-border {
 	.partner-portal-layout__body {
-		padding: 16px 0;
+		padding-block: 16px;
 	}
 
 	@include breakpoint-deprecated( ">660px" ) {

--- a/client/jetpack-cloud/sections/partner-portal/layout/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/layout/style.scss
@@ -12,7 +12,6 @@
 }
 
 .partner-portal-layout__body {
-	padding: 16px 0;
 	margin-block-end: -32px;
 	flex: 1 1 100%;
 }
@@ -69,6 +68,10 @@
 }
 
 .main.partner-portal-layout.is-with-border {
+	.partner-portal-layout__body {
+		padding: 16px 0;
+	}
+
 	@include breakpoint-deprecated( ">660px" ) {
 		.partner-portal-layout__top {
 			border-bottom: 1px solid var(--color-primary-5);

--- a/client/jetpack-cloud/sections/partner-portal/layout/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/layout/style.scss
@@ -1,5 +1,13 @@
 .main.partner-portal-layout {
 	padding-inline: 0;
+
+	header.current-section {
+		padding: 0 16px;
+
+		button {
+			padding: 20px 8px;
+		}
+	}
 }
 
 .partner-portal-layout__container {

--- a/client/jetpack-cloud/sections/partner-portal/layout/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/layout/style.scss
@@ -1,40 +1,74 @@
+.main.partner-portal-layout {
+	padding-inline: 0;
+}
 
+.partner-portal-layout__container {
+	max-width: 100%;
+	margin: auto;
+	padding: 0;
+}
 
-.partner-portal-layout {
-	&__container {
-		max-width: 1500px;
-		margin: auto;
-
-		padding: 0;
+.partner-portal-layout__top {
+	&:not(.is-borderless) {
+		margin-block-end: 16px;
 	}
 
-	&__header {
-		display: flex;
-		align-items: center;
+	@include breakpoint-deprecated( ">660px" ) {
+		// We need these negative margin values because we want to make the container full-width,
+		// but our element is inside a limited-width parent.
+		margin-inline: -73px;
+		padding-inline: 73px;
+
+		&:not(.is-borderless) {
+			border-bottom: 1px solid var(--color-primary-5);
+		}
+	}
+}
+
+.partner-portal-layout__body {
+	padding: 0;
+}
+
+.partner-portal-layout__top,
+.partner-portal-layout__body {
+	width: 100%;
+
+	&-wrapper {
+		margin-inline: 16px;
+	}
+
+	&-wrapper > * {
+		max-width: 1500px;
+		margin-inline: auto !important;
+	}
+}
+
+.partner-portal-layout__header {
+	display: flex;
+	align-items: center;
+
+	> * + * {
+		margin-left: 24px;
+	}
+
+	@include breakpoint-deprecated( "<960px" ) {
+		flex-wrap: wrap;
+
+		> * {
+			width: 100%;
+			margin-bottom: 16px;
+		}
 
 		> * + * {
-			margin-left: 24px;
+			margin-left: 0;
 		}
+	}
 
-		@include breakpoint-deprecated( "<960px" ) {
-			flex-wrap: wrap;
+	.card-heading {
+		margin-block-start: initial;
+	}
 
-			> * {
-				width: 100%;
-				margin-bottom: 16px;
-			}
-
-			> * + * {
-				margin-left: 0;
-			}
-		}
-
-		.card-heading {
-			margin-block-start: initial;
-		}
-
-		a.button {
-			margin-left: auto;
-		}
+	a.button {
+		margin-left: auto;
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/layout/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/layout/style.scss
@@ -42,7 +42,7 @@
 	align-items: center;
 
 	> * + * {
-		margin-left: 24px;
+		margin-inline-start: 24px;
 	}
 
 	@include breakpoint-deprecated( "<960px" ) {
@@ -50,11 +50,11 @@
 
 		> * {
 			width: 100%;
-			margin-bottom: 16px;
+			margin-block-end: 16px;
 		}
 
 		> * + * {
-			margin-left: 0;
+			margin-inline-start: 0;
 		}
 	}
 
@@ -63,7 +63,7 @@
 	}
 
 	a.button {
-		margin-left: auto;
+		margin-inline-start: auto;
 	}
 }
 
@@ -74,7 +74,7 @@
 
 	@include breakpoint-deprecated( ">660px" ) {
 		.partner-portal-layout__top {
-			border-bottom: 1px solid var(--color-primary-5);
+			border-block-end: 1px solid var(--color-primary-5);
 		}
 
 		.partner-portal-layout__body {

--- a/client/jetpack-cloud/sections/partner-portal/layout/top.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/layout/top.tsx
@@ -1,18 +1,12 @@
-import classNames from 'classnames';
 import { ReactNode } from 'react';
 
 type Props = {
 	children: ReactNode;
-	borderless?: boolean;
 };
 
-export default function LayoutTop( { children, borderless }: Props ) {
+export default function LayoutTop( { children }: Props ) {
 	return (
-		<div
-			className={ classNames( 'partner-portal-layout__top', {
-				'is-borderless': borderless,
-			} ) }
-		>
+		<div className="partner-portal-layout__top">
 			<div className="partner-portal-layout__top-wrapper">{ children }</div>
 		</div>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/layout/top.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/layout/top.tsx
@@ -1,0 +1,19 @@
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+
+type Props = {
+	children: ReactNode;
+	borderless?: boolean;
+};
+
+export default function LayoutTop( { children, borderless }: Props ) {
+	return (
+		<div
+			className={ classNames( 'partner-portal-layout__top', {
+				'is-borderless': borderless,
+			} ) }
+		>
+			<div className="partner-portal-layout__top-wrapper">{ children }</div>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
@@ -21,7 +21,7 @@ export default function BillingDashboard() {
 
 	return (
 		<Layout className="billing-dashboard" title={ translate( 'Billing' ) } wide>
-			<LayoutTop borderless>
+			<LayoutTop>
 				<LayoutHeader>
 					<CardHeading size={ 36 }>{ translate( 'Billing' ) }</CardHeading>
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
@@ -7,7 +7,9 @@ import SelectPartnerKeyDropdown from 'calypso/jetpack-cloud/sections/partner-por
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import Layout from '../../layout';
+import LayoutBody from '../../layout/body';
 import LayoutHeader from '../../layout/header';
+import LayoutTop from '../../layout/top';
 
 export default function BillingDashboard() {
 	const translate = useTranslate();
@@ -19,18 +21,22 @@ export default function BillingDashboard() {
 
 	return (
 		<Layout className="billing-dashboard" title={ translate( 'Billing' ) } wide>
-			<LayoutHeader>
-				<CardHeading size={ 36 }>{ translate( 'Billing' ) }</CardHeading>
+			<LayoutTop borderless>
+				<LayoutHeader>
+					<CardHeading size={ 36 }>{ translate( 'Billing' ) }</CardHeading>
 
-				<SelectPartnerKeyDropdown />
+					<SelectPartnerKeyDropdown />
 
-				<Button primary href="/partner-portal/issue-license" onClick={ onIssueNewLicenseClick }>
-					{ translate( 'Issue New License' ) }
-				</Button>
-			</LayoutHeader>
+					<Button primary href="/partner-portal/issue-license" onClick={ onIssueNewLicenseClick }>
+						{ translate( 'Issue New License' ) }
+					</Button>
+				</LayoutHeader>
+			</LayoutTop>
 
-			<BillingSummary />
-			<BillingDetails />
+			<LayoutBody>
+				<BillingSummary />
+				<BillingDetails />
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/company-details-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/company-details-dashboard/index.tsx
@@ -3,7 +3,9 @@ import { useTranslate } from 'i18n-calypso';
 import CardHeading from 'calypso/components/card-heading';
 import UpdateCompanyDetailsForm from 'calypso/jetpack-cloud/sections/partner-portal/update-company-details-form';
 import Layout from '../../layout';
+import LayoutBody from '../../layout/body';
 import LayoutHeader from '../../layout/header';
+import LayoutTop from '../../layout/top';
 
 import './style.scss';
 
@@ -12,19 +14,23 @@ export default function CompanyDetailsDashboard() {
 
 	return (
 		<Layout className="company-details-dashboard" title={ translate( 'Company Details' ) }>
-			<LayoutHeader>
-				<CardHeading size={ 36 }>{ translate( 'Company Details' ) }</CardHeading>
-			</LayoutHeader>
+			<LayoutTop>
+				<LayoutHeader>
+					<CardHeading size={ 36 }>{ translate( 'Company Details' ) }</CardHeading>
+				</LayoutHeader>
 
-			<p className="company-details-dashboard__description">
-				{ translate(
-					'Update your company details. Changes will be applied to all future invoices.'
-				) }
-			</p>
+				<p className="company-details-dashboard__description">
+					{ translate(
+						'Update your company details. Changes will be applied to all future invoices.'
+					) }
+				</p>
+			</LayoutTop>
 
-			<Card>
-				<UpdateCompanyDetailsForm />
-			</Card>
+			<LayoutBody>
+				<Card>
+					<UpdateCompanyDetailsForm />
+				</Card>
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/invoices-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/invoices-dashboard/index.tsx
@@ -12,7 +12,7 @@ export default function InvoicesDashboard() {
 
 	return (
 		<Layout className="invoices-dashboard" title={ translate( 'Invoices' ) } wide>
-			<LayoutTop borderless>
+			<LayoutTop>
 				<LayoutHeader>
 					<CardHeading size={ 36 }>{ translate( 'Invoices' ) }</CardHeading>
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/invoices-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/invoices-dashboard/index.tsx
@@ -3,20 +3,26 @@ import CardHeading from 'calypso/components/card-heading';
 import InvoicesList from 'calypso/jetpack-cloud/sections/partner-portal/invoices-list';
 import SelectPartnerKeyDropdown from 'calypso/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown';
 import Layout from '../../layout';
+import LayoutBody from '../../layout/body';
 import LayoutHeader from '../../layout/header';
+import LayoutTop from '../../layout/top';
 
 export default function InvoicesDashboard() {
 	const translate = useTranslate();
 
 	return (
 		<Layout className="invoices-dashboard" title={ translate( 'Invoices' ) } wide>
-			<LayoutHeader>
-				<CardHeading size={ 36 }>{ translate( 'Invoices' ) }</CardHeading>
+			<LayoutTop borderless>
+				<LayoutHeader>
+					<CardHeading size={ 36 }>{ translate( 'Invoices' ) }</CardHeading>
 
-				<SelectPartnerKeyDropdown />
-			</LayoutHeader>
+					<SelectPartnerKeyDropdown />
+				</LayoutHeader>
+			</LayoutTop>
 
-			<InvoicesList />
+			<LayoutBody>
+				<InvoicesList />
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -6,7 +6,9 @@ import AssignLicenseStepProgress from 'calypso/jetpack-cloud/sections/partner-po
 import IssueMultipleLicensesForm from 'calypso/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form';
 import TotalCost from 'calypso/jetpack-cloud/sections/partner-portal/primary/total-cost';
 import Layout from '../../layout';
+import LayoutBody from '../../layout/body';
 import LayoutHeader from '../../layout/header';
+import LayoutTop from '../../layout/top';
 import { AssignLicenceProps } from '../../types';
 
 import './styles.scss';
@@ -27,19 +29,23 @@ export default function IssueLicense( { selectedSite, suggestedProduct }: Assign
 
 	return (
 		<Layout className="issue-license" title={ translate( 'Issue a new License' ) } wide>
-			<div className="issue-license__step-progress">
-				<AssignLicenseStepProgress currentStep="issueLicense" selectedSite={ selectedSite } />
-				{ isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) && <TotalCost /> }
-			</div>
+			<LayoutTop borderless>
+				<div className="issue-license__step-progress">
+					<AssignLicenseStepProgress currentStep="issueLicense" selectedSite={ selectedSite } />
+					{ isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) && <TotalCost /> }
+				</div>
 
-			<LayoutHeader>
-				<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
-			</LayoutHeader>
+				<LayoutHeader>
+					<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
+				</LayoutHeader>
+			</LayoutTop>
 
-			<IssueMultipleLicensesForm
-				selectedSite={ selectedSite }
-				suggestedProduct={ suggestedProduct }
-			/>
+			<LayoutBody>
+				<IssueMultipleLicensesForm
+					selectedSite={ selectedSite }
+					suggestedProduct={ suggestedProduct }
+				/>
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -29,7 +29,7 @@ export default function IssueLicense( { selectedSite, suggestedProduct }: Assign
 
 	return (
 		<Layout className="issue-license" title={ translate( 'Issue a new License' ) } wide>
-			<LayoutTop borderless>
+			<LayoutTop>
 				<div className="issue-license__step-progress">
 					<AssignLicenseStepProgress currentStep="issueLicense" selectedSite={ selectedSite } />
 					{ isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) && <TotalCost /> }

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -21,7 +21,9 @@ import {
 } from 'calypso/state/partner-portal/licenses/selectors';
 import { showAgencyDashboard } from 'calypso/state/partner-portal/partner/selectors';
 import Layout from '../../layout';
+import LayoutBody from '../../layout/body';
 import LayoutHeader from '../../layout/header';
+import LayoutTop from '../../layout/top';
 import LicenseSearch from '../../license-search';
 import OnboardingWidget from '../onboarding-widget';
 import Banners from './banners';
@@ -76,36 +78,35 @@ export default function Licenses( {
 			<SiteAddLicenseNotification />
 
 			<LicenseListContext.Provider value={ context }>
-				<div className="licenses__container">
-					<div className="licenses__header-container">
-						<div className="licenses__header">
-							<LayoutHeader>
-								<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>
+				<LayoutTop>
+					<LayoutHeader>
+						<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>
 
-								<SelectPartnerKeyDropdown />
+						<SelectPartnerKeyDropdown />
 
-								<Button
-									href="/partner-portal/issue-license"
-									onClick={ onIssueNewLicenseClick }
-									primary
-									style={ { marginLeft: 'auto' } }
-								>
-									{ translate( 'Issue New License' ) }
-								</Button>
-							</LayoutHeader>
-						</div>
-						<LicenseStateFilter />
-					</div>
-				</div>
+						<Button
+							href="/partner-portal/issue-license"
+							onClick={ onIssueNewLicenseClick }
+							primary
+							style={ { marginLeft: 'auto' } }
+						>
+							{ translate( 'Issue New License' ) }
+						</Button>
+					</LayoutHeader>
 
-				{ showEmptyStateContent ? (
-					<OnboardingWidget isLicensesPage />
-				) : (
-					<div className="licenses__content">
-						<LicenseSearch />
-						<LicenseList />
-					</div>
-				) }
+					<LicenseStateFilter />
+				</LayoutTop>
+
+				<LayoutBody>
+					{ showEmptyStateContent ? (
+						<OnboardingWidget isLicensesPage />
+					) : (
+						<>
+							<LicenseSearch />
+							<LicenseList />
+						</>
+					) }
+				</LayoutBody>
 			</LicenseListContext.Provider>
 		</Layout>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -74,11 +74,11 @@ export default function Licenses( {
 			/>
 			<QueryJetpackPartnerPortalLicenseCounts />
 
-			{ isAgencyUser && <Banners /> }
-			<SiteAddLicenseNotification />
-
 			<LicenseListContext.Provider value={ context }>
 				<LayoutTop>
+					{ isAgencyUser && <Banners /> }
+					<SiteAddLicenseNotification />
+
 					<LayoutHeader>
 						<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -66,7 +66,7 @@ export default function Licenses( {
 	const showEmptyStateContent = hasFetched && allLicensesCount === 0;
 
 	return (
-		<Layout className="licenses" title={ translate( 'Licenses' ) } wide>
+		<Layout className="licenses" title={ translate( 'Licenses' ) } wide withBorder>
 			<PageViewTracker
 				title="Partner Portal > Licenses"
 				path="/partner-portal/licenses/:filter"

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
@@ -10,36 +10,6 @@
 		}
 	}
 
-	.partner-portal-layout__container {
-		display: flex;
-		flex-direction: column;
-		// The -111px is to undo the padding of .layout__content (79px + 32px)
-		min-height: calc(100vh - 111px);
-	}
-}
-
-.licenses__header-container {
-	@include breakpoint-deprecated( ">660px" ) {
-		// We need these negative margin values because we want to make the container full-width,
-		// but our element is inside a limited-width parent.
-		margin-inline: -73px;
-		padding-inline: 73px;
-		border-bottom: 1px solid var(--color-primary-5);
-	}
-}
-
-.licenses__content {
-	flex: 1 1 100%;
-	padding-block-start: 8px;
-
-	@include breakpoint-deprecated( ">660px" ) {
-		padding: 16px 73px;
-		// We need these negative margin values because we want to make the container full-width,
-		// but our element is inside a limited-width parent.
-		margin: 0 -73px -73px;
-		background: rgba(255, 255, 255, 0.5);
-	}
-
 	.search {
 		box-shadow: 0 0 0 1px var(--color-neutral-5);
 		margin-block-end: 8px;

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/style.scss
@@ -2,14 +2,6 @@
 @import "@wordpress/base-styles/mixins";
 
 .licenses {
-	header.current-section {
-		padding: 0 16px;
-
-		button {
-			padding: 20px 8px;
-		}
-	}
-
 	.search {
 		box-shadow: 0 0 0 1px var(--color-neutral-5);
 		margin-block-end: 8px;

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/style.scss
@@ -2,6 +2,10 @@
 @import "@wordpress/base-styles/mixins";
 
 .payment-method-add {
+	&__wrapper {
+		margin-inline: 0;
+	}
+
 	&__wrapper .card-heading {
 		display: inline-block;
 		margin-top: 1rem;

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
@@ -17,7 +17,9 @@ import {
 	hasMoreStoredCards,
 } from 'calypso/state/partner-portal/stored-cards/selectors';
 import Layout from '../../layout';
+import LayoutBody from '../../layout/body';
 import LayoutHeader from '../../layout/header';
+import LayoutTop from '../../layout/top';
 
 import './style.scss';
 
@@ -63,32 +65,36 @@ export default function PaymentMethodList() {
 		<Layout className="payment-method-list" title={ translate( 'Payment Methods' ) } wide>
 			<QueryJetpackPartnerPortalStoredCards paging={ paging } />
 
-			<LayoutHeader>
-				<CardHeading size={ 36 }>{ translate( 'Payment Methods' ) }</CardHeading>
-			</LayoutHeader>
+			<LayoutTop borderless>
+				<LayoutHeader>
+					<CardHeading size={ 36 }>{ translate( 'Payment Methods' ) }</CardHeading>
+				</LayoutHeader>
+			</LayoutTop>
 
-			<div className="payment-method-list__body">
-				<AddStoredCreditCard />
+			<LayoutBody>
+				<div className="payment-method-list__body">
+					<AddStoredCreditCard />
 
-				{ isFetching && <StoredCreditCardLoading /> }
+					{ isFetching && <StoredCreditCardLoading /> }
 
-				{ ! isFetching &&
-					storedCards.map( ( card: PaymentMethod ) => (
-						<StoredCreditCard key={ card.id } card={ card } />
-					) ) }
-			</div>
+					{ ! isFetching &&
+						storedCards.map( ( card: PaymentMethod ) => (
+							<StoredCreditCard key={ card.id } card={ card } />
+						) ) }
+				</div>
 
-			{ showPagination && (
-				<Pagination
-					className={ classnames( 'payment-method-list__pagination', {
-						'payment-method-list__pagination--has-prev': page > 1,
-						'payment-method-list__pagination--has-next': isFetching || hasMore,
-					} ) }
-					pageClick={ onPageClick }
-					page={ page }
-					perPage={ perPage }
-				/>
-			) }
+				{ showPagination && (
+					<Pagination
+						className={ classnames( 'payment-method-list__pagination', {
+							'payment-method-list__pagination--has-prev': page > 1,
+							'payment-method-list__pagination--has-next': isFetching || hasMore,
+						} ) }
+						pageClick={ onPageClick }
+						page={ page }
+						perPage={ perPage }
+					/>
+				) }
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-list/index.tsx
@@ -65,7 +65,7 @@ export default function PaymentMethodList() {
 		<Layout className="payment-method-list" title={ translate( 'Payment Methods' ) } wide>
 			<QueryJetpackPartnerPortalStoredCards paging={ paging } />
 
-			<LayoutTop borderless>
+			<LayoutTop>
 				<LayoutHeader>
 					<CardHeading size={ 36 }>{ translate( 'Payment Methods' ) }</CardHeading>
 				</LayoutHeader>

--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
@@ -9,7 +9,9 @@ import { useSelector } from 'calypso/state';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import Layout from '../../layout';
+import LayoutBody from '../../layout/body';
 import LayoutHeader from '../../layout/header';
+import LayoutTop from '../../layout/top';
 
 import './style.scss';
 
@@ -125,53 +127,57 @@ export default function Prices() {
 		<Layout className="prices" title={ translate( 'Prices' ) } wide>
 			<QueryProductsList type="jetpack" currency="USD" />
 
-			<LayoutHeader>
-				<CardHeading size={ 36 }>
-					{ translate( 'Jetpack Agency & Pro Partner Program Product Pricing' ) }
-				</CardHeading>
+			<LayoutTop borderless>
+				<LayoutHeader>
+					<CardHeading size={ 36 }>
+						{ translate( 'Jetpack Agency & Pro Partner Program Product Pricing' ) }
+					</CardHeading>
 
-				<SelectPartnerKeyDropdown />
-			</LayoutHeader>
+					<SelectPartnerKeyDropdown />
+				</LayoutHeader>
+			</LayoutTop>
 
-			<div className="prices__description">
-				<p>
-					{ translate(
-						'The following products are available through the Licenses section. Prices are calculated daily and invoiced at the beginning of the next month. Please note that the Jetpack pro Dashboard prices will be displayed as a monthly cost. If you want to determine a yearly cost for the Agency/Pro pricing, you can take the daily cost x 365.'
-					) }
-				</p>
-			</div>
+			<LayoutBody>
+				<div className="prices__description">
+					<p>
+						{ translate(
+							'The following products are available through the Licenses section. Prices are calculated daily and invoiced at the beginning of the next month. Please note that the Jetpack pro Dashboard prices will be displayed as a monthly cost. If you want to determine a yearly cost for the Agency/Pro pricing, you can take the daily cost x 365.'
+						) }
+					</p>
+				</div>
 
-			<table className="prices__table">
-				<thead>
-					<tr className="prices__head-row" style={ { backgroundColor: 'transparent' } }>
-						<th colSpan={ 3 }></th>
-						<th className="prices__column-highlight">
-							<div className="prices__column-highlight-content">
-								<Gridicon icon="star" size={ 18 } className="prices__column-highlight-icon" />
-								<span className="prices__column-highlight-label">
-									{ translate( 'Your Price' ) }
-								</span>
-							</div>
-						</th>
-					</tr>
-					<tr className="prices__head-row">
-						<th></th>
-						<th>
-							<div>{ translate( 'Jetpack.com Pricing' ) }</div>
-							<span className="prices__th-detail">{ translate( 'billed monthly' ) }</span>
-						</th>
-						<th>
-							<div>{ translate( 'Jetpack.com Pricing' ) }</div>
-							<span className="prices__th-detail">{ translate( 'billed yearly' ) }</span>
-						</th>
-						<th>
-							<div>{ translate( 'Agency/Pro Pricing' ) }</div>
-							<span className="prices__th-detail">{ translate( 'daily pricing' ) }</span>
-						</th>
-					</tr>
-				</thead>
-				<tbody>{ productRows }</tbody>
-			</table>
+				<table className="prices__table">
+					<thead>
+						<tr className="prices__head-row" style={ { backgroundColor: 'transparent' } }>
+							<th colSpan={ 3 }></th>
+							<th className="prices__column-highlight">
+								<div className="prices__column-highlight-content">
+									<Gridicon icon="star" size={ 18 } className="prices__column-highlight-icon" />
+									<span className="prices__column-highlight-label">
+										{ translate( 'Your Price' ) }
+									</span>
+								</div>
+							</th>
+						</tr>
+						<tr className="prices__head-row">
+							<th></th>
+							<th>
+								<div>{ translate( 'Jetpack.com Pricing' ) }</div>
+								<span className="prices__th-detail">{ translate( 'billed monthly' ) }</span>
+							</th>
+							<th>
+								<div>{ translate( 'Jetpack.com Pricing' ) }</div>
+								<span className="prices__th-detail">{ translate( 'billed yearly' ) }</span>
+							</th>
+							<th>
+								<div>{ translate( 'Agency/Pro Pricing' ) }</div>
+								<span className="prices__th-detail">{ translate( 'daily pricing' ) }</span>
+							</th>
+						</tr>
+					</thead>
+					<tbody>{ productRows }</tbody>
+				</table>
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
@@ -127,7 +127,7 @@ export default function Prices() {
 		<Layout className="prices" title={ translate( 'Prices' ) } wide>
 			<QueryProductsList type="jetpack" currency="USD" />
 
-			<LayoutTop borderless>
+			<LayoutTop>
 				<LayoutHeader>
 					<CardHeading size={ 36 }>
 						{ translate( 'Jetpack Agency & Pro Partner Program Product Pricing' ) }


### PR DESCRIPTION
Related to 1202619025189113-as-1205116564628275

The current Partner portal layout does not work well on a wider screen. This PR addresses this issue by refactoring the current layout component so it can scale with wider screens.

**Before**
<img width="1511" alt="Screen Shot 2023-08-11 at 7 04 53 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/af362315-8102-4ab3-a155-7334ad4d239e">
**After**
<img width="1522" alt="Screen Shot 2023-08-14 at 8 36 50 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/33f8b152-5366-4606-8162-9454038afbfc">

## Proposed Changes

* Add Layout **Top** and **Body** components to wrap the contents with proper margins/paddings and border.
* Update existing consuming components to use the additional layout components.


## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack cloud live link below and test the following screens. Make sure you zoom-out your browser to simulate wider screens.

| Screen  | URL |
| ------------- | ------------- |
| Billing  | /partner-portal/billing  |
| Issue License  | /partner-portal/issue-license  |
| Assign License  | /partner-portal/assign-license  |
| Payment Methods | /partner-portal/payment-methods |
| Invoices | /partner-portal/invoices |
| Prices | /partner-portal/prices |

* Also make sure the Mobile view is not affected with this changes and works exactly the same.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1205254810113133