### PR TITLE
Assembler: Fix Update design flow, the Design Picker CTA takes users to the Launchpad

### DIFF
--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -17,10 +17,12 @@ import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import DesignSetup from './internals/steps-repository/design-setup';
+import ErrorStep from './internals/steps-repository/error-step';
 import FreeSetup from './internals/steps-repository/free-setup';
 import LaunchPad from './internals/steps-repository/launchpad';
 import PatternAssembler from './internals/steps-repository/pattern-assembler/lazy';
 import Processing from './internals/steps-repository/processing-step';
+import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import SiteCreationStep from './internals/steps-repository/site-creation-step';
 import {
 	AssertConditionResult,
@@ -49,6 +51,7 @@ const free: Flow = {
 			{ slug: 'launchpad', component: LaunchPad },
 			{ slug: 'designSetup', component: DesignSetup },
 			{ slug: 'patternAssembler', component: PatternAssembler },
+			{ slug: 'error', component: ErrorStep },
 		];
 	},
 
@@ -86,7 +89,7 @@ const free: Flow = {
 			return navigate( 'processing' );
 		};
 
-		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
+		const submit = ( providedDependencies: ProvidedDependencies = {}, ...results: string[] ) => {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
 
 			switch ( _currentStep ) {
@@ -97,6 +100,10 @@ const free: Flow = {
 					return navigate( 'processing' );
 
 				case 'processing':
+					if ( results.some( ( result ) => result === ProcessingResult.FAILURE ) ) {
+						return navigate( 'error' );
+					}
+
 					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
 						return window.location.replace(
 							addQueryArgs( `/home/${ siteId ?? providedDependencies?.siteSlug }`, {

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -97,7 +97,7 @@ const updateDesign: Flow = {
 					return navigate( `processing?siteSlug=${ siteSlug }&flowToReturnTo=${ flowToReturnTo }` );
 
 				case 'patternAssembler': {
-					return navigate( `processing?siteSlug=${ siteSlug }` );
+					return navigate( `processing?siteSlug=${ siteSlug }&flowToReturnTo=${ flowToReturnTo }` );
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related #80625 #80666

## Proposed Changes

* Click on "Start designing" CTA or "Design your own" button to access the assembler
* Go back from assembler to design picker
* Processing redirects to the site editor
* Handle processing errors in **Update design** and **Free** flows

|BEFORE|AFTER|
|--|--|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/0f2fa877-ffdf-495f-b620-978acbdb64a8">|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/78d5443f-f06e-46dd-aa83-e02d81a8c6b2">|









## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Click on the Calypso live link below 
- Update the URL to `/setup/update-design`
- Click the "Design your own" button or scroll down to click the Assembler CTA.
- Expect to be redirected to the Assembler.
- From the assembler main screen, click "Back" and expect to go to the design picker
- Click again on the "Design your own" button or the Assembler CTA.
- Add patterns and click "Continue"
- Expect to be redirected to the editor and see your patterns

Also, verify that the flow works as expected and redirects to LaunchPad when you pick a theme from the Design Picker.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
