### PR TITLE
Revert "Storage Add Ons: Move UI state into wpcom-plans-ui data store (#80158)"

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
@@ -1,24 +1,23 @@
-import { WpcomPlansUI } from '@automattic/data-stores';
 import { CustomSelectControl } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { PlanSelectedStorage } from '..';
 import { getStorageStringFromFeature } from '../util';
-import type { PlanSlug, StorageOption, WPComStorageAddOnSlug } from '@automattic/calypso-products';
+import type { PlanSlug, StorageOption } from '@automattic/calypso-products';
 
 type StorageAddOnDropdownProps = {
 	planSlug: PlanSlug;
 	storageOptions: StorageOption[];
+	selectedStorage: PlanSelectedStorage;
+	setSelectedStorage: ( selectedStorage: PlanSelectedStorage ) => void;
 };
 
-export const StorageAddOnDropdown = ( { planSlug, storageOptions }: StorageAddOnDropdownProps ) => {
+const StorageAddOnDropdown = ( {
+	planSlug,
+	storageOptions,
+	selectedStorage,
+	setSelectedStorage,
+}: StorageAddOnDropdownProps ) => {
 	const translate = useTranslate();
-	const { setSelectedStorageOptionForPlan } = useDispatch( WpcomPlansUI.store );
-	const selectedStorage = useSelect(
-		( select ) => {
-			return select( WpcomPlansUI.store ).getStorageAddOnForPlan( planSlug );
-		},
-		[ planSlug ]
-	);
 
 	// TODO: Consider transforming storageOptions outside of this component
 	const selectControlOptions = storageOptions.reduce( ( acc, storageOption ) => {
@@ -34,7 +33,7 @@ export const StorageAddOnDropdown = ( { planSlug, storageOptions }: StorageAddOn
 	}, [] as { key: string; name: TranslateResult }[] );
 
 	const defaultStorageOption = storageOptions.find( ( storageOption ) => ! storageOption?.isAddOn );
-	const selectedOptionKey = selectedStorage || defaultStorageOption?.slug || '';
+	const selectedOptionKey = selectedStorage[ planSlug ] || defaultStorageOption?.slug || '';
 	const selectedOption = {
 		key: selectedOptionKey,
 		name: getStorageStringFromFeature( selectedOptionKey ),
@@ -44,9 +43,13 @@ export const StorageAddOnDropdown = ( { planSlug, storageOptions }: StorageAddOn
 			label={ translate( 'Storage' ) }
 			options={ selectControlOptions }
 			value={ selectedOption }
-			onChange={ ( { selectedItem }: { selectedItem: { key: WPComStorageAddOnSlug } } ) =>
-				setSelectedStorageOptionForPlan( { addOnSlug: selectedItem?.key || '', planSlug } )
-			}
+			onChange={ ( { selectedItem }: { selectedItem: { key?: string } } ) => {
+				const updatedSelectedStorage = {
+					[ planSlug ]: selectedItem?.key || '',
+				} as PlanSelectedStorage;
+
+				setSelectedStorage( updatedSelectedStorage );
+			} }
 		/>
 	);
 };

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -12,6 +12,7 @@ import {
 	isWooExpressPlan,
 	PlanSlug,
 	isWooExpressPlusPlan,
+	WPComStorageAddOnSlug,
 	FeatureList,
 } from '@automattic/calypso-products';
 import {
@@ -73,6 +74,8 @@ type PlanRowOptions = {
 	isTableCell?: boolean;
 	isStuck?: boolean;
 };
+
+export type PlanSelectedStorage = { [ key: string ]: WPComStorageAddOnSlug | null };
 
 const Container = (
 	props: (
@@ -136,6 +139,10 @@ interface PlanFeatures2023GridType extends PlanFeatures2023GridProps {
 	// temporary: element ref to scroll comparison grid into view once "Compare plans" button is clicked
 	plansComparisonGridRef: ForwardedRef< HTMLDivElement >;
 }
+
+type PlanFeatures2023GridState = {
+	selectedStorage: PlanSelectedStorage;
+};
 
 const PlanLogo: React.FunctionComponent< {
 	planIndex: number;
@@ -210,9 +217,16 @@ const PlanLogo: React.FunctionComponent< {
 	);
 };
 
-export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > {
+export class PlanFeatures2023Grid extends Component<
+	PlanFeatures2023GridType,
+	PlanFeatures2023GridState
+> {
 	observer: IntersectionObserver | null = null;
 	buttonRef: React.RefObject< HTMLButtonElement > = createRef< HTMLButtonElement >();
+
+	state: PlanFeatures2023GridState = {
+		selectedStorage: {},
+	};
 
 	componentDidMount() {
 		this.observer = new IntersectionObserver( ( entries ) => {
@@ -234,6 +248,15 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			this.observer.disconnect();
 		}
 	}
+
+	setSelectedStorage = ( updatedSelectedStorage: PlanSelectedStorage ) => {
+		this.setState( ( { selectedStorage } ) => ( {
+			selectedStorage: {
+				...selectedStorage,
+				...updatedSelectedStorage,
+			},
+		} ) );
+	};
 
 	renderTable( renderedGridPlans: GridPlan[] ) {
 		const { translate, gridPlanForSpotlight, stickyRowOffset, isInSignup } = this.props;
@@ -765,6 +788,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 
 	renderPlanStorageOptions( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
 		const { translate, intervalType, showUpgradeableStorage } = this.props;
+		const { selectedStorage } = this.state;
 
 		return renderedGridPlans.map( ( { planSlug, features: { storageOptions } } ) => {
 			if ( ! options?.isTableCell && isWpcomEnterpriseGridPlan( planSlug ) ) {
@@ -779,7 +803,12 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 				storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage;
 
 			const storageJSX = canUpgradeStorageForPlan ? (
-				<StorageAddOnDropdown planSlug={ planSlug } storageOptions={ storageOptions } />
+				<StorageAddOnDropdown
+					planSlug={ planSlug }
+					storageOptions={ storageOptions }
+					selectedStorage={ selectedStorage }
+					setSelectedStorage={ this.setSelectedStorage }
+				/>
 			) : (
 				storageOptions.map( ( storageOption ) => {
 					if ( ! storageOption?.isAddOn ) {

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -54,7 +54,6 @@
 		"react-dom": "^18.2.0"
 	},
 	"devDependencies": {
-		"@automattic/calypso-products": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@remix-run/router": "^1.5.0",
 		"@types/validator": "^13.7.1",

--- a/packages/data-stores/src/wpcom-plans-ui/actions.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/actions.ts
@@ -1,5 +1,3 @@
-import type { PlanSlug, WPComStorageAddOnSlug } from '@automattic/calypso-products';
-
 export const setShowDomainUpsellDialog = ( show: boolean ) =>
 	( {
 		type: 'WPCOM_PLANS_UI_DOMAIN_UPSELL_DIALOG_SET_SHOW' as const,
@@ -11,19 +9,4 @@ export const resetStore = () =>
 		type: 'WPCOM_PLANS_UI_RESET_STORE',
 	} as const );
 
-export const setSelectedStorageOptionForPlan = ( {
-	addOnSlug,
-	planSlug,
-}: {
-	addOnSlug: WPComStorageAddOnSlug;
-	planSlug: PlanSlug;
-} ) =>
-	( {
-		type: 'WPCOM_PLANS_UI_SET_STORAGE_ADD_ON_FOR_PLAN',
-		addOnSlug,
-		planSlug,
-	} as const );
-
-export type WpcomPlansUIAction = ReturnType<
-	typeof setShowDomainUpsellDialog | typeof resetStore | typeof setSelectedStorageOptionForPlan
->;
+export type WpcomPlansUIAction = ReturnType< typeof setShowDomainUpsellDialog | typeof resetStore >;

--- a/packages/data-stores/src/wpcom-plans-ui/reducer.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/reducer.ts
@@ -1,6 +1,5 @@
 import { combineReducers } from '@wordpress/data';
 import type { WpcomPlansUIAction } from './actions';
-import type { selectedStorageAddOnsForPlans } from './types';
 import type { Reducer } from 'redux';
 
 const showDomainUpsellDialog: Reducer< boolean | undefined, WpcomPlansUIAction > = (
@@ -15,19 +14,8 @@ const showDomainUpsellDialog: Reducer< boolean | undefined, WpcomPlansUIAction >
 	return state;
 };
 
-const selectedStorageAddOnsForPlans: Reducer<
-	selectedStorageAddOnsForPlans | undefined,
-	WpcomPlansUIAction
-> = ( state, action ) => {
-	if ( action.type === 'WPCOM_PLANS_UI_SET_STORAGE_ADD_ON_FOR_PLAN' ) {
-		return { ...state, [ action.planSlug ]: action.addOnSlug };
-	}
-	return state;
-};
-
 const reducer = combineReducers( {
 	showDomainUpsellDialog,
-	selectedStorageAddOnsForPlans,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/wpcom-plans-ui/selectors.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/selectors.ts
@@ -1,6 +1,3 @@
-import { PlanSlug } from '@automattic/calypso-products';
 import type { State } from './reducer';
 
 export const isDomainUpsellDialogShown = ( state: State ) => !! state.showDomainUpsellDialog;
-export const getStorageAddOnForPlan = ( state: State, planSlug: PlanSlug ) =>
-	state.selectedStorageAddOnsForPlans?.[ planSlug ];

--- a/packages/data-stores/src/wpcom-plans-ui/types.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/types.ts
@@ -1,9 +1,3 @@
-import type { WPComStorageAddOnSlug } from '@automattic/calypso-products';
-
 export interface DomainUpsellDialog {
 	show: boolean;
-}
-
-export interface selectedStorageAddOnsForPlans {
-	[ key: string ]: WPComStorageAddOnSlug;
 }

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -9,7 +9,6 @@
 	"exclude": [ "**/test/*" ],
 	"references": [
 		{ "path": "../calypso-analytics" },
-		{ "path": "../calypso-products" },
 		{ "path": "../i18n-utils" },
 		{ "path": "../shopping-cart" },
 		{ "path": "../format-currency" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,7 +606,6 @@ __metadata:
   resolution: "@automattic/data-stores@workspace:packages/data-stores"
   dependencies:
     "@automattic/calypso-analytics": "workspace:^"
-    "@automattic/calypso-products": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/format-currency": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"


### PR DESCRIPTION
This reverts commit 5704332a72ecf57f41e7cccde774205a6462d81c.


Related to #

## Proposed Changes

See thread: p1692298837757799-slack-C02DQP0FP

Something about the change has been messing with the CI type-check builds since it merged. It seems like some kind of yarn issue that we're trying to discuss and 

## Testing Instructions

Looking at the PR, it seems like mostly we just need to test that the plans storage upgrades dropdowns still work when the `?flags=plans/upgradeable-storage` is applied. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?