### PR TITLE
Fix FoldableCard chevron alignment

### DIFF
--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -106,7 +106,7 @@ class FoldableCard extends Component {
 					onClick={ clickAction }
 				>
 					<ScreenReaderText>{ screenReaderText }</ScreenReaderText>
-					<Gridicon icon={ this.props.icon } size={ iconSize } />
+					<Gridicon className="foldable-card__chevron" icon={ this.props.icon } size={ iconSize } />
 				</button>
 			);
 		}

--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -14,6 +14,10 @@
 	}
 }
 
+.foldable-card__chevron {
+	margin: auto;
+}
+
 .foldable-card__header {
 	min-height: 64px;
 	width: 100%;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1205142973434174-as-1205118358493194

Foldable card chevrons are not aligned properly, this was found in the Social connections screen.


| Before | After |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/36671565/3f1fe4ff-a539-492f-a75b-11de6c34ac20)  | <img width="1122" alt="CleanShot 2023-08-14 at 13 42 05 png" src="https://github.com/Automattic/wp-calypso/assets/36671565/c70eb9c6-e3bc-4d9b-afc8-a1e13f4dbbcd"> |

## Proposed Changes

* Added `margin: auto;` to the Icon, so it positions itself in the middle

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Fire Up Calypso and Jetpack cloud
* Check the connections screen, the chevrons should be aligned correctly in the middle

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
