### PR TITLE
BackupBrowser: Disable checkbox for WordPress version

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -53,6 +53,12 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 	// We don't want to add changed extensions or original extensions if the extension version is not available
 	const shouldAddChildNode = useCallback(
 		( childItem: FileBrowserItem ) => {
+			// We won't add checkboxes for WordPres since we don't restore it
+			if ( childItem.type === 'wordpress' ) {
+				return false;
+			}
+
+			// Everything else, except archives are fine, they need some extra checking based on changed/unchanged
 			if ( childItem.type !== 'archive' ) {
 				return true;
 			}
@@ -197,6 +203,11 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 
 	const renderCheckbox = () => {
 		if ( ! showCheckboxes ) {
+			return;
+		}
+
+		// We don't restore WordPress and just download it individually
+		if ( item.type === 'wordpress' ) {
 			return;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* We won't be restoring WordPress just allowing the user to download the version that matches the backup.  This removes the checkbox from that item.

Old:
<img width="676" alt="Screenshot 2023-08-17 at 1 49 29 PM" src="https://github.com/Automattic/wp-calypso/assets/1992658/fd7e5b20-d36e-4215-9f36-65f4b54b69a9">

New:
<img width="673" alt="Screenshot 2023-08-17 at 1 49 38 PM" src="https://github.com/Automattic/wp-calypso/assets/1992658/e3d9b3c1-4f7f-4f17-8d21-f4ffaadf4485">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this branch locally or via the live branch links.  If using live branch, append ?flags=jetpack/backup-granular to the URL
* Visit the Backup Browser and click 'Select' to enable checkboxes.
* Ensure WordPress doesn't have a checkbox.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
