### PR TITLE
Subscriber Stats: Re-arrange 'All time stats' cards

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -68,7 +68,7 @@ export default function useSubscribersTotalsQueries( siteId: number | null ) {
 				queries[ 1 ]?.data?.email_subscribers !== undefined &&
 				queries[ 1 ]?.data?.paid_subscribers !== undefined
 					? queries[ 1 ].data.email_subscribers - queries[ 1 ].data.paid_subscribers
-					: 0,
+					: null,
 			social_followers: queries[ 1 ]?.data?.social_followers,
 		},
 		isLoading: queries.some( ( result ) => result.isLoading ),

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -34,9 +34,9 @@ const selectPaidSubscribers = ( payload: {
 	};
 } ) => {
 	return {
-		email_subscribers: payload?.counts?.email_subscribers || 0,
-		paid_subscribers: payload?.counts?.paid_subscribers || 0,
-		social_followers: payload?.counts?.social_followers || 0,
+		email_subscribers: payload?.counts?.email_subscribers,
+		paid_subscribers: payload?.counts?.paid_subscribers,
+		social_followers: payload?.counts?.social_followers,
 	};
 };
 

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -27,12 +27,16 @@ const selectSubscribers = ( payload: {
 
 // email_subscribers includes both email and wpcom subscribers so it can't be used for calculations
 const selectPaidSubscribers = ( payload: {
-	counts: { email_subscribers: number; paid_subscribers: number; social_followers: number };
+	counts: {
+		email_subscribers: number;
+		paid_subscribers: number;
+		social_followers: number;
+	};
 } ) => {
-	const paidSubscribers = payload?.counts?.paid_subscribers || 0;
-
 	return {
-		total_email_paid: paidSubscribers,
+		email_subscribers: payload?.counts?.email_subscribers || 0,
+		paid_subscribers: payload?.counts?.paid_subscribers || 0,
+		social_followers: payload?.counts?.social_followers || 0,
 	};
 };
 
@@ -58,12 +62,14 @@ export default function useSubscribersTotalsQueries( siteId: number | null ) {
 		data: {
 			total_email: queries[ 0 ]?.data?.total_email,
 			total_wpcom: queries[ 0 ]?.data?.total_wpcom,
-			total_email_free:
-				queries[ 0 ]?.data?.total_email !== undefined &&
-				queries[ 1 ]?.data?.total_email_paid !== undefined
-					? queries[ 0 ]?.data?.total_email - queries[ 1 ]?.data?.total_email_paid
-					: queries[ 0 ]?.data?.total_email,
-			total_email_paid: queries[ 1 ]?.data?.total_email_paid,
+			total: queries[ 1 ]?.data?.email_subscribers,
+			paid_subscribers: queries[ 1 ]?.data?.paid_subscribers,
+			free_subscribers:
+				queries[ 1 ]?.data?.email_subscribers !== undefined &&
+				queries[ 1 ]?.data?.paid_subscribers !== undefined
+					? queries[ 1 ].data.email_subscribers - queries[ 1 ].data.paid_subscribers
+					: 0,
+			social_followers: queries[ 1 ]?.data?.social_followers,
 		},
 		isLoading: queries.some( ( result ) => result.isLoading ),
 		isError: queries.some( ( result ) => result.isError ),

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -7,24 +7,37 @@ function useSubscriberHighlights( siteId: number | null ) {
 	const translate = useTranslate();
 
 	const { data: subscribersTotals, isLoading, isError } = useSubscribersTotalsQueries( siteId );
+	// TODO: follow up on this once we have a way to determine if a site has paid newsletter set up.
+	// issue: https://github.com/Automattic/wp-calypso/issues/80609
+	const hasPaidNewsletter = true;
+
 	const highlights = [
 		{
-			heading: translate( 'Total email subscribers' ),
-			count: subscribersTotals?.total_email,
+			heading: translate( 'Total subscribers' ),
+			count: subscribersTotals?.total,
+			show: true, // Always show total subscribers.
 		},
 		{
-			heading: translate( 'Free email subscribers' ),
-			count: subscribersTotals?.total_email_free,
+			heading: translate( 'Free subscribers' ),
+			count: subscribersTotals?.free_subscribers,
+			show: hasPaidNewsletter,
 		},
 		{
-			heading: translate( 'Paid email subscribers' ),
-			count: subscribersTotals?.total_email_paid,
+			heading: translate( 'Paid subscribers' ),
+			count: subscribersTotals?.paid_subscribers,
+			show: hasPaidNewsletter,
 		},
 		{
 			heading: translate( 'WordPress.com subscribers' ),
 			count: subscribersTotals?.total_wpcom,
+			show: ! hasPaidNewsletter,
 		},
-	] as { heading: string; count: number | null }[];
+		{
+			heading: translate( 'Email subscribers' ),
+			count: subscribersTotals?.total_email,
+			show: ! hasPaidNewsletter,
+		},
+	] as { heading: string; count: number | null; show: boolean }[];
 
 	if ( isLoading || isError ) {
 		// Nulling the count values makes the count comparison card render a '-' instead of a '0'.
@@ -54,14 +67,17 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 
 	return (
 		<div className="highlight-cards-list">
-			{ highlights.map( ( highlight ) => (
-				<CountComparisonCard
-					key={ highlight.heading }
-					heading={ highlight.heading }
-					count={ highlight.count }
-					showValueTooltip
-				/>
-			) ) }
+			{ highlights.map(
+				( highlight ) =>
+					highlight.show && (
+						<CountComparisonCard
+							key={ highlight.heading }
+							heading={ highlight.heading }
+							count={ highlight.count }
+							showValueTooltip
+						/>
+					)
+			) }
 		</div>
 	);
 }

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -16,16 +16,19 @@ function useSubscriberHighlights( siteId: number | null ) {
 			heading: translate( 'Total subscribers' ),
 			count: subscribersTotals?.total,
 			show: true, // Always show total subscribers.
+			note: 'WordPress.com and Email subscribers excluding subscribers from social media',
 		},
 		{
 			heading: translate( 'Paid subscribers' ),
 			count: subscribersTotals?.paid_subscribers,
 			show: hasPaidNewsletter,
+			note: 'Paid WordPress.com subscribers',
 		},
 		{
 			heading: translate( 'Free subscribers' ),
 			count: subscribersTotals?.free_subscribers,
 			show: hasPaidNewsletter,
+			note: 'Email subscribers and free WordPress.com subscribers',
 		},
 		{
 			heading: translate( 'WordPress.com subscribers' ),
@@ -37,7 +40,7 @@ function useSubscriberHighlights( siteId: number | null ) {
 			count: subscribersTotals?.total_email,
 			show: ! hasPaidNewsletter,
 		},
-	] as { heading: string; count: number | null; show: boolean }[];
+	] as { heading: string; count: number | null; show: boolean; note?: string }[];
 
 	if ( isLoading || isError ) {
 		// Nulling the count values makes the count comparison card render a '-' instead of a '0'.
@@ -75,6 +78,7 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 							heading={ highlight.heading }
 							count={ highlight.count }
 							showValueTooltip
+							note={ highlight.note }
 						/>
 					)
 			) }

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -18,13 +18,13 @@ function useSubscriberHighlights( siteId: number | null ) {
 			show: true, // Always show total subscribers.
 		},
 		{
-			heading: translate( 'Free subscribers' ),
-			count: subscribersTotals?.free_subscribers,
+			heading: translate( 'Paid subscribers' ),
+			count: subscribersTotals?.paid_subscribers,
 			show: hasPaidNewsletter,
 		},
 		{
-			heading: translate( 'Paid subscribers' ),
-			count: subscribersTotals?.paid_subscribers,
+			heading: translate( 'Free subscribers' ),
+			count: subscribersTotals?.free_subscribers,
 			show: hasPaidNewsletter,
 		},
 		{

--- a/packages/components/src/highlight-cards/count-comparison-card.tsx
+++ b/packages/components/src/highlight-cards/count-comparison-card.tsx
@@ -11,6 +11,7 @@ type CountComparisonCardProps = {
 	onClick?: ( event: MouseEvent ) => void;
 	previousCount?: number | null;
 	showValueTooltip?: boolean | null;
+	note: string | undefined;
 };
 
 function subtract( a: number | null, b: number | null | undefined ): number | null {
@@ -36,6 +37,7 @@ export default function CountComparisonCard( {
 	icon,
 	heading,
 	showValueTooltip,
+	note = '',
 }: CountComparisonCardProps ) {
 	const difference = subtract( count, previousCount );
 	const differenceMagnitude = Math.abs( difference as number );
@@ -100,6 +102,7 @@ export default function CountComparisonCard( {
 							</span>
 							<span>{ formattedNumber( count ) }</span>
 						</div>
+						{ note && <div className="highlight-card-tooltip-note">{ note }</div> }
 					</Popover>
 				) }
 			</div>

--- a/packages/components/src/highlight-cards/count-comparison-card.tsx
+++ b/packages/components/src/highlight-cards/count-comparison-card.tsx
@@ -11,7 +11,7 @@ type CountComparisonCardProps = {
 	onClick?: ( event: MouseEvent ) => void;
 	previousCount?: number | null;
 	showValueTooltip?: boolean | null;
-	note: string | undefined;
+	note?: string;
 };
 
 function subtract( a: number | null, b: number | null | undefined ): number | null {

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -385,6 +385,10 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 	}
 }
 
+.highlight-card-tooltip-note {
+	font-size: $font-body-extra-small;
+	padding-top: 8px;
+}
 .highlight-card__settings-tooltip {
 	.highlight-card-tooltip-content {
 		flex-direction: column;


### PR DESCRIPTION
Related to #80646 #80591

## Proposed Changes

The PR proposes to show only Total subscriber, Paid subscriber, and Free subscribers when paid newsletter is configured for the site. Otherwise, it would show Total subscribers, WordPress.com subscribers and Email subscribers.

The ability to determine whether a site has paid newsletter set up, which would be tackled separately #80609.

## Testing Instructions

* Open Calypso Live Branch
* Open `/stats/subscribers/:siteSlug`
* Ensure the All time stats cards work as expected

<img width="1215" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/6871cb4a-dd63-47ea-825a-e9da07a59b53">

<img width="1267" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/987b79c7-c6b5-423d-8f6a-f3ad967b5444">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
