### PR TITLE
Renaming the interaction_name key in the event body for Woo Express trial flow

### DIFF
--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -155,7 +155,7 @@ const wooexpress: Flow = {
 					}
 
 					if ( providedDependencies?.pluginsInstalled ) {
-						recordGTMDatalayerEvent( currentStep );
+						recordGTMDatalayerEvent( 'free trial processing' );
 						return exitFlow( `${ adminUrl }admin.php?page=wc-admin` );
 					}
 


### PR DESCRIPTION
Closes Automattic/martech#2066

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This is just a string change from 'processing' to 'free trial processing', to remove ambiguity of what we're tracking here.
* Checking the changeset should be good enough here. It's just changing one string (provided by the `stepName`) to another string.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Just checking the changeset would be sufficient.
* For manual testing:
    * Load Calypso with `cookie-banner` and `ad-tracking` flags set to true.
    * Accept cookie banner depending on your geo
    * Go through the Woo Express trial flow by heading to /setup/wooexpress
    * You will see the GTM container load, and you can inspect the dataLayer by running `window.dataLayer` in the console, look for the `user interaction` entry, and confirm that the interaction_name has changed.
    * You can also test it via the GTM debugger (this requires you to have access to this), via the video shared in the linked issue above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
