### PR TITLE
Refactor plans grid to not use `render<some-jsx>` approach

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -8,6 +8,8 @@ import {
 	planMatches,
 	TERM_ANNUALLY,
 	type PlanSlug,
+	isWooExpressMediumPlan,
+	isWooExpressSmallPlan,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
@@ -39,6 +41,9 @@ type PlanFeaturesActionsButtonProps = {
 	planTitle: TranslateResult;
 	planSlug: PlanSlug;
 	flowName?: string | null;
+	/**
+	 * @deprecated this prop is no longer external
+	 */
 	buttonText?: string;
 	isWpcomEnterpriseGridPlan: boolean;
 	isWooExpressPlusPlan?: boolean;
@@ -349,7 +354,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	planTitle,
 	planSlug,
 	flowName,
-	buttonText,
 	isWpcomEnterpriseGridPlan = false,
 	isWooExpressPlusPlan = false,
 	selectedSiteSlug,
@@ -360,6 +364,21 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
 	const { gridPlansIndex } = usePlansGridContext();
+
+	// Leaving it `undefined` makes it use the default label
+	let buttonText;
+
+	if (
+		isWooExpressMediumPlan( planSlug ) &&
+		! isWooExpressMediumPlan( currentSitePlanSlug || '' )
+	) {
+		buttonText = translate( 'Get Performance', { textOnly: true } );
+	} else if (
+		isWooExpressSmallPlan( planSlug ) &&
+		! isWooExpressSmallPlan( currentSitePlanSlug || '' )
+	) {
+		buttonText = translate( 'Get Essential', { textOnly: true } );
+	}
 
 	const classes = classNames( 'plan-features-2023-grid__actions-button', className, {
 		'is-current-plan': current,

--- a/client/my-sites/plan-features-2023-grid/grid-parts/container.tsx
+++ b/client/my-sites/plan-features-2023-grid/grid-parts/container.tsx
@@ -1,0 +1,13 @@
+export const Container = (
+	props: (
+		| React.HTMLAttributes< HTMLDivElement >
+		| React.HTMLAttributes< HTMLTableCellElement >
+	 ) & { isTableCell?: boolean; scope?: string }
+) => {
+	const { children, isTableCell, ...otherProps } = props;
+	return isTableCell ? (
+		<td { ...otherProps }>{ children }</td>
+	) : (
+		<div { ...otherProps }>{ children }</div>
+	);
+};

--- a/client/my-sites/plan-features-2023-grid/grid-parts/plan-storage-options.tsx
+++ b/client/my-sites/plan-features-2023-grid/grid-parts/plan-storage-options.tsx
@@ -1,0 +1,62 @@
+import { PlanSlug, StorageOption, isWpcomEnterpriseGridPlan } from '@automattic/calypso-products';
+import { useTranslate } from 'i18n-calypso';
+import StorageAddOnDropdown from '../components/storage-add-on-dropdown';
+import { PlanRowOptions } from '../types';
+import { getStorageStringFromFeature } from '../util';
+import { Container } from './container';
+
+interface Props {
+	intervalType?: string;
+	showUpgradeableStorage: boolean;
+	planSlug: PlanSlug;
+	options?: PlanRowOptions;
+	storageOptions: StorageOption[];
+}
+
+export default function PlanStorageOptions( {
+	intervalType,
+	showUpgradeableStorage,
+	options,
+	planSlug,
+	storageOptions,
+}: Props ) {
+	const translate = useTranslate();
+
+	if ( ! options?.isTableCell && isWpcomEnterpriseGridPlan( planSlug ) ) {
+		return null;
+	}
+
+	const shouldRenderStorageTitle =
+		storageOptions.length === 1 ||
+		( intervalType !== 'yearly' && storageOptions.length > 0 ) ||
+		( ! showUpgradeableStorage && storageOptions.length > 0 );
+	const canUpgradeStorageForPlan =
+		storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage;
+
+	const storageJSX = canUpgradeStorageForPlan ? (
+		<StorageAddOnDropdown planSlug={ planSlug } storageOptions={ storageOptions } />
+	) : (
+		storageOptions.map( ( storageOption ) => {
+			if ( ! storageOption?.isAddOn ) {
+				return (
+					<div className="plan-features-2023-grid__storage-buttons" key={ planSlug }>
+						{ getStorageStringFromFeature( storageOption?.slug ) }
+					</div>
+				);
+			}
+		} )
+	);
+
+	return (
+		<Container
+			key={ planSlug }
+			className="plan-features-2023-grid__table-item plan-features-2023-grid__storage"
+			isTableCell={ options?.isTableCell }
+		>
+			{ shouldRenderStorageTitle ? (
+				<div className="plan-features-2023-grid__storage-title">{ translate( 'Storage' ) }</div>
+			) : null }
+			{ storageJSX }
+		</Container>
+	);
+}

--- a/client/my-sites/plan-features-2023-grid/grid-parts/previous-plan-features-included.tsx
+++ b/client/my-sites/plan-features-2023-grid/grid-parts/previous-plan-features-included.tsx
@@ -1,0 +1,75 @@
+import {
+	PlanSlug,
+	getPlanClass,
+	isWooExpressPlusPlan,
+	isWpComFreePlan,
+	isWpcomEnterpriseGridPlan,
+} from '@automattic/calypso-products';
+import {
+	BloombergLogo,
+	CNNLogo,
+	CondenastLogo,
+	DisneyLogo,
+	FacebookLogo,
+	SalesforceLogo,
+	SlackLogo,
+	TimeLogo,
+} from '@automattic/components';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { GridPlan } from '../hooks/npm-ready/data-store/use-grid-plans';
+import { PlanRowOptions } from '../types';
+import { Container } from './container';
+
+interface Props {
+	planSlug: PlanSlug;
+	options?: PlanRowOptions;
+	gridPlansForFeaturesGrid: GridPlan[];
+}
+
+export default function PreviousPlanFeaturesIncludedSection( {
+	planSlug,
+	gridPlansForFeaturesGrid,
+	options,
+}: Props ) {
+	const translate = useTranslate();
+	const shouldRenderEnterpriseLogos =
+		isWpcomEnterpriseGridPlan( planSlug ) || isWooExpressPlusPlan( planSlug );
+	const shouldShowFeatureTitle = ! isWpComFreePlan( planSlug ) && ! shouldRenderEnterpriseLogos;
+	const indexInGridPlansForFeaturesGrid = gridPlansForFeaturesGrid.findIndex(
+		( { planSlug: slug } ) => slug === planSlug
+	);
+	const previousProductName =
+		indexInGridPlansForFeaturesGrid > 0
+			? gridPlansForFeaturesGrid[ indexInGridPlansForFeaturesGrid - 1 ].productNameShort
+			: null;
+	const title =
+		previousProductName &&
+		translate( 'Everything in %(planShortName)s, plus:', {
+			args: { planShortName: previousProductName },
+		} );
+	const classes = classNames( 'plan-features-2023-grid__common-title', getPlanClass( planSlug ) );
+	const rowspanProp = options?.isTableCell && shouldRenderEnterpriseLogos ? { rowSpan: '2' } : {};
+	return (
+		<Container
+			key={ planSlug }
+			isTableCell={ options?.isTableCell }
+			className="plan-features-2023-grid__table-item"
+			{ ...rowspanProp }
+		>
+			{ shouldShowFeatureTitle && <div className={ classes }>{ title }</div> }
+			{ shouldRenderEnterpriseLogos && (
+				<div className="plan-features-2023-grid__item plan-features-2023-grid__enterprise-logo">
+					<TimeLogo />
+					<SlackLogo />
+					<DisneyLogo />
+					<CNNLogo />
+					<SalesforceLogo />
+					<FacebookLogo />
+					<CondenastLogo />
+					<BloombergLogo />
+				</div>
+			) }
+		</Container>
+	);
+}

--- a/client/my-sites/plan-features-2023-grid/grid-parts/spotlight-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/grid-parts/spotlight-plans.tsx
@@ -1,0 +1,177 @@
+import {
+	getPlanClass,
+	isFreePlan,
+	isWpcomEnterpriseGridPlan,
+	isWooExpressPlusPlan,
+	PlanSlug,
+} from '@automattic/calypso-products';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { ForwardedRef } from 'react';
+import { PlanLogo } from '..';
+import PlanFeatures2023GridActions from '../components/actions';
+import PlanFeatures2023GridBillingTimeframe from '../components/billing-timeframe';
+import PlanFeatures2023GridHeaderPrice from '../components/header-price';
+import { GridPlan } from '../hooks/npm-ready/data-store/use-grid-plans';
+import { PlanActionOverrides } from '../types';
+import { Container } from './container';
+
+interface Props {
+	isLaunchPage?: boolean | null;
+	flowName?: string | null;
+	planActionOverrides?: PlanActionOverrides;
+	gridPlanForSpotlight?: GridPlan;
+	isInSignup?: boolean;
+	isReskinned?: boolean;
+	currentSitePlanSlug?: string | null;
+	siteId?: number | null;
+	isLargeCurrency?: boolean;
+	canUserPurchasePlan: boolean | null;
+	manageHref: string;
+	selectedSiteSlug: string | null;
+	isPlanUpgradeCreditEligible?: boolean;
+	// temporary: element ref to scroll comparison grid into view once "Compare plans" button is clicked
+	plansComparisonGridRef: ForwardedRef< HTMLDivElement >;
+	onUpgradeClick: ( planSlug: PlanSlug ) => void;
+}
+
+export default function SpotlightPlans( props: Props ) {
+	const translate = useTranslate();
+	const {
+		manageHref,
+		canUserPurchasePlan,
+		isLaunchPage,
+		selectedSiteSlug,
+		flowName,
+		planActionOverrides,
+		gridPlanForSpotlight,
+		isInSignup,
+		isReskinned,
+		isLargeCurrency,
+		isPlanUpgradeCreditEligible,
+		currentSitePlanSlug,
+		siteId,
+		onUpgradeClick,
+	} = props;
+	if ( ! gridPlanForSpotlight ) {
+		return null;
+	}
+
+	return (
+		<div className="plan-features-2023-grid__plan-spotlight">
+			<div
+				className={ classNames(
+					'plan-features-2023-grid__plan-spotlight-card',
+					getPlanClass( gridPlanForSpotlight.planSlug )
+				) }
+			>
+				<PlanLogo
+					key={ gridPlanForSpotlight.planSlug }
+					planIndex={ 0 }
+					planSlug={ gridPlanForSpotlight.planSlug }
+					renderedGridPlans={ [ gridPlanForSpotlight ] }
+					isTableCell={ true }
+					isInSignup={ isInSignup }
+				/>
+				{ /* PlanHeaders */ }
+				<Container
+					key={ gridPlanForSpotlight.planSlug }
+					className="plan-features-2023-grid__table-item"
+					isTableCell={ true }
+				>
+					<header
+						className={ classNames(
+							'plan-features-2023-grid__header',
+							getPlanClass( gridPlanForSpotlight.planSlug )
+						) }
+					>
+						<h4 className="plan-features-2023-grid__header-title">
+							{ gridPlanForSpotlight.planConstantObj.getTitle() }
+						</h4>
+					</header>
+				</Container>
+
+				{ /* PlanTagline */ }
+				<Container
+					key={ gridPlanForSpotlight.planSlug }
+					className="plan-features-2023-grid__table-item"
+					isTableCell={ true }
+				>
+					<div className="plan-features-2023-grid__header-tagline">
+						{ gridPlanForSpotlight.tagline }
+					</div>
+				</Container>
+				{ /* PlanPrice */ }
+				<Container
+					scope="col"
+					key={ gridPlanForSpotlight.planSlug }
+					className={ classNames( 'plan-features-2023-grid__table-item', 'is-bottom-aligned', {
+						'has-border-top': ! isReskinned,
+					} ) }
+					isTableCell={ true }
+				>
+					<PlanFeatures2023GridHeaderPrice
+						planSlug={ gridPlanForSpotlight.planSlug }
+						isPlanUpgradeCreditEligible={ !! isPlanUpgradeCreditEligible }
+						isLargeCurrency={ !! isLargeCurrency }
+						currentSitePlanSlug={ currentSitePlanSlug }
+						siteId={ siteId }
+					/>
+					{ isWooExpressPlusPlan( gridPlanForSpotlight.planSlug ) && (
+						<div className="plan-features-2023-grid__header-tagline">
+							{ translate( 'Speak to our team for a custom quote.' ) }
+						</div>
+					) }
+				</Container>
+				{ /* BillingTimeframe */ }
+				<Container
+					className={ classNames(
+						'plan-features-2023-grid__table-item',
+						'plan-features-2023-grid__header-billing-info'
+					) }
+					isTableCell={ true }
+					key={ gridPlanForSpotlight.planSlug }
+				>
+					<PlanFeatures2023GridBillingTimeframe
+						planSlug={ gridPlanForSpotlight.planSlug }
+						billingTimeframe={ gridPlanForSpotlight.planConstantObj.getBillingTimeFrame() }
+					/>
+				</Container>
+				{ /* TopButtons */ }
+				<Container
+					key={ gridPlanForSpotlight.planSlug }
+					className={ classNames(
+						'plan-features-2023-grid__table-item',
+						'is-top-buttons',
+						'is-bottom-aligned'
+					) }
+					isTableCell={ false }
+				>
+					<PlanFeatures2023GridActions
+						manageHref={ manageHref }
+						canUserPurchasePlan={ canUserPurchasePlan }
+						availableForPurchase={ gridPlanForSpotlight.availableForPurchase }
+						className={ getPlanClass( gridPlanForSpotlight.planSlug ) }
+						freePlan={ isFreePlan( gridPlanForSpotlight.planSlug ) }
+						isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( gridPlanForSpotlight.planSlug ) }
+						isWooExpressPlusPlan={ isWooExpressPlusPlan( gridPlanForSpotlight.planSlug ) }
+						isInSignup={ isInSignup }
+						isLaunchPage={ isLaunchPage }
+						onUpgradeClick={ () => onUpgradeClick }
+						planTitle={ gridPlanForSpotlight.planConstantObj.getTitle() }
+						planSlug={ gridPlanForSpotlight.planSlug }
+						flowName={ flowName }
+						current={ gridPlanForSpotlight.current ?? false }
+						currentSitePlanSlug={ currentSitePlanSlug }
+						selectedSiteSlug={ selectedSiteSlug }
+						planActionOverrides={ planActionOverrides }
+						showMonthlyPrice={ true }
+						siteId={ siteId }
+						isStuck={ false }
+						isLargeCurrency={ isLargeCurrency }
+					/>
+				</Container>
+			</div>
+		</div>
+	);
+}

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -7,27 +7,12 @@ import {
 	isFreePlan,
 	isPersonalPlan,
 	isPremiumPlan,
-	isWooExpressMediumPlan,
 	isWooExpressPlan,
 	isWooExpressPlusPlan,
-	isWooExpressSmallPlan,
 	isWpComFreePlan,
 	isWpcomEnterpriseGridPlan,
 } from '@automattic/calypso-products';
-import {
-	BloombergLogo,
-	CNNLogo,
-	CloudLogo,
-	CondenastLogo,
-	DisneyLogo,
-	FacebookLogo,
-	JetpackLogo,
-	SalesforceLogo,
-	SlackLogo,
-	TimeLogo,
-	VIPLogo,
-	WooLogo,
-} from '@automattic/components';
+import { CloudLogo, JetpackLogo, VIPLogo, WooLogo } from '@automattic/components';
 import { isAnyHostingFlow } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
@@ -51,7 +36,6 @@ import { PlanComparisonGrid } from './components/plan-comparison-grid';
 import { Plans2023Tooltip } from './components/plans-2023-tooltip';
 import PopularBadge from './components/popular-badge';
 import { StickyContainer } from './components/sticky-container';
-import StorageAddOnDropdown from './components/storage-add-on-dropdown';
 import PlansGridContextProvider, { usePlansGridContext } from './grid-context';
 import { Container } from './grid-parts/container';
 import PlanStorageOptions from './grid-parts/plan-storage-options';
@@ -59,9 +43,8 @@ import PreviousPlanFeaturesIncludedSection from './grid-parts/previous-plan-feat
 import SpotlightPlans from './grid-parts/spotlight-plans';
 import useHighlightAdjacencyMatrix from './hooks/npm-ready/use-highlight-adjacency-matrix';
 import useIsLargeCurrency from './hooks/npm-ready/use-is-large-currency';
-import { getStorageStringFromFeature } from './util';
+import { PlanFeatures2023GridProps, PlanFeatures2023GridType } from './types';
 import type { GridPlan } from './hooks/npm-ready/data-store/use-grid-plans';
-import type { PlanFeatures2023GridProps, PlanFeatures2023GridType, PlanRowOptions } from './types';
 import type { IAppState } from 'calypso/state/types';
 import './style.scss';
 
@@ -745,160 +728,6 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			} );
 	}
 
