### PR TITLE
Jetpack E2E: update selector used to validate published version of the Subscribe block.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/subscribe.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/subscribe.ts
@@ -1,11 +1,6 @@
 import { BlockFlow, PublishedPostContext } from '.';
 
 const editorBlockParentSelector = '[aria-label="Block: Subscribe"]';
-const publishedBlockParentSelector = '.wp-block-jetpack-subscriptions';
-const selectors = {
-	emailInput: `${ publishedBlockParentSelector } input[name=email]`,
-	subscribeButton: `${ publishedBlockParentSelector } button:has-text("Subscribe")`,
-};
 
 /**
  * Class representing the flow of using a Subscription Form block in the editor.
@@ -21,10 +16,14 @@ export class SubscribeFlow implements BlockFlow {
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
 		// Is there an interactive email field?
-		const emailInputLocator = context.page.locator( selectors.emailInput );
+		const emailInputLocator = context.page
+			.getByRole( 'main' )
+			.getByRole( 'textbox', { name: 'Type your email' } );
 		await emailInputLocator.fill( 'foo@example.com' );
 		// And a subscribe button?
-		const subscribeButtonLocator = context.page.locator( selectors.subscribeButton );
+		const subscribeButtonLocator = context.page
+			.getByRole( 'main' )
+			.getByRole( 'button', { name: 'Subscribe' } );
 		await subscribeButtonLocator.waitFor(); // Don't click - we don't want a real subscription!
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80453.

## Proposed Changes

This PR fixes a failing Subscribe flow test.
- anchor selectors on the `main` published content field.
- update `Subscribe` flow to use a11y based locators.

## Testing Instructions

```
 PASS  specs/blocks/blocks__jetpack-grow.ts (39.954 s)
  Blocks: Jetpack Grow (Atomic: default)
    ✓ Go to the new post page (20316 ms)
    Add and configure blocks in the editor
      ✓ Business Hours: Add the block from the sidebar (3841 ms)
      ✓ Business Hours: Configure the block (859 ms)
      ✓ Business Hours: There are no block warnings or errors in the editor (3 ms)
      ✓ Contact Form: Add the block from the sidebar (1365 ms)
      ✓ Contact Form: Configure the block (71 ms)
      ✓ Contact Form: There are no block warnings or errors in the editor (6 ms)
      ✓ Subscribe: Add the block from the sidebar (1252 ms)
      ✓ Subscribe: Configure the block
      ✓ Subscribe: There are no block warnings or errors in the editor (6 ms)
      ✓ Contact Info: Add the block from the sidebar (1344 ms)
      ✓ Contact Info: Configure the block (93 ms)
      ✓ Contact Info: There are no block warnings or errors in the editor (7 ms)
      ✓ WhatsApp Button: Add the block from the sidebar (1213 ms)
      ✓ WhatsApp Button: Configure the block (144 ms)
      ✓ WhatsApp Button: There are no block warnings or errors in the editor (6 ms)
    Publishing the post
      ✓ Publish and visit post (3399 ms)
    Validating blocks in published post.
      ✓ Business Hours: Expected content is in published post (19 ms)
      ✓ Contact Form: Expected content is in published post (15 ms)
      ✓ Subscribe: Expected content is in published post (41 ms)
      ✓ Contact Info: Expected content is in published post (47 ms)
      ✓ WhatsApp Button: Expected content is in published post (25 ms)

Test Suites: 1 passed, 1 total
Tests:       22 passed, 22 total
Snapshots:   0 total
Time:        40.197 s
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
