### PR TITLE
Happy blocks: Fix footer content spacing

### DIFF
--- a/apps/happy-blocks/block-library/support-content-links/style.scss
+++ b/apps/happy-blocks/block-library/support-content-links/style.scss
@@ -1,7 +1,12 @@
+$breakpoint-mobile: 782px; //Mobile size.
 .support-content-links {
 	p {
 		font-size: 1rem;
 		line-height: 24px;
 		margin: 8px 0;
+		@media ( max-width: $breakpoint-mobile ) {
+			display: grid;
+			margin: 16px 0;
+		}
 	}
 }

--- a/apps/happy-blocks/block-library/support-content-links/style.scss
+++ b/apps/happy-blocks/block-library/support-content-links/style.scss
@@ -2,5 +2,6 @@
 	p {
 		font-size: 1rem;
 		line-height: 24px;
+		margin: 8px 0;
 	}
 }


### PR DESCRIPTION
## Proposed Changes

Fixes footer spacing issues reported IceKRdz5qlPYwuqzu6pBgF-fi-5793%3A32391

Issues:
<img width="939" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/85653522-aca7-4adb-bdd9-c66f98fa51bc">

Issues Mobile:
<img width="651" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/c6a5061c-4a39-418a-b231-4ba14dde1338">



## Testing Instructions
Pull and run this branch 
Navigate to `apps/happy-blocks` and run `yarn dev --sync`
Run [wpsupport3](https://github.com/Automattic/wpsupport3) theme
Validate if the comments are fixed

