### PR TITLE
Subscribe modal toggle: update copy

### DIFF
--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -1,5 +1,5 @@
 import { ToggleControl } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 
 export const SUBSCRIBE_MODAL_OPTION = 'sm_enabled';
@@ -9,6 +9,14 @@ type SubscribeModalSettingProps = {
 	handleToggle: ( field: string ) => ( value: boolean ) => void;
 	disabled?: boolean;
 };
+
+const isModalToggleTranslated =
+	getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'Enable subscriber pop-up' );
+const isModalToggleHelpTranslated =
+	getLocaleSlug()?.startsWith( 'en' ) ||
+	i18n.hasTranslation(
+		'Grow your subscriber list by enabling a pop-up modal with a subscribe form. This will show as readers scroll.'
+	);
 
 export const SubscribeModalSetting = ( {
 	value = false,
@@ -23,12 +31,20 @@ export const SubscribeModalSetting = ( {
 				checked={ !! value }
 				onChange={ handleToggle( SUBSCRIBE_MODAL_OPTION ) }
 				disabled={ disabled }
-				label={ translate( 'Enable subscriber modal' ) }
+				label={
+					isModalToggleTranslated
+						? translate( 'Enable subscriber pop-up' )
+						: translate( 'Enable subscriber modal' )
+				}
 			/>
 			<FormSettingExplanation>
-				{ translate(
-					'Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll.'
-				) }
+				{ isModalToggleHelpTranslated
+					? translate(
+							'Grow your subscriber list by enabling a pop-up modal with a subscribe form. This will show as readers scroll.'
+					  )
+					: translate(
+							'Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll.'
+					  ) }
 			</FormSettingExplanation>
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Jetpack version in https://github.com/Automattic/jetpack/pull/32512

## Proposed Changes

* Update subscribe modal toggle copy

Updates copies in a way that allows merging right away without waiting for translations. We'll need to follow back to clean up.

<img width="770" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/5197434b-6f00-40a1-b228-46326caef027">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Newsletter settings
* See modal copy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
