### PR TITLE
Jetpack Pro Dashboard: add UI test cases for downtime monitoring changes(notification-settings components)

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/email-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/email-notification.tsx
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import EmailNotification from '../email-notification';
+import type { RestrictionType } from '../../../types';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const config = () => 'development';
+	config.isEnabled = ( property: string ) => property === 'jetpack/pro-dashboard-monitor-paid-tier';
+	return config;
+} );
+
+describe( 'EmailNotification', () => {
+	const defaultProps = {
+		recordEvent: jest.fn(),
+		enableEmailNotification: true,
+		setEnableEmailNotification: jest.fn(),
+		defaultUserEmailAddresses: [ 'example@example.com' ],
+		toggleAddEmailModal: jest.fn(),
+		allEmailItems: [],
+		restriction: 'none' as RestrictionType,
+	};
+
+	const initialState = {};
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'renders the component with email notifications enabled', () => {
+		render( <EmailNotification { ...defaultProps } /> );
+
+		expect( screen.getByLabelText( 'Disable email notifications' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Receive email notifications with one or more recipients.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders the component with email notifications disabled', () => {
+		render( <EmailNotification { ...defaultProps } enableEmailNotification={ false } /> );
+
+		expect( screen.getByLabelText( 'Enable email notifications' ) ).toBeInTheDocument();
+	} );
+
+	it( 'handles toggle change with email notifications enabled', () => {
+		render( <EmailNotification { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+
+		fireEvent.click( screen.getByLabelText( 'Disable email notifications' ) );
+		expect( defaultProps.recordEvent ).toHaveBeenCalledWith( 'email_notification_disable' );
+		expect( defaultProps.setEnableEmailNotification ).toHaveBeenCalledWith( false );
+	} );
+
+	it( 'handles toggle change with email notifications disabled', () => {
+		render( <EmailNotification { ...defaultProps } enableEmailNotification={ false } />, {
+			wrapper: Wrapper,
+		} );
+
+		fireEvent.click( screen.getByLabelText( 'Enable email notifications' ) );
+		expect( defaultProps.recordEvent ).toHaveBeenCalledWith( 'email_notification_enable' );
+		expect( defaultProps.setEnableEmailNotification ).toHaveBeenCalledWith( true );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/footer.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/footer.tsx
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import NotificationSettingsFormFooter from '../footer';
+
+describe( 'NotificationSettingsFormFooter', () => {
+	const defaultProps = {
+		isLoading: false,
+		validationError: '',
+		isBulkUpdate: false,
+		handleOnClose: jest.fn(),
+		hasUnsavedChanges: false,
+		unsavedChangesExist: true,
+	};
+
+	it( 'renders the component with Cancel and Save buttons', () => {
+		render( <NotificationSettingsFormFooter { ...defaultProps } /> );
+
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Cancel and close notification settings popup',
+			} )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'button', { name: 'Save notification settings' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'handles button clicks', () => {
+		render( <NotificationSettingsFormFooter { ...defaultProps } /> );
+
+		fireEvent.click(
+			screen.getByRole( 'button', {
+				name: 'Cancel and close notification settings popup',
+			} )
+		);
+		expect( defaultProps.handleOnClose ).toHaveBeenCalled();
+
+		const saveButton = screen.getByRole( 'button', { name: 'Save notification settings' } );
+		fireEvent.click( saveButton );
+		expect( saveButton ).toHaveTextContent( 'Save' );
+	} );
+
+	it( 'render component with save button disabled when it is loading', () => {
+		const propsWithDisabledSave = {
+			...defaultProps,
+			isLoading: true,
+		};
+		render( <NotificationSettingsFormFooter { ...propsWithDisabledSave } /> );
+
+		const saveButton = screen.getByRole( 'button', { name: 'Save notification settings' } );
+		expect( saveButton ).toBeDisabled();
+		expect( saveButton ).toHaveTextContent( 'Saving Changes' );
+	} );
+
+	it( 'render component with save button disabled when there are no unsaved changes', () => {
+		const propsWithDisabledSave = {
+			...defaultProps,
+			unsavedChangesExist: false,
+		};
+		render( <NotificationSettingsFormFooter { ...propsWithDisabledSave } /> );
+
+		const saveButton = screen.getByRole( 'button', { name: 'Save notification settings' } );
+		expect( saveButton ).toBeDisabled();
+		expect( saveButton ).toHaveTextContent( 'Save' );
+	} );
+
+	it( 'render component with error message when there are unsaved changes', () => {
+		const propsWithDisabledSave = {
+			...defaultProps,
+			hasUnsavedChanges: true,
+		};
+		render( <NotificationSettingsFormFooter { ...propsWithDisabledSave } /> );
+
+		expect(
+			screen.getByText( 'You have unsaved changes. Are you sure you want to close?' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'render component with save button disabled and show error there is an error', () => {
+		const validationError = 'Validation error message';
+		const propsWithDisabledSave = {
+			...defaultProps,
+			validationError,
+		};
+		render( <NotificationSettingsFormFooter { ...propsWithDisabledSave } /> );
+
+		const saveButton = screen.getByRole( 'button', { name: 'Save notification settings' } );
+		expect( saveButton ).toBeDisabled();
+		expect( saveButton ).toHaveTextContent( 'Save' );
+		expect( screen.getByText( validationError ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/mobile-push-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/mobile-push-notification.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { mobileAppLink } from '../../../../sites-overview/utils';
+import MobilePushNotification from '../mobile-push-notification';
+
+describe( 'MobilePushNotification', () => {
+	const defaultProps = {
+		recordEvent: jest.fn(),
+		enableMobileNotification: true,
+		setEnableMobileNotification: jest.fn(),
+	};
+
+	const initialState = {};
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'renders the component with mobile notifications enabled', () => {
+		render( <MobilePushNotification { ...defaultProps } /> );
+
+		expect( screen.getByLabelText( 'Disable mobile notifications' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Push' ) ).toBeInTheDocument();
+		expect( screen.getByText( /receive notifications via the/i ) ).toBeInTheDocument();
+
+		const link = screen.getByRole( 'link' );
+		expect( link ).toBeInTheDocument();
+		expect( link ).toHaveAttribute( 'href', mobileAppLink );
+	} );
+
+	it( 'renders the component with mobile notifications disabled', () => {
+		render( <MobilePushNotification { ...defaultProps } enableMobileNotification={ false } /> );
+
+		expect( screen.getByLabelText( 'Enable mobile notifications' ) ).toBeInTheDocument();
+	} );
+
+	it( 'handles toggle change with mobile notifications enabled', () => {
+		render( <MobilePushNotification { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+
+		fireEvent.click( screen.getByLabelText( 'Disable mobile notifications' ) );
+		expect( defaultProps.recordEvent ).toHaveBeenCalledWith( 'mobile_notification_disable' );
+		expect( defaultProps.setEnableMobileNotification ).toHaveBeenCalledWith( false );
+	} );
+
+	it( 'handles toggle change with mobile notifications disabled', () => {
+		render( <MobilePushNotification { ...defaultProps } enableMobileNotification={ false } />, {
+			wrapper: Wrapper,
+		} );
+
+		fireEvent.click( screen.getByLabelText( 'Enable mobile notifications' ) );
+		expect( defaultProps.recordEvent ).toHaveBeenCalledWith( 'mobile_notification_enable' );
+		expect( defaultProps.setEnableMobileNotification ).toHaveBeenCalledWith( true );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/notification-duration.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/notification-duration.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import DashboardDataContext from '../../../../sites-overview/dashboard-data-context';
+import NotificationDuration from '../notification-duration';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const config = () => 'development';
+	config.isEnabled = ( property: string ) => property === 'jetpack/pro-dashboard-monitor-paid-tier';
+	return config;
+} );
+
+describe( 'NotificationDuration', () => {
+	const defaultProps = {
+		selectDuration: jest.fn(),
+		recordEvent: jest.fn(),
+	};
+
+	const dashboardContextValue = {
+		verifiedContacts: {
+			emails: [],
+			phoneNumbers: [],
+			refetchIfFailed: jest.fn(),
+		},
+		products: [
+			{
+				name: 'Jetpack Monitor',
+				slug: 'jetpack-monitor',
+				product_id: 123,
+				currency: 'USD',
+				amount: 1,
+				price_interval: 'month',
+				family_slug: 'jetpack-monitor',
+			},
+		],
+		isLargeScreen: true,
+	};
+
+	const initialState = {};
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'renders the component with selected duration and no restriction', () => {
+		render(
+			<NotificationDuration
+				selectedDuration={ { time: 15, label: 'After 15 minutes' } }
+				{ ...defaultProps }
+			/>
+		);
+
+		expect( screen.getByText( 'Notify me about downtime:' ) ).toBeInTheDocument();
+
+		const selectedText = screen.getByRole( 'img', { name: 'Schedules' } );
+		expect( selectedText.parentElement ).toHaveTextContent( 'After 15 minutes' );
+	} );
+
+	it( 'handles dropdown toggle and clicks', () => {
+		render( <NotificationDuration { ...defaultProps } /> );
+
+		fireEvent.click( screen.getByRole( 'menuitem', { name: /after 30 minutes/i } ) );
+		expect( defaultProps.recordEvent ).toHaveBeenCalledWith( 'notification_duration_toggle' );
+		expect( defaultProps.selectDuration ).toHaveBeenCalledWith( {
+			time: 30,
+			label: 'After 30 minutes',
+		} );
+	} );
+
+	it( 'renders the component with upgrade required restriction', () => {
+		render(
+			<DashboardDataContext.Provider value={ dashboardContextValue }>
+				<NotificationDuration restriction="upgrade_required" { ...defaultProps } />
+			</DashboardDataContext.Provider>,
+			{
+				wrapper: Wrapper,
+			}
+		);
+
+		const dropdownToggle = screen.getByRole( 'menuitem', { name: /after 1 minute/i } );
+		expect( dropdownToggle ).toHaveClass( 'is-disabled' );
+		expect( dropdownToggle ).toHaveTextContent( 'After 1 minute' );
+		expect( dropdownToggle ).toHaveTextContent( 'Upgrade' );
+		expect( dropdownToggle ).toHaveTextContent( 'Upgrade ($1.00/m)' );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/sms-counter.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/sms-counter.tsx
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { site } from '../../../../sites-overview/test/test-utils/constants';
+import SMSCounter from '../sms-counter';
+
+describe( 'SMSCounter', () => {
+	it( 'renders the component with usage information when monthlyLimit is available', () => {
+		render( <SMSCounter settings={ site.monitor_settings } /> );
+
+		const counter = screen.getByText( '10/20 SMS used this month on this site' );
+		expect( counter ).toBeInTheDocument();
+		expect( counter ).not.toHaveClass( 'notification-settings__sms-counter-limit-reached' );
+	} );
+
+	it( 'renders the component with limit reached class when is_over_limit is true', () => {
+		render(
+			<SMSCounter
+				settings={ { ...site.monitor_settings, is_over_limit: true, sms_sent_count: 20 } }
+			/>
+		);
+
+		const counter = screen.getByText( '20/20 SMS used this month on this site' );
+		expect( counter ).toBeInTheDocument();
+		expect( counter ).toHaveClass( 'notification-settings__sms-counter-limit-reached' );
+	} );
+
+	it( 'does not render the component when sms_monthly_limit is not available', () => {
+		render( <SMSCounter settings={ { ...site.monitor_settings, sms_monthly_limit: 0 } } /> );
+		const counter = screen.queryByText( '10/20 SMS used this month on this site' );
+		expect( counter ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/sms-notification.tsx
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import DashboardDataContext from '../../../../sites-overview/dashboard-data-context';
+import SMSNotification from '../sms-notification';
+import type { RestrictionType } from '../../../types';
+
+describe( 'SMSNotification', () => {
+	const defaultProps = {
+		recordEvent: jest.fn(),
+		enableSMSNotification: true,
+		setEnableSMSNotification: jest.fn(),
+		toggleModal: jest.fn(),
+		allPhoneItems: [],
+		restriction: 'none' as RestrictionType,
+	};
+
+	const dashboardContextValue = {
+		verifiedContacts: {
+			emails: [],
+			phoneNumbers: [],
+			refetchIfFailed: jest.fn(),
+		},
+		products: [
+			{
+				name: 'Jetpack Monitor',
+				slug: 'jetpack-monitor',
+				product_id: 123,
+				currency: 'USD',
+				amount: 1,
+				price_interval: 'month',
+				family_slug: 'jetpack-monitor',
+			},
+		],
+		isLargeScreen: true,
+	};
+
+	const initialState = {};
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'renders the component with SMS notifications enabled', () => {
+		render( <SMSNotification { ...defaultProps } /> );
+
+		expect( screen.getByLabelText( 'Disable SMS notifications' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'SMS Notification' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Set up text messages to send to one or more people.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders the component with SMS notifications disabled', () => {
+		render( <SMSNotification { ...defaultProps } enableSMSNotification={ false } /> );
+
+		expect( screen.getByLabelText( 'Enable SMS notifications' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the component with SMS notifications enabled with restriction', () => {
+		render(
+			<DashboardDataContext.Provider value={ dashboardContextValue }>
+				<SMSNotification { ...defaultProps } restriction="upgrade_required" />
+			</DashboardDataContext.Provider>,
+			{
+				wrapper: Wrapper,
+			}
+		);
+
+		expect( screen.getByLabelText( 'Disable SMS notifications' ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Upgrade' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Upgrade ($1.00/m)' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'handles toggle change with SMS notifications enabled', () => {
+		render( <SMSNotification { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+
+		fireEvent.click( screen.getByLabelText( 'Disable SMS notifications' ) );
+		expect( defaultProps.recordEvent ).toHaveBeenCalledWith( 'sms_notification_disable' );
+		expect( defaultProps.setEnableSMSNotification ).toHaveBeenCalledWith( false );
+	} );
+
+	it( 'handles toggle change with SMS notifications disabled', () => {
+		render( <SMSNotification { ...defaultProps } enableSMSNotification={ false } />, {
+			wrapper: Wrapper,
+		} );
+
+		fireEvent.click( screen.getByLabelText( 'Enable SMS notifications' ) );
+		expect( defaultProps.recordEvent ).toHaveBeenCalledWith( 'sms_notification_enable' );
+		expect( defaultProps.setEnableSMSNotification ).toHaveBeenCalledWith( true );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/test/notification-settings.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/test/notification-settings.tsx
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { site } from '../../../sites-overview/test/test-utils/constants';
+import NotificationSettings from '../index';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const config = () => 'development';
+	config.isEnabled = ( property: string ) => property.startsWith( 'jetpack/pro-dashboard-monitor' );
+	return config;
+} );
+
+describe( 'NotificationSettings', () => {
+	const sites = [ site ];
+
+	const initialState = {};
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'should render the site monitor settings for single site', () => {
+		const onClose = jest.fn();
+		render( <NotificationSettings sites={ sites } onClose={ onClose } />, {
+			wrapper: Wrapper,
+		} );
+
+		expect( screen.getByText( /set custom notification/i ) ).toBeInTheDocument();
+		expect( screen.getByText( site.url ) ).toBeInTheDocument();
+
+		expect( screen.getByText( /notify me about downtime/i ) ).toBeInTheDocument();
+		expect( screen.getAllByText( /after \d+ minutes/i ).at( 0 ) ).toBeInTheDocument();
+
+		expect( screen.getByText( 'SMS Notification' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( /set up text messages to send to one or more people./i )
+		).toBeInTheDocument();
+
+		expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( /receive email notifications with one or more recipients./i )
+		).toBeInTheDocument();
+
+		expect( screen.getByText( 'Push' ) ).toBeInTheDocument();
+		expect( screen.getByText( /receive notifications via the/i ) ).toBeInTheDocument();
+
+		expect(
+			screen.queryByText( /settings for selected sites will be overwritten./i )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should render the site monitor settings for bulk edit', () => {
+		const onClose = jest.fn();
+		render(
+			<NotificationSettings
+				sites={ sites }
+				onClose={ onClose }
+				bulkUpdateSettings={ site.monitor_settings }
+			/>,
+			{
+				wrapper: Wrapper,
+			}
+		);
+
+		expect(
+			screen.getByText( /settings for selected sites will be overwritten./i )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should show the appropriate error messages', () => {
+		const onClose = jest.fn();
+		render( <NotificationSettings sites={ sites } onClose={ onClose } />, {
+			wrapper: Wrapper,
+		} );
+
+		const cancelButton = screen.getByRole( 'button', { name: /cancel/i } );
+		fireEvent.click( cancelButton );
+		expect( onClose ).toHaveBeenCalled();
+
+		const saveButton = screen.getByRole( 'button', { name: /save/i } );
+		expect( saveButton ).toBeDisabled();
+
+		fireEvent.click( screen.getByRole( 'menuitem', { name: /after 15 minutes/i } ) );
+		expect( saveButton ).toBeEnabled();
+		fireEvent.click( saveButton );
+		expect( screen.getByText( /please select at least one contact method/i ) ).toBeInTheDocument();
+
+		const smsCheckbox = screen.getByRole( 'checkbox', { name: /enable sms notifications/i } );
+		fireEvent.click( smsCheckbox );
+		expect( smsCheckbox ).toBeChecked();
+		fireEvent.click( saveButton );
+		expect( screen.getByText( /please add at least one phone number/i ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/test-utils/constants.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/test-utils/constants.ts
@@ -24,6 +24,12 @@ const site: Site = {
 		monitor_user_emails: [ 'test.com' ],
 		monitor_user_email_notifications: true,
 		monitor_user_wp_note_notifications: true,
+		monitor_user_sms_notifications: false,
+		monitor_notify_additional_user_emails: [],
+		monitor_notify_additional_user_sms: [],
+		is_over_limit: false,
+		sms_sent_count: 10,
+		sms_monthly_limit: 20,
 	},
 	monitor_last_status_change: '2021-01-01T00:00:00+00:00',
 	isSelected: true,
@@ -45,6 +51,8 @@ const site: Site = {
 		desktop: 10,
 	},
 	php_version_num: 7.4,
+	is_connected: true,
+	has_paid_agency_monitor: true,
 };
 
 export { site };


### PR DESCRIPTION
Related to 1202619025189113-as-1205290901768407 

## Proposed Changes

This PR adds test cases to the /notification-settings components added as a part of the downtime monitoring changes.

## Testing Instructions

- Run `git checkout add/test-cases-for-downtime-monitoring-changes-3 && git pull`
- Run `yarn run test-client client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/` to run the tests.
- Verify the tests are passing and code changes make sense

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
