### PR TITLE
Newsletter Categories: Integrate with Newsletter Settings page and create Newsletter Categories toggle

### DIFF
--- a/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
+++ b/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import TermTreeSelector from 'calypso/blocks/term-tree-selector';
 import { useSelector } from 'calypso/state';
@@ -31,33 +32,35 @@ const NewsletterCategoriesSettings = ( {
 				value={ toggleValue }
 			/>
 
-			{ toggleValue && (
-				<>
-					<TermTreeSelector
-						taxonomy="category"
-						addTerm={ true }
-						multiple={ true }
-						selected={ newsletterCategoryIds }
-						onChange={ handleCategoryToggle }
-						onAddTermSuccess={ handleCategoryToggle }
-						height={ 218 }
-					/>
-					<p className="newsletter-categories-settings__description">
-						{ translate(
-							'When adding a new newsletter category, your subscribers will be automatically subscribed to it. They won’t receive any email notification when the category is created.'
-						) }
-					</p>
-					<Button
-						primary
-						compact
-						disabled={ isSaving || disabled }
-						className="newsletter-categories-settings__save-button"
-						onClick={ handleSave }
-					>
-						{ translate( 'Save settings' ) }
-					</Button>
-				</>
-			) }
+			<div
+				className={ classNames( 'newsletter-categories-settings__term-tree-selector', {
+					hidden: ! toggleValue,
+				} ) }
+			>
+				<TermTreeSelector
+					taxonomy="category"
+					addTerm={ true }
+					multiple={ true }
+					selected={ newsletterCategoryIds }
+					onChange={ handleCategoryToggle }
+					onAddTermSuccess={ handleCategoryToggle }
+					height={ 218 }
+				/>
+				<p className="newsletter-categories-settings__description">
+					{ translate(
+						'When adding a new newsletter category, your subscribers will be automatically subscribed to it. They won’t receive any email notification when the category is created.'
+					) }
+				</p>
+				<Button
+					primary
+					compact
+					disabled={ isSaving || disabled }
+					className="newsletter-categories-settings__save-button"
+					onClick={ handleSave }
+				>
+					{ translate( 'Save settings' ) }
+				</Button>
+			</div>
 		</div>
 	);
 };

--- a/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
+++ b/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
@@ -3,10 +3,21 @@ import { useTranslate } from 'i18n-calypso';
 import TermTreeSelector from 'calypso/blocks/term-tree-selector';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import NewsletterCategoriesToggle from './newsletter-categories-toggle';
 import useNewsletterCategoriesSettings from './use-newsletter-categories-settings';
 import './style.scss';
 
