### PR TITLE
Update the copy for the monitor lightbox

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
@@ -185,7 +185,7 @@ export function useProductDescription( productSlug: string ): {
 				break;
 			case 'jetpack-monitor':
 				description = translate(
-					'Swift 1-minute monitoring interval alerts, multiple email recipient and SMS notifications.'
+					'Upgrade Monitor with swift 1-minute monitoring alert intervals, SMS notifications, and multiple email recipients.'
 				);
 				break;
 			case 'woocommerce-bookings':

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -601,7 +601,7 @@ export const getJetpackProductsDescriptions = (): Record< string, TranslateResul
 	const statsCommercialDescription = translate( 'The most advanced stats Jetpack has to offer.' );
 
 	const monitorDescription = translate(
-		'Swift 1-minute monitoring interval alerts, multiple email recipient and SMS notifications.'
+		'Upgrade Monitor with swift 1-minute monitoring alert intervals, SMS notifications, and multiple email recipients.'
 	);
 
 	return {
@@ -745,7 +745,7 @@ export const getJetpackProductsFeaturedDescription = (): Record< string, Transla
 	);
 
 	const monitorFeaturedText = translate(
-		'Swift 1-minute monitoring interval alerts, multiple email recipient and SMS notifications.'
+		'Upgrade Monitor with swift 1-minute monitoring alert intervals, SMS notifications, and multiple email recipients.'
 	);
 
 	return {
@@ -814,7 +814,7 @@ export const getJetpackProductsLightboxDescription = (): Record< string, Transla
 	);
 	const statsLightboxDescription = translate( 'The most advanced stats Jetpack has to offer.' );
 	const monitorLightboxDescription = translate(
-		'Swift 1-minute monitoring interval alerts, multiple email recipient and SMS notifications.'
+		'Upgrade Monitor with swift 1-minute monitoring alert intervals, SMS notifications, and multiple email recipients.'
 	);
 
 	// WooCommerce Products
@@ -1307,16 +1307,13 @@ export const getJetpackProductsBenefits = (): Record< string, Array< TranslateRe
 
 	const monitorBenefits = [
 		translate(
-			'Rapid Detection: With our 1-minute interval monitoring, detect potential issues faster than ever before.'
+			'Rapid detection: With our 1-minute interval monitoring, we detect potential issues faster than ever before.'
 		),
 		translate(
-			'Multi-channel Alerts: Reach multiple people simultaneously through our expanded multi-email and SMS notifications.'
+			'Multi-channel alerts: Get notified immediately when a site that you manage is down via SMS and email (multiple recipients).'
 		),
 		translate(
-			'Enhanced Uptime: Experience less downtime and increased service reliability through prompt response and resolution.'
-		),
-		translate(
-			'Better user experience, because you will have the chance to fix any issue as soon as possible.'
+			'Enhanced uptime: Experience less downtime and increased service reliability through prompt response and resolution.'
 		),
 		translate( 'Reduce potential revenue losses because your site went down.' ),
 	];


### PR DESCRIPTION
Update the copy in the Jetpack monitor lightbox on the dashboard

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1204992567518369-as-1205271201287177

<img width="1068" alt="Screenshot 2023-08-18 at 10 58 21 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d8c90ff2-e724-4fef-9e79-ad44cc4715b6">


## Proposed Changes

* This PR updates the copy with some minor changes in the Jetpack Monitor description light box

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* Visit the dashboard more info page [here](http://jetpack.cloud.localhost:3000/partner-portal/issue-license?show_license_modal=jetpack-monitor) and ensure that the copy is updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
