### PR TITLE
Add "Restore default CNAME record" option

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
@@ -17,6 +17,7 @@ import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import { applyDnsTemplate, updateDns } from 'calypso/state/domains/dns/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import RestoreDefaultARecordsDialog from './restore-default-a-records-dialog';
+import RestoreDefaultCnameRecordDialog from './restore-default-cname-record-dialog';
 import RestoreEmailDnsDialog from './restore-email-dns-dialog';
 import type {
 	DnsMenuOptionsButtonProps,
@@ -62,6 +63,7 @@ const emailProviderKeys: EmailProviderKey[] = [ EmailProvider.TITAN, EmailProvid
 function DnsMenuOptionsButton( {
 	domain,
 	pointsToWpcom,
+	hasDefaultCnameRecord,
 	dns,
 	dispatchApplyDnsTemplate,
 	dispatchUpdateDns,
@@ -79,7 +81,9 @@ function DnsMenuOptionsButton( {
 			} )
 		)
 	);
-	const [ isRestoreDialogVisible, setRestoreDialogVisible ] = useState( false );
+	const [ isRestoreARecordsDialogVisible, setRestoreARecordsDialogVisible ] = useState( false );
+	const [ isRestoreCnameRecordDialogVisible, setRestoreCnameRecordDialogVisible ] =
+		useState( false );
 	const optionsButtonRef = useRef( null );
 
 	const toggleMenu = useCallback( () => {
@@ -88,7 +92,7 @@ function DnsMenuOptionsButton( {
 
 	const closeMenu = useCallback( () => setMenuVisible( false ), [] );
 
-	const getRecordsToRemove = useCallback( () => {
+	const getARecordsToRemove = useCallback( () => {
 		const dnsRecords = dns.records ?? [];
 
 		return dnsRecords.filter(
@@ -98,7 +102,28 @@ function DnsMenuOptionsButton( {
 		);
 	}, [ dns ] );
 
+	const getCnameRecordToRemove = useCallback( () => {
+		const dnsRecords = dns.records ?? [];
+
+		return dnsRecords.filter(
+			( record ) =>
+				record.domain !== record.data?.replace( /\.$/, '' ) &&
+				'CNAME' === record.type &&
+				'*' === record.name
+		);
+	}, [ dns ] );
+
 	const domainName = domain?.domain ?? domain?.name;
+
+	const getDefaultCnameRecord = useCallback( () => {
+		return [
+			{
+				type: 'CNAME',
+				data: `${ domainName }.`,
+				name: '*',
+			},
+		];
+	}, [ domainName ] );
 
 	const restoreEmailDnsRecords = useCallback(
 		async ( {
@@ -122,8 +147,8 @@ function DnsMenuOptionsButton( {
 		[ dispatchApplyDnsTemplate, dispatchErrorNotice, dispatchSuccessNotice, domainName ]
 	);
 
-	const restoreDefaultRecords = useCallback( async () => {
-		dispatchUpdateDns( domainName, [], getRecordsToRemove() )
+	const restoreDefaultARecords = useCallback( async () => {
+		dispatchUpdateDns( domainName, [], getARecordsToRemove() )
 			.then( () => dispatchSuccessNotice( __( 'Default A records restored' ) ) )
 			.catch( () => dispatchErrorNotice( __( 'Failed to restore the default A records' ) ) );
 	}, [
@@ -132,17 +157,45 @@ function DnsMenuOptionsButton( {
 		dispatchSuccessNotice,
 		dispatchUpdateDns,
 		domainName,
-		getRecordsToRemove,
+		getARecordsToRemove,
 	] );
 
-	const closeRestoreDialog = ( result: RestoreDialogResult ) => {
-		setRestoreDialogVisible( false );
+	const restoreDefaultCnameRecord = useCallback( async () => {
+		dispatchUpdateDns( domainName, getDefaultCnameRecord(), getCnameRecordToRemove() )
+			.then( () => dispatchSuccessNotice( __( 'Default CNAME record restored' ) ) )
+			.catch( () => dispatchErrorNotice( __( 'Failed to restore the default CNAME record' ) ) );
+	}, [
+		__,
+		dispatchErrorNotice,
+		dispatchSuccessNotice,
+		dispatchUpdateDns,
+		domainName,
+		getDefaultCnameRecord,
+		getCnameRecordToRemove,
+	] );
+
+	const closeRestoreARecordsDialog = ( result: RestoreDialogResult ) => {
+		setRestoreARecordsDialogVisible( false );
 		if ( result?.shouldRestoreDefaultRecords ?? false ) {
-			restoreDefaultRecords();
+			restoreDefaultARecords();
 		}
 	};
 
-	const showRestoreDialog = useCallback( () => setRestoreDialogVisible( true ), [] );
+	const closeRestoreCnameRecordDialog = ( result: RestoreDialogResult ) => {
+		setRestoreCnameRecordDialogVisible( false );
+		if ( result?.shouldRestoreDefaultRecords ?? false ) {
+			restoreDefaultCnameRecord();
+		}
+	};
+
+	const showRestoreARecordsDialog = useCallback(
+		() => setRestoreARecordsDialogVisible( true ),
+		[]
+	);
+	const showRestoreCnameRecordDialog = useCallback(
+		() => setRestoreCnameRecordDialogVisible( true ),
+		[]
+	);
 
 	const closeEmailRestoreDialog = ( {
 		providerKey,
@@ -208,9 +261,14 @@ function DnsMenuOptionsButton( {
 	return (
 		<>
 			<RestoreDefaultARecordsDialog
-				visible={ isRestoreDialogVisible }
-				onClose={ closeRestoreDialog }
+				visible={ isRestoreARecordsDialogVisible }
+				onClose={ closeRestoreARecordsDialog }
 				defaultRecords={ null }
+			/>
+
+			<RestoreDefaultCnameRecordDialog
+				visible={ isRestoreCnameRecordDialogVisible }
+				onClose={ closeRestoreCnameRecordDialog }
 			/>
 
 			{ emailDnsDialogs }
@@ -231,9 +289,20 @@ function DnsMenuOptionsButton( {
 				context={ optionsButtonRef.current }
 				position="bottom"
 			>
-				<PopoverMenuItem onClick={ showRestoreDialog } disabled={ pointsToWpcom || ! domain }>
+				<PopoverMenuItem
+					onClick={ showRestoreARecordsDialog }
+					disabled={ pointsToWpcom || ! domain }
+				>
 					<Icon icon={ redo } size={ 14 } className="gridicon" viewBox="2 2 20 20" />
 					{ __( 'Restore default A records' ) }
+				</PopoverMenuItem>
+
+				<PopoverMenuItem
+					onClick={ showRestoreCnameRecordDialog }
+					disabled={ hasDefaultCnameRecord || ! domain }
+				>
+					<Icon icon={ redo } size={ 14 } className="gridicon" viewBox="2 2 20 20" />
+					{ __( 'Restore default CNAME record' ) }
 				</PopoverMenuItem>
 
 				{ emailRestoreItems }

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -41,6 +41,16 @@ class DnsRecords extends Component {
 		nameservers: PropTypes.array || null,
 	};
 
+	hasDefaultCnameRecord = () => {
+		const { dns, selectedDomainName } = this.props;
+		return dns?.records?.some(
+			( record ) =>
+				record?.type === 'CNAME' &&
+				record?.name === '*' &&
+				record?.data === `${ selectedDomainName }.`
+		);
+	};
+
 	renderHeader = () => {
 		const { domains, translate, selectedSite, currentRoute, selectedDomainName, dns } = this.props;
 		const selectedDomain = domains?.find( ( domain ) => domain?.name === selectedDomainName );
@@ -77,6 +87,7 @@ class DnsRecords extends Component {
 				domain={ selectedDomain }
 				dns={ dns }
 				pointsToWpcom={ pointsToWpcom }
+				hasDefaultCnameRecord={ this.hasDefaultCnameRecord() }
 			/>
 		);
 

--- a/client/my-sites/domains/domain-management/dns/restore-default-cname-record-dialog.jsx
+++ b/client/my-sites/domains/domain-management/dns/restore-default-cname-record-dialog.jsx
@@ -27,10 +27,10 @@ function RestoreDefaultCnameRecordDialog( { onClose, visible } ) {
 
 	return (
 		<Dialog isVisible={ visible } buttons={ buttons } onClose={ onCancel }>
-			<h1>{ __( 'Restore default C record' ) }</h1>
+			<h1>{ __( 'Restore default CNAME record' ) }</h1>
 			<p>
 				{ __(
-					'Restoring the record will create a wildcard CNAME record pointing to your WordPress.com site. In case a wildcard CNAME record already exists, it will be deleted.'
+					'Restoring the record will create a wildcard CNAME record pointing to your WordPress.com site.'
 				) }
 			</p>
 			<p className="restore-default-cname-record-dialog__message">

--- a/client/my-sites/domains/domain-management/dns/restore-default-cname-record-dialog.jsx
+++ b/client/my-sites/domains/domain-management/dns/restore-default-cname-record-dialog.jsx
@@ -1,0 +1,43 @@
+import { Dialog } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+
+function RestoreDefaultCnameRecordDialog( { onClose, visible } ) {
+	const { __ } = useI18n();
+
+	const onRestore = () => {
+		onClose( { shouldRestoreDefaultRecords: true } );
+	};
+
+	const onCancel = () => {
+		onClose( { shouldRestoreDefaultRecords: false } );
+	};
+
+	const buttons = [
+		{
+			action: 'cancel',
+			label: __( 'Cancel' ),
+		},
+		{
+			action: 'restore',
+			label: __( 'Restore' ),
+			isPrimary: true,
+			onClick: onRestore,
+		},
+	];
+
+	return (
+		<Dialog isVisible={ visible } buttons={ buttons } onClose={ onCancel }>
+			<h1>{ __( 'Restore default C record' ) }</h1>
+			<p>
+				{ __(
+					'Restoring the record will create a wildcard CNAME record pointing to your WordPress.com site. In case a wildcard CNAME record already exists, it will be deleted.'
+				) }
+			</p>
+			<p className="restore-default-cname-record-dialog__message">
+				{ __( 'In case a wildcard CNAME record already exists, it will be deleted.' ) }
+			</p>
+		</Dialog>
+	);
+}
+
+export default RestoreDefaultCnameRecordDialog;

--- a/client/my-sites/domains/domain-management/dns/types.ts
+++ b/client/my-sites/domains/domain-management/dns/types.ts
@@ -31,6 +31,7 @@ type UnpackPromisedValue< T > = T extends ( ...args: unknown[] ) => infer R
 export type DnsMenuOptionsButtonProps = {
 	domain: ResponseDomain | undefined;
 	pointsToWpcom: boolean;
+	hasDefaultCnameRecord: boolean;
 	dns: Dns;
 	dispatchApplyDnsTemplate: UnpackPromisedValue< typeof applyDnsTemplate >;
 	dispatchUpdateDns: UnpackPromisedValue< typeof updateDns >;


### PR DESCRIPTION
## Proposed Changes

In this PR (https://github.com/Automattic/wp-calypso/pull/80253) we allowed users to remove/edit default CNAME record.

This PR add an option to restore the default wildcard cname record, if removed/edited.

## Testing Instructions

- Apply this patch locally or open the direct link below. 
- Visit the settings page of a custom domain you own (that has default wildcard CNAME)
- Click on three dots on the header bar and check that the option `Restore default CNAME record` is disabled
- Remove or edit the wildcard record
- Click on three dots on the header bar and check that the option `Restore default CNAME record` is now enabled
- Select the option and verify that the default record has been restored 

![restore-disabled](https://github.com/Automattic/wp-calypso/assets/2797601/0dc3428c-1d6a-4c68-94cf-144806c3e788)

![restore-enabled](https://github.com/Automattic/wp-calypso/assets/2797601/30654ee8-a619-4023-8ed9-473629b2059e)

![resotre-message](https://github.com/Automattic/wp-calypso/assets/2797601/2b4ae51d-3397-4472-9571-f3ac3d3ad076)

<img width="362" alt="restore-done" src="https://github.com/Automattic/wp-calypso/assets/2797601/804fcaf4-c114-46a4-beb5-dd8d3fc752fd">

## Pre-merge Checklist
- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
