### PR TITLE
BackupBrowser: Add List Calculation Logic

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
@@ -81,7 +81,7 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
 						className={ `${ rootNode && rootNode.checkState === 'mixed' ? 'mixed' : '' }` }
 					/>
 					<div className="file-browser-header__selecting-info">
-						{ translate( 'files selected' ) }
+						{ browserCheckList.totalItems } { translate( 'files selected' ) }
 					</div>
 					<Button
 						className="file-browser-header__download-button"

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
@@ -1,26 +1,31 @@
 import { Button } from '@automattic/components';
 import { Icon } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
 import { close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
-import BulkSelect from 'calypso/components/bulk-select';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import { useDispatch, useSelector } from 'calypso/state';
+import { setNodeCheckState } from 'calypso/state/rewind/browser/actions';
+import getBackupBrowserCheckList from 'calypso/state/rewind/selectors/get-backup-browser-check-list';
+import getBackupBrowserNode from 'calypso/state/rewind/selectors/get-backup-browser-node';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { FileBrowserCheckState } from './types';
 
 interface FileBrowserHeaderProps {
 	setShowCheckboxes: ( enabled: boolean ) => void;
 	showCheckboxes: boolean;
-	currentlySelected: number;
-	totalElements: number;
-	onToggleAll: ( checkedState?: boolean ) => void;
 }
 
 const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
 	setShowCheckboxes,
 	showCheckboxes,
-	currentlySelected,
-	totalElements,
-	onToggleAll,
 } ) => {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const rootNode = useSelector( ( state ) => getBackupBrowserNode( state, siteId, '/' ) );
+	const browserCheckList = useSelector( ( state ) => getBackupBrowserCheckList( state, siteId ) );
 	const onSelectClick = () => {
 		setShowCheckboxes( true );
 	};
@@ -28,10 +33,28 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
 		setShowCheckboxes( false );
 	};
 	const onDownloadClick = () => {
-		alert( 'Not yet implemented' );
+		// eslint-disable-next-line no-console
+		console.log( browserCheckList );
 	};
 	const onRestoreClick = () => {
 		alert( 'Not yet implemented' );
+	};
+
+	// When the checkbox is clicked, we'll update the check state in the state
+	const updateNodeCheckState = useCallback(
+		( siteId: number, path: string, checkState: FileBrowserCheckState ) => {
+			dispatch( setNodeCheckState( siteId, path, checkState ) );
+		},
+		[ dispatch ]
+	);
+
+	// A simple toggle.  Mixed will go to unchecked.
+	const onCheckboxChange = () => {
+		updateNodeCheckState(
+			siteId,
+			'/',
+			rootNode && rootNode.checkState === 'unchecked' ? 'checked' : 'unchecked'
+		);
 	};
 
 	return (
@@ -48,11 +71,14 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
 			) }
 			{ showCheckboxes && (
 				<div className="file-browser-header__selecting">
-					<BulkSelect
-						className="file-browser-header__bulk-select"
-						totalElements={ totalElements }
-						selectedElements={ currentlySelected }
-						onToggle={ onToggleAll }
+					<FormCheckbox
+						checked={
+							rootNode
+								? rootNode.checkState === 'checked' || rootNode.checkState === 'mixed'
+								: false
+						}
+						onChange={ onCheckboxChange }
+						className={ `${ rootNode && rootNode.checkState === 'mixed' ? 'mixed' : '' }` }
 					/>
 					<div className="file-browser-header__selecting-info">
 						{ translate( 'files selected' ) }
@@ -61,7 +87,7 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
 						className="file-browser-header__download-button"
 						onClick={ onDownloadClick }
 						compact
-						disabled={ currentlySelected === 0 }
+						disabled={ browserCheckList.totalItems === 0 }
 					>
 						{ translate( 'Download files' ) }
 					</Button>
@@ -70,7 +96,7 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( {
 						onClick={ onRestoreClick }
 						primary
 						compact
-						disabled={ currentlySelected === 0 }
+						disabled={ browserCheckList.totalItems === 0 }
 					>
 						{ translate( 'Restore files' ) }
 					</Button>

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -1,8 +1,8 @@
 import { Button, Icon } from '@wordpress/components';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useState, useEffect } from '@wordpress/element';
 import { chevronDown, chevronRight } from '@wordpress/icons';
 import classNames from 'classnames';
-import { FunctionComponent, useEffect } from 'react';
+import { FunctionComponent } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import { useDispatch, useSelector } from 'calypso/state';
 import { addChildNodes, setNodeCheckState } from 'calypso/state/rewind/browser/actions';

--- a/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/index.tsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
-import { FunctionComponent, useState } from 'react';
+import { useState } from '@wordpress/element';
+import { FunctionComponent } from 'react';
 import FileBrowserHeader from './file-browser-header';
 import FileBrowserNode from './file-browser-node';
 import { FileBrowserItem } from './types';
@@ -12,17 +13,6 @@ const FileBrowser: FunctionComponent< FileBrowserProps > = ( { rewindId } ) => {
 	// This is the path of the node that is clicked
 	const [ activeNodePath, setActiveNodePath ] = useState< string >( '' );
 	const [ showCheckboxes, setShowCheckboxes ] = useState< boolean >( false );
-
-	// Temporary values and logic for laying out header
-	const [ currentlySelected, setCurrentlySelected ] = useState< number >( 0 );
-	const totalElements = 10;
-	const onToggleAll = ( checkedState?: boolean ) => {
-		if ( checkedState ) {
-			setCurrentlySelected( totalElements );
-		} else {
-			setCurrentlySelected( 0 );
-		}
-	};
 
 	const handleClick = ( path: string ) => {
 		setActiveNodePath( path );
@@ -42,9 +32,6 @@ const FileBrowser: FunctionComponent< FileBrowserProps > = ( { rewindId } ) => {
 				<FileBrowserHeader
 					showCheckboxes={ showCheckboxes }
 					setShowCheckboxes={ setShowCheckboxes }
-					currentlySelected={ currentlySelected }
-					totalElements={ totalElements }
-					onToggleAll={ onToggleAll }
 				/>
 			) }
 			<FileBrowserNode

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -233,6 +233,12 @@
 			.file-browser-header__cancel-button {
 				padding: 0;
 			}
+			.form-checkbox {
+				margin: 8px;
+				&.mixed {
+					background-color: var(--studio-gray-10);
+				}
+			}
 			.button {
 				margin-left: 8px;
 				color: #000;

--- a/client/state/rewind/browser/reducer.ts
+++ b/client/state/rewind/browser/reducer.ts
@@ -128,8 +128,11 @@ const updateParent = ( state: AppState, node: BackupBrowserItem ): AppState => {
 	}
 	const nodePath = [ ...node.ancestors ];
 	const { parent: parentOfParent, index } = getParentAndIndex( state, nodePath );
-	// If we're at the root node we'll just return
+	// Root node is a special case
 	if ( parentOfParent === undefined || index === undefined ) {
+		const newRoot = { ...state.rootNode };
+		newRoot.checkState = getCheckedStatus( newRoot );
+		state.rootNode = newRoot;
 		return state;
 	}
 	const newNode = { ...parentOfParent.children[ index ] };
@@ -148,6 +151,15 @@ export default ( state = initialState, { type, payload }: AnyAction ) => {
 			// parent.children[0]
 			const { parent, index } = getParentAndIndex( newState, nodePath );
 			if ( ! parent || index === undefined ) {
+				// Root node special case
+				if ( '/' === nodePath ) {
+					const newState = { ...state };
+					const newRoot = { ...newState.rootNode };
+					newRoot.checkState = checkState;
+					updateChildrenStatus( newRoot, checkState );
+					newState.rootNode = newRoot;
+					return newState;
+				}
 				return state;
 			}
 			const newNode = { ...parent.children[ index ] };

--- a/client/state/rewind/browser/types.ts
+++ b/client/state/rewind/browser/types.ts
@@ -5,3 +5,9 @@ export type BackupBrowserItem = {
 	childrenLoaded: boolean;
 	children: BackupBrowserItem[];
 };
+
+export type BackupBrowserItemCheckList = {
+	totalItems: number;
+	includeList: string[];
+	excludeList: string[];
+};

--- a/client/state/rewind/selectors/get-backup-browser-check-list.ts
+++ b/client/state/rewind/selectors/get-backup-browser-check-list.ts
@@ -14,6 +14,7 @@ const addChildrenToList = (
 	// If we're in a directory and we're checked, we just add the directory path and return to include all children
 	if ( currentNode.checkState === 'checked' ) {
 		currentList.includeList.push( currentNode.path );
+		currentList.totalItems++;
 		return currentList;
 	}
 

--- a/client/state/rewind/selectors/get-backup-browser-check-list.ts
+++ b/client/state/rewind/selectors/get-backup-browser-check-list.ts
@@ -28,12 +28,7 @@ const addChildrenToList = (
 	// This shouldn't hit, because the currentNode should be checked
 	if ( totalChildren === selectedChildren ) {
 		currentList.includeList.push( currentNode.path );
-		return currentList;
-	}
-
-	// If no children are selected we just return the currentList
-	// This should't hit. No children are selected, but the state wasn't unchecked
-	if ( 0 === selectedChildren ) {
+		currentList.totalItems++;
 		return currentList;
 	}
 
@@ -48,6 +43,10 @@ const addChildrenToList = (
 
 	if ( useExclusion ) {
 		currentList.includeList.push( currentNode.path );
+
+		// Lets sum only the selected children
+		currentList.totalItems = currentList.totalItems + selectedChildren;
+
 		currentNode.children.forEach( ( node: BackupBrowserItem ) => {
 			if ( node.checkState === 'unchecked' ) {
 				currentList.excludeList.push( node.path );
@@ -61,18 +60,13 @@ const addChildrenToList = (
 	currentNode.children.forEach( ( node: BackupBrowserItem ) => {
 		if ( 'checked' === node.checkState ) {
 			currentList.includeList.push( node.path );
+			currentList.totalItems++;
 		}
 		if ( 'mixed' === node.checkState ) {
 			currentList = addChildrenToList( node, currentList );
 		}
 	} );
 	return currentList;
-};
-
-// TODO: Properly calculate these values
-const calculateTotalItems = ( checkList: BackupBrowserItemCheckList ) => {
-	checkList.totalItems = checkList.includeList.length + checkList.excludeList.length;
-	return checkList;
 };
 
 /**
@@ -86,7 +80,7 @@ const getBackupBrowserCheckList = (
 	state: AppState,
 	siteId: number
 ): BackupBrowserItemCheckList => {
-	let retVal: BackupBrowserItemCheckList = {
+	let checkList: BackupBrowserItemCheckList = {
 		totalItems: 0,
 		includeList: [],
 		excludeList: [],
@@ -94,13 +88,12 @@ const getBackupBrowserCheckList = (
 
 	const currentNode = state.rewind[ siteId ]?.browser?.rootNode ?? undefined;
 	if ( currentNode === undefined ) {
-		return retVal;
+		return checkList;
 	}
 
-	retVal = addChildrenToList( currentNode, retVal );
-	retVal = calculateTotalItems( retVal );
+	checkList = addChildrenToList( currentNode, checkList );
 
-	return retVal;
+	return checkList;
 };
 
 export default getBackupBrowserCheckList;

--- a/client/state/rewind/selectors/get-backup-browser-check-list.ts
+++ b/client/state/rewind/selectors/get-backup-browser-check-list.ts
@@ -1,0 +1,106 @@
+import { BackupBrowserItem, BackupBrowserItemCheckList } from 'calypso/state/rewind/browser/types';
+import type { AppState } from 'calypso/types';
+
+// Recursive function to iterate through tree and add items to the list
+const addChildrenToList = (
+	currentNode: BackupBrowserItem,
+	currentList: BackupBrowserItemCheckList
+): BackupBrowserItemCheckList => {
+	// If we're unchecked, just return back out, we shouldn't have any selected children
+	if ( currentNode.checkState === 'unchecked' ) {
+		return currentList;
+	}
+
+	// If we're in a directory and we're checked, we just add the directory path and return to include all children
+	if ( currentNode.checkState === 'checked' ) {
+		currentList.includeList.push( currentNode.path );
+		return currentList;
+	}
+
+	// For each directory we need to see how many children are selected in it
+	const totalChildren = currentNode.children.length;
+	const selectedChildren = currentNode.children.reduce(
+		( accumulator, node ) => ( node.checkState !== 'checked' ? accumulator : accumulator + 1 ),
+		0
+	);
+
+	// If all children are selected we add the directory itself to the list and return
+	// This shouldn't hit, because the currentNode should be checked
+	if ( totalChildren === selectedChildren ) {
+		currentList.includeList.push( currentNode.path );
+		return currentList;
+	}
+
+	// If no children are selected we just return the currentList
+	// This should't hit. No children are selected, but the state wasn't unchecked
+	if ( 0 === selectedChildren ) {
+		return currentList;
+	}
+
+	// If some children are selected determine if more or less than half are selected
+	// If more than half are selected and we have no directories as children (no children have children)
+	// then we can add the directory to the include list, and add all unselected items to the exclude list and return.
+	const useExclusion =
+		selectedChildren > totalChildren / 2 &&
+		! currentNode.children.some( ( node: BackupBrowserItem ) => {
+			return node.children.length > 0;
+		} );
+
+	if ( useExclusion ) {
+		currentList.includeList.push( currentNode.path );
+		currentNode.children.forEach( ( node: BackupBrowserItem ) => {
+			if ( node.checkState === 'unchecked' ) {
+				currentList.excludeList.push( node.path );
+			}
+		} );
+		return currentList;
+	}
+
+	// For each selected child, add it to the inclusion list
+	// For each mixed child, call addChildrenToList
+	currentNode.children.forEach( ( node: BackupBrowserItem ) => {
+		if ( 'checked' === node.checkState ) {
+			currentList.includeList.push( node.path );
+		}
+		if ( 'mixed' === node.checkState ) {
+			currentList = addChildrenToList( node, currentList );
+		}
+	} );
+	return currentList;
+};
+
+// TODO: Properly calculate these values
+const calculateTotalItems = ( checkList: BackupBrowserItemCheckList ) => {
+	checkList.totalItems = checkList.includeList.length + checkList.excludeList.length;
+	return checkList;
+};
+
+/**
+ * Retrieve the list of checked items and totals from the Backup Browser
+ *
+ * @param state The application state.
+ * @param siteId The site ID we're retrieving for.
+ * @returns A node in the backup browser state.
+ */
+const getBackupBrowserCheckList = (
+	state: AppState,
+	siteId: number
+): BackupBrowserItemCheckList => {
+	let retVal: BackupBrowserItemCheckList = {
+		totalItems: 0,
+		includeList: [],
+		excludeList: [],
+	};
+
+	const currentNode = state.rewind[ siteId ]?.browser?.rootNode ?? undefined;
+	if ( currentNode === undefined ) {
+		return retVal;
+	}
+
+	retVal = addChildrenToList( currentNode, retVal );
+	retVal = calculateTotalItems( retVal );
+
+	return retVal;
+};
+
+export default getBackupBrowserCheckList;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This replaces the BulkCheck in the header with a similar form check from the list
* Connects the header logic to the body in terms of the 'Root' checkbox behavior
* Removed the placeholder currently selected counts.  It still needs to be added properly.
* Temporarily replaced the 'Not Yet Implemented' alert of the 'Download' button with a console.log of the list items.  This will be replaced by an API call utilizing the list.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Select some items, click 'Download Files' and check your console log to ensure you're seeing the correct items.
* If you're testing in a live branch, add `?flags=jetpack/backup-granular` to the end of the URL.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