-	/**
-	 * @deprecated moved inline
-	 */
-	renderMobileFreeDomain( planSlug: PlanSlug, isMonthlyPlan?: boolean ) {
-		const { translate } = this.props;
-
-		if ( isMonthlyPlan || isWpComFreePlan( planSlug ) || isWpcomEnterpriseGridPlan( planSlug ) ) {
-			return null;
-		}
-		const { paidDomainName } = this.props;
-
-		const displayText = paidDomainName
-			? translate( '%(paidDomainName)s is included', {
-					args: { paidDomainName },
-			  } )
-			: translate( 'Free domain for one year' );
-
-		return (
-			<div className="plan-features-2023-grid__highlighted-feature">
-				<PlanFeaturesItem>
-					<span className="plan-features-2023-grid__item-info is-annual-plan-feature is-available">
-						<span className="plan-features-2023-grid__item-title is-bold">{ displayText }</span>
-					</span>
-				</PlanFeaturesItem>
-			</div>
-		);
-	}
-
-	/**
-	 * @deprecated moved inline
-	 */
-	renderPlanPrice( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const {
-			isReskinned,
-			isLargeCurrency,
-			translate,
-			isPlanUpgradeCreditEligible,
-			currentSitePlanSlug,
-			siteId,
-		} = this.props;
-		return renderedGridPlans.map( ( { planSlug } ) => {
-			const isWooExpressPlus = isWooExpressPlusPlan( planSlug );
-			const classes = classNames( 'plan-features-2023-grid__table-item', 'is-bottom-aligned', {
-				'has-border-top': ! isReskinned,
-			} );
-
-			return (
-				<Container
-					scope="col"
-					key={ planSlug }
-					className={ classes }
-					isTableCell={ options?.isTableCell }
-				>
-					<PlanFeatures2023GridHeaderPrice
-						planSlug={ planSlug }
-						isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
-						isLargeCurrency={ isLargeCurrency }
-						currentSitePlanSlug={ currentSitePlanSlug }
-						siteId={ siteId }
-					/>
-					{ isWooExpressPlus && (
-						<div className="plan-features-2023-grid__header-tagline">
-							{ translate( 'Speak to our team for a custom quote.' ) }
-						</div>
-					) }
-				</Container>
-			);
-		} );
-	}
-
-	/**
-	 * @deprecated moved inline
-	 */
-	renderBillingTimeframe( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		return renderedGridPlans.map( ( { planConstantObj, planSlug } ) => {
-			const classes = classNames(
-				'plan-features-2023-grid__table-item',
-				'plan-features-2023-grid__header-billing-info'
-			);
-
-			return (
-				<Container className={ classes } isTableCell={ options?.isTableCell } key={ planSlug }>
-					<PlanFeatures2023GridBillingTimeframe
-						planSlug={ planSlug }
-						billingTimeframe={ planConstantObj.getBillingTimeFrame() }
-					/>
-				</Container>
-			);
-		} );
-	}
-
-	/**
-	 * @deprecated moved inline
-	 */
-	renderPlanLogos( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const { isInSignup } = this.props;
-
-		return renderedGridPlans.map( ( { planSlug }, index ) => {
-			return (
-				<PlanLogo
-					key={ planSlug }
-					planIndex={ index }
-					planSlug={ planSlug }
-					renderedGridPlans={ renderedGridPlans }
-					isTableCell={ options?.isTableCell }
-					isInSignup={ isInSignup }
-				/>
-			);
-		} );
-	}
-
-	/**
-	 * @deprecated moved inline
-	 */
-	renderPlanHeaders( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		return renderedGridPlans.map( ( { planSlug, planConstantObj } ) => {
-			const headerClasses = classNames(
-				'plan-features-2023-grid__header',
-				getPlanClass( planSlug )
-			);
-
-			return (
-				<Container
-					key={ planSlug }
-					className="plan-features-2023-grid__table-item"
-					isTableCell={ options?.isTableCell }
-				>
-					<header className={ headerClasses }>
-						<h4 className="plan-features-2023-grid__header-title">
-							{ planConstantObj.getTitle() }
-						</h4>
-					</header>
-				</Container>
-			);
-		} );
-	}
-
-	/**
-	 * @deprecated moved inline
-	 */
-	renderPlanTagline( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		return renderedGridPlans.map( ( { planSlug, tagline } ) => {
-			return (
-				<Container
-					key={ planSlug }
-					className="plan-features-2023-grid__table-item"
-					isTableCell={ options?.isTableCell }
-				>
-					<div className="plan-features-2023-grid__header-tagline">{ tagline }</div>
-				</Container>
-			);
-		} );
-	}
-
 	handleUpgradeClick = ( planSlug: PlanSlug ) => {
 		const { onUpgradeClick: ownPropsOnUpgradeClick, gridPlansForFeaturesGrid } = this.props;
 		const { cartItemForPlan } =
@@ -916,215 +745,6 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			return;
 		}
 	};
