### PR TITLE
Fixes page_view track on the Blaze Dashboard app

### DIFF
--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -163,24 +163,27 @@ export async function showDSP(
 	} );
 }
 
+export const getDSPOrigin = () => {
+	if ( config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+		return 'jetpack';
+	} else if ( isWpMobileApp() ) {
+		return 'wp-mobile-app';
+	} else if ( isWcMobileApp() ) {
+		return 'wc-mobile-app';
+	}
+
+	return 'calypso';
+};
+
 /**
  * Add tracking when launching the DSP widget, in both tracks event and MC stats.
  *
  * @param {string} entryPoint - A slug describing the entry point.
  */
 export function recordDSPEntryPoint( entryPoint: string ) {
-	let origin = 'calypso';
-	if ( config.isEnabled( 'is_running_in_jetpack_site' ) ) {
-		origin = 'jetpack';
-	} else if ( isWpMobileApp() ) {
-		origin = 'wp-mobile-app';
-	} else if ( isWcMobileApp() ) {
-		origin = 'wc-mobile-app';
-	}
-
 	const eventProps = {
 		entry_point: entryPoint,
-		origin,
+		origin: getDSPOrigin(),
 	};
 
 	return composeAnalytics(

--- a/client/my-sites/promote-post-i2/components/blaze-page-view-tracker/index.tsx
+++ b/client/my-sites/promote-post-i2/components/blaze-page-view-tracker/index.tsx
@@ -1,0 +1,56 @@
+import config from '@automattic/calypso-config';
+import { get } from 'lodash';
+import { connect } from 'react-redux';
+import { PageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
+import { getDSPOrigin } from 'calypso/lib/promote-post';
+import { getSiteFragment } from 'calypso/lib/route';
+import {
+	recordPageViewWithClientId as recordPageView,
+	enhanceWithSiteMainProduct,
+	enhanceWithSiteType,
+} from 'calypso/state/analytics/actions';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { withEnhancers } from 'calypso/state/utils';
+
+interface Props {
+	path: string;
+	title: string;
+	delay?: number;
+	properties?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+	options?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+// This component will pass through all properties to PageViewTracker unconnected component from the analytics library
+// We do this to make it compatible with the Blaze Jetpack version of the dashboard that uses hashbang for navigation
+const BlazePageViewTracker = ( props: Props ) => (
+	<PageViewTracker { ...props } properties={ { ...props.properties, origin: getDSPOrigin() } } />
+);
+
+const mapStateToProps = ( state: Record< string, unknown > ) => {
+	const isUserAuthenticated = getCurrentUserId( state );
+	const selectedSiteId = getSelectedSiteId( state );
+	const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
+	const currentSlug =
+		typeof window === 'undefined' || config.isEnabled( 'is_running_in_jetpack_site' )
+			? ''
+			: getSiteFragment( get( window, 'location.pathname', '' ) );
+
+	const hasSelectedSiteLoaded =
+		! currentSlug ||
+		( typeof currentSlug === 'number' && currentSlug === selectedSiteId ) ||
+		currentSlug === selectedSiteSlug;
+
+	return {
+		hasSelectedSiteLoaded,
+		selectedSiteId,
+		isUserAuthenticated,
+	};
+};
+
+const mapDispatchToProps = {
+	recorder: withEnhancers( recordPageView, [ enhanceWithSiteType, enhanceWithSiteMainProduct ] ),
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( BlazePageViewTracker );

--- a/client/my-sites/promote-post-i2/components/blaze-page-view-tracker/test/index.jsx
+++ b/client/my-sites/promote-post-i2/components/blaze-page-view-tracker/test/index.jsx
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+import config from '@automattic/calypso-config';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import BlazePageViewTracker from '../';
+
+const mockPageViewTrackerProps = jest.fn();
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => ( {
+	...jest.requireActual( 'calypso/lib/analytics/page-view-tracker' ),
+	PageViewTracker: ( props ) => {
+		mockPageViewTrackerProps( props );
+		return null;
+	},
+} ) );
+
+const initialState = {
+	sites: {
+		items: {
+			1: {
+				ID: 1,
+				URL: 'example.wordpress.com',
+			},
+		},
+	},
+	ui: {
+		selectedSiteId: 1,
+	},
+	currentUser: {
+		id: 12,
+		user: {
+			email_verified: true,
+			site_count: 1,
+			primary_blog: 1,
+		},
+	},
+};
+
+let features = [];
+
+const mockStore = configureStore();
+const renderWithRedux = ( ui, state = initialState ) => {
+	const store = mockStore( state );
+
+	return render( <Provider store={ store }>{ ui }</Provider> );
+};
+
+describe( 'BlazePageViewTracker', () => {
+	let originalWindowLocation;
+	beforeAll( () => {
+		originalWindowLocation = global.window.location;
+		delete global.window.location;
+
+		jest
+			.spyOn( config, 'isEnabled' )
+			.mockImplementation( ( flag ) => features.indexOf( flag ) > -1 );
+	} );
+	afterAll( () => {
+		global.window.location = originalWindowLocation;
+	} );
+
+	test( 'should pass correct information to PageViewTracker for Calypso', () => {
+		global.window.location = {
+			href: 'http://example.wordpress.com/advertising/example.wordpress.com',
+			pathname: '/advertising/example.wordpress.com',
+		};
+		features = [];
+		mockPageViewTrackerProps.mockClear();
+
+		renderWithRedux( <BlazePageViewTracker path="/advertising/posts/:site" title="Advertising" /> );
+		expect( mockPageViewTrackerProps ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/advertising/posts/:site',
+				title: 'Advertising',
+				properties: {
+					origin: 'calypso',
+				},
+				hasSelectedSiteLoaded: true,
+			} )
+		);
+	} );
+
+	test( 'should pass correct information to PageViewTracker for Jetpack', () => {
+		global.window.location = {
+			href: 'http://example.wordpress.com/wp-admin/tools.php',
+			pathname: '/wp-admin/tools.php',
+		};
+		features = [ 'is_running_in_jetpack_site' ];
+		mockPageViewTrackerProps.mockClear();
+
+		renderWithRedux( <BlazePageViewTracker path="/advertising/posts/:site" title="Advertising" /> );
+		expect( mockPageViewTrackerProps ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/advertising/posts/:site',
+				title: 'Advertising',
+				properties: {
+					origin: 'jetpack',
+				},
+				hasSelectedSiteLoaded: true,
+			} )
+		);
+	} );
+} );

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -16,7 +16,6 @@ import usePostsQueryPaged, {
 	getSearchOptionsQueryParams,
 } from 'calypso/data/promote-post/use-promote-post-posts-query-paged';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import CampaignsList from 'calypso/my-sites/promote-post-i2/components/campaigns-list';
 import PostsList from 'calypso/my-sites/promote-post-i2/components/posts-list';
 import PromotePostTabBar from 'calypso/my-sites/promote-post-i2/components/promoted-post-filter';
