### PR TITLE
Improve ResponsiveToolbarGroup: Selected and Hover states don't have conflicting styles.

### DIFF
--- a/client/my-sites/themes/themes-toolbar-group/style.scss
+++ b/client/my-sites/themes/themes-toolbar-group/style.scss
@@ -47,7 +47,7 @@
 				box-shadow: inset 0 0 0 2px var(--color-primary-light);
 			}
 
-			&:not(.is-pressed):hover::before {
+			&:not(.is-pressed):not(.is-selected):hover::before {
 				background-color: var(--studio-gray-0);
 			}
 

--- a/packages/components/src/responsive-toolbar-group/style.scss
+++ b/packages/components/src/responsive-toolbar-group/style.scss
@@ -15,7 +15,7 @@
 			background-color: #1e1e1e;
 			color: var(--color-text-inverted);
 		}
-		.responsive-toolbar-group__menu-item:not(.is-selected):not(.responsive-toolbar-group__more-item):not(.is-selected) {
+		.responsive-toolbar-group__menu-item:not(.is-selected):not(.responsive-toolbar-group__more-item) {
 			&:hover {
 				background: var(--studio-gray-0);
 			}

--- a/packages/components/src/responsive-toolbar-group/style.scss
+++ b/packages/components/src/responsive-toolbar-group/style.scss
@@ -15,7 +15,7 @@
 			background-color: #1e1e1e;
 			color: var(--color-text-inverted);
 		}
-		.responsive-toolbar-group__menu-item:not(.is-selected):not(.responsive-toolbar-group__more-item) {
+		.responsive-toolbar-group__menu-item:not(.is-selected):not(.responsive-toolbar-group__more-item):not(.is-selected) {
 			&:hover {
 				background: var(--studio-gray-0);
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80492

## Proposed Changes

* Fixed the conflicting state in the component that caused the Selected and Hover state to overlap.

|Before|After|
|----|----|
|![Captura de Pantalla 2023-08-17 a las 13 45 28](https://github.com/Automattic/wp-calypso/assets/1989914/76e1ad6e-2a57-401e-98d6-c6385eb87021)|![Captura de Pantalla 2023-08-17 a las 13 44 09](https://github.com/Automattic/wp-calypso/assets/1989914/1ca17bd7-7bd3-40ce-92c8-93313cca347c)|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Livelink
* Navigate to the Theme Showcase (any or all of its variants)
* Select an item in the `more` menu.
* Now hover over the selected item.
* It should be displayed correctly instead of in the hover state.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
