### PR TITLE
Update instances of Woo where we mean Woo Express in login and signup

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -388,7 +388,7 @@ class Login extends Component {
 						<p className="login__header-subtitle">
 							{ this.showContinueAsUser()
 								? translate(
-										"All Woo stores are powered by WordPress.com!{{br/}}First, select the account you'd like to use.",
+										"All Woo Express stores are powered by WordPress.com!{{br/}}First, select the account you'd like to use.",
 										{
 											components: {
 												br: <br />,
@@ -396,7 +396,7 @@ class Login extends Component {
 										}
 								  )
 								: translate(
-										"All Woo stores are powered by WordPress.com!{{br/}}Please, log in to continue. Don't have an account? {{signupLink}}Sign up{{/signupLink}}",
+										"All Woo Express stores are powered by WordPress.com!{{br/}}Please, log in to continue. Don't have an account? {{signupLink}}Sign up{{/signupLink}}",
 										{
 											components: {
 												signupLink: <a href={ this.getSignupUrl() } />,

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -204,7 +204,7 @@ export class UserStep extends Component {
 						  );
 			} else if ( isWooOAuth2Client( oauth2Client ) && ! wccomFrom ) {
 				subHeaderText = translate(
-					'All Woo stores are powered by WordPress.com.{{br/}}Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
+					'All Woo Express stores are powered by WordPress.com.{{br/}}Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
 					{
 						components: {
 							a: <a href={ loginUrl } />,


### PR DESCRIPTION
This is a simple copy change PR that takes 3 instances of the following text:

> All Woo stores are powered by WordPress.com.

and changes them to:

> All Woo Express stores are powered by WordPress.com.

Related to #80601

## Testing Instructions

* Switch to this branch and build Calypso locally
* Log out of WooCommerce.com, then click the **Log In** link in the top right.
* Change the URL in your browser from `https://wordpress.com` to your local Calypso URL (typically `http://calypso.localhost:3000`)
* Note the verbiage change below the page header: "All Woo Express stores are powered by WordPress.com"
<img width="577" alt="Screen Shot 2023-08-17 at 3 06 11 PM" src="https://github.com/Automattic/wp-calypso/assets/4297811/1a50547e-4066-4a83-8351-804adbe5370c">

* Proceed to login, then note you will be redirected to WordPress.com again. Change the URL in your browser once again to point to your local Calypso install.
* You should see the "Select an account" screen with the same verbiage change:
<img width="582" alt="Screen Shot 2023-08-17 at 3 04 41 PM" src="https://github.com/Automattic/wp-calypso/assets/4297811/678e3088-f45b-4be5-b45f-579d292d9a14">

* Lastly, open an incognito/private tab and visit WooCommerce.com then click on the **Get Started** button up top to get to the NUX flow.
* Click "Skip this step" and then hit the **Continue** button on the "Tell us a bit about your store" screen, then click the **Try Woo Express for free** button on the following screen.
* You're once again redirected to WordPress.com; switch the URL to your local Calypso to verify this screen also mentions "All Woo Express stores" instead of "All Woo stores"
<img width="545" alt="Screen Shot 2023-08-17 at 3 10 47 PM" src="https://github.com/Automattic/wp-calypso/assets/4297811/04ab8c15-ff6c-43d8-b353-ccae30a6b8e8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
