### PR TITLE
Revert "Substack importer: release"

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -44,7 +44,6 @@
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/unified": true,
-		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/api-cache": true,

--- a/config/production.json
+++ b/config/production.json
@@ -51,7 +51,6 @@
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/unified": true,
-		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"is_running_in_jetpack_site": false,
 		"jetpack/agency-dashboard": true,


### PR DESCRIPTION
A prepared revert of Substack importer (Automattic/wp-calypso#80365) in case there are issues.

