### PR TITLE
Stats subscribers: Spread social followers to the top level when value is greater than zero

### DIFF
--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -44,11 +44,6 @@ export const StatsReach = ( props ) => {
 		label: translate( 'Email' ),
 	};
 
-	const socialData = {
-		value: publicizeFollowCount,
-		label: translate( 'Social' ),
-	};
-
 	const data = [ wpData, emailData ];
 
 	if ( ! isOdysseyStats ) {
@@ -69,8 +64,7 @@ export const StatsReach = ( props ) => {
 	}
 
 	if ( publicizeFollowCount > 0 ) {
-		socialData.children = publicizeData;
-		data.push( socialData ); // Only push socialData if publicizeFollowCount is greater than 0
+		data.push( ...publicizeData ); // Spread the publicizeData into the data array if there are any publicize followers
 	}
 
 	// sort descending


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80659

## Proposed Changes

* This PR spreads the social followers to the top level when the number of social followers is greater than zero

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the calypso live branch for this PR
* Switch to a site that has a known social follower count
* navigate to `/stats/subscribers/{site URL}`
* check that the subscriber count (above zero) is showing with the social networks (eg. Facebook, Twitter etc) at the top level, and no longer nested under a 'social' category. 
* switch now to another site with zero social followers
* check that there is still no social count displayed at all

| Before | After |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/30754158/b507b36f-1633-420d-b777-3978e75fd144) | ![image](https://github.com/Automattic/wp-calypso/assets/30754158/397ecb06-3a7a-46fb-bce9-e978c77d1e66) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
