### PR TITLE
Jetpack Error UX: Hide updates indicator for Atomic sites

### DIFF
--- a/client/my-sites/site-indicator/index.jsx
+++ b/client/my-sites/site-indicator/index.jsx
@@ -47,10 +47,14 @@ class SiteIndicator extends Component {
 	}
 
 	showIndicator() {
-		const { siteIsJetpack, userCanManage } = this.props;
+		const { siteIsAutomatedTransfer, siteIsJetpack, userCanManage } = this.props;
 
 		// Until WP.com sites have indicators (upgrades expiring, etc) we only show them for Jetpack sites
-		return userCanManage && siteIsJetpack && ( this.hasUpdate() || this.hasError() );
+		return (
+			userCanManage &&
+			siteIsJetpack &&
+			( ( ! siteIsAutomatedTransfer && this.hasUpdate() ) || this.hasError() )
+		);
 	}
 
 	toggleExpand = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1692280212148099-slack-dotcom-reactor

## Proposed Changes

In this PR I propose to hide updates indicator for Atomic sites.

I enabled errors and updates indicators for Atomic sites in https://github.com/Automattic/wp-calypso/pull/80619 but should have enable it only for errors, leaving updates hidden.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Atomic site with valid Jetpack connection

1. Navigate to the Posts page for the Atomic site
2. Confirm that there is no indicator showing that there are updates available

Incorrect behavior:

![Screenshot 2023-08-17 at 16 42 56](https://github.com/Automattic/wp-calypso/assets/727413/78ff93c9-3de3-4309-9c99-54ea8d21d47d)

Expected behavior:

![Screenshot 2023-08-17 at 16 43 13](https://github.com/Automattic/wp-calypso/assets/727413/6b4c4e17-389c-4026-97cf-b75811617457)

### Atomic site with invalid Jetpack connection due to fatal error on site

1. Create an Atomic site with a Business plan and activate hosting features
2. SSH to the site and cd to your site root
3. Edit the wp-config.php file and add the code:
```
fatal(doit);
```
4. Navigate to the Posts page
3. Confirm that there is an indicator showing that there is an error on the site

![Screenshot 2023-08-17 at 16 43 26](https://github.com/Automattic/wp-calypso/assets/727413/8acf9bfb-eb15-4ab5-87ac-ab1bea0dfef5)

### Non-Atomic site with valid Jetpack connection

1. Navigate to the Posts page for the non-Atomic site, which has updates available
2. Confirm that there is an indicator showing that there are updates available

![Screenshot 2023-08-17 at 16 42 56](https://github.com/Automattic/wp-calypso/assets/727413/78ff93c9-3de3-4309-9c99-54ea8d21d47d)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
