### PR TITLE
Hosting Metrics: August 16th design tweaks

### DIFF
--- a/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
@@ -107,9 +107,7 @@ function addExtraScaleIfDefined( series: Array< SeriesProp > ) {
 				},
 				stroke: '#787C82',
 				ticks: {
-					stroke: '#787C82',
-					width: 1,
-					size: 3,
+					show: false,
 				},
 				values: ( u: uPlot, ticks: number[] ) =>
 					ticks.map( ( rawValue ) => {

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -175,9 +175,9 @@ const useSuccessHttpCodeSeries = () => {
 		},
 		{
 			statusCode: 301,
-			fill: 'rgba(227, 174, 212, 0.1)',
+			fill: 'rgba(235, 101, 148, 0.2)',
 			label: __( '301: Moved Permanently' ),
-			stroke: 'rgba(227, 174, 212, 1)',
+			stroke: 'rgba(235, 101, 148, 1)',
 		},
 		{
 			statusCode: 302,
@@ -201,9 +201,9 @@ const useErrorHttpCodeSeries = () => {
 		},
 		{
 			statusCode: 401,
-			fill: 'rgba(227, 174, 212, 0.1)',
+			fill: 'rgba(140, 143, 148, 0.1)',
 			label: __( '401: Unauthorized Request' ),
-			stroke: 'rgba(227, 174, 212, 1)',
+			stroke: 'rgba(140, 143, 148, 1)',
 		},
 		{
 			statusCode: 403,
@@ -292,9 +292,9 @@ export const MetricsTab = () => {
 						stroke: '#0675C4',
 					},
 					{
-						fill: 'rgba(0, 135, 99, 0.2)',
+						fill: 'rgba(222, 177, 0, 0.2)',
 						label: __( 'Average response time (ms)' ),
-						stroke: '#008763',
+						stroke: 'rgba(222, 177, 0, 1)',
 						scale: 'average-response-time',
 						unit: 'ms',
 					},


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3502

## Proposed Changes

Couple of changes:
* Removes the ticks from the second scale. We'd like to align them, ideally (https://github.com/Automattic/dotcom-forge/issues/3507)
* Adjusts colors on a couple of the line graphs.

<img width="1242" alt="CleanShot 2023-08-16 at 09 44 12@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/60513c04-8658-4e09-8da0-186957fa65f8">

## Testing Instructions

1. Navigate to `/site-monitoring/<site>`.
2. Review the design changes.