-
-	/**
-	 * @deprecated moved inline
-	 */
-	renderTopButtons( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const {
-			isInSignup,
-			isLaunchPage,
-			flowName,
-			canUserPurchasePlan,
-			manageHref,
-			currentSitePlanSlug,
-			selectedSiteSlug,
-			translate,
-			planActionOverrides,
-			siteId,
-			isLargeCurrency,
-		} = this.props;
-
-		return renderedGridPlans.map(
-			( { planSlug, planConstantObj, current, availableForPurchase } ) => {
-				const classes = classNames(
-					'plan-features-2023-grid__table-item',
-					'is-top-buttons',
-					'is-bottom-aligned'
-				);
-
-				// Leaving it `undefined` makes it use the default label
-				let buttonText;
-
-				if (
-					isWooExpressMediumPlan( planSlug ) &&
-					! isWooExpressMediumPlan( currentSitePlanSlug || '' )
-				) {
-					buttonText = translate( 'Get Performance', { textOnly: true } );
-				} else if (
-					isWooExpressSmallPlan( planSlug ) &&
-					! isWooExpressSmallPlan( currentSitePlanSlug || '' )
-				) {
-					buttonText = translate( 'Get Essential', { textOnly: true } );
-				}
-
-				return (
-					<Container key={ planSlug } className={ classes } isTableCell={ options?.isTableCell }>
-						<PlanFeatures2023GridActions
-							manageHref={ manageHref }
-							canUserPurchasePlan={ canUserPurchasePlan }
-							availableForPurchase={ availableForPurchase }
-							className={ getPlanClass( planSlug ) }
-							freePlan={ isFreePlan( planSlug ) }
-							isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planSlug ) }
-							isWooExpressPlusPlan={ isWooExpressPlusPlan( planSlug ) }
-							isInSignup={ isInSignup }
-							isLaunchPage={ isLaunchPage }
-							onUpgradeClick={ () => this.handleUpgradeClick( planSlug ) }
-							planTitle={ planConstantObj.getTitle() }
-							planSlug={ planSlug }
-							flowName={ flowName }
-							current={ current ?? false }
-							currentSitePlanSlug={ currentSitePlanSlug }
-							selectedSiteSlug={ selectedSiteSlug }
-							buttonText={ buttonText }
-							planActionOverrides={ planActionOverrides }
-							showMonthlyPrice={ true }
-							siteId={ siteId }
-							isStuck={ options?.isStuck || false }
-							isLargeCurrency={ isLargeCurrency }
-						/>
-					</Container>
-				);
-			}
-		);
-	}
-
-	/**
-	 * @deprecated moved inline
-	 */
-	maybeRenderRefundNotice( gridPlan: GridPlan[], options?: PlanRowOptions ) {
-		const { translate, flowName } = this.props;
-
-		if ( ! isAnyHostingFlow( flowName ) ) {
-			return false;
-		}
-
-		return gridPlan.map( ( { planSlug, pricing: { billingPeriod } } ) => (
-			<Container
-				key={ planSlug }
-				className="plan-features-2023-grid__table-item"
-				isTableCell={ options?.isTableCell }
-			>
-				{ ! isFreePlan( planSlug ) && (
-					<div className={ `plan-features-2023-grid__refund-notice ${ getPlanClass( planSlug ) }` }>
-						{ translate( 'Refundable within %(dayCount)s days. No questions asked.', {
-							args: {
-								dayCount: billingPeriod === 365 ? 14 : 7,
-							},
-						} ) }
-					</div>
-				) }
-			</Container>
-		) );
-	}
-
-	/**
-	 * @deprecated moved inline
-	 */
-	renderEnterpriseClientLogos() {
-		return (
-			<div className="plan-features-2023-grid__item plan-features-2023-grid__enterprise-logo">
-				<TimeLogo />
-				<SlackLogo />
-				<DisneyLogo />
-				<CNNLogo />
-				<SalesforceLogo />
-				<FacebookLogo />
-				<CondenastLogo />
-				<BloombergLogo />
-			</div>
-		);
-	}
-
-	/**
-	 * @deprecated moved inline
-	 */
-	renderPreviousFeaturesIncludedTitle( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const { translate, gridPlansForFeaturesGrid } = this.props;
-
-		return renderedGridPlans.map( ( { planSlug } ) => {
-			const shouldRenderEnterpriseLogos =
-				isWpcomEnterpriseGridPlan( planSlug ) || isWooExpressPlusPlan( planSlug );
-			const shouldShowFeatureTitle = ! isWpComFreePlan( planSlug ) && ! shouldRenderEnterpriseLogos;
-			const indexInGridPlansForFeaturesGrid = gridPlansForFeaturesGrid.findIndex(
-				( { planSlug: slug } ) => slug === planSlug
-			);
-			const previousProductName =
-				indexInGridPlansForFeaturesGrid > 0
-					? gridPlansForFeaturesGrid[ indexInGridPlansForFeaturesGrid - 1 ].productNameShort
-					: null;
-			const title =
-				previousProductName &&
-				translate( 'Everything in %(planShortName)s, plus:', {
-					args: { planShortName: previousProductName },
-				} );
-			const classes = classNames(
-				'plan-features-2023-grid__common-title',
-				getPlanClass( planSlug )
-			);
-			const rowspanProp =
-				options?.isTableCell && shouldRenderEnterpriseLogos ? { rowSpan: '2' } : {};
-			return (
-				<Container
-					key={ planSlug }
-					isTableCell={ options?.isTableCell }
-					className="plan-features-2023-grid__table-item"
-					{ ...rowspanProp }
-				>
-					{ shouldShowFeatureTitle && <div className={ classes }>{ title }</div> }
-					{ shouldRenderEnterpriseLogos && this.renderEnterpriseClientLogos() }
-				</Container>
-			);
-		} );
-	}
-
-	/**
-	 * @deprecated moved to own component
-	 */
-	renderPlanStorageOptions( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const { translate, intervalType, showUpgradeableStorage } = this.props;
-
-		return renderedGridPlans.map( ( { planSlug, features: { storageOptions } } ) => {
-			if ( ! options?.isTableCell && isWpcomEnterpriseGridPlan( planSlug ) ) {
-				return null;
-			}
-
-			const shouldRenderStorageTitle =
-				storageOptions.length === 1 ||
-				( intervalType !== 'yearly' && storageOptions.length > 0 ) ||
-				( ! showUpgradeableStorage && storageOptions.length > 0 );
-			const canUpgradeStorageForPlan =
-				storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage;
-
-			const storageJSX = canUpgradeStorageForPlan ? (
-				<StorageAddOnDropdown planSlug={ planSlug } storageOptions={ storageOptions } />
-			) : (
-				storageOptions.map( ( storageOption ) => {
-					if ( ! storageOption?.isAddOn ) {
-						return (
-							<div className="plan-features-2023-grid__storage-buttons" key={ planSlug }>
-								{ getStorageStringFromFeature( storageOption?.slug ) }
-							</div>
-						);
-					}
-				} )
-			);
-
-			return (
-				<Container
-					key={ planSlug }
-					className="plan-features-2023-grid__table-item plan-features-2023-grid__storage"
-					isTableCell={ options?.isTableCell }
-				>
-					{ shouldRenderStorageTitle ? (
-						<div className="plan-features-2023-grid__storage-title">{ translate( 'Storage' ) }</div>
-					) : null }
-					{ storageJSX }
-				</Container>
-			);
-		} );
-	}
 
 	render() {
 		const {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -54,6 +54,7 @@ import { StickyContainer } from './components/sticky-container';
 import StorageAddOnDropdown from './components/storage-add-on-dropdown';
 import PlansGridContextProvider, { usePlansGridContext } from './grid-context';
 import { Container } from './grid-parts/container';
+import PlanStorageOptions from './grid-parts/plan-storage-options';
 import PreviousPlanFeaturesIncludedSection from './grid-parts/previous-plan-features-included';
 import SpotlightPlans from './grid-parts/spotlight-plans';
 import useHighlightAdjacencyMatrix from './hooks/npm-ready/use-highlight-adjacency-matrix';
@@ -62,7 +63,6 @@ import { getStorageStringFromFeature } from './util';
 import type { GridPlan } from './hooks/npm-ready/data-store/use-grid-plans';
 import type { PlanFeatures2023GridProps, PlanFeatures2023GridType, PlanRowOptions } from './types';
 import type { IAppState } from 'calypso/state/types';
-
 import './style.scss';
 
 export type PlanSelectedStorage = { [ key: string ]: WPComStorageAddOnSlug | null };
@@ -187,6 +187,8 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			selectedFeature,
 			wpcomFreeDomainSuggestion,
 			isCustomDomainAllowedOnFreePlan,
+			showUpgradeableStorage,
+			intervalType,
 		} = this.props;
 		// Do not render the spotlight plan if it exists
 		const gridPlansWithoutSpotlight = ! gridPlanForSpotlight
@@ -434,7 +436,15 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 							} ) }
 					</tr>
 					<tr>
