### PR TITLE
Remove 'Show all' from the onboarding design picker

### DIFF
--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -59,26 +59,15 @@ export function useCategorizationFromApi(
 	categoryMap: Record< string, Category >,
 	{ defaultSelection }: UseCategorizationOptions
 ): Categorization {
-	const { __ } = useI18n();
-
 	const categories = useMemo( () => {
 		const categoryMapKeys = Object.keys( categoryMap ) || [];
-		const hasCategories = !! categoryMapKeys.length;
-
 		const result = categoryMapKeys.map( ( slug ) => ( {
 			...categoryMap[ slug ],
 			slug,
 		} ) );
 
-		if ( hasCategories ) {
-			result.unshift( {
-				name: __( 'Show All', __i18n_text_domain__ ),
-				slug: SHOW_ALL_SLUG,
-			} );
-		}
-
 		return result;
-	}, [ categoryMap, __ ] );
+	}, [ categoryMap ] );
 
 	const [ selection, onSelect ] = useState< string | null >(
 		chooseDefaultSelection( categories, defaultSelection )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3058

## Proposed Changes

Removing 'Show all' from the `designSetup` `onboarding design picker, with the increased number of themes it feels increasingly chaotic.

Goals which previously led to 'Show all' now go the first category in the list (currently Blog). We can change the appropriate categories for the goals in separate PRs, I think by changing [`getCategorizationOptions`](https://github.com/Automattic/wp-calypso//blob/59d30f8a6498f0ac7170ada0a98eba09b8818126/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts#L26)

Onboarding flows which have alternative design pickers like DIFM are unaffected.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Apply patch / use calypso live link
 2. Go through the /start onboarding process
 3. Try each of the different onboarding goals to ensure everything looks right
 4. Goals which lead to the normal design picker (e.g. Promote myself or business) should open the design picker on an appropriate category (falling back to blog) and without a 'Show all' category being available.




<img width="1458" alt="Screenshot 2023-08-15 at 19 09 32" src="https://github.com/Automattic/wp-calypso/assets/93301/597a3984-0068-478f-a192-246c7a00088b">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
