### PR TITLE
Hosting Metrics: Fix data presentation in donut charts

### DIFF
--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -66,10 +66,10 @@ class PieChart extends Component {
 	renderPieChart() {
 		const { transformedData } = this.state;
 
-		return transformedData.map( ( datum ) => {
+		return transformedData.reverse().map( ( datum ) => {
 			return (
 				<path
-					className={ `pie-chart__chart-section-${ datum.sectionNum }` }
+					className={ `pie-chart__chart-section-${ datum.sectionNum } pie-chart__chart-section-${ datum.className }` }
 					key={ datum.name }
 					d={ datum.path }
 				/>

--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -66,7 +66,7 @@ class PieChart extends Component {
 	renderPieChart() {
 		const { transformedData } = this.state;
 
-		return transformedData.reverse().map( ( datum ) => {
+		return transformedData.map( ( datum ) => {
 			return (
 				<path
 					className={ `pie-chart__chart-section-${ datum.sectionNum } pie-chart__chart-section-${ datum.className }` }

--- a/client/components/pie-chart/legend.js
+++ b/client/components/pie-chart/legend.js
@@ -6,19 +6,25 @@ import DataType from './data-type';
 
 const NUM_COLOR_SECTIONS = 3;
 
-function transformData( data ) {
-	return sortBy( data, ( datum ) => datum.value )
-		.reverse()
-		.map( ( datum, index ) => ( {
-			...datum,
-			sectionNum: index % NUM_COLOR_SECTIONS,
-		} ) );
-}
+function transformData( data, regularOrder ) {
+	const sortedData = sortBy( data, ( datum ) => datum.value );
+	const orderedData = regularOrder ? sortedData.reverse() : sortedData;
 
+	return orderedData.map( ( datum, index ) => {
+		const sectionNum = regularOrder
+			? index % NUM_COLOR_SECTIONS
+			: ( orderedData.length - 1 - index ) % NUM_COLOR_SECTIONS; // Inverts colors when regularOrder is false
+		return {
+			...datum,
+			sectionNum,
+		};
+	} );
+}
 class PieChartLegend extends Component {
 	static propTypes = {
 		data: PropTypes.arrayOf( DataType ).isRequired,
 		onlyPercent: PropTypes.bool,
+		regularOrder: PropTypes.bool,
 	};
 
 	state = {
@@ -31,7 +37,7 @@ class PieChartLegend extends Component {
 			return {
 				data: nextProps.data,
 				dataTotal: nextProps.data.reduce( ( sum, { value } ) => sum + value, 0 ),
-				transformedData: transformData( nextProps.data ),
+				transformedData: transformData( nextProps.data, nextProps.regularOrder ),
 			};
 		}
 
@@ -55,6 +61,7 @@ class PieChartLegend extends Component {
 							circleClassName={ `pie-chart__legend-sample-${ datum.sectionNum }` }
 							percent={ percent }
 							description={ datum.description }
+							regularOrder={ this.props.regularOrder }
 						/>
 					);
 				} ) }

--- a/client/components/pie-chart/legend.js
+++ b/client/components/pie-chart/legend.js
@@ -14,6 +14,7 @@ function transformData( data ) {
 			sectionNum: index % NUM_COLOR_SECTIONS,
 		} ) );
 }
+
 class PieChartLegend extends Component {
 	static propTypes = {
 		data: PropTypes.arrayOf( DataType ).isRequired,

--- a/client/components/pie-chart/legend.js
+++ b/client/components/pie-chart/legend.js
@@ -7,15 +7,12 @@ import DataType from './data-type';
 const NUM_COLOR_SECTIONS = 3;
 
 function transformData( data ) {
-	const sortedData = sortBy( data, ( datum ) => datum.value );
-
-	return sortedData.map( ( datum, index ) => {
-		const sectionNum = index % NUM_COLOR_SECTIONS;
-		return {
+	return sortBy( data, ( datum ) => datum.value )
+		.reverse()
+		.map( ( datum, index ) => ( {
 			...datum,
-			sectionNum,
-		};
-	} );
+			sectionNum: index % NUM_COLOR_SECTIONS,
+		} ) );
 }
 class PieChartLegend extends Component {
 	static propTypes = {

--- a/client/components/pie-chart/legend.js
+++ b/client/components/pie-chart/legend.js
@@ -6,14 +6,11 @@ import DataType from './data-type';
 
 const NUM_COLOR_SECTIONS = 3;
 
-function transformData( data, regularOrder ) {
+function transformData( data ) {
 	const sortedData = sortBy( data, ( datum ) => datum.value );
-	const orderedData = regularOrder ? sortedData.reverse() : sortedData;
 
-	return orderedData.map( ( datum, index ) => {
-		const sectionNum = regularOrder
-			? index % NUM_COLOR_SECTIONS
-			: ( orderedData.length - 1 - index ) % NUM_COLOR_SECTIONS; // Inverts colors when regularOrder is false
+	return sortedData.map( ( datum, index ) => {
+		const sectionNum = index % NUM_COLOR_SECTIONS;
 		return {
 			...datum,
 			sectionNum,
@@ -24,7 +21,7 @@ class PieChartLegend extends Component {
 	static propTypes = {
 		data: PropTypes.arrayOf( DataType ).isRequired,
 		onlyPercent: PropTypes.bool,
-		regularOrder: PropTypes.bool,
+		fixedOrder: PropTypes.bool,
 	};
 
 	state = {
@@ -37,7 +34,7 @@ class PieChartLegend extends Component {
 			return {
 				data: nextProps.data,
 				dataTotal: nextProps.data.reduce( ( sum, { value } ) => sum + value, 0 ),
-				transformedData: transformData( nextProps.data, nextProps.regularOrder ),
+				transformedData: transformData( nextProps.data ),
 			};
 		}
 
@@ -47,9 +44,11 @@ class PieChartLegend extends Component {
 	render() {
 		const { transformedData, dataTotal } = this.state;
 
+		const legendItems = this.props.fixedOrder ? this.props.data : transformedData;
+
 		return (
 			<div className="pie-chart__legend">
-				{ transformedData.map( ( datum ) => {
+				{ legendItems.map( ( datum ) => {
 					const percent =
 						dataTotal > 0 ? Math.round( ( datum.value / dataTotal ) * 100 ).toString() : '0';
 
@@ -58,10 +57,9 @@ class PieChartLegend extends Component {
 							key={ datum.name }
 							name={ datum.name }
 							value={ this.props.onlyPercent ? '' : datum.value.toString() }
-							circleClassName={ `pie-chart__legend-sample-${ datum.sectionNum }` }
+							circleClassName={ `pie-chart__legend-sample-${ datum.sectionNum } pie-chart__legend-sample-${ datum.className }` }
 							percent={ percent }
 							description={ datum.description }
-							regularOrder={ this.props.regularOrder }
 						/>
 					);
 				} ) }

--- a/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/index.tsx
@@ -9,8 +9,13 @@ type Props = {
 	title: string;
 	subtitle?: string | React.ReactNode;
 	className?: string;
-	data: Array< { name: string; value: number; description: string | undefined } >;
-	regularOrder?: boolean;
+	data: Array< {
+		name: string;
+		value: number;
+		description: string | undefined;
+		className: string;
+	} >;
+	fixedOrder?: boolean;
 };
 
 export const SiteMonitoringPieChart = ( {
@@ -18,7 +23,7 @@ export const SiteMonitoringPieChart = ( {
 	subtitle,
 	className,
 	data,
-	regularOrder,
+	fixedOrder,
 }: Props ) => {
 	const classes = [ 'site-monitoring-pie-chart', 'site-monitoring__chart' ];
 	if ( className ) {
@@ -35,7 +40,7 @@ export const SiteMonitoringPieChart = ( {
 				{ ! data.length ? <Spinner /> : null }
 				<PieChart data={ data } donut startAngle={ 0 } />
 			</div>
-			<PieChartLegend data={ data } onlyPercent regularOrder={ regularOrder } />
+			<PieChartLegend data={ data } onlyPercent fixedOrder={ fixedOrder } />
 		</div>
 	);
 };

--- a/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/index.tsx
@@ -10,9 +10,16 @@ type Props = {
 	subtitle?: string | React.ReactNode;
 	className?: string;
 	data: Array< { name: string; value: number; description: string | undefined } >;
+	regularOrder?: boolean;
 };
 
-export const SiteMonitoringPieChart = ( { title, subtitle, className, data }: Props ) => {
+export const SiteMonitoringPieChart = ( {
+	title,
+	subtitle,
+	className,
+	data,
+	regularOrder,
+}: Props ) => {
 	const classes = [ 'site-monitoring-pie-chart', 'site-monitoring__chart' ];
 	if ( className ) {
 		classes.push( className );
@@ -28,7 +35,7 @@ export const SiteMonitoringPieChart = ( { title, subtitle, className, data }: Pr
 				{ ! data.length ? <Spinner /> : null }
 				<PieChart data={ data } donut startAngle={ 0 } />
 			</div>
-			<PieChartLegend data={ data } onlyPercent />
+			<PieChartLegend data={ data } onlyPercent regularOrder={ regularOrder } />
 		</div>
 	);
 };

--- a/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/style.scss
+++ b/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/style.scss
@@ -3,6 +3,7 @@
 		height: 250px;
 		width: 250px;
 		max-width: none;
+		transform: scaleX(-1);
 	}
 	.pie-chart__chart-drawing-empty {
 		visibility: hidden;

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -310,12 +310,12 @@ export const MetricsTab = () => {
 				></SiteMonitoringPieChart>
 				<SiteMonitoringPieChart
 					title={ __( 'Response types' ) }
-					subtitle={ __( 'Percentage of dynamic PHP responses versus static content responses' ) }
+					subtitle={ __( 'Percentage of dynamic versus static responses' ) }
 					className="site-monitoring-php-static-pie-chart"
 					data={ getFormattedDataForPieChart( phpVsStaticFormattedData, {
 						php: {
-							name: 'PHP',
-							className: 'php',
+							name: 'Dynamic',
+							className: 'dynamic',
 						},
 						static: {
 							name: 'Static',

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -144,12 +144,20 @@ function useAggregateSiteMetricsData(
 
 function getFormattedDataForPieChart(
 	data: Record< string, number >,
-	labels: Record< string, string >
+	labels: Record<
+		string,
+		{
+			name: string;
+			className?: string;
+		}
+	>
 ) {
 	return Object.keys( data ).map( ( key ) => {
-		const name = labels[ key ] || key;
+		const name = labels[ key ]?.name || key;
+		const className = labels[ key ]?.className || key;
 		return {
 			name,
+			className,
 			value: data[ key ],
 			description: undefined,
 		};
@@ -289,20 +297,32 @@ export const MetricsTab = () => {
 					subtitle={ __( 'Percentage of cache hits versus cache misses' ) }
 					className="site-monitoring-cache-pie-chart"
 					data={ getFormattedDataForPieChart( cacheHitMissFormattedData, {
-						0: 'Cache miss',
-						1: 'Cache hit',
+						1: {
+							name: 'Cache hit',
+							className: 'cache-hit',
+						},
+						0: {
+							name: 'Cache miss',
+							className: 'cache-miss',
+						},
 					} ) }
-					regularOrder={ false }
+					fixedOrder
 				></SiteMonitoringPieChart>
 				<SiteMonitoringPieChart
 					title={ __( 'Response types' ) }
 					subtitle={ __( 'Percentage of dynamic PHP responses versus static content responses' ) }
 					className="site-monitoring-php-static-pie-chart"
 					data={ getFormattedDataForPieChart( phpVsStaticFormattedData, {
-						php: 'PHP',
-						static: 'Static',
+						php: {
+							name: 'PHP',
+							className: 'php',
+						},
+						static: {
+							name: 'Static',
+							className: 'static',
+						},
 					} ) }
-					regularOrder={ true }
+					fixedOrder
 				></SiteMonitoringPieChart>
 			</div>
 			<SiteMonitoringLineChart

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -305,7 +305,7 @@ export const MetricsTab = () => {
 							name: 'Cache miss',
 							className: 'cache-miss',
 						},
-					} ) }
+					} ).reverse() }
 					fixedOrder
 				></SiteMonitoringPieChart>
 				<SiteMonitoringPieChart

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -292,6 +292,7 @@ export const MetricsTab = () => {
 						0: 'Cache miss',
 						1: 'Cache hit',
 					} ) }
+					regularOrder={ false }
 				></SiteMonitoringPieChart>
 				<SiteMonitoringPieChart
 					title={ __( 'Response types' ) }
@@ -301,6 +302,7 @@ export const MetricsTab = () => {
 						php: 'PHP',
 						static: 'Static',
 					} ) }
+					regularOrder={ true }
 				></SiteMonitoringPieChart>
 			</div>
 			<SiteMonitoringLineChart

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -106,7 +106,7 @@
 	gap: 16px;
 	flex-direction: column;
 	.site-monitoring__chart {
-		flex-grow: 1;
+		flex: 1;
 	}
 	@include break-large {
 		flex-direction: row;

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -126,8 +126,8 @@
 }
 
 .site-monitoring-php-static-pie-chart {
-	.pie-chart__chart-section-php,
-	.pie-chart__legend-sample-php {
+	.pie-chart__chart-section-dynamic,
+	.pie-chart__legend-sample-dynamic {
 		fill: #09b585;
 	}
 	.pie-chart__chart-section-static,

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -114,24 +114,24 @@
 }
 
 .site-monitoring-cache-pie-chart {
-	.pie-chart__chart-section-0,
-	.pie-chart__legend-sample-0 {
+	.pie-chart__chart-section-cache-miss,
+	.pie-chart__legend-sample-cache-miss {
 		fill: #bae0f9;
 
 	}
-	.pie-chart__chart-section-1,
-	.pie-chart__legend-sample-1 {
+	.pie-chart__chart-section-cache-hit,
+	.pie-chart__legend-sample-cache-hit {
 		fill: var(--studio-blue-30);
 	}
 }
 
 .site-monitoring-php-static-pie-chart {
-	.pie-chart__chart-section-0,
-	.pie-chart__legend-sample-0 {
+	.pie-chart__chart-section-php,
+	.pie-chart__legend-sample-php {
 		fill: #09b585;
 	}
-	.pie-chart__chart-section-1,
-	.pie-chart__legend-sample-1 {
+	.pie-chart__chart-section-static,
+	.pie-chart__legend-sample-static {
 		fill: var(--studio-green-5);
 	}
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3496
Related to: https://github.com/Automattic/dotcom-forge/issues/3502

## Proposed Changes

This PR makes the data presentation consistent with [Figma design](https://www.figma.com/file/7LKer2QaciNxdOgX7O9oqP/Hosting-Metrics?type=design&node-id=511-1357&mode=design&t=OUZtQTNH5D51UHuE-0):

**Pie Charts**:

<img width="1373" alt="Screenshot 2023-08-16 at 2 20 41 PM" src="https://github.com/Automattic/wp-calypso/assets/25575134/f1a94e54-6a57-4b9d-86bb-353727da879c">

**Suggested Figma design**:

<img width="604" alt="Screenshot 2023-08-16 at 2 21 16 PM" src="https://github.com/Automattic/wp-calypso/assets/25575134/4a6330c3-333a-4749-a2d9-81ba65f4e90b">

Some changes that are included in the PR:

* Making the legend fixed instead of dynamically generating it based on data size 
* Making the chart start in the opposite direction
* Assigning the colors to the chart not based on the data size but based on the CSS class
* Fixing the sizing of the `Response types` chart on mobile
* Making the charts width 50% width each

## Testing Instructions

1. Make sure you have an Atomic site
2. Navigate to `site-monitoring/{yourAtomicSite}?page=metrics`
3. Confirm that the design of the graphs is consistent with Figma design

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
