### PR TITLE
Marketplace: add useGetRelatedPlugins hook

### DIFF
--- a/client/data/marketplace/types.ts
+++ b/client/data/marketplace/types.ts
@@ -94,3 +94,35 @@ export type SearchParams = {
 export type ReinstallPluginsResponse = {
 	message: string;
 };
+
+export type ESRelatedPluginsResult = {
+	fields: ESRelatedPlugin;
+};
+
+export type ESRelatedPlugin = {
+	categories: Array< string >;
+	excerpt?: string;
+	icon?: string;
+	marketplace_slug?: string;
+	product_slug?: string;
+	slug?: string;
+	title?: string;
+	variations: {
+		monthly: { product_slug?: string; product_id?: number };
+		yearly: { product_slug?: string; product_id?: number };
+	};
+};
+
+export type RelatedPlugin = {
+	categories: Array< string >;
+	excerpt?: string;
+	icon?: string;
+	marketplaceSlug?: string;
+	productSlug?: string;
+	slug?: string;
+	title?: string;
+	variations?: {
+		monthly: { product_slug?: string; product_id?: number };
+		yearly: { product_slug?: string; product_id?: number };
+	};
+};

--- a/client/data/marketplace/use-get-related-plugins.ts
+++ b/client/data/marketplace/use-get-related-plugins.ts
@@ -1,0 +1,39 @@
+import {
+	useQuery,
+	QueryKey,
+	QueryFunction,
+	UseQueryOptions,
+	UseQueryResult,
+} from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { BASE_STALE_TIME } from 'calypso/state/initial-state';
+
+const getRelatedPluginsQueryParams = (
+	pluginSlug: string,
+	size: number
+): { queryKey: QueryKey; queryFn: QueryFunction } => {
+	const queryKey: QueryKey = [ 'related-plugins', pluginSlug, size ];
+	const queryFn = () => {
+		return wpcom.req.get(
+			{
+				path: `/marketplace/${ pluginSlug }/related`,
+				apiNamespace: 'rest/v1.3',
+			},
+			{ size }
+		);
+	};
+	return { queryKey, queryFn };
+};
+
+export const useGetRelatedPlugins = (
+	pluginSlug: string,
+	size = 4,
+	{ enabled = true, staleTime = BASE_STALE_TIME, refetchOnMount = true }: UseQueryOptions = {}
+): UseQueryResult => {
+	return useQuery( {
+		...getRelatedPluginsQueryParams( pluginSlug, size ),
+		enabled: enabled,
+		staleTime: staleTime,
+		refetchOnMount: refetchOnMount,
+	} );
+};

--- a/client/data/marketplace/use-get-related-plugins.ts
+++ b/client/data/marketplace/use-get-related-plugins.ts
@@ -40,9 +40,8 @@ const getRelatedPluginsQueryParams = (
 			.get(
 				{
 					path: `/marketplace/${ pluginSlug }/related`,
-					apiNamespace: 'rest/v1.3',
 				},
-				{ size }
+				{ size, apiVersion: '1.3' }
 			)
 			.then( ( { data }: { data: Array< ESRelatedPluginsResult > } ) =>
 				mapESDataToReatedPluginData( data )


### PR DESCRIPTION
Resolves #80287

## Proposed Changes

Create the `useGetRelatedPlugins` hook to retrieve related plugins from a given plugin and return the results mapped to the `RelatedPlugin` type.

## Testing Instructions
* Checkout this branch locally 
* Open `client/my-sites/plugins/plugin-details.jsx`
* Add this on line `73`
```jsx
import { useGetRelatedPlugins } from 'calypso/data/marketplace/use-get-related-plugins';
```

* Add this on line `79`
```jsx
const { data: relatedPlugins } = useGetRelatedPlugins( props.pluginSlug, 4, { staleTime: 0 } );
console.log( { relatedPlugins } );
```

* Go to `/plugins/:plugin-slug`. Ex: `/plugins/wordpress-seo`
* You should see the `relatedPlugins` property on the console as an array with 4 results and adequately mapped to the `RelatedPlugin` type.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
