### PR TITLE
Update copy for domain redirect nameserver notice

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-redirect-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-redirect-card.tsx
@@ -185,7 +185,15 @@ export default function DomainRedirectCard( {
 					viewBox="2 2 20 20"
 				/>
 				<div className="domain-redirect-card-notice__message">
-					{ translate( 'You are not currently using WordPress.com name servers.' ) }
+					{ translate(
+						'You are currently not using WordPress.com name servers.{{br/}}For redirects to work correctly, please {{a}}use WordPress.com name servers{{/a}}.',
+						{
+							components: {
+								a: <a href="?nameservers=true" />,
+								br: <br />,
+							},
+						}
+					) }
 				</div>
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/settings/cards/domain-redirect-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-redirect-card.tsx
@@ -1,5 +1,7 @@
 import { Button, FormInputValidation } from '@automattic/components';
+import { englishLocales, useLocale } from '@automattic/i18n-utils';
 import { Icon, trash, info } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -31,6 +33,9 @@ export default function DomainRedirectCard( {
 } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const locale = useLocale();
+	const { hasTranslation } = useI18n();
+
 	const { data: redirect, isLoading, isError } = useDomainRedirectQuery( domainName );
 
 	// Manage local state for target url and protocol as we split redirect target into host, path and protocol when we store it
@@ -176,6 +181,22 @@ export default function DomainRedirectCard( {
 			return null;
 		}
 
+		const noticeText =
+			englishLocales.includes( locale ) ||
+			hasTranslation(
+				'Domain redirection requires using WordPress.com nameservers.{{br/}}{{a}}Update your nameservers now{{/a}}.'
+			)
+				? translate(
+						'Domain redirection requires using WordPress.com nameservers.{{br/}}{{a}}Update your nameservers now{{/a}}.',
+						{
+							components: {
+								a: <a href="?nameservers=true" />,
+								br: <br />,
+							},
+						}
+				  )
+				: translate( 'You are not currently using WordPress.com name servers.' );
+
 		return (
 			<div className="domain-redirect-card-notice">
 				<Icon
@@ -184,17 +205,7 @@ export default function DomainRedirectCard( {
 					className="domain-redirect-card-notice__icon gridicon"
 					viewBox="2 2 20 20"
 				/>
-				<div className="domain-redirect-card-notice__message">
-					{ translate(
-						'Domain redirection requires using WordPress.com nameservers.{{br/}}{{a}}Update your nameservers now{{/a}}.',
-						{
-							components: {
-								a: <a href="?nameservers=true" />,
-								br: <br />,
-							},
-						}
-					) }
-				</div>
+				<div className="domain-redirect-card-notice__message">{ noticeText }</div>
 			</div>
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/cards/domain-redirect-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-redirect-card.tsx
@@ -186,7 +186,7 @@ export default function DomainRedirectCard( {
 				/>
 				<div className="domain-redirect-card-notice__message">
 					{ translate(
-						'You are currently not using WordPress.com name servers.{{br/}}For redirects to work correctly, please {{a}}use WordPress.com name servers{{/a}}.',
+						'Domain redirection requires using WordPress.com nameservers.{{br/}}{{a}}Update your nameservers now{{/a}}.',
 						{
 							components: {
 								a: <a href="?nameservers=true" />,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3470

## Proposed Changes

* Update copy to be more informative

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/ed87831a-e6b2-49d8-81d8-2b779caaee0b">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/0e06d801-4fbe-4412-996d-082495ea6494">|

## Testing Instructions



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/domains/manage` and select a domain
* Set name servers to custom, for example:
```
ns1.google.com
ns2.google.com
```
* Check the notice, clicking on the link opens the name server accordion tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
