### PR TITLE
Make `/stats/purchase/` accessible without a site selected

### DIFF
--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -51,8 +51,7 @@ export default function () {
 	statsPage( `/stats/:period(${ validPeriods })`, overview );
 
 	// Stat Purchase Page
-	statsPage( '/stats/purchase', sites );
-	statsPage( '/stats/purchase/:site', purchase );
+	statsPage( '/stats/purchase/:site?', purchase );
 
 	// Stat Insights Page
 	statsPage( '/stats/insights', sites );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -5,11 +5,11 @@ import {
 } from '@automattic/calypso-products';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
-const setUrlParam = ( url: URL, paramName: string, paramValue: string ): void => {
-	if ( paramValue ) {
-		url.searchParams.set( paramName, paramValue );
-	} else {
+const setUrlParam = ( url: URL, paramName: string, paramValue?: string | null ): void => {
+	if ( paramValue === null || paramValue === undefined || paramValue === '' ) {
 		url.searchParams.delete( paramName );
+	} else {
+		url.searchParams.set( paramName, paramValue );
 	}
 };
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -11,8 +11,9 @@ const getStatsPurchaseURL = (
 	redirectUrl: string,
 	checkoutBackUrl: string
 ) => {
+	// Get the checkout URL for the product, or the siteless checkout URL if no siteSlug is provided
 	const checkoutProductUrl = new URL(
-		`/checkout/${ siteSlug }/${ product }`,
+		`/checkout/${ siteSlug || 'jetpack' }/${ product }`,
 		window.location.origin
 	);
 
@@ -77,7 +78,7 @@ const getRedirectUrl = ( {
 
 	if ( ! isStartedFromJetpackSite ) {
 		redirectUri = addPurchaseTypeToUri(
-			redirectUri || `/stats/day/${ siteSlug }`,
+			redirectUri || `/stats/day/${ siteSlug || '' }`,
 			statsPurchaseSuccess
 		);
 		return redirectUri;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -81,7 +81,7 @@ const ProductCard = ( {
 
 	if ( ! siteSlug ) {
 		// Default to a generic label if no site slug is provided.
-		typeSelectionScreenLabel = translate( 'What type is your site?' );
+		typeSelectionScreenLabel = translate( 'Which type is your site?' );
 	}
 
 	if ( siteType === TYPE_PERSONAL ) {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -79,6 +79,11 @@ const ProductCard = ( {
 	} );
 	let purchaseScreenLabel = personalProductTitle;
 
+	if ( ! siteSlug ) {
+		// Default to a generic label if no site slug is provided.
+		typeSelectionScreenLabel = translate( 'What type is your site?' );
+	}
+
 	if ( siteType === TYPE_PERSONAL ) {
 		typeSelectionScreenLabel = personalLabel;
 		purchaseScreenLabel = personalProductTitle;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1HpG7-nWn-p2#comment-65319

## Proposed Changes

* Update the `stats-purchase` controller to make `:site:` option when accessing `/stats/purchase`. This way, users will be able to visit the siteless checkout if they haven't selected a site, or the contextual checkout if they have a site selected.
<img width="1182" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5714212/d19b18d0-f37f-48bd-a702-5167e1e601c1">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link for this PR
* Visit `/stats/purchase`
* Make sure the plan selection flow works with no errors:
  * Visit `/stats/purchase/` and confirm that you're redirected to `/checkout/jetpack/{planName}`
  * Visit `/stats/purchase/{siteSlug}`, confirm that you're redirected to `/checkout/:site`
* Confirm that you're redirect to the expected URLs after the checkout, or if you remove the product from the cart:
  * For siteless checkout, after purchase you'll be redirected to the Thank You page. If you remove the product, you'll be redirected to cloud.jetpack.com/pricing
  * For the checkout with a site, the behavior remains the same (check the code)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
