### PR TITLE
VideoPress TV: Use inter font on signup flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -73,7 +73,8 @@
 
 }
 
-.is-videopress-tv-stepper {
+.is-videopress-tv-stepper,
+.is-videopress-tv-purchase-stepper {
 	font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 
 	.processing-step__progress-step {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -73,6 +73,17 @@
 
 }
 
+.is-videopress-tv-stepper {
+	font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+
+	.processing-step__progress-step {
+		font-family: inherit;
+		font-size: rem(38px); //typography-exception
+		font-weight: 700;
+		letter-spacing: -0.02em;
+	}
+}
+
 .is-videopress-stepper.is-processing-step,
 .is-videopress-tv-stepper,
 .is-videopress-tv-purchase-stepper {

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -2,7 +2,8 @@
 @import "./videopress-constants.scss";
 
 
-body.is-videopress-tv-stepper {
+body.is-videopress-tv-stepper,
+body.is-videopress-tv-purchase-stepper {
 	.step-container .step-container__header .formatted-header .formatted-header__title,
 	.signup-header h1 {
 		font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -2,6 +2,14 @@
 @import "./videopress-constants.scss";
 
 
+body.is-videopress-tv-stepper {
+	.step-container .step-container__header .formatted-header .formatted-header__title,
+	.signup-header h1 {
+		font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+		font-weight: 700;
+	}
+}
+
 body.is-videopress-stepper,
 body.is-videopress-tv-stepper,
 body.is-videopress-tv-purchase-stepper {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -65,6 +65,14 @@ export const addVideoPressSignupClassName = () => {
 	document.body.classList.add( 'is-videopress-signup' );
 };
 
+export const addVideoPressTvSignupClassName = () => {
+	if ( ! document ) {
+		return;
+	}
+
+	document.body.classList.add( 'is-videopress-tv-signup' );
+};
+
 export const addP2SignupClassName = () => {
 	if ( ! document ) {
 		return;
@@ -102,6 +110,10 @@ export default {
 			next();
 		} else if ( context.pathname.includes( 'p2' ) ) {
 			addP2SignupClassName();
+			removeWhiteBackground();
+			next();
+		} else if ( context.query.flow === 'videopress-tv' ) {
+			addVideoPressTvSignupClassName();
 			removeWhiteBackground();
 			next();
 		} else if ( context.pathname.includes( 'videopress' ) ) {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -30,7 +30,8 @@ body.is-section-signup {
 			}
 		}
 	}
-	&.is-videopress-signup {
+	&.is-videopress-signup,
+	&.is-videopress-tv-signup {
 		background: var(--videopress-color-background-dark);
 		color: var(--videopress-color-text);
 

--- a/client/signup/videopress-step-wrapper/style.scss
+++ b/client/signup/videopress-step-wrapper/style.scss
@@ -1,4 +1,14 @@
-@import url( https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;900&display=swap );
+@font-face {
+	font-family: Inter;
+	font-weight: 400 700;
+	font-style: normal;
+	// stylelint-disable-next-line property-no-unknown
+	font-named-instance: "Regular";
+	src:
+		url(https://s0.wp.com/i/fonts/inter/Inter-roman.var.woff2?t=woff2-variations&v=3.19) format("woff2-variations"),
+		url(https://s0.wp.com/i/fonts/inter/Inter-roman.var.woff2?t=woff2&v=3.19) format("woff2");
+}
+
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "calypso/assets/stylesheets/videopress-extends";

--- a/client/signup/videopress-step-wrapper/style.scss
+++ b/client/signup/videopress-step-wrapper/style.scss
@@ -409,7 +409,16 @@
 	}
 }
 
-.is-videopress-signup {
+.is-videopress-tv-signup {
+	font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+
+	.videopress-step-wrapper__middle .videopress-step-wrapper__header-text {
+		font-family: inherit;
+	}
+}
+
+.is-videopress-signup,
+.is-videopress-tv-signup {
 	.progress-bar {
 		display: block;
 		border-radius: 0;

--- a/client/signup/videopress-step-wrapper/style.scss
+++ b/client/signup/videopress-step-wrapper/style.scss
@@ -414,6 +414,9 @@
 
 	.videopress-step-wrapper__middle .videopress-step-wrapper__header-text {
 		font-family: inherit;
+		font-size: rem(38px); //typography-exception
+		font-weight: 700;
+		letter-spacing: -0.02em;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/greenhouse/issues/1816

## Proposed Changes

* detect the videopress-tv flow on the signup screen and swap `Recoleta` for `Inter`.

| original flow | videopress-tv flow |
| -- | -- |
| <img width="894" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4081020/738c2323-8ddd-402a-ba6b-0c12e48a3912"> | <img width="985" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4081020/f51f6a6b-e63c-4e3f-bd90-9031a9abab76"> |

cc @evilluendas 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* visit the original videopress and the new videopress-tv signup page
   * original should use Recoleta: `/start/videopress-account/user/en?variationName=videopress&flow=videopress&pageTitle=VideoPress&redirect_to=/setup/videopress/processing`
   * new should use Inter: `/start/videopress-account/user/en?variationName=videopress-tv&flow=videopress-tv&pageTitle=VideoPress.TV&redirect_to=/setup/videopress-tv/processing`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
