### PR TITLE
Design picker: Display a screenshot instead of mshots when externally managed

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -55,6 +55,12 @@ jest.mock( 'calypso/components/data/query-themes', () => ( {
 	},
 } ) );
 
+jest.mock( 'calypso/components/data/query-products-list', () => ( {
+	useQueryProductsList: () => {
+		return;
+	},
+} ) );
+
 /**
  * Mock wpcom-proxy-request so that we could use wpcom-xhr-request to call the endpoint
  * and get the response from nock

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -22,6 +22,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState, useEffect, useMemo } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
+import { useQueryProductsList } from 'calypso/components/data/query-products-list';
 import { useQuerySiteFeatures } from 'calypso/components/data/query-site-features';
 import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import { useQueryThemes } from 'calypso/components/data/query-themes';
@@ -324,6 +325,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		number: 1000,
 		...( ! isEnabled( 'design-picker/query-marketplace-themes' ) ? { tier: '-marketplace' } : {} ),
 	} );
+	useQueryProductsList();
 	useQuerySitePurchases( site ? site.ID : -1 );
 	useQuerySiteFeatures( [ site?.ID ] );
 

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -39,6 +39,8 @@ interface StarterDesign {
 	is_virtual: boolean;
 	preview_data: PreviewData | null;
 	design_type?: DesignType;
+	theme_type?: string;
+	screenshot?: string;
 }
 
 export function useStarterDesignsQuery(
@@ -86,9 +88,12 @@ function apiStarterDesignsToDesign( design: StarterDesign ): Design {
 		software_sets,
 		preview_data,
 		design_type,
+		screenshot,
 	} = design;
 	const is_premium =
 		( design.recipe.stylesheet && design.recipe.stylesheet.startsWith( 'premium/' ) ) || false;
+
+	const is_externally_managed = design.theme_type === 'managed-external';
 
 	const is_bundled_with_woo_commerce = ( design.software_sets || [] ).some(
 		( { slug } ) => slug === 'woo-on-plans'
@@ -101,6 +106,7 @@ function apiStarterDesignsToDesign( design: StarterDesign ): Design {
 		recipe,
 		categories,
 		is_premium,
+		is_externally_managed,
 		is_bundled_with_woo_commerce,
 		price,
 		software_sets,
@@ -112,5 +118,6 @@ function apiStarterDesignsToDesign( design: StarterDesign ): Design {
 		features: [],
 		template: '',
 		theme: '',
+		screenshot,
 	};
 }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -3,6 +3,7 @@ import { Button } from '@automattic/components';
 import { MShotsImage } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
 import classnames from 'classnames';
+import photon from 'photon';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { SHOW_ALL_SLUG, DEFAULT_ASSEMBLER_DESIGN } from '../constants';
@@ -35,6 +36,20 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 	styleVariation,
 } ) => {
 	const isMobile = useViewportMatch( 'small', '<' );
+
+	if ( design.is_externally_managed && design.screenshot ) {
+		const fit = '479,360';
+		const themeImgSrc = photon( design.screenshot, { fit } ) || design.screenshot;
+		const themeImgSrcDoubleDpi = photon( design.screenshot, { fit, zoom: 2 } ) || design.screenshot;
+
+		return (
+			<img
+				src={ themeImgSrc }
+				srcSet={ `${ themeImgSrcDoubleDpi } 2x` }
+				alt={ design.description }
+			/>
+		);
+	}
 
 	return (
 		<MShotsImage

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -99,6 +99,7 @@ export interface Design {
 	description?: string;
 	recipe?: DesignRecipe;
 	is_premium: boolean;
+	is_externally_managed: boolean;
 	categories: Category[];
 	features: DesignFeatures[];
 	is_featured_picks?: boolean; // Whether this design will be featured in the sidebar. Example: Blank Canvas
@@ -111,6 +112,7 @@ export interface Design {
 	is_bundled_with_woo_commerce?: boolean;
 	is_virtual?: boolean;
 	preview_data?: PreviewData;
+	screenshot?: string;
 
 	/** @deprecated used for Gutenboarding (/new flow) */
 	stylesheet?: string;

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -99,7 +99,7 @@ export interface Design {
 	description?: string;
 	recipe?: DesignRecipe;
 	is_premium: boolean;
-	is_externally_managed: boolean;
+	is_externally_managed?: boolean;
 	categories: Category[];
 	features: DesignFeatures[];
 	is_featured_picks?: boolean; // Whether this design will be featured in the sidebar. Example: Blank Canvas


### PR DESCRIPTION
Resolves https://github.com/Automattic/dotcom-forge/issues/3447
Related to D118900-code

## Proposed Changes

* Check if the theme for a given design is externally managed and display a screenshot instead of mshots
* Remove the filter out for Marketplace producs
* Query the Product List to receive Marketplace themes prices

## Testing Instructions

* Apply the diff D118900-code to your sandbox and direct requests to the sandbox
* Go to the route `/setup/update-design/designSetup?siteSlug=:site`
* The Marketplace Themes (ex: Yuna, Olsen) should have the partner tag and properly show the screenshot
* Verify the price is available when hovering the partners tag

![CleanShot 2023-08-14 at 14 13 19@2x](https://github.com/Automattic/wp-calypso/assets/5039531/bda7a175-80f6-42d1-8769-8c457a7e9f6b)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
