### PR TITLE
Domain Management i1: Move all label related styles into the `domains-table` package

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.scss
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.scss
@@ -1,5 +1,0 @@
-.domains-table .domains-table__primary-domain-label {
-	height: 20px;
-	border-radius: 4px;
-	margin-bottom: 4px;
-}

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -10,7 +10,6 @@ import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import DomainHeader from '../components/domain-header';
 import OptionsDomainButton from './options-domain-button';
-import './bulk-site-domains.scss';
 
 interface BulkSiteDomainsProps {
 	analyticsPath: string;

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -32,4 +32,8 @@
 			color: var(--color-link);
 		}
 	}
+
+	.domains-table__primary-domain-label {
+		margin-bottom: 4px;
+	}
 }

--- a/packages/domains-table/src/primary-domain-label/style.scss
+++ b/packages/domains-table/src/primary-domain-label/style.scss
@@ -1,11 +1,17 @@
 @import "@automattic/typography/styles/variables";
 
 .domains-table__primary-domain-label {
-	display: flex !important;
-	align-items: center;
-	gap: 4px;
-	width: max-content;
-	line-height: 1 !important;
+	// Uses the extra class selector to bump up the specificty so we can more reliably
+	// override the usual badge styles.
+	&.badge {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		width: max-content;
+		line-height: 1;
+		height: 20px;
+		border-radius: 4px;
+	}
 
 	&-popover-content {
 		padding: 16px;


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/80723

## Proposed Changes

The extra specificty of adding the `.badge` selector the label styles allows us to override the default badge styles without the !import.

Also moves the margin between the label and domain name into the domains table styles, so that everyone will get them regardless of where <DomainsTable> is rendered.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The storybook used to look like this:

<img width="200" alt="CleanShot 2023-08-18 at 17 40 14@2x" src="https://github.com/Automattic/wp-calypso/assets/1500769/9c2bb34e-f429-4363-9999-4d323043054a">

But now it looks like this:

<img width="184" alt="CleanShot 2023-08-18 at 17 39 38@2x" src="https://github.com/Automattic/wp-calypso/assets/1500769/a2e4d2bd-4d48-4be9-88f5-2f480394425b">

Which matches what it looks like in the domains table

<img width="1153" alt="CleanShot 2023-08-18 at 17 41 03@2x" src="https://github.com/Automattic/wp-calypso/assets/1500769/9b4e9b97-27c7-4a62-9cf9-d3b2b19d769c">
