### PR TITLE
Virtual Themes: Switch to the assembleSite endpoint to get rid of the headstart

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -6,6 +6,7 @@ import {
 	updateLaunchpadSettings,
 	useStarterDesignBySlug,
 	useStarterDesignsQuery,
+	getThemeIdFromStylesheet,
 } from '@automattic/data-stores';
 import {
 	isDefaultGlobalStylesVariationSlug,
@@ -32,7 +33,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { urlToSlug } from 'calypso/lib/url';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
-import { setActiveTheme } from 'calypso/state/themes/actions';
+import { setActiveTheme, activateOrInstallThenActivate } from 'calypso/state/themes/actions';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 import useCheckout from '../../../../hooks/use-checkout';
 import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
@@ -65,6 +66,8 @@ import type {
 } from '@automattic/data-stores';
 import type { Design, StyleVariation } from '@automattic/design-picker';
 import type { GlobalStylesObject } from '@automattic/global-styles';
+import type { AnyAction } from 'redux';
+import type { ThunkAction } from 'redux-thunk';
 
 const SiteIntent = Onboard.SiteIntent;
 const SITE_ASSEMBLER_AVAILABLE_INTENTS: string[] = [ SiteIntent.Build, SiteIntent.Write ];
@@ -482,7 +485,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	// ********** Logic for submitting the selected design
 
-	const { setDesignOnSite, applyThemeWithPatterns } = useDispatch( SITE_STORE );
+	const { setDesignOnSite, assembleSite } = useDispatch( SITE_STORE );
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
 	async function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
@@ -501,10 +504,29 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 			setPendingAction( () => {
 				if ( _selectedDesign?.is_virtual ) {
-					return applyThemeWithPatterns( siteSlugOrId, _selectedDesign ).then(
-						( theme: ActiveTheme ) => reduxDispatch( setActiveTheme( site?.ID || -1, theme ) )
-					);
+					const themeId = getThemeIdFromStylesheet( _selectedDesign.recipe?.stylesheet ?? '' );
+					return Promise.resolve()
+						.then( () =>
+							reduxDispatch(
+								activateOrInstallThenActivate(
+									themeId ?? '',
+									site?.ID ?? 0,
+									'assembler',
+									false,
+									false
+								) as ThunkAction< PromiseLike< string >, any, any, AnyAction >
+							)
+						)
+						.then( ( activeThemeStylesheet: string ) =>
+							assembleSite( siteSlugOrId, activeThemeStylesheet, {
+								homeHtml: _selectedDesign.recipe?.pattern_html,
+								headerHtml: _selectedDesign.recipe?.header_html,
+								footerHtml: _selectedDesign.recipe?.footer_html,
+								siteSetupOption: 'assembler-virtual-theme',
+							} )
+						);
 				}
+
 				return setDesignOnSite( siteSlugOrId, _selectedDesign, {
 					styleVariation: selectedStyleVariation,
 					globalStyles,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,3 +1,4 @@
+import { getThemeIdFromStylesheet } from '@automattic/data-stores';
 import {
 	useSyncGlobalStylesUserConfig,
 	getVariationTitle,
@@ -19,7 +20,6 @@ import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-s
 import { createRecordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { activateOrInstallThenActivate } from 'calypso/state/themes/actions';
-import { getThemeIdFromStylesheet } from 'calypso/state/themes/utils';
 import { useQuery } from '../../../../hooks/use-query';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';

--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import { getThemeIdFromStylesheet } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import QueryTheme from 'calypso/components/data/query-theme';
@@ -7,7 +8,6 @@ import { isFrontPage, isPostsPage } from 'calypso/state/pages/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import { getTheme } from 'calypso/state/themes/selectors';
-import { getThemeIdFromStylesheet } from 'calypso/state/themes/utils';
 
 import './style.scss';
 

--- a/client/state/themes/actions/theme-activated.js
+++ b/client/state/themes/actions/theme-activated.js
@@ -1,3 +1,4 @@
+import { getThemeIdFromStylesheet } from '@automattic/data-stores';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { requestSitePosts } from 'calypso/state/posts/actions';
@@ -9,7 +10,6 @@ import {
 	getThemeType,
 	prependThemeFilterKeys,
 } from 'calypso/state/themes/selectors';
-import { getThemeIdFromStylesheet } from 'calypso/state/themes/utils';
 
 import 'calypso/state/themes/init';
 

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -1,3 +1,4 @@
+import { getThemeIdFromStylesheet } from '@automattic/data-stores';
 import { withStorageKey } from '@automattic/state-utils';
 import { mapValues, omit, map } from 'lodash';
 import { decodeEntities } from 'calypso/lib/formatting';
@@ -56,7 +57,7 @@ import {
 } from './schema';
 import themesUI from './themes-ui/reducer';
 import uploadTheme from './upload-theme/reducer';
-import { getSerializedThemesQuery, getThemeIdFromStylesheet } from './utils';
+import { getSerializedThemesQuery } from './utils';
 
 /**
  * Returns the updated active theme state after an action has been

--- a/client/state/themes/test/utils.js
+++ b/client/state/themes/test/utils.js
@@ -3,7 +3,6 @@ import {
 	normalizeJetpackTheme,
 	normalizeWpcomTheme,
 	normalizeWporgTheme,
-	getThemeIdFromStylesheet,
 	getNormalizedThemesQuery,
 	getSerializedThemesQuery,
 	getDeserializedThemesQueryDetails,
@@ -147,23 +146,6 @@ describe( 'utils', () => {
 					],
 				},
 			} );
-		} );
-	} );
-
-	describe( '#getThemeIdFromStylesheet()', () => {
-		test( 'should return undefined when given no argument', () => {
-			const themeId = getThemeIdFromStylesheet();
-			expect( themeId ).toBeUndefined();
-		} );
-
-		test( "should return the argument if it doesn't contain a slash (/)", () => {
-			const themeId = getThemeIdFromStylesheet( 'twentysixteen' );
-			expect( themeId ).toEqual( 'twentysixteen' );
-		} );
-
-		test( "should return argument's part after the slash if it does contain a slash (/)", () => {
-			const themeId = getThemeIdFromStylesheet( 'pub/twentysixteen' );
-			expect( themeId ).toEqual( 'twentysixteen' );
 		} );
 	} );
 

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -109,20 +109,6 @@ export function normalizeWporgTheme( theme ) {
 }
 
 /**
- * Given a theme stylesheet string (like 'pub/twentysixteen'), returns the corresponding theme ID ('twentysixteen').
- *
- * @param  {string}  stylesheet Theme stylesheet
- * @returns {?string}            Theme ID
- */
-export function getThemeIdFromStylesheet( stylesheet ) {
-	const [ , slug ] = stylesheet?.split( '/', 2 ) ?? [];
-	if ( ! slug ) {
-		return stylesheet;
-	}
-	return slug;
-}
-
-/**
  * Returns a normalized themes query, excluding any values which match the
  * default theme query.
  *

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -19,6 +19,7 @@ export * from './templates';
 export * from './onboard/types';
 export * from './domain-suggestions/types';
 export * from './plans/types';
+export * from './theme';
 export * from './user/types';
 export * from './queries/use-launchpad';
 export * from './queries/use-all-domains-query';

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -498,48 +498,6 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		} );
 	}
 
-	function* applyThemeWithPatterns(
-		siteSlug: string,
-		design: Design,
-		globalStyles: GlobalStyles | null = null,
-		sourceSiteId?: number
-	) {
-		const stylesheet = design?.recipe?.stylesheet || '';
-		const theme = stylesheet?.split( '/' )[ 1 ] || design.theme;
-
-		// We have to switch theme first. Otherwise, the unique suffix might append to
-		// the slug of newly created Home template if the current activated theme has
-		// modified Home template.
-		const activatedTheme: ActiveTheme = yield setThemeOnSite( siteSlug, theme, {
-			keepHomepage: false,
-		} );
-
-		if ( globalStyles ) {
-			yield setGlobalStyles( siteSlug, stylesheet, globalStyles, activatedTheme );
-		}
-
-		const hasHeader = !! design?.recipe?.header_pattern_ids?.length;
-		const hasFooter = !! design?.recipe?.footer_pattern_ids?.length;
-		const hasSections = !! design?.recipe?.pattern_ids?.length;
-
-		yield createCustomTemplate(
-			siteSlug,
-			stylesheet,
-			'home',
-			__( 'Home' ),
-			createCustomHomeTemplateContent( stylesheet, hasHeader, hasFooter, hasSections )
-		);
-
-		yield runThemeSetupOnSite( siteSlug, design, {
-			// trimContent true ensures that the starter content is trimmed in case sourceSiteId is defined
-			// For instance only a max of three posts will be added to the user site
-			trimContent: true,
-			posts_source_site_id: sourceSiteId,
-		} );
-
-		return activatedTheme;
-	}
-
 	function* assembleSite(
 		siteSlug: string,
 		stylesheet = '',
@@ -793,11 +751,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveNewSiteFailed,
 		resetNewSiteFailed,
 		installTheme,
-		setThemeOnSite,
-		runThemeSetupOnSite,
 		setDesignOnSite,
 		createCustomTemplate,
-		applyThemeWithPatterns,
 		assembleSite,
 		createSite,
 		receiveSite,

--- a/packages/data-stores/src/theme/index.ts
+++ b/packages/data-stores/src/theme/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/packages/data-stores/src/theme/test/utils.ts
+++ b/packages/data-stores/src/theme/test/utils.ts
@@ -1,0 +1,13 @@
+import { getThemeIdFromStylesheet } from '../utils';
+
+describe( '#getThemeIdFromStylesheet()', () => {
+	test( "should return the argument if it doesn't contain a slash (/)", () => {
+		const themeId = getThemeIdFromStylesheet( 'twentysixteen' );
+		expect( themeId ).toEqual( 'twentysixteen' );
+	} );
+
+	test( "should return argument's part after the slash if it does contain a slash (/)", () => {
+		const themeId = getThemeIdFromStylesheet( 'pub/twentysixteen' );
+		expect( themeId ).toEqual( 'twentysixteen' );
+	} );
+} );

--- a/packages/data-stores/src/theme/utils.ts
+++ b/packages/data-stores/src/theme/utils.ts
@@ -1,0 +1,10 @@
+/**
+ * Given a theme stylesheet string (like 'pub/twentysixteen'), returns the corresponding theme ID ('twentysixteen').
+ */
+export const getThemeIdFromStylesheet = ( stylesheet: string ) => {
+	const [ , slug ] = stylesheet?.split( '/', 2 ) ?? [];
+	if ( ! slug ) {
+		return stylesheet;
+	}
+	return slug;
+};

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -60,8 +60,11 @@ export interface StyleVariationStylesColor {
 export interface DesignRecipe {
 	stylesheet?: string;
 	pattern_ids?: number[] | string[];
+	pattern_html?: string;
 	header_pattern_ids?: number[] | string[];
+	header_html?: string;
 	footer_pattern_ids?: number[] | string[];
+	footer_html?: string;
 	color_variation_title?: string;
 	font_variation_title?: string;
 	slug?: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80732

## Proposed Changes

* In favor of the `assembleSite` action instead of the `applyThemeWithPatterns` to build your homepage with the virtual theme so that we don't need to rely on the headstart.
* Move the `getThemeIdFromStylesheet` function into `@automattic/data-stores` so that it can be used by other packages as well

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before we get started, apply D119160-code to your sandbox

**Design Picker**

1. Go to /setup?siteSlug=<your_site>
2. Continue to the Design Picker
3. Pick any virtual theme
4. Continue
5. When you land on the launchpad, ensure the preview looks as expected

**Link in Bio**

1. Go to /setup/link-in-bio
2. Pick any LiB design
3. When you land on the launchpad, ensure the preview looks as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
