### PR TITLE
Update jetpack menu functionality and markup

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/bundle.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/bundle.tsx
@@ -1,0 +1,74 @@
+import { useLocale, localizeUrl } from '@automattic/i18n-utils';
+import { Fragment } from 'react';
+import ExternalLink from 'calypso/components/external-link';
+import AntispamIcon from '../icons/jetpack-bundle-icon-antispam';
+import BackupIcon from '../icons/jetpack-bundle-icon-backup';
+import BoostIcon from '../icons/jetpack-bundle-icon-boost';
+import CRMIcon from '../icons/jetpack-bundle-icon-crm';
+import ScanIcon from '../icons/jetpack-bundle-icon-scan';
+import SearchIcon from '../icons/jetpack-bundle-icon-search';
+import SocialIcon from '../icons/jetpack-bundle-icon-social';
+import VideopressIcon from '../icons/jetpack-bundle-icon-videopress';
+import { onLinkClick } from '../utils';
+import type { FC, MouseEvent } from 'react';
+
+interface BundleType {
+	bundle: {
+		id: string;
+		label: string;
+		href: string;
+	};
+}
+
+const Bundle: FC< BundleType > = ( { bundle } ) => {
+	const locale = useLocale();
+	const { href, label, id } = bundle;
+
+	const onBundlesLinkClick = ( e: MouseEvent< HTMLAnchorElement > ) => {
+		onLinkClick( e, 'calypso_jetpack_nav_bundles_click' );
+	};
+
+	const getBundleIcons = ( bundle: string ) => {
+		// Using a soft match in case the menu item gets deleted and recreated in wp-admin
+		// causing the name to change to `complete-2` or something similar.
+		if ( bundle.includes( 'complete' ) ) {
+			return [
+				<BackupIcon />,
+				<AntispamIcon />,
+				<ScanIcon />,
+				<SearchIcon />,
+				<SocialIcon />,
+				<VideopressIcon />,
+				<CRMIcon />,
+				<BoostIcon />,
+			];
+		}
+
+		if ( bundle.includes( 'security' ) ) {
+			return [ <BackupIcon />, <AntispamIcon />, <ScanIcon /> ];
+		}
+
+		return [];
+	};
+
+	return (
+		<li key={ `bundles-${ href }-${ label }` }>
+			<ExternalLink
+				className="header__submenu-link"
+				href={ localizeUrl( href, locale ) }
+				onClick={ onBundlesLinkClick }
+			>
+				<p className="header__submenu-label">
+					<span>{ label }</span>
+				</p>
+				<div className="header__submenu-bundle-icons">
+					{ getBundleIcons( id ).map( ( icon, index ) => (
+						<Fragment key={ `bundle-icon-${ id }${ index }` }>{ icon }</Fragment>
+					) ) }
+				</div>
+			</ExternalLink>
+		</li>
+	);
+};
+
+export default Bundle;

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/bundles-section.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/bundles-section.tsx
@@ -1,0 +1,91 @@
+import { useLocale, localizeUrl } from '@automattic/i18n-utils';
+import { Fragment, useCallback } from 'react';
+import ExternalLink from 'calypso/components/external-link';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import AntispamIcon from '../icons/jetpack-bundle-icon-antispam';
+import BackupIcon from '../icons/jetpack-bundle-icon-backup';
+import BoostIcon from '../icons/jetpack-bundle-icon-boost';
+import CRMIcon from '../icons/jetpack-bundle-icon-crm';
+import ScanIcon from '../icons/jetpack-bundle-icon-scan';
+import SearchIcon from '../icons/jetpack-bundle-icon-search';
+import SocialIcon from '../icons/jetpack-bundle-icon-social';
+import VideopressIcon from '../icons/jetpack-bundle-icon-videopress';
+import type { MenuItem } from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
+import type { FC } from 'react';
+
+interface BundlesSectionProps {
+	bundles: MenuItem | null;
+}
+
+const BundlesSection: FC< BundlesSectionProps > = ( { bundles } ) => {
+	const locale = useLocale();
+
+	const sortByMenuOrder = ( a: MenuItem, b: MenuItem ) => a.menu_order - b.menu_order;
+
+	const getBundleIcons = ( bundle: string ) => {
+		// Using a soft match in case the menu item gets deleted and recreated in wp-admin
+		// causing the name to change to `complete-2` or something similar.
+		if ( bundle.includes( 'complete' ) ) {
+			return [
+				<BackupIcon />,
+				<AntispamIcon />,
+				<ScanIcon />,
+				<SearchIcon />,
+				<SocialIcon />,
+				<VideopressIcon />,
+				<CRMIcon />,
+				<BoostIcon />,
+			];
+		}
+
+		if ( bundle.includes( 'security' ) ) {
+			return [ <BackupIcon />, <AntispamIcon />, <ScanIcon /> ];
+		}
+
+		return [];
+	};
+
+	const onLinkClick = useCallback( ( e: React.MouseEvent< HTMLAnchorElement > ) => {
+		recordTracksEvent( 'calypso_jetpack_nav_bundle_click', {
+			nav_item: e.currentTarget
+				.getAttribute( 'href' )
+				// Remove the hostname https://jetpack.com/ from the href
+				// (including other languages, ie. es.jetpack.com, fr.jetpack.com, etc.)
+				?.replace( /https?:\/\/[a-z]{0,2}.?jetpack.com/, '' ),
+		} );
+	}, [] );
+
+	return (
+		<div className="header__submenu-bottom-section">
+			<div className="header__submenu-bundles">
+				<p className="header__submenu-category-heading">{ bundles?.label }</p>
+
+				<ul className="header__submenu-links-list">
+					{ bundles &&
+						Array.from( Object.values( bundles.items ) )
+							.sort( sortByMenuOrder )
+							.map( ( { id, label, href } ) => (
+								<li key={ `bundles-${ href }-${ label }` }>
+									<ExternalLink
+										className="header__submenu-link"
+										href={ localizeUrl( href, locale ) }
+										onClick={ onLinkClick }
+									>
+										<p className="header__submenu-label">
+											<span>{ label }</span>
+										</p>
+										<div className="header__submenu-bundle-icons">
+											{ getBundleIcons( id ).map( ( icon, index ) => (
+												<Fragment key={ `bundle-icon-${ id }${ index }` }>{ icon }</Fragment>
+											) ) }
+										</div>
+									</ExternalLink>
+								</li>
+							) ) }
+				</ul>
+			</div>
+		</div>
+	);
+};
+
+export default BundlesSection;

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/bundles-section.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/bundles-section.tsx
@@ -1,55 +1,16 @@
-import { useLocale, localizeUrl } from '@automattic/i18n-utils';
-import { Fragment } from 'react';
-import ExternalLink from 'calypso/components/external-link';
-import AntispamIcon from '../icons/jetpack-bundle-icon-antispam';
-import BackupIcon from '../icons/jetpack-bundle-icon-backup';
-import BoostIcon from '../icons/jetpack-bundle-icon-boost';
-import CRMIcon from '../icons/jetpack-bundle-icon-crm';
-import ScanIcon from '../icons/jetpack-bundle-icon-scan';
-import SearchIcon from '../icons/jetpack-bundle-icon-search';
-import SocialIcon from '../icons/jetpack-bundle-icon-social';
-import VideopressIcon from '../icons/jetpack-bundle-icon-videopress';
-import { onLinkClick, sortByMenuOrder } from '../utils';
+import { sortByMenuOrder } from '../utils';
+import Bundle from './bundle';
 import type { MenuItem } from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
