### PR TITLE
Stats: Updating empty message with a link to doc

### DIFF
--- a/client/my-sites/stats/const.js
+++ b/client/my-sites/stats/const.js
@@ -1,0 +1,3 @@
+// No need to localize this URL, since it's used as the prefix for other localized URLs.
+// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+export const SUPPORT_URL = 'https://wordpress.com/support/stats/';

--- a/client/my-sites/stats/stats-comments/index.jsx
+++ b/client/my-sites/stats/stats-comments/index.jsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { get, flowRight } from 'lodash';
 import PropTypes from 'prop-types';
@@ -13,6 +14,7 @@ import {
 	isRequestingSiteStatsForQuery,
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { SUPPORT_URL } from '../const';
 import StatsErrorPanel from '../stats-error';
 import StatsListCard from '../stats-list/stats-list-card';
 import StatsModuleContent from '../stats-module/content-text';
@@ -132,7 +134,16 @@ class StatsComments extends Component {
 					moduleType="comments"
 					data={ data }
 					title={ translate( 'Comments' ) }
-					emptyMessage={ translate( 'No comments posted' ) }
+					emptyMessage={ translate(
+						'{{link}}Top commentors{{/link}} on your pages will show here.',
+						{
+							comment: '{{link}} links to support documentation.',
+							components: {
+								link: <a href={ localizeUrl( `${ SUPPORT_URL }#:~:text=Comments:` ) } />,
+							},
+							context: 'Stats: Info box label when the Comments module is empty',
+						}
+					) }
 					mainItemLabel={ translate( 'Author' ) }
 					metricLabel={ translate( 'Comments' ) }
 					splitHeader

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { flowRight, get } from 'lodash';
 import { Component } from 'react';
@@ -13,6 +14,7 @@ import {
 	hasSiteStatsQueryFailed,
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { SUPPORT_URL } from '../const';
 import ErrorPanel from '../stats-error';
 import StatsListCard from '../stats-list/stats-list-card';
 import StatsModulePlaceholder from '../stats-module/placeholder';
@@ -148,7 +150,16 @@ class StatModuleFollowers extends Component {
 					} ) ) }
 					usePlainCard
 					title={ translate( 'Subscribers' ) }
-					emptyMessage={ translate( 'No subscribers' ) }
+					emptyMessage={ translate(
+						'Once you get a few, {{link}}your subscribers{{/link}} will appear here.',
+						{
+							comment: '{{link}} links to support documentation.',
+							components: {
+								link: <a href={ localizeUrl( `${ SUPPORT_URL }#subscribers` ) } />,
+							},
+							context: 'Stats: Info box label when the Subscribers module is empty',
+						}
+					) }
 					mainItemLabel={ translate( 'Subscriber' ) }
 					metricLabel={ translate( 'Since' ) }
 					splitHeader

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -1,9 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
-
-// No need to localize this URL, since it's used as the prefix for other localized URLs.
-// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
-const SUPPORT_URL = 'https://wordpress.com/support/stats/';
+import { SUPPORT_URL } from './const';
 
 export default function () {
 	const statsStrings = {};
@@ -143,7 +140,11 @@ export default function () {
 		value: translate( 'Views', {
 			context: 'Stats: module row header for number of views per tag or category.',
 		} ),
-		empty: translate( 'No tagged posts or pages viewed', {
+		empty: translate( 'Most viewed {{link}}tags & categories{{/link}} will be listed here.', {
+			comment: '{{link}} links to support documentation.',
+			components: {
+				link: <a href={ localizeUrl( `${ SUPPORT_URL }#:~:text=Tags%20,%20Categories` ) } />,
+			},
 			context: 'Stats: Info box label when the Tags module is empty',
 		} ),
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80483

## Proposed Changes

* Replaced existing copy with newer copy incorporating links to our support documentation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live branch and select a brand-new site
* Make sure that the link from the empty message goes to the right section of the support documentation
* Make sure that the link from the empty message is correctly localized to the interface language you've selected

| Before | After |
| --- | --- |
| <img width="901" alt="SCR-20230817-jwvl" src="https://github.com/Automattic/wp-calypso/assets/112354940/edd00ead-aab0-44df-9857-4f451c99b94b"> | <img width="885" alt="SCR-20230817-jxad" src="https://github.com/Automattic/wp-calypso/assets/112354940/a2209ac9-14a1-4a74-9ee6-aea910ac08e4"> |
| <img width="884" alt="SCR-20230817-jxhn" src="https://github.com/Automattic/wp-calypso/assets/112354940/1bacc81d-3713-4582-9dc8-dd62d91a0edd"> | <img width="884" alt="SCR-20230817-jxna" src="https://github.com/Automattic/wp-calypso/assets/112354940/f4c59053-2d39-4ba4-b584-974ac7b9f376"> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
