### PR TITLE
Domain Transfer: Remove old copy for translation compatibility

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/google-domains-transfer-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/google-domains-transfer-instructions/index.tsx
@@ -1,4 +1,3 @@
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { Button, Modal } from '@wordpress/components';
 import { useState, createElement, createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
@@ -17,13 +16,9 @@ const GoogleDomainsModal: React.FC< Props > = ( { children, className, focusedSt
 	const [ isOpen, setOpen ] = useState( false );
 	const openModal = () => setOpen( true );
 	const closeModal = () => setOpen( false );
-	const step2Text = useHasEnTranslation()(
+	const step2Text = __(
 		'Click on the name of the domain that you\'d like to transfer in the "My domains" section.'
-	)
-		? __(
-				'Click on the name of the domain that you\'d like to transfer in the "My domains" section.'
-		  )
-		: __( 'Select the domain you want to transfer in the "My domains" section.' );
+	);
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FormInputValidation, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
-import { localizeUrl, englishLocales, useLocale } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { GOOGLE_TRANSFER } from '@automattic/onboarding';
 import { Button, Icon } from '@wordpress/components';
 import { check, closeSmall } from '@wordpress/icons';
@@ -65,8 +65,7 @@ const domainInputFieldIcon = ( isValidDomain: boolean, shouldReportError: boolea
 };
 
 const DomainPrice = ( { rawPrice, saleCost, currencyCode = 'USD' }: DomainPriceProps ) => {
-	const { __, hasTranslation } = useI18n();
-	const locale = useLocale();
+	const { __ } = useI18n();
 
 	if ( ! rawPrice ) {
 		return <div className="domains__domain-price-number disabled"></div>;
@@ -80,10 +79,7 @@ const DomainPrice = ( { rawPrice, saleCost, currencyCode = 'USD' }: DomainPriceP
 		);
 	}
 
-	let pricetext = __( 'First year free' );
-	if ( englishLocales.includes( locale ) || hasTranslation( 'We’ll pay for an extra year' ) ) {
-		pricetext = __( 'We’ll pay for an extra year' );
-	}
+	const pricetext = __( 'We’ll pay for an extra year' );
 
 	return (
 		<div className="domains__domain-price-value">

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@automattic/components';
-import { localizeUrl, englishLocales } from '@automattic/i18n-utils';
-import i18n, { getLocaleSlug } from 'i18n-calypso';
+import { localizeUrl } from '@automattic/i18n-utils';
 import moment from 'moment';
 import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import { isExpiringSoon } from 'calypso/lib/domains/utils/is-expiring-soon';
@@ -481,50 +480,26 @@ export function resolveDomainStatus(
 			}
 
 			if ( domain.transferStatus === transferStatus.COMPLETED && ! domain.pointsToWpcom ) {
-				const hasTranslation =
-					englishLocales.includes( String( getLocaleSlug() ) ) ||
-					i18n.hasTranslation(
-						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com name servers.{{/a}}'
-					);
-
-				const oldCopy = translate(
-					'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need {{a}}point it to WordPress.com name servers.{{/a}}',
-					{
-						components: {
-							strong: <strong />,
-							a: (
-								<a
-									href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute, {
-										nameservers: true,
-									} ) }
-								/>
-							),
-						},
-					}
-				);
-
-				const newCopy = translate(
-					'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com name servers.{{/a}}',
-					{
-						components: {
-							strong: <strong />,
-							a: (
-								<a
-									href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute, {
-										nameservers: true,
-									} ) }
-								/>
-							),
-						},
-					}
-				);
-
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-success',
 					status: translate( 'Active' ),
 					icon: 'info',
-					noticeText: hasTranslation ? newCopy : oldCopy,
+					noticeText: translate(
+						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com name servers.{{/a}}',
+						{
+							components: {
+								strong: <strong />,
+								a: (
+									<a
+										href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute, {
+											nameservers: true,
+										} ) }
+									/>
+								),
+							},
+						}
+					),
 					listStatusWeight: 600,
 				};
 			}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/DomainsTransferredList.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/DomainsTransferredList.tsx
@@ -1,11 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import formatCurrency from '@automattic/format-currency';
-import { englishLocales } from '@automattic/i18n-utils';
 import { joinClasses } from '@automattic/wpcom-checkout';
 import { Button } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import i18n, { getLocaleSlug } from 'i18n-calypso';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 import './style.scss';
 
@@ -24,12 +22,8 @@ const DomainsTransferredList = ( { purchases, currency = 'USD' }: Props ) => {
 	};
 
 	const purchaseLabel = ( priceInteger: number ) => {
-		const hasTranslation =
-			englishLocales.includes( String( getLocaleSlug() ) ) ||
-			i18n.hasTranslation( 'We’ve paid for an extra year' );
-
 		if ( priceInteger === 0 ) {
-			return hasTranslation ? __( 'We’ve paid for an extra year' ) : __( 'Free for one year' );
+			return __( 'We’ve paid for an extra year' );
 		}
 
 		const priceFormatted = formatCurrency( priceInteger, currency, {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* We're removing old logic for copy compatibility on the following tasks:

    - https://github.com/Automattic/wp-calypso/pull/79935
    - https://github.com/Automattic/wp-calypso/pull/79993
    - https://github.com/Automattic/wp-calypso/pull/80098
    - https://github.com/Automattic/wp-calypso/pull/80106
   

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check each PR we have changed to see if current changes still match the new copies.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
