### PR TITLE
Domains/manage: Update add domain options

### DIFF
--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -67,18 +67,15 @@ class AddDomainButton extends Component {
 		if ( allDomainsList ) {
 			return (
 				<Fragment>
-					<PopoverMenuItem icon="plus" href="/new" onClick={ this.trackMenuClick }>
-						{ translate( 'Add a domain to a new site' ) }
-					</PopoverMenuItem>
 					<PopoverMenuItem icon="domains" href="/start/domain" onClick={ this.trackMenuClick }>
-						{ translate( 'Add a domain without a site' ) }
+						{ translate( 'Register a new domain' ) }
 					</PopoverMenuItem>
 					<PopoverMenuItem
 						icon="domains"
 						href="/setup/domain-transfer"
 						onClick={ this.trackMenuClick }
 					>
-						{ translate( 'Transfer domains' ) }
+						{ translate( 'Transfer one or more domains' ) }
 					</PopoverMenuItem>
 				</Fragment>
 			);

--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -75,7 +75,7 @@ class AddDomainButton extends Component {
 						href="/setup/domain-transfer"
 						onClick={ this.trackMenuClick }
 					>
-						{ translate( 'Transfer one or more domains' ) }
+						{ translate( 'Transfer domains' ) }
 					</PopoverMenuItem>
 				</Fragment>
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3505

## Proposed Changes

* Consolidate the two "add a domain" options into one.

Before | After
------ | ------
<img width="468" alt="Screen Shot 2023-08-18 at 10 36 29 AM" src="https://github.com/Automattic/wp-calypso/assets/1689238/ac64ba14-36d0-4bb5-8cff-9c92c0aa5517"> | <img width="436" alt="Screen Shot 2023-08-18 at 3 40 49 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/f8ad29d5-bded-4419-b9ff-25b714e2de23">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /domains/manage
* Click "Add a domain"
* Test the two different flows available.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
