### PR TITLE
Subscribe modal: add back edit link

### DIFF
--- a/client/data/themes/use-active-theme-query.ts
+++ b/client/data/themes/use-active-theme-query.ts
@@ -9,6 +9,7 @@ interface ThemeSupports {
 
 export type ActiveTheme = {
 	is_block_theme: boolean;
+	template: string;
 	theme_supports: ThemeSupports;
 };
 

--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -43,7 +43,7 @@ export const SubscribeModalSetting = ( {
 	const subscribeModalEditorUrl = themeSlug
 		? addQueryArgs( siteEditorUrl, {
 				postType: 'wp_template_part',
-				postId: `${ themeSlug }//subscribe-modal`,
+				postId: `${ themeSlug }//jetpack-subscribe-modal`,
 				canvas: 'edit',
 		  } )
 		: siteEditorUrl;

--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -35,7 +35,7 @@ export const SubscribeModalSetting = ( {
 	// Construct a link to edit the modal
 	const { data: activeThemeData } = useActiveThemeQuery( siteId, true );
 	const isFSEActive = activeThemeData?.[ 0 ]?.is_block_theme ?? false;
-	const themeSlug = activeThemeData?.[ 0 ]?.template; // stylesheet | template;
+	const themeSlug = activeThemeData?.[ 0 ]?.template;
 	const siteEditorUrl = useSelector( ( state: object ) => getSiteEditorUrl( state, siteId ) );
 	const subscribeModalEditorUrl = isFSEActive
 		? addQueryArgs( siteEditorUrl, {

--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import { getSiteOption } from 'calypso/state/sites/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export const SUBSCRIBE_MODAL_OPTION = 'sm_enabled';
 
@@ -33,12 +33,12 @@ export const SubscribeModalSetting = ( {
 	const translate = useTranslate();
 
 	// Construct a link to edit the modal
-	const selectedSite = useSelector( getSelectedSite );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const siteEditorUrl = useSelector( ( state: object ) =>
-		getSiteEditorUrl( state, selectedSite?.ID || null )
+		getSiteEditorUrl( state, selectedSiteId )
 	);
 	const themeSlug = useSelector( ( state ) =>
-		getSiteOption( state, selectedSite?.ID, 'theme_slug' )
+		getSiteOption( state, selectedSiteId, 'theme_slug' )
 	);
 	const subscribeModalEditorUrl = themeSlug
 		? addQueryArgs( siteEditorUrl, {
@@ -46,7 +46,7 @@ export const SubscribeModalSetting = ( {
 				postId: `${ themeSlug }//jetpack-subscribe-modal`,
 				canvas: 'edit',
 		  } )
-		: siteEditorUrl;
+		: false;
 
 	return (
 		<>
@@ -68,7 +68,7 @@ export const SubscribeModalSetting = ( {
 					: translate(
 							'Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll.'
 					  ) }
-				{ isModalEditTranslated && (
+				{ isModalEditTranslated && subscribeModalEditorUrl && (
 					<>
 						{ ' ' }
 						<ExternalLink href={ subscribeModalEditorUrl }>

--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -3,10 +3,9 @@ import { addQueryArgs } from '@wordpress/url';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
-import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-
 export const SUBSCRIBE_MODAL_OPTION = 'sm_enabled';
 
 type SubscribeModalSettingProps = {
@@ -31,16 +30,14 @@ export const SubscribeModalSetting = ( {
 	disabled,
 }: SubscribeModalSettingProps ) => {
 	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) as number;
 
 	// Construct a link to edit the modal
-	const selectedSiteId = useSelector( getSelectedSiteId );
-	const siteEditorUrl = useSelector( ( state: object ) =>
-		getSiteEditorUrl( state, selectedSiteId )
-	);
-	const themeSlug = useSelector( ( state ) =>
-		getSiteOption( state, selectedSiteId, 'theme_slug' )
-	);
-	const subscribeModalEditorUrl = themeSlug
+	const { data: activeThemeData } = useActiveThemeQuery( siteId, true );
+	const isFSEActive = activeThemeData?.[ 0 ]?.is_block_theme ?? false;
+	const themeSlug = activeThemeData?.[ 0 ]?.template; // stylesheet | template;
+	const siteEditorUrl = useSelector( ( state: object ) => getSiteEditorUrl( state, siteId ) );
+	const subscribeModalEditorUrl = isFSEActive
 		? addQueryArgs( siteEditorUrl, {
 				postType: 'wp_template_part',
 				postId: `${ themeSlug }//jetpack-subscribe-modal`,

--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -3,7 +3,9 @@ import { addQueryArgs } from '@wordpress/url';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 export const SUBSCRIBE_MODAL_OPTION = 'sm_enabled';
 
@@ -31,11 +33,20 @@ export const SubscribeModalSetting = ( {
 	const translate = useTranslate();
 
 	// Construct a link to edit the modal
-	const editApiUrl = 'https://wordpress.com'; // @TODO
-	const siteSlug = useSelector( getSelectedSiteSlug ); // alternatively get getSelectedSiteId or whole object getSelectedSite
-	const subscribeModalEditUrl = addQueryArgs( editApiUrl, {
-		siteSlug,
-	} );
+	const selectedSite = useSelector( getSelectedSite );
+	const siteEditorUrl = useSelector( ( state: object ) =>
+		getSiteEditorUrl( state, selectedSite?.ID || null )
+	);
+	const themeSlug = useSelector( ( state ) =>
+		getSiteOption( state, selectedSite?.ID, 'theme_slug' )
+	);
+	const subscribeModalEditorUrl = themeSlug
+		? addQueryArgs( siteEditorUrl, {
+				postType: 'wp_template_part',
+				postId: `${ themeSlug }//subscribe-modal`,
+				canvas: 'edit',
+		  } )
+		: siteEditorUrl;
 
 	return (
 		<>
@@ -60,7 +71,7 @@ export const SubscribeModalSetting = ( {
 				{ isModalEditTranslated && (
 					<>
 						{ ' ' }
-						<ExternalLink href={ subscribeModalEditUrl }>
+						<ExternalLink href={ subscribeModalEditorUrl }>
 							{ translate( 'Preview and edit the popup' ) }
 						</ExternalLink>
 					</>

--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -1,6 +1,9 @@
-import { ToggleControl } from '@wordpress/components';
+import { ExternalLink, ToggleControl } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 export const SUBSCRIBE_MODAL_OPTION = 'sm_enabled';
 
@@ -10,6 +13,8 @@ type SubscribeModalSettingProps = {
 	disabled?: boolean;
 };
 
+const isModalEditTranslated =
+	getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'Preview and edit the popup' );
 const isModalToggleTranslated =
 	getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'Enable subscriber pop-up' );
 const isModalToggleHelpTranslated =
@@ -24,6 +29,13 @@ export const SubscribeModalSetting = ( {
 	disabled,
 }: SubscribeModalSettingProps ) => {
 	const translate = useTranslate();
+
+	// Construct a link to edit the modal
+	const editApiUrl = 'https://wordpress.com'; // @TODO
+	const siteSlug = useSelector( getSelectedSiteSlug ); // alternatively get getSelectedSiteId or whole object getSelectedSite
+	const subscribeModalEditUrl = addQueryArgs( editApiUrl, {
+		siteSlug,
+	} );
 
 	return (
 		<>
@@ -45,6 +57,14 @@ export const SubscribeModalSetting = ( {
 					: translate(
 							'Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll.'
 					  ) }
+				{ isModalEditTranslated && (
+					<>
+						{ ' ' }
+						<ExternalLink href={ subscribeModalEditUrl }>
+							{ translate( 'Preview and edit the popup' ) }
+						</ExternalLink>
+					</>
+				) }
 			</FormSettingExplanation>
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Adds back the edit link we removed in https://github.com/Automattic/wp-calypso/pull/80297 but with different copy and link destination.

<img width="594" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/fbc741f2-b627-48e7-8330-93294bdf164b">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Newsletter settings (`/settings/newsletter/`) for site created via `/setup/newsletter`
* Test that the link works, regardless if the toggle is enabled or not?


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
