### PR TITLE
Updating the Sensei plans step to reflect 50 GB of storage

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/constants.ts
@@ -1,4 +1,5 @@
 import { useI18n } from '@wordpress/react-i18n';
+import i18n, { getLocaleSlug } from 'i18n-calypso';
 import type { Props as PlanItemProps } from 'calypso/../packages/plans-grid/src/plans-table/plan-item';
 
 export enum Status {
@@ -6,6 +7,15 @@ export enum Status {
 	Bundling,
 	Error,
 }
+
+const useSenseiPlanStorageText = () => {
+	const { __ } = useI18n();
+	// If we have the new CTA translated or the locale is EN, return the new string, otherwise use the simpler already translated one.
+	return i18n.hasTranslation( '50GB file and video storage' ) ||
+		[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
+		? __( '50 GB file and video storage' )
+		: __( '50 GB Storage' );
+};
 
 export function useFeatures(): PlanItemProps[ 'features' ] {
 	const { __ } = useI18n();
@@ -32,7 +42,7 @@ export function useFeatures(): PlanItemProps[ 'features' ] {
 			requiresAnnuallyBilledPlan: false,
 		},
 		{
-			name: __( '200GB file and video storage' ),
+			name: useSenseiPlanStorageText(),
 			requiresAnnuallyBilledPlan: false,
 		},
 		{


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/martech#2052
## Proposed Changes

* Adds the correct storage amount to the Sensei plans step for the tailored course flow.
* Returns the new text if it's translated, or if the user is in an EN locale, and falling back to the simpler text from the plans grids/features for now while the text is getting translated.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch and run locally or via the Calypso.live link. Make sure your language is set to English in wordpress.com/me/
* Go to /setup/sensei/senseiPlan
    * You should see 50 GB of storage
* Change your language to any other language, and refresh the above page
    * As this new string is not translated yet, you should see the simpler "50 GB Storage" string translated for now.


   
![Screenshot 2023-08-15 at 11 10 00](https://github.com/Automattic/wp-calypso/assets/52675688/d4b07819-7f6a-4c3b-b21a-a250d7155c4f)
![Screenshot 2023-08-15 at 11 09 20](https://github.com/Automattic/wp-calypso/assets/52675688/aa30b4f8-7b9a-4352-99ac-451d3f810f47)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
