### PR TITLE
Checkout: Add chat launcher to Checkout masterbar

### DIFF
--- a/client/components/chat-button/index.tsx
+++ b/client/components/chat-button/index.tsx
@@ -83,6 +83,8 @@ const ChatButton: FC< Props > = ( {
 		if ( isEligibleForChat && isChatAvailable ) {
 			return true;
 		}
+
+		return false;
 	}
 
 	const { isOpeningChatWidget, openChatWidget } = useChatWidget();

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -91,11 +91,7 @@ const CheckoutMasterbar = ( {
 		responseCart.products.map( ( product ) => product.product_name ).join( ', ' );
 
 	const handleClick = () => {
-		reduxDispatch(
-			recordTracksEvent( 'calypso_checkout_masterbar_support_click', {
-				cart: JSON.stringify( responseCart ),
-			} )
-		);
+		reduxDispatch( recordTracksEvent( 'calypso_checkout_masterbar_support_click' ) );
 	};
 
 	return (

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -6,12 +6,16 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import AkismetLogo from 'calypso/components/akismet-logo';
+import ChatButton from 'calypso/components/chat-button';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import MaterialIcon from 'calypso/components/material-icon';
+import { reduxDispatch } from 'calypso/lib/redux-bridge';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { DefaultMasterbarContact } from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/src/hooks/use-valid-checkout-back-url';
 import { leaveCheckout } from 'calypso/my-sites/checkout/src/lib/leave-checkout';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import Item from './item';
 import Masterbar from './masterbar';
 
@@ -81,6 +85,19 @@ const CheckoutMasterbar = ( {
 
 	const showCloseButton = isLeavingAllowed && checkoutType === 'wpcom';
 
+	const initialMessage =
+		'Customer is contacting us from the checkout pre-sales flow.\n' +
+		`Product${ responseCart.products.length > 1 && 's' } they're attempting to purchase: ` +
+		responseCart.products.map( ( product ) => product.product_name ).join( ', ' );
+
+	const handleClick = () => {
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_masterbar_support_click', {
+				cart: JSON.stringify( responseCart ),
+			} )
+		);
+	};
+
 	return (
 		<Masterbar
 			className={ classnames( 'masterbar--is-checkout', {
@@ -108,6 +125,15 @@ const CheckoutMasterbar = ( {
 				<span className="masterbar__secure-checkout-text">{ translate( 'Secure checkout' ) }</span>
 			</div>
 			{ title && <Item className="masterbar__item-title">{ title }</Item> }
+			<ChatButton
+				chatIntent="PRESALES"
+				initialMessage={ initialMessage }
+				siteUrl={ siteSlug }
+				className="masterbar__item"
+				onClick={ handleClick }
+			>
+				<MaterialIcon icon="chat_bubble" />
+			</ChatButton>
 			{ loadHelpCenterIcon && <DefaultMasterbarContact /> }
 			<CheckoutModal
 				title={ modalTitleText }

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -125,16 +125,18 @@ const CheckoutMasterbar = ( {
 				<span className="masterbar__secure-checkout-text">{ translate( 'Secure checkout' ) }</span>
 			</div>
 			{ title && <Item className="masterbar__item-title">{ title }</Item> }
-			<ChatButton
-				chatIntent="PRESALES"
-				initialMessage={ initialMessage }
-				siteUrl={ siteSlug }
-				className="masterbar__item"
-				onClick={ handleClick }
-			>
-				<MaterialIcon icon="chat_bubble" />
-			</ChatButton>
-			{ loadHelpCenterIcon && <DefaultMasterbarContact /> }
+			<div className="masterbar__support-icons">
+				<ChatButton
+					chatIntent="PRESALES"
+					initialMessage={ initialMessage }
+					siteUrl={ siteSlug }
+					className="masterbar__item"
+					onClick={ handleClick }
+				>
+					<MaterialIcon icon="chat_bubble" />
+				</ChatButton>
+				{ loadHelpCenterIcon && <DefaultMasterbarContact /> }
+			</div>
 			<CheckoutModal
 				title={ modalTitleText }
 				copy={ modalBodyText }

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -87,7 +87,7 @@ const CheckoutMasterbar = ( {
 
 	const initialMessage =
 		'Customer is contacting us from the checkout pre-sales flow.\n' +
-		`Product${ responseCart.products.length > 1 && 's' } they're attempting to purchase: ` +
+		`Product${ responseCart.products?.length > 1 ? 's' : '' } they're attempting to purchase: ` +
 		responseCart.products.map( ( product ) => product.product_name ).join( ', ' );
 
 	const handleClick = () => {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -278,6 +278,13 @@ body.is-mobile-app-view {
 		padding: 0 0 0 6px;
 	}
 
+	.masterbar--is-checkout &.chat-button {
+
+		@include breakpoint-deprecated( ">480px" ) {
+			display: none;
+		}
+	}
+
 	&:hover {
 		@include breakpoint-deprecated( ">480px" ) {
 			background: var(--color-masterbar-item-hover-background);

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -893,6 +893,18 @@ a.masterbar__quick-language-switcher {
 	pointer-events: none;
 }
 
+.masterbar__support-icons {
+	display: flex;
+	justify-content: flex-end;
+
+	& .chat-button {
+		position: relative;
+		top: 1px;
+		left: 10px;
+		flex: 1;
+	}
+}
+
 .masterbar__secure-checkout {
 	display: flex;
 	align-items: center;
@@ -929,11 +941,13 @@ a.masterbar__quick-language-switcher {
 		line-height: 1.2em;
 		font-size: 0.75rem;
 		margin-left: 5px;
+		display: none;
 
 		@include breakpoint-deprecated( ">480px" ) {
 			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 100%;
 			margin-left: 0;
+			display: block;
 		}
 
 		.masterbar--is-jetpack & {

--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -89,7 +89,12 @@ export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabil
 	useEffect( () => {
 		// presales chat is always shown by default
 		if ( enabled && isPresalesChatAvailable && isMessagingScriptLoaded ) {
-			! isMobile() ? window.zE( 'messenger', 'show' ) : window.zE( 'messenger', 'hide' );
+			if ( ! isMobile() ) {
+				window.zE( 'messenger', 'show' );
+			} else {
+				window.zE( 'messenger', 'close' );
+				window.zE( 'messenger', 'hide' );
+			}
 		}
 	}, [ enabled, isMessagingScriptLoaded, isPresalesChatAvailable, renderCount ] );
 

--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -89,11 +89,7 @@ export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabil
 	useEffect( () => {
 		// presales chat is always shown by default
 		if ( enabled && isPresalesChatAvailable && isMessagingScriptLoaded ) {
-			window.zE( 'messenger', 'show' );
-		}
-
-		if ( isMobile() ) {
-			window.zE( 'messenger', 'hide' );
+			! isMobile() ? window.zE( 'messenger', 'show' ) : window.zE( 'messenger', 'hide' );
 		}
 	}, [ enabled, isMessagingScriptLoaded, isPresalesChatAvailable, renderCount ] );
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
@@ -13,6 +13,7 @@ const HELP_CENTER_STORE = HelpCenter.register();
 
 const ContactContainer = styled.div`
 	display: flex;
+	flex: 1;
 	align-items: center;
 	column-gap: 8px;
 	padding-right: 24px;

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -106,7 +106,7 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	const { hasActiveChats, isEligibleForChat } = useChatStatus( 'wpcom_messaging', false );
 	const { isMessagingScriptLoaded } = useZendeskMessaging(
 		'zendesk_support_chat_key',
-		( isHelpCenterShown && isEligibleForChat ) || hasActiveChats,
+		isHelpCenterShown || isEligibleForChat || hasActiveChats,
 		isEligibleForChat && hasActiveChats
 	);
 


### PR DESCRIPTION
As noted in #79018, the current Zendesk Messaging launcher overlaps the checkout payment button when the browser window is showing a mobile webview:

![image](https://github.com/Automattic/wp-calypso/assets/16580129/9735d7c4-5d74-4c19-a266-6737bb4ba772)

The proposed solution is to add a secondary custom Zendesk launcher icon to the checkout masterbar when the viewport is at a mobile width (<480px) and to conditionally hide the bottom right Zendesk launcher FAB (fancy action button) when the viewport drops below the mobile width breakpoint.

~**Note**: one noted issue at this point is that the masterbar mobile icon sometimes requires multiple presses to actually launch the chat widget. I am not sure why this is the case so I added team Vertex to review, maybe @escapemanuele has some insight since you just recently worked with the presales chat code.~ This is now https://github.com/Automattic/wp-calypso/pull/81982.

![image](https://github.com/Automattic/wp-calypso/assets/16580129/5f4cf7c1-1fc7-4016-a058-f30060d3f8bd)

Related to #79018 

## Proposed Changes

Steps to complete:

- [x] Add custom launcher code to masterbar
- [x] Update CSS to properly align checkout masterbar icons
- [ ] ~Fix checkout masterbar position on scroll~ (Probably won't do this here)
- [x] Ensure custom launcher sends all required data to Zendesk agent
- [x] Ensure custom launcher also tracks clicks correctly
- [x] Conditionally hide Zendesk launcher FAB when viewport is under 480px

## Testing Instructions

- Open up this PR locally or use the Calypso live link below
- Add a product to your cart and proceed to checkout
- While in checkout with a desktop viewport you should see the fancy chat button in the bottom right corner (Note: you may need to refresh the page a few times as the launcher only seems to appears if chat is available, though that may have changed recently. *
- Shrink the window to a mobile size, under 480px should work
- In a mobile viewport the bottom right chat launcher should be hidden and a new chat icon should appear in the checkout masterbar
- Click on the new chat icon, it should load the chat messaging widget
- Close the widget, ensure that the bottom right fancy chat button doesn't reappear in mobile view
- Load the help center by clicking on the ? symbol, loading the help center should minimize the chat, and vice versa
- Look for any functional or visual inconsistencies or degraded UX

> **Skip the availability checks - you can set the third parameter of `usePresalesChat()` in `wp-checkout.tsx` to true which will skip the availability check for the regular launcher icon on desktop. You'll also need to remove the second condition in the `ChatButton` component definition where it says `if ( isEligibleForChat && isChatAvailable ) {`, this will skip the availability check for the mobile icon.)

https://github.com/Automattic/wp-calypso/pull/79448 for posterity.