### PR TITLE
Storage Add Ons: Move UI state into wpcom-plans-ui data store Attempt 2

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
@@ -1,23 +1,23 @@
+import { WpcomPlansUI } from '@automattic/data-stores';
 import { CustomSelectControl } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { PlanSelectedStorage } from '..';
 import { getStorageStringFromFeature } from '../util';
-import type { PlanSlug, StorageOption } from '@automattic/calypso-products';
 
 type StorageAddOnDropdownProps = {
-	planSlug: PlanSlug;
-	storageOptions: StorageOption[];
-	selectedStorage: PlanSelectedStorage;
-	setSelectedStorage: ( selectedStorage: PlanSelectedStorage ) => void;
+	planSlug: string;
+	storageOptions: { slug: string; isAddOn: boolean }[];
 };
 
-const StorageAddOnDropdown = ( {
-	planSlug,
-	storageOptions,
-	selectedStorage,
-	setSelectedStorage,
-}: StorageAddOnDropdownProps ) => {
+export const StorageAddOnDropdown = ( { planSlug, storageOptions }: StorageAddOnDropdownProps ) => {
 	const translate = useTranslate();
+	const { setStorageAddOnForPlan } = useDispatch( WpcomPlansUI.store );
+	const selectedStorage = useSelect(
+		( select ) => {
+			return select( WpcomPlansUI.store ).getStorageAddOnForPlan()( planSlug );
+		},
+		[ planSlug ]
+	);
 
 	// TODO: Consider transforming storageOptions outside of this component
 	const selectControlOptions = storageOptions.reduce( ( acc, storageOption ) => {
@@ -33,7 +33,7 @@ const StorageAddOnDropdown = ( {
 	}, [] as { key: string; name: TranslateResult }[] );
 
 	const defaultStorageOption = storageOptions.find( ( storageOption ) => ! storageOption?.isAddOn );
-	const selectedOptionKey = selectedStorage[ planSlug ] || defaultStorageOption?.slug || '';
+	const selectedOptionKey = selectedStorage || defaultStorageOption?.slug || '';
 	const selectedOption = {
 		key: selectedOptionKey,
 		name: getStorageStringFromFeature( selectedOptionKey ),
@@ -43,13 +43,9 @@ const StorageAddOnDropdown = ( {
 			label={ translate( 'Storage' ) }
 			options={ selectControlOptions }
 			value={ selectedOption }
-			onChange={ ( { selectedItem }: { selectedItem: { key?: string } } ) => {
-				const updatedSelectedStorage = {
-					[ planSlug ]: selectedItem?.key || '',
-				} as PlanSelectedStorage;
-
-				setSelectedStorage( updatedSelectedStorage );
-			} }
+			onChange={ ( { selectedItem }: { selectedItem: { key?: string } } ) =>
+				setStorageAddOnForPlan( { addOnSlug: selectedItem?.key || '', plan: planSlug } )
+			}
 		/>
 	);
 };

--- a/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
@@ -3,11 +3,11 @@ import { CustomSelectControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { getStorageStringFromFeature } from '../util';
-import type { PlanSlug, WPComStorageAddOnSlug } from '@automattic/calypso-products';
+import type { PlanSlug, StorageOption, WPComStorageAddOnSlug } from '@automattic/calypso-products';
 
 type StorageAddOnDropdownProps = {
 	planSlug: PlanSlug;
-	storageOptions: { slug: string; isAddOn: boolean }[];
+	storageOptions: StorageOption[];
 };
 
 export const StorageAddOnDropdown = ( { planSlug, storageOptions }: StorageAddOnDropdownProps ) => {

--- a/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
@@ -3,9 +3,10 @@ import { CustomSelectControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { getStorageStringFromFeature } from '../util';
+import type { PlanSlug, WPComStorageAddOnSlug } from '@automattic/calypso-products';
 
 type StorageAddOnDropdownProps = {
-	planSlug: string;
+	planSlug: PlanSlug;
 	storageOptions: { slug: string; isAddOn: boolean }[];
 };
 
@@ -43,8 +44,8 @@ export const StorageAddOnDropdown = ( { planSlug, storageOptions }: StorageAddOn
 			label={ translate( 'Storage' ) }
 			options={ selectControlOptions }
 			value={ selectedOption }
-			onChange={ ( { selectedItem }: { selectedItem: { key?: string } } ) =>
-				setSelectedStorageOptionForPlan( { addOnSlug: selectedItem?.key || '', plan: planSlug } )
+			onChange={ ( { selectedItem }: { selectedItem: { key: WPComStorageAddOnSlug } } ) =>
+				setSelectedStorageOptionForPlan( { addOnSlug: selectedItem?.key || '', planSlug } )
 			}
 		/>
 	);

--- a/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
@@ -15,7 +15,7 @@ export const StorageAddOnDropdown = ( { planSlug, storageOptions }: StorageAddOn
 	const { setSelectedStorageOptionForPlan } = useDispatch( WpcomPlansUI.store );
 	const selectedStorage = useSelect(
 		( select ) => {
-			return select( WpcomPlansUI.store ).getStorageAddOnForPlan()( planSlug );
+			return select( WpcomPlansUI.store ).getStorageAddOnForPlan( planSlug );
 		},
 		[ planSlug ]
 	);

--- a/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
@@ -11,7 +11,7 @@ type StorageAddOnDropdownProps = {
 
 export const StorageAddOnDropdown = ( { planSlug, storageOptions }: StorageAddOnDropdownProps ) => {
 	const translate = useTranslate();
-	const { setStorageAddOnForPlan } = useDispatch( WpcomPlansUI.store );
+	const { setSelectedStorageOptionForPlan } = useDispatch( WpcomPlansUI.store );
 	const selectedStorage = useSelect(
 		( select ) => {
 			return select( WpcomPlansUI.store ).getStorageAddOnForPlan()( planSlug );
@@ -44,7 +44,7 @@ export const StorageAddOnDropdown = ( { planSlug, storageOptions }: StorageAddOn
 			options={ selectControlOptions }
 			value={ selectedOption }
 			onChange={ ( { selectedItem }: { selectedItem: { key?: string } } ) =>
-				setStorageAddOnForPlan( { addOnSlug: selectedItem?.key || '', plan: planSlug } )
+				setSelectedStorageOptionForPlan( { addOnSlug: selectedItem?.key || '', plan: planSlug } )
 			}
 		/>
 	);

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -137,10 +137,6 @@ interface PlanFeatures2023GridType extends PlanFeatures2023GridProps {
 	plansComparisonGridRef: ForwardedRef< HTMLDivElement >;
 }
 
-type PlanFeatures2023GridState = {
-	selectedStorage: PlanSelectedStorage;
-};
-
 const PlanLogo: React.FunctionComponent< {
 	planIndex: number;
 	planSlug: PlanSlug;
@@ -214,10 +210,7 @@ const PlanLogo: React.FunctionComponent< {
 	);
 };
 
-export class PlanFeatures2023Grid extends Component<
-	PlanFeatures2023GridType,
-	PlanFeatures2023GridState
-> {
+export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > {
 	observer: IntersectionObserver | null = null;
 	buttonRef: React.RefObject< HTMLButtonElement > = createRef< HTMLButtonElement >();
 

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -12,7 +12,6 @@ import {
 	isWooExpressPlan,
 	PlanSlug,
 	isWooExpressPlusPlan,
-	WPComStorageAddOnSlug,
 	FeatureList,
 } from '@automattic/calypso-products';
 import {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -75,8 +75,6 @@ type PlanRowOptions = {
 	isStuck?: boolean;
 };
 
-export type PlanSelectedStorage = { [ key: string ]: WPComStorageAddOnSlug | null };
-
 const Container = (
 	props: (
 		| React.HTMLAttributes< HTMLDivElement >
@@ -224,10 +222,6 @@ export class PlanFeatures2023Grid extends Component<
 	observer: IntersectionObserver | null = null;
 	buttonRef: React.RefObject< HTMLButtonElement > = createRef< HTMLButtonElement >();
 
-	state: PlanFeatures2023GridState = {
-		selectedStorage: {},
-	};
-
 	componentDidMount() {
 		this.observer = new IntersectionObserver( ( entries ) => {
 			entries.forEach( ( entry ) => {
@@ -248,15 +242,6 @@ export class PlanFeatures2023Grid extends Component<
 			this.observer.disconnect();
 		}
 	}
-
-	setSelectedStorage = ( updatedSelectedStorage: PlanSelectedStorage ) => {
-		this.setState( ( { selectedStorage } ) => ( {
-			selectedStorage: {
-				...selectedStorage,
-				...updatedSelectedStorage,
-			},
-		} ) );
-	};
 
 	renderTable( renderedGridPlans: GridPlan[] ) {
 		const { translate, gridPlanForSpotlight, stickyRowOffset, isInSignup } = this.props;
@@ -788,7 +773,6 @@ export class PlanFeatures2023Grid extends Component<
 
 	renderPlanStorageOptions( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
 		const { translate, intervalType, showUpgradeableStorage } = this.props;
-		const { selectedStorage } = this.state;
 
 		return renderedGridPlans.map( ( { planSlug, features: { storageOptions } } ) => {
 			if ( ! options?.isTableCell && isWpcomEnterpriseGridPlan( planSlug ) ) {
@@ -803,12 +787,7 @@ export class PlanFeatures2023Grid extends Component<
 				storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage;
 
 			const storageJSX = canUpgradeStorageForPlan ? (
-				<StorageAddOnDropdown
-					planSlug={ planSlug }
-					storageOptions={ storageOptions }
-					selectedStorage={ selectedStorage }
-					setSelectedStorage={ this.setSelectedStorage }
-				/>
+				<StorageAddOnDropdown planSlug={ planSlug } storageOptions={ storageOptions } />
 			) : (
 				storageOptions.map( ( storageOption ) => {
 					if ( ! storageOption?.isAddOn ) {

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -32,7 +32,6 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "workspace:^",
-		"@automattic/calypso-products": "workspace:^",
 		"@automattic/format-currency": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",
 		"@tanstack/react-query": "^4.29.1",
@@ -55,6 +54,7 @@
 		"react-dom": "^18.2.0"
 	},
 	"devDependencies": {
+		"@automattic/calypso-products": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@remix-run/router": "^1.5.0",
 		"@types/validator": "^13.7.1",

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -32,6 +32,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "workspace:^",
+		"@automattic/calypso-products": "workspace:^",
 		"@automattic/format-currency": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",
 		"@tanstack/react-query": "^4.29.1",

--- a/packages/data-stores/src/wpcom-plans-ui/actions.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/actions.ts
@@ -9,4 +9,19 @@ export const resetStore = () =>
 		type: 'WPCOM_PLANS_UI_RESET_STORE',
 	} as const );
 
-export type WpcomPlansUIAction = ReturnType< typeof setShowDomainUpsellDialog | typeof resetStore >;
+export const setStorageAddOnForPlan = ( {
+	addOnSlug,
+	plan,
+}: {
+	addOnSlug: string;
+	plan: string;
+} ) =>
+	( {
+		type: 'WPCOM_PLANS_UI_SET_STORAGE_ADD_ON_FOR_PLAN',
+		addOnSlug,
+		plan,
+	} as const );
+
+export type WpcomPlansUIAction = ReturnType<
+	typeof setShowDomainUpsellDialog | typeof resetStore | typeof setStorageAddOnForPlan
+>;

--- a/packages/data-stores/src/wpcom-plans-ui/actions.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/actions.ts
@@ -1,3 +1,5 @@
+import type { PlanSlug } from '@automattic/calypso-products';
+
 export const setShowDomainUpsellDialog = ( show: boolean ) =>
 	( {
 		type: 'WPCOM_PLANS_UI_DOMAIN_UPSELL_DIALOG_SET_SHOW' as const,
@@ -11,15 +13,15 @@ export const resetStore = () =>
 
 export const setSelectedStorageOptionForPlan = ( {
 	addOnSlug,
-	plan,
+	planSlug,
 }: {
 	addOnSlug: string;
-	plan: string;
+	planSlug: PlanSlug;
 } ) =>
 	( {
 		type: 'WPCOM_PLANS_UI_SET_STORAGE_ADD_ON_FOR_PLAN',
 		addOnSlug,
-		plan,
+		planSlug,
 	} as const );
 
 export type WpcomPlansUIAction = ReturnType<

--- a/packages/data-stores/src/wpcom-plans-ui/actions.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/actions.ts
@@ -9,7 +9,7 @@ export const resetStore = () =>
 		type: 'WPCOM_PLANS_UI_RESET_STORE',
 	} as const );
 
-export const setStorageAddOnForPlan = ( {
+export const setSelectedStorageOptionForPlan = ( {
 	addOnSlug,
 	plan,
 }: {
@@ -23,5 +23,5 @@ export const setStorageAddOnForPlan = ( {
 	} as const );
 
 export type WpcomPlansUIAction = ReturnType<
-	typeof setShowDomainUpsellDialog | typeof resetStore | typeof setStorageAddOnForPlan
+	typeof setShowDomainUpsellDialog | typeof resetStore | typeof setSelectedStorageOptionForPlan
 >;

--- a/packages/data-stores/src/wpcom-plans-ui/actions.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/actions.ts
@@ -1,4 +1,4 @@
-import type { PlanSlug } from '@automattic/calypso-products';
+import type { PlanSlug, WPComStorageAddOnSlug } from '@automattic/calypso-products';
 
 export const setShowDomainUpsellDialog = ( show: boolean ) =>
 	( {
@@ -15,7 +15,7 @@ export const setSelectedStorageOptionForPlan = ( {
 	addOnSlug,
 	planSlug,
 }: {
-	addOnSlug: string;
+	addOnSlug: WPComStorageAddOnSlug;
 	planSlug: PlanSlug;
 } ) =>
 	( {

--- a/packages/data-stores/src/wpcom-plans-ui/reducer.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/reducer.ts
@@ -1,5 +1,6 @@
 import { combineReducers } from '@wordpress/data';
 import type { WpcomPlansUIAction } from './actions';
+import type { selectedStorageAddOnsForPlans } from './types';
 import type { Reducer } from 'redux';
 
 const showDomainUpsellDialog: Reducer< boolean | undefined, WpcomPlansUIAction > = (
@@ -14,8 +15,19 @@ const showDomainUpsellDialog: Reducer< boolean | undefined, WpcomPlansUIAction >
 	return state;
 };
 
+const selectedStorageAddOnsForPlans: Reducer<
+	selectedStorageAddOnsForPlans | undefined,
+	WpcomPlansUIAction
+> = ( state, action ) => {
+	if ( action.type === 'WPCOM_PLANS_UI_SET_STORAGE_ADD_ON_FOR_PLAN' ) {
+		return { ...state, [ action.plan ]: action.addOnSlug };
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	showDomainUpsellDialog,
+	selectedStorageAddOnsForPlans,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/wpcom-plans-ui/reducer.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/reducer.ts
@@ -20,7 +20,7 @@ const selectedStorageAddOnsForPlans: Reducer<
 	WpcomPlansUIAction
 > = ( state, action ) => {
 	if ( action.type === 'WPCOM_PLANS_UI_SET_STORAGE_ADD_ON_FOR_PLAN' ) {
-		return { ...state, [ action.plan ]: action.addOnSlug };
+		return { ...state, [ action.planSlug ]: action.addOnSlug };
 	}
 	return state;
 };

--- a/packages/data-stores/src/wpcom-plans-ui/selectors.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/selectors.ts
@@ -1,3 +1,7 @@
 import type { State } from './reducer';
 
 export const isDomainUpsellDialogShown = ( state: State ) => !! state.showDomainUpsellDialog;
+export const getStorageAddOnForPlan = ( state: State ) => ( plan: string ) => {
+	const selectedStorageAddOnsForPlans = state?.selectedStorageAddOnsForPlans;
+	return selectedStorageAddOnsForPlans ? selectedStorageAddOnsForPlans[ plan ] : null;
+};

--- a/packages/data-stores/src/wpcom-plans-ui/selectors.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/selectors.ts
@@ -1,7 +1,8 @@
+import { PlanSlug } from '@automattic/calypso-products';
 import type { State } from './reducer';
 
 export const isDomainUpsellDialogShown = ( state: State ) => !! state.showDomainUpsellDialog;
-export const getStorageAddOnForPlan = ( state: State ) => ( plan: string ) => {
+export const getStorageAddOnForPlan = ( state: State ) => ( planSlug: PlanSlug ) => {
 	const selectedStorageAddOnsForPlans = state?.selectedStorageAddOnsForPlans;
-	return selectedStorageAddOnsForPlans ? selectedStorageAddOnsForPlans[ plan ] : null;
+	return selectedStorageAddOnsForPlans ? selectedStorageAddOnsForPlans[ planSlug ] : null;
 };

--- a/packages/data-stores/src/wpcom-plans-ui/selectors.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/selectors.ts
@@ -2,5 +2,5 @@ import { PlanSlug } from '@automattic/calypso-products';
 import type { State } from './reducer';
 
 export const isDomainUpsellDialogShown = ( state: State ) => !! state.showDomainUpsellDialog;
-export const getStorageAddOnForPlan = ( state: State ) => ( planSlug: PlanSlug ) =>
+export const getStorageAddOnForPlan = ( state: State, planSlug: PlanSlug ) =>
 	state.selectedStorageAddOnsForPlans?.[ planSlug ];

--- a/packages/data-stores/src/wpcom-plans-ui/selectors.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/selectors.ts
@@ -2,7 +2,5 @@ import { PlanSlug } from '@automattic/calypso-products';
 import type { State } from './reducer';
 
 export const isDomainUpsellDialogShown = ( state: State ) => !! state.showDomainUpsellDialog;
-export const getStorageAddOnForPlan = ( state: State ) => ( planSlug: PlanSlug ) => {
-	const selectedStorageAddOnsForPlans = state?.selectedStorageAddOnsForPlans;
-	return selectedStorageAddOnsForPlans ? selectedStorageAddOnsForPlans[ planSlug ] : null;
-};
+export const getStorageAddOnForPlan = ( state: State ) => ( planSlug: PlanSlug ) =>
+	state.selectedStorageAddOnsForPlans?.[ planSlug ];

--- a/packages/data-stores/src/wpcom-plans-ui/types.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/types.ts
@@ -1,3 +1,9 @@
+import type { WPComStorageAddOnSlug } from '@automattic/calypso-products';
+
 export interface DomainUpsellDialog {
 	show: boolean;
+}
+
+export interface selectedStorageAddOnsForPlans {
+	[ key: string ]: WPComStorageAddOnSlug | null;
 }

--- a/packages/data-stores/src/wpcom-plans-ui/types.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/types.ts
@@ -5,5 +5,5 @@ export interface DomainUpsellDialog {
 }
 
 export interface selectedStorageAddOnsForPlans {
-	[ key: string ]: WPComStorageAddOnSlug | null;
+	[ key: string ]: WPComStorageAddOnSlug;
 }

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -9,6 +9,7 @@
 	"exclude": [ "**/test/*" ],
 	"references": [
 		{ "path": "../calypso-analytics" },
+		{ "path": "../calypso-products" },
 		{ "path": "../i18n-utils" },
 		{ "path": "../shopping-cart" },
 		{ "path": "../format-currency" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,6 +606,7 @@ __metadata:
   resolution: "@automattic/data-stores@workspace:packages/data-stores"
   dependencies:
     "@automattic/calypso-analytics": "workspace:^"
+    "@automattic/calypso-products": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/format-currency": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/80158

## Proposed Changes

* Clone of https://github.com/Automattic/wp-calypso/pull/80158. The PR was reverted because of failing yarn issues. We included `@automattic/calypso-products` as a new workspace dependency to `@automattic/data-stores`.
* Unfortunately, `@automattic/calypso-products` had it's own dependencies incorrectly specified.

## GIF
![2023-08-02 17 37 45](https://github.com/Automattic/wp-calypso/assets/5414230/b82d131f-d50d-470b-bf82-825ff4130e30)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a local dev environment or use calypso live
* Navigate to `/start/plans?flags=plans/upgradeable-storage`
* Verify that selecting items in the storage add ons dropdown continues to behave as expected. To be clear, all we're checking is that dropdown selections persist. No other functionality is wired up at this point
* Do the same for /plans

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
