### PR TITLE
Map build intent to portfolio design picker category

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -2,6 +2,7 @@ import { Category } from '@automattic/design-picker';
 
 const CATEGORY_BLOG = 'blog';
 const CATEGORY_STORE = 'store';
+const CATEGORY_PORTFOLIO = 'portfolio';
 
 /**
  * Ensures the category appears at the top of the design category list
@@ -22,6 +23,7 @@ function makeSortCategoryToTop( slug: string ) {
 
 const sortBlogToTop = makeSortCategoryToTop( CATEGORY_BLOG );
 const sortStoreToTop = makeSortCategoryToTop( CATEGORY_STORE );
+const sortPortfolioToTop = makeSortCategoryToTop( CATEGORY_PORTFOLIO );
 
 export function getCategorizationOptions( intent: string ) {
 	const result = {
@@ -43,6 +45,12 @@ export function getCategorizationOptions( intent: string ) {
 				...result,
 				defaultSelection: CATEGORY_STORE,
 				sort: sortStoreToTop,
+			};
+		case 'build':
+			return {
+				...result,
+				defaultSelection: CATEGORY_PORTFOLIO,
+				sort: sortPortfolioToTop,
 			};
 		default:
 			return {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3058

## Proposed Changes

Since the removal of the 'Show all' category in #80637 the 'Build' intent (aka 'Promote myself or business') has meant the design picker starts at the first category - Blog. With this change it will start at 'Portfolio' instead.

Portfolio currently has a wide range of themes - TT3, business, blogs, galleries etc, and the naming feels consistent with 'Promote'.

## Testing Instructions

 1. Apply patch or use calypso live link
 2. Go to /start
 3. Work your way through onboarding until you reach the 'Goals' screen
 4. Choose Promote myself or business and continue
 5. Note that the design picker defaults to the Portfolio category


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before | After
-------|------
<img width="1272" alt="Screenshot 2023-08-17 at 13 50 28" src="https://github.com/Automattic/wp-calypso/assets/93301/f9445097-ced2-4d20-ad8e-a98722538865"> | <img width="1272" alt="Screenshot 2023-08-17 at 13 48 51" src="https://github.com/Automattic/wp-calypso/assets/93301/f8665ed5-e33f-4569-ac2b-48e12db49625">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2) - _no ui components changed_
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? - _N/A onboarding_
- [x] Have you checked for TypeScript, React or other console errors? Only unrelated/existing errors
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) - none
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? - no strings changed
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)? n/a