### PR TITLE
Theme showcase: Sort themes in "All" tab by date

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -367,6 +367,7 @@ export const ConnectedThemesSelection = connect(
 			filter: compact( [ filter, vertical ] ).concat( hiddenFilters ).join( ',' ),
 			number,
 			...( tabFilter === 'recommended' && { collection: 'recommended' } ),
+			...( tabFilter === 'all' && { sort: 'date' } ),
 		};
 
 		const themes = getThemesForQueryIgnoringPage( state, sourceSiteId, query ) || [];


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/80557
Requires D118967-code

## Proposed Changes

Changes the order of the themes in the "All" tab so they are sorted by release date.

Before | After
--- | ---
<img width="1899" alt="Screenshot 2023-08-15 at 16 41 02" src="https://github.com/Automattic/wp-calypso/assets/1233880/25dc6207-e6db-4bac-b3d5-c118571847cd"> | <img width="1899" alt="Screenshot 2023-08-15 at 16 40 35" src="https://github.com/Automattic/wp-calypso/assets/1233880/1d3944ad-ae46-40c9-810b-05cfdb15c301">


## Testing Instructions

- Apply D118967-code to your sandbox
- Sandbox the API
- Use the Calypso live link below
- Go to Appearance > Themes
- Switch to the "All" tab
- Make sure themes are sorted by date
- Switch to any other tab
- Make sure they are sorted by curation order