### PR TITLE
Domain management: add basic site-specific table

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -29,18 +29,27 @@ import DomainManagement from '.';
 
 export default {
 	domainManagementList( pageContext, next ) {
-		pageContext.primary = (
-			<DomainManagementData
-				analyticsPath={ domainManagementList( ':site' ) }
-				analyticsTitle="Domain Management"
-				component={ DomainManagement.SiteDomains }
-				context={ pageContext }
-				needsContactDetails
-				needsDomains
-				needsPlans
-				needsProductsList
-			/>
-		);
+		if ( isEnabled( 'domains/management' ) ) {
+			pageContext.primary = (
+				<DomainManagement.BulkSiteDomains
+					analyticsPath={ domainManagementRoot( ':site' ) }
+					analyticsTitle="Domain Management"
+				/>
+			);
+		} else {
+			pageContext.primary = (
+				<DomainManagementData
+					analyticsPath={ domainManagementList( ':site' ) }
+					analyticsTitle="Domain Management"
+					component={ DomainManagement.SiteDomains }
+					context={ pageContext }
+					needsContactDetails
+					needsDomains
+					needsPlans
+					needsProductsList
+				/>
+			);
+		}
 		next();
 	},
 

--- a/client/my-sites/domains/domain-management/index.jsx
+++ b/client/my-sites/domains/domain-management/index.jsx
@@ -1,5 +1,6 @@
 import AllDomains from 'calypso/my-sites/domains/domain-management/list/all-domains';
 import BulkAllDomains from 'calypso/my-sites/domains/domain-management/list/bulk-all-domains';
+import BulkSiteDomains from 'calypso/my-sites/domains/domain-management/list/bulk-site-domains';
 import SiteDomains from 'calypso/my-sites/domains/domain-management/list/site-domains';
 import ContactsPrivacy from './contacts-privacy';
 import AddDnsRecord from './dns/add-dns-record';
@@ -32,4 +33,5 @@ export default {
 	TransferDomainToOtherSite,
 	TransferDomainToOtherUser,
 	BulkAllDomains,
+	BulkSiteDomains,
 };

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.scss
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.scss
@@ -1,0 +1,5 @@
+.domains-table .domains-table__primary-domain-label {
+	height: 20px;
+	border-radius: 4px;
+	margin-bottom: 4px;
+}

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -10,6 +10,7 @@ import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import DomainHeader from '../components/domain-header';
 import OptionsDomainButton from './options-domain-button';
+import './bulk-site-domains.scss';
 
 interface BulkSiteDomainsProps {
 	analyticsPath: string;
@@ -43,7 +44,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 			<Main wideLayout>
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
-				<DomainsTable domains={ data?.domains } />
+				<DomainsTable domains={ data?.domains } displayPrimaryDomainLabel />
 			</Main>
 			<UsePresalesChat />
 		</>

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -1,0 +1,51 @@
+import { useSiteDomainsQuery } from '@automattic/data-stores';
+import { DomainsTable } from '@automattic/domains-table';
+import { useTranslate } from 'i18n-calypso';
+import { UsePresalesChat } from 'calypso/components/data/domain-management';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import Main from 'calypso/components/main';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import DomainHeader from '../components/domain-header';
+import OptionsDomainButton from './options-domain-button';
+
+interface BulkSiteDomainsProps {
+	analyticsPath: string;
+	analyticsTitle: string;
+}
+
+export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const { data } = useSiteDomainsQuery( siteSlug );
+	const translate = useTranslate();
+
+	const item = {
+		label: translate( 'Domains' ),
+		helpBubble: translate(
+			'Manage the domains connected to your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+			{
+				components: {
+					learnMoreLink: <InlineSupportLink supportContext="domains" showIcon={ false } />,
+				},
+			}
+		),
+	};
+
+	const buttons = [
+		<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions allDomainsList />,
+	];
+
+	return (
+		<>
+			<PageViewTracker path={ props.analyticsPath } title={ props.analyticsTitle } />
+			<Main wideLayout>
+				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
+				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
+				<DomainsTable domains={ data?.domains } />
+			</Main>
+			<UsePresalesChat />
+		</>
+	);
+}

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -19,6 +19,23 @@ test( 'domain name is rendered in the row', () => {
 	expect( screen.queryByText( 'example1.com' ) ).toBeInTheDocument();
 } );
 
