### PR TITLE
Stats: Fix selected product title and styling for the purchase page

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -105,6 +105,7 @@ const ProductCard = ( {
 		}
 
 		setWizardStep( SCREEN_TYPE_SELECTION );
+		setSiteType( null );
 	};
 
 	// change the plan to commercial on the personal plan confirmation

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -68,7 +68,17 @@ const ProductCard = ( {
 
 	const personalLabel = translate( 'Personal site' );
 	const commercialLabel = translate( 'Commercial site' );
-	const selectedTypeLabel = siteType === TYPE_PERSONAL ? personalLabel : commercialLabel;
+	const personalProductTitle = translate( 'What is Jetpack Stats worth to you?' );
+	const commercialProductTitle = translate( 'Upgrade your Jetpack Stats' );
+
+	let selectedSiteTypeLabel = commercialLabel;
+	let selectedSiteTypeTitle = commercialProductTitle;
+
+	if ( siteType === TYPE_PERSONAL ) {
+		selectedSiteTypeLabel = personalLabel;
+		selectedSiteTypeTitle = personalProductTitle;
+	}
+
 	const showCelebration =
 		siteType &&
 		wizardStep === SCREEN_PURCHASE &&
@@ -115,7 +125,7 @@ const ProductCard = ( {
 								site: siteSlug,
 							},
 					  } )
-					: selectedTypeLabel
+					: selectedSiteTypeLabel
 			}
 			active={ wizardStep === SCREEN_TYPE_SELECTION }
 		/>
