### PR TITLE
Domain Management i1: add primary domain label component

### DIFF
--- a/packages/components/src/badge/index.tsx
+++ b/packages/components/src/badge/index.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
-import type { ReactNode } from 'react';
-
+import { memo, forwardRef, ReactNode, HTMLAttributes } from 'react';
 import './style.scss';
 
 export type BadgeType =
@@ -18,6 +17,20 @@ type BadgeProps = {
 	children?: ReactNode;
 };
 
-export default function Badge( { className, children, type = 'warning' }: BadgeProps ) {
-	return <div className={ classNames( `badge badge--${ type }`, className ) }>{ children }</div>;
-}
+const Badge = memo(
+	forwardRef< HTMLDivElement, BadgeProps & HTMLAttributes< HTMLDivElement > >(
+		( { className, children, type = 'warning', ...props }, ref ) => {
+			return (
+				<div
+					ref={ ref }
+					className={ classNames( `badge badge--${ type }`, className ) }
+					{ ...props }
+				>
+					{ children }
+				</div>
+			);
+		}
+	)
+);
+
+export default Badge;

--- a/packages/domains-table/src/index.ts
+++ b/packages/domains-table/src/index.ts
@@ -1,2 +1,3 @@
 export { DomainsTable } from './domains-table';
+export { PrimaryDomainLabel } from './primary-domain-label';
 export { useDomainsTable } from './use-domains-table';

--- a/packages/domains-table/src/primary-domain-label/index.stories.tsx
+++ b/packages/domains-table/src/primary-domain-label/index.stories.tsx
@@ -1,0 +1,22 @@
+import { Meta } from '@storybook/react';
+import React from 'react';
+import { PrimaryDomainLabel } from './index';
+import './stories.scss';
+
+export default {
+	title: 'packages/domains-table/PrimaryDomainLabel',
+	component: PrimaryDomainLabel,
+	parameters: {
+		viewport: {
+			defaultViewport: 'LARGE',
+		},
+	},
+} as Meta;
+
+const Template = () => (
+	<div className="domains-table-stories__primary-domain-label-container">
+		<PrimaryDomainLabel />
+	</div>
+);
+
+export const Default = Template.bind( {} );

--- a/packages/domains-table/src/primary-domain-label/index.tsx
+++ b/packages/domains-table/src/primary-domain-label/index.tsx
@@ -1,0 +1,33 @@
+import { Badge, Gridicon, Popover } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { useRef, useState, ComponentRef } from 'react';
+import './style.scss';
+
+export const PrimaryDomainLabel = () => {
+	const [ showPrimaryDomainInfo, setShowPrimaryDomainInfo ] = useState( false );
+	const { __ } = useI18n();
+	const popoverRef = useRef< ComponentRef< typeof Badge > >( null );
+
+	return (
+		<Badge
+			ref={ popoverRef }
+			className="domains-table__primary-domain-label"
+			type="info-green"
+			onMouseEnter={ () => setShowPrimaryDomainInfo( true ) }
+			onMouseLeave={ () => setShowPrimaryDomainInfo( false ) }
+		>
+			{ __( 'Primary domain' ) }
+			<Gridicon size={ 16 } icon="info-outline" />
+			<Popover
+				className="domains-table__primary-domain-label-popover"
+				position="top right"
+				context={ popoverRef.current }
+				isVisible={ showPrimaryDomainInfo }
+			>
+				<div className="domains-table__primary-domain-label-popover-content">
+					{ __( 'Your other domains will redirect to this primary domain.' ) }
+				</div>
+			</Popover>
+		</Badge>
+	);
+};

--- a/packages/domains-table/src/primary-domain-label/index.tsx
+++ b/packages/domains-table/src/primary-domain-label/index.tsx
@@ -16,7 +16,7 @@ export const PrimaryDomainLabel = () => {
 			onMouseEnter={ () => setShowPrimaryDomainInfo( true ) }
 			onMouseLeave={ () => setShowPrimaryDomainInfo( false ) }
 		>
-			{ __( 'Primary domain' ) }
+			{ __( 'Primary domain', __i18n_text_domain__ ) }
 			<Gridicon size={ 16 } icon="info-outline" />
 			<Popover
 				className="domains-table__primary-domain-label-popover"
@@ -25,7 +25,7 @@ export const PrimaryDomainLabel = () => {
 				isVisible={ showPrimaryDomainInfo }
 			>
 				<div className="domains-table__primary-domain-label-popover-content">
-					{ __( 'Your other domains will redirect to this primary domain.' ) }
+					{ __( 'Your other domains will redirect to this primary domain.', __i18n_text_domain__ ) }
 				</div>
 			</Popover>
 		</Badge>

--- a/packages/domains-table/src/primary-domain-label/stories.scss
+++ b/packages/domains-table/src/primary-domain-label/stories.scss
@@ -1,0 +1,5 @@
+.domains-table-stories__primary-domain-label-container {
+	padding: 128px 0 0 340px;
+	width: 100vw;
+	box-sizing: border-box;
+}

--- a/packages/domains-table/src/primary-domain-label/style.scss
+++ b/packages/domains-table/src/primary-domain-label/style.scss
@@ -1,0 +1,14 @@
+@import "@automattic/typography/styles/variables";
+
+.domains-table__primary-domain-label {
+	display: flex !important;
+	align-items: center;
+	gap: 4px;
+	width: max-content;
+
+	&-popover-content {
+		padding: 16px;
+		font-size: $font-body-small;
+		color: var(--studio-gray-50);
+	}
+}


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3452.

## Proposed Changes

This PR adds the primary domain label component to the `domains-table` package. It's completely context-free and will be introduced to the UI whenever the new version of the site-specific table is included in Calypso.

I didn't make it pixel-perfect with p9Jlb4-8DU-p2 as the priority right now is to get this out the door, then refine the styles.

Here's how it looks: 

![image](https://github.com/Automattic/wp-calypso/assets/26530524/54187c29-540e-4b70-a0f1-3aa3ea206ec0)

## Testing Instructions

Run `yarn storybook:start`, browse `Packages > domains-table > PrimaryDomainLabel` and hover the label component. It should open a tooltip with the "Your other domains will redirect to this primary domain." copy.