### PR TITLE
Improve the all domains list performance

### DIFF
--- a/client/components/data/query-site-purchases/index.jsx
+++ b/client/components/data/query-site-purchases/index.jsx
@@ -7,16 +7,16 @@ import { isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 
 const debug = debugFactory( 'calypso:query-site-purchases' );
 
-export const useQuerySitePurchases = ( siteId ) => {
+export const useQuerySitePurchases = ( siteId, skipSiteCheck = false ) => {
 	const isRequesting = useSelector( ( state ) => isFetchingSitePurchases( state ) );
 	const reduxDispatch = useDispatch();
 	const previousSiteId = useRef();
 
 	useEffect( () => {
-		if ( ! siteId || isRequesting ) {
+		if ( ! skipSiteCheck && ( ! siteId || isRequesting ) ) {
 			return;
 		}
-		if ( siteId === previousSiteId.current ) {
+		if ( ! skipSiteCheck && siteId === previousSiteId.current ) {
 			return;
 		}
 		debug(
@@ -25,14 +25,15 @@ export const useQuerySitePurchases = ( siteId ) => {
 		previousSiteId.current = siteId;
 
 		reduxDispatch( fetchSitePurchases( siteId ) );
-	}, [ siteId, reduxDispatch, isRequesting ] );
+	}, [ siteId, skipSiteCheck, reduxDispatch, isRequesting ] );
 };
 
-export default function QuerySitePurchases( { siteId } ) {
-	useQuerySitePurchases( siteId );
+export default function QuerySitePurchases( { siteId, skipSiteCheck } ) {
+	useQuerySitePurchases( siteId, skipSiteCheck );
 	return null;
 }
 
 QuerySitePurchases.propTypes = {
 	siteId: PropTypes.number,
+	skipSiteCheck: PropTypes.bool,
 };

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryAllDomains from 'calypso/components/data/query-all-domains';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -28,7 +27,7 @@ import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/ac
 import { infoNotice } from 'calypso/state/notices/actions';
 import {
 	getUserPurchases,
-	hasLoadedUserPurchasesFromServer,
+	hasLoadedSitePurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
 import canCurrentUserForSites from 'calypso/state/selectors/can-current-user-for-sites';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
@@ -694,7 +693,6 @@ class AllDomains extends Component {
 				<div>{ this.renderActionForm() }</div>
 				<div>
 					<QueryAllDomains />
-					<QueryUserPurchases />
 					<>
 						<DocumentHead title={ translate( 'Domains', { context: 'A navigation label.' } ) } />
 						<div>{ this.renderDomainsList() }</div>
@@ -772,7 +770,7 @@ export default connect( ( state, { context } ) => {
 		hasAllSitesLoaded: hasAllSitesList( state ),
 		isContactEmailEditContext: ListAllActions.editContactEmail === action,
 		purchases: getUserPurchases( state ) || [],
-		hasLoadedUserPurchases: hasLoadedUserPurchasesFromServer( state ),
+		hasLoadedUserPurchases: hasLoadedSitePurchasesFromServer( state ),
 		requestingFlatDomains: isRequestingAllDomains( state ),
 		requestingSiteDomains: getAllRequestingSiteDomains( state ),
 		sites,

--- a/client/my-sites/domains/domain-management/list/domains-table.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table.jsx
@@ -1,6 +1,7 @@
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Fragment, PureComponent } from 'react';
+import { InView } from 'react-intersection-observer';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import DomainRow from './domain-row';
@@ -79,19 +80,51 @@ class DomainsTable extends PureComponent {
 	};
 
 	renderQuerySitePurchasesOnce( blogId ) {
-		if ( this.renderedQuerySitePurchases[ blogId ] ) {
-			return null;
-		}
-		this.renderedQuerySitePurchases[ blogId ] = true;
-		return <QuerySitePurchases key={ `query-purchases-${ blogId }` } siteId={ blogId } />;
+		return (
+			<InView>
+				{ ( { inView, ref } ) => {
+					if ( this.renderedQuerySitePurchases[ blogId ] ) {
+						return <div ref={ ref }></div>;
+					}
+					if ( inView ) {
+						this.renderedQuerySitePurchases[ blogId ] = true;
+					}
+					return (
+						<div ref={ ref }>
+							{ inView ? (
+								<QuerySitePurchases
+									key={ `query-purchases-${ blogId }` }
+									siteId={ blogId }
+									skipSiteCheck={ true }
+								/>
+							) : null }
+						</div>
+					);
+				} }
+			</InView>
+		);
 	}
 
 	renderQuerySiteDomainsOnce( blogId ) {
-		if ( this.renderedQuerySiteDomains[ blogId ] ) {
-			return null;
-		}
-		this.renderedQuerySiteDomains[ blogId ] = true;
-		return <QuerySiteDomains key={ `query-purchases-${ blogId }` } siteId={ blogId } />;
+		return (
+			<InView>
+				{ ( { inView, ref } ) => {
+					if ( this.renderedQuerySiteDomains[ blogId ] ) {
+						return <div ref={ ref }></div>;
+					}
+					if ( inView ) {
+						this.renderedQuerySiteDomains[ blogId ] = true;
+					}
+					return (
+						<div ref={ ref }>
+							{ inView ? (
+								<QuerySiteDomains key={ `query-purchases-${ blogId }` } siteId={ blogId } />
+							) : null }
+						</div>
+					);
+				} }
+			</InView>
+		);
 	}
 
 	render() {
@@ -153,9 +186,7 @@ class DomainsTable extends PureComponent {
 			// TODO: how can we optimize the data loading? Can we load the daomin data using `InView` component as in list-all.jsx?
 			return (
 				<Fragment key={ `${ domain.name }-${ index }` }>
-					{ ! isManagingAllSites &&
-						domain.blogId &&
-						this.renderQuerySitePurchasesOnce( domain.blogId ) }
+					{ domain.blogId && this.renderQuerySitePurchasesOnce( domain.blogId ) }
 					{ isManagingAllSites &&
 						domain.blogId &&
 						this.renderQuerySiteDomainsOnce( domain.blogId ) }


### PR DESCRIPTION
We got a report that customers with lots of domains are having performance issues, and indeed they are. We had some of those optimisations before but it seems they got lost during the last domains list redesign. So me and @gius80 paired on this one to try to improve the all domains loading performance.

So far we have:
* moved the domain details loading to happen only when the domain row is rendered (we use the InView component for that)
* stopped loading all the user purchases at once - that's too slow - use the QuerySitePurchases instead

And I think we need to:
* look into improving the site loading endpoint (that's taking a while) or maybe even not wait for it to render the domains. We can probably provide the site slug within the domains list endpoint and that would save a ton of lookups and etc
* properly render the auto-renew toggle - seems it's broken if we use the `QuerySitePurchases` component but not sure why
* properly render the loading state for hte auto-renew toggle
* explore other things we can optimise - probably not reloading everything if you click on a domain and back? We should look into memoizing some data - we'll need to profile all the things better

Related to #

## Proposed Changes

* 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
