### PR TITLE
Jetpack E2E: accomodate WP-Admin home dashboard for Media-related specs.

### DIFF
--- a/test/e2e/specs/media/media__edit.ts
+++ b/test/e2e/specs/media/media__edit.ts
@@ -20,29 +20,39 @@ import { TEST_IMAGE_PATH } from '../constants';
 
 declare const browser: Browser;
 
+/**
+ * Ensures media can be uploaded then edited in the gallery.
+ *
+ * Keywords: Media, Image, Gallery, Upload
+ */
 describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
-	let testImage: TestFile;
 	let page: Page;
 	let mediaPage: MediaPage;
-	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
-		{
-			gutenberg: 'stable',
-			siteType: 'simple',
-			accountName: 'simpleSitePersonalPlanUser',
-		},
-	] );
+	let testAccount: TestAccount;
+	let testImage: TestFile;
+
+	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 
 	beforeAll( async () => {
 		testImage = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
+
 		page = await browser.newPage();
-		const testAccount = new TestAccount( accountName );
+
+		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
+
+		mediaPage = new MediaPage( page );
 	} );
 
 	it( 'Navigate to Media', async function () {
-		const sidebarComponent = new SidebarComponent( page );
-		await sidebarComponent.navigate( 'Media' );
-		mediaPage = new MediaPage( page );
+		// eCommerce plan loads WP-Admin for home dashboard,
+		// so instead navigate straight to the Media page.
+		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
+			await mediaPage.visit( testAccount.credentials.testSites?.primary.url as string );
+		} else {
+			const sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Media' );
+		}
 	} );
 
 	it( 'Upload image', async function () {

--- a/test/e2e/specs/media/media__edit.ts
+++ b/test/e2e/specs/media/media__edit.ts
@@ -21,7 +21,7 @@ import { TEST_IMAGE_PATH } from '../constants';
 declare const browser: Browser;
 
 /**
- * Ensures media can be uploaded then edited in the gallery.
+ * Ensures image media can be uploaded then edited in the gallery.
  *
  * Keywords: Media, Image, Gallery, Upload
  */
@@ -39,7 +39,14 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
+			// Switching to or logging into eCommerce plan sites inevitably
+			// loads WP-Admin instead of Calypso, but the rediret occurs
+			// only after Calypso attempts to load.
+			await testAccount.authenticate( page, { url: /wp-admin/ } );
+		} else {
+			await testAccount.authenticate( page );
+		}
 
 		mediaPage = new MediaPage( page );
 	} );

--- a/test/e2e/specs/media/media__upload.ts
+++ b/test/e2e/specs/media/media__upload.ts
@@ -21,17 +21,22 @@ import { TEST_IMAGE_PATH, TEST_AUDIO_PATH, TEST_UNSUPPORTED_FILE_PATH } from '..
 
 declare const browser: Browser;
 
+/**
+ * Ensures various types of media can be uploaded to the gallery.
+ *
+ * If any steps begin to fail permanently, check the following:
+ * 	- test user plan is set on production;
+ * 	- check with MarTech that plan details have not changed.
+ *
+ * Keywords: Media, Image, Video, Audio, Gallery, Upload
+ */
 describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
-	let testFiles: { image: TestFile; audio: TestFile; unsupported: TestFile };
 	let page: Page;
+	let mediaPage: MediaPage;
+	let testAccount: TestAccount;
+	let testFiles: { image: TestFile; audio: TestFile; unsupported: TestFile };
 
-	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
-		{
-			gutenberg: 'stable',
-			siteType: 'simple',
-			accountName: 'simpleSitePersonalPlanUser',
-		},
-	] );
+	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 
 	beforeAll( async () => {
 		testFiles = {
@@ -39,53 +44,47 @@ describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
 			audio: await MediaHelper.createTestFile( TEST_AUDIO_PATH ),
 			unsupported: await MediaHelper.createTestFile( TEST_UNSUPPORTED_FILE_PATH ),
 		};
+
+		page = await browser.newPage();
+
+		testAccount = new TestAccount( accountName );
+		await testAccount.authenticate( page );
+
+		mediaPage = new MediaPage( page );
 	} );
 
