### PR TITLE
Jetpack Pro Dashboard: Fix backup add-ons breaking the license lightbox

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
@@ -162,6 +162,13 @@ export function useProductDescription( productSlug: string ): {
 			case 'jetpack-backup-t2':
 				description = translate( 'Real-time cloud backups with one-click restores.' );
 				break;
+			case 'jetpack-backup-addon-storage-10gb-monthly':
+			case 'jetpack-backup-addon-storage-100gb-monthly':
+			case 'jetpack-backup-addon-storage-1tb-monthly':
+			case 'jetpack-backup-addon-storage-3tb-monthly':
+			case 'jetpack-backup-addon-storage-5tb-monthly':
+				description = translate( 'Additional storage for your Jetpack VaultPress Backup plan.' );
+				break;
 			case 'jetpack-boost':
 				description = translate( 'Essential tools to speed up your site - no developer required.' );
 				break;

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/hooks/use-license-lightbox-data.ts
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/hooks/use-license-lightbox-data.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
 import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
-import { getProductTitle, isWooCommerceProduct } from '../../utils';
+import { getProductTitle } from '../../utils';
 
 type LicenseLightboxData = {
 	title: string;
@@ -15,9 +15,10 @@ export function useLicenseLightboxData( product: APIProductFamilyProduct ): Lice
 		 * To reuse existing product info, we need to convert the product slug to the format used in the product store.
 		 * We are also using only the monthly slug to ensure we hit the equivalent product in the product store.
 		 */
-		const slugSuffix = isWooCommerceProduct( product.slug ) ? '_yearly' : '_monthly';
-		const normalizedSlug = product.slug.replaceAll( /-/g, '_' ) + slugSuffix;
-		const productInfo = slugToSelectorProduct( normalizedSlug );
+		const baseSlug = product.slug.replaceAll( /-/g, '_' ).replace( /_(monthly|yearly)$/, '' );
+		const productInfo =
+			slugToSelectorProduct( baseSlug + '_monthly' ) ||
+			slugToSelectorProduct( baseSlug + '_yearly' );
 
 		const title = getProductTitle( product.name );
 

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -120,7 +120,9 @@ export default function LicenseProductCard( props: Props ) {
 
 								<div className="license-product-card__description">{ productDescription }</div>
 
-								<LicenseLightboxLink productName={ productTitle } onClick={ onShowLightbox } />
+								{ ! /^jetpack-backup-addon-storage-/.test( product.slug ) && (
+									<LicenseLightboxLink productName={ productTitle } onClick={ onShowLightbox } />
+								) }
 							</div>
 
 							<div

--- a/client/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon.ts
@@ -2,6 +2,7 @@ import {
 	JETPACK_AI_PRODUCTS,
 	JETPACK_ANTI_SPAM_PRODUCTS,
 	JETPACK_BACKUP_PRODUCTS,
+	JETPACK_BACKUP_ADDON_PRODUCTS,
 	JETPACK_BOOST_PRODUCTS,
 	JETPACK_CRM_PRODUCTS,
 	JETPACK_SCAN_PRODUCTS,
@@ -51,6 +52,10 @@ interface IconResource {
 
 const PRODUCT_ICON_MAP: Record< string, IconResource > = {
 	...setProductsIcon( JETPACK_BACKUP_PRODUCTS, {
+		regular: JetpackProductIconBackup,
+		light: JetpackProductIconBackupLight,
+	} ),
+	...setProductsIcon( JETPACK_BACKUP_ADDON_PRODUCTS, {
 		regular: JetpackProductIconBackup,
 		light: JetpackProductIconBackupLight,
 	} ),


### PR DESCRIPTION
https://app.asana.com/0/1204137270272763/1205292472298456

## Proposed Changes

* Jetpack Pro Dashboard: Fix backup add-ons breaking the license lightbox due to missing configuration. In addition, hide the lightbox button for these products because it is unnecessary for the product.

## Testing Instructions

* You need an agency account with billing scheme 871 assigned - if you are not sure what this means please reach out to team Avalon.
* Open up http://jetpack.cloud.localhost:3000/partner-portal/issue-license and confirm that the backup add-on products do not have a details popup button like other products do. Also make sure the products have an appropriate tagline:

![Screenshot 2023-08-17 at 19 23 00](https://github.com/Automattic/wp-calypso/assets/22746396/5a767266-d057-47fb-bc83-036741925386)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