-const NewsletterCategoriesSettings = () => {
+type NewsletterCategoriesSettingsProps = {
+	disabled?: boolean;
+	handleAutosavingToggle: ( field: string ) => ( value: boolean ) => void;
+	toggleValue?: boolean;
+};
+
+const NewsletterCategoriesSettings = ( {
+	disabled,
+	handleAutosavingToggle,
+	toggleValue,
+}: NewsletterCategoriesSettingsProps ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const { isSaving, newsletterCategoryIds, handleCategoryToggle, handleSave } =
@@ -14,29 +25,39 @@ const NewsletterCategoriesSettings = () => {
 
 	return (
 		<div className="newsletter-categories-settings">
-			<p className="newsletter-categories-settings__description">
-				{ translate( 'Allow your visitors to specifically subscribe to the selected categories.' ) }
-			</p>
-
-			<TermTreeSelector
-				taxonomy="category"
-				addTerm={ true }
-				multiple={ true }
-				selected={ newsletterCategoryIds }
-				onChange={ handleCategoryToggle }
-				onAddTermSuccess={ handleCategoryToggle }
-				height={ 218 }
+			<NewsletterCategoriesToggle
+				disabled={ disabled }
+				handleAutosavingToggle={ handleAutosavingToggle }
+				value={ toggleValue }
 			/>
 
-			<Button
-				primary
-				compact
-				disabled={ isSaving }
-				className="newsletter-categories-settings__save-button"
-				onClick={ handleSave }
-			>
-				{ translate( 'Save settings' ) }
-			</Button>
+			{ toggleValue && (
+				<>
+					<TermTreeSelector
+						taxonomy="category"
+						addTerm={ true }
+						multiple={ true }
+						selected={ newsletterCategoryIds }
+						onChange={ handleCategoryToggle }
+						onAddTermSuccess={ handleCategoryToggle }
+						height={ 218 }
+					/>
+					<p className="newsletter-categories-settings__description">
+						{ translate(
+							'When adding a new newsletter category, your subscribers will be automatically subscribed to it. They won’t receive any email notification when the category is created.'
+						) }
+					</p>
+					<Button
+						primary
+						compact
+						disabled={ isSaving || disabled }
+						className="newsletter-categories-settings__save-button"
+						onClick={ handleSave }
+					>
+						{ translate( 'Save settings' ) }
+					</Button>
+				</>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
+++ b/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
@@ -9,7 +9,7 @@ import './style.scss';
 const NewsletterCategoriesSettings = () => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
-	const { newsletterCategoryIds, handleCategoryToggle, handleSave } =
+	const { isSaving, newsletterCategoryIds, handleCategoryToggle, handleSave } =
 		useNewsletterCategoriesSettings( siteId );
 
 	return (
@@ -30,6 +30,8 @@ const NewsletterCategoriesSettings = () => {
 
 			<Button
 				primary
+				compact
+				disabled={ isSaving }
 				className="newsletter-categories-settings__save-button"
 				onClick={ handleSave }
 			>

--- a/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-toggle.tsx
+++ b/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-toggle.tsx
@@ -1,0 +1,37 @@
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+
+export const NEWSLETTER_CATEGORIES_ENABLED_OPTION = 'wpcom_newsletter_categories_enabled';
+
+type NewsletterCategoriesToggleProps = {
+	disabled?: boolean;
+	value?: boolean;
+	handleAutosavingToggle: ( field: string ) => ( value: boolean ) => void;
+};
+
+const NewsletterCategoriesToggle = ( {
+	disabled,
+	handleAutosavingToggle,
+	value = false,
+}: NewsletterCategoriesToggleProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="newsletter-categories-toggle">
+			<ToggleControl
+				checked={ !! value }
+				onChange={ handleAutosavingToggle( NEWSLETTER_CATEGORIES_ENABLED_OPTION ) }
+				disabled={ disabled }
+				label={ translate( 'Enable newsletter categories' ) }
+			/>
+			<FormSettingExplanation>
+				{ translate(
+					'This will allow your visitors to specifically subscribed to the selected categories. When this is enabled, only posts published under the created newsletter categories will be send out to your subscribers.'
+				) }
+			</FormSettingExplanation>
+		</div>
+	);
+};
+
+export default NewsletterCategoriesToggle;

--- a/client/my-sites/site-settings/newsletter-categories-settings/style.scss
+++ b/client/my-sites/site-settings/newsletter-categories-settings/style.scss
@@ -2,9 +2,12 @@
 @import "@automattic/typography/styles/variables";
 
 .newsletter-categories-settings {
-	display: flex;
-	flex-direction: column;
-	gap: 24px;
+	&,
+	.newsletter-categories-settings__term-tree-selector {
+		display: flex;
+		flex-direction: column;
+		gap: 24px;
+	}
 
 	.newsletter-categories-settings__description {
 		color: $studio-gray-70;
@@ -20,7 +23,13 @@
 		line-height: 20px;
 	}
 
-	.term-tree-selector__add-term {
-		margin-bottom: 0;
+	.newsletter-categories-settings__term-tree-selector {
+		&.hidden {
+			display: none;
+		}
+
+		.term-tree-selector__add-term {
+			margin-bottom: 0;
+		}
 	}
 }

--- a/client/my-sites/site-settings/newsletter-categories-settings/style.scss
+++ b/client/my-sites/site-settings/newsletter-categories-settings/style.scss
@@ -17,5 +17,10 @@
 
 	.newsletter-categories-settings__save-button {
 		align-self: flex-start;
+		line-height: 20px;
+	}
+
+	.term-tree-selector__add-term {
+		margin-bottom: 0;
 	}
 }

--- a/client/my-sites/site-settings/newsletter-categories-settings/use-newsletter-categories-settings.ts
+++ b/client/my-sites/site-settings/newsletter-categories-settings/use-newsletter-categories-settings.ts
@@ -80,12 +80,17 @@ const useNewsletterCategoriesSettings = ( siteId: number ) => {
 
 		Promise.all( promises )
 			.then( () => {
-				dispatch( successNotice( translate( 'Your newsletter categories have been saved.' ) ) );
+				dispatch(
+					successNotice( translate( 'Your newsletter categories have been saved.' ), {
+						duration: 2000,
+					} )
+				);
 			} )
 			.catch( () => {
 				dispatch(
 					errorNotice(
-						translate( 'There was an error when trying to save your newsletter categories.' )
+						translate( 'There was an error when trying to save your newsletter categories.' ),
+						{ duration: 2000 }
 					)
 				);
 			} );

--- a/client/my-sites/site-settings/newsletter-categories-settings/use-newsletter-categories-settings.ts
+++ b/client/my-sites/site-settings/newsletter-categories-settings/use-newsletter-categories-settings.ts
@@ -30,7 +30,7 @@ const convertToNewsletterCategory = ( category: Category ): NewsletterCategory =
 const useNewsletterCategoriesSettings = ( siteId: number ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const { data: initialData } = useNewsletterCategoriesQuery( { siteId } );
+	const { data: initialData, isLoading } = useNewsletterCategoriesQuery( { siteId } );
 	const [ newsletterCategories, setNewsletterCategories ] = useState(
 		initialData?.newsletterCategories ?? []
 	);
@@ -38,8 +38,10 @@ const useNewsletterCategoriesSettings = ( siteId: number ) => {
 		() => newsletterCategories.map( ( { id } ) => id ),
 		[ newsletterCategories ]
 	);
-	const { mutateAsync: markNewsletterCategory } = useMarkAsNewsletterCategoryMutation( siteId );
-	const { mutateAsync: unmarkNewsletterCategory } = useUnmarkAsNewsletterCategoryMutation( siteId );
+	const { mutateAsync: markNewsletterCategory, isLoading: isMarking } =
+		useMarkAsNewsletterCategoryMutation( siteId );
+	const { mutateAsync: unmarkNewsletterCategory, isLoading: isUnmarking } =
+		useUnmarkAsNewsletterCategoryMutation( siteId );
 
 	const handleCategoryToggle = ( category: Category ) => {
 		const index = newsletterCategories.findIndex( ( { id } ) => id === category.ID );
@@ -90,6 +92,8 @@ const useNewsletterCategoriesSettings = ( siteId: number ) => {
 	};
 
 	return {
+		isLoading,
+		isSaving: isMarking || isUnmarking,
 		newsletterCategories,
 		newsletterCategoryIds,
 		handleCategoryToggle,

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -1,9 +1,11 @@
+import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { useSiteOption } from 'calypso/state/sites/hooks';
+import { NewsletterCategoriesSettings } from '../newsletter-categories-settings';
 import { SubscriptionOptions } from '../settings-reading/main';
 import { EmailsTextSetting } from './EmailsTextSetting';
 import { ExcerptSetting } from './ExcerptSetting';
@@ -12,6 +14,7 @@ import { SubscribeModalSetting } from './SubscribeModalSetting';
 
 type Fields = {
 	wpcom_featured_image_in_email?: boolean;
+	wpcom_newsletter_categories_enabled?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
 	subscription_options?: SubscriptionOptions;
 	sm_enabled?: boolean;
@@ -19,6 +22,7 @@ type Fields = {
 
 type NewsletterSettingsSectionProps = {
 	fields: Fields;
+	handleAutosavingToggle: ( field: string ) => ( value: boolean ) => void;
 	handleToggle: ( field: string ) => ( value: boolean ) => void;
 	handleSubmitForm: ( event: React.FormEvent< HTMLFormElement > ) => void;
 	disabled?: boolean;
@@ -29,6 +33,7 @@ type NewsletterSettingsSectionProps = {
 
 export const NewsletterSettingsSection = ( {
 	fields,
+	handleAutosavingToggle,
 	handleToggle,
 	handleSubmitForm,
 	disabled,
@@ -41,6 +46,7 @@ export const NewsletterSettingsSection = ( {
 	const translate = useTranslate();
 	const {
 		wpcom_featured_image_in_email,
+		wpcom_newsletter_categories_enabled,
 		wpcom_subscription_emails_use_excerpt,
 		subscription_options,
 		sm_enabled,
@@ -57,6 +63,15 @@ export const NewsletterSettingsSection = ( {
 
 	return (
 		<>
+			{ config.isEnabled( 'settings/newsletter-settings-page' ) && (
+				<Card className="site-settings__card">
+					<NewsletterCategoriesSettings
+						disabled={ disabled }
+						handleAutosavingToggle={ handleAutosavingToggle }
+						toggleValue={ wpcom_newsletter_categories_enabled }
+					/>
+				</Card>
+			) }
 			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
 			<SettingsSectionHeader
 				id="newsletter-settings"

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -13,6 +13,7 @@ export type SubscriptionOptions = {
 type Fields = {
 	subscription_options?: SubscriptionOptions;
 	wpcom_featured_image_in_email?: boolean;
+	wpcom_newsletter_categories_enabled?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
 	sm_enabled?: boolean;
 };
@@ -25,6 +26,7 @@ const getFormSettings = ( settings?: Fields ) => {
 	const {
 		subscription_options,
 		wpcom_featured_image_in_email,
+		wpcom_newsletter_categories_enabled,
 		wpcom_subscription_emails_use_excerpt,
 		sm_enabled,
 	} = settings;
@@ -32,6 +34,7 @@ const getFormSettings = ( settings?: Fields ) => {
 	return {
 		...( subscription_options && { subscription_options } ),
 		wpcom_featured_image_in_email: !! wpcom_featured_image_in_email,
+		wpcom_newsletter_categories_enabled: !! wpcom_newsletter_categories_enabled,
 		wpcom_subscription_emails_use_excerpt: !! wpcom_subscription_emails_use_excerpt,
 		sm_enabled: !! sm_enabled,
 	};
@@ -39,6 +42,7 @@ const getFormSettings = ( settings?: Fields ) => {
 
 type NewsletterSettingsFormProps = {
 	fields: Fields;
+	handleAutosavingToggle: ( field: string ) => ( value: boolean ) => void;
 	handleToggle: ( field: string ) => ( value: boolean ) => void;
 	handleSubmitForm: ( event: React.FormEvent< HTMLFormElement > ) => void;
 	isRequestingSettings: boolean;
@@ -50,6 +54,7 @@ type NewsletterSettingsFormProps = {
 const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )(
 	( {
 		fields,
+		handleAutosavingToggle,
 		handleSubmitForm,
 		handleToggle,
 		isRequestingSettings,
@@ -63,6 +68,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )(
 			<form onSubmit={ handleSubmitForm }>
 				<NewsletterSettingsSection
 					fields={ fields }
+					handleAutosavingToggle={ handleAutosavingToggle }
 					handleToggle={ handleToggle }
 					handleSubmitForm={ handleSubmitForm }
 					disabled={ disabled }

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -177,6 +177,7 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 					) : (
 						<NewsletterSettingsSection
 							fields={ fields }
+							handleAutosavingToggle={ handleAutosavingToggle }
 							handleToggle={ handleToggle }
 							handleSubmitForm={ handleSubmitForm }
 							disabled={ disabled }

--- a/config/development.json
+++ b/config/development.json
@@ -170,6 +170,7 @@
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
+		"settings/newsletter-categories": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/80728
Closes https://github.com/Automattic/wp-calypso/issues/80729

## Proposed Changes

* Integrate `NewsletterCategoriesSettings` component with Newsletter Settings page
* Create `settings/newsletter-categories` feature flag
* Create Enable Newsletter Categories toggle
* Fix styling issues
* Add 2 seconds timeout to the success and error notices

## Testing Instructions

* Should be tested together with https://github.com/Automattic/jetpack/pull/32569
* Apply this PR to your local
* Go to http://calypso.localhost:3000/settings/newsletter/{site-slug}
* You should see the "Enable newsletter categories" toggle disabled
* Click to enable and you should see the Newsletter Categories list
* Select/unselect categories and save changes

<img width="753" alt="Screenshot 2023-08-17 at 18 19 19" src="https://github.com/Automattic/wp-calypso/assets/3113712/2eda0e03-94cf-435b-849c-ac10b85a56b0">

<img width="747" alt="Screenshot 2023-08-17 at 18 19 33" src="https://github.com/Automattic/wp-calypso/assets/3113712/f282df38-4e1e-43ea-aad6-405660e6ea0e">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
