### PR TITLE
Improve how Renovate groups NodeJS PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/tooling_request.yml
+++ b/.github/ISSUE_TEMPLATE/tooling_request.yml
@@ -19,5 +19,4 @@ body:
     attributes:
       label: Context
       description: Provide more context as applicable.
-      placeholder: |
-            e.g. OS: ubuntu
+      placeholder: 'e.g. OS: ubuntu'

--- a/.github/ISSUE_TEMPLATE/tooling_request.yml
+++ b/.github/ISSUE_TEMPLATE/tooling_request.yml
@@ -20,5 +20,4 @@ body:
       label: Context
       description: Provide more context as applicable.
       placeholder: |
-        eg. nodeJS: 18.13.0
-            browser: Firefox Nightly 92.0a1
+            e.g. OS: ubuntu

--- a/.github/workflows/editing-toolkit-plugin.yml
+++ b/.github/workflows/editing-toolkit-plugin.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '^18.13.0'
+          node-version-file: '.nvmrc'
 
       - name: Checkout code
         uses: actions/checkout@HEAD

--- a/.github/workflows/editing-toolkit-plugin.yml
+++ b/.github/workflows/editing-toolkit-plugin.yml
@@ -11,13 +11,11 @@ jobs:
     name: Run PHPunit tests.
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-
       - name: Checkout code
         uses: actions/checkout@HEAD
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Composer install
         uses: nick-zh/composer-php@HEAD

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -27,7 +27,7 @@ jobs:
      - name: Setup Node
        uses: actions/setup-node@v3
        with:
-         node-version: ^18.13.0
+         node-version-file: '.nvmrc'
 
      - name: Wait for prior instances of the workflow to finish
        uses: softprops/turnstyle@v1

--- a/.github/workflows/icfy-stats.yml
+++ b/.github/workflows/icfy-stats.yml
@@ -9,12 +9,11 @@ jobs:
     env:
       NODE_OPTIONS: --max-old-space-size=4096
     steps:
-      - name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
       - name: Checkout code
         uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
       - name: Fetch git history
         run: git fetch --prune --unshallow
       - name: Install dependencies

--- a/.github/workflows/icfy-stats.yml
+++ b/.github/workflows/icfy-stats.yml
@@ -10,9 +10,9 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=4096
     steps:
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '^18.13.0'
+          node-version-file: '.nvmrc'
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Fetch git history

--- a/packages/calypso-package-generator/package.json
+++ b/packages/calypso-package-generator/package.json
@@ -16,10 +16,6 @@
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/generators#readme",
 	"type": "module",
-	"engines": {
-		"node": "^16.17.0",
-		"yarn": "^3.1.1"
-	},
 	"scripts": {
 		"generate": "generate-calypso-package"
 	},

--- a/renovate.json5
+++ b/renovate.json5
@@ -15,6 +15,9 @@
 			matchDepNames: [ 'node', 'cimg/node' ],
 			matchDatasources: [ 'docker' ],
 			prPriority: 2,
+		},
+		{
+			matchDepNames: [ 'node' ],
 			// This gets published with broader Node support, so we'll update it when needed.
 			ignorePaths: [ 'packages/eslint-plugin-wpcalypso' ],
 		},

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,10 +13,11 @@
 			groupName: 'nodejs',
 			matchPackagePatterns: [ '/node$' ],
 			matchDepNames: [ 'node', 'cimg/node' ],
