### PR TITLE
Stats Subscribers: Hide line for social subscribers if value is zero

### DIFF
--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -1,6 +1,8 @@
 import config from '@automattic/calypso-config';
+import { Popover } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get, reduce } from 'lodash';
+import React, { useState, useRef } from 'react';
 import { connect } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -22,6 +24,9 @@ export const StatsReach = ( props ) => {
 		siteSlug,
 		isOdysseyStats,
 	} = props;
+
+	const [ isPopoverVisible, setPopoverVisible ] = useState( false );
+	const socialRef = useRef( null );
 
 	const isLoadingFollowData = ! followData;
 	const wpcomFollowCount = get( followData, 'total_wpcom', 0 );
@@ -48,7 +53,15 @@ export const StatsReach = ( props ) => {
 
 	const socialData = {
 		value: publicizeFollowCount,
-		label: translate( 'Social' ),
+		label: (
+			<span
+				ref={ socialRef }
+				onMouseEnter={ () => setPopoverVisible( true ) }
+				onMouseLeave={ () => setPopoverVisible( false ) }
+			>
+				{ translate( 'Social Test' ) }
+			</span>
+		),
 	};
 
 	if ( ! isOdysseyStats ) {
@@ -100,6 +113,17 @@ export const StatsReach = ( props ) => {
 					)
 				}
 			/>
+
+			<Popover
+				className="tooltip tooltip--darker highlight-card-tooltip highlight-card__settings-tooltip"
+				isVisible={ isPopoverVisible }
+				position="bottom left"
+				context={ socialRef.current }
+			>
+				<div className="highlight-card-tooltip-content">
+					<p>{ translate( 'This represents the count of social media subscribers.' ) }</p>
+				</div>
+			</Popover>
 		</>
 	);
 };

--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -1,8 +1,6 @@
 import config from '@automattic/calypso-config';
-import { Popover } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get, reduce } from 'lodash';
-import React, { useState, useRef } from 'react';
 import { connect } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -24,9 +22,6 @@ export const StatsReach = ( props ) => {
 		siteSlug,
 		isOdysseyStats,
 	} = props;
-
-	const [ isPopoverVisible, setPopoverVisible ] = useState( false );
-	const socialRef = useRef( null );
 
 	const isLoadingFollowData = ! followData;
 	const wpcomFollowCount = get( followData, 'total_wpcom', 0 );
@@ -53,15 +48,7 @@ export const StatsReach = ( props ) => {
 
 	const socialData = {
 		value: publicizeFollowCount,
-		label: (
-			<span
-				ref={ socialRef }
-				onMouseEnter={ () => setPopoverVisible( true ) }
-				onMouseLeave={ () => setPopoverVisible( false ) }
-			>
-				{ translate( 'Social' ) }
-			</span>
-		),
+		label: translate( 'Social' ),
 	};
 
 	if ( ! isOdysseyStats ) {
@@ -113,17 +100,6 @@ export const StatsReach = ( props ) => {
 					)
 				}
 			/>
-
-			<Popover
-				className="tooltip tooltip--darker highlight-card-tooltip highlight-card__settings-tooltip"
-				isVisible={ isPopoverVisible }
-				position="bottom left"
-				context={ socialRef.current }
-			>
-				<div className="highlight-card-tooltip-content">
-					<p>{ translate( 'This represents the count of social media subscribers.' ) }</p>
-				</div>
-			</Popover>
 		</>
 	);
 };

--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -34,8 +34,6 @@ export const StatsReach = ( props ) => {
 		0
 	);
 
-	let data = [];
-
 	const wpData = {
 		value: wpcomFollowCount,
 		label: translate( 'WordPress.com' ),
@@ -50,6 +48,8 @@ export const StatsReach = ( props ) => {
 		value: publicizeFollowCount,
 		label: translate( 'Social' ),
 	};
+
+	const data = [ wpData, emailData ];
 
 	if ( ! isOdysseyStats ) {
 		wpData.actions = [
@@ -70,9 +70,8 @@ export const StatsReach = ( props ) => {
 
 	if ( publicizeFollowCount > 0 ) {
 		socialData.children = publicizeData;
+		data.push( socialData ); // Only push socialData if publicizeFollowCount is greater than 0
 	}
-
-	data = [ wpData, emailData, socialData ];
 
 	// sort descending
 	data.sort( ( a, b ) => b.value - a.value );

--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -59,7 +59,7 @@ export const StatsReach = ( props ) => {
 				onMouseEnter={ () => setPopoverVisible( true ) }
 				onMouseLeave={ () => setPopoverVisible( false ) }
 			>
-				{ translate( 'Social Test' ) }
+				{ translate( 'Social' ) }
 			</span>
 		),
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR hides the line for social subscribers if value is zero

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the calypso live branch for this PR
* Switch to a site which has a known social follower count
* navigate to `/stats/subscribers/{site URL}`
* check that the subscriber count (above zero) is showing
* switch now to another site with zero social followers
* check that there is no social count displayed at all

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
