### PR TITLE
Add/limitted time offer plan pg notice

### DIFF
--- a/client/components/marketing-message/index.tsx
+++ b/client/components/marketing-message/index.tsx
@@ -85,6 +85,10 @@ const Text = styled.p< Pick< NudgeProps, 'path' > >`
 	margin: 0;
 `;
 
+const BoldText = styled.b`
+	font-weight: bold;
+`;
+
 function slugify( text: string ) {
 	return text
 		.trim()
@@ -138,7 +142,7 @@ export default function MarketingMessage( { siteId, useMockData, ...props }: Nud
 							<div className="banner__content">
 								<div className="banner__info">
 									<div className="banner__title">
-										<b>{ msg.text }</b>
+										<BoldText>{ msg.text }</BoldText>
 									</div>
 								</div>
 							</div>

--- a/client/components/marketing-message/index.tsx
+++ b/client/components/marketing-message/index.tsx
@@ -1,4 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
+import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
 import cx from 'classnames';
 import { useEffect } from 'react';
@@ -61,6 +62,23 @@ const Message = styled.div< { isPlansStep: boolean } >`
 	}
 `;
 
+const LimitedTimeOfferNudgeMessage = styled.div< { isPlansStep: boolean } >`
+	position: relative;
+	font-size: 0.875rem;
+	margin-bottom: 9px;
+	width: 100%;
+
+	.button {
+		position: relative;
+		left: 1.5em;
+		right: auto;
+		min-width: 92px;
+	}
+	.banner__icon-circle {
+		background-color: var( --color-accent );
+	}
+`;
+
 const Text = styled.p< Pick< NudgeProps, 'path' > >`
 	white-space: pre-wrap;
 	text-indent: -1.5em;
@@ -73,6 +91,17 @@ function slugify( text: string ) {
 		.toLowerCase()
 		.replace( /[^a-z0-9]+/g, '-' )
 		.replace( /^-+|-+$/g, '' );
+}
+
+function renderCTAButton( msg: any ) {
+	if ( msg.buttonText && msg.buttonLink ) {
+		return (
+			<Button className="button is-compact is-primary" href={ msg.buttonLink } target="_blank">
+				{ msg.buttonText }
+			</Button>
+		);
+	}
+	return null;
 }
 
 export default function MarketingMessage( { siteId, useMockData, ...props }: NudgeProps ) {
@@ -91,14 +120,40 @@ export default function MarketingMessage( { siteId, useMockData, ...props }: Nud
 
 	return (
 		<Container path={ props.path } className={ classNames } role="status">
-			{ messages.map( ( msg ) => (
-				<Message key={ msg.id } isPlansStep={ props.path === 'signup/plans' }>
-					<Text path={ props.path }>{ msg.text }</Text>
-					<Button compact borderless onClick={ () => removeMessage( msg.id ) }>
-						<Gridicon icon="cross" size={ 24 } />
-					</Button>
-				</Message>
-			) ) }
+			{ messages.map( ( msg ) =>
+				msg.id === 'limited_time_offer' ? (
+					<LimitedTimeOfferNudgeMessage
+						key={ msg.id }
+						isPlansStep={ props.path === 'signup/plans' }
+					>
+						<a
+							href={ msg.buttonLink }
+							className={ cx( 'card banner upsell-nudge is-card-link is-clickable' ) }
+						>
+							<div className="banner__icons">
+								<div className="banner__icon-circle">
+									<Gridicon icon="star" size={ isMobile() ? 24 : 18 } />
+								</div>
+							</div>
+							<div className="banner__content">
+								<div className="banner__info">
+									<div className="banner__title">
+										<b>{ msg.text }</b>
+									</div>
+								</div>
+							</div>
+							{ renderCTAButton( msg ) }
+						</a>
+					</LimitedTimeOfferNudgeMessage>
+				) : (
+					<Message key={ msg.id } isPlansStep={ props.path === 'signup/plans' }>
+						<Text path={ props.path }>{ msg.text }</Text>
+						<Button compact borderless onClick={ () => removeMessage( msg.id ) }>
+							<Gridicon icon="cross" size={ 24 } />
+						</Button>
+					</Message>
+				)
+			) }
 		</Container>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
https://github.com/Automattic/martech/issues/1748

## Proposed Changes
Add a limited-time offer admin notification on the plans page that shows when
1- The user is on a free plan
2- User blog is less than 48 hours old
3- Targets English users only.
4- Can be geographically targeted.
*

## Testing Instructions
(WE CAN'T PROPERLY TEST THIS UNTILL  D117246-code is deployed 
This PR only caters to the front-end display of the notice.

**Screenshot**
<img width="1193" alt="Screenshot 2023-08-15 at 16 01 19" src="https://github.com/Automattic/wp-calypso/assets/11347472/67d13e75-fa62-435a-8bb9-b5576b96419d">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
