### PR TITLE
Jetpack Error UX: Add Jetpack connection inactivity error message

### DIFF
--- a/client/components/jetpack/connection-health/constants.js
+++ b/client/components/jetpack/connection-health/constants.js
@@ -2,6 +2,7 @@ export const FATAL_ERROR = 'fatal_error';
 export const USER_TOKEN_ERROR = 'user_token_error';
 export const BLOG_TOKEN_ERROR = 'blog_token_error';
 export const HTTP_ERROR = 'http_error';
+export const INACTIVITY_ERROR = 'inactivity_error';
 export const PLUGIN_ERROR = 'plugin_error';
 export const DNS_ERROR = 'dns_error';
 export const UNKNOWN_ERROR = 'unknown_error';

--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -6,6 +6,7 @@ import {
 	USER_TOKEN_ERROR,
 	BLOG_TOKEN_ERROR,
 	HTTP_ERROR,
+	INACTIVITY_ERROR,
 	PLUGIN_ERROR,
 	DNS_ERROR,
 	UNKNOWN_ERROR,
@@ -92,6 +93,19 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 				errorType={ errorType }
 				errorText={ translate(
 					'Jetpack can’t communicate with your site because your site isn’t responding to requests.'
+				) }
+				noticeActionHref={ localizeUrl( 'https://wordpress.com/support/why-is-my-site-down/' ) }
+				noticeActionText={ translate( 'Learn how to fix' ) }
+			/>
+		);
+	}
+
+	if ( errorType === INACTIVITY_ERROR ) {
+		return (
+			<ErrorNotice
+				errorType={ errorType }
+				errorText={ translate(
+					'Jetpack can’t communicate with your site because your site has not been in contact for 7 days.'
 				) }
 				noticeActionHref={ localizeUrl( 'https://wordpress.com/support/why-is-my-site-down/' ) }
 				noticeActionText={ translate( 'Learn how to fix' ) }

--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -105,7 +105,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 			<ErrorNotice
 				errorType={ errorType }
 				errorText={ translate(
-					'Jetpack can’t communicate with your site because your site has not been in contact for 7 days.'
+					"Jetpack can’t communicate with your site because it hasn't seen your site for 7 days."
 				) }
 				noticeActionHref={ localizeUrl( 'https://wordpress.com/support/why-is-my-site-down/' ) }
 				noticeActionText={ translate( 'Learn how to fix' ) }

--- a/client/components/jetpack/connection-health/test/index.jsx
+++ b/client/components/jetpack/connection-health/test/index.jsx
@@ -11,6 +11,7 @@ import {
 	USER_TOKEN_ERROR,
 	BLOG_TOKEN_ERROR,
 	HTTP_ERROR,
+	INACTIVITY_ERROR,
 	PLUGIN_ERROR,
 	DNS_ERROR,
 	UNKNOWN_ERROR,
@@ -142,6 +143,25 @@ describe( 'JetpackConnectionHealthBanner', () => {
 			expect(
 				screen.queryByText(
 					/Jetpack can’t communicate with your site because your site isn’t responding to requests./i
+				)
+			).toBeVisible();
+			expect( screen.queryByText( /Learn how to fix/i ) ).toBeVisible();
+		} );
+
+		test( 'shows inactivity error message', () => {
+			mockError.mockReturnValue( INACTIVITY_ERROR );
+
+			const initialState = {
+				jetpackConnectionHealth: {
+					1: { jetpack_connection_problem: true },
+				},
+			};
+
+			render( <JetpackConnectionHealthBanner siteId={ 1 } />, { initialState } );
+
+			expect(
+				screen.queryByText(
+					/Jetpack can’t communicate with your site because your site has not been in contact for 7 days./i
 				)
 			).toBeVisible();
 			expect( screen.queryByText( /Learn how to fix/i ) ).toBeVisible();

--- a/client/components/jetpack/connection-health/test/index.jsx
+++ b/client/components/jetpack/connection-health/test/index.jsx
@@ -161,7 +161,7 @@ describe( 'JetpackConnectionHealthBanner', () => {
 
 			expect(
 				screen.queryByText(
-					/Jetpack can’t communicate with your site because your site has not been in contact for 7 days./i
+					/Jetpack can’t communicate with your site because it hasn't seen your site for 7 days./i
 				)
 			).toBeVisible();
 			expect( screen.queryByText( /Learn how to fix/i ) ).toBeVisible();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3242

## Proposed Changes

In this PR, I propose to add an error message for the Jetpack connection problem related to a site not being in contact for 7 days.

![Screenshot 2023-08-16 at 16 23 31](https://github.com/Automattic/wp-calypso/assets/727413/f974f3de-7cf4-4b38-a321-5c5281a274ea)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply D118948-code and add a site according to the testing steps there
2. Navigate to the Posts page in Calypso.
3. Confirm that the error message appears
4. Confirm that the "Learn how to fix" link points to the proper page in the documentation.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
