### PR TITLE
I18N: Localise Related content dummy date

### DIFF
--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -92,12 +92,13 @@ export const RelatedPostsSetting = ( {
 					}
 				) }
 			</FormSettingExplanation>
-
 			<RelatedContentPreview
 				showContext={ fields.jetpack_relatedposts_show_context }
 				showDate={ fields.jetpack_relatedposts_show_date }
 				showHeadline={ fields.jetpack_relatedposts_show_headline }
 				showThumbnails={ fields.jetpack_relatedposts_show_thumbnails }
+				dateFormat={ fields.date_format }
+				timezoneString={ fields.timezone_string }
 			/>
 		</FormFieldset>
 	);

--- a/client/my-sites/site-settings/related-posts/related-content-preview.jsx
+++ b/client/my-sites/site-settings/related-posts/related-content-preview.jsx
@@ -1,5 +1,9 @@
 import { localize } from 'i18n-calypso';
 import FormLabel from 'calypso/components/forms/form-label';
+import {
+	getLocalizedDate,
+	phpToMomentDatetimeFormat,
+} from 'calypso/my-sites/site-settings/date-time-format/utils';
 
 const RelatedContentPreview = ( {
 	showContext,
@@ -7,6 +11,8 @@ const RelatedContentPreview = ( {
 	showHeadline,
 	showThumbnails,
 	translate,
+	dateFormat,
+	timezoneString,
 } ) => {
 	const posts = [
 		{
@@ -40,7 +46,13 @@ const RelatedContentPreview = ( {
 			} ),
 		},
 	];
-	const postDate = `August 8, ${ new Date().getFullYear() - 1 }`;
+	let postDate = '';
+	if ( dateFormat && timezoneString ) {
+		const localizedDate = getLocalizedDate( timezoneString );
+		postDate = phpToMomentDatetimeFormat( localizedDate, dateFormat );
+	} else {
+		postDate = `August 8, ${ new Date().getFullYear() - 1 }`;
+	}
 
 	return (
 		<div className="related-posts__preview">

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -45,6 +45,8 @@ type Fields = {
 	wpcom_reader_views_enabled?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
 	sm_enabled?: boolean;
+	date_format?: string;
+	timezone_string?: string;
 };
 
 const getFormSettings = ( settings: unknown & Fields ) => {
@@ -69,6 +71,8 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 		wpcom_reader_views_enabled,
 		wpcom_subscription_emails_use_excerpt,
 		sm_enabled,
+		date_format,
+		timezone_string,
 	} = settings;
 
 	return {
@@ -88,6 +92,8 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 		wpcom_reader_views_enabled: !! wpcom_reader_views_enabled,
 		wpcom_subscription_emails_use_excerpt: !! wpcom_subscription_emails_use_excerpt,
 		sm_enabled: !! sm_enabled,
+		date_format: date_format,
+		timezone_string: timezone_string,
 	};
 };
 


### PR DESCRIPTION
## Proposed Changes

On https://wordpress.com/settings/reading/, when activating the “Show post publish date” option in the Related Posts options, the date displayed below the sample posts is in the American format instead of the localized format set in https://wordpress.com/settings/writing/.

![image](https://github.com/Automattic/wp-calypso/assets/23708351/ecbba60b-404b-4118-b3d4-6f6483a77632)

This PR updates the dummy date to take into account the set format and timezone:
<img width="718" alt="image" src="https://github.com/Automattic/wp-calypso/assets/23708351/859ad63f-d0ad-4334-81b6-9442f2f1650c">


## Testing Instructions
1. Switch your Calypso locale to a Mag-16 one. 
1. Navigate to https://wordpress.com/settings/writing/ for a simple site and set a custom date format
1. Navigate to https://wordpress.com/settings/reading/, enable “Show post publish date” option in the Related Posts options and confirm the shown date is using the format you set.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
