### PR TITLE
DNS manage: Add notice when not using WPCOM nameservers

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -1,5 +1,6 @@
+import { englishLocales } from '@automattic/i18n-utils';
 import { Icon, info } from '@wordpress/icons';
-import { localize } from 'i18n-calypso';
+import i18n, { getLocaleSlug, localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -123,7 +124,15 @@ class DnsRecords extends Component {
 	renderNotice = () => {
 		const { translate, selectedSite, currentRoute, selectedDomainName, nameservers } = this.props;
 
-		if ( this.hasWpcomNameservers() || ! nameservers || ! nameservers.length ) {
+		if (
+			( ! englishLocales.includes( getLocaleSlug() ) &&
+				! i18n.hasTranslation(
+					'DNS records requires using WordPress.com nameservers. {{a}}Update your nameservers now{{/a}}.'
+				) ) ||
+			this.hasWpcomNameservers() ||
+			! nameservers ||
+			! nameservers.length
+		) {
 			return null;
 		}
 

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -1,3 +1,4 @@
+import { Icon, info } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
@@ -104,6 +105,44 @@ class DnsRecords extends Component {
 		);
 	};
 
+	renderNotice = () => {
+		const { translate, selectedSite, currentRoute, selectedDomainName } = this.props;
+
+		if ( selectedDomainName.hasWpcomNameservers ) {
+			return null;
+		}
+
+		return (
+			<div className="dns-records-notice">
+				<Icon
+					icon={ info }
+					size={ 18 }
+					className="dns-records-notice__icon gridicon"
+					viewBox="2 2 20 20"
+				/>
+				<div className="dns-records-notice__message">
+					{ translate(
+						'Domain redirection requires using WordPress.com nameservers. {{a}}Update your nameservers now{{/a}}.',
+						{
+							components: {
+								a: (
+									<a
+										href={ domainManagementEdit(
+											selectedSite.slug,
+											selectedDomainName,
+											currentRoute,
+											{ nameservers: true }
+										) }
+									></a>
+								),
+							},
+						}
+					) }
+				</div>
+			</div>
+		);
+	};
+
 	renderMain() {
 		const { dns, selectedDomainName, selectedSite, translate, domains } = this.props;
 		const selectedDomain = domains?.find( ( domain ) => domain?.name === selectedDomainName );
@@ -117,6 +156,7 @@ class DnsRecords extends Component {
 				{ selectedDomain?.canManageDnsRecords ? (
 					<>
 						<DnsDetails />
+						{ this.renderNotice() }
 						<DnsRecordsList
 							dns={ dns }
 							selectedSite={ selectedSite }

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -12,6 +12,8 @@ import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/co
 import DomainHeader from 'calypso/my-sites/domains/domain-management/components/domain-header';
 import DnsRecordsList from 'calypso/my-sites/domains/domain-management/dns/dns-records-list';
 import EmailSetup from 'calypso/my-sites/domains/domain-management/email-setup';
+import { WPCOM_DEFAULT_NAMESERVERS_REGEX } from 'calypso/my-sites/domains/domain-management/name-servers/constants';
+import withDomainNameservers from 'calypso/my-sites/domains/domain-management/name-servers/with-domain-nameservers';
 import {
 	domainManagementEdit,
 	domainManagementList,
@@ -35,6 +37,7 @@ class DnsRecords extends Component {
 		showPlaceholder: PropTypes.bool.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
+		nameservers: PropTypes.array || null,
 	};
 
 	renderHeader = () => {
@@ -105,10 +108,22 @@ class DnsRecords extends Component {
 		);
 	};
 
-	renderNotice = () => {
-		const { translate, selectedSite, currentRoute, selectedDomainName } = this.props;
+	hasWpcomNameservers = () => {
+		const { nameservers } = this.props;
 
-		if ( selectedDomainName.hasWpcomNameservers ) {
+		if ( ! nameservers || nameservers.length === 0 ) {
+			return false;
+		}
+
+		return nameservers.every( ( nameserver ) => {
+			return WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
+		} );
+	};
+
+	renderNotice = () => {
+		const { translate, selectedSite, currentRoute, selectedDomainName, nameservers } = this.props;
+
+		if ( this.hasWpcomNameservers() || ! nameservers || ! nameservers.length ) {
 			return null;
 		}
 
@@ -204,4 +219,4 @@ export default connect(
 		};
 	},
 	{ successNotice, errorNotice, fetchDns }
-)( localize( DnsRecords ) );
+)( localize( withDomainNameservers( DnsRecords ) ) );

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -137,7 +137,7 @@ class DnsRecords extends Component {
 				/>
 				<div className="dns-records-notice__message">
 					{ translate(
-						'Domain redirection requires using WordPress.com nameservers. {{a}}Update your nameservers now{{/a}}.',
+						'DNS records requires using WordPress.com nameservers. {{a}}Update your nameservers now{{/a}}.',
 						{
 							components: {
 								a: (

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -159,6 +159,28 @@ body.dns__body-white {
 			}
 		}
 	}
+	.dns-records-notice {
+		flex-basis: 100%;
+		background-color: var(--studio-gray-0);
+		display: flex;
+		align-items: center;
+		padding: 8px;
+		gap: 8px;
+		border-radius: 2px;
+		margin-top: 24px;
+
+		&__icon.gridicon {
+			min-width: 18px;
+			fill: var(--studio-orange-40);
+		}
+
+		&__message {
+			font-weight: 400;
+			font-size: $font-body-small;
+			color: var(--studio-gray-80);
+		}
+	}
+
 }
 
 .dns-records-list__action-menu-item.gridicon {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3485

## Proposed Changes

We want to add a notice on the DNS page when the domain nameservers are not managed by WPCOM as we did on Domain Redirect card when editing a domain.

| Domain Redirect | DNS |
| --- | --- |
| ![Image](https://user-images.githubusercontent.com/402286/260753041-83b8c3bb-1c65-44b2-8cf6-9b9c89bf495d.png) | <img width="1102" alt="image" src="https://github.com/Automattic/wp-calypso/assets/402286/752ac88e-86f5-49e1-8796-48c8ea23f995"> |


## Testing Instructions

* Disable WPCOM nameservers on a domain
* Go to edit DNS records
* You should see the notice
* The CTA should link to the edit domain page with the nameservers card open.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
