### PR TITLE
Jetpack Error UX: Add is_atomic property for Jetpack connection health tracks

### DIFF
--- a/client/components/jetpack/connection-health/error-notice.tsx
+++ b/client/components/jetpack/connection-health/error-notice.tsx
@@ -9,7 +9,7 @@ interface Props {
 	errorText: string;
 	noticeActionHref?: string;
 	noticeActionText?: string;
-	isAtomic: bool;
+	isAtomic: boolean;
 }
 
 export const ErrorNotice = ( {

--- a/client/components/jetpack/connection-health/error-notice.tsx
+++ b/client/components/jetpack/connection-health/error-notice.tsx
@@ -9,6 +9,7 @@ interface Props {
 	errorText: string;
 	noticeActionHref?: string;
 	noticeActionText?: string;
+	isAtomic: bool;
 }
 
 export const ErrorNotice = ( {
@@ -16,6 +17,7 @@ export const ErrorNotice = ( {
 	errorText,
 	noticeActionHref,
 	noticeActionText,
+	isAtomic,
 }: Props ) => {
 	const dispatch = useDispatch();
 
@@ -23,6 +25,7 @@ export const ErrorNotice = ( {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_connection_health_issue_click', {
 				error_type: errorType,
+				is_atomic: isAtomic,
 			} )
 		);
 	};
@@ -31,7 +34,7 @@ export const ErrorNotice = ( {
 		<>
 			<TrackComponentView
 				eventName="calypso_jetpack_connection_health_issue_view"
-				eventProperties={ { error_type: errorType } }
+				eventProperties={ { error_type: errorType, is_atomic: isAtomic } }
 			/>
 			<Notice status="is-error" showDismiss={ false } text={ errorText }>
 				{ noticeActionText && noticeActionHref && (

--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -22,8 +22,8 @@ interface Props {
 
 export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 	const translate = useTranslate();
-	const siteIsAutomatedTransfer = useSelector( ( state ) =>
-		isSiteAutomatedTransfer( state, siteId )
+	const siteIsAutomatedTransfer = useSelector(
+		( state ) => !! isSiteAutomatedTransfer( state, siteId )
 	);
 
 	const [ isErrorCheckJetpackConnectionHealth, setIsErrorCheckJetpackConnectionHealth ] =

--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -1,6 +1,8 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import {
 	FATAL_ERROR,
 	USER_TOKEN_ERROR,
@@ -20,6 +22,9 @@ interface Props {
 
 export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 	const translate = useTranslate();
+	const siteIsAutomatedTransfer = useSelector( ( state ) =>
+		isSiteAutomatedTransfer( state, siteId )
+	);
 
 	const [ isErrorCheckJetpackConnectionHealth, setIsErrorCheckJetpackConnectionHealth ] =
 		useState( false );
@@ -52,6 +57,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 					'https://wordpress.com/support/why-is-my-site-down/#theres-an-issue-with-your-domain-name'
 				) }
 				noticeActionText={ translate( 'Learn how to fix' ) }
+				isAtomic={ siteIsAutomatedTransfer }
 			/>
 		);
 	}
@@ -67,6 +73,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 					'https://wordpress.com/support/why-is-my-site-down/#theres-a-critical-error-on-your-site'
 				) }
 				noticeActionText={ translate( 'Learn how to fix' ) }
+				isAtomic={ siteIsAutomatedTransfer }
 			/>
 		);
 	}
@@ -82,6 +89,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 					'https://wordpress.com/support/why-is-my-site-down/#theres-an-issue-with-your-sites-jetpack-connection'
 				) }
 				noticeActionText={ translate( 'Learn how to reconnect Jetpack' ) }
+				isAtomic={ siteIsAutomatedTransfer }
 			/>
 		);
 	}
@@ -95,6 +103,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 				) }
 				noticeActionHref={ localizeUrl( 'https://wordpress.com/support/why-is-my-site-down/' ) }
 				noticeActionText={ translate( 'Learn how to fix' ) }
+				isAtomic={ siteIsAutomatedTransfer }
 			/>
 		);
 	}
@@ -110,6 +119,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 					'https://wordpress.com/support/why-is-my-site-down/#theres-an-issue-with-your-sites-jetpack-connection'
 				) }
 				noticeActionText={ translate( 'Learn how to reactivate Jetpack' ) }
+				isAtomic={ siteIsAutomatedTransfer }
 			/>
 		);
 	}
@@ -121,6 +131,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 				errorText={ translate(
 					'Jetpack can’t communicate with your site. Please contact site administrator.'
 				) }
+				isAtomic={ siteIsAutomatedTransfer }
 			/>
 		);
 	}
@@ -133,6 +144,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 				'https://wordpress.com/support/why-is-my-site-down/#theres-an-issue-with-your-sites-jetpack-connection'
 			) }
 			noticeActionText={ translate( 'Learn how to fix' ) }
+			isAtomic={ siteIsAutomatedTransfer }
 		/>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3491

## Proposed Changes

In this PR, I propose to add the `is_atomic` property to Jetpack connection health tracks.

The following screenshot shows sample message that triggers event that includes the `is_atomic` property:

![Screenshot 2023-08-16 at 16 23 31](https://github.com/Automattic/wp-calypso/assets/727413/06e9ff55-e8b8-48c2-aa16-5d579fffb986)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Load the posts page for a blog with a broken connection
2. Confirm that the message is displayed
3. Click the message link
4. Confirm that there is a track logged for notice view and notice action click
5. Confirm that `is_atomic` property was logged with a track

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
