### PR TITLE
Revert "Customer Home: Fix chevron position on foldable card on Safari"

### DIFF
--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -112,6 +112,7 @@ button.foldable-card__action {
 		fill: var(--color-neutral-30);
 		display: flex;
 		align-items: center;
+		width: 100%;
 		vertical-align: middle;
 
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#79691

This change caused alignment issues with other chevrons across foldable cards in Calypso.

Ref: p1692106454455809-slack-C9EJ7KSGH