@@ -27,6 +26,7 @@ import {
 import { getPagedBlazeSearchData } from 'calypso/my-sites/promote-post-i2/utils';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import BlazePageViewTracker from './components/blaze-page-view-tracker';
 import CreditBalance from './components/credit-balance';
 import MainWrapper from './components/main-wrapper';
 import PostsListBanner from './components/posts-list-banner';
@@ -253,7 +253,7 @@ export default function PromotedPosts( { tab }: Props ) {
 			{ /* Render campaigns tab */ }
 			{ selectedTab === 'campaigns' && (
 				<>
-					<PageViewTracker
+					<BlazePageViewTracker
 						path={ getAdvertisingDashboardPath( '/campaigns/:site' ) }
 						title="Advertising > Campaigns"
 					/>
@@ -273,7 +273,7 @@ export default function PromotedPosts( { tab }: Props ) {
 			{ /* Render credits tab */ }
 			{ selectedTab === 'credits' && (
 				<>
-					<PageViewTracker
+					<BlazePageViewTracker
 						path={ getAdvertisingDashboardPath( '/credits/:site' ) }
 						title="Advertising > Credits"
 					/>
@@ -284,7 +284,7 @@ export default function PromotedPosts( { tab }: Props ) {
 			{ /* Render posts tab */ }
 			{ selectedTab !== 'campaigns' && selectedTab !== 'credits' && (
 				<>
-					<PageViewTracker
+					<BlazePageViewTracker
 						path={ getAdvertisingDashboardPath( '/posts/:site' ) }
 						title="Advertising > Ready to Promote"
 					/>


### PR DESCRIPTION
Related to SELFSERVE-697

The calypso_page_view event is not being fired in the Jetpack Blaze Dashbaord. 

The logic behind the logging of that metric assumes that you will get the site_slug from the URL, but that is not the case for Jetpack. The Blaze Dashboard app uses hashbang as navigation, which will bring the calypso route inside a hash (not the location pathname).

## Proposed Changes

I created a wrapper PageView component inside the Advertising section that will use the same `PageViewTracker` but calculation its parameters slightly differently to include the case of Jetpack.

The logic is very similar to the one used by the PageViewTracker (code [here](https://github.com/Automattic/wp-calypso/blob/bfb6fae30cfef6bdf0e673e6e990bc5c1b7aff65/client/lib/analytics/page-view-tracker/index.jsx#L98-L114)).

I didn't want to add more logic to that component because the change will affect already running apps (like stats that also has it own wrapper in place).

## Testing Instructions

### Calypso testing steps:

* Open the live preview
* Open your browser's network tab and filter request from `pixel.wp.com/t.gif`
* Navigate to Tools->Advertising
* Verify that you see a request to `pixel.wp.com/t.gif` with the event `calypso_page_view` and with an `origin` prop.

## Jetpack Blaze testing steps
We have a guide with multiples way to test the dashboard here: PCYsg-SuD-p2
I will describe the local steps in the description, but feel free to use any of the other methods described on that guide.

Set up a [Jetpack development](https://href.li/?https://github.com/Automattic/jetpack/blob/trunk/docs/development-environment.md) environment.

1. Open a terminal and navigate to `/some-path-to/wp-calypso/apps/blaze-dashboard`
2. Execute: `BLAZE_DASHBOARD_PACKAGE_PATH=/some-path-to/jetpack/projects/packages/blaze yarn dev`
3. Open the site in your browser using a tunnel of your choice
4. Open your browser's network tab and filter request from `pixel.wp.com/t.gif`
5. Navigate to Tools->Advertising
6. Verify that you see a request to `pixel.wp.com/t.gif` with the event `calypso_page_view` and with an `origin` prop.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
