### PR TITLE
Domain redirect: Validation error if DNS A record won't point to WPCOM

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -1,7 +1,5 @@
 import { Button, FormInputValidation } from '@automattic/components';
-import { englishLocales, useLocale } from '@automattic/i18n-utils';
 import { Icon, trash, info } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -15,7 +13,6 @@ import useDeleteDomainForwardingMutation from 'calypso/data/domains/forwarding/u
 import useDomainForwardingQuery from 'calypso/data/domains/forwarding/use-domain-forwarding-query';
 import useUpdateDomainForwardingMutation from 'calypso/data/domains/forwarding/use-update-domain-forwarding-mutation';
 import { withoutHttp } from 'calypso/lib/url';
-import { WPCOM_DEFAULT_NAMESERVERS_REGEX } from 'calypso/my-sites/domains/domain-management/name-servers/constants';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import './style.scss';
@@ -27,17 +24,13 @@ const noticeOptions = {
 
 export default function DomainForwardingCard( {
 	domainName,
-	nameservers,
 	domain,
 }: {
 	domainName: string;
-	nameservers: string[] | null;
 	domain: ResponseDomain;
 } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const locale = useLocale();
-	const { hasTranslation } = useI18n();
 
 	const { data: forwarding, isLoading, isError } = useDomainForwardingQuery( domainName );
 
@@ -189,36 +182,20 @@ export default function DomainForwardingCard( {
 		return false;
 	};
 
-	const hasWpcomNameservers = () => {
-		if ( ! nameservers || nameservers.length === 0 ) {
-			return false;
-		}
-
-		return nameservers.every( ( nameserver ) => {
-			return WPCOM_DEFAULT_NAMESERVERS_REGEX.test( nameserver );
-		} );
-	};
-
 	const renderNotice = () => {
-		if ( hasWpcomNameservers() || ! nameservers || ! nameservers.length || pointsToWpcom ) {
+		if ( pointsToWpcom ) {
 			return null;
 		}
 
-		const noticeText =
-			englishLocales.includes( locale ) ||
-			hasTranslation(
-				'Domain redirection requires using WordPress.com nameservers.{{br/}}{{a}}Update your nameservers now{{/a}}.'
-			)
-				? translate(
-						'Domain redirection requires using WordPress.com nameservers.{{br/}}{{a}}Update your nameservers now{{/a}}.',
-						{
-							components: {
-								a: <a href="?nameservers=true" />,
-								br: <br />,
-							},
-						}
-				  )
-				: translate( 'You are not currently using WordPress.com name servers.' );
+		const noticeText = translate(
+			'Your domain is not connected to WordPress.com and Domain forwarding requires it.{{br/}}{{a}}More info{{/a}}.',
+			{
+				components: {
+					a: <a href="?nameservers=true" />,
+					br: <br />,
+				},
+			}
+		);
 
 		return (
 			<div className="domain-forwarding-card-notice">

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -185,7 +185,7 @@ export default function DomainForwardingCard( {
 	};
 
 	const renderNotice = () => {
-		if ( ! pointsToWpcom ) {
+		if ( pointsToWpcom ) {
 			return null;
 		}
 

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -185,16 +185,15 @@ export default function DomainForwardingCard( {
 	};
 
 	const renderNotice = () => {
-		if ( pointsToWpcom ) {
+		if ( ! pointsToWpcom ) {
 			return null;
 		}
 
 		const noticeText = translate(
-			'Connect your domain to WordPress.com to enable domain forwarding.{{br/}}{{a}}Learn more{{/a}}.',
+			'Connect your domain to WordPress.com to enable domain forwarding. {{a}}Learn more{{/a}}.',
 			{
 				components: {
 					a: <a href={ localizeUrl( MAP_EXISTING_DOMAIN ) } />,
-					br: <br />,
 				},
 			}
 		);

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -24,27 +24,21 @@ const noticeOptions = {
 	id: `domain-forwarding-notification`,
 };
 
-export default function DomainForwardingCard( {
-	domainName,
-	domain,
-}: {
-	domainName: string;
-	domain: ResponseDomain;
-} ) {
+export default function DomainForwardingCard( { domain }: { domain: ResponseDomain } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const { data: forwarding, isLoading, isError } = useDomainForwardingQuery( domainName );
+	const { data: forwarding, isLoading, isError } = useDomainForwardingQuery( domain.name );
 
 	// Manage local state for target url and protocol as we split forwarding target into host, path and protocol when we store it
 	const [ targetUrl, setTargetUrl ] = useState( '' );
 	const [ protocol, setProtocol ] = useState( 'https' );
 	const [ isValidUrl, setIsValidUrl ] = useState( true );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
-	const pointsToWpcom = domain?.pointsToWpcom ?? false;
+	const pointsToWpcom = domain.pointsToWpcom;
 
 	// Display success notices when the forwarding is updated
-	const { updateDomainForwarding } = useUpdateDomainForwardingMutation( domainName, {
+	const { updateDomainForwarding } = useUpdateDomainForwardingMutation( domain.name, {
 		onSuccess() {
 			dispatch(
 				successNotice( translate( 'Domain redirect updated and enabled.' ), noticeOptions )
@@ -58,7 +52,7 @@ export default function DomainForwardingCard( {
 	} );
 
 	// Display success notices when the forwarding is deleted
-	const { deleteDomainForwarding } = useDeleteDomainForwardingMutation( domainName, {
+	const { deleteDomainForwarding } = useDeleteDomainForwardingMutation( domain.name, {
 		onSuccess() {
 			setTargetUrl( '' );
 			dispatch(
@@ -123,7 +117,7 @@ export default function DomainForwardingCard( {
 
 			// Disallow subdomain forwardings to the main domain, e.g. www.example.com => example.com
 			// Disallow same domain forwardings (for now, this may change in the future)
-			if ( url.hostname === domainName || url.hostname.endsWith( `.${ domainName }` ) ) {
+			if ( url.hostname === domain.name || url.hostname.endsWith( `.${ domain.name }` ) ) {
 				setErrorMessage( translate( 'Redirects to the same domain are not allowed.' ) );
 				setIsValidUrl( false );
 				return;

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -1,4 +1,5 @@
 import { Button, FormInputValidation } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Icon, trash, info } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -13,6 +14,7 @@ import useDeleteDomainForwardingMutation from 'calypso/data/domains/forwarding/u
 import useDomainForwardingQuery from 'calypso/data/domains/forwarding/use-domain-forwarding-query';
 import useUpdateDomainForwardingMutation from 'calypso/data/domains/forwarding/use-update-domain-forwarding-mutation';
 import { withoutHttp } from 'calypso/lib/url';
+import { MAP_EXISTING_DOMAIN } from 'calypso/lib/url/support';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import './style.scss';
@@ -188,10 +190,10 @@ export default function DomainForwardingCard( {
 		}
 
 		const noticeText = translate(
-			'Your domain is not connected to WordPress.com and Domain forwarding requires it.{{br/}}{{a}}More info{{/a}}.',
+			'Connect your domain to WordPress.com to enable domain forwarding.{{br/}}{{a}}Learn more{{/a}}.',
 			{
 				components: {
-					a: <a href="?nameservers=true" />,
+					a: <a href={ localizeUrl( MAP_EXISTING_DOMAIN ) } />,
 					br: <br />,
 				},
 			}

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -17,6 +17,7 @@ import useUpdateDomainForwardingMutation from 'calypso/data/domains/forwarding/u
 import { withoutHttp } from 'calypso/lib/url';
 import { WPCOM_DEFAULT_NAMESERVERS_REGEX } from 'calypso/my-sites/domains/domain-management/name-servers/constants';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
 import './style.scss';
 
 const noticeOptions = {
@@ -27,9 +28,11 @@ const noticeOptions = {
 export default function DomainForwardingCard( {
 	domainName,
 	nameservers,
+	domain,
 }: {
 	domainName: string;
 	nameservers: string[] | null;
+	domain: ResponseDomain;
 } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -43,6 +46,7 @@ export default function DomainForwardingCard( {
 	const [ protocol, setProtocol ] = useState( 'https' );
 	const [ isValidUrl, setIsValidUrl ] = useState( true );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
+	const pointsToWpcom = domain?.pointsToWpcom ?? false;
 
 	// Display success notices when the forwarding is updated
 	const { updateDomainForwarding } = useUpdateDomainForwardingMutation( domainName, {
@@ -196,7 +200,7 @@ export default function DomainForwardingCard( {
 	};
 
 	const renderNotice = () => {
-		if ( hasWpcomNameservers() || ! nameservers || ! nameservers.length ) {
+		if ( hasWpcomNameservers() || ! nameservers || ! nameservers.length || pointsToWpcom ) {
 			return null;
 		}
 

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -354,7 +354,7 @@ const Settings = ( {
 				title={ translate( 'Redirect Domain', { textOnly: true } ) }
 				subtitle={ translate( 'Redirect from your domain to another' ) }
 			>
-				<DomainForwardingCard domainName={ selectedDomainName } domain={ domain } />
+				<DomainForwardingCard domain={ domain } />
 			</Accordion>
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -354,7 +354,7 @@ const Settings = ( {
 				title={ translate( 'Redirect Domain', { textOnly: true } ) }
 				subtitle={ translate( 'Redirect from your domain to another' ) }
 			>
-				<DomainForwardingCard domainName={ selectedDomainName } nameservers={ nameservers } />
+				<DomainForwardingCard domainName={ selectedDomainName } domain={ domain } />
 			</Accordion>
 		);
 	};


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3472

## Proposed Changes

Remove the notice when the nameserver is not pointing to us but the A record does.

- Show notice when domain DNS has no A record pointing to WPCOM.
- Remove the WPCOM nameservers condition.
- Copy:`Connect your domain to WordPress.com to enable domain forwarding. Learn more.`
- `Learn more` should link to [this support doc](https://wordpress.com/support/domains/connect-existing-domain/) (until we work with the new one).

## Testing Instructions

With a domain using WPCOM nameservers
* Go to DNS settings
* Create an A record (root) and point to random IP like `222.222.222.222`
* The notice should show after a couple of minutes (cache)

With domain not using WPCOM nameserver
* Point your domain root A record to the IP not in the range of `192.0.XX.XX`
* The notice should show after a couple of minutes (cache)
* Now point your domain root A record to the IP `192.0.78.25`
* The notice should hide after a couple of minutes (cache)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
