### PR TITLE
Individual subscriber stats: Show notice when blog is registered before we started collecting data

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-stats/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-stats/style.scss
@@ -11,6 +11,10 @@
 		line-height: 20px;
 		margin-top: 8px;
 
+		svg {
+			margin-right: 2px;
+		}
+
 		path {
 			fill: var(--studio-gray-50);
 		}

--- a/client/my-sites/subscribers/components/subscriber-stats/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-stats/style.scss
@@ -1,4 +1,18 @@
+@import "@wordpress/base-styles/mixins";
 
 .subscriber-details .subscriber-stats {
 	margin-bottom: 32px;
+
+	&__tip {
+		display: flex;
+		align-items: center;
+		color: var(--studio-gray-50);
+		font-size: $font-body-extra-small;
+		line-height: 20px;
+		margin-top: 8px;
+
+		path {
+			fill: var(--studio-gray-50);
+		}
+	}
 }

--- a/client/my-sites/subscribers/components/subscriber-stats/subscriber-stats.tsx
+++ b/client/my-sites/subscribers/components/subscriber-stats/subscriber-stats.tsx
@@ -49,7 +49,7 @@ const SubscriberStats = ( { siteId, subscriptionId, userId }: SubscriberStatsPro
 			{ subscriberStats?.blog_registration_date &&
 			subscriberStats.blog_registration_date < new Date( '2023-08-17' ) ? (
 				<div className="subscriber-stats__tip">
-					<Icon icon={ tip } size={ 20 } />
+					<Icon icon={ tip } size={ 16 } />
 					{ translate( 'Data available since August 17th, 2023' ) }
 				</div>
 			) : null }

--- a/client/my-sites/subscribers/components/subscriber-stats/subscriber-stats.tsx
+++ b/client/my-sites/subscribers/components/subscriber-stats/subscriber-stats.tsx
@@ -1,4 +1,4 @@
-import { Icon, chartBar } from '@wordpress/icons';
+import { Icon, chartBar, tip } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useSubscriberStatsRate } from '../../hooks';
 import { useSubscriberStatsQuery } from '../../queries';
@@ -25,26 +25,34 @@ const SubscriberStats = ( { siteId, subscriptionId, userId }: SubscriberStatsPro
 	const clickRate = useSubscriberStatsRate( subscriberStats, 'unique_clicks' );
 
 	return (
-		<div className="subscriber-stats highlight-cards-list">
-			<SubscriberStatsCard
-				heading="Emails sent"
-				isLoading={ isLoading }
-				icon={ <Icon icon={ MailIcon } /> }
-				helpText={ translate( 'Total number of emails sent to this subscriber.' ) }
-				value={ subscriberStats?.emails_sent }
-			/>
-			<SubscriberStatsCard
-				heading="Open rate"
-				isLoading={ isLoading }
-				icon={ <Icon icon={ chartBar } /> }
-				value={ `${ openRate }%` }
-			/>
-			<SubscriberStatsCard
-				heading="Click rate"
-				icon={ <Icon icon={ SelectIcon } /> }
-				isLoading={ isLoading }
-				value={ `${ clickRate }%` }
-			/>
+		<div className="subscriber-stats">
+			<div className="subscriber-stats__list highlight-cards-list">
+				<SubscriberStatsCard
+					heading="Emails sent"
+					isLoading={ isLoading }
+					icon={ <Icon icon={ MailIcon } /> }
+					value={ subscriberStats?.emails_sent }
+				/>
+				<SubscriberStatsCard
+					heading="Open rate"
+					isLoading={ isLoading }
+					icon={ <Icon icon={ chartBar } /> }
+					value={ `${ openRate }%` }
+				/>
+				<SubscriberStatsCard
+					heading="Click rate"
+					icon={ <Icon icon={ SelectIcon } /> }
+					isLoading={ isLoading }
+					value={ `${ clickRate }%` }
+				/>
+			</div>
+			{ subscriberStats?.blog_registration_date &&
+			subscriberStats.blog_registration_date < new Date( '2023-08-17' ) ? (
+				<div className="subscriber-stats__tip">
+					<Icon icon={ tip } size={ 20 } />
+					{ translate( 'Data available since August 17th, 2023' ) }
+				</div>
+			) : null }
 		</div>
 	);
 };