-import type { FC, MouseEvent } from 'react';
+import type { FC } from 'react';
 
 interface BundlesSectionProps {
 	bundles: MenuItem | null;
 }
 
 const BundlesSection: FC< BundlesSectionProps > = ( { bundles } ) => {
-	const locale = useLocale();
-
 	if ( ! bundles || Array( bundles.items ).length < 1 ) {
 		return null;
 	}
-
-	const getBundleIcons = ( bundle: string ) => {
-		// Using a soft match in case the menu item gets deleted and recreated in wp-admin
-		// causing the name to change to `complete-2` or something similar.
-		if ( bundle.includes( 'complete' ) ) {
-			return [
-				<BackupIcon />,
-				<AntispamIcon />,
-				<ScanIcon />,
-				<SearchIcon />,
-				<SocialIcon />,
-				<VideopressIcon />,
-				<CRMIcon />,
-				<BoostIcon />,
-			];
-		}
-
-		if ( bundle.includes( 'security' ) ) {
-			return [ <BackupIcon />, <AntispamIcon />, <ScanIcon /> ];
-		}
-
-		return [];
-	};
-
-	const onBundlesLinkClick = ( e: MouseEvent< HTMLAnchorElement > ) => {
-		onLinkClick( e, 'calypso_jetpack_nav_bundles_click' );
-	};
 
 	return (
 		<div className="header__submenu-bottom-section">
@@ -61,22 +22,7 @@ const BundlesSection: FC< BundlesSectionProps > = ( { bundles } ) => {
 						Array.from( Object.values( bundles.items ) )
 							.sort( sortByMenuOrder )
 							.map( ( { id, label, href } ) => (
-								<li key={ `bundles-${ href }-${ label }` }>
-									<ExternalLink
-										className="header__submenu-link"
-										href={ localizeUrl( href, locale ) }
-										onClick={ onBundlesLinkClick }
-									>
-										<p className="header__submenu-label">
-											<span>{ label }</span>
-										</p>
-										<div className="header__submenu-bundle-icons">
-											{ getBundleIcons( id ).map( ( icon, index ) => (
-												<Fragment key={ `bundle-icon-${ id }${ index }` }>{ icon }</Fragment>
-											) ) }
-										</div>
-									</ExternalLink>
-								</li>
+								<Bundle key={ `bundles-${ href }-${ label }` } bundle={ { id, label, href } } />
 							) ) }
 				</ul>
 			</div>

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/bundles-section.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/bundles-section.tsx
@@ -20,6 +20,10 @@ interface BundlesSectionProps {
 const BundlesSection: FC< BundlesSectionProps > = ( { bundles } ) => {
 	const locale = useLocale();
 
+	if ( ! bundles || Array( bundles.items ).length < 1 ) {
+		return null;
+	}
+
 	const getBundleIcons = ( bundle: string ) => {
 		// Using a soft match in case the menu item gets deleted and recreated in wp-admin
 		// causing the name to change to `complete-2` or something similar.
@@ -50,7 +54,7 @@ const BundlesSection: FC< BundlesSectionProps > = ( { bundles } ) => {
 	return (
 		<div className="header__submenu-bottom-section">
 			<div className="header__submenu-bundles">
-				<p className="header__submenu-category-heading">{ bundles?.label }</p>
+				<p className="header__submenu-category-heading">{ bundles.label }</p>
 
 				<ul className="header__submenu-links-list">
 					{ bundles &&

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/bundles-section.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/bundles-section.tsx
@@ -1,7 +1,6 @@
 import { useLocale, localizeUrl } from '@automattic/i18n-utils';
-import { Fragment, useCallback } from 'react';
+import { Fragment } from 'react';
 import ExternalLink from 'calypso/components/external-link';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import AntispamIcon from '../icons/jetpack-bundle-icon-antispam';
 import BackupIcon from '../icons/jetpack-bundle-icon-backup';
 import BoostIcon from '../icons/jetpack-bundle-icon-boost';
@@ -10,8 +9,9 @@ import ScanIcon from '../icons/jetpack-bundle-icon-scan';
 import SearchIcon from '../icons/jetpack-bundle-icon-search';
 import SocialIcon from '../icons/jetpack-bundle-icon-social';
 import VideopressIcon from '../icons/jetpack-bundle-icon-videopress';
+import { onLinkClick, sortByMenuOrder } from '../utils';
 import type { MenuItem } from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
-import type { FC } from 'react';
+import type { FC, MouseEvent } from 'react';
 
 interface BundlesSectionProps {
 	bundles: MenuItem | null;
@@ -19,8 +19,6 @@ interface BundlesSectionProps {
 
 const BundlesSection: FC< BundlesSectionProps > = ( { bundles } ) => {
 	const locale = useLocale();
-
-	const sortByMenuOrder = ( a: MenuItem, b: MenuItem ) => a.menu_order - b.menu_order;
 
 	const getBundleIcons = ( bundle: string ) => {
 		// Using a soft match in case the menu item gets deleted and recreated in wp-admin
@@ -45,15 +43,9 @@ const BundlesSection: FC< BundlesSectionProps > = ( { bundles } ) => {
 		return [];
 	};
 
-	const onLinkClick = useCallback( ( e: React.MouseEvent< HTMLAnchorElement > ) => {
-		recordTracksEvent( 'calypso_jetpack_nav_bundle_click', {
-			nav_item: e.currentTarget
-				.getAttribute( 'href' )
-				// Remove the hostname https://jetpack.com/ from the href
-				// (including other languages, ie. es.jetpack.com, fr.jetpack.com, etc.)
-				?.replace( /https?:\/\/[a-z]{0,2}.?jetpack.com/, '' ),
-		} );
-	}, [] );
+	const onBundlesLinkClick = ( e: MouseEvent< HTMLAnchorElement > ) => {
+		onLinkClick( e, 'calypso_jetpack_nav_bundles_click' );
+	};
 
 	return (
 		<div className="header__submenu-bottom-section">
@@ -69,7 +61,7 @@ const BundlesSection: FC< BundlesSectionProps > = ( { bundles } ) => {
 									<ExternalLink
 										className="header__submenu-link"
 										href={ localizeUrl( href, locale ) }
-										onClick={ onLinkClick }
+										onClick={ onBundlesLinkClick }
 									>
 										<p className="header__submenu-label">
 											<span>{ label }</span>

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/main-menu-item.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/main-menu-item.tsx
@@ -1,0 +1,162 @@
+import { Gridicon } from '@automattic/components';
+import { useLocale, localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState, useEffect, useRef } from 'react';
+import ExternalLink from 'calypso/components/external-link';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getLastFocusableElement } from 'calypso/lib/dom/focus';
+import BundlesSection from './bundles-section';
+import type { MenuItem } from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
+import type { FC } from 'react';
+
+interface MainMenuItemProps {
+	section: MenuItem | null;
+	bundles: MenuItem | null;
+}
+
+const MainMenuItem: FC< MainMenuItemProps > = ( { section, bundles } ) => {
+	const locale = useLocale();
+	const translate = useTranslate();
+	const [ isOpen, setIsOpen ] = useState< boolean >( false );
+	const submenu = useRef< HTMLDivElement >( null );
+
+	const isMobile = () => {
+		return window.innerWidth <= 900;
+	};
+
+	const sortByMenuOrder = ( a: MenuItem, b: MenuItem ) => a.menu_order - b.menu_order;
+
+	const onLinkClick = useCallback( ( e: React.MouseEvent< HTMLAnchorElement > ) => {
+		recordTracksEvent( 'calypso_jetpack_nav_item_click', {
+			nav_item: e.currentTarget
+				.getAttribute( 'href' )
+				// Remove the hostname https://jetpack.com/ from the href
+				// (including other languages, ie. es.jetpack.com, fr.jetpack.com, etc.)
+				?.replace( /https?:\/\/[a-z]{0,2}.?jetpack.com/, '' ),
+		} );
+	}, [] );
+
+	const desktopOnKeyDown = ( e: KeyboardEvent ) => {
+		if ( e.key === 'Escape' ) {
+			setIsOpen( false );
+		}
+	};
+
+	useEffect( () => {
+		document.addEventListener( 'keydown', desktopOnKeyDown );
+
+		return () => {
+			document.addEventListener( 'keydown', desktopOnKeyDown );
+		};
+	}, [] );
+
+	if ( ! section ) {
+		return <></>;
+	}
+
+	const isValidLink = ( url: string ) => {
+		return url && url !== '#';
+	};
+
+	const toggleMenuItem = () => {
+		setIsOpen( ( open ) => ! open );
+	};
+
+	const onBlur = () => {
+		const lastFocusable = submenu.current
+			? getLastFocusableElement( submenu.current as HTMLDivElement )
+			: null;
+
+		if ( lastFocusable ) {
+			lastFocusable.addEventListener(
+				'focusout',
+				() => {
+					if ( isOpen ) {
+						toggleMenuItem();
+					}
+				},
+				{ once: true }
+			);
+		}
+	};
+
+	const { label, id, href, items } = section;
+	const hasChildren = Object.keys( items ).length > 0;
+	const MainMenuTag = hasChildren ? 'a' : ExternalLink;
+
+	return (
+		<>
+			<MainMenuTag
+				className={ hasChildren ? 'header__menu-btn js-menu-btn' : '' }
+				href={ isValidLink( href ) ? localizeUrl( href, locale ) : `#${ id }` }
+				aria-expanded={ hasChildren ? isOpen : undefined }
+				onClick={ isValidLink( href ) ? onLinkClick : toggleMenuItem }
+				onBlur={ onBlur }
+			>
+				{ label }
+				{ hasChildren && <Gridicon icon="chevron-down" size={ 18 } /> }
+			</MainMenuTag>
+			{ hasChildren && (
+				// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+				<div
+					id={ id }
+					className="header__submenu js-menu js"
+					tabIndex={ -1 }
+					hidden={ ! isOpen }
+					onClick={ ! isMobile() ? toggleMenuItem : undefined }
+					ref={ submenu }
+				>
+					<div className="header__submenu-content">
+						<div className="header__submenu-wrapper">
+							<button className="header__back-btn js-menu-back" onClick={ toggleMenuItem }>
+								<Gridicon icon="chevron-left" size={ 18 } />
+								{ translate( 'Back' ) }
+							</button>
+							<ul className="header__submenu-categories-list">
+								{ Array.from( Object.values( items ) )
+									.sort( sortByMenuOrder )
+									.map( ( { label, href, items } ) => {
+										return (
+											<li key={ `submenu-category-${ href }${ label }` }>
+												{ isValidLink( href ) ? (
+													<ExternalLink
+														className="header__submenu-category header__submenu-link"
+														href={ localizeUrl( href, locale ) }
+														onClick={ onLinkClick }
+													>
+														<span className="header__submenu-label">{ label }</span>
+													</ExternalLink>
+												) : (
+													<p className="header__submenu-category header__submenu-link">
+														<span className="header__submenu-label">{ label }</span>
+													</p>
+												) }
+												<ul className="header__submenu-links-list">
+													{ Array.from( Object.values( items ) )
+														.sort( sortByMenuOrder )
+														.map( ( { label, href } ) => (
+															<li key={ `submenu-${ href }${ label }` }>
+																<ExternalLink
+																	className="header__submenu-link"
+																	href={ localizeUrl( href, locale ) }
+																	onClick={ onLinkClick }
+																>
+																	<span className="header__submenu-label">{ label }</span>
+																</ExternalLink>
+															</li>
+														) ) }
+												</ul>
+											</li>
+										);
+									} ) }
+							</ul>
+							<BundlesSection bundles={ bundles } />
+						</div>
+					</div>
+				</div>
+			) }
+		</>
+	);
+};
+
+export default MainMenuItem;

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/menu-items.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/menu-items.tsx
@@ -20,7 +20,7 @@ interface MenuItemProps {
 const MenuItems: FC< MenuItemsProps > = ( { pathname } ) => {
 	const { data: menuData, status: menuDataStatus } = useJetpackMasterbarDataQuery();
 
-	const sections = menuData?.sections ? Array.from( Object.values( menuData.sections ) ) : null;
+	const sections = menuData?.sections ? Object.values( menuData.sections ) : null;
 	const bundles = menuData?.bundles ?? null;
 
 	return (

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/menu-items.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/menu-items.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames';
 import useJetpackMasterbarDataQuery from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
 import { trailingslashit } from 'calypso/lib/route';
+import { sortByMenuOrder, isValidLink } from '../utils';
 import MainMenuItem from './main-menu-item';
-import type { MenuItem } from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
 import type { FC } from 'react';
 
 interface MenuItemsProps {
@@ -14,12 +14,6 @@ const MenuItems: FC< MenuItemsProps > = ( { pathname } ) => {
 
 	const sections = menuData?.sections ? Array.from( Object.values( menuData.sections ) ) : null;
 	const bundles = menuData?.bundles ?? null;
-
-	const sortByMenuOrder = ( a: MenuItem, b: MenuItem ) => a.menu_order - b.menu_order;
-
-	const isValidLink = ( url: string ) => {
-		return url && url !== '#';
-	};
 
 	return (
 		<ul className="header__sections-list js-nav-list">

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/menu-items.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/menu-items.tsx
@@ -1,0 +1,51 @@
+import classNames from 'classnames';
+import useJetpackMasterbarDataQuery from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
+import { trailingslashit } from 'calypso/lib/route';
+import MainMenuItem from './main-menu-item';
+import type { MenuItem } from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
+import type { FC } from 'react';
+
+interface MenuItemsProps {
+	pathname: string | undefined;
+}
+
+const MenuItems: FC< MenuItemsProps > = ( { pathname } ) => {
+	const { data: menuData, status: menuDataStatus } = useJetpackMasterbarDataQuery();
+
+	const sections = menuData?.sections ? Array.from( Object.values( menuData.sections ) ) : null;
+	const bundles = menuData?.bundles ?? null;
+
+	const sortByMenuOrder = ( a: MenuItem, b: MenuItem ) => a.menu_order - b.menu_order;
+
+	const isValidLink = ( url: string ) => {
+		return url && url !== '#';
+	};
+
+	return (
+		<ul className="header__sections-list js-nav-list">
+			{ menuDataStatus === 'success' && sections ? (
+				sections.sort( sortByMenuOrder ).map( ( section ) => {
+					const { label, href } = section;
+
+					return (
+						<li
+							className={ classNames( {
+								'is-active':
+									pathname &&
+									isValidLink( href ) &&
+									new URL( trailingslashit( href ) ).pathname === trailingslashit( pathname ),
+							} ) }
+							key={ `main-menu-${ href }${ label }` }
+						>
+							<MainMenuItem section={ section } bundles={ bundles } />
+						</li>
+					);
+				} )
+			) : (
+				<></>
+			) }
+		</ul>
+	);
+};
+
+export default MenuItems;

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/menu-items.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/menu-items.tsx
@@ -1,11 +1,19 @@
 import classNames from 'classnames';
+import { useMemo } from 'react';
 import useJetpackMasterbarDataQuery from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
 import { trailingslashit } from 'calypso/lib/route';
 import { sortByMenuOrder, isValidLink } from '../utils';
 import MainMenuItem from './main-menu-item';
+import type { MenuItem } from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
 import type { FC } from 'react';
 
 interface MenuItemsProps {
+	pathname: string | undefined;
+}
+
+interface MenuItemProps {
+	section: MenuItem;
+	bundles: MenuItem | null;
 	pathname: string | undefined;
 }
 
@@ -22,17 +30,12 @@ const MenuItems: FC< MenuItemsProps > = ( { pathname } ) => {
 					const { label, href } = section;
 
 					return (
-						<li
-							className={ classNames( {
-								'is-active':
-									pathname &&
-									isValidLink( href ) &&
-									new URL( trailingslashit( href ) ).pathname === trailingslashit( pathname ),
-							} ) }
+						<MenuItem
 							key={ `main-menu-${ href }${ label }` }
-						>
-							<MainMenuItem section={ section } bundles={ bundles } />
-						</li>
+							section={ section }
+							bundles={ bundles }
+							pathname={ pathname }
+						/>
 					);
 				} )
 			) : (
@@ -43,3 +46,26 @@ const MenuItems: FC< MenuItemsProps > = ( { pathname } ) => {
 };
 
 export default MenuItems;
+
+const MenuItem: FC< MenuItemProps > = ( { section, bundles, pathname } ) => {
+	const { label, href } = section;
+
+	const isActive = useMemo( () => {
+		return (
+			pathname &&
+			isValidLink( href ) &&
+			new URL( trailingslashit( href ) ).pathname === trailingslashit( pathname )
+		);
+	}, [ href, pathname ] );
+
+	return (
+		<li
+			className={ classNames( {
+				'is-active': isActive,
+			} ) }
+			key={ `main-menu-${ href }${ label }` }
+		>
+			<MainMenuItem section={ section } bundles={ bundles } />
+		</li>
+	);
+};

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/mobile-menu-button.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/mobile-menu-button.tsx
@@ -1,12 +1,12 @@
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useCallback } from 'react';
-import { getLastFocusableElement } from 'calypso/lib/dom/focus';
+import { closeOnFocusOut } from '../utils';
 import type { MouseEvent, FC, SetStateAction, Dispatch, RefObject } from 'react';
 
 interface MobileMenuButtonProps {
 	isOpen: boolean;
 	setIsOpen: Dispatch< SetStateAction< boolean > >;
-	mobileMenu: RefObject< HTMLElement >;
+	mobileMenu: RefObject< HTMLDivElement >;
 }
 
 const MobileMenuButton: FC< MobileMenuButtonProps > = ( { isOpen, setIsOpen, mobileMenu } ) => {
@@ -38,21 +38,7 @@ const MobileMenuButton: FC< MobileMenuButtonProps > = ( { isOpen, setIsOpen, mob
 	};
 
 	const onBlur = () => {
-		const lastFocusable = mobileMenu.current
-			? getLastFocusableElement( mobileMenu.current as HTMLDivElement )
-			: null;
-
-		if ( lastFocusable ) {
-			lastFocusable.addEventListener(
-				'focusout',
-				() => {
-					if ( isOpen ) {
-						mobileMenuToggle();
-					}
-				},
-				{ once: true }
-			);
-		}
+		closeOnFocusOut( mobileMenu, isOpen, mobileMenuToggle );
 	};
 
 	useEffect( () => {

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/mobile-menu-button.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/mobile-menu-button.tsx
@@ -12,7 +12,7 @@ interface MobileMenuButtonProps {
 const MobileMenuButton: FC< MobileMenuButtonProps > = ( { isOpen, setIsOpen, mobileMenu } ) => {
 	const translate = useTranslate();
 
-	const mobileMenuToggle = useCallback( () => {
+	const menuToggle = useCallback( () => {
 		setIsOpen( ( open ) => {
 			if ( ! open ) {
 				document.body.classList.add( 'no-scroll' );
@@ -23,38 +23,38 @@ const MobileMenuButton: FC< MobileMenuButtonProps > = ( { isOpen, setIsOpen, mob
 		} );
 	}, [ setIsOpen ] );
 
-	const mobileOnKeyDown = useCallback(
+	const onKeyDown = useCallback(
 		( e: KeyboardEvent ) => {
 			if ( e.key === 'Escape' && isOpen ) {
-				mobileMenuToggle();
+				menuToggle();
 			}
 		},
-		[ mobileMenuToggle, isOpen ]
+		[ menuToggle, isOpen ]
 	);
 
-	const onMobileButtonClick = ( e: MouseEvent ) => {
+	const onButtonClick = ( e: MouseEvent ) => {
 		e.preventDefault();
 
-		mobileMenuToggle();
+		menuToggle();
 	};
 
 	const onBlur = () => {
-		closeOnFocusOut( mobileMenu, isOpen, mobileMenuToggle );
+		closeOnFocusOut( mobileMenu, isOpen, menuToggle );
 	};
 
 	useEffect( () => {
-		document.addEventListener( 'keydown', mobileOnKeyDown );
+		document.addEventListener( 'keydown', onKeyDown );
 
 		return () => {
-			document.removeEventListener( 'keydown', mobileOnKeyDown );
+			document.removeEventListener( 'keydown', onKeyDown );
 		};
-	}, [ mobileOnKeyDown ] );
+	}, [ onKeyDown ] );
 
 	return (
 		<a
 			className="header__mobile-btn mobile-btn js-mobile-btn"
 			href="#mobile-menu"
-			onClick={ onMobileButtonClick }
+			onClick={ onButtonClick }
 			onBlur={ onBlur }
 			aria-expanded={ isOpen }
 		>

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/mobile-menu-button.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/mobile-menu-button.tsx
@@ -13,14 +13,15 @@ const MobileMenuButton: FC< MobileMenuButtonProps > = ( { isOpen, setIsOpen, mob
 	const translate = useTranslate();
 
 	const mobileMenuToggle = useCallback( () => {
-		setIsOpen( ( open ) => ! open );
-
-		if ( ! isOpen ) {
-			document.body.classList.add( 'no-scroll' );
-		} else {
-			document.body.classList.remove( 'no-scroll' );
-		}
-	}, [ isOpen, setIsOpen ] );
+		setIsOpen( ( open ) => {
+			if ( ! open ) {
+				document.body.classList.add( 'no-scroll' );
+			} else {
+				document.body.classList.remove( 'no-scroll' );
+			}
+			return ! open;
+		} );
+	}, [ setIsOpen ] );
 
 	const mobileOnKeyDown = useCallback(
 		( e: KeyboardEvent ) => {

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/mobile-menu-button.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/mobile-menu-button.tsx
@@ -38,7 +38,9 @@ const MobileMenuButton: FC< MobileMenuButtonProps > = ( { isOpen, setIsOpen, mob
 	};
 
 	const onBlur = () => {
-		const lastFocusable = getLastFocusableElement( mobileMenu.current as HTMLDivElement );
+		const lastFocusable = mobileMenu.current
+			? getLastFocusableElement( mobileMenu.current as HTMLDivElement )
+			: null;
 
 		if ( lastFocusable ) {
 			lastFocusable.addEventListener(

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/mobile-menu-button.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/mobile-menu-button.tsx
@@ -1,0 +1,80 @@
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useCallback } from 'react';
+import { getLastFocusableElement } from 'calypso/lib/dom/focus';
+import type { MouseEvent, FC, SetStateAction, Dispatch, RefObject } from 'react';
+
+interface MobileMenuButtonProps {
+	isOpen: boolean;
+	setIsOpen: Dispatch< SetStateAction< boolean > >;
+	mobileMenu: RefObject< HTMLElement >;
+}
+
+const MobileMenuButton: FC< MobileMenuButtonProps > = ( { isOpen, setIsOpen, mobileMenu } ) => {
+	const translate = useTranslate();
+
+	const mobileMenuToggle = useCallback( () => {
+		setIsOpen( ( open ) => ! open );
+
+		if ( ! isOpen ) {
+			document.body.classList.add( 'no-scroll' );
+		} else {
+			document.body.classList.remove( 'no-scroll' );
+		}
+	}, [ isOpen, setIsOpen ] );
+
+	const mobileOnKeyDown = useCallback(
+		( e: KeyboardEvent ) => {
+			if ( e.key === 'Escape' && isOpen ) {
+				mobileMenuToggle();
+			}
+		},
+		[ mobileMenuToggle, isOpen ]
+	);
+
+	const onMobileButtonClick = ( e: MouseEvent ) => {
+		e.preventDefault();
+
+		mobileMenuToggle();
+	};
+
+	const onBlur = () => {
+		const lastFocusable = getLastFocusableElement( mobileMenu.current as HTMLDivElement );
+
+		if ( lastFocusable ) {
+			lastFocusable.addEventListener(
+				'focusout',
+				() => {
+					if ( isOpen ) {
+						mobileMenuToggle();
+					}
+				},
+				{ once: true }
+			);
+		}
+	};
+
+	useEffect( () => {
+		document.addEventListener( 'keydown', mobileOnKeyDown );
+
+		return () => {
+			document.removeEventListener( 'keydown', mobileOnKeyDown );
+		};
+	}, [ mobileOnKeyDown ] );
+
+	return (
+		<a
+			className="header__mobile-btn mobile-btn js-mobile-btn"
+			href="#mobile-menu"
+			onClick={ onMobileButtonClick }
+			onBlur={ onBlur }
+			aria-expanded={ isOpen }
+		>
+			<span className="mobile-btn__icon" aria-hidden="true">
+				<span className="mobile-btn__inner"></span>
+			</span>
+			<span className="mobile-btn__label">{ translate( 'Menu' ) }</span>
+		</a>
+	);
+};
+
+export default MobileMenuButton;

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/user-menu.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/user-menu.tsx
@@ -5,9 +5,9 @@ import { useState, useCallback } from 'react';
 import Gravatar from 'calypso/components/gravatar';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
-import type { MouseEvent as ReactMouseEvent } from 'react';
+import type { MouseEvent as ReactMouseEvent, FC } from 'react';
 
-const UserMenu = () => {
+const UserMenu: FC = () => {
 	const locale = useLocale();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const user = useSelector( getCurrentUser );

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/user-menu.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/user-menu.tsx
@@ -25,7 +25,7 @@ const UserMenu: FC = () => {
 			document.addEventListener( 'click', onDocumentClick );
 		}
 
-		setIsMenuOpen( ( prevStatus ) => ! prevStatus );
+		setIsMenuOpen( ( open ) => ! open );
 	}, [ isMenuOpen ] );
 
 	const onUserBtnClick = ( e: ReactMouseEvent< HTMLAnchorElement, MouseEvent > ) => {

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/user-menu.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/user-menu.tsx
@@ -5,7 +5,77 @@ import { useState, useCallback } from 'react';
 import Gravatar from 'calypso/components/gravatar';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
+import type { UserData } from 'calypso/lib/user/user';
 import type { MouseEvent as ReactMouseEvent, FC } from 'react';
+
+interface MenuButtonProps {
+	isMenuOpen: boolean;
+	user: UserData | null;
+	toggleUserMenu: () => void;
+}
+
+interface ProfileProps {
+	isMenuOpen: boolean;
+	user: UserData | null;
+	toggleUserMenu: () => void;
+}
+
+interface TooltipProps {
+	user: UserData | null;
+}
+
+const MenuButton: FC< MenuButtonProps > = ( { isMenuOpen, user, toggleUserMenu } ) => {
+	const onUserBtnClick = ( e: ReactMouseEvent< HTMLAnchorElement, MouseEvent > ) => {
+		e.preventDefault();
+		e.stopPropagation();
+
+		toggleUserMenu();
+	};
+
+	return (
+		<a
+			className="user-menu__btn js-user-menu-btn"
+			href="#profile"
+			onClick={ onUserBtnClick }
+			aria-expanded={ isMenuOpen }
+		>
+			<Gravatar user={ user } className="user-menu__avatar" />
+		</a>
+	);
+};
+
+const Tooltip: FC< TooltipProps > = ( { user } ) => {
+	const locale = useLocale();
+	const translate = useTranslate();
+
+	return (
+		<div className="tooltip">
+			<span className="user-menu__greetings">
+				{ translate( 'Hi, %s!', {
+					args: user?.display_name || user?.username,
+				} ) }
+			</span>
+			<ul className="user-menu__list">
+				<li>
+					<a className="js-manage-sites" href={ localizeUrl( '/', locale ) }>
+						{ translate( 'Manage your sites' ) }
+					</a>
+				</li>
+			</ul>
+		</div>
+	);
+};
+
+const Profile: FC< ProfileProps > = ( { isMenuOpen, user, toggleUserMenu } ) => (
+	<div
+		id="profile"
+		className="user-menu__tooltip js-user-menu js"
+		hidden={ ! isMenuOpen }
+		onBlur={ toggleUserMenu }
+	>
+		<Tooltip user={ user } />
+	</div>
+);
 
 const UserMenu: FC = () => {
 	const locale = useLocale();
@@ -28,13 +98,6 @@ const UserMenu: FC = () => {
 		setIsMenuOpen( ( open ) => ! open );
 	}, [ isMenuOpen ] );
 
-	const onUserBtnClick = ( e: ReactMouseEvent< HTMLAnchorElement, MouseEvent > ) => {
-		e.preventDefault();
-		e.stopPropagation();
-
-		toggleUserMenu();
-	};
-
 	return (
 		<ul className="header__actions-list">
 			<li
@@ -42,38 +105,9 @@ const UserMenu: FC = () => {
 					'is-logged-in': isLoggedIn,
 				} ) }
 			>
+				<MenuButton isMenuOpen={ isMenuOpen } user={ user } toggleUserMenu={ toggleUserMenu } />
 				{ isLoggedIn ? (
-					<>
-						<a
-							className="user-menu__btn js-user-menu-btn"
-							href="#profile"
-							onClick={ onUserBtnClick }
-							aria-expanded={ isMenuOpen }
-						>
-							<Gravatar user={ user } className="user-menu__avatar" />
-						</a>
-						<div
-							id="profile"
-							className="user-menu__tooltip js-user-menu js"
-							hidden={ ! isMenuOpen }
-							onBlur={ toggleUserMenu }
-						>
-							<div className="tooltip">
-								<span className="user-menu__greetings">
-									{ translate( 'Hi, %s!', {
-										args: user?.display_name || user?.username,
-									} ) }
-								</span>
-								<ul className="user-menu__list">
-									<li>
-										<a className="js-manage-sites" href={ localizeUrl( '/', locale ) }>
-											{ translate( 'Manage your sites' ) }
-										</a>
-									</li>
-								</ul>
-							</div>
-						</div>
-					</>
+					<Profile isMenuOpen={ isMenuOpen } user={ user } toggleUserMenu={ toggleUserMenu } />
 				) : (
 					<a className="header__action-link js-login" href={ localizeUrl( '/login/', locale ) }>
 						{ translate( 'Log in' ) }

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/user-menu.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/user-menu.tsx
@@ -1,0 +1,87 @@
+import { localizeUrl, useLocale } from '@automattic/i18n-utils';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useCallback } from 'react';
+import Gravatar from 'calypso/components/gravatar';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
+import type { MouseEvent as ReactMouseEvent } from 'react';
+
+const UserMenu = () => {
+	const locale = useLocale();
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	const user = useSelector( getCurrentUser );
+	const translate = useTranslate();
+	const [ isMenuOpen, setIsMenuOpen ] = useState( false );
+
+	const onDocumentClick = () => {
+		setIsMenuOpen( false );
+	};
+
+	const toggleUserMenu = useCallback( () => {
+		if ( isMenuOpen ) {
+			document.removeEventListener( 'click', onDocumentClick );
+		} else {
+			document.addEventListener( 'click', onDocumentClick );
+		}
+
+		setIsMenuOpen( ( prevStatus ) => ! prevStatus );
+	}, [ isMenuOpen ] );
+
+	const onUserBtnClick = ( e: ReactMouseEvent< HTMLAnchorElement, MouseEvent > ) => {
+		e.preventDefault();
+		e.stopPropagation();
+
+		toggleUserMenu();
+	};
+
+	return (
+		<ul className="header__actions-list">
+			<li
+				className={ classNames( 'header__user-menu user-menu ', {
+					'is-logged-in': isLoggedIn,
+				} ) }
+			>
+				{ isLoggedIn ? (
+					<>
+						<a
+							className="user-menu__btn js-user-menu-btn"
+							href="#profile"
+							onClick={ onUserBtnClick }
+							aria-expanded={ isMenuOpen }
+						>
+							<Gravatar user={ user } className="user-menu__avatar" />
+						</a>
+						<div
+							id="profile"
+							className="user-menu__tooltip js-user-menu js"
+							hidden={ ! isMenuOpen }
+							onBlur={ toggleUserMenu }
+						>
+							<div className="tooltip">
+								<span className="user-menu__greetings">
+									{ translate( 'Hi, %s!', {
+										args: user?.display_name || user?.username,
+									} ) }
+								</span>
+								<ul className="user-menu__list">
+									<li>
+										<a className="js-manage-sites" href={ localizeUrl( '/', locale ) }>
+											{ translate( 'Manage your sites' ) }
+										</a>
+									</li>
+								</ul>
+							</div>
+						</div>
+					</>
+				) : (
+					<a className="header__action-link js-login" href={ localizeUrl( '/login/', locale ) }>
+						{ translate( 'Log in' ) }
+					</a>
+				) }
+			</li>
+		</ul>
+	);
+};
+
+export default UserMenu;

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -2,7 +2,7 @@ import { Gridicon } from '@automattic/components';
 import { useLocale, localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo, Fragment, useEffect, useState } from 'react';
+import { useCallback, useMemo, useEffect, useState } from 'react';
 import * as React from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import JetpackLogo from 'calypso/components/jetpack-logo';
@@ -18,15 +18,8 @@ import { useSelector } from 'calypso/state';
 import { getJetpackSaleCoupon } from 'calypso/state/marketing/selectors';
 import { isJetpackCloudCartEnabled } from 'calypso/state/sites/selectors';
 import CloudCart from './cloud-cart';
+import BundlesSection from './components/bundles-section';
 import UserMenu from './components/user-menu';
-import AntispamIcon from './icons/jetpack-bundle-icon-antispam';
-import BackupIcon from './icons/jetpack-bundle-icon-backup';
-import BoostIcon from './icons/jetpack-bundle-icon-boost';
-import CRMIcon from './icons/jetpack-bundle-icon-crm';
-import ScanIcon from './icons/jetpack-bundle-icon-scan';
-import SearchIcon from './icons/jetpack-bundle-icon-search';
-import SocialIcon from './icons/jetpack-bundle-icon-social';
-import VideopressIcon from './icons/jetpack-bundle-icon-videopress';
 import type { MenuItem } from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
 
 import './style.scss';
@@ -88,29 +81,6 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 				?.replace( /https?:\/\/[a-z]{0,2}.?jetpack.com/, '' ),
 		} );
 	}, [] );
-
-	const getBundleIcons = ( bundle: string ) => {
-		// Using a soft match in case the menu item gets deleted and recreated in wp-admin
-		// causing the name to change to `complete-2` or something similar.
-		if ( bundle.includes( 'complete' ) ) {
-			return [
-				<BackupIcon />,
-				<AntispamIcon />,
-				<ScanIcon />,
-				<SearchIcon />,
-				<SocialIcon />,
-				<VideopressIcon />,
-				<CRMIcon />,
-				<BoostIcon />,
-			];
-		}
-
-		if ( bundle.includes( 'security' ) ) {
-			return [ <BackupIcon />, <AntispamIcon />, <ScanIcon /> ];
-		}
-
-		return [];
-	};
 
 	// All the functionality in this useEffect is copied from the old js files that were copied from jetpack.com
 	// They were moved here due to the new data query causing the header to re-render and add too many event listeners
@@ -385,44 +355,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 																					);
 																				} ) }
 																		</ul>
-
-																		<div className="header__submenu-bottom-section">
-																			<div className="header__submenu-bundles">
-																				<p className="header__submenu-category-heading">
-																					{ bundles?.label }
-																				</p>
-
-																				<ul className="header__submenu-links-list">
-																					{ bundles &&
-																						Array.from( Object.values( bundles.items ) )
-																							.sort( sortByMenuOrder )
-																							.map( ( { id, label, href } ) => (
-																								<li key={ `bundles-${ href }-${ label }` }>
-																									<ExternalLink
-																										className="header__submenu-link"
-																										href={ localizeUrl( href, locale ) }
-																										onClick={ onLinkClick }
-																									>
-																										<p className="header__submenu-label">
-																											<span>{ label }</span>
-																										</p>
-																										<div className="header__submenu-bundle-icons">
-																											{ getBundleIcons( id ).map(
-																												( icon, index ) => (
-																													<Fragment
-																														key={ `bundle-icon-${ id }${ index }` }
-																													>
-																														{ icon }
-																													</Fragment>
-																												)
-																											) }
-																										</div>
-																									</ExternalLink>
-																								</li>
-																							) ) }
-																				</ul>
-																			</div>
-																		</div>
+																		<BundlesSection bundles={ bundles } />
 																	</div>
 																</div>
 															</div>

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -1,27 +1,22 @@
-import { Gridicon } from '@automattic/components';
 import { useLocale, localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo, useEffect, useState, useRef } from 'react';
+import { useMemo, useEffect, useState, useRef } from 'react';
 import * as React from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import JetpackLogo from 'calypso/components/jetpack-logo';
-import useJetpackMasterbarDataQuery from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
 import JetpackSaleBanner from 'calypso/jetpack-cloud/sections/pricing/sale-banner';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
-import { getLastFocusableElement } from 'calypso/lib/dom/focus';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { trailingslashit } from 'calypso/lib/route';
 import { isConnectStore } from 'calypso/my-sites/plans/jetpack-plans/product-grid/utils';
 import { useSelector } from 'calypso/state';
 import { getJetpackSaleCoupon } from 'calypso/state/marketing/selectors';
 import { isJetpackCloudCartEnabled } from 'calypso/state/sites/selectors';
 import CloudCart from './cloud-cart';
-import BundlesSection from './components/bundles-section';
+import MenuItems from './components/menu-items';
 import MobileMenuButton from './components/mobile-menu-button';
 import UserMenu from './components/user-menu';
-import type { MenuItem } from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
 
 import './style.scss';
 
@@ -43,15 +38,8 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 	const translate = useTranslate();
 	const locale = useLocale();
 	const jetpackSaleCoupon = useSelector( getJetpackSaleCoupon );
-	const { data: menuData, status: menuDataStatus } = useJetpackMasterbarDataQuery();
 	const mobileMenu = useRef< HTMLDivElement >( null );
-	const [ eventHandlersAdded, setEventHandlersAdded ] = useState( false );
 	const [ isMobileMenuOpen, setIsMobileMenuOpen ] = useState( false );
-
-	const sortByMenuOrder = ( a: MenuItem, b: MenuItem ) => a.menu_order - b.menu_order;
-
-	const sections = menuData?.sections ? Array.from( Object.values( menuData.sections ) ) : null;
-	const bundles = menuData?.bundles ?? null;
 
 	const shouldShowCart = useSelector( isJetpackCloudCartEnabled );
 
@@ -70,115 +58,6 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 	const classes = classNames( 'header__content-background-wrapper', {
 		'header__content-background-wrapper--sticky': shouldShowCart && hasCrossed,
 	} );
-
-	const isValidLink = ( url: string ) => {
-		return url && url !== '#';
-	};
-
-	const onLinkClick = useCallback( ( e: React.MouseEvent< HTMLAnchorElement > ) => {
-		recordTracksEvent( 'calypso_jetpack_nav_item_click', {
-			nav_item: e.currentTarget
-				.getAttribute( 'href' )
-				// Remove the hostname https://jetpack.com/ from the href
-				// (including other languages, ie. es.jetpack.com, fr.jetpack.com, etc.)
-				?.replace( /https?:\/\/[a-z]{0,2}.?jetpack.com/, '' ),
-		} );
-	}, [] );
-
-	// All the functionality in this useEffect is copied from the old js files that were copied from jetpack.com
-	// They were moved here due to the new data query causing the header to re-render and add too many event listeners
-	// This will be refactored very soon
-	useEffect( () => {
-		// SUBMENU TOGGLE FUNCTIONALITY
-		function toggleMenuItem( btn: HTMLAnchorElement, menu: HTMLDivElement ) {
-			const expanded = btn.getAttribute( 'aria-expanded' ) === 'true' || false;
-			btn.setAttribute( 'aria-expanded', String( ! expanded ) );
-
-			menu.hidden = ! menu.hidden;
-		}
-
-		function collapseExpandedMenu() {
-			const expandedBtn = document.querySelector(
-				'.js-menu-btn[aria-expanded="true"]'
-			) as HTMLAnchorElement;
-
-			if ( expandedBtn ) {
-				const menu = expandedBtn?.parentNode?.querySelector( '.js-menu' ) as HTMLDivElement;
-
-				if ( menu ) {
-					toggleMenuItem( expandedBtn, menu );
-				}
-			}
-		}
-
-		function initMenu( btn: HTMLAnchorElement ) {
-			const menu = btn?.parentNode?.querySelector( '.js-menu' ) as HTMLDivElement;
-
-			if ( ! menu ) {
-				return;
-			}
-
-			const toggleSubmenu = function () {
-				toggleMenuItem( btn, menu );
-			};
-
-			menu.addEventListener( 'click', function ( e ) {
-				// If user clicks menu backdrop
-				if ( e.target === menu ) {
-					toggleSubmenu();
-				}
-			} );
-
-			btn.addEventListener( 'click', function ( e ) {
-				e.preventDefault();
-
-				if ( btn.getAttribute( 'aria-expanded' ) === 'false' ) {
-					collapseExpandedMenu();
-				}
-
-				toggleSubmenu();
-			} );
-
-			const backBtn = menu.querySelector( '.js-menu-back' );
-
-			if ( backBtn ) {
-				backBtn.addEventListener( 'click', function () {
-					toggleSubmenu();
-				} );
-			}
-
-			// Collapse menu when focusing out
-			const lastFocusable = getLastFocusableElement( menu );
-
-			if ( lastFocusable ) {
-				lastFocusable.addEventListener( 'focusout', toggleSubmenu );
-			}
-		}
-
-		// Close expanded menu on Esc keypress
-		function onKeyDown( e: KeyboardEvent ) {
-			if ( e.key === 'Escape' ) {
-				collapseExpandedMenu();
-			}
-		}
-		// END SUBMENU TOGGLE FUNCTIONALITY
-
-		if ( menuDataStatus === 'success' && ! eventHandlersAdded ) {
-			setEventHandlersAdded( true );
-
-			// SUBMENU SETUP
-			const menuBtns = document.querySelectorAll( '.js-menu-btn' );
-
-			Array.prototype.forEach.call( menuBtns, initMenu );
-
-			document.addEventListener( 'keydown', onKeyDown );
-			// END SUBMENU SETUP
-
-			return () => {
-				document.removeEventListener( 'keydown', onKeyDown );
-			};
-		}
-	}, [ menuDataStatus, eventHandlersAdded ] );
 
 	useEffect( () => {
 		window.addEventListener( 'resize', () => {
@@ -224,103 +103,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 									id="mobile-menu"
 									ref={ mobileMenu }
 								>
-									<ul className="header__sections-list js-nav-list">
-										{ menuDataStatus === 'success' && sections ? (
-											sections.sort( sortByMenuOrder ).map( ( { label, id, href, items } ) => {
-												const hasChildren = Object.keys( items ).length > 0;
-												const MainMenuTag = hasChildren ? 'a' : ExternalLink;
-
-												return (
-													<li
-														className={ classNames( {
-															'is-active':
-																pathname &&
-																isValidLink( href ) &&
-																new URL( trailingslashit( href ) ).pathname ===
-																	trailingslashit( pathname ),
-														} ) }
-														key={ `main-menu-${ href }${ label }` }
-													>
-														<MainMenuTag
-															className={ hasChildren ? 'header__menu-btn js-menu-btn' : '' }
-															href={
-																isValidLink( href ) ? localizeUrl( href, locale ) : `#${ id }`
-															}
-															aria-expanded={ hasChildren ? false : undefined }
-															onClick={ isValidLink( href ) ? onLinkClick : undefined }
-														>
-															{ label }
-															{ hasChildren && <Gridicon icon="chevron-down" size={ 18 } /> }
-														</MainMenuTag>
-														{ hasChildren && (
-															<div
-																id={ id }
-																className="header__submenu js-menu js"
-																tabIndex={ -1 }
-																hidden
-															>
-																<div className="header__submenu-content">
-																	<div className="header__submenu-wrapper">
-																		<button className="header__back-btn js-menu-back">
-																			<Gridicon icon="chevron-left" size={ 18 } />
-																			{ translate( 'Back' ) }
-																		</button>
-																		<ul className="header__submenu-categories-list">
-																			{ Array.from( Object.values( items ) )
-																				.sort( sortByMenuOrder )
-																				.map( ( { label, href, items } ) => {
-																					return (
-																						<li key={ `submenu-category-${ href }${ label }` }>
-																							{ isValidLink( href ) ? (
-																								<ExternalLink
-																									className="header__submenu-category header__submenu-link"
-																									href={ localizeUrl( href, locale ) }
-																									onClick={ onLinkClick }
-																								>
-																									<span className="header__submenu-label">
-																										{ label }
-																									</span>
-																								</ExternalLink>
-																							) : (
-																								<p className="header__submenu-category header__submenu-link">
-																									<span className="header__submenu-label">
-																										{ label }
-																									</span>
-																								</p>
-																							) }
-																							<ul className="header__submenu-links-list">
-																								{ Array.from( Object.values( items ) )
-																									.sort( sortByMenuOrder )
-																									.map( ( { label, href } ) => (
-																										<li key={ `submenu-${ href }${ label }` }>
-																											<ExternalLink
-																												className="header__submenu-link"
-																												href={ localizeUrl( href, locale ) }
-																												onClick={ onLinkClick }
-																											>
-																												<span className="header__submenu-label">
-																													{ label }
-																												</span>
-																											</ExternalLink>
-																										</li>
-																									) ) }
-																							</ul>
-																						</li>
-																					);
-																				} ) }
-																		</ul>
-																		<BundlesSection bundles={ bundles } />
-																	</div>
-																</div>
-															</div>
-														) }
-													</li>
-												);
-											} )
-										) : (
-											<></>
-										) }
-									</ul>
+									<MenuItems pathname={ pathname } />
 									{ shouldShowCart && <CloudCart /> }
 									<UserMenu />
 								</div>

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -17,6 +17,7 @@ import CloudCart from './cloud-cart';
 import MenuItems from './components/menu-items';
 import MobileMenuButton from './components/mobile-menu-button';
 import UserMenu from './components/user-menu';
+import { isMobile } from './utils';
 
 import './style.scss';
 
@@ -61,9 +62,8 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 
 	useEffect( () => {
 		window.addEventListener( 'resize', () => {
-			const body = document.querySelector( 'body' );
-			if ( window.innerWidth > 900 ) {
-				body?.classList.remove( 'no-scroll' );
+			if ( isMobile() ) {
+				document.body.classList.remove( 'no-scroll' );
 			}
 		} );
 	}, [] );

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -5,7 +5,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, Fragment, useEffect, useState } from 'react';
 import * as React from 'react';
 import ExternalLink from 'calypso/components/external-link';
-import Gravatar from 'calypso/components/gravatar';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import useJetpackMasterbarDataQuery from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
 import JetpackSaleBanner from 'calypso/jetpack-cloud/sections/pricing/sale-banner';
@@ -16,10 +15,10 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { trailingslashit } from 'calypso/lib/route';
 import { isConnectStore } from 'calypso/my-sites/plans/jetpack-plans/product-grid/utils';
 import { useSelector } from 'calypso/state';
-import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getJetpackSaleCoupon } from 'calypso/state/marketing/selectors';
 import { isJetpackCloudCartEnabled } from 'calypso/state/sites/selectors';
 import CloudCart from './cloud-cart';
+import UserMenu from './components/user-menu';
 import AntispamIcon from './icons/jetpack-bundle-icon-antispam';
 import BackupIcon from './icons/jetpack-bundle-icon-backup';
 import BoostIcon from './icons/jetpack-bundle-icon-boost';
@@ -50,8 +49,6 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 	const translate = useTranslate();
 	const locale = useLocale();
 	const jetpackSaleCoupon = useSelector( getJetpackSaleCoupon );
-	const isLoggedIn = useSelector( isUserLoggedIn );
-	const user = useSelector( getCurrentUser );
 	const { data: menuData, status: menuDataStatus } = useJetpackMasterbarDataQuery();
 	const [ eventHandlersAdded, setEventHandlersAdded ] = useState( false );
 
@@ -193,38 +190,6 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 		}
 		// END SUBMENU TOGGLE FUNCTIONALITY
 
-		// USER MENU FUNCTIONALITY
-		const userMenu = document.querySelector( '.js-user-menu' ) as HTMLDivElement;
-		const userBtn = document.querySelector( '.js-user-menu-btn' ) as HTMLAnchorElement;
-
-		function onDocumentClick( { target }: MouseEvent ) {
-			if ( ! userMenu?.contains( target as Node ) ) {
-				userBtn?.setAttribute( 'aria-expanded', 'false' );
-				userMenu.hidden = true;
-			}
-		}
-
-		function toggleUserMenu() {
-			const expanded = userBtn.getAttribute( 'aria-expanded' ) === 'true' || false;
-
-			if ( expanded ) {
-				document.removeEventListener( 'click', onDocumentClick );
-			} else {
-				document.addEventListener( 'click', onDocumentClick );
-			}
-
-			userBtn.setAttribute( 'aria-expanded', String( ! expanded ) );
-			userMenu.hidden = ! userMenu.hidden;
-		}
-
-		function onUserBtnClick( e: MouseEvent ) {
-			e.preventDefault();
-			e.stopPropagation();
-
-			toggleUserMenu();
-		}
-		// END USER MENU FUNCTIONALITY
-
 		// MOBILE MENU FUNCTIONALITY
 		const mobileMenu = document.querySelector( '.js-mobile-menu' ) as HTMLDivElement;
 		const mobileBtn = document.querySelector( '.js-mobile-btn' );
@@ -263,19 +228,6 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 			document.addEventListener( 'keydown', onKeyDown );
 			// END SUBMENU SETUP
 
-			// USER MENU SETUP
-			if ( userMenu && userBtn ) {
-				userBtn.addEventListener( 'click', onUserBtnClick );
-
-				const lastFocusable = getLastFocusableElement( userMenu );
-
-				// Collapse menu when focusing out
-				if ( lastFocusable ) {
-					lastFocusable.addEventListener( 'focusout', toggleUserMenu );
-				}
-			}
-			// END MENU SETUP
-
 			// MOBILE MENU SETUP
 			if ( mobileMenu && mobileBtn ) {
 				mobileBtn.addEventListener( 'click', function ( e ) {
@@ -300,7 +252,6 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 
 			return () => {
 				document.removeEventListener( 'keydown', onKeyDown );
-				document.removeEventListener( 'click', onDocumentClick );
 				document.removeEventListener( 'keydown', mobileOnKeyDown );
 			};
 		}
@@ -484,47 +435,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 										) }
 									</ul>
 									{ shouldShowCart && <CloudCart /> }
-									<ul className="header__actions-list">
-										<li
-											className={ classNames( 'header__user-menu user-menu ', {
-												'is-logged-in': isLoggedIn,
-											} ) }
-										>
-											{ isLoggedIn ? (
-												<>
-													<a className="user-menu__btn js-user-menu-btn" href="#profile">
-														<Gravatar user={ user } className="user-menu__avatar" />
-													</a>
-													<div id="profile" className="user-menu__tooltip js-user-menu js" hidden>
-														<div className="tooltip">
-															<span className="user-menu__greetings">
-																{ translate( 'Hi, %s!', {
-																	args: user?.display_name || user?.username,
-																} ) }
-															</span>
-															<ul className="user-menu__list">
-																<li>
-																	<a
-																		className="js-manage-sites"
-																		href={ localizeUrl( '/', locale ) }
-																	>
-																		{ translate( 'Manage your sites' ) }
-																	</a>
-																</li>
-															</ul>
-														</div>
-													</div>
-												</>
-											) : (
-												<a
-													className="header__action-link js-login"
-													href={ localizeUrl( '/login/', locale ) }
-												>
-													{ translate( 'Log in' ) }
-												</a>
-											) }
-										</li>
-									</ul>
+									<UserMenu />
 								</div>
 							</nav>
 						</div>

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/utils.ts
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/utils.ts
@@ -1,0 +1,46 @@
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getLastFocusableElement } from 'calypso/lib/dom/focus';
+import type { MenuItem } from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';
+import type { MouseEvent, RefObject } from 'react';
+
+export const isMobile = () => {
+	return window.innerWidth <= 900;
+};
+
+export const sortByMenuOrder = ( a: MenuItem, b: MenuItem ) => a.menu_order - b.menu_order;
+
+export const onLinkClick = ( e: MouseEvent< HTMLAnchorElement >, track: string ) => {
+	recordTracksEvent( track, {
+		nav_item: e.currentTarget
+			.getAttribute( 'href' )
+			// Remove the hostname https://jetpack.com/ from the href
+			// (including other languages, ie. es.jetpack.com, fr.jetpack.com, etc.)
+			?.replace( /https?:\/\/[a-z]{0,2}.?jetpack.com/, '' ),
+	} );
+};
+
+// 'calypso_jetpack_nav_item_click'
+
+export const isValidLink = ( url: string ) => {
+	return url && url !== '#';
+};
+
+export const closeOnFocusOut = (
+	ref: RefObject< HTMLDivElement >,
+	isOpen: boolean,
+	toggle: () => void
+) => {
+	const lastFocusable = ref.current ? getLastFocusableElement( ref.current ) : null;
+
+	if ( lastFocusable ) {
+		lastFocusable.addEventListener(
+			'focusout',
+			() => {
+				if ( isOpen ) {
+					toggle();
+				}
+			},
+			{ once: true }
+		);
+	}
+};


### PR DESCRIPTION
## Proposed Changes

* Move several blocks of code in the jetpack masterbar to their own components
* Remove the use of query and element selectors and instead use React hooks to achieve the functionality we need

## Testing Instructions

1. Click on the Calypso Green live link or checkout this branch locally and start your environment
2. Make sure the header looks exactly as it did before
3. On the mobile menu, test the menu button, the product's tab, the back button, and make sure to test tabbing through it all to make sure the menu closes when tabbed through completely
4. On the desktop menu, test out the products tab, the user menu, and also tabbing through it all to make sure it works as expected
5. Try to break the functionality, there was a lot of moving code in this PR so I could have missed something

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
