### PR TITLE
Substack importer: add Atomic sites exception

### DIFF
--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -308,10 +308,12 @@ function getConfig( {
 	return importerConfig;
 }
 
-export function getImporters( args: ImporterConfigArgs = { siteSlug: '', siteTitle: '' } ) {
+export function getImporters(
+	args: ImporterConfigArgs = { isAtomic: false, siteSlug: '', siteTitle: '' }
+) {
 	const importerConfig = getConfig( args );
 
-	if ( ! config.isEnabled( 'importers/substack' ) ) {
+	if ( ! config.isEnabled( 'importers/substack' ) || args.isAtomic ) {
 		delete importerConfig.substack;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Hides the Substack import just for Atomic sites, due to possible bug with image files being hot-linked to the original site instead of pulled from media library.

Keeps importer for simple sites.

I'll merge right away to avoid accidental imports into broken state.

## Proposed Changes

Atomic
<img width="597" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/c25f39df-6c37-491b-a8f1-3853518d32bd">

Simple
<img width="599" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/0eff579c-3c22-418e-808d-d3fe2a055fca">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Tools -> Import
* On simple sites, you see Substack.
* On Atomic sites, you don't.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
