### PR TITLE
GF Signup : Experiment Allow Paid Domain redirect For all Domains

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -70,6 +70,7 @@ const SignupFlowPlanFeatureActionButton = ( {
 	isStuck,
 	isLargeCurrency,
 	handleUpgradeButtonClick,
+	busy,
 }: {
 	freePlan: boolean;
 	planTitle: TranslateResult;
@@ -78,6 +79,7 @@ const SignupFlowPlanFeatureActionButton = ( {
 	isStuck: boolean;
 	isLargeCurrency: boolean;
 	handleUpgradeButtonClick: () => void;
+	busy?: boolean;
 } ) => {
 	const translate = useTranslate();
 	let btnText;
@@ -102,7 +104,7 @@ const SignupFlowPlanFeatureActionButton = ( {
 	}
 
 	return (
-		<Button className={ classes } onClick={ handleUpgradeButtonClick }>
+		<Button className={ classes } onClick={ handleUpgradeButtonClick } busy={ busy }>
 			{ btnText }
 		</Button>
 	);
@@ -456,6 +458,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 				isStuck={ isStuck }
 				isLargeCurrency={ !! isLargeCurrency }
 				handleUpgradeButtonClick={ handleUpgradeButtonClick }
+				busy={ freePlan && planActionOverrides?.loggedInFreePlan?.status === 'blocked' }
 			/>
 		);
 	}

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -8,8 +8,9 @@ export type TransformedFeatureObject = FeatureObject & {
 
 export interface PlanActionOverrides {
 	loggedInFreePlan?: {
-		callback: () => void;
-		text: TranslateResult;
+		callback?: () => void;
+		text?: TranslateResult;
+		status?: 'blocked' | 'enabled';
 	};
 }
 

--- a/client/my-sites/plans-features-main/components/loading-placeholder.tsx
+++ b/client/my-sites/plans-features-main/components/loading-placeholder.tsx
@@ -3,12 +3,18 @@ import styled from '@emotion/styled';
 /**
  * Simple placeholder that renders as a pulsing line.
  */
-export const LoadingPlaceHolder = styled.div`
+export const LoadingPlaceHolder = styled.div< {
+	display: 'block' | 'inline-block';
+	width: string;
+	height: string;
+	borderRadius: string;
+} >`
 	margin: 0;
 	background: var( --color-neutral-10 );
-	border-radius: 20px;
+	border-radius: ${ ( { borderRadius } ) => borderRadius ?? '20px' };
 	content: '';
-	display: block;
-	height: 8px;
+	display: ${ ( { display } ) => display ?? 'block' };
+	width: ${ ( { width } ) => width ?? '100%' };
+	height: ${ ( { height } ) => height ?? '8px' };
 	animation: pulse-light 0.8s ease-in-out infinite;
 `;

--- a/client/my-sites/plans-features-main/components/loading-placeholder.tsx
+++ b/client/my-sites/plans-features-main/components/loading-placeholder.tsx
@@ -4,10 +4,10 @@ import styled from '@emotion/styled';
  * Simple placeholder that renders as a pulsing line.
  */
 export const LoadingPlaceHolder = styled.div< {
-	display: 'block' | 'inline-block';
-	width: string;
-	height: string;
-	borderRadius: string;
+	display?: 'block' | 'inline-block';
+	width?: string;
+	height?: string;
+	borderRadius?: string;
 } >`
 	margin: 0;
 	background: var( --color-neutral-10 );

--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -5,16 +5,17 @@ const useIsCustomDomainAllowedOnFreePlan = (
 	flowName?: string | null,
 	hasPaidDomainName?: boolean
 ): DataResponse< boolean > => {
-	const [ isLoadingAnyDomainExperiment, assignmentAnyDomainExperiment ] = useExperiment(
-		'calypso_onboardingpm_plans_paid_domain_on_free_plan',
-		{
-			isEligible: [ 'onboarding', 'onboarding-pm' ].includes( flowName ?? '' ) && hasPaidDomainName,
-		}
-	);
+	const EXPERIMENT_NAME =
+		flowName === 'onboarding'
+			? 'calypso_onboarding_plans_paid_domain_on_free_plan'
+			: 'calypso_onboardingpm_plans_paid_domain_on_free_plan';
+	const [ isLoading, assignment ] = useExperiment( EXPERIMENT_NAME, {
+		isEligible: [ 'onboarding', 'onboarding-pm' ].includes( flowName ?? '' ) && hasPaidDomainName,
+	} );
 
 	return {
-		isLoading: isLoadingAnyDomainExperiment,
-		result: assignmentAnyDomainExperiment?.variationName === 'treatment',
+		isLoading,
+		result: assignment?.variationName === 'treatment',
 	};
 };
 

--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -1,31 +1,20 @@
-import { getTld } from 'calypso/lib/domains';
 import { useExperiment } from 'calypso/lib/explat';
 import type { DataResponse } from 'calypso/my-sites/plan-features-2023-grid/types';
 
 const useIsCustomDomainAllowedOnFreePlan = (
 	flowName?: string | null,
-	domainName?: string
+	hasPaidDomainName?: boolean
 ): DataResponse< boolean > => {
-	const [ isLoadingBlogAllowExperiment, assignmentDotBlogAllowExperiment ] = useExperiment(
-		'calypso_onboarding_plans_dotblog_on_free_plan_202307',
-		{
-			isEligible:
-				flowName === 'onboarding' && domainName != null && getTld( domainName ) === 'blog',
-		}
-	);
-
 	const [ isLoadingAnyDomainExperiment, assignmentAnyDomainExperiment ] = useExperiment(
 		'calypso_onboardingpm_plans_paid_domain_on_free_plan',
 		{
-			isEligible: flowName === 'onboarding-pm' && domainName != null,
+			isEligible: [ 'onboarding', 'onboarding-pm' ].includes( flowName ?? '' ) && hasPaidDomainName,
 		}
 	);
 
 	return {
-		isLoading: isLoadingAnyDomainExperiment || isLoadingBlogAllowExperiment,
-		result:
-			assignmentDotBlogAllowExperiment?.variationName === 'treatment' ||
-			assignmentAnyDomainExperiment?.variationName === 'treatment',
+		isLoading: isLoadingAnyDomainExperiment,
+		result: assignmentAnyDomainExperiment?.variationName === 'treatment',
 	};
 };
 

--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -6,7 +6,7 @@ const useIsCustomDomainAllowedOnFreePlan = (
 	flowName?: string | null,
 	domainName?: string
 ): DataResponse< boolean > => {
-	const [ isLoadingAssignment, experimentAssignment ] = useExperiment(
+	const [ isLoadingBlogAllowExperiment, assignmentDotBlogAllowExperiment ] = useExperiment(
 		'calypso_onboarding_plans_dotblog_on_free_plan_202307',
 		{
 			isEligible:
@@ -14,9 +14,15 @@ const useIsCustomDomainAllowedOnFreePlan = (
 		}
 	);
 
+	const [ isLoadingAnyDomainExperiment, assignmentAnyDomainExperiment ] = useExperiment( '<TBD>', {
+		isEligible: flowName === 'onboarding-pm' && domainName != null,
+	} );
+
 	return {
-		isLoading: isLoadingAssignment,
-		result: experimentAssignment?.variationName === 'treatment',
+		isLoading: isLoadingAnyDomainExperiment || isLoadingBlogAllowExperiment,
+		result:
+			assignmentDotBlogAllowExperiment?.variationName === 'treatment' ||
+			assignmentAnyDomainExperiment?.variationName === 'treatment',
 	};
 };
 

--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -14,9 +14,12 @@ const useIsCustomDomainAllowedOnFreePlan = (
 		}
 	);
 
-	const [ isLoadingAnyDomainExperiment, assignmentAnyDomainExperiment ] = useExperiment( '<TBD>', {
-		isEligible: flowName === 'onboarding-pm' && domainName != null,
-	} );
+	const [ isLoadingAnyDomainExperiment, assignmentAnyDomainExperiment ] = useExperiment(
+		'calypso_onboardingpm_plans_paid_domain_on_free_plan',
+		{
+			isEligible: flowName === 'onboarding-pm' && domainName != null,
+		}
+	);
 
 	return {
 		isLoading: isLoadingAnyDomainExperiment || isLoadingBlogAllowExperiment,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -280,16 +280,6 @@ const PlansFeaturesMain = ( {
 			recordTracksEvent( 'calypso_signup_free_plan_click' );
 
 			/**
-			 * Delay showing modal until the experiments have loaded
-			 */
-			if (
-				isCustomDomainAllowedOnFreePlan.isLoading ||
-				isPlanUpsellEnabledOnFreeDomain.isLoading
-			) {
-				return;
-			}
-
-			/**
 			 * After the experiments are loaded now open the relevant modal based on previous step parameters
 			 */
 			if ( paidDomainName ) {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -44,6 +44,7 @@ import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSitePlanSlug, getSiteSlug } from 'calypso/state/sites/selectors';
 import { FreePlanFreeDomainDialog } from './components/free-plan-free-domain-dialog';
 import { FreePlanPaidDomainDialog } from './components/free-plan-paid-domain-dialog';
+import { LoadingPlaceHolder } from './components/loading-placeholder';
 import usePricedAPIPlans from './hooks/data-store/use-priced-api-plans';
 import usePricingMetaForGridPlans from './hooks/data-store/use-pricing-meta-for-grid-plans';
 import useFilterPlansForPlanFeatures from './hooks/use-filter-plans-for-plan-features';
@@ -606,18 +607,34 @@ const PlansFeaturesMain = ( {
 						} ) }
 				/>
 			) }
-			{ intent === 'plans-paid-media' && (
-				<FreePlanSubHeader>
-					{ translate(
-						`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
-						{
+			{ intent === 'plans-paid-media' &&
+				( isCustomDomainAllowedOnFreePlan.isLoading ? (
+					<FreePlanSubHeader>
+						{ translate( `Unlock a powerful bundle of features. Or {{loader}}{{/loader}}`, {
 							components: {
-								link: <Button onClick={ () => handleUpgradeClick() } borderless />,
+								loader: (
+									<LoadingPlaceHolder
+										display="inline-block"
+										width="155px"
+										height="15px"
+										borderRadius="2px"
+									/>
+								),
 							},
-						}
-					) }
-				</FreePlanSubHeader>
-			) }
+						} ) }
+					</FreePlanSubHeader>
+				) : (
+					<FreePlanSubHeader>
+						{ translate(
+							`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
+							{
+								components: {
+									link: <Button onClick={ () => handleUpgradeClick() } borderless />,
+								},
+							}
+						) }
+					</FreePlanSubHeader>
+				) ) }
 			{ isDisplayingPlansNeededForFeature() && <SecondaryFormattedHeader siteSlug={ siteSlug } /> }
 			{ ! intentFromSiteMeta.processing && (
 				<>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -211,7 +211,7 @@ const PlansFeaturesMain = ( {
 	isSpotlightOnCurrentPlan,
 }: PlansFeaturesMainProps ) => {
 	const [ isFreePlanPaidDomainDialogOpen, setIsFreePlanPaidDomainDialogOpen ] = useState( false );
-	const [ isFreeFreeUpsellOpen, setIsFreeFreeUpsellOpen ] = useState( false );
+	const [ isFreePlanFreeDomainDialogOpen, setIsFreePlanFreeDomainDialogOpen ] = useState( false );
 	const [ showPlansComparisonGrid, setShowPlansComparisonGrid ] = useState( false );
 	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
 	const translate = useTranslate();
@@ -296,7 +296,7 @@ const PlansFeaturesMain = ( {
 				return;
 			}
 			if ( isPlanUpsellEnabledOnFreeDomain.result ) {
-				setIsFreeFreeUpsellOpen( true );
+				setIsFreePlanFreeDomainDialogOpen( true );
 				return;
 			}
 		}
@@ -570,11 +570,11 @@ const PlansFeaturesMain = ( {
 					} }
 				/>
 			) }
-			{ isFreeFreeUpsellOpen && (
+			{ isFreePlanFreeDomainDialogOpen && (
 				<FreePlanFreeDomainDialog
 					suggestedPlanSlug={ PLAN_PERSONAL }
 					freeSubdomain={ resolvedSubdomainName }
-					onClose={ () => setIsFreeFreeUpsellOpen( false ) }
+					onClose={ () => setIsFreePlanFreeDomainDialogOpen( false ) }
 					onFreePlanSelected={ () => {
 						if ( ! signupFlowSubdomain && wpcomFreeDomainSuggestion.result ) {
 							setSiteUrlAsFreeDomainSuggestion?.( wpcomFreeDomainSuggestion.result );

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -439,22 +439,27 @@ const PlansFeaturesMain = ( {
 		plans: gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ),
 	};
 
-	const planActionOverrides: PlanActionOverrides | undefined =
-		sitePlanSlug && isFreePlan( sitePlanSlug )
-			? {
-					loggedInFreePlan: domainFromHomeUpsellFlow
-						? {
-								callback: showDomainUpsellDialog,
-								text: translate( 'Keep my plan', { context: 'verb' } ),
-						  }
-						: {
-								callback: () => {
-									page.redirect( `/add-ons/${ siteSlug }` );
-								},
-								text: translate( 'Manage add-ons', { context: 'verb' } ),
-						  },
-			  }
-			: undefined;
+	const planActionOverrides: PlanActionOverrides | undefined = {
+		loggedInFreePlan: {
+			status: isPlanUpsellEnabledOnFreeDomain.isLoading ? 'blocked' : 'enabled',
+		},
+	};
+	if ( sitePlanSlug && isFreePlan( sitePlanSlug ) ) {
+		planActionOverrides.loggedInFreePlan = {
+			...planActionOverrides.loggedInFreePlan,
+			callback: () => {
+				page.redirect( `/add-ons/${ siteSlug }` );
+			},
+			text: translate( 'Manage add-ons', { context: 'verb' } ),
+		};
+		if ( domainFromHomeUpsellFlow ) {
+			planActionOverrides.loggedInFreePlan = {
+				...planActionOverrides.loggedInFreePlan,
+				callback: showDomainUpsellDialog,
+				text: translate( 'Keep my plan', { context: 'verb' } ),
+			};
+		}
+	}
 
 	/**
 	 * The spotlight in smaller grids looks broken.
@@ -598,7 +603,7 @@ const PlansFeaturesMain = ( {
 				/>
 			) }
 			{ intent === 'plans-paid-media' &&
-				( isCustomDomainAllowedOnFreePlan.isLoading ? (
+				( isPlanUpsellEnabledOnFreeDomain.isLoading ? (
 					<FreePlanSubHeader>
 						{ translate( `Unlock a powerful bundle of features. Or {{loader}}{{/loader}}`, {
 							components: {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -230,7 +230,7 @@ const PlansFeaturesMain = ( {
 	const previousRoute = useSelector( ( state: IAppState ) => getPreviousRoute( state ) );
 	const isCustomDomainAllowedOnFreePlan = useIsCustomDomainAllowedOnFreePlan(
 		flowName,
-		paidDomainName
+		!! paidDomainName
 	);
 	const isPlanUpsellEnabledOnFreeDomain = useIsPlanUpsellEnabledOnFreeDomain(
 		flowName,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -293,11 +293,13 @@ class DomainsStep extends Component {
 					loadExperimentAssignment(
 						'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3'
 					);
+					loadExperimentAssignment( 'calypso_onboarding_plans_paid_domain_on_free_plan' );
 					break;
 				case 'onboarding-pm':
 					loadExperimentAssignment(
 						'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3'
 					);
+					loadExperimentAssignment( 'calypso_onboardingpm_plans_paid_domain_on_free_plan' );
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
- Fixes Automattic/growth-foundations#159

Related to 
- Experiment : 21362-explat-experiment, 21363-explat-experiment

## Proposed Changes
* An evolution on the experiment: https://github.com/Automattic/wp-calypso/pull/78825. This adds a plan upsell modal when `any custom paid domain` is selected.
* The .blog based experiment was removed and replaced with the above so control will not allow a plans purchase.
* Loads the above experiments on the domain step
* Fixes a previous bug related to the free/free experiment by adding a loader in place of the free plan button on onboarding and the free plan link on the onboarding-pm flows.

## Typical Testing Path
- Go through the main `/start` or `/start/onboarding-pm` flow, and pick ~a .blog domain~ ANY PAID DOMAIN in the domain step.
- In the plans page, it should say "<url> is a redirect"
- Clicking the Free plan button, the modal should show the new copy of explaining why a paid plan is required for a custom primary domain.
- Make sure both the CTAs work as expected.
- Pick a free domain, and it the above copy modal should not be shown (Either the free/free modal or site creation step should be shown depending on the variant that you are assigned to in that experiment).
- Make sure relevant loaders are working related to the Link loader int the subtitle and button loader in the grid
## Comprehensive experiment testing plan including regression tests

### Experiment `calypso_onboardingpm_plans_paid_domain_on_free_plan`

#### Preconditions
- Experiment should be active: 21362-explat-experiment
- Should be in `onboarding-pm` flow
- Select any paid domain on the domain step

**Event** : Click on `Start with a free plan` link on the page subtitle

| Control | Variant | 
| ---- | ---- |
| <img width="1336" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/36320148-a95d-4626-b3fb-cbc2134c7eaa"> | <img width="1320" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/77999ae2-6935-42f2-89aa-2e8b5e55f0c0">  | 

### Experiment `calypso_onboarding_plans_paid_domain_on_free_plan`

#### Preconditions

- Experiment should be active: 21363-explat-experiment
- Should be in `onboarding` flow
- Select any paid domain on the domain step

**Event** : Click on the free plan button

| Control | Variant | 
| ---- | ---- |
| <img width="1282" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/3a2dde17-b860-4a6e-a919-f7bf19356f42"> | <img width="1301" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/73ef09fd-06f1-4004-bc78-bf383d56c288">  | 

### Experiment `calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3`

#### Preconditions
- Experiment should be active: 21344-explat-experiment 
- Should be in `onboarding-pm` flow
- Select the free subdomain on the domain step

**Event** : Click on `Start with a free plan` link on the page subtitle


| Control | Variant | 
| ---- | ---- |
| `Proceed to next step` | <img width="1319" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/67231b37-ce16-4ecb-a5d6-dae2bc1e48fb">  | 

### Experiment `calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3`

#### Preconditions
- Experiment should be active: 21343-explat-experiment 
- Should be in `onboarding` flow
- Select the free subdomain on the domain step

**Event** : Click on the free plan button

| Control | Variant | 
| ---- | ---- |
| `Proceed to next step` | <img width="1305" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/c1b933cc-6501-4e16-aeb5-0016e405c361">  | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
