### PR TITLE
Subscribe modal: remove gating for newsletter flow

### DIFF
--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -4,7 +4,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
-import { useSiteOption } from 'calypso/state/sites/hooks';
 import { NewsletterCategoriesSettings } from '../newsletter-categories-settings';
 import { SubscriptionOptions } from '../settings-reading/main';
 import { EmailsTextSetting } from './EmailsTextSetting';
@@ -41,8 +40,6 @@ export const NewsletterSettingsSection = ( {
 	savedSubscriptionOptions,
 	updateFields,
 }: NewsletterSettingsSectionProps ) => {
-	const siteIntent = useSiteOption( 'site_intent' );
-	const isNewsletterSite = siteIntent === 'newsletter';
 	const translate = useTranslate();
 	const {
 		wpcom_featured_image_in_email,
@@ -95,15 +92,13 @@ export const NewsletterSettingsSection = ( {
 					disabled={ disabled }
 				/>
 			</Card>
-			{ isNewsletterSite && (
-				<Card className="site-settings__card">
-					<SubscribeModalSetting
-						value={ sm_enabled }
-						handleToggle={ handleToggle }
-						disabled={ disabled }
-					/>
-				</Card>
-			) }
+			<Card className="site-settings__card">
+				<SubscribeModalSetting
+					value={ sm_enabled }
+					handleToggle={ handleToggle }
+					disabled={ disabled }
+				/>
+			</Card>
 			<Card className="site-settings__card">
 				<ExcerptSetting
 					value={ wpcom_subscription_emails_use_excerpt }


### PR DESCRIPTION

## Proposed Changes

* Remove client-side gating for subscribe modal for newsletter sites only

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the toggle appears (and works!) for non-newlsetter flow sites (e.g. /setup/free) and newsletter sites. Test different themes.


<img width="806" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/108f6077-ecd0-4907-af8a-de1b962235c0">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
