### PR TITLE
Stats: Fixing cursor for purchase step titles

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -139,6 +139,9 @@ const ProductCard = ( {
 								initialOpen
 								onToggle={ ( shouldOpen ) => toggleFirstStep( shouldOpen ) }
 								opened={ wizardStep === SCREEN_TYPE_SELECTION }
+								className={ classNames( `${ COMPONENT_CLASS_NAME }__card-panel-title`, {
+									[ `${ COMPONENT_CLASS_NAME }__card-panel--type-selected` ]: !! siteType,
+								} ) }
 							>
 								<PanelRow>
 									<div className={ `${ COMPONENT_CLASS_NAME }__card-grid` }>
@@ -175,7 +178,11 @@ const ProductCard = ( {
 									</div>
 								</PanelRow>
 							</PanelBody>
-							<PanelBody title={ secondStepTitleNode } opened={ wizardStep === SCREEN_PURCHASE }>
+							<PanelBody
+								title={ secondStepTitleNode }
+								opened={ wizardStep === SCREEN_PURCHASE }
+								className={ classNames( `${ COMPONENT_CLASS_NAME }__card-panel-title` ) }
+							>
 								<PanelRow>
 									{ siteType === TYPE_PERSONAL ? (
 										<PersonalPurchase

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -215,6 +215,19 @@
 		}
 	}
 
+	.stats-purchase-wizard__card-panel-title {
+		h2 > button {
+			cursor: auto;
+
+		}
+
+		&.stats-purchase-wizard__card-panel--type-selected {
+			h2 > button {
+				cursor: pointer;
+			}
+		}
+	}
+
 	.components-button {
 		&.is-primary {
 			border-radius: 4px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80792

## Proposed Changes

* fixing cursor indicator for purchase step headers (second step shouldn't have a cursor indicating interaction but the first header should when a site type was selected)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch and navigate to a page without a plan
* got to the purchase page and verify that the header for the second step doesn't have the cursor indicating an interaction
* (after merging #80795 the first header shouldn't indicate interaction until a site type is selected)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
