### PR TITLE
Assembler - Fetch patterns using a new tag called Assembler

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
@@ -15,7 +15,7 @@ const useDotcomPatterns = (
 				method: 'GET',
 				apiVersion: '1.1',
 				query: new URLSearchParams( {
-					tags: 'pattern',
+					tags: 'assembler',
 					pattern_meta: 'is_web',
 					categories: PATTERN_CATEGORIES.join( ',' ),
 				} ).toString(),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-patterns-map-by-category.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-patterns-map-by-category.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useMemo } from 'react';
 import { PATTERN_CATEGORIES } from '../constants';
 import type { Pattern, Category } from '../types';
@@ -8,13 +7,6 @@ const usePatternsMapByCategory = ( patterns: Pattern[], categories: Category[] )
 		const categoriesMap: Record< string, Pattern[] > = {};
 
 		patterns.forEach( ( pattern ) => {
-			// Filter pattern with the meta assembler_waitlist because of rendering issues
-			if (
-				pattern.pattern_meta?.assembler_waitlist &&
-				! isEnabled( 'pattern-assembler/show-waitlist-patterns' )
-			) {
-				return;
-			}
 			Object.keys( pattern.categories ).forEach( ( category ) => {
 				if ( ! PATTERN_CATEGORIES.includes( category ) ) {
 					// Only show allowed categories

--- a/config/development.json
+++ b/config/development.json
@@ -140,7 +140,6 @@
 		"onboarding/import-redesign": true,
 		"p2/p2-plus": true,
 		"page/export": true,
-		"pattern-assembler/show-waitlist-patterns": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -82,7 +82,6 @@
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redesign": true,
 		"p2/p2-plus": true,
-		"pattern-assembler/show-waitlist-patterns": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/production.json
+++ b/config/production.json
@@ -104,7 +104,6 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/import-redesign": true,
 		"p2/p2-plus": true,
-		"pattern-assembler/show-waitlist-patterns": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -111,7 +111,6 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/import-redesign": true,
 		"p2/p2-plus": true,
-		"pattern-assembler/show-waitlist-patterns": false,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fetch patterns using the **tag** `assembler`
* Remove logic for the **pattern_meta** `assembler_waitlist`

We tagged the patterns with the tag `assembler` because that allow us to:

- Maintain and test easily the list of patterns in the assembler - See p1691545917041729-slack-CRWCHQGUB
  - Create pages in dotcompatterns with a query block filtering by `tag` to test the patterns in the assembler
  - Or even simpler, just visit https://dotcompatterns.wordpress.com/tag/assembler/ 

Note: We have created another tag called `assembler_priority` that will be used in Assembler i4 to curate the list of patterns in the list with a "show more" option. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }` 
* Verify you see the same categories and patterns as before, the only change is the query param `tag`

|BEFORE|AFTER|
|--|--|
|<img width="417" alt="Screenshot 2566-08-16 at 17 04 08" src="https://github.com/Automattic/wp-calypso/assets/1881481/49c0e8eb-d421-46de-bb30-e621509efdad">|<img width="418" alt="Screenshot 2566-08-16 at 17 03 05" src="https://github.com/Automattic/wp-calypso/assets/1881481/2e3b3a54-e5c0-45cb-8d6c-b15543a4cc86">|

|BEFORE|AFTER|
|--|--|
|<img width="326" alt="Screenshot 2566-08-16 at 17 05 10" src="https://github.com/Automattic/wp-calypso/assets/1881481/347e46dc-791a-4f7f-9269-e613174a9b02">|<img width="318" alt="Screenshot 2566-08-16 at 17 05 26" src="https://github.com/Automattic/wp-calypso/assets/1881481/e962c3c4-0172-472f-83eb-25f24fe28d88">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
