### PR TITLE
Launchpad: Complete the "Add an about page" task when clicking on it

### DIFF
--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -3,6 +3,8 @@ import { isMobile } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
 import type { LaunchpadTaskActionsProps, Task } from './types';
 
+const TASKS_TO_COMPLETE_ON_CLICK = [ 'add_about_page' ];
+
 export const setUpActionsForTasks = ( {
 	siteSlug,
 	tasks,
@@ -42,9 +44,9 @@ export const setUpActionsForTasks = ( {
 			}
 
 			action = () => {
-				if ( task.id === 'add_about_page' ) {
-					updateLaunchpadSettings( siteSlug as string, {
-						checklist_statuses: { add_about_page: true },
+				if ( siteSlug && TASKS_TO_COMPLETE_ON_CLICK.includes( task.id ) ) {
+					updateLaunchpadSettings( siteSlug, {
+						checklist_statuses: { [ task.id ]: true },
 					} );
 				}
 				window.location.assign( targetPath );

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -1,3 +1,4 @@
+import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { isMobile } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
 import type { LaunchpadTaskActionsProps, Task } from './types';
@@ -41,6 +42,11 @@ export const setUpActionsForTasks = ( {
 			}
 
 			action = () => {
+				if ( task.id === 'add_about_page' ) {
+					updateLaunchpadSettings( siteSlug as string, {
+						checklist_statuses: { add_about_page: true },
+					} );
+				}
 				window.location.assign( targetPath );
 			};
 		} else {


### PR DESCRIPTION
## Proposed Changes

* We experienced some problems completing the "Add your About page", which led Mikael Korpela to suggest we complete the task by simply clicking on it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new Newsletter(`/setup/newsletter/intro`)
* Go through the setup flow until you land on the Customer Home
* Click on the "Add your About page" task
* You should be redirected to `/page/:siteSlug`
* Go back to the Home page. The task "Add your About page" should be complete

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