-	// If any of the tests start failing unexpectedly and permanently, check the following:
-	// - ensure that plans, where appropriate, are enabled for the users;
-	// - ensure with MarTech that nothing with plans have changed;
-	describe( 'Upload media files ($siteType)', () => {
-		let mediaPage: MediaPage;
-		let testAccount: TestAccount;
-
-		beforeAll( async () => {
-			page = await browser.newPage();
-
-			testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
-		} );
-
-		it( 'Navigate to Media', async function () {
+	it( 'Navigate to Media', async function () {
+		// eCommerce plan loads WP-Admin for home dashboard,
+		// so instead navigate straight to the Media page.
+		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
+			await mediaPage.visit( testAccount.credentials.testSites?.primary.url as string );
+		} else {
 			const sidebarComponent = new SidebarComponent( page );
 			await sidebarComponent.navigate( 'Media' );
-		} );
+		}
+	} );
 
-		it( 'See media gallery', async function () {
-			mediaPage = new MediaPage( page );
-		} );
+	it( 'Upload image and confirm addition to gallery', async function () {
+		await mediaPage.upload( testFiles.image.fullpath );
+	} );
 
-		it( 'Upload image and confirm addition to gallery', async function () {
-			await mediaPage.upload( testFiles.image.fullpath );
-		} );
+	it( 'Upload audio and confirm addition to gallery', async function () {
+		await mediaPage.upload( testFiles.audio.fullpath );
+	} );
 
-		it( 'Upload audio and confirm addition to gallery', async function () {
-			await mediaPage.upload( testFiles.audio.fullpath );
-		} );
-
-		it( 'Upload an unsupported file type and see the rejection notice', async function () {
-			try {
-				await mediaPage.upload( testFiles.unsupported.fullpath );
-			} catch ( error: unknown ) {
-				if ( error instanceof Error ) {
-					assert.match( error.message, /could not be uploaded/i );
-				}
+	it( 'Upload an unsupported file type and see the rejection notice', async function () {
+		try {
+			await mediaPage.upload( testFiles.unsupported.fullpath );
+		} catch ( error: unknown ) {
+			if ( error instanceof Error ) {
+				assert.match( error.message, /could not be uploaded/i );
 			}
-		} );
+		}
+	} );
 
-		// If we get to here, let's clean up after ourselves.
-		// This will minimize test data over time.
-		it( 'Delete uploaded media', async function () {
-			await mediaPage.deleteSelectedMediaFromLibrary();
-		} );
+	// If we get to here, let's clean up after ourselves.
+	// This will minimize test data over time.
+	it( 'Delete uploaded media', async function () {
+		await mediaPage.deleteSelectedMediaFromLibrary();
 	} );
 } );

--- a/test/e2e/specs/media/media__upload.ts
+++ b/test/e2e/specs/media/media__upload.ts
@@ -25,7 +25,7 @@ declare const browser: Browser;
  * Ensures various types of media can be uploaded to the gallery.
  *
  * If any steps begin to fail permanently, check the following:
- * 	- test user plan is set on production;
+ * 	- test user has the approprite plan on production store;
  * 	- check with MarTech that plan details have not changed.
  *
  * Keywords: Media, Image, Video, Audio, Gallery, Upload
@@ -48,7 +48,14 @@ describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
+			// Switching to or logging into eCommerce plan sites inevitably
+			// loads WP-Admin instead of Calypso, but the rediret occurs
+			// only after Calypso attempts to load.
+			await testAccount.authenticate( page, { url: /wp-admin/ } );
+		} else {
+			await testAccount.authenticate( page );
+		}
 
 		mediaPage = new MediaPage( page );
 	} );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80453.

## Proposed Changes

This PR adds a (temporary) workaround for `ATOMIC_VARIATION=ecomm-plan` for the `Navigate to Media` step.

In the longer term, if we are to run E2E tests on eCommerce AT users, this workaround should be replaced with a full-fledged WPAdmin Sidebar POM.

Key changes:
- add JSDoc explaining what the test does along with keywords.
- add switcher inside `Navigate to Media` step to accommodate the WP-Admin homepage that ecomm-plan uses.
- simplify the dynamic `accountName` criteria.

## Testing Instructions

Run the specs locally. Example:

```
➜  ~/workspace/wp-calypso-second git:(fix/jetpack-media-specs) ✗ TEST_ON_ATOMIC=true ATOMIC_VARIATION=default RUN_ID='Atomic: default' JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/media/media__upload.ts
 PASS  specs/media/media__upload.ts (13.638 s)
  Media: Upload (Atomic: default)
    ✓ Navigate to Media (3664 ms)
    ✓ Upload image and confirm addition to gallery (3192 ms)
    ✓ Upload audio and confirm addition to gallery (1356 ms)
    ✓ Upload an unsupported file type and see the rejection notice (92 ms)
    ✓ Delete uploaded media (112 ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        13.795 s, estimated 40 s
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