-						{ this.renderPlanStorageOptions( gridPlansWithoutSpotlight, { isTableCell: true } ) }
+						{ gridPlansWithoutSpotlight.map( ( gridPlan ) => (
+							<PlanStorageOptions
+								storageOptions={ gridPlan.features.storageOptions }
+								planSlug={ gridPlan.planSlug }
+								intervalType={ intervalType }
+								showUpgradeableStorage={ showUpgradeableStorage }
+								options={ { isTableCell: true } }
+							/>
+						) ) }
 					</tr>
 				</tbody>
 			</table>
@@ -488,6 +498,8 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			hideUnavailableFeatures,
 			wpcomFreeDomainSuggestion,
 			isCustomDomainAllowedOnFreePlan,
+			intervalType,
+			showUpgradeableStorage,
 		} = this.props;
 		const CardContainer = (
 			props: React.ComponentProps< typeof FoldableCard > & { planSlug: string }
@@ -719,7 +731,13 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 								/>
 							</Container>
 
-							{ this.renderPlanStorageOptions( [ gridPlan ] ) }
+							<PlanStorageOptions
+								storageOptions={ gridPlan.features.storageOptions }
+								planSlug={ gridPlan.planSlug }
+								intervalType={ intervalType }
+								showUpgradeableStorage={ showUpgradeableStorage }
+								options={ { isTableCell: false } }
+							/>
 						</CardContainer>
 					</div>
 				);
