### PR TITLE
Jetpack Error UX: Remove feature flag

### DIFF
--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -81,11 +80,10 @@ class PostsMain extends Component {
 		// Since searches are across all statuses, the status needs to be shown
 		// next to each post.
 		const showPublishedStatus = Boolean( query.search );
-		const isJetpackErrorUxEnabled = isEnabled( 'yolo/jetpack-error-ux-i1' );
 
 		return (
 			<Main wideLayout className="posts">
-				{ isJetpack && isPossibleJetpackConnectionProblem && isJetpackErrorUxEnabled && (
+				{ isJetpack && isPossibleJetpackConnectionProblem && (
 					<JetpackConnectionHealthBanner siteId={ siteId } />
 				) }
 				<ScreenOptionsTab wpAdminPath="edit.php" />

--- a/config/development.json
+++ b/config/development.json
@@ -215,7 +215,6 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
-		"yolo/hosting-metrics-i1": true,
-		"yolo/jetpack-error-ux-i1": true
+		"yolo/hosting-metrics-i1": true
 	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -148,8 +148,7 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/hosting-metrics-i1": false,
-		"yolo/jetpack-error-ux-i1": true
+		"yolo/hosting-metrics-i1": false
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/production.json
+++ b/config/production.json
@@ -177,8 +177,7 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/hosting-metrics-i1": false,
-		"yolo/jetpack-error-ux-i1": true
+		"yolo/hosting-metrics-i1": false
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -171,8 +171,7 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"newsletter/stats": false,
-		"yolo/hosting-metrics-i1": false,
-		"yolo/jetpack-error-ux-i1": true
+		"yolo/hosting-metrics-i1": false
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/test.json
+++ b/config/test.json
@@ -108,7 +108,6 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
-		"yolo/hosting-metrics-i1": true,
-		"yolo/jetpack-error-ux-i1": true
+		"yolo/hosting-metrics-i1": true
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -182,8 +182,7 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/hosting-metrics-i1": true,
-		"yolo/jetpack-error-ux-i1": true
+		"yolo/hosting-metrics-i1": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",


### PR DESCRIPTION
## Proposed Changes

Removes the `yolo/jetpack-error-ux-i1` feature flag. The feature has been enabled in production for a while, so no longer necessary to keep this around.

## Testing Instructions

1. Follow one of the testing instructions on https://github.com/Automattic/wp-calypso/pull/80429
2. Verify the Jetpack connection error notice still appears on the Posts screen.