### PR TITLE
Newsletter Categories: Create NewsletterCategoriesSettings component

### DIFF
--- a/client/blocks/term-tree-selector/search.scss
+++ b/client/blocks/term-tree-selector/search.scss
@@ -15,6 +15,7 @@
 		border-width: 0 0 1px;
 		background: var(--color-surface);
 		font-size: $font-body-small;
-		-webkit-appearance: none;
+		appearance: none;
+		border-radius: 2px 2px 0 0;
 	}
 }

--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -406,7 +406,7 @@ class TermTreeSelectorList extends Component {
 					{ ( { width } ) => (
 						<List
 							ref={ this.setListRef }
-							width={ width }
+							width={ width - 2 } // -2 for border
 							height={ isSmall ? this.getCompactContainerHeight() : height }
 							onRowsRendered={ this.setRequestedPages }
 							rowCount={ rowCount }

--- a/client/my-sites/site-settings/newsletter-categories-settings/index.ts
+++ b/client/my-sites/site-settings/newsletter-categories-settings/index.ts
@@ -1,0 +1,1 @@
+export { default as NewsletterCategoriesSettings } from './newsletter-categories-settings';

--- a/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
+++ b/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
@@ -1,19 +1,16 @@
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
 import TermTreeSelector from 'calypso/blocks/term-tree-selector';
-import { useNewsletterCategoriesQuery } from 'calypso/data/newsletter-categories';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import useNewsletterCategoriesSettings from './use-newsletter-categories-settings';
 import './style.scss';
 
 const NewsletterCategoriesSettings = () => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
-	const { data } = useNewsletterCategoriesQuery( { siteId } );
-	const newsletterCategoryIds = useMemo(
-		() => data?.newsletterCategories?.map( ( { id } ) => id ) ?? [],
-		[ data ]
-	);
+	const { newsletterCategoryIds, handleCategoryToggle, handleSave } =
+		useNewsletterCategoriesSettings( siteId );
 
 	return (
 		<div className="newsletter-categories-settings">
@@ -26,10 +23,18 @@ const NewsletterCategoriesSettings = () => {
 				addTerm={ true }
 				multiple={ true }
 				selected={ newsletterCategoryIds }
-				onChange={ () => undefined }
-				onAddTermSuccess={ () => undefined }
+				onChange={ handleCategoryToggle }
+				onAddTermSuccess={ handleCategoryToggle }
 				height={ 218 }
 			/>
+
+			<Button
+				primary
+				className="newsletter-categories-settings__save-button"
+				onClick={ handleSave }
+			>
+				{ translate( 'Save settings' ) }
+			</Button>
 		</div>
 	);
 };

--- a/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
+++ b/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
@@ -1,0 +1,37 @@
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import TermTreeSelector from 'calypso/blocks/term-tree-selector';
+import { useNewsletterCategoriesQuery } from 'calypso/data/newsletter-categories';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import './style.scss';
+
+const NewsletterCategoriesSettings = () => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const { data } = useNewsletterCategoriesQuery( { siteId } );
+	const newsletterCategoryIds = useMemo(
+		() => data?.newsletterCategories?.map( ( { id } ) => id ) ?? [],
+		[ data ]
+	);
+
+	return (
+		<div className="newsletter-categories-settings">
+			<p className="newsletter-categories-settings__description">
+				{ translate( 'Allow your visitors to specifically subscribe to the selected categories.' ) }
+			</p>
+
+			<TermTreeSelector
+				taxonomy="category"
+				addTerm={ true }
+				multiple={ true }
+				selected={ newsletterCategoryIds }
+				onChange={ () => undefined }
+				onAddTermSuccess={ () => undefined }
+				height={ 218 }
+			/>
+		</div>
+	);
+};
+
+export default NewsletterCategoriesSettings;

--- a/client/my-sites/site-settings/newsletter-categories-settings/style.scss
+++ b/client/my-sites/site-settings/newsletter-categories-settings/style.scss
@@ -2,11 +2,20 @@
 @import "@automattic/typography/styles/variables";
 
 .newsletter-categories-settings {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+
 	.newsletter-categories-settings__description {
 		color: $studio-gray-70;
 		font-family: "SF Pro Text", $sans;
 		font-size: $font-body-small;
 		font-weight: 400;
 		line-height: 20px;
+		margin-bottom: 0;
+	}
+
+	.newsletter-categories-settings__save-button {
+		align-self: flex-start;
 	}
 }

--- a/client/my-sites/site-settings/newsletter-categories-settings/style.scss
+++ b/client/my-sites/site-settings/newsletter-categories-settings/style.scss
@@ -1,0 +1,12 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
+
+.newsletter-categories-settings {
+	.newsletter-categories-settings__description {
+		color: $studio-gray-70;
+		font-family: "SF Pro Text", $sans;
+		font-size: $font-body-small;
+		font-weight: 400;
+		line-height: 20px;
+	}
+}

--- a/client/my-sites/site-settings/newsletter-categories-settings/use-newsletter-categories-settings.ts
+++ b/client/my-sites/site-settings/newsletter-categories-settings/use-newsletter-categories-settings.ts
@@ -1,0 +1,100 @@
+import { useTranslate } from 'i18n-calypso';
+import { useMemo, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import {
+	useMarkAsNewsletterCategoryMutation,
+	useNewsletterCategoriesQuery,
+	useUnmarkAsNewsletterCategoryMutation,
+} from 'calypso/data/newsletter-categories';
+import { NewsletterCategory } from 'calypso/data/newsletter-categories/types';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+
+type Category = {
+	ID: number;
+	description: string;
+	feed_url: string;
+	name: string;
+	parent: number;
+	post_count: number;
+	slug: string;
+};
+
+const convertToNewsletterCategory = ( category: Category ): NewsletterCategory => ( {
+	id: category.ID,
+	name: category.name,
+	slug: category.slug,
+	description: category.description,
+	parent: category.parent,
+} );
+
+const useNewsletterCategoriesSettings = ( siteId: number ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const { data: initialData } = useNewsletterCategoriesQuery( { siteId } );
+	const [ newsletterCategories, setNewsletterCategories ] = useState(
+		initialData?.newsletterCategories ?? []
+	);
+	const newsletterCategoryIds = useMemo(
+		() => newsletterCategories.map( ( { id } ) => id ),
+		[ newsletterCategories ]
+	);
+	const { mutateAsync: markNewsletterCategory } = useMarkAsNewsletterCategoryMutation( siteId );
+	const { mutateAsync: unmarkNewsletterCategory } = useUnmarkAsNewsletterCategoryMutation( siteId );
+
+	const handleCategoryToggle = ( category: Category ) => {
+		const index = newsletterCategories.findIndex( ( { id } ) => id === category.ID );
+		const newNewsletterCategories = [ ...newsletterCategories ];
+
+		if ( index === -1 ) {
+			newNewsletterCategories.push( convertToNewsletterCategory( category ) );
+		} else {
+			newNewsletterCategories.splice( index, 1 );
+		}
+
+		setNewsletterCategories( newNewsletterCategories );
+	};
+
+	const handleSave = () => {
+		const categoriesToMark =
+			newsletterCategories.filter(
+				( category ) =>
+					! initialData?.newsletterCategories?.some( ( { id } ) => id === category.id )
+			) ?? [];
+
+		const categoriesToUnmark =
+			initialData?.newsletterCategories?.filter(
+				( category ) => ! newsletterCategories.some( ( { id } ) => id === category.id )
+			) ?? [];
+
+		const promises = [] as Promise< unknown >[];
+
+		categoriesToMark.forEach( ( category ) => {
+			promises.push( markNewsletterCategory( category.id ) );
+		} );
+
+		categoriesToUnmark.forEach( ( category ) => {
+			promises.push( unmarkNewsletterCategory( category.id ) );
+		} );
+
+		Promise.all( promises )
+			.then( () => {
+				dispatch( successNotice( translate( 'Your newsletter categories have been saved.' ) ) );
+			} )
+			.catch( () => {
+				dispatch(
+					errorNotice(
+						translate( 'There was an error when trying to save your newsletter categories.' )
+					)
+				);
+			} );
+	};
+
+	return {
+		newsletterCategories,
+		newsletterCategoryIds,
+		handleCategoryToggle,
+		handleSave,
+	};
+};
+
+export default useNewsletterCategoriesSettings;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/80578
Closes https://github.com/Automattic/wp-calypso/issues/80582
Closes https://github.com/Automattic/wp-calypso/issues/80583

## Proposed Changes

* Creates `NewsletterCategoriesSettings` component (isolated component, not applied to a page)
* Creates a `useNewsletterCategoriesSettings` hook to encapsulate the component logic and make it easier to test
* Display current newsletter categories querying data from `useNewsletterCategoriesQuery` 
* Display success and error notices after saving changes
* Fix minor styling issues on `TermTreeSelector`

**Not included (will be on follow-up PRs)**
* Integration with the Newsletter Settings page
* Unit/integration tests
  * `TermTreeSelector` uses some components that are incompatible with jest, and it seems a lot of work to fix the errors
  * I moved the component logic to a hook `useNewsletterCategoriesSettings` to make at least this part testable (tests will be added on a follow-up PR)

## Testing Instructions

* Apply this PR to your local
* Apply `NewsletterCategoriesSettings` to the Reading Settings page (just to make it visible)
```
import { NewsletterCategoriesSettings } from '../newsletter-categories-settings';
...
export const SiteSettingsSection = () => {
return (
		<>
			<SettingsSectionHeader ... />
			<Card className="site-settings__card">
				...
				<NewsletterCategoriesSettings />
			</Card>
			...
		</>
};
```
* Go to http://calypso.localhost:3000/settings/reading/{site-slug}
* You should see the list of categories, and the newsletter categories should be checked
  * If you have less than 8 categories, it should render with a borderless style (and without search)
* Perform multiple tests by selecting and unselecting categories, adding new categories, and saving changes

<img width="732" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/9874a4dd-46c8-4ea3-85f1-31ee7926093f">
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
