### PR TITLE
Hosting Metrics: Add unit to second y axis

### DIFF
--- a/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
@@ -34,6 +34,7 @@ interface SeriesProp {
 	label: string;
 	stroke: string;
 	scale?: string;
+	unit?: string;
 }
 
 export function formatChartHour( date: Date ): string {
@@ -94,11 +95,12 @@ function createSeries( series: Array< SeriesProp > ) {
 }
 
 function addExtraScaleIfDefined( series: Array< SeriesProp > ) {
-	const scale = series.find( ( serie ) => serie.scale )?.scale;
-	if ( scale ) {
+	const serie = series.find( ( serie ) => serie.scale );
+
+	if ( serie?.scale ) {
 		return [
 			{
-				scale,
+				scale: serie.scale,
 				side: 1,
 				grid: {
 					show: false,
@@ -109,6 +111,10 @@ function addExtraScaleIfDefined( series: Array< SeriesProp > ) {
 					width: 1,
 					size: 3,
 				},
+				values: ( u: uPlot, ticks: number[] ) =>
+					ticks.map( ( rawValue ) => {
+						return rawValue + ( serie?.unit ? ' ' + serie.unit : '' );
+					} ),
 			},
 		];
 	}

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -279,6 +279,7 @@ export const MetricsTab = () => {
 						label: __( 'Average response time (ms)' ),
 						stroke: '#008763',
 						scale: 'average-response-time',
+						unit: 'ms',
 					},
 				] }
 				isLoading={ isLoadingLineChart }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3494

## Proposed Changes

In this PR, I propose to add the ability to set a unit for an additional y-axis and display the unit along with the value.

<img width="1206" alt="CleanShot 2023-08-16 at 05 26 32@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/b38e9c3b-cc07-4195-9817-2b3d18a7cc74">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/site-monitoring/${siteSlug}`
2. Observe that second axis on the first chart displays `ms`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
