### PR TITLE
Jetpack E2E: don't set `variant: siteEditor` in feature keys if testing Jetpack deploys in `Site Editor: Smoke Test`.

### DIFF
--- a/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
+++ b/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
@@ -163,6 +163,63 @@ const defaultCriteria: FeatureCriteria[] = [
 		atomicVariation: 'wp-previous',
 		accountName: 'jetpackAtomicWpPreviousUser',
 	},
+	// Jetpack Atomic Deploy Users, but with the
+	// variant: siteEditor set.
+	{
+		siteType: 'atomic',
+		gutenberg: 'stable',
+		jetpackTarget: 'wpcom-deployment',
+		variant: 'siteEditor',
+		accountName: 'jetpackAtomicDefaultUser',
+	},
+	{
+		siteType: 'atomic',
+		gutenberg: 'stable',
+		jetpackTarget: 'wpcom-deployment',
+		atomicVariation: 'php-old',
+		variant: 'siteEditor',
+		accountName: 'jetpackAtomicPhpOldUser',
+	},
+	{
+		siteType: 'atomic',
+		gutenberg: 'stable',
+		jetpackTarget: 'wpcom-deployment',
+		atomicVariation: 'php-new',
+		variant: 'siteEditor',
+		accountName: 'jetpackAtomicPhpNewUser',
+	},
+	{
+		siteType: 'atomic',
+		gutenberg: 'stable',
+		jetpackTarget: 'wpcom-deployment',
+		atomicVariation: 'ecomm-plan',
+		variant: 'siteEditor',
+		accountName: 'jetpackAtomicEcommPlanUser',
+	},
+	{
+		siteType: 'atomic',
+		gutenberg: 'stable',
+		jetpackTarget: 'wpcom-deployment',
+		atomicVariation: 'private',
+		variant: 'siteEditor',
+		accountName: 'jetpackAtomicPrivateUser',
+	},
+	{
+		siteType: 'atomic',
+		gutenberg: 'stable',
+		jetpackTarget: 'wpcom-deployment',
+		atomicVariation: 'wp-beta',
+		variant: 'siteEditor',
+		accountName: 'jetpackAtomicWpBetaUser',
+	},
+	{
+		siteType: 'atomic',
+		gutenberg: 'stable',
+		jetpackTarget: 'wpcom-deployment',
+		atomicVariation: 'wp-previous',
+		variant: 'siteEditor',
+		accountName: 'jetpackAtomicWpPreviousUser',
+	},
 	// Atomic GB nightly tests
 	{
 		siteType: 'atomic',

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -80,7 +80,14 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
+			// Switching to or logging into eCommerce plan sites inevitably
+			// loads WP-Admin instead of Calypso, but the rediret occurs
+			// only after Calypso attempts to load.
+			await testAccount.authenticate( page, { url: /wp-admin/ } );
+		} else {
+			await testAccount.authenticate( page );
+		}
 	} );
 
 	it( 'Navigate to Full Site Editor', async function () {
@@ -89,7 +96,7 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 		// eCommerce plan loads WP-Admin for home dashboard,
 		// so instead navigate straight to the FSE page.
 		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
-			await fullSiteEditorPage.visit( testAccount.getSiteURL() );
+			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 		} else {
 			// Explicitly doing sidebar navigation to ensure Calypso navigation is intact.
 			const sidebarComponent = new SidebarComponent( page );

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -39,7 +39,7 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	// no valid match because none of the Jetpack deploy test users in the default criteria have
 	// `variant` keys.
 	let features = envToFeatureKey( envVariables );
-	if ( envVariables.ATOMIC_VARIATION === 'default' ) {
+	if ( envVariables.JETPACK_TARGET !== 'wpcom-deployment' ) {
 		features = { ...features, variant: 'siteEditor' };
 	}
 

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -32,18 +32,8 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	let testAccount: TestAccount;
 	let fullSiteEditorPage: FullSiteEditorPage;
 
-	// Jetpack deploy (`atomicVariation`) and "regular" Calypso E2E have to use different sets of
-	// feature keys that are not mutually compatible.
-	// Regular and CoBlocks runs must override the feature keys to add the `variant: siteEditor` clause.
-	// Meanwhile, for Jetpack deploys the extra `variant` causes `getTestAccountByFeature` to report
-	// no valid match because none of the Jetpack deploy test users in the default criteria have
-	// `variant` keys.
-	let features = envToFeatureKey( envVariables );
-	if ( envVariables.JETPACK_TARGET !== 'wpcom-deployment' ) {
-		features = { ...features, variant: 'siteEditor' };
-	}
-
-	const accountName = getTestAccountByFeature( features, [
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( { ...features, variant: 'siteEditor' }, [
 		// None of our CoBlocks users use block themes, so we need to fall back to the default Gutenberg users
 		// if COBLOCKS_EDGE is set.
 		{

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -32,14 +32,14 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	let testAccount: TestAccount;
 	let fullSiteEditorPage: FullSiteEditorPage;
 
-	// Jetpack deploy (`atomicVariation`) and CoBlocks (`coblocks`) have to use different sets of
-	// feature keys.
-	// Normal and CoBlocks runs need to override the feature keys to specify the `variant: siteEditor`,
-	// otherwise the CoBlocks EDGE test users are returned - which don't have FSE-capable themes.
+	// Jetpack deploy (`atomicVariation`) and "regular" Calypso E2E have to use different sets of
+	// feature keys that are not mutually compatible.
+	// Regular and CoBlocks runs must override the feature keys to add the `variant: siteEditor` clause.
 	// Meanwhile, for Jetpack deploys the extra `variant` causes `getTestAccountByFeature` to report
-	// no valid match, because none of the Jetpack deploy test users contain the key `variant`.
+	// no valid match because none of the Jetpack deploy test users in the default criteria have
+	// `variant` keys.
 	let features = envToFeatureKey( envVariables );
-	if ( ! envVariables.ATOMIC_VARIATION ) {
+	if ( envVariables.ATOMIC_VARIATION === 'default' ) {
 		features = { ...features, variant: 'siteEditor' };
 	}
 

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -71,9 +71,9 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 
 		testAccount = new TestAccount( accountName );
 		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-			// Switching to or logging into eCommerce plan sites inevitably
-			// loads WP-Admin instead of Calypso, but the rediret occurs
-			// only after Calypso attempts to load.
+			// eCommerce plan sites attempt to load Calypso, but with
+			// third-party cookies disabled the fallback route to WP-Admin
+			// kicks in after some time.
 			await testAccount.authenticate( page, { url: /wp-admin/ } );
 		} else {
 			await testAccount.authenticate( page );

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -34,12 +34,12 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 
 	// Jetpack deploy (`atomicVariation`) and CoBlocks (`coblocks`) have to use different sets of
 	// feature keys.
-	// CoBlocks needs to override what `getTestAccountByFeature` would return in case of CoBlocks EDGE and
-	// FSE, so the additional `variant` value is set.
+	// Normal and CoBlocks runs need to override the feature keys to specify the `variant: siteEditor`,
+	// otherwise the CoBlocks EDGE test users are returned - which don't have FSE-capable themes.
 	// Meanwhile, for Jetpack deploys the extra `variant` causes `getTestAccountByFeature` to report
 	// no valid match, because none of the Jetpack deploy test users contain the key `variant`.
 	let features = envToFeatureKey( envVariables );
-	if ( envVariables.COBLOCKS_EDGE ) {
+	if ( ! envVariables.ATOMIC_VARIATION ) {
 		features = { ...features, variant: 'siteEditor' };
 	}
 

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -32,8 +32,18 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	let testAccount: TestAccount;
 	let fullSiteEditorPage: FullSiteEditorPage;
 
-	const features = envToFeatureKey( envVariables );
-	const accountName = getTestAccountByFeature( { ...features, variant: 'siteEditor' }, [
+	// Jetpack deploy (`atomicVariation`) and CoBlocks (`coblocks`) have to use different sets of
+	// feature keys.
+	// CoBlocks needs to override what `getTestAccountByFeature` would return in case of CoBlocks EDGE and
+	// FSE, so the additional `variant` value is set.
+	// Meanwhile, for Jetpack deploys the extra `variant` causes `getTestAccountByFeature` to report
+	// no valid match, because none of the Jetpack deploy test users contain the key `variant`.
+	let features = envToFeatureKey( envVariables );
+	if ( envVariables.COBLOCKS_EDGE ) {
+		features = { ...features, variant: 'siteEditor' };
+	}
+
+	const accountName = getTestAccountByFeature( features, [
 		// None of our CoBlocks users use block themes, so we need to fall back to the default Gutenberg users
 		// if COBLOCKS_EDGE is set.
 		{
@@ -63,16 +73,6 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 			siteType: 'atomic',
 			variant: 'siteEditor',
 			accountName: 'siteEditorAtomicSiteEdgeUser',
-		},
-		// The jetpackAtomicEcommPlanUser already has an FSE-enabled
-		// test site.
-		{
-			gutenberg: 'stable',
-			siteType: 'atomic',
-			variant: 'siteEditor',
-			atomicVariation: 'ecomm-plan',
-			jetpackTarget: 'wpcom-deployment',
-			accountName: 'jetpackAtomicEcommPlanUser',
 		},
 	] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80453.

## Proposed Changes

This PR adds override criterion to the existing list for FSE: Smoke Test spec.

Key changes:
- navigate directly to the FSE page for `ATOMIC_VARIATION=ecomm-plan`.
- when determining a test account to use, only add the `variant: siteEditor` clause if the test being run is for non-Jetpack E2E.

## Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Jetpack E2E Atomic Deploy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
