### PR TITLE
Theme showcase: Clear category param from URL

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -338,6 +338,7 @@ class ThemeShowcase extends Component {
 		} else {
 			const subjectTerm = filterToTermTable[ `subject:${ tabFilter.key }` ];
 			newUrlParams.filter = [ filterWithoutSubjects, subjectTerm ].join( '+' );
+			newUrlParams.category = null;
 		}
 
 		page( this.constructUrl( newUrlParams ) );


### PR DESCRIPTION
## Proposed Changes

Clears the category param from the URL if a non-generic/non-static category is selected, since such category is always ignored.

Before | After
--- | ---
<img width="1274" alt="Screenshot 2023-08-14 at 12 40 15" src="https://github.com/Automattic/wp-calypso/assets/1233880/2da42574-c89f-4aff-bb14-be56b668aabe"> | <img width="1276" alt="Screenshot 2023-08-14 at 12 39 34" src="https://github.com/Automattic/wp-calypso/assets/1233880/fdf5f48e-abba-4b8e-a2cd-1026c7afa32f">



Props to @arthur791004 for reporting this in p1692004034109489/1692002901.809559-slack-C048CUFRGFQ.

## Testing Instructions

- Use the Calypso live link below.
- Go to `/themes`.
- Select the "All" category.
- Make sure the URL changes to `/theme/all`.
- Select the "Blog" category.
- Make sure the URL changes to `/themes/filter/blog` (used to be `/themes/all/filter/blog`).