### PR TITLE
Onboarding flows: Fix button component background colors

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -198,6 +198,10 @@ button {
 	// This changes the primary color to blue-50 to conform to the WordPress.com colors.
 	--color-accent: var(--studio-blue-50);
 	--color-accent-60: var(--studio-blue-60);
+	--wp-components-color-accent-darker-10: var(--studio-blue-60);
+	--wp-components-color-accent-darker-20: var(--studio-blue-70);
+	--wp-components-color-accent: var(--studio-blue-50);
+
 }
 
 .import-focused .step-container.site-picker {


### PR DESCRIPTION
## Proposed Changes

* Set missing CSS variables for the onboarding flows

## Testing Instructions

* Pass through the import onboarding flow
* Check button color styles

<table>
  <tr>
    <td width="50%">
      <strong>Now:</strong>
      <img width="507" alt="Screenshot 2023-08-14 at 16 48 12" src="https://github.com/Automattic/wp-calypso/assets/1241413/d1ba1ff7-d7ee-450c-b2c6-3f73d54a3736">
    <td width="50%">
      <strong>Before:</strong>
      <img width="505" alt="Screenshot 2023-08-14 at 16 48 19" src="https://github.com/Automattic/wp-calypso/assets/1241413/1ef1f07b-a984-4791-9890-af79b75cd871">
  <tr>
    <td width="50%">
      <img width="585" alt="Screenshot 2023-08-14 at 16 48 40" src="https://github.com/Automattic/wp-calypso/assets/1241413/df692b6e-d2d6-4fae-a114-c1deb99d6a13">
    <td width="50%">
      <img width="583" alt="Screenshot 2023-08-14 at 16 48 47" src="https://github.com/Automattic/wp-calypso/assets/1241413/6b07a659-e679-4311-8a80-5c4c15ac5595">
</table>



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
