### PR TITLE
Stats: Updating initial site type selection

### DIFF
--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -24,7 +24,6 @@ import StatsPurchaseWizard, {
 	SCREEN_PURCHASE,
 	SCREEN_TYPE_SELECTION,
 	TYPE_COMMERCIAL,
-	TYPE_PERSONAL,
 } from './stats-purchase-wizard';
 
 const isProductOwned = ( ownedProducts: SiteProduct[] | null, searchedProduct: string ) => {
@@ -100,7 +99,8 @@ const StatsPurchasePage = ( { query }: { query: { redirect_uri: string; from: st
 		if ( isPWYWOwned && ! isCommercialOwned ) {
 			return [ SCREEN_PURCHASE, TYPE_COMMERCIAL ];
 		}
-		return [ SCREEN_TYPE_SELECTION, TYPE_PERSONAL ];
+		// if nothing is owned don't specify the type
+		return [ SCREEN_TYPE_SELECTION, null ];
 	}, [ isPWYWOwned, isCommercialOwned ] );
 
 	const maxSliderPrice = commercialMonthlyProduct?.cost;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -50,7 +50,7 @@ const ProductCard = ( {
 	from,
 	disableFreeProduct = false,
 	initialStep = SCREEN_TYPE_SELECTION,
-	initialSiteType = TYPE_PERSONAL,
+	initialSiteType,
 } ) => {
 	const sliderStepPrice = pwywProduct.cost / MIN_STEP_SPLITS;
 
@@ -70,6 +70,7 @@ const ProductCard = ( {
 	const commercialLabel = translate( 'Commercial site' );
 	const selectedTypeLabel = siteType === TYPE_PERSONAL ? personalLabel : commercialLabel;
 	const showCelebration =
+		siteType &&
 		wizardStep === SCREEN_PURCHASE &&
 		( siteType === TYPE_COMMERCIAL || subscriptionValue >= uiImageCelebrationTier );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80789

## Proposed Changes

* remove default selection of personal plan type

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to a live branch for a page that doesn't have any plan purchased
* navigate to a purchase page
* verify that the header for the first step starts with `What site type is {domain}?`

| Before | After |
| --- | --- |
| <img width="1019" alt="SCR-20230818-ntqh" src="https://github.com/Automattic/wp-calypso/assets/112354940/9969580b-37c5-4495-9c5e-79f68f1caca4"> | <img width="1128" alt="SCR-20230818-nssx" src="https://github.com/Automattic/wp-calypso/assets/112354940/50081e1b-5f8c-433e-b3a8-c10e4abc8ba3"> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
