### PR TITLE
Domain Management i1: Only load detailed domain data when that row is in view

### DIFF
--- a/packages/domains-table/__mocks__/react-intersection-observer.ts
+++ b/packages/domains-table/__mocks__/react-intersection-observer.ts
@@ -1,0 +1,9 @@
+import { createRef } from 'react';
+
+// jsdom doesn't mock the IntersectionObserver API used by react-intersection-observer
+export function useInView() {
+	return {
+		ref: createRef(),
+		inView: true,
+	};
+}

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,5 +1,6 @@
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { useMemo } from 'react';
+import { useInView } from 'react-intersection-observer';
 import { PrimaryDomainLabel } from '../primary-domain-label';
 import type { PartialDomainData, SiteDomainsQueryFnData } from '@automattic/data-stores';
 
@@ -17,12 +18,12 @@ export function DomainsTableRow( {
 	fetchSiteDomains,
 	displayPrimaryDomainLabel,
 }: DomainsTableRowProps ) {
-	const { data } = useSiteDomainsQuery(
-		domain.blog_id,
-		fetchSiteDomains && {
-			queryFn: () => fetchSiteDomains( domain.blog_id ),
-		}
-	);
+	const { ref, inView } = useInView( { triggerOnce: true } );
+
+	const { data } = useSiteDomainsQuery( domain.blog_id, {
+		enabled: inView,
+		...( fetchSiteDomains && { queryFn: () => fetchSiteDomains( domain.blog_id ) } ),
+	} );
 
 	const { siteSlug, primaryDomain } = useMemo( () => {
 		const primaryDomain = data?.domains?.find( ( d ) => d.primary_domain );
@@ -42,7 +43,7 @@ export function DomainsTableRow( {
 	const shouldDisplayPrimaryDomainLabel = displayPrimaryDomainLabel && isPrimaryDomain;
 
 	return (
-		<tr key={ domain.domain }>
+		<tr key={ domain.domain } ref={ ref }>
 			<td>
 				{ shouldDisplayPrimaryDomainLabel && <PrimaryDomainLabel /> }
 				{ isManageableDomain ? (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3422

## Proposed Changes

It could be a very long domain table. So after loading the skeleton domain info using `/all-domains` we should only fetch the detailed info once that domain has scrolled into view.

Similar technique to the `/sites` table.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the network tools
* Make the browser viewport short so you can't see all the domains in one screen
* `/domains/manage?flags=domains/management`
* As you scroll down the table notice all the requests for detailed site domain info
* As you scroll up notice it doesn't refetch that data again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
