### PR TITLE
PurchaseNotice: Add alternative expiry text for temporary site purchases

### DIFF
--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -44,7 +44,7 @@ import {
 import { managePurchase } from 'calypso/me/purchases/paths';
 import UpcomingRenewalsDialog from 'calypso/me/purchases/upcoming-renewals/upcoming-renewals-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getAddNewPaymentMethodPath } from '../utils';
+import { getAddNewPaymentMethodPath, isTemporarySitePurchase } from '../utils';
 import type { SiteDetails } from '@automattic/data-stores';
 import type {
 	GetManagePurchaseUrlFor,
@@ -103,6 +103,15 @@ class PurchaseNotice extends Component<
 		if ( isMonthly( purchase.productSlug ) ) {
 			const daysToExpiry = moment( expiry.diff( moment() ) ).format( 'D' );
 
+			if ( isTemporarySitePurchase( purchase ) ) {
+				return translate( '%(purchaseName)s will expire and be removed %(expiry)s days. ', {
+					args: {
+						purchaseName: getName( purchase ),
+						expiry: daysToExpiry,
+					},
+				} );
+			}
+
 			return translate(
 				'%(purchaseName)s will expire and be removed from your site %(expiry)s days. ',
 				{
@@ -112,6 +121,15 @@ class PurchaseNotice extends Component<
 					},
 				}
 			);
+		}
+
+		if ( isTemporarySitePurchase( purchase ) ) {
+			return translate( '%(purchaseName)s will expire and be removed %(expiry)s.', {
+				args: {
+					purchaseName: getName( purchase ),
+					expiry: expiry.fromNow(),
+				},
+			} );
 		}
 
 		return translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s.', {

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -104,19 +104,16 @@ class PurchaseNotice extends Component<
 			const daysToExpiry = expiry.diff( moment(), 'days' );
 
 			if ( isTemporarySitePurchase( purchase ) ) {
-				return translate(
-					'%(purchaseName)s will expire and be removed in %(daysToExpiry)d days. ',
-					{
-						args: {
-							purchaseName: getName( purchase ),
-							daysToExpiry,
-						},
-					}
-				);
+				return translate( '%(purchaseName)s will expire and be removed in %(daysToExpiry)d days.', {
+					args: {
+						purchaseName: getName( purchase ),
+						daysToExpiry,
+					},
+				} );
 			}
 
 			return translate(
-				'%(purchaseName)s will expire and be removed from your site in %(daysToExpiry)d days. ',
+				'%(purchaseName)s will expire and be removed from your site in %(daysToExpiry)d days.',
 				{
 					args: {
 						purchaseName: getName( purchase ),

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -101,23 +101,26 @@ class PurchaseNotice extends Component<
 		}
 
 		if ( isMonthlyPurchase( purchase ) ) {
-			const daysToExpiry = moment( expiry.diff( moment() ) ).format( 'D' );
+			const daysToExpiry = expiry.diff( moment(), 'days' );
 
 			if ( isTemporarySitePurchase( purchase ) ) {
-				return translate( '%(purchaseName)s will expire and be removed %(expiry)s days. ', {
-					args: {
-						purchaseName: getName( purchase ),
-						expiry: daysToExpiry,
-					},
-				} );
+				return translate(
+					'%(purchaseName)s will expire and be removed in %(daysToExpiry)d days. ',
+					{
+						args: {
+							purchaseName: getName( purchase ),
+							daysToExpiry,
+						},
+					}
+				);
 			}
 
 			return translate(
-				'%(purchaseName)s will expire and be removed from your site %(expiry)s days. ',
+				'%(purchaseName)s will expire and be removed from your site in %(daysToExpiry)d days. ',
 				{
 					args: {
 						purchaseName: getName( purchase ),
-						expiry: daysToExpiry,
+						daysToExpiry,
 					},
 				}
 			);

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -5,7 +5,6 @@ import {
 	isConciergeSession,
 	isPlan,
 	isDomainRegistration,
-	isMonthly,
 	isAkismetFreeProduct,
 	PLAN_BUSINESS,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
@@ -40,6 +39,7 @@ import {
 	showCreditCardExpiringWarning,
 	isPaidWithCredits,
 	shouldAddPaymentSourceInsteadOfRenewingNow,
+	isMonthlyPurchase,
 } from 'calypso/lib/purchases';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import UpcomingRenewalsDialog from 'calypso/me/purchases/upcoming-renewals/upcoming-renewals-dialog';
@@ -100,7 +100,7 @@ class PurchaseNotice extends Component<
 			return this.getExpiringLaterText( purchase );
 		}
 
-		if ( isMonthly( purchase.productSlug ) ) {
+		if ( isMonthlyPurchase( purchase ) ) {
 			const daysToExpiry = moment( expiry.diff( moment() ) ).format( 'D' );
 
 			if ( isTemporarySitePurchase( purchase ) ) {


### PR DESCRIPTION
This pull request adds alternative text to the purchase expiry notice for siteless purchases. The new text still says the purchase will expire and be removed, but does not mention "from this site," since it's not associated with a site.

Resolves `1202619025189113-as-1203845960301499`.

## Proposed Changes

* Add two new forms of expiry text in `getExpiryText`, which are only displayed when the current purchase evaluates to true when passed to `isTemporarySitePurchase`.

## Testing Instructions

* In your Calypso Blue test environment, visit `/me/purchases` and select a purchase that is not associated with any site (e.g., an unassigned Jetpack Boost license).
* Verify you see an expiration notice at the top of the purchase details as shown in the screenshots below. Notably, the text should not mention "this site."

### Reference screenshots

#### Before

<img width="1053" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/424a2b43-1b3b-446e-9d73-449a3030f15f">

#### After

<img width="1052" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/d8f332a5-ed91-4d7d-b4f2-4662b5aca78c">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203845960301499