### PR TITLE
Domains Management: First pass at domain only user transfer flow

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -117,27 +117,25 @@ const TransferPage = ( props: TransferPageProps ) => {
 	const renderTransferOptions = () => {
 		const options = [];
 
-		if ( ! isDomainOnly ) {
-			const mainText = isMapping
-				? __( 'Transfer this domain connection to any administrator on this site' )
-				: __( 'Transfer this domain to any administrator on this site' );
+		const userTransferText = isMapping
+			? __( 'Transfer this domain connection to any administrator on this site' )
+			: __( 'Transfer this domain to any administrator on this site' );
 
-			options.push(
-				<ActionCard
-					key="transfer-to-another-user"
-					buttonHref={ domainManagementTransferToAnotherUser(
-						selectedSite?.slug,
-						selectedDomainName,
-						currentRoute
-					) }
-					// translators: Continue is a verb
-					buttonText={ __( 'Continue' ) }
-					// translators: Transfer a domain to another user
-					headerText={ __( 'To another user' ) }
-					mainText={ mainText }
-				/>
-			);
-		}
+		options.push(
+			<ActionCard
+				key="transfer-to-another-user"
+				buttonHref={ domainManagementTransferToAnotherUser(
+					selectedSite?.slug,
+					selectedDomainName,
+					currentRoute
+				) }
+				// translators: Continue is a verb
+				buttonText={ __( 'Continue' ) }
+				// translators: Transfer a domain to another user
+				headerText={ __( 'To another user' ) }
+				mainText={ userTransferText }
+			/>
+		);
 
 		if ( domain?.pendingRegistration ) {
 			return (

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/transfer-domain-to-other-user.jsx
@@ -1,4 +1,5 @@
 import { Dialog, Gridicon } from '@automattic/components';
+import { Modal, Button } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -27,6 +28,7 @@ import {
 	domainManagementTransfer,
 	isUnderDomainManagementAll,
 } from 'calypso/my-sites/domains/paths';
+import InviteForm from 'calypso/my-sites/people/team-invite/invite-form';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -56,6 +58,7 @@ class TransferDomainToOtherUser extends Component {
 			selectedUserId: '',
 			showConfirmationDialog: false,
 			disableDialogButtons: false,
+			modalIsOpen: false,
 		};
 
 		this.handleUserChange = this.handleUserChange.bind( this );
@@ -77,6 +80,16 @@ class TransferDomainToOtherUser extends Component {
 	handleTransferCancel = () => {
 		const { selectedSite, selectedDomainName, currentRoute } = this.props;
 		page( domainManagementTransfer( selectedSite?.slug, selectedDomainName, currentRoute ) );
+	};
+
+	openModal = ( event ) => {
+		console.log( 'hello world' );
+		event.preventDefault();
+		this.setState( { isModalOpen: true } );
+	};
+
+	closeModal = () => {
+		this.setState( { isModalOpen: false } );
 	};
 
 	handleConfirmTransferDomain( closeDialog ) {
@@ -345,44 +358,38 @@ class TransferDomainToOtherUser extends Component {
 	}
 
 	renderTransferInformation() {
-		const { isMapping, selectedDomainName: domainName, selectedSite, translate } = this.props;
+		const { isMapping, selectedDomainName: domainName, translate } = this.props;
+		const { isModalOpen } = this.state;
 
-		if ( isMapping ) {
-			return (
-				<>
-					<p>
-						{ translate(
-							'Please choose an administrator to transfer domain connection of {{strong}}%(domainName)s{{/strong}} to.',
-							{ args: { domainName }, components: { strong: <strong /> } }
-						) }
-					</p>
-					<p>
-						{ translate(
-							'You can transfer this domain connection to any administrator on this site. If the user you want to ' +
-								'transfer is not currently an administrator, please {{a}}add them to the site first{{/a}}.',
-							{ components: { a: <a href={ `/people/new/${ selectedSite?.slug }` } /> } }
-						) }
-					</p>
-				</>
-			);
-		}
+		const explanationText = isMapping
+			? translate(
+					'Please choose an administrator to transfer domain connection of {{strong}}%(domainName)s{{/strong}} to.',
+					{ args: { domainName }, components: { strong: <strong /> } }
+			  )
+			: translate(
+					'Transferring a domain to another user will give all the rights of the domain to that user. ' +
+						'Please choose an administrator to transfer {{strong}}%(domainName)s{{/strong}} to.',
+					{ args: { domainName }, components: { strong: <strong /> } }
+			  );
 
 		return (
 			<>
-				<p>
-					{ translate(
-						'Transferring a domain to another user will give all the rights of the domain to that user. ' +
-							'Please choose an administrator to transfer {{strong}}%(domainName)s{{/strong}} to.',
-						{ args: { domainName }, components: { strong: <strong /> } }
-					) }
-				</p>
+				<p>{ explanationText }</p>
 				<p>
 					{ translate(
 						'You can transfer this domain to any administrator on this site. If the user you want to ' +
 							'transfer is not currently an administrator, please {{a}}add them to the site first{{/a}}.',
-						{ components: { a: <a href={ `/people/new/${ selectedSite?.slug }` } /> } }
+						{ components: { a: <Button onClick={ this.openModal } variant="link" /> } }
 					) }
 				</p>
+				{ isModalOpen && (
+					<Modal
+						title={ translate( 'Invite Domain Administrator' ) }
+						onRequestClose={ this.closeModal }
+					>
+						<InviteForm onInviteSuccess={ this.closeModal } />
+					</Modal>
+				) }
 			</>
 		);
 	}

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -327,6 +327,8 @@ export function generateFlows( {
 			description: 'An experimental approach for WordPress.com/domains',
 			disallowResume: true,
 			lastModified: '2022-02-15',
+			providesDependenciesInQuery: [ 'siteOrDomain' ],
+			optionalDependenciesInQuery: [ 'siteOrDomain' ],
 			showRecaptcha: true,
 			hideProgressIndicator: true,
 		},

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -515,6 +515,7 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'themeItem',
 				'useThemeHeadstart',
+				'siteOrDomain',
 			],
 			props: {
 				isDomainOnly: true,
@@ -675,7 +676,9 @@ export function generateSteps( {
 				'siteUrl',
 				'domainItem',
 				'themeSlugWithRepo',
+				'siteOrDomain',
 			],
+			optionalDependencies: [ 'siteOrDomain' ],
 		},
 		'site-picker': {
 			stepName: 'site-picker',

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -21,6 +21,16 @@ import NewSiteImage from './new-site-image';
 import './style.scss';
 
 class SiteOrDomain extends Component {
+	constructor( props ) {
+		super( props );
+
+		const { signupDependencies } = props;
+		if ( signupDependencies && signupDependencies.siteOrDomain === '0' ) {
+			this.skipRender = true;
+			this.submitDomainOnlyChoice();
+		}
+	}
+
 	getDomainName() {
 		const { signupDependencies } = this.props;
 		let isValidDomain = false;
@@ -233,6 +243,8 @@ class SiteOrDomain extends Component {
 	};
 
 	render() {
+		const { signupDependencies } = this.props;
+
 		const { translate, productsLoaded, isReskinned } = this.props;
 		const domainName = this.getDomainName();
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3509

## Proposed Changes

- Allow transferring of domains for domain only sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
