### PR TITLE
Fixes the visibility of the Campaign cancel button for Jetpack Mobile app

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -639,6 +639,7 @@ export default function CampaignItemDetails( props: Props ) {
 											</Button>
 										) }
 										<Button
+											className="contact-support-button"
 											href={ localizeUrl( 'https://wordpress.com/help/contact' ) }
 											target="_blank"
 										>

--- a/client/my-sites/promote-post-i2/style.scss
+++ b/client/my-sites/promote-post-i2/style.scss
@@ -418,7 +418,7 @@ body.is-section-promote-post-i2 {
 			.promote-post-i2 .section-nav,
 			.promote-post-i2 .post-item__view-link,
 			.promote-post-i2 .campaign-item-breadcrumb,
-			.promote-post-i2 .campaign-item-details__support-buttons {
+			.promote-post-i2 .campaign-item-details__support-buttons .contact-support-button {
 				display: none;
 			}
 


### PR DESCRIPTION
Related to SELFSERVE-672

We are hiding all the buttons on the support area of the Advertising campaign details page when the app is running in the Jetpack App web view. We need to consider that the cancel campaign button is inside that section, and that button need to be visible.
This PR changes the hiding rule to only affect the contact support button on that section.

## Proposed Changes

* Added a class to differentiate the contact support button on the campaign details page
* Change the hiding rule to only apply to that new class name (only hide the contact support button).

## Testing Instructions

* Open the Live preview and navigate to Tools->Advertising
* Change your browser screen size to a mobile device, and use this custom user agent:
`Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 wp-android/22.8`
* Promote any of your posts, and then go to the campaign details page for that specific campaign
* Verify that the "Cancel campaign" button is shown at the bottom of the page, and that the "Contact support" button is hidden.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
