### PR TITLE
composite-checkout: Center CheckoutErrorBoundary content in a sized box

### DIFF
--- a/packages/composite-checkout/src/components/checkout-error-boundary.tsx
+++ b/packages/composite-checkout/src/components/checkout-error-boundary.tsx
@@ -3,8 +3,12 @@ import { Component } from 'react';
 import type { ReactNode } from 'react';
 
 const ErrorContainer = styled.div`
-	margin: 2em;
+	display: flex;
 	text-align: center;
+	height: 190px;
+	width: 100%;
+	align-items: center;
+	justify-content: center;
 `;
 
 export default class CheckoutErrorBoundary extends Component< CheckoutErrorBoundaryProps > {


### PR DESCRIPTION
## Proposed Changes

The `CheckoutErrorBoundary` is a React error boundary which is used to display error messages if something throws a fatal error. It currently has some margins, but there are cases where those margins are not enough for it to be visible. Notably, if the full-page checkout error boundary is shown, then the checkout masterbar hides the error message (since https://github.com/Automattic/wp-calypso/pull/77353).

This PR adds a 190px tall box around the error message so it is visible.

Before:

<img width="933" alt="Screenshot 2023-08-14 at 2 51 37 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/028d4e8b-64ca-48a0-9eb0-19c78576ba46">

After:

<img width="934" alt="Screenshot 2023-08-14 at 3 08 29 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/c63536ef-66ec-40c7-8f5f-2ebd9ff26b22">

Although they were not having a problem, this change also affects some inline error boundaries. Here's how it looks for a payment method:

<img width="928" alt="Screenshot 2023-08-14 at 3 08 49 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/9eeb3e1e-8b03-48f8-b615-50351d0434aa">

Here's how it looks for a step:

<img width="763" alt="Screenshot 2023-08-14 at 3 10 05 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/0238b613-019c-4c29-abf7-4b103fce827e">

## Testing Instructions

You'll need to throw an error in various parts of the page component tree to see the error boundary show up. Try something like this:

```diff
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -171,6 +171,7 @@ export default function CheckoutMain( {
                [ reduxDispatch, translate ]
        );

+       throw new Error( 'testing error' );
        const checkoutFlow = useCheckoutFlowTrackKey( {
                hasJetpackSiteSlug: !! jetpackSiteSlug,
                sitelessCheckoutType,
```

Or, to see an inline error:

```diff
--- a/client/my-sites/checkout/composite-checkout/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-contact-form.tsx
@@ -42,6 +42,7 @@ export default function WPContactForm( {

        useCachedDomainContactDetails( setShouldShowContactDetailsValidationErrors, countriesList );

+       throw new Error( 'testing error' );
        return (
                <BillingFormFields>
                        <ContactDetailsContainer
```