### PR TITLE
Support content footer: Add paddings

### DIFF
--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -11,7 +11,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 	max-width: none !important;
 	align-items: normal !important;
 	box-sizing: border-box;
-	padding: 96px 24px 64px 24px;
+	padding: 96px 24px 76px 24px;
 
 	p {
 		font-size: 1rem;
@@ -38,7 +38,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 		.support-content-cta-left {
 			flex: 1;
-			padding: 40px 20px 20px 0;
+			padding: 40px 20px 32px 0;
 
 			h4 {
 				line-height: 32px;
@@ -46,6 +46,8 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 			p {
 				color: var(--studio-gray-60);
+				margin-top: 16px;
+				margin-bottom: 28px;
 			}
 		}
 
@@ -82,6 +84,8 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 		p {
 			color: var(--studio-gray-60);
+			margin-top: 16px;
+			margin-bottom: 28px;
 		}
 
 		h4 {
@@ -120,7 +124,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 		p,
 		form {
-			margin-bottom: 8px;
+			margin-bottom: 10px;
 			margin-top: 0;
 		}
 
@@ -194,6 +198,11 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 			.support-content-cta-left {
 				padding: 0 48px 24px 0;
+
+				p {
+					margin-top: 4px;
+					margin-bottom: 16px;
+				}
 			}
 
 			.support-content-cta-right {
@@ -212,6 +221,12 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 				.resource-link {
 					line-height: 20px;
 				}
+
+
+				p {
+					margin-top: 4px;
+					margin-bottom: 16px;
+				}
 			}
 		}
 
@@ -228,7 +243,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 		.support-content-links-subscribe {
 			flex-direction: column;
 			padding-bottom: 36px;
-			margin-top: 24px;
+			margin-top: 48px;
 
 			.support-content-subscribe form {
 				.support-content-subscribe-email {


### PR DESCRIPTION
In designs we have new paddings: <img width="1063" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/658f9903-e469-406f-9410-ac773c7771d2">

This PR addressed this

## Testing
1. Checkout and `cd apps/happy-blocks` and `yarn dev --sync`
2. Check https://learncft.wordpress.com/