### PR TITLE
Enable individual subscriber stats across all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -44,7 +44,7 @@
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/unified": true,
-		"individual-subscriber-stats": false,
+		"individual-subscriber-stats": true,
 		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-messaging-i3": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -49,7 +49,7 @@
 		"i18n/empathy-mode": true,
 		"importer/unified": true,
 		"importers/substack": true,
-		"individual-subscriber-stats": false,
+		"individual-subscriber-stats": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/api-cache": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -60,7 +60,7 @@
 		"i18n/translation-scanner": true,
 		"importers/substack": true,
 		"importer/unified": true,
-		"individual-subscriber-stats": false,
+		"individual-subscriber-stats": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/api-cache": true,


### PR DESCRIPTION

## Proposed Changes

This change enables the "individual-subscriber-stats" in the 'stage', 'wpcalypso' and 'horizon' configurations.

I only enabled it for production 🫠

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
