### PR TITLE
Stats: Set static height for mini carousel and centred vertically

### DIFF
--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -206,7 +206,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 	return (
 		<DotPager
 			className="mini-carousel"
-			hasDynamicHeight
+			hasDynamicHeight={ false }
 			onPageSelected={ pagerDidSelectPage }
 			rotateTime={ 5000 }
 		>

--- a/client/my-sites/stats/mini-carousel/style.scss
+++ b/client/my-sites/stats/mini-carousel/style.scss
@@ -18,4 +18,8 @@
 	&-blaze {
 		margin: 0;
 	}
+
+	.swipeable__pages {
+		align-items: center;
+	}
 }


### PR DESCRIPTION
Related to p1692032856194139-slack-C0438NHCLSY

## Proposed Changes

The PR proposes to use static height - max height of the blocks -  for the mini carousel, so that everything below wouldn't jump up and down after a few seconds.

## Testing Instructions

* Open Calypso Live Branch
* Open a site with several items in the mini carousel `/stats/day/:siteSlug`
 ( You could set the conditions to `true` for easier testing [here](https://github.com/Automattic/wp-calypso/blob/d2e42e5a427267a963237c3cd4f24430d2c2d76f/client/my-sites/stats/mini-carousel/index.jsx#L117) and some places below )
* Ensure the height of the mini carousel doesn't change when switching between the cards
* Ensure the cards are all centred

https://github.com/Automattic/wp-calypso/assets/1425433/e9f08054-7049-4b86-ac94-c15d47cbdf1e


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
