### PR TITLE
Substack import: make description dynamic based on state

### DIFF
--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { TranslateResult, translate } from 'i18n-calypso';
 import { filter, orderBy, values } from 'lodash';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { appStates } from 'calypso/state/imports/constants';
 
 export interface ImporterOptionalURL {
 	title: TranslateResult;
@@ -27,6 +28,7 @@ interface ImporterConfigMap {
 }
 
 interface ImporterConfigArgs {
+	importerState?: string;
 	isAtomic?: boolean;
 	isJetpack?: boolean;
 	siteSlug?: string;
@@ -34,12 +36,15 @@ interface ImporterConfigArgs {
 }
 
 function getConfig( {
+	importerState = '',
 	isAtomic = false,
 	isJetpack = false,
 	siteSlug = '',
 	siteTitle = '',
 } ): ImporterConfigMap {
 	let importerConfig: ImporterConfigMap = {};
+
+	const isFinished = importerState === appStates.IMPORT_SUCCESS;
 
 	importerConfig.wordpress = {
 		engine: 'wordpress',
@@ -182,13 +187,15 @@ function getConfig( {
 						}
 					) }
 				</p>
-				<p>
-					{ translate( 'To import your subscribers, go to {{a}}subscribers page{{/a}}.', {
-						components: {
-							a: <a href={ `/subscribers/${ siteSlug }#add-subscribers` } />,
-						},
-					} ) }
-				</p>
+				{ ! isFinished && (
+					<p>
+						{ translate( 'To import your subscribers, go to {{a}}subscribers page{{/a}}.', {
+							components: {
+								a: <a href={ `/subscribers/${ siteSlug }#add-subscribers` } />,
+							},
+						} ) }
+					</p>
+				) }
 			</>
 		),
 		uploadDescription: (

--- a/client/my-sites/importer/importer-substack.jsx
+++ b/client/my-sites/importer/importer-substack.jsx
@@ -25,6 +25,7 @@ class ImporterSubstack extends PureComponent {
 
 	render() {
 		const importerData = importerConfig( {
+			importerState: this.props.importerStatus.importerState,
 			siteSlug: this.props.siteSlug,
 			siteTitle: this.props.siteTitle,
 		} ).substack;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Addresses feedback in pdtkmj-1IE-p2/#comment-3192

Part of https://github.com/Automattic/wp-calypso/issues/80364

## Proposed Changes

Make Substack importer description dynamic. Won't show link to subscription importer once importing has finished, to avoid nudging twice in the same screen.

We could remove the link altogether, but we felt like having the link here _before_ they start importing is helpful.

<img width="758" alt="Screenshot 2023-08-18 at 12 26 18" src="https://github.com/Automattic/wp-calypso/assets/87168/2b89a30c-ceb9-45b9-87ee-e58e67e7cd89">

<img width="776" alt="Screenshot 2023-08-18 at 12 25 27" src="https://github.com/Automattic/wp-calypso/assets/87168/e76b4c39-9638-4c56-ab28-e6cac627982e">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through Substack importer
* Observe description become shorter at last step when import completes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