--- a/client/my-sites/subscribers/hooks/use-subscriber-stats-rate.ts
+++ b/client/my-sites/subscribers/hooks/use-subscriber-stats-rate.ts
@@ -9,7 +9,7 @@ function formatNumber( num: number ) {
 }
 const useSubscriberStatsRate = (
 	subscriberStats: SubscriberStats | undefined,
-	property: keyof Omit< SubscriberStats, 'emails_sent' >
+	property: keyof Omit< SubscriberStats, 'emails_sent' | 'blog_registration_date' >
 ) => {
 	return useMemo( () => {
 		if ( subscriberStats && subscriberStats.emails_sent && subscriberStats[ property ] ) {

--- a/client/my-sites/subscribers/queries/use-subscriber-stats-query.ts
+++ b/client/my-sites/subscribers/queries/use-subscriber-stats-query.ts
@@ -2,6 +2,17 @@ import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import type { SubscriberStats } from '../types';
 
+type SubscriberStatsApiResponse = SubscriberStats & {
+	blog_registration_date: string;
+};
+
+const transformData = ( data: SubscriberStatsApiResponse ) => {
+	return {
+		...data,
+		blog_registration_date: new Date( data.blog_registration_date ),
+	};
+};
+
 const useSubscriberStatsQuery = (
 	siteId: number | null,
 	subscriptionId: number | undefined,
@@ -11,16 +22,20 @@ const useSubscriberStatsQuery = (
 		queryKey: [ 'subscriber-stats', { subscriptionId, userId } ],
 		queryFn: () => {
 			if ( userId ) {
-				return wpcom.req.get( {
-					path: `/sites/${ siteId }/individual-subscriber-stats?user_id=${ userId }`,
-					args: { user_id: userId },
-					apiNamespace: 'wpcom/v2',
-				} );
+				return wpcom.req
+					.get( {
+						path: `/sites/${ siteId }/individual-subscriber-stats?user_id=${ userId }`,
+						args: { user_id: userId },
+						apiNamespace: 'wpcom/v2',
+					} )
+					.then( transformData );
 			} else if ( subscriptionId ) {
-				return wpcom.req.get( {
-					path: `/sites/${ siteId }/individual-subscriber-stats?subscription_id=${ subscriptionId }`,
-					apiNamespace: 'wpcom/v2',
-				} );
+				return wpcom.req
+					.get( {
+						path: `/sites/${ siteId }/individual-subscriber-stats?subscription_id=${ subscriptionId }`,
+						apiNamespace: 'wpcom/v2',
+					} )
+					.then( transformData );
 			}
 		},
 		enabled: !! siteId,

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -49,4 +49,5 @@ export type SubscriberStats = {
 	emails_sent: number;
 	unique_opens: number;
 	unique_clicks: number;
+	blog_registration_date: Date;
 };


### PR DESCRIPTION
Discussion:p1692262264754989-slack-C02TCEHP3HA

## Proposed Changes

This PR adds a notice when the blog is registered before 2023-08-17.

<img width="1085" alt="CleanShot 2023-08-17 at 17 13 00@2x" src="https://github.com/Automattic/wp-calypso/assets/528287/9d66ca54-0b96-48c6-9cc6-09f4e744a8a0">

## Testing Instructions

1. Apply this PR
2. Open Calypso for a site registered before 2023-08-17 
3. Visit Users > Subscribers and click a subscriber
4. You should see the the notice

Repeat with either a newly registered site, or change the date in `client/my-sites/subscribers/components/subscriber-stats/subscriber-stats.tsx`, and verify the notice is gone.

Compare with the design: h8tMpJlCqNFemEerU9owHI-fi 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
