### PR TITLE
Fediverse settings: vastly improve everything

### DIFF
--- a/client/my-sites/site-settings/reading-fediverse-settings/JetpackFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/reading-fediverse-settings/JetpackFediverseSettingsSection.js
@@ -4,12 +4,15 @@ import page from 'page';
 import { useSelector } from 'react-redux';
 import QueryPlugins from 'calypso/components/data/query-plugins';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
-import { getSiteDomain } from 'calypso/state/sites/selectors';
+import { getSiteDomain, getSiteAdminUrl } from 'calypso/state/sites/selectors';
 
 export const JetpackFediverseSettingsSection = ( { siteId } ) => {
 	const translate = useTranslate();
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 	const plugin = useSelector( ( state ) => getPluginOnSite( state, siteId, 'activitypub' ) );
+	const adminUrl = useSelector( ( state ) =>
+		getSiteAdminUrl( state, siteId, 'options-general.php?page=activitypub' )
+	);
 	const pluginIsActive = plugin?.active;
 
 	return (
@@ -17,16 +20,27 @@ export const JetpackFediverseSettingsSection = ( { siteId } ) => {
 			<QueryPlugins siteId={ siteId } />
 			<Card className="site-settings__card">
 				<p>
-					The fediverse is a network of social media sites like Mastodon and Pixelfed and Firefish
-					and Peertube and Pleroma, oh my!
+					{ translate(
+						'With ActivityPub your blog becomes part of a federated social network. This means you can share and talk to everyone using the ActivityPub protocol, including users of Mastodon, Friendica, and Pleroma.'
+					) }
 				</p>
 				<p>
-					Your site can publish to the same ActivityPub protocol that powers all of them, just
-					install the ActivityPub plugin:
+					{ translate(
+						'Allow people on the fediverse to follow your site, receive updates, and leave comments.'
+					) }
 				</p>
 				<p>
 					{ pluginIsActive ? (
-						<strong>{ translate( 'ActivityPub is already enabled for your site!' ) }</strong>
+						<>
+							<strong>{ translate( 'ActivityPub is already enabled for your site!' ) }</strong>
+							<p>
+								{ translate( '{{link}}Manage ActivityPub settings{{/link}}', {
+									components: {
+										link: <a href={ adminUrl } />,
+									},
+								} ) }
+							</p>
+						</>
 					) : (
 						<Button primary={ true } onClick={ () => page( `/plugins/activitypub/${ domain }` ) }>
 							{ translate( 'Install ActivityPub' ) }

--- a/client/my-sites/site-settings/reading-fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/reading-fediverse-settings/WpcomFediverseSettingsSection.js
@@ -1,67 +1,64 @@
 import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import ClipboardButton from 'calypso/components/forms/clipboard-button';
-import { getCurrentUserName } from 'calypso/state/current-user/selectors';
+import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
+import { domainAddNew } from 'calypso/my-sites/domains/paths';
 import { successNotice } from 'calypso/state/notices/actions';
-import { getSiteDomain, getSiteTitle } from 'calypso/state/sites/selectors';
+import { getSiteTitle, getSiteDomain } from 'calypso/state/sites/selectors';
 import { useActivityPubStatus } from './hooks';
 
-const CopyButton = ( { alias } ) => {
-	const translate = useTranslate();
-	const [ isCopied, setIsCopied ] = useState( false );
-	const text = isCopied ? translate( '✅ Copied!' ) : <code>{ alias }</code>;
-	const onCopy = () => {
-		setIsCopied( true );
-		setTimeout( () => setIsCopied( false ), 3333 );
-	};
-
+const DomainUpsellCard = ( { siteId } ) => {
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+	const linkUrl = domainAddNew( domain );
 	return (
-		<ClipboardButton text={ alias } onCopy={ onCopy }>
-			{ text }
-		</ClipboardButton>
+		<Card className="site-settings__card">
+			<code>{ '<blink>' }</code>
+			<a href={ linkUrl }>
+				Link to Domain Upsell, with tracking and return path, needs moar design.
+			</a>
+			<code>{ '</blink>' }</code>
+		</Card>
 	);
 };
 
-const EnabledSettingsSection = ( { siteId } ) => {
+const DomainCongratsCard = ( { user } ) => {
 	const translate = useTranslate();
-	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
-	const username = useSelector( getCurrentUserName );
-	const catchallAlias = `${ domain }@${ domain }`;
-	const userAlias = `${ username }@${ domain }`;
-
-	// todo: only show the user alias when the blog has > 1 user, and/or is upgraded.
-	// todo: warnings for non-custom domains
 	return (
 		<Card className="site-settings__card">
-			<p>
-				Lots of cool customizations and bonus features coming soon with WordPress.com Premium and
-				up!
-			</p>
-			<hr />
-			<p>{ translate( 'The fediverse can follow your site with this alias:' ) }</p>
-			<p>
-				<CopyButton alias={ catchallAlias } />
-			</p>
-			<p>Upgraded sites will receive an option for user-based aliases</p>
-			<p>
-				<CopyButton alias={ userAlias } />
-			</p>
+			{ translate(
+				'Your site is using a custom domain! You can now set up a custom ActivityPub alias.'
+			) }
+			<ClipboardButtonInput value={ user } />
 		</Card>
+	);
+};
+
+const EnabledSettingsSection = ( { data, siteId } ) => {
+	const translate = useTranslate();
+	const { blogIdentifier = '', userIdentifier } = data;
+
+	return (
+		<>
+			{ ! data.userIdentifier && <DomainUpsellCard siteId={ siteId } /> }
+			<Card className="site-settings__card">
+				<p>{ translate( 'Anyone in the fediverse can follow your site with this alias:' ) }</p>
+				<p>
+					<ClipboardButtonInput value={ blogIdentifier } />
+				</p>
+			</Card>
+			{ data.userIdentifier && <DomainCongratsCard user={ userIdentifier } /> }
+		</>
 	);
 };
 
 function useDispatchSuccessNotice() {
 	const dispatch = useDispatch();
-	return ( message ) => dispatch( successNotice( message ) );
+	return ( message ) => dispatch( successNotice( message, { duration: 3333 } ) );
 }
 
 export const WpcomFediverseSettingsSection = ( { siteId } ) => {
 	const translate = useTranslate();
-	const { isEnabled, setEnabled, isLoading, isError } = useActivityPubStatus( siteId );
-	const disabled = isLoading || isError;
 	const dispatchSuccessNotice = useDispatchSuccessNotice();
 	const siteTitle = useSelector( ( state ) => getSiteTitle( state, siteId ) );
 	const noticeArgs = {
@@ -69,35 +66,38 @@ export const WpcomFediverseSettingsSection = ( { siteId } ) => {
 			site_title: siteTitle,
 		},
 	};
+	const { isEnabled, setEnabled, isLoading, isError, data } = useActivityPubStatus(
+		siteId,
+		( response ) => {
+			const message = response.enabled
+				? translate( '%(site_title)s has entered the fediverse!', noticeArgs )
+				: translate( '%(site_title)s has exited the fediverse.', noticeArgs );
+			dispatchSuccessNotice( message );
+		}
+	);
+	const disabled = isLoading || isError;
 
-	const onChange = async () => {
-		// Setting the message before the update so the message seems counterintuitive.
-		const message = ! isEnabled
-			? translate( '%(site_title)s has entered the fediverse!', noticeArgs )
-			: translate( '%(site_title)s has exited the fediverse.', noticeArgs );
-
-		await setEnabled( ! isEnabled );
-		dispatchSuccessNotice( message, { duration: 3333 } );
-	};
 	return (
 		<>
 			<Card className="site-settings__card">
 				<p>
-					The fediverse is a network of social media sites like Mastodon and Pixelfed and Firefish
-					and Peertube and Pleroma, oh my!
+					{ translate(
+						'With ActivityPub your blog becomes part of a federated social network. This means you can share and talk to everyone using the ActivityPub protocol, including users of Mastodon, Friendica, and Pleroma.'
+					) }
 				</p>
 				<p>
-					Your site can publish to the same ActivityPub protocol that powers all of them, just
-					enable:
+					{ translate(
+						'Allow people on the fediverse to follow your site, receive updates, and leave comments.'
+					) }
 				</p>
 				<ToggleControl
 					label={ translate( 'Enter the fediverse' ) }
 					disabled={ disabled }
 					checked={ isEnabled }
-					onChange={ onChange }
+					onChange={ ( value ) => setEnabled( value ) }
 				/>
 			</Card>
-			{ isEnabled && <EnabledSettingsSection siteId={ siteId } /> }
+			{ isEnabled && <EnabledSettingsSection data={ data } siteId={ siteId } /> }
 		</>
 	);
 };

--- a/client/my-sites/site-settings/reading-fediverse-settings/hooks.js
+++ b/client/my-sites/site-settings/reading-fediverse-settings/hooks.js
@@ -1,21 +1,21 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
-export const useActivityPubStatus = ( blogId ) => {
-	const queryKey = [ 'activitypub/status', blogId ];
-	const reqArgs = {
-		path: `/sites/${ blogId }/activitypub/status`,
-		apiNamespace: 'wpcom/v2',
-	};
+export const useActivityPubStatus = ( blogId, onUpdate = () => {} ) => {
+	const path = `/sites/${ blogId }/activitypub/status`;
+	const queryKey = [ path ];
 
 	const { data, isInitialLoading, isError } = useQuery( {
 		queryKey,
-		queryFn: () => wpcom.req.get( reqArgs ),
+		queryFn: () => wpcom.req.get( { path, apiNamespace: 'wpcom/v2' } ),
 	} );
 	const queryClient = useQueryClient();
 	const { mutate, isLoading } = useMutation( {
-		mutationFn: ( enabled ) => wpcom.req.post( { body: { enabled }, ...reqArgs } ),
-		onSuccess: ( responseData ) => queryClient.setQueryData( queryKey, responseData ),
+		mutationFn: ( enabled ) => wpcom.req.post( { path, apiNamespace: 'wpcom/v2' }, { enabled } ),
+		onSuccess: ( responseData ) => {
+			queryClient.setQueryData( queryKey, responseData );
+			onUpdate( responseData );
+		},
 	} );
 
 	return {
@@ -23,5 +23,6 @@ export const useActivityPubStatus = ( blogId ) => {
 		setEnabled: mutate,
 		isLoading: isInitialLoading || isLoading,
 		isError,
+		data,
 	};
 };

--- a/client/my-sites/site-settings/reading-fediverse-settings/hooks.js
+++ b/client/my-sites/site-settings/reading-fediverse-settings/hooks.js
@@ -3,15 +3,16 @@ import wpcom from 'calypso/lib/wp';
 
 export const useActivityPubStatus = ( blogId, onUpdate = () => {} ) => {
 	const path = `/sites/${ blogId }/activitypub/status`;
-	const queryKey = [ path ];
+	const apiNamespace = 'wpcom/v2';
+	const queryKey = [ path, apiNamespace ];
 
 	const { data, isInitialLoading, isError } = useQuery( {
 		queryKey,
-		queryFn: () => wpcom.req.get( { path, apiNamespace: 'wpcom/v2' } ),
+		queryFn: () => wpcom.req.get( { path, apiNamespace } ),
 	} );
 	const queryClient = useQueryClient();
 	const { mutate, isLoading } = useMutation( {
-		mutationFn: ( enabled ) => wpcom.req.post( { path, apiNamespace: 'wpcom/v2' }, { enabled } ),
+		mutationFn: ( enabled ) => wpcom.req.post( { path, apiNamespace }, { enabled } ),
 		onSuccess: ( responseData ) => {
 			queryClient.setQueryData( queryKey, responseData );
 			onUpdate( responseData );

--- a/client/my-sites/site-settings/reading-fediverse-settings/hooks.js
+++ b/client/my-sites/site-settings/reading-fediverse-settings/hooks.js
@@ -8,6 +8,8 @@ export const useActivityPubStatus = ( blogId, onUpdate = () => {} ) => {
 
 	const { data, isInitialLoading, isError } = useQuery( {
 		queryKey,
+		staleTime: 2 * 60 * 1000, // 2 mins
+		cacheTime: 10 * 60 * 1000, // 10 mins
 		queryFn: () => wpcom.req.get( { path, apiNamespace } ),
 	} );
 	const queryClient = useQueryClient();


### PR DESCRIPTION
Now that we're getting closer to launch (sshhh don't tell anyone) the fediverse settings panel could really use a refactoring. It still needs refactoring after this, but now mostly localized to the domain upsell. Hurray.

Related to pdtkmj-1ED-p2#comment-3139 and cf.

## Proposed Changes

* make enabling/disabling work properly (`reqArgs` was mutating weirdly)
* use proper `ClipboardButtonInput` instead of rolling my own (dumb)
* use genuine server-side provided identifier/aliases 
* link to ActivityPub settings from Jetpack sites
* less jocular language

Some screenshots of the Fediverse settings in different contexts:

Simple site, free (no domain):
<img width="735" alt="Screenshot 2023-08-16 at 10 58 38" src="https://github.com/Automattic/wp-calypso/assets/195089/d36ff8c0-cc3b-4fff-aaaf-ef97e9d00b0a">

Simple site with domain upgrade:
<img width="732" alt="Screenshot 2023-08-16 at 10 58 14" src="https://github.com/Automattic/wp-calypso/assets/195089/2c2fb9f6-ddb2-449a-b6d2-6901211b6cdb">

Atomic/Jetpack sites:
<img width="734" alt="Screenshot 2023-08-16 at 10 59 05" src="https://github.com/Automattic/wp-calypso/assets/195089/06367a10-d666-4b7c-82a2-91e34125e2e2">


## Testing Instructions

requires D119027-code and sandboxed public-api (update: now landed)

go to Settings -> Reading in local dev (works on calypso.live too) 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
