### PR TITLE
Limited GS: Fix modal in view canvas

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/use-canvas.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/use-canvas.js
@@ -15,16 +15,12 @@ export function useCanvas() {
 		}
 
 		const unsubscribe = subscribe( () => {
-			// Subscriber callbacks run before the URL actually changes, so we need
-			// to delay the execution.
-			setTimeout( () => {
-				const params = new URLSearchParams( window.location.search );
+			const params = new URLSearchParams( window.location.search );
 
-				const _canvas = params.get( 'canvas' ) ?? 'view';
-				setCanvas( _canvas );
-				setViewCanvasPath( _canvas === 'view' ? params.get( 'path' ) : undefined );
-			}, 0 );
-		}, 'core/edit-site' );
+			const _canvas = params.get( 'canvas' ) ?? 'view';
+			setCanvas( _canvas );
+			setViewCanvasPath( _canvas === 'view' ? params.get( 'path' ) : undefined );
+		} );
 
 		return () => unsubscribe();
 	}, [ isSiteEditor ] );


### PR DESCRIPTION
## Proposed Changes

Fixes a bug that was preventing the Limited Global Styles from being visible when first loading the Styles section of the site editor when on the view canvas mode.

<img width="1274" alt="Screenshot 2023-08-18 at 16 48 46" src="https://github.com/Automattic/wp-calypso/assets/1233880/dea2c240-963b-4b6e-8825-f8da56293734">

Apparently this regressed on a recent Gutenberg upgrade which caused the `core/edit-site` store to no longer trigger a state update when the path of the view canvas changes, effectively breaking our `subscribe` logic that determines the view canvas path.

This PR fixes that by listening to state changes in all stores rather than in `core/edit-site` only.

We have a E2E test that should have caught this, but looks like it was muted because it was considered flakey (see https://github.com/Automattic/wp-calypso/pull/80612) and this regression has been unnoticed. With this PR (and https://github.com/Automattic/wp-calypso/pull/80612) I hope we can enable again the Limited GS E2E test.

## Testing Instructions

- Apply these ETK changes to your sandbox.
- Create a new site.
- Sandbox it.
- Go to the site editor.
- Select the "Styles" section in the left sidebar.
- Make sure the Limited GS modal shows up.