+test( 'wpcom domains do not link to management interface', async () => {
+	const [ partialDomain, fullDomain ] = testDomain( {
+		domain: 'example.wordpress.com',
+		blog_id: 123,
+		primary_domain: false,
+		wpcom_domain: true,
+	} );
+
+	const fetchSiteDomains = jest.fn().mockResolvedValue( {
+		domains: [ fullDomain ],
+	} );
+
+	render( <DomainsTableRow domain={ partialDomain } fetchSiteDomains={ fetchSiteDomains } /> );
+
+	expect( screen.getByText( 'example.wordpress.com' ) ).not.toHaveAttribute( 'href' );
+} );
+
 test( 'domain name links to management interface', async () => {
 	const [ partialDomain, fullDomain ] = testDomain( {
 		domain: 'example.com',

--- a/packages/domains-table/src/domains-table/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/index.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { screen } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { DomainsTable } from '..';
 import { renderWithProvider, testDomain, testPartialDomain } from '../../test-utils';
@@ -63,4 +63,44 @@ test( 'when two domains share the same underlying site, there is only one fetch 
 	expect( fetchSiteDomains ).toHaveBeenCalledTimes( 2 );
 	expect( fetchSiteDomains ).toHaveBeenCalledWith( 123 );
 	expect( fetchSiteDomains ).toHaveBeenCalledWith( 1337 );
+} );
+
+test( 'when shouldDisplayPrimaryDomainLabel is true, the primary domain label is displayed if a domain is marked as primary', async () => {
+	const [ primaryPartial, primaryFull ] = testDomain( {
+		domain: 'example.com',
+		blog_id: 123,
+		primary_domain: true,
+		wpcom_domain: false,
+	} );
+
+	const [ notPrimaryPartial, notPrimaryFull ] = testDomain( {
+		domain: 'example.wordpress.com',
+		blog_id: 123,
+		primary_domain: false,
+		wpcom_domain: true,
+	} );
+
+	const fetchSiteDomains = jest.fn().mockImplementation( ( siteId ) =>
+		Promise.resolve( {
+			domains: siteId === 123 ? [ primaryFull, notPrimaryFull ] : [],
+		} )
+	);
+
+	render(
+		<DomainsTable
+			domains={ [ primaryPartial, notPrimaryPartial ] }
+			fetchSiteDomains={ fetchSiteDomains }
+			displayPrimaryDomainLabel
+		/>
+	);
+
+	await waitFor( () => {
+		const [ , rowOne, rowTwo ] = screen.getAllByRole( 'row' );
+
+		expect( within( rowOne ).queryByText( 'example.com' ) ).toBeDefined();
+		expect( within( rowOne ).queryByText( 'Primary domain' ) ).toBeDefined();
+
+		expect( within( rowTwo ).queryByText( 'example.wordpress.com' ) ).toBeDefined();
+		expect( within( rowTwo ).queryByText( 'Primary domain' ) ).toBeNull();
+	} );
 } );

--- a/packages/domains-table/src/domains-table/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/index.tsx
@@ -86,7 +86,7 @@ test( 'when shouldDisplayPrimaryDomainLabel is true, the primary domain label is
 		} )
 	);
 
-	render(
+	const { rerender } = render(
 		<DomainsTable
 			domains={ [ primaryPartial, notPrimaryPartial ] }
 			fetchSiteDomains={ fetchSiteDomains }
@@ -97,10 +97,21 @@ test( 'when shouldDisplayPrimaryDomainLabel is true, the primary domain label is
 	await waitFor( () => {
 		const [ , rowOne, rowTwo ] = screen.getAllByRole( 'row' );
 
-		expect( within( rowOne ).queryByText( 'example.com' ) ).toBeDefined();
-		expect( within( rowOne ).queryByText( 'Primary domain' ) ).toBeDefined();
+		expect( within( rowOne ).queryByText( 'example.com' ) ).toBeInTheDocument();
+		expect( within( rowOne ).queryByText( 'Primary domain' ) ).toBeInTheDocument();
 
-		expect( within( rowTwo ).queryByText( 'example.wordpress.com' ) ).toBeDefined();
-		expect( within( rowTwo ).queryByText( 'Primary domain' ) ).toBeNull();
+		expect( within( rowTwo ).queryByText( 'example.wordpress.com' ) ).toBeInTheDocument();
+		expect( within( rowTwo ).queryByText( 'Primary domain' ) ).not.toBeInTheDocument();
 	} );
+
+	// Test that the label is not displayed when displayPrimaryDomainLabel is false
+	rerender(
+		<DomainsTable
+			domains={ [ primaryPartial, notPrimaryPartial ] }
+			fetchSiteDomains={ fetchSiteDomains }
+			displayPrimaryDomainLabel={ false }
+		/>
+	);
+
+	expect( screen.queryByText( 'Primary domain' ) ).not.toBeInTheDocument();
 } );

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,16 +1,22 @@
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { useMemo } from 'react';
+import { PrimaryDomainLabel } from '../primary-domain-label';
 import type { PartialDomainData, SiteDomainsQueryFnData } from '@automattic/data-stores';
 
 interface DomainsTableRowProps {
 	domain: PartialDomainData;
+	displayPrimaryDomainLabel?: boolean;
 
 	fetchSiteDomains?: (
 		siteIdOrSlug: number | string | null | undefined
 	) => Promise< SiteDomainsQueryFnData >;
 }
 
-export function DomainsTableRow( { domain, fetchSiteDomains }: DomainsTableRowProps ) {
+export function DomainsTableRow( {
+	domain,
+	fetchSiteDomains,
+	displayPrimaryDomainLabel,
+}: DomainsTableRowProps ) {
 	const { data } = useSiteDomainsQuery(
 		domain.blog_id,
 		fetchSiteDomains && {
@@ -18,7 +24,7 @@ export function DomainsTableRow( { domain, fetchSiteDomains }: DomainsTableRowPr
 		}
 	);
 
-	const { siteSlug } = useMemo( () => {
+	const { siteSlug, primaryDomain } = useMemo( () => {
 		const primaryDomain = data?.domains?.find( ( d ) => d.primary_domain );
 		const unmappedDomain = data?.domains?.find( ( d ) => d.wpcom_domain );
 		const siteSlug =
@@ -27,12 +33,17 @@ export function DomainsTableRow( { domain, fetchSiteDomains }: DomainsTableRowPr
 		return {
 			// Fall back to the site's ID if we're still loading detailed domain data
 			siteSlug: siteSlug || domain.blog_id.toString( 10 ),
+			primaryDomain,
 		};
 	}, [ data, domain.blog_id ] );
+
+	const isPrimaryDomain = primaryDomain?.domain === domain.domain;
+	const shouldDisplayPrimaryDomainLabel = displayPrimaryDomainLabel && isPrimaryDomain;
 
 	return (
 		<tr key={ domain.domain }>
 			<td>
+				{ shouldDisplayPrimaryDomainLabel && <PrimaryDomainLabel /> }
 				<a className="domains-table__domain-link" href={ domainManagementLink( domain, siteSlug ) }>
 					{ domain.domain }
 				</a>

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -38,15 +38,23 @@ export function DomainsTableRow( {
 	}, [ data, domain.blog_id ] );
 
 	const isPrimaryDomain = primaryDomain?.domain === domain.domain;
+	const isManageableDomain = ! domain.wpcom_domain;
 	const shouldDisplayPrimaryDomainLabel = displayPrimaryDomainLabel && isPrimaryDomain;
 
 	return (
 		<tr key={ domain.domain }>
 			<td>
 				{ shouldDisplayPrimaryDomainLabel && <PrimaryDomainLabel /> }
-				<a className="domains-table__domain-link" href={ domainManagementLink( domain, siteSlug ) }>
-					{ domain.domain }
-				</a>
+				{ isManageableDomain ? (
+					<a
+						className="domains-table__domain-link"
+						href={ domainManagementLink( domain, siteSlug ) }
+					>
+						{ domain.domain }
+					</a>
+				) : (
+					domain.domain
+				) }
 			</td>
 		</tr>
 	);

--- a/packages/domains-table/src/domains-table/index.stories.tsx
+++ b/packages/domains-table/src/domains-table/index.stories.tsx
@@ -39,3 +39,15 @@ const storyDefaults = {
 };
 
 export const TableWithRows = { ...storyDefaults };
+
+export const TableWithPrimaryDomainLabel = {
+	...storyDefaults,
+	args: {
+		...defaultArgs,
+		domains: [
+			{ domain: 'example1.com', blog_id: 1, primary_domain: true },
+			{ domain: 'example2.com', blog_id: 1, primary_domain: false },
+		],
+		displayPrimaryDomainLabel: true,
+	},
+};

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -5,6 +5,7 @@ import './style.scss';
 
 interface DomainsTableProps {
 	domains: PartialDomainData[] | undefined;
+	displayPrimaryDomainLabel?: boolean;
 
 	// Detailed domain data is fetched on demand. The ability to customise fetching
 	// is provided to allow for testing.
@@ -13,7 +14,11 @@ interface DomainsTableProps {
 	) => Promise< SiteDomainsQueryFnData >;
 }
 
-export function DomainsTable( { domains, fetchSiteDomains }: DomainsTableProps ) {
+export function DomainsTable( {
+	domains,
+	fetchSiteDomains,
+	displayPrimaryDomainLabel,
+}: DomainsTableProps ) {
 	const { __ } = useI18n();
 
 	if ( ! domains ) {
@@ -33,6 +38,7 @@ export function DomainsTable( { domains, fetchSiteDomains }: DomainsTableProps )
 						key={ domain.domain }
 						domain={ domain }
 						fetchSiteDomains={ fetchSiteDomains }
+						displayPrimaryDomainLabel={ displayPrimaryDomainLabel }
 					/>
 				) ) }
 			</tbody>

--- a/packages/domains-table/src/primary-domain-label/style.scss
+++ b/packages/domains-table/src/primary-domain-label/style.scss
@@ -5,6 +5,7 @@
 	align-items: center;
 	gap: 4px;
 	width: max-content;
+	line-height: 1 !important;
 
 	&-popover-content {
 		padding: 16px;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3451. Fixes https://github.com/Automattic/dotcom-forge/issues/3452.

## Proposed Changes

This PR implements a basic site-specific table, and adds the "primary domain" label above the domain URL.

![Capture-2023-08-16-202748](https://github.com/Automattic/wp-calypso/assets/26530524/a6317f34-83bc-4cff-83f2-a06ac56b6b9b)

## Testing Instructions

1. Visit `/domains/manage/:siteId` with the `domains/management` flag turned off and verify that you see the existing domains table
2. Turn the feature flag on and refresh the page, you should see the new site-specific table take place

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
~- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~