### PR TITLE
Shopping Cart: Disallow calling addProductsToCart with 'undefined' slug

### DIFF
--- a/packages/shopping-cart/src/create-request-cart-product.ts
+++ b/packages/shopping-cart/src/create-request-cart-product.ts
@@ -4,7 +4,7 @@ export default function createRequestCartProduct(
 	properties: MinimalRequestCartProduct
 ): RequestCartProduct {
 	if ( ! properties.product_slug || properties.product_slug === 'undefined' ) {
-		throw new Error( 'product_slug is required for request cart products' );
+		throw new Error( 'A product_slug is required when adding a product to the cart.' );
 	}
 	const { product_slug, product_id, meta, volume, quantity, extra } = properties;
 	return {

--- a/packages/shopping-cart/src/create-request-cart-product.ts
+++ b/packages/shopping-cart/src/create-request-cart-product.ts
@@ -3,7 +3,7 @@ import type { RequestCartProduct, MinimalRequestCartProduct } from './types';
 export default function createRequestCartProduct(
 	properties: MinimalRequestCartProduct
 ): RequestCartProduct {
-	if ( ! properties.product_slug ) {
+	if ( ! properties.product_slug || properties.product_slug === 'undefined' ) {
 		throw new Error( 'product_slug is required for request cart products' );
 	}
 	const { product_slug, product_id, meta, volume, quantity, extra } = properties;


### PR DESCRIPTION
## Proposed Changes

We intermittently see a lot of instances where something tries to add a product to the cart with the product slug `'undefined'` (see logstash `cart_add_product_id_zero` feature). I haven't been able to track down where this is coming from, but presumably it's something that is calling the `addProductsToCart()` method of the `@automattic/shopping-cart` package and serializing an undefined value into a string.

We already have a guard to prevent adding a product with an undefined slug to the cart, but this PR also disallows adding a product with the slug 'undefined'.

## Testing Instructions

None should be necessary.