### PR TITLE
Fix border for the Customer Home site preview

### DIFF
--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -11,6 +11,8 @@
 		max-height: 235px;
 		cursor: pointer;
 		transition: all 200ms ease-in-out;
+		border: 1px solid #eee;
+		border-radius: 4px;
 
 		&:hover,
 		&:focus {

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -11,7 +11,7 @@
 		max-height: 235px;
 		cursor: pointer;
 		transition: all 200ms ease-in-out;
-		border: 1px solid #eee;
+		border: 1px solid var(--color-border-subtle);
 		border-radius: 4px;
 
 		&:hover,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #80733

More context: pdtkmj-1G6-p2#comment-3177 

## Proposed Changes

* Brings the border back to the site Preview. Somehow it got lost with our recent changes.

#### Before

<img width="386" alt="Screen Shot 2023-08-17 at 10 11 42" src="https://github.com/Automattic/wp-calypso/assets/1234758/838a87c6-07fb-498b-b8be-1bea7ed87c5c">

#### After

<img width="389" alt="Screen Shot 2023-08-17 at 10 11 31" src="https://github.com/Automattic/wp-calypso/assets/1234758/565dd8da-4d8f-43a9-95f6-143b202d225a">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the calypso.live link below
* Navigate to the Customer Home page on a site with the Launchpad
* You should see the preview with the border

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
