### PR TITLE
Domain Management i1: Site specific domains table links to site specific domain management

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -47,7 +47,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			<Main wideLayout>
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
-				<DomainsTable domains={ domains } />
+				<DomainsTable domains={ domains } isAllSitesView />
 			</Main>
 			<UsePresalesChat />
 		</>

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -44,7 +44,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 			<Main wideLayout>
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
-				<DomainsTable domains={ data?.domains } displayPrimaryDomainLabel />
+				<DomainsTable domains={ data?.domains } isAllSitesView={ false } />
 			</Main>
 			<UsePresalesChat />
 		</>

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -14,7 +14,9 @@ const render = ( el ) =>
 	);
 
 test( 'domain name is rendered in the row', () => {
-	render( <DomainsTableRow domain={ testPartialDomain( { domain: 'example1.com' } ) } /> );
+	render(
+		<DomainsTableRow domain={ testPartialDomain( { domain: 'example1.com' } ) } isAllSitesView />
+	);
 
 	expect( screen.queryByText( 'example1.com' ) ).toBeInTheDocument();
 } );
@@ -31,7 +33,13 @@ test( 'wpcom domains do not link to management interface', async () => {
 		domains: [ fullDomain ],
 	} );
 
-	render( <DomainsTableRow domain={ partialDomain } fetchSiteDomains={ fetchSiteDomains } /> );
+	render(
+		<DomainsTableRow
+			domain={ partialDomain }
+			fetchSiteDomains={ fetchSiteDomains }
+			isAllSitesView
+		/>
+	);
 
 	expect( screen.getByText( 'example.wordpress.com' ) ).not.toHaveAttribute( 'href' );
 } );
@@ -47,7 +55,13 @@ test( 'domain name links to management interface', async () => {
 		domains: [ fullDomain ],
 	} );
 
-	render( <DomainsTableRow domain={ partialDomain } fetchSiteDomains={ fetchSiteDomains } /> );
+	render(
+		<DomainsTableRow
+			domain={ partialDomain }
+			fetchSiteDomains={ fetchSiteDomains }
+			isAllSitesView
+		/>
+	);
 
 	// Expect the row to fetch detailed domain data
 	expect( fetchSiteDomains ).toHaveBeenCalledWith( 123 );
@@ -83,7 +97,13 @@ test( 'non primary domain uses the primary domain as the site slug in its link U
 		domains: [ fullDomain, primaryDomain ],
 	} );
 
-	render( <DomainsTableRow domain={ partialDomain } fetchSiteDomains={ fetchSiteDomains } /> );
+	render(
+		<DomainsTableRow
+			domain={ partialDomain }
+			fetchSiteDomains={ fetchSiteDomains }
+			isAllSitesView
+		/>
+	);
 
 	expect( fetchSiteDomains ).toHaveBeenCalledWith( 123 );
 
@@ -116,7 +136,11 @@ test( 'redirect links use the unmapped domain for the site slug', async () => {
 	} );
 
 	render(
-		<DomainsTableRow domain={ partialRedirectDomain } fetchSiteDomains={ fetchSiteDomains } />
+		<DomainsTableRow
+			domain={ partialRedirectDomain }
+			fetchSiteDomains={ fetchSiteDomains }
+			isAllSitesView
+		/>
 	);
 
 	expect( fetchSiteDomains ).toHaveBeenCalledWith( 123 );
@@ -142,7 +166,13 @@ test( 'transfer links use the unmapped domain for the site slug', async () => {
 		domains: [ fullDomain ],
 	} );
 
-	render( <DomainsTableRow domain={ partialDomain } fetchSiteDomains={ fetchSiteDomains } /> );
+	render(
+		<DomainsTableRow
+			domain={ partialDomain }
+			fetchSiteDomains={ fetchSiteDomains }
+			isAllSitesView
+		/>
+	);
 
 	expect( fetchSiteDomains ).toHaveBeenCalledWith( 123 );
 

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -7,11 +7,13 @@ import { renderWithProvider, testDomain, testPartialDomain } from '../../test-ut
 import { DomainsTableRow } from '../domains-table-row';
 
 const render = ( el ) =>
