### PR TITLE
Domain redirect: Show notice when nameserver is not WPCOM

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -92,6 +92,7 @@
 }
 
 // TODO: This should be extracted into a new component
+.domain-redirect-card-notice,
 .custom-name-servers-notice {
 	flex-basis: 100%;
 	background-color: var(--studio-gray-0);
@@ -111,6 +112,10 @@
 		font-size: $font-body-small;
 		color: var(--studio-gray-80);
 	}
+}
+
+.domain-redirect-card-notice {
+	margin-bottom: 16px;
 }
 
 .site-redirect-card__explanation,

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -348,12 +348,13 @@ const Settings = ( {
 		) {
 			return null;
 		}
+
 		return (
 			<Accordion
 				title={ translate( 'Redirect Domain', { textOnly: true } ) }
 				subtitle={ translate( 'Redirect from your domain to another' ) }
 			>
-				<DomainRedirectCard domainName={ selectedDomainName } />
+				<DomainRedirectCard domainName={ selectedDomainName } nameservers={ nameservers } />
 			</Accordion>
 		);
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3470

## Proposed Changes

Show a notice when the domain nameservers are not managed by WPCOM.

| nameserver NOT on WPCOM | nameserver on WPCOM |
| --- | --- |
| <img width="1426" alt="image" src="https://github.com/Automattic/wp-calypso/assets/402286/c2f3a745-ab56-4c0f-b5b9-97544889c719"> | <img width="1402" alt="image" src="https://github.com/Automattic/wp-calypso/assets/402286/9764ce3b-2bfe-431d-82c6-8e2bebc1aa08"> |

## Testing Instructions

* Edit a domain
* Open the `Name servers` card.
* Disable `Use WordPress.com name servers`
* Add two nameservers not from WordPress. (you can use ns1.google.com / ns2.google.com)
* Open `Redirect Domain`
* You should see the notice.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
