### PR TITLE
Update add domain without site flow

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -506,6 +506,7 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'themeItem',
 				'useThemeHeadstart',
+				'designType',
 			], // note: siteId, siteSlug are not provided when used in domain flow
 			optionalDependencies: [
 				'signupDomainOrigin',

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -363,7 +363,6 @@ class DomainsStep extends Component {
 		);
 
 		this.props.setDesignType( this.getDesignType() );
-
 		this.props.goToNextStep();
 
 		// Start the username suggestion process.

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -283,6 +283,8 @@ class DomainsStep extends Component {
 			  } )
 			: undefined;
 
+		const designType = this.getDesignType();
+
 		/**
 		 * If we do not select a paid domain.
 		 * We want to pre load an experiment to show a plan upsell modal in the plans step
@@ -311,6 +313,33 @@ class DomainsStep extends Component {
 			submitSignupStep: this.props.submitSignupStep,
 		} );
 
+		// If this is a domain only purchase, skip to checkout.
+		if ( this.props.isDomainOnly ) {
+			this.props.submitSignupStep(
+				{
+					stepName: this.props.stepName,
+					domainItem,
+					designType,
+					siteSlug: domainItem.meta,
+					siteUrl,
+					isPurchasingItem: true,
+				},
+				{ designType, domainItem, siteUrl }
+			);
+
+			this.props.submitSignupStep( { stepName: 'site-picker', wasSkipped: true } );
+			this.props.submitSignupStep( { stepName: 'site-or-domain', wasSkipped: true } );
+			this.props.submitSignupStep(
+				{ stepName: 'themes', wasSkipped: true },
+				{ themeSlugWithRepo: 'pub/twentysixteen' }
+			);
+			this.props.submitSignupStep(
+				{ stepName: 'plans-site-selected', wasSkipped: true },
+				{ cartItem: null }
+			);
+			this.props.goToStep( 'user' );
+		}
+
 		this.props.submitSignupStep(
 			Object.assign(
 				{
@@ -334,6 +363,7 @@ class DomainsStep extends Component {
 		);
 
 		this.props.setDesignType( this.getDesignType() );
+
 		this.props.goToNextStep();
 
 		// Start the username suggestion process.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3505

# Do not merge -- needs test fixes and decisions.
- [ ] Use query instead of `isDomainOnly`.

## Proposed Changes

* Skip to checkout instead of showing the `site-or-domain` or other steps. I copied the skipping from `site-or-domain` into the `domain-only` step.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /domains/manage
* Click Add a Domain > Add a domain without a site
* Select a domain
* You should land on checkout.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
