### PR TITLE
Launchpad: Centralize repeated logic in the components

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -1,5 +1,5 @@
 import { Button, CircularProgressBar, Gridicon } from '@automattic/components';
-import { updateLaunchpadSettings, useLaunchpad, SiteDetails } from '@automattic/data-stores';
+import { updateLaunchpadSettings, useLaunchpad } from '@automattic/data-stores';
 import { Launchpad, Task, setUpActionsForTasks } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -25,10 +25,7 @@ const CustomerHomeLaunchpad = ( {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
 
-	// The type definition for getSite is incorrect, it returns a SiteDetails object
-	const site = useSelector(
-		( state: AppState ) => siteId && ( getSite( state as object, siteId ) as any as SiteDetails )
-	);
+	const site = useSelector( ( state: AppState ) => siteId && getSite( state as object, siteId ) );
 
 	const translate = useTranslate();
 	const [ isDismissed, setIsDismissed ] = useState( false );

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -1,6 +1,6 @@
 import { Button, CircularProgressBar, Gridicon } from '@automattic/components';
 import { updateLaunchpadSettings, useLaunchpad } from '@automattic/data-stores';
-import { Launchpad, Task, setUpActionsForTasks } from '@automattic/launchpad';
+import { Launchpad, PermittedActions, Task, setUpActionsForTasks } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -14,7 +14,7 @@ import './style.scss';
 
 interface CustomerHomeLaunchpadProps {
 	checklistSlug: string;
-	extraActions?: any;
+	extraActions?: PermittedActions;
 }
 
 const CustomerHomeLaunchpad = ( {

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -43,9 +43,10 @@ const CustomerHomeLaunchpad = ( {
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
 	const tasklistCompleted = completedSteps === numberOfSteps;
 	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext };
+	const hasShareSiteTask = checklist?.some( ( task: Task ) => task.id === 'share_site' );
 
 	const defaultExtraActions = {
-		setShareSiteModalIsOpen,
+		...( hasShareSiteTask ? { setShareSiteModalIsOpen } : {} ),
 		...extraActions,
 	};
 

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -1,27 +1,34 @@
 import { Button, CircularProgressBar, Gridicon } from '@automattic/components';
-import { updateLaunchpadSettings, useLaunchpad } from '@automattic/data-stores';
-import { Launchpad, Task } from '@automattic/launchpad';
+import { updateLaunchpadSettings, useLaunchpad, SiteDetails } from '@automattic/data-stores';
+import { Launchpad, Task, setUpActionsForTasks } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import ShareSiteModal from '../../components/share-site-modal';
 import type { AppState } from 'calypso/types';
 
 import './style.scss';
 
 interface CustomerHomeLaunchpadProps {
 	checklistSlug: string;
-	taskFilter: ( tasks: Task[] ) => Task[];
+	extraActions?: any;
 }
 
 const CustomerHomeLaunchpad = ( {
 	checklistSlug,
-	taskFilter,
+	extraActions = {},
 }: CustomerHomeLaunchpadProps ): JSX.Element => {
+	const launchpadContext = 'customer-home';
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
+
+	// The type definition for getSite is incorrect, it returns a SiteDetails object
+	const site = useSelector(
+		( state: AppState ) => siteId && ( getSite( state as object, siteId ) as any as SiteDetails )
+	);
 
 	const translate = useTranslate();
 	const [ isDismissed, setIsDismissed ] = useState( false );
@@ -33,9 +40,26 @@ const CustomerHomeLaunchpad = ( {
 		setIsDismissed( initialIsChecklistDismissed );
 	}, [ initialIsChecklistDismissed ] );
 
+	const [ shareSiteModalIsOpen, setShareSiteModalIsOpen ] = useState( false );
+
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
 	const tasklistCompleted = completedSteps === numberOfSteps;
+	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext };
+
+	const defaultExtraActions = {
+		setShareSiteModalIsOpen,
+		...extraActions,
+	};
+
+	const taskFilter = ( tasks: Task[] ) => {
+		return setUpActionsForTasks( {
+			tasks,
+			siteSlug,
+			tracksData,
+			extraActions: defaultExtraActions,
+		} );
+	};
 
 	useEffect( () => {
 		// Record task list view as a whole.
@@ -109,6 +133,9 @@ const CustomerHomeLaunchpad = ( {
 					</div>
 				) }
 			</div>
+			{ shareSiteModalIsOpen && site && (
+				<ShareSiteModal setModalIsOpen={ setShareSiteModalIsOpen } site={ site } />
+			) }
 			<Launchpad siteSlug={ siteSlug } checklistSlug={ checklistSlug } taskFilter={ taskFilter } />
 		</div>
 	);

--- a/client/my-sites/customer-home/cards/launchpad/intent-build.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-build.tsx
@@ -1,7 +1,5 @@
 import CustomerHomeLaunchpad from '.';
 
-import './style.scss';
-
 const checklistSlug = 'intent-build';
 
 const LaunchpadIntentBuild = (): JSX.Element => {

--- a/client/my-sites/customer-home/cards/launchpad/intent-build.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-build.tsx
@@ -1,55 +1,13 @@
-import { useLaunchpad } from '@automattic/data-stores';
-import { setUpActionsForTasks } from '@automattic/launchpad';
-import { useState } from 'react';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useSelector } from 'calypso/state';
-import { getSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import ShareSiteModal from '../../components/share-site-modal';
 import CustomerHomeLaunchpad from '.';
-import type { SiteDetails } from '@automattic/data-stores';
-import type { Task } from '@automattic/launchpad';
-import type { AppState } from 'calypso/types';
 
 import './style.scss';
 
-const launchpadContext = 'customer-home';
 const checklistSlug = 'intent-build';
 
 const LaunchpadIntentBuild = (): JSX.Element => {
-	const siteId = useSelector( getSelectedSiteId ) || undefined;
-	// The type definition for getSite is incorrect, it returns a SiteDetails object
-	const site = useSelector(
-		( state: AppState ) => getSite( state as object, siteId ) as any as SiteDetails
-	);
-
-	const siteSlug = site?.slug || null;
-
-	const {
-		data: { checklist },
-	} = useLaunchpad( siteSlug, checklistSlug );
-
-	const [ shareSiteModalIsOpen, setShareSiteModalIsOpen ] = useState( false );
-
-	const numberOfSteps = checklist?.length || 0;
-	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
-	const tasklistCompleted = completedSteps === numberOfSteps;
-	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext };
-	const extraActions = { setShareSiteModalIsOpen };
-
-	const sortedTasksWithActions = ( tasks: Task[] ) => {
-		return setUpActionsForTasks( { tasks, siteSlug, tracksData, extraActions } );
-	};
-
 	return (
 		<>
-			<CustomerHomeLaunchpad
-				checklistSlug={ checklistSlug }
-				taskFilter={ sortedTasksWithActions }
-			></CustomerHomeLaunchpad>
-			{ shareSiteModalIsOpen && (
-				<ShareSiteModal setModalIsOpen={ setShareSiteModalIsOpen } site={ site } />
-			) }
+			<CustomerHomeLaunchpad checklistSlug={ checklistSlug }></CustomerHomeLaunchpad>
 		</>
 	);
 };

--- a/client/my-sites/customer-home/cards/launchpad/intent-newsletter.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-newsletter.tsx
@@ -1,46 +1,9 @@
-import { useLaunchpad } from '@automattic/data-stores';
-import { setUpActionsForTasks } from '@automattic/launchpad';
-import { useState } from 'react';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useSelector } from 'calypso/state';
-import { getSite, getSiteSlug } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import ShareSiteModal from '../../components/share-site-modal';
 import CustomerHomeLaunchpad from '.';
-import type { Task } from '@automattic/launchpad';
-import type { AppState } from 'calypso/types';
 
 const LaunchpadIntentNewsletter = ( { checklistSlug }: { checklistSlug: string } ): JSX.Element => {
-	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
-	const site = useSelector( ( state: AppState ) => siteId && getSite( state, siteId ) );
-	const launchpadContext = 'customer-home';
-
-	const {
-		data: { checklist },
-	} = useLaunchpad( siteSlug, checklistSlug );
-
-	const [ shareSiteModalIsOpen, setShareSiteModalIsOpen ] = useState( false );
-
-	const numberOfSteps = checklist?.length || 0;
-	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
-	const tasklistCompleted = numberOfSteps > 0 && completedSteps === numberOfSteps;
-	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext };
-	const extraActions = { setShareSiteModalIsOpen };
-
-	const sortedTasksWithActions = ( tasks: Task[] ) => {
-		return setUpActionsForTasks( { tasks, siteSlug, tracksData, extraActions } );
-	};
-
 	return (
 		<>
-			<CustomerHomeLaunchpad
-				checklistSlug={ checklistSlug }
-				taskFilter={ sortedTasksWithActions }
-			></CustomerHomeLaunchpad>
-			{ shareSiteModalIsOpen && site && (
-				<ShareSiteModal setModalIsOpen={ setShareSiteModalIsOpen } site={ site } />
-			) }
+			<CustomerHomeLaunchpad checklistSlug={ checklistSlug }></CustomerHomeLaunchpad>
 		</>
 	);
 };

--- a/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
@@ -1,39 +1,9 @@
-import { useLaunchpad } from '@automattic/data-stores';
-import { setUpActionsForTasks } from '@automattic/launchpad';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useSelector } from 'calypso/state';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CustomerHomeLaunchpad from '.';
-import type { Task } from '@automattic/launchpad';
-import type { AppState } from 'calypso/types';
 
 const checklistSlug = 'intent-write';
-const launchpadContext = 'customer-home';
 
 const LaunchpadIntentWrite = (): JSX.Element => {
-	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
-
-	const {
-		data: { checklist },
-	} = useLaunchpad( siteSlug, checklistSlug );
-
-	const numberOfSteps = checklist?.length || 0;
-	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
-	const tasklistCompleted = numberOfSteps > 0 && completedSteps === numberOfSteps;
-	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext };
-
-	const sortedTasksWithActions = ( tasks: Task[] ) => {
-		return setUpActionsForTasks( { tasks, siteSlug, tracksData } );
-	};
-
-	return (
-		<CustomerHomeLaunchpad
-			checklistSlug={ checklistSlug }
-			taskFilter={ sortedTasksWithActions }
-		></CustomerHomeLaunchpad>
-	);
+	return <CustomerHomeLaunchpad checklistSlug={ checklistSlug }></CustomerHomeLaunchpad>;
 };
 
 export default LaunchpadIntentWrite;

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -54,12 +54,14 @@ export interface LaunchpadResponse {
 	checklist_statuses: LaunchpadStatuses[];
 }
 
+export interface PermittedActions {
+	setShareSiteModalIsOpen?: ( isOpen: boolean ) => void;
+}
+
 export interface LaunchpadTaskActionsProps {
 	siteSlug: string | null;
 	tasks: Task[];
 	tracksData: LaunchpadTracksData;
-	extraActions?: {
-		setShareSiteModalIsOpen?: ( isOpen: boolean ) => void;
-	};
+	extraActions?: PermittedActions;
 	uiContext?: 'calypso';
 }


### PR DESCRIPTION
## Proposed Changes

* The logic of the Launchpad components was repeated across all the components, varying only a few parts that were easily integrated together on the CustomerHomeLaunchpad. Now the definition of components will be much simpler, and we also will be able to use the modal easily in all the use cases.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For this PR, we will need to test all the Customer Home launchpads that we have(intent Build, Write, and Newsletter)

#### Intent Build Test
* Create a new site from `/start` with the `build` intent (select "Promote myself and business" during the intent selection step), and Launch the site.
* Check that the Launchpad in Customer Home still works (you can click on tasks and complete them).

#### Intent Write Test
* Create a new site from /start with the write intent (select "Write & publish" during the intent selection step), and Launch the site.
* Check that the Launchpad in Customer Home still works (you can click on tasks and complete them).

#### Newsletter(Free)
* Create a new Newsletter `/setup/newsletter/intro`
* Select "Free newsletter" on the "Choose a way to get started" step
* Go through the flow until you land on the Customer Home
* Check that the Launchpad in Customer Home still works (you can click on tasks and complete them).
* Make sure the "Share your site" task still works.

#### Newsletter(Paid)
* Create a new Newsletter `/setup/newsletter/intro`
* Select "Paid newsletter" on the "Choose a way to get started" step
* Go through the flow until you land on the Customer Home
* Check that the Launchpad in Customer Home still works (you can click on tasks and complete them).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
