### PR TITLE
Domain Management: Link from domain table rows to the detailed domain management page

### DIFF
--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -22,6 +22,7 @@ export * from './plans/types';
 export * from './user/types';
 export * from './queries/use-launchpad';
 export * from './queries/use-all-domains-query';
+export * from './queries/use-site-domains-query';
 
 const { SubscriptionManager } = Reader;
 

--- a/packages/data-stores/src/queries/use-all-domains-query.ts
+++ b/packages/data-stores/src/queries/use-all-domains-query.ts
@@ -1,19 +1,21 @@
 import { UseQueryOptions, useQuery } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
+import type { DomainData } from './use-site-domains-query';
 
 // The data returned by the /all-domains endpoint only includes the basic data
 // related to a domain.
-export interface PartialDomainData {
-	domain: string;
-	blog_id: number;
-	type: 'mapping' | 'wpcom';
-	is_wpcom_staging_domain: boolean;
-	has_registration: boolean;
-	registration_date: string;
-	expiry: string;
-	wpcom_domain: boolean;
-	current_user_is_owner: boolean;
-}
+export type PartialDomainData = Pick<
+	DomainData,
+	| 'domain'
+	| 'blog_id'
+	| 'type'
+	| 'is_wpcom_staging_domain'
+	| 'has_registration'
+	| 'registration_date'
+	| 'expiry'
+	| 'wpcom_domain'
+	| 'current_user_is_owner'
+>;
 
 export interface AllDomainsQueryFnData {
 	domains: PartialDomainData[];

--- a/packages/data-stores/src/queries/use-site-domains-query.ts
+++ b/packages/data-stores/src/queries/use-site-domains-query.ts
@@ -1,0 +1,109 @@
+import { UseQueryOptions, useQuery } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+
+export interface DomainData {
+	primary_domain: boolean;
+	blog_id: number;
+	subscription_id: string;
+	can_manage_dns_records: boolean;
+	can_manage_name_servers: boolean;
+	can_update_contact_info: boolean;
+	cannot_manage_dns_records_reason: unknown;
+	cannot_manage_name_servers_reason: unknown;
+	cannot_update_contact_info_reason: unknown;
+	connection_mode: unknown;
+	current_user_can_add_email: boolean;
+	current_user_can_create_site_from_domain_only: boolean;
+	current_user_cannot_add_email_reason: unknown;
+	current_user_can_manage: boolean;
+	current_user_is_owner: boolean;
+	can_set_as_primary: boolean;
+	domain: string;
+	domain_notice_states: unknown;
+	supports_domain_connect: unknown;
+	email_forwards_count: 0;
+	expiry: string;
+	expiry_soon: boolean;
+	expired: boolean;
+	auto_renewing: 0;
+	pending_registration: boolean;
+	pending_registration_time: string;
+	has_registration: boolean;
+	has_email_forward_dns_records: unknown;
+	points_to_wpcom: boolean;
+	privacy_available: boolean;
+	private_domain: boolean;
+	partner_domain: boolean;
+	wpcom_domain: boolean;
+	has_zone: boolean;
+	is_renewable: boolean;
+	is_redeemable: boolean;
+	is_subdomain: boolean;
+	is_eligible_for_inbound_transfer: boolean;
+	is_locked: boolean;
+	is_wpcom_staging_domain: boolean;
+	transfer_away_eligible_at: string;
+	type: 'mapping' | 'wpcom' | 'registered' | 'redirect' | 'transfer';
+	registration_date: string;
+	auto_renewal_date: string;
+	google_apps_subscription: {
+		status: string;
+		is_eligible_for_introductory_offer: boolean;
+	};
+	titan_mail_subscription: {
+		status: string;
+		is_eligible_for_introductory_offer: boolean;
+	};
+	pending_whois_update: boolean;
+	tld_maintenance_end_time: 0;
+	ssl_status: string;
+	supports_gdpr_consent_management: boolean;
+	supports_transfer_approval: boolean;
+	domain_registration_agreement_url: string;
+	contact_info_disclosure_available: boolean;
+	contact_info_disclosed: boolean;
+	renewable_until: string;
+	redeemable_until: unknown;
+	bundled_plan_subscription_id: unknown;
+	product_slug: string;
+	owner: string;
+	pending_renewal: boolean;
+	aftermarket_auction: boolean;
+	aftermarket_auction_start: unknown;
+	aftermarket_auction_end: unknown;
+	nominet_pending_contact_verification_request: boolean;
+	nominet_domain_suspended: boolean;
+	transfer_status: unknown;
+	last_transfer_error: string;
+	has_private_registration: boolean;
+	is_pending_icann_verification: boolean;
+	manual_transfer_required: boolean;
+	registrar: string;
+	domain_locking_available: boolean;
+	is_premium: boolean;
+	transfer_lock_on_whois_update_optional: boolean;
+	whois_update_unmodifiable_fields: [];
+	is_whois_editable: boolean;
+	pending_transfer: boolean;
+	has_wpcom_nameservers: boolean;
+}
+
+export interface SiteDomainsQueryFnData {
+	domains: DomainData[];
+}
+
+export function useSiteDomainsQuery(
+	siteIdOrSlug: number | string | null | undefined,
+	options: UseQueryOptions< SiteDomainsQueryFnData > = {}
+) {
+	return useQuery( {
+		queryKey: [ 'site-domains', siteIdOrSlug ],
+		queryFn: () =>
+			wpcomRequest< SiteDomainsQueryFnData >( {
+				path: `/sites/${ siteIdOrSlug }/domains`,
+				apiVersion: '1.2',
+			} ),
+		enabled: Boolean( siteIdOrSlug ) && options.enabled,
+		...options,
+	} );
+}

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { renderWithProvider, testDomain, testPartialDomain } from '../../test-utils';
+import { DomainsTableRow } from '../domains-table-row';
+
+const render = ( el ) =>
+	renderWithProvider(
+		<table>
+			<tbody>{ el }</tbody>
+		</table>
+	);
+
+test( 'domain name is rendered in the row', () => {
+	render( <DomainsTableRow domain={ testPartialDomain( { domain: 'example1.com' } ) } /> );
+
+	expect( screen.queryByText( 'example1.com' ) ).toBeInTheDocument();
+} );
+
+test( 'domain name links to management interface', async () => {
+	const [ partialDomain, fullDomain ] = testDomain( {
+		domain: 'example.com',
+		blog_id: 123,
+		primary_domain: true,
+	} );
+
+	const fetchSiteDomains = jest.fn().mockResolvedValue( {
+		domains: [ fullDomain ],
+	} );
+
+	render( <DomainsTableRow domain={ partialDomain } fetchSiteDomains={ fetchSiteDomains } /> );
+
+	// Expect the row to fetch detailed domain data
+	expect( fetchSiteDomains ).toHaveBeenCalledWith( 123 );
+
+	// Before detailed domain data has loaded the link will use the blog ID
+	expect( screen.getByRole( 'link', { name: 'example.com' } ) ).toHaveAttribute(
+		'href',
+		'/domains/manage/all/example.com/edit/123'
+	);
+
+	// After detailed domain data is loaded we expect the site's primary domain to be used in the URL fragment
+	await waitFor( () =>
+		expect( screen.getByRole( 'link', { name: 'example.com' } ) ).toHaveAttribute(
+			'href',
+			'/domains/manage/all/example.com/edit/example.com'
+		)
+	);
+} );
+
+test( 'non primary domain uses the primary domain as the site slug in its link URL', async () => {
+	const [ partialDomain, fullDomain ] = testDomain( {
+		domain: 'not-primary-domain.blog',
+		blog_id: 123,
+		primary_domain: false,
+	} );
+	const [ , primaryDomain ] = testDomain( {
+		domain: 'primary-domain.blog',
+		blog_id: 123,
+		primary_domain: true,
+	} );
+
+	const fetchSiteDomains = jest.fn().mockResolvedValue( {
+		domains: [ fullDomain, primaryDomain ],
+	} );
+
+	render( <DomainsTableRow domain={ partialDomain } fetchSiteDomains={ fetchSiteDomains } /> );
+
+	expect( fetchSiteDomains ).toHaveBeenCalledWith( 123 );
+
+	await waitFor( () =>
+		expect( screen.getByRole( 'link', { name: 'not-primary-domain.blog' } ) ).toHaveAttribute(
+			'href',
+			'/domains/manage/all/not-primary-domain.blog/edit/primary-domain.blog'
+		)
+	);
+} );
+
+test( 'redirect links use the unmapped domain for the site slug', async () => {
+	const [ partialRedirectDomain, fullRedirectDomain ] = testDomain( {
+		domain: 'redirect.blog',
+		primary_domain: true,
+		wpcom_domain: false,
+		type: 'redirect',
+		blog_id: 123,
+	} );
+	const [ , fullUnmappedDomain ] = testDomain( {
+		domain: 'redirect-site.wordpress.com',
+		primary_domain: false,
+		wpcom_domain: true,
+		type: 'wpcom',
+		blog_id: 123,
+	} );
+
+	const fetchSiteDomains = jest.fn().mockResolvedValue( {
+		domains: [ fullRedirectDomain, fullUnmappedDomain ],
+	} );
+
+	render(
+		<DomainsTableRow domain={ partialRedirectDomain } fetchSiteDomains={ fetchSiteDomains } />
+	);
+
+	expect( fetchSiteDomains ).toHaveBeenCalledWith( 123 );
+
+	await waitFor( () =>
+		expect( screen.getByRole( 'link', { name: 'redirect.blog' } ) ).toHaveAttribute(
+			'href',
+			'/domains/manage/all/redirect.blog/redirect/redirect-site.wordpress.com'
+		)
+	);
+} );
+
+test( 'transfer links use the unmapped domain for the site slug', async () => {
+	const [ partialDomain, fullDomain ] = testDomain( {
+		domain: 'example.com',
+		blog_id: 123,
+		primary_domain: true,
+		wpcom_domain: false,
+		type: 'transfer',
+	} );
+
+	const fetchSiteDomains = jest.fn().mockResolvedValue( {
+		domains: [ fullDomain ],
+	} );
+
+	render( <DomainsTableRow domain={ partialDomain } fetchSiteDomains={ fetchSiteDomains } /> );
+
+	expect( fetchSiteDomains ).toHaveBeenCalledWith( 123 );
+
+	await waitFor( () =>
+		expect( screen.getByRole( 'link', { name: 'example.com' } ) ).toHaveAttribute(
+			'href',
+			'/domains/manage/all/example.com/transfer/in/example.com'
+		)
+	);
+} );

--- a/packages/domains-table/src/domains-table/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/index.tsx
@@ -1,10 +1,21 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render as rtlRender, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { DomainsTable } from '..';
 import type { PartialDomainData } from '@automattic/data-stores';
+
+function render( ui, renderOptions = {} ) {
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+
+	return rtlRender( ui, { wrapper: Wrapper, ...renderOptions } );
+}
 
 function testDomain( defaults: Partial< PartialDomainData > = {} ): PartialDomainData {
 	return {
@@ -43,11 +54,95 @@ test( 'all domain names are rendered in the table', () => {
 	expect( screen.queryByText( 'example3.com' ) ).not.toBeInTheDocument();
 } );
 
-test( 'domain name links to management interface', () => {
-	render( <DomainsTable domains={ [ testDomain( { domain: 'example.com', blog_id: 123 } ) ] } /> );
+test( 'domain name links to management interface', async () => {
+	const fetchSiteDomains = jest.fn().mockResolvedValue( {
+		domains: [
+			{
+				domain: 'example.com',
+				primary_domain: true,
+			},
+		],
+	} );
 
+	render(
+		<DomainsTable
+			domains={ [ testDomain( { domain: 'example.com', blog_id: 123 } ) ] }
+			fetchSiteDomains={ fetchSiteDomains }
+		/>
+	);
+
+	// Expect the row to fetch detailed domain data
+	expect( fetchSiteDomains ).toHaveBeenCalledWith( 123 );
+
+	// Before detailed domain data has loaded the link will use the blog ID
 	expect( screen.getByRole( 'link', { name: 'example.com' } ) ).toHaveAttribute(
 		'href',
 		expect.stringContaining( '/domains/manage/all/example.com/edit/123' )
+	);
+
+	// After detailed domain data is loaded we expect the site's primary domain to be used in the URL fragment
+	await waitFor( () =>
+		expect( screen.getByRole( 'link', { name: 'example.com' } ) ).toHaveAttribute(
+			'href',
+			expect.stringContaining( '/domains/manage/all/example.com/edit/example.com' )
+		)
+	);
+} );
+
+test( 'all domains use the primary domain as the site slug in their link URLs', async () => {
+	const fetchSiteDomains = jest.fn( ( siteId ) =>
+		Promise.resolve( {
+			domains:
+				siteId === 123
+					? [
+							{
+								domain: 'not-primary-domain.blog',
+								primary_domain: false,
+							},
+							{
+								domain: 'primary-domain.blog',
+								primary_domain: true,
+							},
+					  ]
+					: [ { domain: 'a-different-site.com', primary_domain: true } ],
+		} )
+	);
+
+	render(
+		<DomainsTable
+			domains={ [
+				testDomain( { domain: 'primary-domain.blog', blog_id: 123 } ),
+				testDomain( { domain: 'not-primary-domain.blog', blog_id: 123 } ),
+				testDomain( { domain: 'a-different-site.com', blog_id: 1337 } ),
+			] }
+			fetchSiteDomains={ fetchSiteDomains }
+		/>
+	);
+
+	expect( fetchSiteDomains ).toHaveBeenCalledTimes( 2 );
+	expect( fetchSiteDomains ).toHaveBeenCalledWith( 123 );
+	expect( fetchSiteDomains ).toHaveBeenCalledWith( 1337 );
+
+	await waitFor( () =>
+		expect( screen.getByRole( 'link', { name: 'primary-domain.blog' } ) ).toHaveAttribute(
+			'href',
+			expect.stringContaining( '/domains/manage/all/primary-domain.blog/edit/primary-domain.blog' )
+		)
+	);
+	await waitFor( () =>
+		expect( screen.getByRole( 'link', { name: 'not-primary-domain.blog' } ) ).toHaveAttribute(
+			'href',
+			expect.stringContaining(
+				'/domains/manage/all/not-primary-domain.blog/edit/primary-domain.blog'
+			)
+		)
+	);
+	await waitFor( () =>
+		expect( screen.getByRole( 'link', { name: 'a-different-site.com' } ) ).toHaveAttribute(
+			'href',
+			expect.stringContaining(
+				'/domains/manage/all/a-different-site.com/edit/a-different-site.com'
+			)
+		)
 	);
 } );

--- a/packages/domains-table/src/domains-table/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/index.tsx
@@ -42,3 +42,12 @@ test( 'all domain names are rendered in the table', () => {
 	expect( screen.queryByText( 'example2.com' ) ).not.toBeInTheDocument();
 	expect( screen.queryByText( 'example3.com' ) ).not.toBeInTheDocument();
 } );
+
+test( 'domain name links to management interface', () => {
+	render( <DomainsTable domains={ [ testDomain( { domain: 'example.com', blog_id: 123 } ) ] } /> );
+
+	expect( screen.getByRole( 'link', { name: 'example.com' } ) ).toHaveAttribute(
+		'href',
+		expect.stringContaining( '/domains/manage/all/example.com/edit/123' )
+	);
+} );

--- a/packages/domains-table/src/domains-table/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/index.tsx
@@ -1,44 +1,20 @@
 /**
  * @jest-environment jsdom
  */
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render as rtlRender, screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
 import { DomainsTable } from '..';
-import type { PartialDomainData } from '@automattic/data-stores';
+import { renderWithProvider, testDomain, testPartialDomain } from '../../test-utils';
 
-function render( ui, renderOptions = {} ) {
-	const queryClient = new QueryClient();
-
-	const Wrapper = ( { children } ) => (
-		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
-	);
-
-	return rtlRender( ui, { wrapper: Wrapper, ...renderOptions } );
-}
-
-function testDomain( defaults: Partial< PartialDomainData > = {} ): PartialDomainData {
-	return {
-		domain: 'example.com',
-		blog_id: 113,
-		type: 'mapping',
-		is_wpcom_staging_domain: false,
-		has_registration: true,
-		registration_date: '2020-03-11T22:23:58+00:00',
-		expiry: '2026-03-11T00:00:00+00:00',
-		wpcom_domain: false,
-		current_user_is_owner: true,
-		...defaults,
-	};
-}
+const render = ( el ) => renderWithProvider( el );
 
 test( 'all domain names are rendered in the table', () => {
 	const { rerender } = render(
 		<DomainsTable
 			domains={ [
-				testDomain( { domain: 'example1.com' } ),
-				testDomain( { domain: 'example2.com' } ),
-				testDomain( { domain: 'example3.com' } ),
+				testPartialDomain( { domain: 'example1.com' } ),
+				testPartialDomain( { domain: 'example2.com' } ),
+				testPartialDomain( { domain: 'example3.com' } ),
 			] }
 		/>
 	);
@@ -54,67 +30,32 @@ test( 'all domain names are rendered in the table', () => {
 	expect( screen.queryByText( 'example3.com' ) ).not.toBeInTheDocument();
 } );
 
-test( 'domain name links to management interface', async () => {
-	const fetchSiteDomains = jest.fn().mockResolvedValue( {
-		domains: [
-			{
-				domain: 'example.com',
-				primary_domain: true,
-			},
-		],
+test( 'when two domains share the same underlying site, there is only one fetch for detailed domain info for that site', () => {
+	const [ primaryPartial, primaryFull ] = testDomain( {
+		domain: 'primary-domain.blog',
+		blog_id: 123,
+		primary_domain: true,
+	} );
+	const [ notPrimaryPartial, notPrimaryFull ] = testDomain( {
+		domain: 'not-primary-domain.blog',
+		blog_id: 123,
+		primary_domain: false,
+	} );
+	const [ differentSitePartial, differentSiteFull ] = testDomain( {
+		domain: 'a-different-site.com',
+		blog_id: 1337,
+		primary_domain: true,
 	} );
 
-	render(
-		<DomainsTable
-			domains={ [ testDomain( { domain: 'example.com', blog_id: 123 } ) ] }
-			fetchSiteDomains={ fetchSiteDomains }
-		/>
-	);
-
-	// Expect the row to fetch detailed domain data
-	expect( fetchSiteDomains ).toHaveBeenCalledWith( 123 );
-
-	// Before detailed domain data has loaded the link will use the blog ID
-	expect( screen.getByRole( 'link', { name: 'example.com' } ) ).toHaveAttribute(
-		'href',
-		expect.stringContaining( '/domains/manage/all/example.com/edit/123' )
-	);
-
-	// After detailed domain data is loaded we expect the site's primary domain to be used in the URL fragment
-	await waitFor( () =>
-		expect( screen.getByRole( 'link', { name: 'example.com' } ) ).toHaveAttribute(
-			'href',
-			expect.stringContaining( '/domains/manage/all/example.com/edit/example.com' )
-		)
-	);
-} );
-
-test( 'all domains use the primary domain as the site slug in their link URLs', async () => {
-	const fetchSiteDomains = jest.fn( ( siteId ) =>
+	const fetchSiteDomains = jest.fn().mockImplementation( ( siteId ) =>
 		Promise.resolve( {
-			domains:
-				siteId === 123
-					? [
-							{
-								domain: 'not-primary-domain.blog',
-								primary_domain: false,
-							},
-							{
-								domain: 'primary-domain.blog',
-								primary_domain: true,
-							},
-					  ]
-					: [ { domain: 'a-different-site.com', primary_domain: true } ],
+			domains: siteId === 123 ? [ primaryFull, notPrimaryFull ] : [ differentSiteFull ],
 		} )
 	);
 
 	render(
 		<DomainsTable
-			domains={ [
-				testDomain( { domain: 'primary-domain.blog', blog_id: 123 } ),
-				testDomain( { domain: 'not-primary-domain.blog', blog_id: 123 } ),
-				testDomain( { domain: 'a-different-site.com', blog_id: 1337 } ),
-			] }
+			domains={ [ primaryPartial, notPrimaryPartial, differentSitePartial ] }
 			fetchSiteDomains={ fetchSiteDomains }
 		/>
 	);
@@ -122,27 +63,4 @@ test( 'all domains use the primary domain as the site slug in their link URLs', 
 	expect( fetchSiteDomains ).toHaveBeenCalledTimes( 2 );
 	expect( fetchSiteDomains ).toHaveBeenCalledWith( 123 );
 	expect( fetchSiteDomains ).toHaveBeenCalledWith( 1337 );
-
-	await waitFor( () =>
-		expect( screen.getByRole( 'link', { name: 'primary-domain.blog' } ) ).toHaveAttribute(
-			'href',
-			expect.stringContaining( '/domains/manage/all/primary-domain.blog/edit/primary-domain.blog' )
-		)
-	);
-	await waitFor( () =>
-		expect( screen.getByRole( 'link', { name: 'not-primary-domain.blog' } ) ).toHaveAttribute(
-			'href',
-			expect.stringContaining(
-				'/domains/manage/all/not-primary-domain.blog/edit/primary-domain.blog'
-			)
-		)
-	);
-	await waitFor( () =>
-		expect( screen.getByRole( 'link', { name: 'a-different-site.com' } ) ).toHaveAttribute(
-			'href',
-			expect.stringContaining(
-				'/domains/manage/all/a-different-site.com/edit/a-different-site.com'
-			)
-		)
-	);
 } );

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,0 +1,21 @@
+import type { PartialDomainData, SiteDomainsQueryFnData } from '@automattic/data-stores';
+
+interface DomainsTableRowProps {
+	domain: PartialDomainData;
+}
+
+export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
+	return (
+		<tr key={ domain.domain }>
+			<td>
+				<a className="domains-table__domain-link" href={ getDomainManagementLink( domain ) }>
+					{ domain.domain }
+				</a>
+			</td>
+		</tr>
+	);
+}
+
+function getDomainManagementLink( { blog_id, domain }: PartialDomainData ) {
+	return `/domains/manage/all/${ domain }/edit/${ blog_id }`;
+}

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -18,20 +18,22 @@ export function DomainsTableRow( { domain, fetchSiteDomains }: DomainsTableRowPr
 		}
 	);
 
-	const { primaryDomain } = useMemo(
-		() => ( {
-			primaryDomain: data?.domains?.find( ( d ) => d.primary_domain )?.domain,
-		} ),
-		[ data ]
-	);
+	const { siteSlug } = useMemo( () => {
+		const primaryDomain = data?.domains?.find( ( d ) => d.primary_domain );
+		const unmappedDomain = data?.domains?.find( ( d ) => d.wpcom_domain );
+		const siteSlug =
+			primaryDomain?.type === 'redirect' ? unmappedDomain?.domain : primaryDomain?.domain;
+
+		return {
+			// Fall back to the site's ID if we're still loading detailed domain data
+			siteSlug: siteSlug || domain.blog_id.toString( 10 ),
+		};
+	}, [ data, domain.blog_id ] );
 
 	return (
 		<tr key={ domain.domain }>
 			<td>
-				<a
-					className="domains-table__domain-link"
-					href={ getDomainManagementLink( domain, primaryDomain ) }
-				>
+				<a className="domains-table__domain-link" href={ domainManagementLink( domain, siteSlug ) }>
 					{ domain.domain }
 				</a>
 			</td>
@@ -39,9 +41,26 @@ export function DomainsTableRow( { domain, fetchSiteDomains }: DomainsTableRowPr
 	);
 }
 
-function getDomainManagementLink(
-	{ blog_id, domain }: PartialDomainData,
-	sitePrimaryDomain: string | undefined
-) {
-	return `/domains/manage/all/${ domain }/edit/${ sitePrimaryDomain ?? blog_id }`;
+function domainManagementLink( { domain, type }: PartialDomainData, siteSlug: string ) {
+	const viewSlug = domainManagementViewSlug( type );
+
+	// Encodes only real domain names and not parameter placeholders
+	if ( ! domain.startsWith( ':' ) ) {
+		// Encodes domain names so addresses with slashes in the path (e.g. used in site redirects) don't break routing.
+		// Note they are encoded twice since page.js decodes the path by default.
+		domain = encodeURIComponent( encodeURIComponent( domain ) );
+	}
+
+	return `/domains/manage/all/${ domain }/${ viewSlug }/${ siteSlug }`;
+}
+
+function domainManagementViewSlug( type: PartialDomainData[ 'type' ] ) {
+	switch ( type ) {
+		case 'transfer':
+			return 'transfer/in';
+		case 'redirect':
+			return 'redirect';
+		default:
+			return 'edit';
+	}
 }

--- a/packages/domains-table/src/domains-table/index.stories.tsx
+++ b/packages/domains-table/src/domains-table/index.stories.tsx
@@ -1,9 +1,20 @@
 import { Meta } from '@storybook/react';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import React from 'react';
 import { DomainsTable } from './index';
+
+const queryClient = new QueryClient();
 
 export default {
 	title: 'packages/domains-table/DomainsTable',
 	component: DomainsTable,
+	decorators: [
+		( Story ) => (
+			<QueryClientProvider client={ queryClient }>
+				<Story />
+			</QueryClientProvider>
+		),
+	],
 	parameters: {
 		viewport: {
 			defaultViewport: 'LARGE',
@@ -11,12 +22,16 @@ export default {
 	},
 } as Meta;
 
+const defaultDomains = [
+	{ domain: 'example1.com', blog_id: 1, primary_domain: true },
+	{ domain: 'example2.com', blog_id: 1, primary_domain: false },
+	{ domain: 'example3.com', blog_id: 2, primary_domain: true },
+];
+
 const defaultArgs = {
-	domains: [
-		{ domain: 'example1.com', blog_id: 1 },
-		{ domain: 'example2.com', blog_id: 1 },
-		{ domain: 'example3.com', blog_id: 2 },
-	],
+	domains: defaultDomains,
+	fetchSiteDomains: ( siteId ) =>
+		Promise.resolve( { domains: defaultDomains.filter( ( d ) => d.blog_id === siteId ) } ),
 };
 
 const storyDefaults = {

--- a/packages/domains-table/src/domains-table/index.stories.tsx
+++ b/packages/domains-table/src/domains-table/index.stories.tsx
@@ -12,7 +12,11 @@ export default {
 } as Meta;
 
 const defaultArgs = {
-	domains: [ { domain: 'example1.com' }, { domain: 'example2.com' }, { domain: 'example3.com' } ],
+	domains: [
+		{ domain: 'example1.com', blog_id: 1 },
+		{ domain: 'example2.com', blog_id: 1 },
+		{ domain: 'example3.com', blog_id: 2 },
+	],
 };
 
 const storyDefaults = {

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -1,4 +1,5 @@
 import { useI18n } from '@wordpress/react-i18n';
+import { DomainsTableRow } from './domains-table-row';
 import type { PartialDomainData } from '@automattic/data-stores';
 import './style.scss';
 
@@ -21,10 +22,8 @@ export function DomainsTable( { domains }: DomainsTableProps ) {
 				</tr>
 			</thead>
 			<tbody>
-				{ domains.map( ( { domain } ) => (
-					<tr key={ domain }>
-						<td>{ domain }</td>
-					</tr>
+				{ domains.map( ( domain ) => (
+					<DomainsTableRow key={ domain.domain } domain={ domain } />
 				) ) }
 			</tbody>
 		</table>

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -1,13 +1,19 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { DomainsTableRow } from './domains-table-row';
-import type { PartialDomainData } from '@automattic/data-stores';
+import type { PartialDomainData, SiteDomainsQueryFnData } from '@automattic/data-stores';
 import './style.scss';
 
 interface DomainsTableProps {
 	domains: PartialDomainData[] | undefined;
+
+	// Detailed domain data is fetched on demand. The ability to customise fetching
+	// is provided to allow for testing.
+	fetchSiteDomains?: (
+		siteIdOrSlug: number | string | null | undefined
+	) => Promise< SiteDomainsQueryFnData >;
 }
 
-export function DomainsTable( { domains }: DomainsTableProps ) {
+export function DomainsTable( { domains, fetchSiteDomains }: DomainsTableProps ) {
 	const { __ } = useI18n();
 
 	if ( ! domains ) {
@@ -23,7 +29,11 @@ export function DomainsTable( { domains }: DomainsTableProps ) {
 			</thead>
 			<tbody>
 				{ domains.map( ( domain ) => (
-					<DomainsTableRow key={ domain.domain } domain={ domain } />
+					<DomainsTableRow
+						key={ domain.domain }
+						domain={ domain }
+						fetchSiteDomains={ fetchSiteDomains }
+					/>
 				) ) }
 			</tbody>
 		</table>

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -24,4 +24,12 @@
 		font-weight: 500;
 		line-height: 24px;
 	}
+
+	.domains-table__domain-link {
+		color: var(--studio-gray-100);
+
+		&:hover {
+			color: var(--color-link);
+		}
+	}
 }

--- a/packages/domains-table/src/test-utils.tsx
+++ b/packages/domains-table/src/test-utils.tsx
@@ -1,0 +1,125 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render as rtlRender, RenderResult, RenderOptions } from '@testing-library/react';
+import React from 'react';
+import type { PartialDomainData, DomainData } from '@automattic/data-stores';
+
+export function renderWithProvider(
+	ui: React.ReactElement,
+	renderOptions: Omit< RenderOptions, 'queries' > = {}
+): RenderResult {
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children }: { children: React.ReactElement } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+
+	return rtlRender( ui, { wrapper: Wrapper, ...renderOptions } );
+}
+
+export function testDomain(
+	defaults: Partial< DomainData > = {}
+): [ PartialDomainData, DomainData ] {
+	const defaultPartialDomain: PartialDomainData = {
+		domain: 'example.com',
+		blog_id: 113,
+		type: 'mapping',
+		is_wpcom_staging_domain: false,
+		has_registration: true,
+		registration_date: '2020-03-11T22:23:58+00:00',
+		expiry: '2026-03-11T00:00:00+00:00',
+		wpcom_domain: false,
+		current_user_is_owner: true,
+	};
+
+	const partialOnlyDefaults = Object.entries( defaults ).filter( ( [ key ] ) =>
+		Object.hasOwn( defaultPartialDomain, key )
+	);
+
+	const partialDomain = { ...defaultPartialDomain, ...Object.fromEntries( partialOnlyDefaults ) };
+
+	const fullDomain: DomainData = {
+		...defaultPartialDomain,
+		primary_domain: false,
+		subscription_id: '',
+		can_manage_dns_records: false,
+		can_manage_name_servers: false,
+		can_update_contact_info: false,
+		cannot_manage_dns_records_reason: null,
+		cannot_manage_name_servers_reason: null,
+		cannot_update_contact_info_reason: null,
+		connection_mode: null,
+		current_user_can_add_email: false,
+		current_user_can_create_site_from_domain_only: false,
+		current_user_cannot_add_email_reason: null,
+		current_user_can_manage: false,
+		can_set_as_primary: false,
+		domain_notice_states: null,
+		supports_domain_connect: null,
+		email_forwards_count: 0,
+		expiry_soon: false,
+		expired: false,
+		auto_renewing: 0,
+		pending_registration: false,
+		pending_registration_time: '',
+		has_email_forward_dns_records: null,
+		points_to_wpcom: false,
+		privacy_available: false,
+		private_domain: false,
+		partner_domain: false,
+		has_zone: false,
+		is_renewable: false,
+		is_redeemable: false,
+		is_subdomain: false,
+		is_eligible_for_inbound_transfer: false,
+		is_locked: false,
+		transfer_away_eligible_at: '',
+		auto_renewal_date: '',
+		google_apps_subscription: {
+			status: '',
+			is_eligible_for_introductory_offer: false,
+		},
+		titan_mail_subscription: {
+			status: '',
+			is_eligible_for_introductory_offer: false,
+		},
+		pending_whois_update: false,
+		tld_maintenance_end_time: 0,
+		ssl_status: '',
+		supports_gdpr_consent_management: false,
+		supports_transfer_approval: false,
+		domain_registration_agreement_url: '',
+		contact_info_disclosure_available: false,
+		contact_info_disclosed: false,
+		renewable_until: '',
+		redeemable_until: null,
+		bundled_plan_subscription_id: null,
+		product_slug: '',
+		owner: '',
+		pending_renewal: false,
+		aftermarket_auction: false,
+		aftermarket_auction_start: null,
+		aftermarket_auction_end: null,
+		nominet_pending_contact_verification_request: false,
+		nominet_domain_suspended: false,
+		transfer_status: null,
+		last_transfer_error: '',
+		has_private_registration: false,
+		is_pending_icann_verification: false,
+		manual_transfer_required: false,
+		registrar: '',
+		domain_locking_available: false,
+		is_premium: false,
+		transfer_lock_on_whois_update_optional: false,
+		whois_update_unmodifiable_fields: [],
+		is_whois_editable: false,
+		pending_transfer: false,
+		has_wpcom_nameservers: false,
+		...defaults,
+	};
+
+	return [ partialDomain, fullDomain ];
+}
+
+export function testPartialDomain( defaults: Partial< PartialDomainData > = {} ) {
+	return testDomain( defaults )[ 0 ];
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3414

## Proposed Changes

* Refactors `<DomainsTableRow>` into its own component
* Add hyperlink from the table row to the domain's "edit" page
* Adds a new `useSiteDomainsQuery` hook for fetching detailed data about a site's domains
* Updated tests/storybook

The URL for the domain's "edit" page includes the site slug. This isn't data we have access to as part of the payload from `/all-domains`. So while we're loading domain data the hyperlink uses the site ID in place of the site slug.

Eventually in https://github.com/Automattic/dotcom-forge/issues/3422 the detailed domain data won't be fetched until the row has scrolled into view.

Notice that despite the domains table now making its own network requests, it remains testable by doing some very explicit dependency injection. We have other ways to mock network calls in Jest, but not in storybook. [Storybook supports mocking network requests using MSW](https://storybook.js.org/docs/react/writing-stories/build-pages-with-storybook#mocking-connected-components), however we don't use MSW elsewhere in the codebase. The standard tool we use is Nock, but Nock doesn't work in browsers 🤔 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/domains/manage?flags=domains/management` and confirm the domain links work
* "Redirect" domains link to a different page. [You can create a redirect site using these instructions](https://wordpress.com/support/site-redirect/).
* "Transfer" domains also link to a different page. But I don't know how to test those 🤔

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
