### PR TITLE
Fix the email manage links for domain-only sites to work in the all domains view

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -242,6 +242,7 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		`/purchases/subscriptions/${ slug }`,
 		// Any page under `/domains/manage/all` should be accessible in domain-only sites now that we allow multiple domains in them
 		'/domains/manage/all/',
+		'/email/all/',
 		// Add A Domain > Search for a domain
 		domainAddNew( slug ),
 		// Add A Domain > Use a domain I own


### PR DESCRIPTION
Fixes https://github.com/Automattic/nomado-issues/issues/293

## Proposed Changes

This PR allows the /email/all/... path to work properly for users who have only domain-only sites.

## Testing Instructions

Find a user who has only domain-only sites and make sure that the `View email` button from the domain management page works as expected for them.