### PR TITLE
Customer Home: Fix for Quick Links chevron alignment in Safari

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -7,10 +7,6 @@
 		border-radius: 3px; /* stylelint-disable-line scales/radii */
 	}
 
-	&:not(.is-expanded) {
-		box-shadow: 0 0 0 1px var(--color-border-subtle);
-	}
-
 	.foldable-card__header {
 		padding: 16px;
 		min-height: auto;

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -34,6 +34,10 @@
 		padding-bottom: 0;
 		padding-top: 0;
 	}
+
+	.foldable-card__expand .gridicon {
+		width: auto;
+	}
 }
 
 .quick-links__boxes {

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -35,6 +35,7 @@
 		padding-top: 0;
 	}
 
+	// Fix for alignment issue in Safari.
 	.foldable-card__expand .gridicon {
 		width: auto;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79691

## Proposed Changes

* Add more specific fix for chevron alignment in Safari; adding it at the component level caused other foldable card components to break across Calypso, [reverted here](https://github.com/Automattic/wp-calypso/pull/80623).

| Before  | After |
| ------------- | ------------- |
| <img width="499" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/8a5646e7-8601-4c50-b0b4-a6a431422471"> | <img width="634" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/85759d7f-1449-4ef8-932f-0004e22be86c"> |


Also removes a slight box shadow applied when the Quick Links card is collapsed; it looked pretty rough now that the links take up the full width of the column:

<img width="360" alt="Screenshot 2023-08-15 at 2 12 59 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/fa579389-d3ff-4a7f-8443-0a3843513c75">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR and navigate to `/home` on any site that has Customer Home enabled
* Verify the position of the chevron is correct in Safari 
* Verify the position of the chevron is correct in other browsers
* Verify other chevron instances across Calypso are not broken/changed (good examples under Tools -> Export)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
