### PR TITLE
Add a redirect to plan selection for expired business trial sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -1,9 +1,5 @@
 import config from '@automattic/calypso-config';
-import {
-	PLAN_FREE,
-	PLAN_JETPACK_FREE,
-	PLAN_MIGRATION_TRIAL_MONTHLY,
-} from '@automattic/calypso-products';
+import { PLAN_FREE, PLAN_JETPACK_FREE } from '@automattic/calypso-products';
 import { removeQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
 import { some, startsWith } from 'lodash';
@@ -67,8 +63,7 @@ import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import wasBusinessTrialSite from 'calypso/state/selectors/was-business-trial-site';
-import wasEcommerceTrialSite from 'calypso/state/selectors/was-ecommerce-trial-site';
+import wasTrialSite from 'calypso/state/selectors/was-trial-site';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import {
@@ -299,36 +294,12 @@ function onSelectedSiteAvailable( context ) {
 	}
 
 	// If we had an eCommerce trial, and the user doesn't have an active paid plan,
-	// redirect to
-	if ( wasEcommerceTrialSite( state, selectedSite.ID ) ) {
+	// redirect to fullpage trial expired page.
+	if ( wasTrialSite( state, selectedSite.ID ) ) {
 		// Use getSitePlanSlug() as it ignores expired plans.
 		const currentPlanSlug = getSitePlanSlug( state, selectedSite.ID );
 
 		if ( [ PLAN_FREE, PLAN_JETPACK_FREE ].includes( currentPlanSlug ) ) {
-			const permittedPathPrefixes = [
-				'/checkout/',
-				'/domains/',
-				'/email/',
-				'/export/',
-				'/plans/my-plan/trial-expired/',
-				'/purchases/',
-				'/settings/delete-site/',
-			];
-
-			if ( ! permittedPathPrefixes.some( ( prefix ) => context.pathname.startsWith( prefix ) ) ) {
-				page.redirect( `/plans/my-plan/trial-expired/${ selectedSite.slug }` );
-				return false;
-			}
-
-			context.hideLeftNavigation = true;
-		}
-	}
-
-	if ( wasBusinessTrialSite( state, selectedSite.ID ) ) {
-		// Use getSitePlanSlug() as it ignores expired plans.
-		const currentPlanSlug = getSitePlanSlug( state, selectedSite.ID );
-
-		if ( currentPlanSlug === PLAN_MIGRATION_TRIAL_MONTHLY ) {
 			const permittedPathPrefixes = [
 				'/checkout/',
 				'/domains/',

--- a/client/my-sites/plans/ecommerce-trial/controller.jsx
+++ b/client/my-sites/plans/ecommerce-trial/controller.jsx
@@ -1,8 +1,20 @@
+import wasBusinessTrialSite from 'calypso/state/selectors/was-business-trial-site';
+import wasEcommerceTrialSite from 'calypso/state/selectors/was-ecommerce-trial-site';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import BusinessTrialExpired from '../trials/business-trial-expired';
 import ECommerceTrialExpired from './ecommerce-trial-expired';
 import TrialUpgradeConfirmation from './upgrade-confirmation';
 
 export function trialExpired( context, next ) {
-	context.primary = <ECommerceTrialExpired />;
+	const state = context.store.getState();
+	const selectedSite = getSelectedSite( state );
+
+	if ( wasEcommerceTrialSite( state, selectedSite.ID ) ) {
+		context.primary = <ECommerceTrialExpired />;
+	} else if ( wasBusinessTrialSite( state, selectedSite.ID ) ) {
+		context.primary = <BusinessTrialExpired />;
+	}
+
 	next();
 }
 

--- a/client/my-sites/plans/trials/business-trial-expired/index.tsx
+++ b/client/my-sites/plans/trials/business-trial-expired/index.tsx
@@ -1,0 +1,95 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { Button, Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo } from 'react';
+import QueryPlans from 'calypso/components/data/query-plans';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import Main from 'calypso/components/main';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useSelector } from 'calypso/state';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import './style.scss';
+import { BusinessTrialPlans } from '../business-trial-plans';
+
+const BusinessTrialExpired = (): JSX.Element => {
+	const translate = useTranslate();
+	const selectedSite = useSelector( getSelectedSite );
+	const siteId = selectedSite?.ID ?? null;
+	const siteSlug = selectedSite?.slug ?? null;
+	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
+	const siteIsAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
+
+	const nonBusinessTrialPurchases = useMemo(
+		() =>
+			sitePurchases.filter( ( purchase ) => purchase.productSlug !== PLAN_MIGRATION_TRIAL_MONTHLY ),
+		[ sitePurchases ]
+	);
+
+	const triggerPlansGridTracksEvent = useCallback( ( planSlug: string ) => {
+		recordTracksEvent( 'calypso_business_expired_trial_upgrade_cta_clicked', {
+			location: 'plans_grid',
+			plan_slug: planSlug,
+		} );
+	}, [] );
+
+	// Note that the Calypso URL always works, so we only want the wp-admin URL when we have the site's URL.
+	const exportUrl =
+		siteIsAtomic && selectedSite?.URL
+			? `${ selectedSite.URL }/wp-admin/export.php`
+			: `/export/${ siteSlug }`;
+
+	return (
+		<>
+			<QueryPlans />
+			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
+			<BodySectionCssClass bodyClass={ [ 'is-expired-business-trial-plan' ] } />
+			<Main wideLayout>
+				<PageViewTracker
+					path="/plans/my-plan/trial-expired/:site"
+					title="Plans > Business Trial Expired"
+				/>
+				<div className="business-trial-expired__content">
+					<div className="business-trial-expired__header">
+						<h1 className="business-trial-expired__title">
+							{ translate( 'Your free trial has ended' ) }
+						</h1>
+						<div className="business-trial-expired__subtitle">
+							{ translate(
+								'Don’t lose all that hard work! Upgrade to a paid plan to continue working on your site.'
+							) }
+						</div>
+						{ nonBusinessTrialPurchases && nonBusinessTrialPurchases.length > 0 && (
+							<div className="business-trial-expired__manage-purchases">
+								<a href={ `/purchases/subscriptions/${ siteSlug }` }>
+									{ translate( 'Manage your previous purchases' ) }
+								</a>
+							</div>
+						) }
+					</div>
+				</div>
+				<BusinessTrialPlans
+					siteId={ siteId ?? 0 }
+					siteSlug={ siteSlug ?? '' }
+					triggerTracksEvent={ triggerPlansGridTracksEvent }
+				/>
+
+				<div className="business-trial-expired__footer">
+					<Button href={ exportUrl }>
+						<Gridicon icon="cloud-download" />
+						<span>{ translate( 'Export your content' ) }</span>
+					</Button>
+					<Button href={ `/settings/delete-site/${ siteSlug }` } scary>
+						<Gridicon icon="trash" />
+						<span>{ translate( 'Delete your site permanently' ) }</span>
+					</Button>
+				</div>
+			</Main>
+		</>
+	);
+};
+
+export default BusinessTrialExpired;

--- a/client/my-sites/plans/trials/business-trial-expired/style.scss
+++ b/client/my-sites/plans/trials/business-trial-expired/style.scss
@@ -1,0 +1,59 @@
+@import "@automattic/typography/styles/woo-commerce";
+@import "@wordpress/base-styles/breakpoints";
+
+body.is-section-plans.is-expired-business-trial-plan {
+	&.color-scheme {
+		--color-surface-backdrop: var(--color-surface);
+	}
+
+	.main.is-wide-layout {
+		@media ( max-width: $break-medium ) {
+			padding-left: 20px;
+			padding-right: 20px;
+		}
+	}
+
+	.business-trial-expired__content {
+		text-align: center;
+
+		@media ( max-width: $break-medium ) {
+			padding-top: 40px;
+		}
+
+		.business-trial-expired__title {
+			font-size: $woo-font-title-medium;
+
+			@media ( min-width: $break-medium ) {
+				font-size: $woo-font-title-large;
+			}
+		}
+
+		.business-trial-expired__subtitle {
+			margin: 16px auto 0;
+
+			@media ( min-width: $break-medium ) {
+				max-width: 580px;
+			}
+		}
+
+		.business-trial-expired__manage-purchases {
+			font-size: $woo-font-body-extra-small;
+			margin-top: 16px;
+		}
+	}
+
+	.business-trial-expired__footer {
+		border-top: 1px solid var(--color-border-subtle);
+		display: flex;
+		flex-direction: column;
+		gap: 2em;
+		justify-content: center;
+		margin: auto;
+		max-width: 800px;
+		padding-top: 1.5em;
+
+		@media ( min-width: $break-small ) {
+			flex-direction: row;
+		}
+	}
+}

--- a/client/state/selectors/was-business-trial-site.ts
+++ b/client/state/selectors/was-business-trial-site.ts
@@ -4,5 +4,5 @@ import type { AppState } from 'calypso/types';
 export default function wasBusinessTrialSite( state: AppState, siteId: number ) {
 	const site = getRawSite( state, siteId );
 
-	return site?.plan?.is_free && site?.was_migration_trial;
+	return site?.was_migration_trial;
 }

--- a/client/state/selectors/was-business-trial-site.ts
+++ b/client/state/selectors/was-business-trial-site.ts
@@ -1,8 +1,8 @@
-import { getSite } from '../sites/selectors';
+import getRawSite from './get-raw-site';
 import type { AppState } from 'calypso/types';
 
 export default function wasBusinessTrialSite( state: AppState, siteId: number ) {
-	const site = getSite( state, siteId );
+	const site = getRawSite( state, siteId );
 
-	return site?.was_migration_trial === true;
+	return site?.plan?.is_free && site?.was_migration_trial;
 }

--- a/client/state/selectors/was-business-trial-site.ts
+++ b/client/state/selectors/was-business-trial-site.ts
@@ -1,0 +1,8 @@
+import { getSite } from '../sites/selectors';
+import type { AppState } from 'calypso/types';
+
+export default function wasBusinessTrialSite( state: AppState, siteId: number ) {
+	const site = getSite( state, siteId );
+
+	return site?.was_migration_trial === true;
+}

--- a/client/state/selectors/was-trial-site.ts
+++ b/client/state/selectors/was-trial-site.ts
@@ -1,0 +1,7 @@
+import { AppState } from 'calypso/types';
+import wasBusinessTrialSite from './was-business-trial-site';
+import wasEcommerceTrialSite from './was-ecommerce-trial-site';
+
+export default function wasTrialSite( state: AppState, siteId: number ) {
+	return wasEcommerceTrialSite( state, siteId ) || wasBusinessTrialSite( state, siteId );
+}

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -23,6 +23,7 @@ export const SITE_REQUEST_FIELDS = [
 	'is_wpcom_atomic',
 	'is_wpcom_staging_site',
 	'was_ecommerce_trial',
+	'was_migration_trial',
 	'description',
 	'user_interactions',
 ].join();

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -131,6 +131,7 @@ export interface SiteDetails {
 	title: string;
 	visible?: boolean;
 	was_ecommerce_trial?: boolean;
+	was_migration_trial?: boolean;
 	wpcom_url?: string;
 	user_interactions?: string[];
 


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/80417
Related to: https://github.com/Automattic/wp-calypso/issues/80694

## Proposed Changes
Please take a look at the related issue for a description.

* Added the new redirect page
* Added new `wasTrialSite` selector
* Added a check for the free plan in the `wasBusinessTrialSite` selector.
* Fix: missing `was_migration_trial` in types and constants

## Testing Instructions

You need:
1. A business trial plan site
2. An expired business trial plan site
3. A woocommerce trial plan site
4. An expired woocommerce trial plan site

Open the four sites, and for the four of those:
1. **Business trial plan site**: nothing must happen
2. **Expired business trial plan site**: you should be redirected to `/plans/my-plan/trial-expired/_SLUG_` with the new business trial page
3. **WooCommerce trial plan site**: nothing must happen
4. **Expired WooCommerce trial plan site**: you should be redirected to `/plans/my-plan/trial-expired/_SLUG_` with woocommerce plan page

![image](https://github.com/Automattic/wp-calypso/assets/167611/faca9a2b-2361-4936-aae8-6add902639cd)

![image](https://github.com/Automattic/wp-calypso/assets/167611/c0052ae2-8fe9-4ba9-b65f-46d635704fbf)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
