### PR TITLE
Launchpad: Centralize task completion

### DIFF
--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -1,4 +1,3 @@
-import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { localize } from 'i18n-calypso';
 import { capitalize, find } from 'lodash';
 import PropTypes from 'prop-types';
@@ -35,14 +34,6 @@ class EarningsMain extends Component {
 		site: PropTypes.object,
 		query: PropTypes.object,
 	};
-
-	constructor( props ) {
-		super( props );
-		// Mark the task as done
-		updateLaunchpadSettings( props.siteSlug, {
-			checklist_statuses: { earn_money: true },
-		} );
-	}
 
 	getSelectedText() {
 		const selected = find( this.getFilters(), { path: this.props.path } );

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -4,7 +4,6 @@ import {
 	FEATURE_RECURRING_PAYMENTS,
 } from '@automattic/calypso-products';
 import { Badge, Button, CompactCard, Gridicon } from '@automattic/components';
-import { updateLaunchpadSettings } from '@automattic/data-stores';
 import formatCurrency from '@automattic/format-currency';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
@@ -41,12 +40,6 @@ class MembershipsProductsSection extends Component {
 		showDeleteDialog: false,
 		product: null,
 	};
-
-	componentDidMount() {
-		updateLaunchpadSettings( this.props.siteSlug, {
-			checklist_statuses: { manage_paid_newsletter_plan: true },
-		} );
-	}
 
 	renderEllipsisMenu( productId ) {
 		return (

--- a/client/my-sites/marketing/connections/connections.jsx
+++ b/client/my-sites/marketing/connections/connections.jsx
@@ -1,4 +1,6 @@
+import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { localize } from 'i18n-calypso';
+import { useEffect } from 'react';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import QueryP2Connections from 'calypso/components/data/query-p2-connections';
@@ -9,8 +11,15 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 import SharingServicesGroup from './services-group';
 
-const SharingConnections = ( { translate, isP2Hub, siteId } ) => {
+const SharingConnections = ( { translate, isP2Hub, siteId, siteSlug } ) => {
 	useRequestSiteChecklistTaskUpdate( siteId, CHECKLIST_KNOWN_TASKS.POST_SHARING_ENABLED );
+
+	useEffect( () => {
+		// Mark the task as done
+		updateLaunchpadSettings( siteSlug, {
+			checklist_statuses: { drive_traffic: true },
+		} );
+	}, [] );
 
 	return (
 		<div className="connections__sharing-settings connections__sharing-connections">

--- a/client/my-sites/marketing/connections/connections.jsx
+++ b/client/my-sites/marketing/connections/connections.jsx
@@ -1,6 +1,4 @@
-import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { localize } from 'i18n-calypso';
-import { useEffect } from 'react';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import QueryP2Connections from 'calypso/components/data/query-p2-connections';
@@ -11,15 +9,8 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 import SharingServicesGroup from './services-group';
 
-const SharingConnections = ( { translate, isP2Hub, siteId, siteSlug } ) => {
+const SharingConnections = ( { translate, isP2Hub, siteId } ) => {
 	useRequestSiteChecklistTaskUpdate( siteId, CHECKLIST_KNOWN_TASKS.POST_SHARING_ENABLED );
-
-	useEffect( () => {
-		// Mark the task as done
-		updateLaunchpadSettings( siteSlug, {
-			checklist_statuses: { drive_traffic: true },
-		} );
-	}, [] );
 
 	return (
 		<div className="connections__sharing-settings connections__sharing-connections">

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,8 +1,6 @@
-import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import page from 'page';
-import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { Item } from 'calypso/components/breadcrumb';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -41,15 +39,6 @@ const SubscribersPage = ( {
 	sortTermChanged,
 }: SubscribersProps ) => {
 	const selectedSite = useSelector( getSelectedSite );
-
-	useEffect( () => {
-		if ( selectedSite ) {
-			// Mark the `manage_subscribers` task as done when we visit this page.
-			updateLaunchpadSettings( selectedSite.slug, {
-				checklist_statuses: { manage_subscribers: true },
-			} );
-		}
-	}, [] );
 
 	const pageArgs = {
 		currentPage: pageNumber,

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -3,7 +3,13 @@ import { isMobile } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
 import type { LaunchpadTaskActionsProps, Task } from './types';
 
-const TASKS_TO_COMPLETE_ON_CLICK = [ 'add_about_page' ];
+const TASKS_TO_COMPLETE_ON_CLICK = [
+	'add_about_page',
+	'manage_paid_newsletter_plan',
+	'earn_money',
+	'manage_subscribers',
+	'drive_traffic',
+];
 
 export const setUpActionsForTasks = ( {
 	siteSlug,

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -8,8 +8,6 @@ const TASKS_TO_COMPLETE_ON_CLICK = [
 	'manage_paid_newsletter_plan',
 	'earn_money',
 	'manage_subscribers',
-	'drive_traffic',
-	'connect_social_media',
 ];
 
 export const setUpActionsForTasks = ( {

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -9,6 +9,7 @@ const TASKS_TO_COMPLETE_ON_CLICK = [
 	'earn_money',
 	'manage_subscribers',
 	'drive_traffic',
+	'connect_social_media',
 ];
 
 export const setUpActionsForTasks = ( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #80586

## Proposed Changes

* Centralizes the completion logic in the `setUpActionsForTasks` function. This will make it easy to add new tasks, which should be marked as complete when the user visits a page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Some of the tasks are not being used yet, due to the shortening of the Newsletter task list we did.
* Sandbox the public API.
* Open the `wp-content/mu-plugins/jetpack-mu-wpcom-plugin/production/vendor/automattic/jetpack-mu-wpcom/src/features/launchpad/launchpad.php` file on your sandbox.
* Add the following task to the `intent-free-newsletter` task list definition:
  * earn_money 
* Create a new Newsletter and select "Import an existing newsletter" under the "Choose a way to get started" step.
* Go through the setup flow until you land on the Customer Home.
* Make sure that by clicking on the tasks listed below, they are marked as complete:
  * Manage your subscribers
  * Earn money with your newsletter
* Now create a Paid newsletter(select "Paid newsletter"  under the "Choose a way to get started" step)
* Once you land on the Customer Home, click on the "Manage your paid Newsletter plan" task
* Then return to the Customer Home and make sure it was marked as complete

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
