### PR TITLE
Launchpad: Add the "Connect social media" task to the completion allow list

### DIFF
--- a/client/my-sites/marketing/connections/connections.jsx
+++ b/client/my-sites/marketing/connections/connections.jsx
@@ -1,6 +1,4 @@
-import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { localize } from 'i18n-calypso';
-import { useEffect } from 'react';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import QueryP2Connections from 'calypso/components/data/query-p2-connections';
@@ -11,15 +9,8 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 import SharingServicesGroup from './services-group';
 
-const SharingConnections = ( { translate, isP2Hub, siteId, siteSlug } ) => {
+const SharingConnections = ( { translate, isP2Hub, siteId } ) => {
 	useRequestSiteChecklistTaskUpdate( siteId, CHECKLIST_KNOWN_TASKS.POST_SHARING_ENABLED );
-
-	useEffect( () => {
-		// Mark the task as done
-		updateLaunchpadSettings( siteSlug, {
-			checklist_statuses: { drive_traffic: true },
-		} );
-	}, [] );
 
 	return (
 		<div className="connections__sharing-settings connections__sharing-connections">

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -9,6 +9,7 @@ const TASKS_TO_COMPLETE_ON_CLICK = [
 	'manage_paid_newsletter_plan',
 	'earn_money',
 	'manage_subscribers',
+	'connect_social_media',
 ];
 
 export const setUpActionsForTasks = ( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Move the completion logic for the "Connect social media" task to the click handler. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* As of now, https://github.com/Automattic/jetpack/pull/32591 has not been deployed yet. You need to apply the trunk branch to your sandbox with the following command:
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin trunk
```
* Edit one of the Newsletter task lists to include the `connect_social_media` task.
```
> /home/wpcom/public_html/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/production/vendor/automattic/jetpack-mu-wpcom/src/features/launchpad/launchpad.php

'intent-free-newsletter' => array(
	'title'               => 'Free Newsletter',
	'task_ids'            => array(
		'verify_email',
		'share_site',
		'enable_subscribers_modal',
		'manage_subscribers',
		'update_about_page',
		'add_about_page',
		'connect_social_media',
	),
	'is_enabled_callback' => 'wpcom_launchpad_is_free_newsletter_enabled',
),
```
* Create a new site or use an existing one
* On the Customer Home page, click on `Connect your social media accounts` task
* Go back to the Customer Home page. The task should be marked as complete

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
