### PR TITLE
Launchpad: Simplify newsletter payment plans modal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -249,7 +249,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 				{ showPlansModal && site?.ID && (
 					<RecurringPaymentsPlanAddEditModal
 						closeDialog={ () => setShowPlansModal( false ) }
-						product={ { subscribe_as_site_subscriber: true } }
+						product={ { subscribe_as_site_subscriber: true, price: 5 } }
 						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 						// @ts-ignore - Underlying component is JS class component with props supplied by connect() and mapstatetoprops.
 						siteId={ site.ID }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -484,3 +484,10 @@
 		display: none;
 	}
 }
+
+// Customizations to the payments modal when it shows on Launchpad
+.memberships__dialog-sections-type,
+.memberships__dialog-sections-message,
+.memberships__dialog-advanced-options {
+	display: none;
+}

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.jsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.jsx
@@ -335,7 +335,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						/>
 					</div>
 				</FormFieldset>
-				<FormFieldset>
+				<FormFieldset className="memberships__dialog-sections-type">
 					<ToggleControl
 						onChange={ handleMarkAsDonation }
 						checked={ 'donation' === editedMarkAsDonation }
@@ -347,7 +347,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						label={ translate( 'Paid newsletter subscription' ) }
 					/>
 				</FormFieldset>
-				<FormFieldset>
+				<FormFieldset className="memberships__dialog-sections-message">
 					<FormLabel htmlFor="renewal_schedule">{ translate( 'Welcome message' ) }</FormLabel>
 					<CountedTextArea
 						value={ editedCustomConfirmationMessage }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Hides non-essential elements of the modal by adding some classes and css
* Updates default price of a plan to 5

New modal looks like this: 
<img width="662" alt="plans-modal" src="https://github.com/Automattic/wp-calypso/assets/21228350/ecb258ef-a450-4762-ad4b-26f6c0a09670">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Checkout this branch and start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro. Choose the paid option and proceed to Launchpad. If you already have a paid newsletter site that still has full screen launchpad enabled, you can also go directly to that at http://calypso.localhost:3000/setup/newsletter/launchpad?siteSlug=YOURDOMAIN
2) If needed, connect Stripe. You can avoid fully connecting stripe by adding `define( 'USE_STORE_SANDBOX', true ); `to your sandbox at wp-content/mu-plugins/0-sandbox.php, and sandboxing public-api.wordpress.com and the domain of your test site. If you do this, when you go to Stripe, you'll see a button to click the setup.
3) Click the 'Create paid newsletter' task. Confirm the modal open and looks like the screenshot above. Add a plan, save, and confirm you see a success notification in the upper right of your screen after the modal closes. Go to https://wordpress.com/earn/payments-plans/YOURDOMAIN and confirm your new plan shows on the list.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
