### PR TITLE
Only redirect to path without locale if the lang param is detected

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -186,11 +186,11 @@ export function redirectLoggedOutToSignup( context, next ) {
  * @returns {void}
  */
 export function redirectWithoutLocaleParamIfLoggedIn( context, next ) {
-	const langSlugs = getLanguageSlugs();
-	const langSlugPathSegmentMatcher = new RegExp( `\\/(${ langSlugs.join( '|' ) })(\\/|\\?|$)` );
-	const pathWithoutLocale = context.path.replace( langSlugPathSegmentMatcher, '$2' );
+	if ( isUserLoggedIn( context.store.getState() ) && context.params.lang ) {
+		const langSlugs = getLanguageSlugs();
+		const langSlugPathSegmentMatcher = new RegExp( `\\/(${ langSlugs.join( '|' ) })(\\/|\\?|$)` );
+		const pathWithoutLocale = context.path.replace( langSlugPathSegmentMatcher, '$2' );
 
-	if ( isUserLoggedIn( context.store.getState() ) && pathWithoutLocale !== context.path ) {
 		return page.redirect( pathWithoutLocale );
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1692333989441939-slack-CRWCHQGUB

## Proposed Changes

* Now we have a new theme called `snd` but the `redirectWithoutLocaleParamIfLoggedIn` middleware misread the theme name to treat it as a lang param so that it tries to redirect to another path without the theme slug. Hence, this PR made a change to replace the URL without the lang param only when the lang param is detected to avoid this situation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase
* Search for `snd`
* Click “...” > “Info” to go to the Theme Details page
* Ensure you're able to see the Theme Details page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
