### PR TITLE
Domain Forward: Blocking Domain Forward for primary domain addresses

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -205,11 +205,40 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 		);
 	};
 
+	const renderNoticeForPrimaryDomain = () => {
+		if ( ! domain?.isPrimary ) {
+			return;
+		}
+
+		return (
+			<div className="domain-forwarding-card-notice">
+				<Icon
+					icon={ info }
+					size={ 18 }
+					className="domain-forwarding-card-notice__icon gridicon"
+					viewBox="2 2 20 20"
+				/>
+				<div className="domain-forwarding-card-notice__message">
+					{ translate(
+						'Domains set as the {{strong}}primary site address{{/strong}} can not be forwarded. To forward this domain, please {{a}}set a new primary site address{{/a}}.',
+						{
+							components: {
+								strong: <strong />,
+								a: <a href={ `/domains/manage/${ domain.domain }` } />,
+							},
+						}
+					) }
+				</div>
+			</div>
+		);
+	};
+
 	return (
 		<>
 			{ renderNotice() }
+			{ renderNoticeForPrimaryDomain() }
 			<form onSubmit={ handleSubmit }>
-				<FormFieldset className="domain-forwarding-card__fields">
+				<FormFieldset disabled={ domain?.isPrimary } className="domain-forwarding-card__fields">
 					<FormTextInputWithAffixes
 						disabled={ isLoading }
 						name="destination"

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -238,7 +238,10 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 			{ renderNotice() }
 			{ renderNoticeForPrimaryDomain() }
 			<form onSubmit={ handleSubmit }>
-				<FormFieldset disabled={ domain?.isPrimary } className="domain-forwarding-card__fields">
+				<FormFieldset
+					disabled={ domain?.isPrimary || ! pointsToWpcom }
+					className="domain-forwarding-card__fields"
+				>
 					<FormTextInputWithAffixes
 						disabled={ isLoading }
 						name="destination"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to this Slack Thread: p1692294150030769-slack-CKZHG0QCR

## Proposed Changes

* Blocks Domain Forwarding on Primary domain addresses

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try to set a Domain Forwarding to a NON PRIMARY_DOMAIN and it should work fine
* Try to set a Domain Forwarding in the PRIMARY_DOMAIN, you should see this warning:
<img width="723" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/97c83a26-8397-416b-8bcd-c3722ff10dfb">

* Check if the link and copy communicate it well


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?