### PR TITLE
Update auth header copy for Jetpack AI and Jetpack Boost A/B test

### DIFF
--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -7,6 +7,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import Site from 'calypso/blocks/site';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { ProvideExperimentData } from 'calypso/lib/explat';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { login } from 'calypso/lib/paths';
 import versionCompare from 'calypso/lib/version-compare';
@@ -142,28 +143,63 @@ export class AuthFormHeader extends Component {
 		if ( isWooCoreProfiler ) {
 			switch ( currentState ) {
 				case 'logged-out':
-					return translate(
-						"We'll make it quick – promise. In order to take advantage of the benefits offered by Jetpack, you'll need to connect your store to your WordPress.com account. {{br/}} Already have one? {{a}}Log in{{/a}}",
-						{
-							components: {
-								br: <br />,
-								a: (
-									<a
-										href={ login( {
-											isJetpack: true,
-											redirectTo: window.location.href,
-											from: this.props.authQuery.from,
-										} ) }
-									/>
-								),
-							},
-							comment:
-								'Link displayed on the Jetpack Connect signup page for users to log in with a WordPress.com account',
-						}
+					return (
+						<ProvideExperimentData name="coreprofiler_jetpack_or_jetpack_boost">
+							{ ( isLoading, experimentAssignment ) => {
+								if ( isLoading ) {
+									return <></>;
+								}
+
+								const translateData = {
+									components: {
+										br: <br />,
+										a: (
+											<a
+												href={ login( {
+													isJetpack: true,
+													redirectTo: window.location.href,
+													from: this.props.authQuery.from,
+												} ) }
+											/>
+										),
+									},
+									comment:
+										'Link displayed on the Jetpack Connect signup page for users to log in with a WordPress.com account',
+								};
+								if ( 'treatment' === experimentAssignment?.variationName ) {
+									return translate(
+										"We'll make it quick – promise. In order to take advantage of the benefits offered by Jetpack Boost, you'll need to connect your store to your WordPress.com account. {{br/}} Already have one? {{a}}Log in{{/a}}",
+										translateData
+									);
+								}
+
+								return translate(
+									"We'll make it quick – promise. In order to take advantage of the benefits offered by Jetpack AI, you'll need to connect your store to your WordPress.com account. {{br/}} Already have one? {{a}}Log in{{/a}}",
+									translateData
+								);
+							} }
+						</ProvideExperimentData>
 					);
+
 				default:
-					return translate(
-						"We'll make it quick – promise. In order to take advantage of the benefits offered by Jetpack, you'll need to connect your store to your WordPress.com account."
+					return (
+						<ProvideExperimentData name="coreprofiler_jetpack_or_jetpack_boost">
+							{ ( isLoading, experimentAssignment ) => {
+								if ( isLoading ) {
+									return <></>;
+								}
+
+								if ( 'treatment' === experimentAssignment?.variationName ) {
+									return translate(
+										"We'll make it quick – promise. In order to take advantage of the benefits offered by Jetpack Boost, you'll need to connect your store to your WordPress.com account."
+									);
+								}
+
+								return translate(
+									"We'll make it quick – promise. In order to take advantage of the benefits offered by Jetpack AI, you'll need to connect your store to your WordPress.com account."
+								);
+							} }
+						</ProvideExperimentData>
 					);
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/woocommerce/woocommerce/issues/39629



## Proposed Changes

Things to do: Preload the experiment data.

* Updated Auth Form Header copies for Jetpack AI and Jetpack Boost A/B test

Control: Displays "Jetpack AI"
Treatment: Display  "Jetpack Boost"

## Testing Instructions

1. Create a new JN site with WooCommerce
2. Start the core profiler and proceed to the plugins page.
3. Make sure to choose Jetpack
4. Click the continue button to install
5. You should be redirected to Jetpack connect page.
6. Copy the URL
7. Checkout this branch and open your local wp-calypso
8. Replace the copied URL and replace the host to your local wp-calypso
9. You should see Jetpack connect page on your local wp-calpso with `Jetpack AI` copy
10. Open your browser console and run `'{"experimentName":"coreprofiler_jetpack_or_jetpack_boost","variationName":"treatment","retrievedTimestamp":1692316355457,"ttl":60,"isFallbackExperimentAssignment":true}'` 
11. Refresh the page
12. You should see `Jetpack Boost` copy now.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
