### PR TITLE
Remove unneeded ts ignore

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -250,8 +250,6 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 					<RecurringPaymentsPlanAddEditModal
 						closeDialog={ () => setShowPlansModal( false ) }
 						product={ { subscribe_as_site_subscriber: true, price: 5 } }
-						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-						// @ts-ignore - Underlying component is JS class component with props supplied by connect() and mapstatetoprops.
 						siteId={ site.ID }
 					/>
 				) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

In a prior PR we added a @ts-ignore comment when invoking a older component that was not written in TypeScript and was still using the redux connect() method to map state to props. I refactored that underlying component here, and so this PR removes the now unneeded @ts-ignore comment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Behavior should be the same before and after this PR. We want to test there are no TypeScript errors and the code still works as expected. 

1) Checkout this branch, go to the affected file, and confirm you see now TypeScript issues in your editor. 

2) Test the plans modal in Launchpad. 
   - Start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro, choose the Paid option, and proceed to Launchpad. You can also use an existing paid newsletter site that still has full screen launchpad if you have one.
   - If needed, connect Stripe. If you want to avoid fully connecting Stripe, add `define( 'USE_STORE_SANDBOX', true ); `to wp-content/mu-plugins/0-sandbox.php in your sandbox, and sandbox public-api.wordpress.com and the domain of your test site. Then click the link to go to Stripe and you'll see a button to skip the setup. When done, you should return to Launchpad. 
   - Click the Launchpad task to `Create paid newsletter`. Confirm the Plans Modal opens and looks like it is supposed to look. Create a plan, save, and confirm you see a success notification in the upper right corner of your screen. Navigate to `http://calypso.localhost:3000/earn/payments-plans/YOURDOMAIN` and confirm the plan you just created is visible on your plans page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
