### PR TITLE
E2E: reduce flakiness in `Site Assembler` spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
@@ -2,7 +2,7 @@ import { Page } from 'playwright';
 type LayoutType = 'Header' | 'Sections' | 'Footer';
 
 /**
- * Class encapsulating the Site Assembler flow
+ * Class encapsulating the Site Assembler flow.
  */
 export class SiteAssemblerFlow {
 	private page: Page;
@@ -35,18 +35,51 @@ export class SiteAssemblerFlow {
 	}
 
 	/**
-	 * Selects a layout component at matching index.
+	 * Selects a site assembler component with the given name from the
+	 * list of available components, inserts it, then validate the insertion
+	 * was successful.
 	 *
-	 * @param {number} index Index of the item to choose. Defaults to 0.
+	 * The name has to match exactly to the string in the tooltip.
+	 *
+	 * @param {string} name Exact name of the component to select.
 	 */
-	async selectLayoutComponent( index = 0 ): Promise< void > {
-		await this.page
+	async selectLayoutComponent( name: string ): Promise< void > {
+		await this.page.route( '*.png', ( route ) => {
+			route.abort( 'aborted' );
+		} );
+
+		// Get the initial count of components in the preview pane.
+		const target = this.page
 			.getByRole( 'listbox', { name: 'Block patterns' } )
-			.getByRole( 'option' )
-			.nth( index )
-			// Pierce through the iframe holding the component preview.
-			.frameLocator( 'iframe' )
-			.locator( '.block-editor-iframe__body' )
-			.click();
+			.getByRole( 'option', { name: name, exact: true } );
+
+		await target.scrollIntoViewIfNeeded();
+		await target.click();
+
+		// The inserted component does not load immediately, especially on
+		// slower networks or a weaker CPU.
+		// Wait for the last component to be visible.
+		// Note, this may not fully wait for the renders to appear.
+		await this.page
+			.locator( '.device-switcher__viewport' )
+			.getByRole( 'list' )
+			.getByRole( 'listitem' )
+			.last()
+			.waitFor();
+	}
+
+	/**
+	 * Returns the number of components added to the Site Assembler preview pane.
+	 *
+	 * @returns {Promise<number>} Number of components in the preview pane.
+	 */
+	async getAssembledComponentsCount(): Promise< number > {
+		// CSS selector must be used as the anchor due to the preview panel
+		// not having an accessible name.
+		return await this.page
+			.locator( '.device-switcher__viewport' )
+			.getByRole( 'list' )
+			.getByRole( 'listitem' )
+			.count();
 	}
 }

--- a/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
@@ -44,7 +44,9 @@ export class SiteAssemblerFlow {
 	 * @param {string} name Exact name of the component to select.
 	 */
 	async selectLayoutComponent( name: string ): Promise< void > {
-		await this.page.route( '*.png', ( route ) => {
+		// To reduce network load times, abort any request for
+		// placeholder images.
+		await this.page.route( '**/*.png', ( route ) => {
 			route.abort( 'aborted' );
 		} );
 

--- a/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
@@ -50,7 +50,6 @@ export class SiteAssemblerFlow {
 			route.abort( 'aborted' );
 		} );
 
-		// Get the initial count of components in the preview pane.
 		const target = this.page
 			.getByRole( 'listbox', { name: 'Block patterns' } )
 			.getByRole( 'option', { name: name, exact: true } );
@@ -61,13 +60,14 @@ export class SiteAssemblerFlow {
 		// The inserted component does not load immediately, especially on
 		// slower networks or a weaker CPU.
 		// Wait for the last component to be visible.
-		// Note, this may not fully wait for the renders to appear.
+		// Note, component being visible do not necessarily mean
+		// the preview images are visible.
 		await this.page
 			.locator( '.device-switcher__viewport' )
 			.getByRole( 'list' )
 			.getByRole( 'listitem' )
 			.last()
-			.waitFor();
+			.waitFor( { timeout: 15 * 1000 } );
 	}
 
 	/**

--- a/test/e2e/specs/onboarding/ftme__site-assembler.ts
+++ b/test/e2e/specs/onboarding/ftme__site-assembler.ts
@@ -13,7 +13,7 @@ import {
 	TestAccount,
 	SiteAssemblerFlow,
 } from '@automattic/calypso-e2e';
-import { Browser, Locator, Page } from 'playwright';
+import { Browser, Page } from 'playwright';
 import { apiDeleteSite } from '../shared';
 
 declare const browser: Browser;
@@ -83,43 +83,31 @@ describe( 'Site Assembler', () => {
 	} );
 
 	describe( 'Site Assembler', function () {
-		let assembledPreviewLocator: Locator;
-		let startSiteFlow: SiteAssemblerFlow;
+		let siteAssemblerFlow: SiteAssemblerFlow;
 
 		beforeAll( async function () {
-			startSiteFlow = new SiteAssemblerFlow( page );
-			assembledPreviewLocator = page.locator( '.pattern-large-preview__patterns .block-renderer' );
+			siteAssemblerFlow = new SiteAssemblerFlow( page );
 		} );
 
 		it( 'Select "Header"', async function () {
-			await startSiteFlow.selectLayoutComponentType( 'Header' );
-			await startSiteFlow.selectLayoutComponent( 1 );
+			await siteAssemblerFlow.selectLayoutComponentType( 'Header' );
+			await siteAssemblerFlow.selectLayoutComponent( 'Simple Header' );
 
-			expect( await assembledPreviewLocator.count() ).toBe( 1 );
+			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 1 );
 		} );
 
 		it( 'Select "Sections"', async function () {
-			await startSiteFlow.selectLayoutComponentType( 'Sections' );
-			await startSiteFlow.selectLayoutComponent( 1 );
+			await siteAssemblerFlow.selectLayoutComponentType( 'Sections' );
+			await siteAssemblerFlow.selectLayoutComponent( 'Heading with two images and descriptions' );
 
-			expect( await assembledPreviewLocator.count() ).toBe( 2 );
+			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 2 );
 		} );
 
 		it( 'Select "Footer"', async function () {
-			await startSiteFlow.selectLayoutComponentType( 'Footer' );
-			await startSiteFlow.selectLayoutComponent( 1 );
+			await siteAssemblerFlow.selectLayoutComponentType( 'Footer' );
+			await siteAssemblerFlow.selectLayoutComponent( 'Simple centered footer' );
 
-			expect( await assembledPreviewLocator.count() ).toBe( 3 );
-		} );
-
-		it( 'Click "Save and continue" and land on the Site Editor', async function () {
-			await Promise.all( [
-				page.waitForURL( /processing/ ),
-				startSiteFlow.clickButton( 'Save and continue' ),
-			] );
-			await page.waitForURL( /site-editor/, {
-				timeout: 30 * 1000,
-			} );
+			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 3 );
 		} );
 	} );
 

--- a/test/e2e/specs/onboarding/ftme__site-assembler.ts
+++ b/test/e2e/specs/onboarding/ftme__site-assembler.ts
@@ -109,6 +109,16 @@ describe( 'Site Assembler', () => {
 
 			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 3 );
 		} );
+
+		it( 'Click "Save and continue" and land on the Site Editor', async function () {
+			await Promise.all( [
+				page.waitForURL( /processing/ ),
+				siteAssemblerFlow.clickButton( 'Save and continue' ),
+			] );
+			await page.waitForURL( /site-editor/, {
+				timeout: 30 * 1000,
+			} );
+		} );
 	} );
 
 	afterAll( async function () {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/80699.

## Proposed Changes

This PR refactors both the Site Assembler spec and the SiteAssemblerFlow POM to be less flaky.

Key changes:
- change behavior of `selectLayoutComponent` to select based on name, instead of index.
- add network interception to abort all requests for placeholder images.
- add explicit wait for component to be successfully inserted into the preview pane.
- move the counting method into the `SiteAssemblerFlow` POM.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Pre-Release E2E

![image](https://github.com/Automattic/wp-calypso/assets/6549265/7df54eb8-ff4d-45d2-860b-7cc56b980cdf)

Locally tested in a loop of 20 iterations focused solely on selecting the site assembler components passed without issue.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
