### PR TITLE
Customer Home: Use site slug rather than URL for preview on the front end

### DIFF
--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -93,7 +93,7 @@ const SitePreview = ( { isFSEActive }: SitePreviewProps ): JSX.Element => {
 				<div className="home-site-preview__site-info">
 					<h2 className="home-site-preview__info-title">{ selectedSite.name }</h2>
 					<SiteUrl href={ selectedSite.URL } title={ selectedSite.URL }>
-						<Truncated>{ selectedSite.URL }</Truncated>
+						<Truncated>{ selectedSite.slug }</Truncated>
 					</SiteUrl>
 				</div>
 				<SitePreviewEllipsisMenu />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/80564

## Proposed Changes

* Swap selected site `URL` for `slug` so we're not showing the URL protocol (https://)

**Before**

<img width="353" alt="Screenshot 2023-08-14 at 1 34 41 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/ed5234d9-026d-44bf-920c-89a14be9b7cf">

**After**

<img width="356" alt="Screenshot 2023-08-14 at 1 34 22 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/fdb138af-a437-4a96-87bb-bdac019ce308">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/home/siteSlug` on a site with a post-launch Launchpad (new Write, Build, or Newsletter flows)
* You should not see the `https://` part of the URL under the site preview image.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