@@ -124,7 +134,7 @@ const ProductCard = ( {
 	const secondStepTitleNode = (
 		<TitleNode
 			indicatorNumber="2"
-			label={ translate( 'What is Jetpack Stats worth to you?' ) }
+			label={ selectedSiteTypeTitle }
 			active={ wizardStep === SCREEN_PURCHASE }
 		/>
 	);

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -71,12 +71,22 @@ const ProductCard = ( {
 	const personalProductTitle = translate( 'What is Jetpack Stats worth to you?' );
 	const commercialProductTitle = translate( 'Upgrade your Jetpack Stats' );
 
-	let selectedSiteTypeLabel = commercialLabel;
-	let selectedSiteTypeTitle = commercialProductTitle;
+	// Default titles for no site type selected.
+	let selectedSiteTypeLabel = translate( 'What site type is %(site)s?', {
+		args: {
+			site: siteSlug,
+		},
+	} );
+	let selectedSiteTypeTitle = personalProductTitle;
 
 	if ( siteType === TYPE_PERSONAL ) {
 		selectedSiteTypeLabel = personalLabel;
 		selectedSiteTypeTitle = personalProductTitle;
+	}
+
+	if ( siteType === TYPE_COMMERCIAL ) {
+		selectedSiteTypeLabel = commercialLabel;
+		selectedSiteTypeTitle = commercialProductTitle;
 	}
 
 	const showCelebration =
@@ -119,15 +129,7 @@ const ProductCard = ( {
 	const firstStepTitleNode = (
 		<TitleNode
 			indicatorNumber="1"
-			label={
-				! siteType
-					? translate( 'What site type is %(site)s?', {
-							args: {
-								site: siteSlug,
-							},
-					  } )
-					: selectedSiteTypeLabel
-			}
+			label={ selectedSiteTypeLabel }
 			active={ wizardStep === SCREEN_TYPE_SELECTION }
 		/>
 	);
@@ -179,12 +181,12 @@ const ProductCard = ( {
 										</div>
 										<div className={ `${ COMPONENT_CLASS_NAME }__card-grid-action--left` }>
 											<Button variant="primary" onClick={ setPersonalSite }>
-												{ translate( 'Personal site' ) }
+												{ personalLabel }
 											</Button>
 										</div>
 										<div className={ `${ COMPONENT_CLASS_NAME }__card-grid-action--right` }>
 											<Button variant="primary" onClick={ setCommercialSite }>
-												{ translate( 'Commercial site' ) }
+												{ commercialLabel }
 											</Button>
 										</div>
 									</div>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -72,21 +72,21 @@ const ProductCard = ( {
 	const commercialProductTitle = translate( 'Upgrade your Jetpack Stats' );
 
 	// Default titles for no site type selected.
-	let selectedSiteTypeLabel = translate( 'What site type is %(site)s?', {
+	let typeSelectionScreenLabel = translate( 'What site type is %(site)s?', {
 		args: {
 			site: siteSlug,
 		},
 	} );
-	let selectedSiteTypeTitle = personalProductTitle;
+	let purchaseScreenLabel = personalProductTitle;
 
 	if ( siteType === TYPE_PERSONAL ) {
-		selectedSiteTypeLabel = personalLabel;
-		selectedSiteTypeTitle = personalProductTitle;
+		typeSelectionScreenLabel = personalLabel;
+		purchaseScreenLabel = personalProductTitle;
 	}
 
 	if ( siteType === TYPE_COMMERCIAL ) {
-		selectedSiteTypeLabel = commercialLabel;
-		selectedSiteTypeTitle = commercialProductTitle;
+		typeSelectionScreenLabel = commercialLabel;
+		purchaseScreenLabel = commercialProductTitle;
 	}
 
 	const showCelebration =
@@ -129,7 +129,7 @@ const ProductCard = ( {
 	const firstStepTitleNode = (
 		<TitleNode
 			indicatorNumber="1"
-			label={ selectedSiteTypeLabel }
+			label={ typeSelectionScreenLabel }
 			active={ wizardStep === SCREEN_TYPE_SELECTION }
 		/>
 	);
@@ -137,7 +137,7 @@ const ProductCard = ( {
 	const secondStepTitleNode = (
 		<TitleNode
 			indicatorNumber="2"
-			label={ selectedSiteTypeTitle }
+			label={ purchaseScreenLabel }
 			active={ wizardStep === SCREEN_PURCHASE }
 		/>
 	);

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -203,8 +203,7 @@
 		min-width: 24px;
 		height: 24px;
 		margin-right: 8px;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		font-size: 14px;
+		font-size: $font-body-small;
 		border: 1.5px solid var(--jp-black);
 		border-radius: 50%;
 
@@ -224,6 +223,11 @@
 		&.stats-purchase-wizard__card-panel--type-selected {
 			h2 > button {
 				cursor: pointer;
+			}
+
+			.stats-purchase-wizard__card-title-indicator {
+				color: var(--jp-white);
+				background: var(--jp-black);
 			}
 		}
 	}

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -262,8 +262,16 @@
 	}
 
 	// override panel
-	.components-panel__body > .components-panel__body-title:hover {
-		background-color: transparent;
+	.components-panel__body {
+		& > .components-panel__body-title:hover {
+			background-color: transparent;
+		}
+
+		&.is-opened {
+			& > .components-panel__body-title {
+				margin-bottom: 8px;
+			}
+		}
 	}
 
 	.components-panel__body-toggle.components-button {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80793 

## Proposed Changes

* Adjust the title of the selected `Stats Commercial` product.
* Restore the selected site type to `null` when going back to purchase `Step 1`.
* Adjust the indicator background color of `Step 1` and the title gap in line with the design.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the change with the Live Calypso link.
* Navigate to the Stats purchase page: `/stats/purchase/{site-slug}`.
* Click on the `Commercial site` button.
* Ensure the title displays with the correct copy: `Upgrade your Jetpack Stats`.
* Ensure the icon of `Step 1` displays in line with the design.

|Before|After|
|-|-|
|<img width="615" alt="before_1" src="https://github.com/Automattic/wp-calypso/assets/6869813/a0207db1-e287-4a68-98a8-30ff122ccf23">|<img width="617" alt="after_1" src="https://github.com/Automattic/wp-calypso/assets/6869813/a9e97870-4e1c-467f-8342-a03913729b0f">|

* Click on the button of `Step 1`.
* Ensure the `Step 1` title is reset to the copy: `What site type is {site-slug}?`.

|Before|After|
|-|-|
|<img width="630" alt="before" src="https://github.com/Automattic/wp-calypso/assets/6869813/215d8396-3d92-4ddd-baec-5b9da8ac8d50">|<img width="621" alt="after" src="https://github.com/Automattic/wp-calypso/assets/6869813/d6c586c4-c0e6-4b05-8d13-258465648e07">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