-	renderWithProvider(
-		<table>
-			<tbody>{ el }</tbody>
-		</table>
-	);
+	renderWithProvider( el, {
+		wrapper: ( { children } ) => (
+			<table>
+				<tbody>{ children }</tbody>
+			</table>
+		),
+	} );
 
 test( 'domain name is rendered in the row', () => {
 	render(
@@ -55,7 +57,7 @@ test( 'domain name links to management interface', async () => {
 		domains: [ fullDomain ],
 	} );
 
-	render(
+	const { rerender } = render(
 		<DomainsTableRow
 			domain={ partialDomain }
 			fetchSiteDomains={ fetchSiteDomains }
@@ -79,6 +81,20 @@ test( 'domain name links to management interface', async () => {
 			'/domains/manage/all/example.com/edit/example.com'
 		)
 	);
+
+	// Test site-specific link
+	rerender(
+		<DomainsTableRow
+			domain={ partialDomain }
+			fetchSiteDomains={ fetchSiteDomains }
+			isAllSitesView={ false }
+		/>
+	);
+
+	expect( screen.getByRole( 'link', { name: 'example.com' } ) ).toHaveAttribute(
+		'href',
+		'/domains/manage/example.com/edit/example.com'
+	);
 } );
 
 test( 'non primary domain uses the primary domain as the site slug in its link URL', async () => {
@@ -97,7 +113,7 @@ test( 'non primary domain uses the primary domain as the site slug in its link U
 		domains: [ fullDomain, primaryDomain ],
 	} );
 
-	render(
+	const { rerender } = render(
 		<DomainsTableRow
 			domain={ partialDomain }
 			fetchSiteDomains={ fetchSiteDomains }
@@ -112,6 +128,20 @@ test( 'non primary domain uses the primary domain as the site slug in its link U
 			'href',
 			'/domains/manage/all/not-primary-domain.blog/edit/primary-domain.blog'
 		)
+	);
+
+	// Test site-specific link
+	rerender(
+		<DomainsTableRow
+			domain={ partialDomain }
+			fetchSiteDomains={ fetchSiteDomains }
+			isAllSitesView={ false }
+		/>
+	);
+
+	expect( screen.getByRole( 'link', { name: 'not-primary-domain.blog' } ) ).toHaveAttribute(
+		'href',
+		'/domains/manage/not-primary-domain.blog/edit/primary-domain.blog'
 	);
 } );
 
@@ -135,7 +165,7 @@ test( 'redirect links use the unmapped domain for the site slug', async () => {
 		domains: [ fullRedirectDomain, fullUnmappedDomain ],
 	} );
 
-	render(
+	const { rerender } = render(
 		<DomainsTableRow
 			domain={ partialRedirectDomain }
 			fetchSiteDomains={ fetchSiteDomains }
@@ -150,6 +180,20 @@ test( 'redirect links use the unmapped domain for the site slug', async () => {
 			'href',
 			'/domains/manage/all/redirect.blog/redirect/redirect-site.wordpress.com'
 		)
+	);
+
+	// Test site-specific link
+	rerender(
+		<DomainsTableRow
+			domain={ partialRedirectDomain }
+			fetchSiteDomains={ fetchSiteDomains }
+			isAllSitesView={ false }
+		/>
+	);
+
+	expect( screen.getByRole( 'link', { name: 'redirect.blog' } ) ).toHaveAttribute(
+		'href',
+		'/domains/manage/redirect.blog/redirect/redirect-site.wordpress.com'
 	);
 } );
 
@@ -166,7 +210,7 @@ test( 'transfer links use the unmapped domain for the site slug', async () => {
 		domains: [ fullDomain ],
 	} );
 
-	render(
+	const { rerender } = render(
 		<DomainsTableRow
 			domain={ partialDomain }
 			fetchSiteDomains={ fetchSiteDomains }
@@ -181,5 +225,19 @@ test( 'transfer links use the unmapped domain for the site slug', async () => {
 			'href',
 			'/domains/manage/all/example.com/transfer/in/example.com'
 		)
+	);
+
+	// Test site-specific link
+	rerender(
+		<DomainsTableRow
+			domain={ partialDomain }
+			fetchSiteDomains={ fetchSiteDomains }
+			isAllSitesView={ false }
+		/>
+	);
+
+	expect( screen.getByRole( 'link', { name: 'example.com' } ) ).toHaveAttribute(
+		'href',
+		'/domains/manage/example.com/transfer/in/example.com'
 	);
 } );

--- a/packages/domains-table/src/domains-table/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/index.tsx
@@ -16,6 +16,7 @@ test( 'all domain names are rendered in the table', () => {
 				testPartialDomain( { domain: 'example2.com' } ),
 				testPartialDomain( { domain: 'example3.com' } ),
 			] }
+			isAllSitesView
 		/>
 	);
 
@@ -23,7 +24,7 @@ test( 'all domain names are rendered in the table', () => {
 	expect( screen.queryByText( 'example2.com' ) ).toBeInTheDocument();
 	expect( screen.queryByText( 'example3.com' ) ).toBeInTheDocument();
 
-	rerender( <DomainsTable domains={ [] } /> );
+	rerender( <DomainsTable domains={ [] } isAllSitesView /> );
 
 	expect( screen.queryByText( 'example1.com' ) ).not.toBeInTheDocument();
 	expect( screen.queryByText( 'example2.com' ) ).not.toBeInTheDocument();
@@ -56,6 +57,7 @@ test( 'when two domains share the same underlying site, there is only one fetch 
 	render(
 		<DomainsTable
 			domains={ [ primaryPartial, notPrimaryPartial, differentSitePartial ] }
+			isAllSitesView
 			fetchSiteDomains={ fetchSiteDomains }
 		/>
 	);
@@ -90,7 +92,7 @@ test( 'when shouldDisplayPrimaryDomainLabel is true, the primary domain label is
 		<DomainsTable
 			domains={ [ primaryPartial, notPrimaryPartial ] }
 			fetchSiteDomains={ fetchSiteDomains }
-			displayPrimaryDomainLabel
+			isAllSitesView={ false }
 		/>
 	);
 
@@ -109,7 +111,7 @@ test( 'when shouldDisplayPrimaryDomainLabel is true, the primary domain label is
 		<DomainsTable
 			domains={ [ primaryPartial, notPrimaryPartial ] }
 			fetchSiteDomains={ fetchSiteDomains }
-			displayPrimaryDomainLabel={ false }
+			isAllSitesView={ true }
 		/>
 	);
 

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -48,7 +48,7 @@ export function DomainsTableRow( {
 				{ isManageableDomain ? (
 					<a
 						className="domains-table__domain-link"
-						href={ domainManagementLink( domain, siteSlug ) }
+						href={ domainManagementLink( domain, siteSlug, isAllSitesView ) }
 					>
 						{ domain.domain }
 					</a>
@@ -60,7 +60,11 @@ export function DomainsTableRow( {
 	);
 }
 
-function domainManagementLink( { domain, type }: PartialDomainData, siteSlug: string ) {
+function domainManagementLink(
+	{ domain, type }: PartialDomainData,
+	siteSlug: string,
+	isAllSitesView: boolean
+) {
 	const viewSlug = domainManagementViewSlug( type );
 
 	// Encodes only real domain names and not parameter placeholders
@@ -70,7 +74,11 @@ function domainManagementLink( { domain, type }: PartialDomainData, siteSlug: st
 		domain = encodeURIComponent( encodeURIComponent( domain ) );
 	}
 
-	return `/domains/manage/all/${ domain }/${ viewSlug }/${ siteSlug }`;
+	if ( isAllSitesView ) {
+		return `/domains/manage/all/${ domain }/${ viewSlug }/${ siteSlug }`;
+	}
+
+	return `/domains/manage/${ domain }/${ viewSlug }/${ siteSlug }`;
 }
 
 function domainManagementViewSlug( type: PartialDomainData[ 'type' ] ) {

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -5,7 +5,7 @@ import type { PartialDomainData, SiteDomainsQueryFnData } from '@automattic/data
 
 interface DomainsTableRowProps {
 	domain: PartialDomainData;
-	displayPrimaryDomainLabel?: boolean;
+	isAllSitesView: boolean;
 
 	fetchSiteDomains?: (
 		siteIdOrSlug: number | string | null | undefined
@@ -14,8 +14,8 @@ interface DomainsTableRowProps {
 
 export function DomainsTableRow( {
 	domain,
+	isAllSitesView,
 	fetchSiteDomains,
-	displayPrimaryDomainLabel,
 }: DomainsTableRowProps ) {
 	const { data } = useSiteDomainsQuery(
 		domain.blog_id,
@@ -39,7 +39,7 @@ export function DomainsTableRow( {
 
 	const isPrimaryDomain = primaryDomain?.domain === domain.domain;
 	const isManageableDomain = ! domain.wpcom_domain;
-	const shouldDisplayPrimaryDomainLabel = displayPrimaryDomainLabel && isPrimaryDomain;
+	const shouldDisplayPrimaryDomainLabel = ! isAllSitesView && isPrimaryDomain;
 
 	return (
 		<tr key={ domain.domain }>

--- a/packages/domains-table/src/domains-table/index.stories.tsx
+++ b/packages/domains-table/src/domains-table/index.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/react';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import React from 'react';
+import { testDomain } from '../test-utils';
 import { DomainsTable } from './index';
 
 const queryClient = new QueryClient();
@@ -22,32 +23,37 @@ export default {
 	},
 } as Meta;
 
-const defaultDomains = [
-	{ domain: 'example1.com', blog_id: 1, primary_domain: true },
-	{ domain: 'example2.com', blog_id: 1, primary_domain: false },
-	{ domain: 'example3.com', blog_id: 2, primary_domain: true },
+const testDomains = [
+	testDomain( { domain: 'example1.com', blog_id: 1, primary_domain: true } ),
+	testDomain( {
+		domain: 'example1.wordpress.com',
+		blog_id: 1,
+		primary_domain: false,
+		wpcom_domain: true,
+	} ),
+	testDomain( { domain: 'example3.com', blog_id: 2, primary_domain: true } ),
 ];
 
 const defaultArgs = {
-	domains: defaultDomains,
+	domains: testDomains.map( ( [ partial ] ) => partial ),
+	isAllSitesView: true,
 	fetchSiteDomains: ( siteId ) =>
-		Promise.resolve( { domains: defaultDomains.filter( ( d ) => d.blog_id === siteId ) } ),
+		Promise.resolve( {
+			domains: testDomains.map( ( [ , full ] ) => full ).filter( ( d ) => d.blog_id === siteId ),
+		} ),
 };
 
 const storyDefaults = {
 	args: defaultArgs,
 };
 
-export const TableWithRows = { ...storyDefaults };
+export const AllSitesTable = { ...storyDefaults };
 
-export const TableWithPrimaryDomainLabel = {
+export const SiteSpecificTable = {
 	...storyDefaults,
 	args: {
 		...defaultArgs,
-		domains: [
-			{ domain: 'example1.com', blog_id: 1, primary_domain: true },
-			{ domain: 'example2.com', blog_id: 1, primary_domain: false },
-		],
-		displayPrimaryDomainLabel: true,
+		domains: defaultArgs.domains.filter( ( d ) => d.blog_id === 1 ),
+		isAllSitesView: false,
 	},
 };

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -5,7 +5,7 @@ import './style.scss';
 
 interface DomainsTableProps {
 	domains: PartialDomainData[] | undefined;
-	displayPrimaryDomainLabel?: boolean;
+	isAllSitesView: boolean;
 
 	// Detailed domain data is fetched on demand. The ability to customise fetching
 	// is provided to allow for testing.
@@ -14,11 +14,7 @@ interface DomainsTableProps {
 	) => Promise< SiteDomainsQueryFnData >;
 }
 
-export function DomainsTable( {
-	domains,
-	fetchSiteDomains,
-	displayPrimaryDomainLabel,
-}: DomainsTableProps ) {
+export function DomainsTable( { domains, fetchSiteDomains, isAllSitesView }: DomainsTableProps ) {
 	const { __ } = useI18n();
 
 	if ( ! domains ) {
@@ -38,7 +34,7 @@ export function DomainsTable( {
 						key={ domain.domain }
 						domain={ domain }
 						fetchSiteDomains={ fetchSiteDomains }
-						displayPrimaryDomainLabel={ displayPrimaryDomainLabel }
+						isAllSitesView={ isAllSitesView }
 					/>
 				) ) }
 			</tbody>

--- a/packages/domains-table/src/test-utils.tsx
+++ b/packages/domains-table/src/test-utils.tsx
@@ -9,11 +9,14 @@ export function renderWithProvider(
 ): RenderResult {
 	const queryClient = new QueryClient();
 
-	const Wrapper = ( { children }: { children: React.ReactElement } ) => (
-		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
-	);
+	const Wrapper = ( { children }: { children: React.ReactElement } ) => {
+		if ( renderOptions.wrapper ) {
+			children = <renderOptions.wrapper>{ children }</renderOptions.wrapper>;
+		}
+		return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+	};
 
-	return rtlRender( ui, { wrapper: Wrapper, ...renderOptions } );
+	return rtlRender( ui, { ...renderOptions, wrapper: Wrapper } );
 }
 
 export function testDomain(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3451

## Proposed Changes

* Renamed the `displayPrimaryDomainLabel` prop and repurposed it to the `isAllSitesView`
* Fixes the domain management breadcrumb links so they're aware of whether they're in the all-sites or site-specific context



https://github.com/Automattic/wp-calypso/assets/1500769/18884810-cff8-4a8c-81d0-23854d168d1e





Let me know what you think about the way I've renamed your prop @zaguiini. It would be more generic to have a flag for each behaviour, so we could keep the `displayPrimaryDomainLabel` prop and then add another `linkToAllSitesView` prop. Maybe that'd be better than some uber "mode A" or "mode B" flag that controls a whole lot of different behaviours.

On the other hand there seems to be two modes the domains interface operates in, and it seems pretty baked in to the way the existing domains interface works too. Maybe it's more straightforward to represent those two modes with a prop. I also like the idea of how well it fits with storybook: one story for the all domain view, one story for the site-specific view.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test site-specific breadcrumb
   * `/domains/manage/{{ SITE }}?flags=domains/management`
   * Click a domain
   * Use breadcrumb to go back to table
   * You should stay within the site-specific context
* Test all-sites breadcrumb
   * `/domains/manage?flags=domains/management`
   * Click a domain
   * Use breadcrumb to go back to table
   * You should stay within the all-sites context
   * You'll notice that when you drill into a domain the Calypso sidebar switches to the site-specific sidebar. This is existing behaviour.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
