### PR TITLE
Hosting Metrics: Fix header styling on mobile

### DIFF
--- a/client/my-sites/site-monitoring/components/time-range-picker/style.scss
+++ b/client/my-sites/site-monitoring/components/time-range-picker/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .site-monitoring-time-range-picker__controls {
 	max-width: 329px;
 	flex-grow: 1;
@@ -16,7 +19,7 @@
 	justify-content: flex-end;
 	flex-direction: column;
 	gap: 10px;
-	@include breakpoint-deprecated( ">660px" ) {
+	@include break-medium {
 		flex-direction: row;
 		align-items: center;
 	}

--- a/client/my-sites/site-monitoring/components/time-range-picker/style.scss
+++ b/client/my-sites/site-monitoring/components/time-range-picker/style.scss
@@ -13,12 +13,16 @@
 
 .site-monitoring-time-range-picker__container {
 	display: flex;
-	align-items: center;
 	justify-content: flex-end;
+	flex-direction: column;
+	gap: 10px;
+	@include breakpoint-deprecated( ">660px" ) {
+		flex-direction: row;
+		align-items: center;
+	}
 }
 
 .site-monitoring-time-range-picker__heading {
-	margin-right: 10px; /* Adjust the spacing between heading and controls */
 	font-weight: 400;
 	font-size: 0.875rem;
 	line-height: 20px;

--- a/client/my-sites/site-monitoring/components/time-range-picker/style.scss
+++ b/client/my-sites/site-monitoring/components/time-range-picker/style.scss
@@ -2,7 +2,6 @@
 @import "@wordpress/base-styles/mixins";
 
 .site-monitoring-time-range-picker__controls {
-	max-width: 329px;
 	flex-grow: 1;
 	&.segmented-control .segmented-control__item:first-of-type .segmented-control__link {
 		border-top-left-radius: 4px;
@@ -12,6 +11,9 @@
 		border-top-right-radius: 4px;
 		border-bottom-right-radius: 4px;
 	}
+	@include break-medium {
+		max-width: 329px;
+	}
 }
 
 .site-monitoring-time-range-picker__container {
@@ -19,6 +21,7 @@
 	justify-content: flex-end;
 	flex-direction: column;
 	gap: 10px;
+	flex-grow: 1;
 	@include break-medium {
 		flex-direction: row;
 		align-items: center;

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -249,12 +249,21 @@ export const MetricsTab = () => {
 
 	const startDate = moment( timeRange.start * 1000 );
 	const endDate = moment( timeRange.end * 1000 );
-	let dateRange = '';
+	let dateRange = null;
 
 	if ( endDate.isSame( startDate, 'day' ) ) {
 		dateRange = endDate.format( 'LL' );
+		dateRange = (
+			<>
+				<span>{ endDate.format( 'LL' ) }</span>
+			</>
+		);
 	} else {
-		dateRange = `${ startDate.format( 'LL' ) } - ${ endDate.format( 'LL' ) }`;
+		dateRange = (
+			<>
+				<span>{ startDate.format( 'LL' ) }</span> - <span>{ endDate.format( 'LL' ) }</span>
+			</>
+		);
 	}
 
 	return (

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -42,6 +42,12 @@
 
 .site-monitoring__formatted-header.formatted-header.modernized-header.is-left-align {
 	padding-bottom: 24px;
+	margin-left: 16px;
+	margin-right: 16px;
+	@include breakpoint-deprecated( ">660px" ) {
+		margin-left: 0;
+		margin-right: 0;
+	}
 }
 
 .site-monitoring-metrics-tab {

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -70,6 +70,9 @@
 	font-size: $font-title-large;
 	line-height: 40px;
 	color: var(--studio-gray-100);
+	span {
+		white-space: nowrap;
+	}
 }
 
 .site-monitoring__chart {

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -44,7 +44,7 @@
 	padding-bottom: 24px;
 	margin-left: 16px;
 	margin-right: 16px;
-	@include breakpoint-deprecated( ">660px" ) {
+	@include break-medium {
 		margin-left: 0;
 		margin-right: 0;
 	}


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/3502

## Proposed Changes

* Restores left and right margin to mobile heading.
* Puts the 'Time range' label on top for smaller screen widths.

### Before

<img width="511" alt="CleanShot 2023-08-16 at 05 22 43@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/faa7109f-b2d5-4e0a-b0e7-4fd53864acb3">


### After

<img width="516" alt="CleanShot 2023-08-16 at 06 51 03@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/4e21e007-2334-4618-9024-46c337bf1751">

## Testing Instructions

1. Navigate to `/site-monitoring/<site>`
2. Verify everything looks peachy.