### PR TITLE
Jetpack E2E: fix `Editor: Post Basic Flow` to work with all atomic variations.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Locator, Page } from 'playwright';
 
 const selectors = {
 	// Post body
@@ -10,6 +10,7 @@ const selectors = {
  */
 export class PublishedPostPage {
 	private page: Page;
+	private anchor: Locator;
 
 	/**
 	 * Constructs an instance of the component.
@@ -18,6 +19,7 @@ export class PublishedPostPage {
 	 */
 	constructor( page: Page ) {
 		this.page = page;
+		this.anchor = this.page.getByRole( 'main' );
 	}
 
 	/**
@@ -83,10 +85,13 @@ export class PublishedPostPage {
 	 *
 	 * @param {string} title Title text to check.
 	 */
-	async validateTitle( title: string ): Promise< void > {
-		const dash = /-/g;
-		title = title.replace( dash, '–' );
-		await this.page.waitForSelector( `:text("${ title }")` );
+	async validateTitle( title: string ) {
+		// The dash is used in the title of the published post is
+		// not a "standard" dash, instead being U+2013.
+		// We have to replace any expectatiosn of "normal" dashes
+		// with the U+2013 version, otherwise the match will fail.
+		const sanitizedTitle = title.replace( /-/g, '–' );
+		await this.anchor.getByRole( 'heading', { name: sanitizedTitle } ).waitFor();
 	}
 
 	/**


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80453.

## Proposed Changes

This PR updates the selectors in `PublishedPostPage.validateTitle` to use modern a11y-based locators.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Jetpack Atomic Deployment

There are no more failures on `Editor: Basic Post Flow` on this branch.
![image](https://github.com/Automattic/wp-calypso/assets/6549265/848cb8ee-0485-456a-b11a-3a4cd710e9ee)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
