### PR TITLE
Hosting metrics: replace breakpoint-deprecated

### DIFF
--- a/client/my-sites/site-monitoring/components/time-range-picker/style.scss
+++ b/client/my-sites/site-monitoring/components/time-range-picker/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .site-monitoring-time-range-picker__controls {
 	max-width: 329px;
 	flex-grow: 1;
@@ -16,7 +19,7 @@
 	justify-content: flex-end;
 	flex-direction: column;
 	gap: 10px;
-	@include breakpoint-deprecated( ">660px" ) {
+	@include break-medium {
 		flex-direction: row;
 		align-items: center;
 	}

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -44,7 +44,7 @@
 	padding-bottom: 24px;
 	margin-left: 16px;
 	margin-right: 16px;
-	@include breakpoint-deprecated( ">660px" ) {
+	@include break-medium {
 		margin-left: 0;
 		margin-right: 0;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/wp-calypso/pull/80692
- https://github.com/Automattic/dotcom-forge/issues/3502

