### PR TITLE
Hosting Metrics: Log Site Monitoring pageviews

### DIFF
--- a/client/my-sites/site-monitoring/main.tsx
+++ b/client/my-sites/site-monitoring/main.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { SiteMonitoringTabPanel } from './components/site-monitoring-tab-panel';
 import { LogsTab } from './logs-tab';
 import { MetricsTab } from './metrics-tab';
@@ -21,6 +22,7 @@ export function SiteMetrics() {
 
 	return (
 		<Main className="site-monitoring" fullWidthLayout>
+			<PageViewTracker path="/site-monitoring/:site" title="Site Monitoring" />
 			<DocumentHead title={ titleHeader } />
 			<FormattedHeader
 				className="site-monitoring__formatted-header modernized-header"


### PR DESCRIPTION
## Proposed Changes

Logs visits to Site Monitoring with the `<PageViewTracker>` component.

## Testing Instructions

1. Navigate to `/site-monitoring/<site>`.
2. Verify the pageview Tracks event is fired as expected.

<img width="1116" alt="CleanShot 2023-08-17 at 05 09 33@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/5898cce8-2e1f-4890-abe2-fdfa634e9abc">