-			matchDatasources: [ 'docker' ],
+			matchDatasources: [ 'docker', 'node' ],
 			prPriority: 2,
 		},
 		{
+			groupName: 'nodejs',
 			matchDepNames: [ 'node' ],
 			// This gets published with broader Node support, so we'll update it when needed.
 			ignorePaths: [ 'packages/eslint-plugin-wpcalypso' ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -10,10 +10,12 @@
 			minimumReleaseAge: '0 days',
 		},
 		{
+			matchPackagePatterns: [ '/node$' ],
 			matchDepNames: [ 'node' ],
+			matchDatasources: [ 'docker' ],
 			prPriority: 2,
 			// This gets published with broader Node support, so we'll update it when needed.
-			ignorePaths: [ 'packages/eslint-plugin-wpcalypso' ]
+			ignorePaths: [ 'packages/eslint-plugin-wpcalypso' ],
 		},
 		{
 			extends: [ 'monorepo:react', ':widenPeerDependencies' ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -12,7 +12,7 @@
 		{
 			groupName: 'nodejs',
 			matchPackagePatterns: [ '/node$' ],
-			matchDepNames: [ 'node', 'cimg/node' ],
+			matchDepNames: [ 'node', 'cimg/node', '@types/node' ],
 			matchDatasources: [ 'docker', 'node' ],
 			prPriority: 2,
 		},

--- a/renovate.json5
+++ b/renovate.json5
@@ -12,7 +12,7 @@
 		{
 			groupName: 'nodejs',
 			matchPackagePatterns: [ '/node$' ],
-			matchDepNames: [ 'node', 'cimg/node', '@types/node' ],
+			matchDepNames: [ 'node', 'cimg/node' ],
 			matchDatasources: [ 'docker', 'node' ],
 			prPriority: 2,
 		},
@@ -21,6 +21,10 @@
 			matchDepNames: [ 'node' ],
 			// This gets published with broader Node support, so we'll update it when needed.
 			ignorePaths: [ 'packages/eslint-plugin-wpcalypso' ],
+		},
+		{
+			groupName: 'nodejs',
+			matchDepNames: [ '@types/node' ],
 		},
 		{
 			extends: [ 'monorepo:react', ':widenPeerDependencies' ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -10,12 +10,20 @@
 			minimumReleaseAge: '0 days',
 		},
 		{
+			groupName: 'nodejs',
 			matchPackagePatterns: [ '/node$' ],
-			matchDepNames: [ 'node' ],
+			matchDepNames: [ 'node', 'cimg/node' ],
 			matchDatasources: [ 'docker' ],
 			prPriority: 2,
 			// This gets published with broader Node support, so we'll update it when needed.
 			ignorePaths: [ 'packages/eslint-plugin-wpcalypso' ],
+		},
+		{
+			groupName: 'nodejs',
+			fileMatch: [ '^Dockerfile$' ],
+			matchStrings: [ 'ARG node_version=(?<currentValue>.*?)\\n' ],
+			depNameTemplate: 'node',
+			datasourceTemplate: 'node',
 		},
 		{
 			extends: [ 'monorepo:react', ':widenPeerDependencies' ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -19,13 +19,6 @@
 			ignorePaths: [ 'packages/eslint-plugin-wpcalypso' ],
 		},
 		{
-			groupName: 'nodejs',
-			fileMatch: [ '^Dockerfile$' ],
-			matchStrings: [ 'ARG node_version=(?<currentValue>.*?)\\n' ],
-			depNameTemplate: 'node',
-			datasourceTemplate: 'node',
-		},
-		{
 			extends: [ 'monorepo:react', ':widenPeerDependencies' ],
 			prPriority: 2,
 			ignorePaths: [ 'packages/interpolate-components' ],
@@ -82,6 +75,13 @@
 			datasourceTemplate: 'docker',
 			depNameTemplate: 'renovate',
 			packageNameTemplate: 'ghcr.io/renovatebot/renovate',
+		},
+		{
+			groupName: 'nodejs',
+			fileMatch: [ '^Dockerfile$' ],
+			matchStrings: [ 'ARG node_version=(?<currentValue>.*?)\\n' ],
+			depNameTemplate: 'node',
+			datasourceTemplate: 'node',
 		},
 	],
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -77,7 +77,6 @@
 			packageNameTemplate: 'ghcr.io/renovatebot/renovate',
 		},
 		{
-			groupName: 'nodejs',
 			fileMatch: [ '^Dockerfile$' ],
 			matchStrings: [ 'ARG node_version=(?<currentValue>.*?)\\n' ],
 			depNameTemplate: 'node',

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -23,10 +23,9 @@ Automated end-to-end acceptance tests for the [wp-calypso](https://github.com/Au
 
 Calypso E2E requires the following:
 
-- [NodeJS 18.13.0](https://nodejs.org/en/blog/release/v16.17.0/) or higher
-- [TypeScript 4.5](https://www.staging-typescript.org/docs/handbook/release-notes/typescript-4-5.html) or higher
-- [Playwright 1.28](https://playwright.dev/docs/release-notes#version-128) or higher
-- [yarn 3.1](https://github.com/yarnpkg/berry) or higher
+- [NodeJS](https://nodejs.org/) at the version in the root package.json "engines" field. (Typically latest LTS.)
+- The [yarn](https://github.com/yarnpkg/berry) version available in the repo.
+- Dependencies such as [Typescript](https://typescript.org) and [Playwright](https://playwright.dev) are installed via yarn, and you can find information about the versions we use in ./package.json.
 
 ## Quick start
 


### PR DESCRIPTION
## Proposed Changes
Renovate opens too many PRs for NodeJS. For example:
- Random engines field: https://github.com/Automattic/wp-calypso/pull/80522
- Another random engines field: https://github.com/Automattic/wp-calypso/pull/80523
- Most Node things: https://github.com/Automattic/wp-calypso/pull/80345
- CircleCI: https://github.com/Automattic/wp-calypso/pull/80649

On top of that, Renovate doesn't update a few other version constants in the repo, like GitHub actions.

To fix:
- Attempt to group the CircleCi update in with the main Node PR
- Attempt to exclude one package.json file from node updates, since it should stay low
- Remove the engines field from the generator package; it isn't needed.
- Use nvmrc for `setup-node` in GH actions, since it's supported.
- Remove some cases where we hardcoded the Node version in readmes; it doesn't seem worth keeping these updates when we can just reference the nvmrc or engines field.
- Use regex to update one of the Docker images

## Testing Instructions
See if Renovate combines these PRs.
