### PR TITLE
Assembler: Avoid the large previewing shaking due to the scrollbar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -30,6 +30,15 @@
 	list-style-type: none;
 	overflow: auto;
 	background: var(--pattern-large-preview-background);
+
+	/**
+	 * Hides the scrollbar to avoid the layout keeps changes forever
+	 * See https://github.com/Automattic/wp-calypso/issues/78357.
+	 */
+	scrollbar-width: none;
+	&::-webkit-scrollbar {
+		display: none;
+	}
 }
 
 .pattern-large-preview__pattern {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78357

## Proposed Changes

The preview shakes because the scrollbar shows. There are two ways to resolve this issue
  * Use `scrollbar-gutter` to preserve the width of the scrollbar, so the layout won't be affected when the scrollbar shows
  * Hide the scrollbar to avoid the layout change

Seems the preserved scrollbar width makes the UI look a bit weird, so I think hiding the scrollbar might be better. WDYT?

**Before**

https://github.com/Automattic/wp-calypso/assets/13596067/7682b790-eb84-4ba0-9422-7abf0546e07b 

**After**

https://github.com/Automattic/wp-calypso/assets/13596067/4b15522c-aebc-4745-8dd2-92352a2c771e

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Assembler
* Select a pattern, e.g.: Full-width media and text with background
* Adjust your window height to make the preview overflow
* Ensure the preview won't shake anymore

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
