### PR TITLE
Request JITMs on the All Posts page

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -12,7 +12,6 @@ import { Button, Card, Gridicon } from '@automattic/components';
 import { isMobile } from '@automattic/viewport';
 import classNames from 'classnames';
 import DOMPurify from 'dompurify';
-import { JSDOM } from 'jsdom';
 import { size } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -185,9 +184,7 @@ export class Banner extends Component {
 
 	sanitize( html ) {
 		// Getting an instance of DOMPurify this way is needed to fix a related JEST test.
-		const { window } = new JSDOM( '<!DOCTYPE html>' );
-		const domPurify = DOMPurify( window );
-		return domPurify.sanitize( html, {
+		return DOMPurify.sanitize( html, {
 			ALLOWED_TAGS: [ 'a' ],
 			ALLOWED_ATTR: [ 'href', 'target' ],
 		} );

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -11,6 +11,7 @@ import {
 import { Button, Card, Gridicon } from '@automattic/components';
 import { isMobile } from '@automattic/viewport';
 import classNames from 'classnames';
+import DOMPurify from 'dompurify';
 import { size } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -202,6 +203,11 @@ export class Banner extends Component {
 
 		const prices = Array.isArray( price ) ? price : [ price ];
 
+		const sanitizedDescription = DOMPurify.sanitize( description, {
+			ALLOWED_TAGS: [ 'a' ],
+			ALLOWED_ATTR: [ 'href', 'target' ],
+		} );
+
 		return (
 			<div className="banner__content">
 				{ tracksImpressionName && event && (
@@ -217,7 +223,12 @@ export class Banner extends Component {
 				) }
 				<div className="banner__info">
 					<div className="banner__title">{ title }</div>
-					{ description && <div className="banner__description">{ description }</div> }
+					{ description && (
+						<div
+							className="banner__description"
+							dangerouslySetInnerHTML={ { __html: sanitizedDescription } } // eslint-disable-line react/no-danger
+						></div>
+					) }
 					{ size( list ) > 0 && (
 						<ul className="banner__list">
 							{ list.map( ( item, key ) => (

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -12,6 +12,7 @@ import { Button, Card, Gridicon } from '@automattic/components';
 import { isMobile } from '@automattic/viewport';
 import classNames from 'classnames';
 import DOMPurify from 'dompurify';
+import { JSDOM } from 'jsdom';
 import { size } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -182,6 +183,16 @@ export class Banner extends Component {
 		);
 	}
 
+	sanitize( html ) {
+		// Getting an instance of DOMPurify this way is needed to fix a related JEST test.
+		const { window } = new JSDOM( '<!DOCTYPE html>' );
+		const domPurify = DOMPurify( window );
+		return domPurify.sanitize( html, {
+			ALLOWED_TAGS: [ 'a' ],
+			ALLOWED_ATTR: [ 'href', 'target' ],
+		} );
+	}
+
 	getContent() {
 		const {
 			callToAction,
@@ -203,11 +214,6 @@ export class Banner extends Component {
 
 		const prices = Array.isArray( price ) ? price : [ price ];
 
-		const sanitizedDescription = DOMPurify.sanitize( description, {
-			ALLOWED_TAGS: [ 'a' ],
-			ALLOWED_ATTR: [ 'href', 'target' ],
-		} );
-
 		return (
 			<div className="banner__content">
 				{ tracksImpressionName && event && (
@@ -226,7 +232,7 @@ export class Banner extends Component {
 					{ description && (
 						<div
 							className="banner__description"
-							dangerouslySetInnerHTML={ { __html: sanitizedDescription } } // eslint-disable-line react/no-danger
+							dangerouslySetInnerHTML={ { __html: this.sanitize( description ) } } // eslint-disable-line react/no-danger
 						></div>
 					) }
 					{ size( list ) > 0 && (

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -2,6 +2,7 @@ import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
+import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -85,6 +86,14 @@ class PostsMain extends Component {
 			<Main wideLayout className="posts">
 				{ isJetpack && isPossibleJetpackConnectionProblem && (
 					<JetpackConnectionHealthBanner siteId={ siteId } />
+				) }
+				{ ! isJetpack && isEnabled( 'jitms' ) && (
+					<AsyncLoad
+						require="calypso/blocks/jitm"
+						template="notice"
+						placeholder={ null }
+						messagePath="calypso:edit-post:admin_notices"
+					/>
 				) }
 				<ScreenOptionsTab wpAdminPath="edit.php" />
 				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -93,7 +93,7 @@ class PostsMain extends Component {
 						require="calypso/blocks/jitm"
 						template="notice"
 						placeholder={ null }
-						messagePath="calypso:edit-post:admin_notices"
+						messagePath="wp:edit-post:admin_notices"
 					/>
 				) }
 				<ScreenOptionsTab wpAdminPath="edit.php" />

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -88,7 +88,7 @@ class PostsMain extends Component {
 				{ isJetpack && isPossibleJetpackConnectionProblem && (
 					<JetpackConnectionHealthBanner siteId={ siteId } />
 				) }
-				{ ! isJetpack && isEnabled( 'jitms' ) && (
+				{ isEnabled( 'jitms' ) && (
 					<AsyncLoad
 						require="calypso/blocks/jitm"
 						template="notice"

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -10,6 +10,9 @@ jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/my-sites/themes/theme-preview', () =>
 	require( 'calypso/components/empty-component' )
 );
+jest.mock( 'dompurify', () => ( {
+	sanitize: jest.fn().mockImplementation( ( text ) => text ),
+} ) );
 
 const themeData = {
 	name: 'Twenty Sixteen',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to SELFSERVE-535

According to the mentioned JIRA ticket we change a JITM for Blaze. I noticed that `Posts > All Posts` in Calypso does not fetch JITM as Jetpack plugin does. To fill the gap, this PR fetches a JITM with the `wp:edit-post:admin_notices` as a `messagePath`.

This changes relate to the D118846-code and a follow up fix D119298-code.

<img width="1053" alt="Screenshot 2023-08-16 at 15 35 16" src="https://github.com/Automattic/wp-calypso/assets/115007291/be3f1436-8cb1-460c-a702-22f5b9c40b54">

## Caveat
(At the moment, the diffs that provides JITM were deployed, to the paragraph below doesn't make much sense)

Testing JITMs is a complicated topic due to its architecture. WPCOM should be sandboxed to test changes that are not deployed yet. For Atomic and Self-hosted sites it solves by sandboxing Jetpack API with the WPCOM sandbox. For Calypso that trick does not work, so here's the [patch](https://github.com/Automattic/wp-calypso/files/12358980/calypso-jitm.patch.txt) that mocks JITM response instead of calling production WPCOM for a JITM.

## Proposed Changes

- Fetch a JITM message from `Post > All Posts` page with a messagePath of `wp:edit-post:admin_notices`,
- Allow an anchor HTML tag for a Banner component (instead of plain text),
- Mock `DOMPurify.sanitize` call (to fix a JEST test).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run Calypso locally,
- Open `Posts > All Posts` page for one of your sites 
- Ensure that you see a JITM
<img width="1272" alt="image" src="https://github.com/Automattic/wp-calypso/assets/115007291/78aa1895-c674-49a5-81e5-2ec31acda944">

## For extra points ⭐  
- Apply this [patch](https://github.com/Automattic/wp-calypso/files/12358980/calypso-jitm.patch.txt) to your WPCOM sandbox, it will provide your request with the content including dangerous HTML markup,
- Sandbox WPCOM,
- Open Posts > All Posts for your site in the local Calypso (e.g. http://calypso.localhost:3000/posts/adpurchasetest.wordpress.com)
- Ensure that the JITM's description has a link (the point 1 on the image below),
- Banner's content provided by JITM should be sanitized properly (the point 2 on the image below):
<img width="1421" alt="Screenshot 2023-08-16 at 14 50 45" src="https://github.com/Automattic/wp-calypso/assets/115007291/a72e6726-5725-4a10-a934-6c0aa5475035">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
