### PR TITLE
Newsletter Settings: Switch newsletter settings page feature flag to production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -108,6 +108,7 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/modernize-reading-settings": true,
+		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,
 		"signup/design-picker-pattern-assembler": true,

--- a/config/production.json
+++ b/config/production.json
@@ -133,6 +133,7 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/modernize-reading-settings": true,
+		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -129,6 +129,7 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/modernize-reading-settings": true,
+		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -141,6 +141,7 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/modernize-reading-settings": true,
+		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR will release the new dedicated Newsletter Settings page in Calypso
* Merge this PR only once we are ready to release the new dedicated Newsletter Settings page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
