### PR TITLE
SupportContentFooter: fix spacing on mobile

### DIFF
--- a/apps/happy-blocks/block-library/support-content-footer/index.php
+++ b/apps/happy-blocks/block-library/support-content-footer/index.php
@@ -97,7 +97,7 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 			</p>
 		</div>
 		<div class="support-content-subscribe">
-			<p><?php esc_html_e( 'Get the latest learning in your inbox::', 'happy-blocks' ); ?></p>
+			<p><?php esc_html_e( 'Get the latest learning in your inbox:', 'happy-blocks' ); ?></p>
 			<form action="https://subscribe.wordpress.com" method="post" accept-charset="utf-8" data-blog="<?php echo get_current_blog_id(); ?>" data-post_access_level="everybody" id="subscribe-blog">
 				<input class="support-content-subscribe-email" required="required" type="email" name="email" placeholder="<?php esc_html_e( 'Type your email', 'happy-blocks' ); ?>"  id="subscribe-field">
 				<input type="hidden" name="action" value="subscribe">

--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -128,7 +128,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 		.support-content-subscribe-disclaimer {
 			color: var(--studio-gray-60);
 			font-size: 0.75rem;
-			line-height: 26px;
+			line-height: 20px;
 
 			a {
 				color: inherit;
@@ -181,21 +181,19 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 		h4 {
 			font-size: 1.25rem;
-			line-height: 26px;
+			line-height: 26px !important;
 		}
 
 		p {
-			font-size: 0.875rem;
 			margin-top: 4px;
-			margin-bottom: 8px;
-			line-height: 20px;
+			margin-bottom: 16px;
 		}
 
 		.support-content-cta {
 			margin-bottom: 0;
 
 			.support-content-cta-left {
-				padding: 0 48px 16px 0;
+				padding: 0 48px 24px 0;
 			}
 
 			.support-content-cta-right {
@@ -205,11 +203,11 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 		.support-content-resources {
 			flex-direction: column;
-			gap: 8px;
+			gap: 0;
 
 			.support-content-resource {
 				min-width: 317px;
-				padding: 16px 48px 16px 0;
+				padding: 24px 48px 24px 0;
 
 				.resource-link {
 					line-height: 20px;
@@ -217,13 +215,20 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 			}
 		}
 
+		.support-content-links {
+			a {
+				display: inline-block;
+			}
+
+			p {
+				margin-bottom: 16px !important;
+			}
+		}
+
 		.support-content-links-subscribe {
 			flex-direction: column;
 			padding-bottom: 36px;
-
-			.support-content-subscribe {
-				margin-top: 32px;
-			}
+			margin-top: 24px;
 
 			.support-content-subscribe form {
 				.support-content-subscribe-email {


### PR DESCRIPTION
This PR customizes the SupportContentFooter for mobile devices.

**Testing**
- Pull and sync this branch 
- Ensure that the spacing matches the designs IceKRdz5qlPYwuqzu6pBgF-fi-3812%3A81308&mode=dev

Related to #


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?