### PR TITLE
Fix action buttons in conversations tab

### DIFF
--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -36,7 +36,13 @@ const CommentActions = ( {
 	return (
 		<div className="comments__comment-actions">
 			{ showReadMore && (
-				<Button className="comments__comment-actions-read-more" onClick={ onReadMore }>
+				<Button
+					className="comments__comment-actions-read-more"
+					onClick={ ( e ) => {
+						onReadMore();
+						e.preventDefault();
+					} }
+				>
 					<Gridicon
 						icon="chevron-down"
 						size={ 18 }
@@ -46,7 +52,13 @@ const CommentActions = ( {
 				</Button>
 			) }
 			{ showReplyButton && (
-				<Button className="comments__comment-actions-reply" onClick={ handleReply }>
+				<Button
+					className="comments__comment-actions-reply"
+					onClick={ ( e ) => {
+						handleReply();
+						e.preventDefault();
+					} }
+				>
 					<Gridicon icon="reply" size={ 18 } />
 					<span className="comments__comment-actions-reply-label">{ translate( 'Reply' ) }</span>
 				</Button>
@@ -63,7 +75,13 @@ const CommentActions = ( {
 				/>
 			) }
 			{ showCancelReplyButton && (
-				<Button className="comments__comment-actions-cancel-reply" onClick={ onReplyCancel }>
+				<Button
+					className="comments__comment-actions-cancel-reply"
+					onClick={ ( e ) => {
+						onReplyCancel();
+						e.preventDefault();
+					} }
+				>
 					{ translate( 'Cancel reply' ) }
 				</Button>
 			) }

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -36,13 +36,7 @@ const CommentActions = ( {
 	return (
 		<div className="comments__comment-actions">
 			{ showReadMore && (
-				<Button
-					className="comments__comment-actions-read-more"
-					onClick={ ( e ) => {
-						onReadMore();
-						e.preventDefault();
-					} }
-				>
+				<Button className="comments__comment-actions-read-more" onClick={ onReadMore }>
 					<Gridicon
 						icon="chevron-down"
 						size={ 18 }
@@ -52,13 +46,7 @@ const CommentActions = ( {
 				</Button>
 			) }
 			{ showReplyButton && (
-				<Button
-					className="comments__comment-actions-reply"
-					onClick={ ( e ) => {
-						handleReply();
-						e.preventDefault();
-					} }
-				>
+				<Button className="comments__comment-actions-reply" onClick={ handleReply }>
 					<Gridicon icon="reply" size={ 18 } />
 					<span className="comments__comment-actions-reply-label">{ translate( 'Reply' ) }</span>
 				</Button>
@@ -75,13 +63,7 @@ const CommentActions = ( {
 				/>
 			) }
 			{ showCancelReplyButton && (
-				<Button
-					className="comments__comment-actions-cancel-reply"
-					onClick={ ( e ) => {
-						onReplyCancel();
-						e.preventDefault();
-					} }
-				>
+				<Button className="comments__comment-actions-cancel-reply" onClick={ onReplyCancel }>
 					{ translate( 'Cancel reply' ) }
 				</Button>
 			) }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -88,6 +88,11 @@ class ReaderPostCard extends Component {
 			return;
 		}
 
+		// ignore clicks on comments
+		if ( closest( event.target, '.conversations__comment-list', rootNode ) ) {
+			return;
+		}
+
 		// ignore clicks on anchors inside inline content
 		if (
 			closest( event.target, 'a', rootNode ) &&


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/78677

The [handleCardClick](https://github.com/Automattic/wp-calypso/blob/trunk/client/blocks/reader-post-card/index.jsx#L63) event handler on the card was overwriting the button click events, this change prevents that.

### Testing instructions
<img width="435" alt="Screen Shot 2023-08-15 at 2 37 08 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/1117ec8a-1260-42b8-ad16-afb5d1082e25">


On the `/conversations` page, test the action buttons
* Read More
* Reply
* Cancel Reply
* Reblog
* Like/Unlike
