### PR TITLE
[Only Chrome >= 117] Assembler - Fix orphans in step and category descriptions with text-wrap: pretty

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
@@ -41,5 +41,5 @@
 	font-weight: 400;
 	color: var(--studio-gray-60);
 	letter-spacing: -0.15px;
-	text-wrap: balance;
+	text-wrap: pretty;
 }

--- a/packages/onboarding/src/navigator/navigator-header/style.scss
+++ b/packages/onboarding/src/navigator/navigator-header/style.scss
@@ -14,7 +14,7 @@
 .navigator-header__heading {
 	margin-bottom: 8px;
 	color: var(--color-neutral-100);
-	text-wrap: balance;
+	text-wrap: pretty;
 
 	h2 {
 		font-family: Recoleta, sans-serif;
@@ -41,5 +41,5 @@
 	letter-spacing: -0.15px;
 	color: var(--color-neutral-60);
 	margin: 0;
-	text-wrap: balance;
+	text-wrap: pretty;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80311 #80727

## Proposed Changes

* Use `text-wrap: pretty` rather than balance

We have on production `text-wrap: balance` and while it's solving the orphans it's [not looking good](https://github.com/Automattic/wp-calypso/pull/80311#issuecomment-1682628031). 

**Important note:** `pretty` is still not supported in the current version of Chrome (v116), but will be supported soon in the next version (v117) on September 6. 

See Matias's comment about Gutenberg adopting it soon without waiting for wide support. p1692194241019269/1692190691.450239-slack-C9EJ7KSGH

See [Chrome roadmap](https://chromestatus.com/roadmap).

<img width="1386" alt="Screenshot 2566-08-18 at 16 21 55" src="https://github.com/Automattic/wp-calypso/assets/1881481/08de723d-af8e-4267-ade3-c0b498b43890">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Download [Chrome Beta ](https://www.google.com/chrome/beta/)
* Visit the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }`
* Click `Header` and `Sections > Newsletter` to verify the category descriptions don't have an orphan (a single word in the last line)

|Before: text-wrap: balance|No text-wrap|After: text-wrap: pretty|
|--|--|--|
|<img width="338" alt="Screenshot 2566-08-18 at 16 30 34" src="https://github.com/Automattic/wp-calypso/assets/1881481/7f1cef4e-5ef8-445d-9ec5-b1836dc95a20">|<img width="335" alt="Screenshot 2566-08-18 at 16 18 36" src="https://github.com/Automattic/wp-calypso/assets/1881481/764d4335-b33f-4f3d-8d6d-b1990b6d4fe8">|<img width="340" alt="Screenshot 2566-08-18 at 16 18 45" src="https://github.com/Automattic/wp-calypso/assets/1881481/0a9af3c5-da29-432b-b310-21166bdb304b">|

|Before: text-wrap: balance|No text-wrap|After: text-wrap: pretty|
|--|--|--|
|<img width="340" alt="Screenshot 2566-08-18 at 16 30 07" src="https://github.com/Automattic/wp-calypso/assets/1881481/4d1c1725-7347-4e88-b865-ec052996fc38">|<img width="341" alt="Screenshot 2566-08-18 at 16 19 36" src="https://github.com/Automattic/wp-calypso/assets/1881481/49ec4e80-5bf8-4a79-9eee-63f9de4fb94e">|<img width="339" alt="Screenshot 2566-08-18 at 16 19 51" src="https://github.com/Automattic/wp-calypso/assets/1881481/c9830dc0-c85d-4a58-9228-755bf19b1b7a">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
