### PR TITLE
Hosting Metrics: Remove '?page=' query param for default page

### DIFF
--- a/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
+++ b/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
@@ -12,7 +12,11 @@ export function getPageQueryParam(): SiteMonitoringTab | null {
 
 export function updatePageQueryParam( tabName: SiteMonitoringTab ) {
 	const url = new URL( window.location.href );
-	url.searchParams.set( 'page', tabName );
+	if ( tabName === 'metrics' ) {
+		url.searchParams.delete( 'page' );
+	} else {
+		url.searchParams.set( 'page', tabName );
+	}
 	page.replace( url.pathname + url.search );
 }
 


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/3498

## Proposed Changes

Removes the `?page=` query param when `?page=metrics`.

### Before

<img width="829" alt="CleanShot 2023-08-17 at 06 37 12@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/e4e8a34e-48ea-4ce7-a9cc-63f64dc9a771">

### After

<img width="797" alt="CleanShot 2023-08-17 at 06 37 24@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/631388bf-bb70-454e-8a37-f2ccdd3e4e8d">


## Testing Instructions

1. Navigate to `/site-monitoring/<site>`.
2. Verify `?page=metrics` is not added to the URL.
3. Navigate to `/site-monitoring/<site>?page=metrics`.
4. Verify the `?page=metrics` is removed from the URL and the page loads as expected.
5. Switch to one of the log tabs, then click on "Metrics", and verify the page loads as expected.