### PR TITLE
Earn: Convert delete plan dialog to TypeScript

### DIFF
--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -21,24 +21,10 @@ import {
 } from 'calypso/state/memberships/product-list/actions';
 import { getconnectedAccountDefaultCurrencyForSiteId } from 'calypso/state/memberships/settings/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { Product } from '../../types';
 import type { ChangeEvent } from 'react';
 
 import './style.scss';
-
-type Product = {
-	ID?: string;
-	currency?: string;
-	price?: number;
-	title?: string;
-	interval?: string;
-	buyer_can_change_amount?: boolean;
-	multiple_per_user?: boolean;
-	welcome_email_content?: string;
-	subscribe_as_site_subscriber?: boolean;
-	renewal_schedule?: string;
-	type?: string;
-	is_editable?: boolean;
-};
 
 type RecurringPaymentsPlanAddEditModalProps = {
 	closeDialog: () => void;

--- a/client/my-sites/earn/memberships/delete-plan-modal.tsx
+++ b/client/my-sites/earn/memberships/delete-plan-modal.tsx
@@ -1,16 +1,33 @@
 import { Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import Notice from 'calypso/components/notice';
+import { useDispatch, useSelector } from 'calypso/state';
 import { requestDeleteProduct } from 'calypso/state/memberships/product-list/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { Product } from '../types';
 
-const RecurringPaymentsPlanDeleteModal = ( { closeDialog, deleteProduct, product, siteId } ) => {
+type RecurringPaymentsPlanDeleteModalProps = {
+	closeDialog: () => void;
+	product: Product;
+};
+
+const RecurringPaymentsPlanDeleteModal = ( {
+	closeDialog,
+	product,
+}: RecurringPaymentsPlanDeleteModalProps ) => {
 	const translate = useTranslate();
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const dispatch = useDispatch();
 
-	const onClose = ( reason ) => {
-		if ( reason === 'delete' ) {
-			deleteProduct( siteId, product, translate( '"%s" was deleted.', { args: product.title } ) );
+	const onClose = ( action?: string ) => {
+		if ( action === 'delete' ) {
+			dispatch(
+				requestDeleteProduct(
+					siteId,
+					product,
+					translate( '"%s" was deleted.', { args: product.title } )
+				)
+			);
 		}
 		closeDialog();
 	};
@@ -48,9 +65,4 @@ const RecurringPaymentsPlanDeleteModal = ( { closeDialog, deleteProduct, product
 	);
 };
 
-export default connect(
-	( state ) => ( {
-		siteId: getSelectedSiteId( state ),
-	} ),
-	{ deleteProduct: requestDeleteProduct }
-)( RecurringPaymentsPlanDeleteModal );
+export default RecurringPaymentsPlanDeleteModal;

--- a/client/my-sites/earn/types.ts
+++ b/client/my-sites/earn/types.ts
@@ -1,0 +1,14 @@
+export type Product = {
+	ID?: string;
+	currency?: string;
+	price?: number;
+	title?: string;
+	interval?: string;
+	buyer_can_change_amount?: boolean;
+	multiple_per_user?: boolean;
+	welcome_email_content?: string;
+	subscribe_as_site_subscriber?: boolean;
+	renewal_schedule?: string;
+	type?: string;
+	is_editable?: boolean;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Converts the Earn > RecurringPaymentsPlanDeleteModal to TypeScript. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There should be no change in functionality before/after this PR. 

1) You will need a stripe connected site to test. 
2) Go to `https://wordpress.com/earn/payments/YOURDOMAIN`. Create on Payment Plans in the Manage Plans section. 
3) Confirm the Payment Plans page loads like usual. 
4) Test adding, editing and deleting plans, and confirm that all functionality works as expected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