@@ -1062,65 +1080,8 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 	}
 
 	/**
-	 * @deprecated moved inline
+	 * @deprecated moved to own component
 	 */
-	renderPlanFeaturesList( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const {
-			paidDomainName,
-			translate,
-			hideUnavailableFeatures,
-			selectedFeature,
-			wpcomFreeDomainSuggestion,
-			isCustomDomainAllowedOnFreePlan,
-		} = this.props;
-		const plansWithFeatures = renderedGridPlans.filter(
-			( gridPlan ) =>
-				! isWpcomEnterpriseGridPlan( gridPlan.planSlug ) &&
-				! isWooExpressPlusPlan( gridPlan.planSlug )
-		);
-
-		return plansWithFeatures.map(
-			( { planSlug, features: { wpcomFeatures, jetpackFeatures } }, mapIndex ) => {
-				return (
-					<Container
-						key={ `${ planSlug }-${ mapIndex }` }
-						isTableCell={ options?.isTableCell }
-						className="plan-features-2023-grid__table-item"
-					>
-						<PlanFeatures2023GridFeatures
-							features={ wpcomFeatures }
-							planSlug={ planSlug }
-							paidDomainName={ paidDomainName }
-							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
-							hideUnavailableFeatures={ hideUnavailableFeatures }
-							selectedFeature={ selectedFeature }
-							isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-						/>
-						{ jetpackFeatures.length !== 0 && (
-							<div className="plan-features-2023-grid__jp-logo" key="jp-logo">
-								<Plans2023Tooltip
-									text={ translate(
-										'Security, performance and growth tools made by the WordPress experts.'
-									) }
-								>
-									<JetpackLogo size={ 16 } />
-								</Plans2023Tooltip>
-							</div>
-						) }
-						<PlanFeatures2023GridFeatures
-							features={ jetpackFeatures }
-							planSlug={ planSlug }
-							paidDomainName={ paidDomainName }
-							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
-							hideUnavailableFeatures={ hideUnavailableFeatures }
-							isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-						/>
-					</Container>
-				);
-			}
-		);
-	}
-
 	renderPlanStorageOptions( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
 		const { translate, intervalType, showUpgradeableStorage } = this.props;
 

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -1,5 +1,15 @@
+import { FeatureList } from '@automattic/calypso-products';
+import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import { ForwardedRef } from 'react';
 import { FeatureObject } from 'calypso/lib/plans/features-list';
-import type { TranslateResult } from 'i18n-calypso';
+import { PlanTypeSelectorProps } from '../plans-features-main/components/plan-type-selector';
+import {
+	GridPlan,
+	PlansIntent,
+	UsePricingMetaForGridPlans,
+} from './hooks/npm-ready/data-store/use-grid-plans';
+import type { DomainSuggestion } from '@automattic/data-stores';
+import type { LocalizeProps, TranslateResult } from 'i18n-calypso';
 
 export type TransformedFeatureObject = FeatureObject & {
 	availableForCurrentPlan: boolean;
@@ -19,4 +29,58 @@ export interface PlanActionOverrides {
 export type DataResponse< T > = {
 	isLoading: boolean;
 	result?: T;
+};
+
+export interface PlanFeatures2023GridProps {
+	gridPlansForFeaturesGrid: GridPlan[];
+	gridPlansForComparisonGrid: GridPlan[];
+	gridPlanForSpotlight?: GridPlan;
+	// allFeaturesList temporary until feature definitions are ported to calypso-products package
+	allFeaturesList: FeatureList;
+	isInSignup?: boolean;
+	siteId?: number | null;
+	isLaunchPage?: boolean | null;
+	isReskinned?: boolean;
+	onUpgradeClick?: ( cartItem?: MinimalRequestCartProduct | null ) => void;
+	flowName?: string | null;
+	paidDomainName?: string;
+	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >; // used to show a wpcom free domain in the Free plan column when a paid domain is picked.
+	intervalType?: string;
+	currentSitePlanSlug?: string | null;
+	hidePlansFeatureComparison?: boolean;
+	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
+	planActionOverrides?: PlanActionOverrides;
+	// Value of the `?plan=` query param, so we can highlight a given plan.
+	selectedPlan?: string;
+	// Value of the `?feature=` query param, so we can highlight a given feature and hide plans without it.
+	selectedFeature?: string;
+	intent?: PlansIntent;
+	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >; // indicate when a custom domain is allowed to be used with the Free plan.
+	isGlobalStylesOnPersonal?: boolean;
+	showLegacyStorageFeature?: boolean;
+	showUpgradeableStorage: boolean; // feature flag used to show the storage add-on dropdown
+	stickyRowOffset: number;
+	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
+	showOdie?: () => void;
+	// temporary
+	showPlansComparisonGrid: boolean;
+	// temporary
+	toggleShowPlansComparisonGrid: () => void;
+	planTypeSelectorProps: PlanTypeSelectorProps;
+}
+
+export interface PlanFeatures2023GridType extends PlanFeatures2023GridProps {
+	isLargeCurrency: boolean;
+	translate: LocalizeProps[ 'translate' ];
+	canUserPurchasePlan: boolean | null;
+	manageHref: string;
+	selectedSiteSlug: string | null;
+	isPlanUpgradeCreditEligible: boolean;
+	// temporary: element ref to scroll comparison grid into view once "Compare plans" button is clicked
+	plansComparisonGridRef: ForwardedRef< HTMLDivElement >;
+}
+
+export type PlanRowOptions = {
+	isTableCell?: boolean;
+	isStuck?: boolean;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
