### PR TITLE
Move site-default design subject to the front

### DIFF
--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -57,7 +57,7 @@ export function useCategorization(
 
 export function useCategorizationFromApi(
 	categoryMap: Record< string, Category >,
-	{ defaultSelection }: UseCategorizationOptions
+	{ defaultSelection, sort }: UseCategorizationOptions
 ): Categorization {
 	const categories = useMemo( () => {
 		const categoryMapKeys = Object.keys( categoryMap ) || [];
@@ -66,7 +66,7 @@ export function useCategorizationFromApi(
 			slug,
 		} ) );
 
-		return result;
+		return result.sort( sort );
 	}, [ categoryMap ] );
 
 	const [ selection, onSelect ] = useState< string | null >(


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

First mentioned in https://github.com/Automattic/wp-calypso/pull/80637#pullrequestreview-1579963177

## Proposed Changes

When starting a site and choosing an intent that has a specific design picker subject associated with it (e.g. write -> blog, sell online -> store) the design picker should show that theme picker subject at the front of the subject list.

In theory one of these subjects could even be hidden behind the 'more' menu.

## Testing Instructions

 1. Checkout or use calypso live live
 2. Go to /start and work through the process until reaching the goals screen
 3. Choose the 'Sell online' goal
 4. Note that 'Store' is at the front of the category list
 5. Go back and choose a different intent like 'Other'
 6. Note that 'Blog' is at the front of the category list

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before | After
-------|------
<img width="1272" alt="Screenshot 2023-08-17 at 14 10 45" src="https://github.com/Automattic/wp-calypso/assets/93301/6ae26064-df6f-4474-a241-a0f7ef0e728c"> | <img width="1272" alt="Screenshot 2023-08-17 at 14 10 35" src="https://github.com/Automattic/wp-calypso/assets/93301/a0210826-a3dc-4795-893d-2795ed68be2e">


*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
