### PR TITLE
Jetpack Pro Dashboard: set max height for dashboard modal to 80%

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal-form/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal-form/style.scss
@@ -27,13 +27,6 @@
 	}
 
 	@include break-mobile {
-		position: static;
-		justify-content: right;
-		flex-direction: initial;
-		margin-block-start: 32px;
-		width: auto;
-		padding: 0;
-
 		.dashboard-modal-form__footer-buttons {
 			justify-content: end;
 			width: 100%;

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/style.scss
@@ -13,7 +13,7 @@
 
 		@include break-mobile {
 			margin-block-start: 76px;
-			padding-block-end: 32px;
+			padding-block-end: 76px;
 		}
 	}
 
@@ -29,6 +29,11 @@
 		@include break-mobile {
 			margin-block-start: 16px;
 		}
+	}
+
+	@include break-mobile {
+		max-height: 80%;
+		margin: auto;
 	}
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-modal/style.scss
@@ -6,6 +6,7 @@
 	width: 480px;
 	animation: components-modal__appear-animation 0.1s ease-out;
 	animation-fill-mode: forwards;
+	margin-block-start: 0;
 
 	.components-modal__content {
 		margin-block-start: 50px;

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/style.scss
@@ -22,7 +22,7 @@
 	padding-block-end: 120px;
 
 	@include break-mobile {
-		padding-block-end: 0;
+		padding-block-end: 35px;
 	}
 }
 


### PR DESCRIPTION
Related to 1204992567518369-as-1205271201287172

## Proposed Changes

This PR updates the max height set to the dashboard modal to 80%.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/max-height-for-pro-dashboard-modal` and `yarn start-jetpack-cloud` or open the Jetpack Cloud live link. 
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Buy a paid monitor plan and assign it to a site and enable the monitor. Follow D117782-code to buy a paid monitor plan.
4. Enable SMS notification and add a phone number and add multiple email addresses.
5. Verify the downtime monitor modal looks like below.
6. Verify it looks good on all the screen sizes

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>

https://github.com/Automattic/wp-calypso/assets/10586875/7e16f0c4-ae0f-4062-97a4-13ae337f559f

</td>
<td>

https://github.com/Automattic/wp-calypso/assets/10586875/1e8ebe87-1275-4c69-9353-4ac55c072f7b

</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
