### PR TITLE
Webinars: Support content and header fixes

### DIFF
--- a/apps/happy-blocks/block-library/education-header/style.scss
+++ b/apps/happy-blocks/block-library/education-header/style.scss
@@ -249,6 +249,7 @@ body.archive {
 		margin: 0;
 		@media ( max-width: $breakpoint-tablet ) {
 			font-size: 1.75rem;
+			line-height: 29px;
 		}
 	}
 

--- a/apps/happy-blocks/block-library/support-content-footer/index.php
+++ b/apps/happy-blocks/block-library/support-content-footer/index.php
@@ -80,7 +80,7 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 			require WP_CONTENT_DIR . '/a8c-plugins/happy-blocks/block-library/support-content-links/index.php';
 		?>
 		<div class="support-content-subscribe">
-			<p><?php esc_html_e( 'Get the latest learning in your inbox:', 'happy-blocks' ); ?></p>
+			<p><?php esc_html_e( 'Sign up for educational resources updates:', 'happy-blocks' ); ?></p>
 			<form action="https://subscribe.wordpress.com" method="post" accept-charset="utf-8" data-blog="<?php echo get_current_blog_id(); ?>" data-post_access_level="everybody" id="subscribe-blog">
 				<input class="support-content-subscribe-email" required="required" type="email" name="email" placeholder="<?php esc_html_e( 'Type your email', 'happy-blocks' ); ?>"  id="subscribe-field">
 				<input type="hidden" name="action" value="subscribe">

--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -232,7 +232,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 		.support-content-links {
 			a {
-				display: block;
+				display: inline-block;
 			}
 
 			p {

--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -232,7 +232,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 		.support-content-links {
 			a {
-				display: inline-block;
+				display: block;
 			}
 
 			p {


### PR DESCRIPTION
On mobile we now show "Contact our Happiness Engineers." on a new line
![image](https://github.com/Automattic/wp-calypso/assets/52076348/9023f8d3-da62-4603-926d-32a12e3b58fe)

Fixed line-height of "Webinars"
![image](https://github.com/Automattic/wp-calypso/assets/52076348/10309cf1-ca0f-41b0-a8d1-102680b129b4)

Changed Copy (Sign up...):
![image](https://github.com/Automattic/wp-calypso/assets/52076348/98c5a70d-8f28-444b-8878-743e39d6836b)

## Testing
1. Checkout and sync Happy Blocks
2. Check the changes on learncft.wordpress.com/webinars
