### PR TITLE
Subscriber Stats: Check if the payment processor is connected to show Paid subscribers stats

### DIFF
--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -1,18 +1,21 @@
 import config from '@automattic/calypso-config';
 import { CountComparisonCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
+import QueryMembershipProducts from 'calypso/components/data/query-memberships';
 import { useSelector } from 'calypso/state';
-import { getConnectedAccountIdForSiteId } from 'calypso/state/memberships/settings/selectors';
+import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
 import useSubscribersTotalsQueries from '../hooks/use-subscribers-totals-query';
 import './style.scss';
 
-function useSubscriberHighlights( siteId: number | null, isPaymentProcessorConnected: boolean ) {
+function useSubscriberHighlights(
+	siteId: number | null,
+	hasAddedPaidSubscriptionProduct: boolean
+) {
 	const translate = useTranslate();
 
 	const { data: subscribersTotals, isLoading, isError } = useSubscribersTotalsQueries( siteId );
 	// Check if the payment processor Stripe is connected to the site.
-	const hasPaidNewsletter = isPaymentProcessorConnected;
+	const hasPaidNewsletter = hasAddedPaidSubscriptionProduct;
 
 	const highlights = [
 		{
@@ -71,15 +74,15 @@ function SubscriberHighlightsHeader() {
 function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
-	const isPaymentProcessorConnected: boolean = useSelector(
-		( state ) => !! getConnectedAccountIdForSiteId( state, siteId )
-	);
+	const products = useSelector( ( state ) => getProductsForSiteId( state, siteId ) );
+	// Check if the site has any paid subscription products added.
+	const hasAddedPaidSubscriptionProduct = products.length > 0;
 
-	const highlights = useSubscriberHighlights( siteId, isPaymentProcessorConnected );
+	const highlights = useSubscriberHighlights( siteId, hasAddedPaidSubscriptionProduct );
 
 	return (
 		<div className="highlight-cards-list">
-			{ siteId && ! isOdysseyStats && <QueryMembershipsSettings siteId={ siteId } /> }
+			{ siteId && ! isOdysseyStats && <QueryMembershipProducts siteId={ siteId } /> }
 			{ highlights.map(
 				( highlight ) =>
 					highlight.show && (

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -1,15 +1,17 @@
 import { CountComparisonCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
+import { useSelector } from 'calypso/state';
+import { getConnectedAccountIdForSiteId } from 'calypso/state/memberships/settings/selectors';
 import useSubscribersTotalsQueries from '../hooks/use-subscribers-totals-query';
 import './style.scss';
 
-function useSubscriberHighlights( siteId: number | null ) {
+function useSubscriberHighlights( siteId: number | null, isPaymentProcessorConnected: boolean ) {
 	const translate = useTranslate();
 
 	const { data: subscribersTotals, isLoading, isError } = useSubscribersTotalsQueries( siteId );
-	// TODO: follow up on this once we have a way to determine if a site has paid newsletter set up.
-	// issue: https://github.com/Automattic/wp-calypso/issues/80609
-	const hasPaidNewsletter = true;
+	// Check if the payment processor Stripe is connected to the site.
+	const hasPaidNewsletter = isPaymentProcessorConnected;
 
 	const highlights = [
 		{
@@ -66,10 +68,15 @@ function SubscriberHighlightsHeader() {
 }
 
 function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
-	const highlights = useSubscriberHighlights( siteId );
+	const isPaymentProcessorConnected: boolean = useSelector(
+		( state ) => !! getConnectedAccountIdForSiteId( state, siteId )
+	);
+
+	const highlights = useSubscriberHighlights( siteId, isPaymentProcessorConnected );
 
 	return (
 		<div className="highlight-cards-list">
+			{ siteId && <QueryMembershipsSettings siteId={ siteId } /> }
 			{ highlights.map(
 				( highlight ) =>
 					highlight.show && (

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -14,8 +14,6 @@ function useSubscriberHighlights(
 	const translate = useTranslate();
 
 	const { data: subscribersTotals, isLoading, isError } = useSubscribersTotalsQueries( siteId );
-	// Check if the payment processor Stripe is connected to the site.
-	const hasPaidNewsletter = hasAddedPaidSubscriptionProduct;
 
 	const highlights = [
 		{
@@ -27,24 +25,24 @@ function useSubscriberHighlights(
 		{
 			heading: translate( 'Paid subscribers' ),
 			count: subscribersTotals?.paid_subscribers,
-			show: hasPaidNewsletter,
+			show: hasAddedPaidSubscriptionProduct,
 			note: 'Paid WordPress.com subscribers',
 		},
 		{
 			heading: translate( 'Free subscribers' ),
 			count: subscribersTotals?.free_subscribers,
-			show: hasPaidNewsletter,
+			show: hasAddedPaidSubscriptionProduct,
 			note: 'Email subscribers and free WordPress.com subscribers',
 		},
 		{
 			heading: translate( 'WordPress.com subscribers' ),
 			count: subscribersTotals?.total_wpcom,
-			show: ! hasPaidNewsletter,
+			show: ! hasAddedPaidSubscriptionProduct,
 		},
 		{
 			heading: translate( 'Email subscribers' ),
 			count: subscribersTotals?.total_email,
-			show: ! hasPaidNewsletter,
+			show: ! hasAddedPaidSubscriptionProduct,
 		},
 	] as { heading: string; count: number | null; show: boolean; note?: string }[];
 

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -58,7 +58,7 @@ function useSubscriberHighlights( siteId: number | null, isPaymentProcessorConne
 
 function SubscriberHighlightsHeader() {
 	const translate = useTranslate();
-	const localizedTitle = translate( 'All time stats', {
+	const localizedTitle = translate( 'All-time stats', {
 		comment: 'Heading for Subscribers page highlights section',
 	} );
 

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { CountComparisonCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
@@ -68,6 +69,8 @@ function SubscriberHighlightsHeader() {
 }
 
 function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+
 	const isPaymentProcessorConnected: boolean = useSelector(
 		( state ) => !! getConnectedAccountIdForSiteId( state, siteId )
 	);
@@ -76,7 +79,7 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 
 	return (
 		<div className="highlight-cards-list">
-			{ siteId && <QueryMembershipsSettings siteId={ siteId } /> }
+			{ siteId && ! isOdysseyStats && <QueryMembershipsSettings siteId={ siteId } /> }
 			{ highlights.map(
 				( highlight ) =>
 					highlight.show && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80609 

## Proposed Changes

* Check if the payment processor `Stripe` is connected to show the `Paid subscribers` stats card appropriately.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the change with the Live Calypso link.
* Navigate to Stats > `Subscribers` page.
* Ensure the `Paid subscribers` card in the `All-time stats` section display according to the `Stripe` account connect status.

> For a11n: p1692210394892629-slack-C82FZ5T4G

|Not Connected|Connected|
|-|-|
|<img width="1299" alt="截圖 2023-08-17 上午2 01 37" src="https://github.com/Automattic/wp-calypso/assets/6869813/3101d601-8538-4b7f-8f4c-a5d06e397ca2">|<img width="1304" alt="截圖 2023-08-17 上午2 01 46" src="https://github.com/Automattic/wp-calypso/assets/6869813/dcf1c3c9-8603-462c-8701-3cd7ebae9658">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
