### PR TITLE
Domain management: allow bulk-selecting domains

### DIFF
--- a/packages/data-stores/src/queries/use-all-domains-query.ts
+++ b/packages/data-stores/src/queries/use-all-domains-query.ts
@@ -25,7 +25,10 @@ export function useAllDomainsQuery( options: UseQueryOptions< AllDomainsQueryFnD
 	return useQuery( {
 		queryKey: [ 'all-domains' ],
 		queryFn: () =>
-			wpcomRequest< AllDomainsQueryFnData >( { path: '/all-domains', apiVersion: '1.1' } ),
+			wpcomRequest< AllDomainsQueryFnData >( {
+				path: '/all-domains?test_data=true&domain_count=2',
+				apiVersion: '1.1',
+			} ),
 		...options,
 	} );
 }

--- a/packages/data-stores/src/queries/use-all-domains-query.ts
+++ b/packages/data-stores/src/queries/use-all-domains-query.ts
@@ -25,10 +25,7 @@ export function useAllDomainsQuery( options: UseQueryOptions< AllDomainsQueryFnD
 	return useQuery( {
 		queryKey: [ 'all-domains' ],
 		queryFn: () =>
-			wpcomRequest< AllDomainsQueryFnData >( {
-				path: '/all-domains?test_data=true&domain_count=2',
-				apiVersion: '1.1',
-			} ),
+			wpcomRequest< AllDomainsQueryFnData >( { path: '/all-domains', apiVersion: '1.1' } ),
 		...options,
 	} );
 }

--- a/packages/domains-table/src/domains-table-header/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table-header/__tests__/index.tsx
@@ -6,6 +6,8 @@ import React from 'react';
 import { renderWithProvider } from '../../test-utils';
 import { DomainsTableColumn, DomainsTableHeader } from '../index';
 
+const noop = jest.fn();
+
 const render = ( el ) =>
 	renderWithProvider( el, {
 		wrapper: ( { children } ) => <table>{ children }</table>,
@@ -33,6 +35,8 @@ test( 'domain columns are rendered in the header', () => {
 			activeSortKey="domain"
 			activeSortDirection="asc"
 			onChangeSortOrder={ jest.fn() }
+			bulkSelectionStatus="no-domains"
+			onBulkSelectionChange={ noop }
 		/>
 	);
 
@@ -56,6 +60,8 @@ test( 'renders custom header component', () => {
 			activeSortKey="domain"
 			activeSortDirection="asc"
 			onChangeSortOrder={ jest.fn() }
+			bulkSelectionStatus="no-domains"
+			onBulkSelectionChange={ noop }
 		/>
 	);
 
@@ -70,6 +76,8 @@ test( 'renders a chevron next to sortable columns', () => {
 			activeSortKey="domain"
 			activeSortDirection="asc"
 			onChangeSortOrder={ jest.fn() }
+			bulkSelectionStatus="no-domains"
+			onBulkSelectionChange={ noop }
 		/>
 	);
 
@@ -87,6 +95,8 @@ test( 'columns that are not sortable do not renders a chevron', () => {
 			activeSortKey="domain"
 			activeSortDirection="asc"
 			onChangeSortOrder={ jest.fn() }
+			bulkSelectionStatus="no-domains"
+			onBulkSelectionChange={ noop }
 		/>
 	);
 

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { DomainData } from '@automattic/data-stores';
 import { CheckboxControl, Icon } from '@wordpress/components';
 import { chevronDown, chevronUp } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import './style.scss';
 
@@ -46,6 +47,7 @@ export const DomainsTableHeader = ( {
 	onChangeSortOrder,
 	headerClasses,
 }: DomainsTableHeaderProps ) => {
+	const { __ } = useI18n();
 	const listHeaderClasses = classNames(
 		'domains-table-header',
 		'domains-table-header__desktop',
@@ -76,6 +78,7 @@ export const DomainsTableHeader = ( {
 						onChange={ onBulkSelectionChange }
 						indeterminate={ bulkSelectionStatus === 'some-domains' }
 						checked={ bulkSelectionStatus === 'all-domains' }
+						aria-label={ __( 'Select all tick boxes for domains in table', __i18n_text_domain__ ) }
 					/>
 				</th>
 				{ columns.map( ( column ) => (

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -1,9 +1,11 @@
 import { Button } from '@automattic/components';
 import { DomainData } from '@automattic/data-stores';
-import { Icon } from '@wordpress/components';
+import { CheckboxControl, Icon } from '@wordpress/components';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 import classNames from 'classnames';
 import './style.scss';
+
+export type DomainsTableBulkSelectionStatus = 'no-domains' | 'some-domains' | 'all-domains';
 
 export type DomainsTableColumn =
 	| {
@@ -30,6 +32,8 @@ type DomainsTableHeaderProps = {
 	activeSortKey: string;
 	activeSortDirection: 'asc' | 'desc';
 	onChangeSortOrder: ( selectedColumn: DomainsTableColumn ) => void;
+	bulkSelectionStatus: DomainsTableBulkSelectionStatus;
+	onBulkSelectionChange(): void;
 	headerClasses?: string;
 };
 
@@ -37,6 +41,8 @@ export const DomainsTableHeader = ( {
 	columns,
 	activeSortKey,
 	activeSortDirection,
+	bulkSelectionStatus,
+	onBulkSelectionChange,
 	onChangeSortOrder,
 	headerClasses,
 }: DomainsTableHeaderProps ) => {
@@ -64,6 +70,14 @@ export const DomainsTableHeader = ( {
 	return (
 		<thead className={ listHeaderClasses }>
 			<tr>
+				<th className="domains-table__bulk-action-container">
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						onChange={ onBulkSelectionChange }
+						indeterminate={ bulkSelectionStatus === 'some-domains' }
+						checked={ bulkSelectionStatus === 'all-domains' }
+					/>
+				</th>
 				{ columns.map( ( column ) => (
 					<th key={ column.name }>
 						<Button

--- a/packages/domains-table/src/domains-table-header/style.scss
+++ b/packages/domains-table/src/domains-table-header/style.scss
@@ -5,8 +5,6 @@
 @import "@wordpress/base-styles/colors";
 
 .domains-table-header {
-	display: flex;
-	justify-content: space-between;
 	padding: 8px 0 16px;
 	font-size: $font-body-small;
 	font-weight: 500;
@@ -31,9 +29,6 @@
 		}
 	}
 
-	&.domains-table-header__desktop {
-		display: none;
-	}
 	&.domains-table-header__mobile {
 		display: flex;
 		padding: 16px;
@@ -50,9 +45,6 @@
 	}
 
 	@include break-large {
-		&.domains-table-header__desktop {
-			display: flex;
-		}
 		&.domains-table-header__mobile {
 			display: none;
 		}

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -6,6 +6,8 @@ import React from 'react';
 import { renderWithProvider, testDomain, testPartialDomain } from '../../test-utils';
 import { DomainsTableRow } from '../domains-table-row';
 
+const noop = jest.fn();
+
 const render = ( el ) =>
 	renderWithProvider( el, {
 		wrapper: ( { children } ) => (
@@ -17,7 +19,12 @@ const render = ( el ) =>
 
 test( 'domain name is rendered in the row', () => {
 	render(
-		<DomainsTableRow domain={ testPartialDomain( { domain: 'example1.com' } ) } isAllSitesView />
+		<DomainsTableRow
+			domain={ testPartialDomain( { domain: 'example1.com' } ) }
+			isAllSitesView
+			isSelected={ false }
+			onSelect={ noop }
+		/>
 	);
 
 	expect( screen.queryByText( 'example1.com' ) ).toBeInTheDocument();
@@ -40,6 +47,8 @@ test( 'wpcom domains do not link to management interface', async () => {
 			domain={ partialDomain }
 			fetchSiteDomains={ fetchSiteDomains }
 			isAllSitesView
+			isSelected={ false }
+			onSelect={ noop }
 		/>
 	);
 
@@ -62,6 +71,8 @@ test( 'domain name links to management interface', async () => {
 			domain={ partialDomain }
 			fetchSiteDomains={ fetchSiteDomains }
 			isAllSitesView
+			isSelected={ false }
+			onSelect={ noop }
 		/>
 	);
 
@@ -88,6 +99,8 @@ test( 'domain name links to management interface', async () => {
 			domain={ partialDomain }
 			fetchSiteDomains={ fetchSiteDomains }
 			isAllSitesView={ false }
+			isSelected={ false }
+			onSelect={ noop }
 		/>
 	);
 
@@ -118,6 +131,8 @@ test( 'non primary domain uses the primary domain as the site slug in its link U
 			domain={ partialDomain }
 			fetchSiteDomains={ fetchSiteDomains }
 			isAllSitesView
+			isSelected={ false }
+			onSelect={ noop }
 		/>
 	);
 
@@ -136,6 +151,8 @@ test( 'non primary domain uses the primary domain as the site slug in its link U
 			domain={ partialDomain }
 			fetchSiteDomains={ fetchSiteDomains }
 			isAllSitesView={ false }
+			isSelected={ false }
+			onSelect={ noop }
 		/>
 	);
 
@@ -170,6 +187,8 @@ test( 'redirect links use the unmapped domain for the site slug', async () => {
 			domain={ partialRedirectDomain }
 			fetchSiteDomains={ fetchSiteDomains }
 			isAllSitesView
+			isSelected={ false }
+			onSelect={ noop }
 		/>
 	);
 
@@ -188,6 +207,8 @@ test( 'redirect links use the unmapped domain for the site slug', async () => {
 			domain={ partialRedirectDomain }
 			fetchSiteDomains={ fetchSiteDomains }
 			isAllSitesView={ false }
+			isSelected={ false }
+			onSelect={ noop }
 		/>
 	);
 
@@ -215,6 +236,8 @@ test( 'transfer links use the unmapped domain for the site slug', async () => {
 			domain={ partialDomain }
 			fetchSiteDomains={ fetchSiteDomains }
 			isAllSitesView
+			isSelected={ false }
+			onSelect={ noop }
 		/>
 	);
 
@@ -233,6 +256,8 @@ test( 'transfer links use the unmapped domain for the site slug', async () => {
 			domain={ partialDomain }
 			fetchSiteDomains={ fetchSiteDomains }
 			isAllSitesView={ false }
+			isSelected={ false }
+			onSelect={ noop }
 		/>
 	);
 

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { renderWithProvider, testDomain, testPartialDomain } from '../../test-utils';
 import { DomainsTableRow } from '../domains-table-row';
@@ -265,4 +265,83 @@ test( 'transfer links use the unmapped domain for the site slug', async () => {
 		'href',
 		'/domains/manage/example.com/transfer/in/example.com'
 	);
+} );
+
+test( 'when a domain is selected, the checkbox is checked', () => {
+	const [ partialDomain, fullDomain ] = testDomain( {
+		domain: 'example.wordpress.com',
+		blog_id: 123,
+		primary_domain: false,
+		wpcom_domain: true,
+	} );
+
+	const fetchSiteDomains = jest.fn().mockResolvedValue( {
+		domains: [ fullDomain ],
+	} );
+
+	render(
+		<DomainsTableRow
+			domain={ partialDomain }
+			fetchSiteDomains={ fetchSiteDomains }
+			isAllSitesView
+			isSelected={ true }
+			onSelect={ noop }
+		/>
+	);
+
+	expect( screen.getByRole( 'checkbox' ) ).toBeChecked();
+} );
+
+test( 'when a domain is not selected, the checkbox is unchecked', () => {
+	const [ partialDomain, fullDomain ] = testDomain( {
+		domain: 'example.wordpress.com',
+		blog_id: 123,
+		primary_domain: false,
+		wpcom_domain: true,
+	} );
+
+	const fetchSiteDomains = jest.fn().mockResolvedValue( {
+		domains: [ fullDomain ],
+	} );
+
+	render(
+		<DomainsTableRow
+			domain={ partialDomain }
+			fetchSiteDomains={ fetchSiteDomains }
+			isAllSitesView
+			isSelected={ false }
+			onSelect={ noop }
+		/>
+	);
+
+	expect( screen.getByRole( 'checkbox' ) ).not.toBeChecked();
+} );
+
+test( 'when the user selects a domain, the onSelect function is triggered', () => {
+	const [ partialDomain, fullDomain ] = testDomain( {
+		domain: 'example.wordpress.com',
+		blog_id: 123,
+		primary_domain: false,
+		wpcom_domain: true,
+	} );
+
+	const fetchSiteDomains = jest.fn().mockResolvedValue( {
+		domains: [ fullDomain ],
+	} );
+
+	const handleSelect = jest.fn();
+
+	render(
+		<DomainsTableRow
+			domain={ partialDomain }
+			fetchSiteDomains={ fetchSiteDomains }
+			isAllSitesView
+			isSelected={ false }
+			onSelect={ handleSelect }
+		/>
+	);
+
+	fireEvent.click( screen.getByRole( 'checkbox' ) );
+
+	expect( handleSelect ).toHaveBeenCalledWith( partialDomain );
 } );

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { renderWithProvider, testDomain, testPartialDomain } from '../../test-utils';
 import { DomainsTableRow } from '../domains-table-row';
@@ -265,83 +265,4 @@ test( 'transfer links use the unmapped domain for the site slug', async () => {
 		'href',
 		'/domains/manage/example.com/transfer/in/example.com'
 	);
-} );
-
-test( 'when a domain is selected, the checkbox is checked', () => {
-	const [ partialDomain, fullDomain ] = testDomain( {
-		domain: 'example.wordpress.com',
-		blog_id: 123,
-		primary_domain: false,
-		wpcom_domain: true,
-	} );
-
-	const fetchSiteDomains = jest.fn().mockResolvedValue( {
-		domains: [ fullDomain ],
-	} );
-
-	render(
-		<DomainsTableRow
-			domain={ partialDomain }
-			fetchSiteDomains={ fetchSiteDomains }
-			isAllSitesView
-			isSelected={ true }
-			onSelect={ noop }
-		/>
-	);
-
-	expect( screen.getByRole( 'checkbox' ) ).toBeChecked();
-} );
-
-test( 'when a domain is not selected, the checkbox is unchecked', () => {
-	const [ partialDomain, fullDomain ] = testDomain( {
-		domain: 'example.wordpress.com',
-		blog_id: 123,
-		primary_domain: false,
-		wpcom_domain: true,
-	} );
-
-	const fetchSiteDomains = jest.fn().mockResolvedValue( {
-		domains: [ fullDomain ],
-	} );
-
-	render(
-		<DomainsTableRow
-			domain={ partialDomain }
-			fetchSiteDomains={ fetchSiteDomains }
-			isAllSitesView
-			isSelected={ false }
-			onSelect={ noop }
-		/>
-	);
-
-	expect( screen.getByRole( 'checkbox' ) ).not.toBeChecked();
-} );
-
-test( 'when the user selects a domain, the onSelect function is triggered', () => {
-	const [ partialDomain, fullDomain ] = testDomain( {
-		domain: 'example.wordpress.com',
-		blog_id: 123,
-		primary_domain: false,
-		wpcom_domain: true,
-	} );
-
-	const fetchSiteDomains = jest.fn().mockResolvedValue( {
-		domains: [ fullDomain ],
-	} );
-
-	const handleSelect = jest.fn();
-
-	render(
-		<DomainsTableRow
-			domain={ partialDomain }
-			fetchSiteDomains={ fetchSiteDomains }
-			isAllSitesView
-			isSelected={ false }
-			onSelect={ handleSelect }
-		/>
-	);
-
-	fireEvent.click( screen.getByRole( 'checkbox' ) );
-
-	expect( handleSelect ).toHaveBeenCalledWith( partialDomain );
 } );

--- a/packages/domains-table/src/domains-table/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/index.tsx
@@ -8,6 +8,11 @@ import { renderWithProvider, testDomain, testPartialDomain } from '../../test-ut
 
 const render = ( el ) => renderWithProvider( el );
 
+const getBulkCheckbox = () =>
+	screen.getByRole( 'checkbox', { name: 'Select all tick boxes for domains in table' } );
+const getDomainCheckbox = ( domain: string ) =>
+	screen.getByRole( 'checkbox', { name: `Tick box for ${ domain }` } );
+
 test( 'all domain names are rendered in the table', () => {
 	const { rerender } = render(
 		<DomainsTable
@@ -129,8 +134,9 @@ test( 'when the user has no selected domains, all checkboxes are unchecked', () 
 		/>
 	);
 
-	const [ bulkCheckbox, firstDomainsCheckbox, secondDomainsCheckbox ] =
-		screen.getAllByRole< HTMLInputElement >( 'checkbox' );
+	const bulkCheckbox = getBulkCheckbox();
+	const firstDomainsCheckbox = getDomainCheckbox( 'example1.com' );
+	const secondDomainsCheckbox = getDomainCheckbox( 'example2.com' );
 
 	expect( bulkCheckbox ).not.toBeChecked();
 	expect( firstDomainsCheckbox ).not.toBeChecked();
@@ -148,8 +154,9 @@ test( 'when the user selects one domain, the bulk domains checkbox becomes parti
 		/>
 	);
 
-	const [ bulkCheckbox, firstDomainsCheckbox, secondDomainsCheckbox ] =
-		screen.getAllByRole< HTMLInputElement >( 'checkbox' );
+	const bulkCheckbox = getBulkCheckbox();
+	const firstDomainsCheckbox = getDomainCheckbox( 'example1.com' );
+	const secondDomainsCheckbox = getDomainCheckbox( 'example2.com' );
 
 	fireEvent.click( firstDomainsCheckbox );
 
@@ -169,8 +176,9 @@ test( 'when the user selects all domains, the bulk domains checkbox becomes chec
 		/>
 	);
 
-	const [ bulkCheckbox, firstDomainsCheckbox, secondDomainsCheckbox ] =
-		screen.getAllByRole< HTMLInputElement >( 'checkbox' );
+	const bulkCheckbox = getBulkCheckbox();
+	const firstDomainsCheckbox = getDomainCheckbox( 'example1.com' );
+	const secondDomainsCheckbox = getDomainCheckbox( 'example2.com' );
 
 	fireEvent.click( firstDomainsCheckbox );
 	fireEvent.click( secondDomainsCheckbox );
@@ -191,8 +199,9 @@ test( 'when no domains are checked and the user clicks the bulk checkbox, all do
 		/>
 	);
 
-	const [ bulkCheckbox, firstDomainsCheckbox, secondDomainsCheckbox ] =
-		screen.getAllByRole< HTMLInputElement >( 'checkbox' );
+	const bulkCheckbox = getBulkCheckbox();
+	const firstDomainsCheckbox = getDomainCheckbox( 'example1.com' );
+	const secondDomainsCheckbox = getDomainCheckbox( 'example2.com' );
 
 	fireEvent.click( bulkCheckbox );
 
@@ -212,8 +221,9 @@ test( 'when a subset of domains are checked and the user clicks the bulk checkbo
 		/>
 	);
 
-	const [ bulkCheckbox, firstDomainsCheckbox, secondDomainsCheckbox ] =
-		screen.getAllByRole< HTMLInputElement >( 'checkbox' );
+	const bulkCheckbox = getBulkCheckbox();
+	const firstDomainsCheckbox = getDomainCheckbox( 'example1.com' );
+	const secondDomainsCheckbox = getDomainCheckbox( 'example2.com' );
 
 	fireEvent.click( firstDomainsCheckbox );
 
@@ -239,8 +249,9 @@ test( 'when all domains are checked and the user clicks the bulk checkbox, all d
 		/>
 	);
 
-	const [ bulkCheckbox, firstDomainsCheckbox, secondDomainsCheckbox ] =
-		screen.getAllByRole< HTMLInputElement >( 'checkbox' );
+	const bulkCheckbox = getBulkCheckbox();
+	const firstDomainsCheckbox = getDomainCheckbox( 'example1.com' );
+	const secondDomainsCheckbox = getDomainCheckbox( 'example2.com' );
 
 	fireEvent.click( bulkCheckbox );
 	expect( bulkCheckbox ).toBeChecked();
@@ -265,8 +276,9 @@ test( 'when the domains list changes, all domains become unchecked', () => {
 		/>
 	);
 
-	const [ bulkCheckbox, firstDomainsCheckbox, secondDomainsCheckbox ] =
-		screen.getAllByRole< HTMLInputElement >( 'checkbox' );
+	const bulkCheckbox = getBulkCheckbox();
+	const firstDomainsCheckbox = getDomainCheckbox( 'example1.com' );
+	const secondDomainsCheckbox = getDomainCheckbox( 'example2.com' );
 
 	fireEvent.click( bulkCheckbox );
 	expect( bulkCheckbox ).toBeChecked();

--- a/packages/domains-table/src/domains-table/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/index.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { DomainsTable } from '..';
 import { renderWithProvider, testDomain, testPartialDomain } from '../../test-utils';
@@ -116,4 +116,175 @@ test( 'when shouldDisplayPrimaryDomainLabel is true, the primary domain label is
 	);
 
 	expect( screen.queryByText( 'Primary domain' ) ).not.toBeInTheDocument();
+} );
+
+test( 'when the user has no selected domains, all checkboxes are unchecked', () => {
+	render(
+		<DomainsTable
+			domains={ [
+				testPartialDomain( { domain: 'example1.com' } ),
+				testPartialDomain( { domain: 'example2.com' } ),
+			] }
+			isAllSitesView
+		/>
+	);
+
+	const [ bulkCheckbox, firstDomainsCheckbox, secondDomainsCheckbox ] =
+		screen.getAllByRole< HTMLInputElement >( 'checkbox' );
+
+	expect( bulkCheckbox ).not.toBeChecked();
+	expect( firstDomainsCheckbox ).not.toBeChecked();
+	expect( secondDomainsCheckbox ).not.toBeChecked();
+} );
+
+test( 'when the user selects one domain, the bulk domains checkbox becomes partially checked', () => {
+	render(
+		<DomainsTable
+			domains={ [
+				testPartialDomain( { domain: 'example1.com' } ),
+				testPartialDomain( { domain: 'example2.com' } ),
+			] }
+			isAllSitesView
+		/>
+	);
+
+	const [ bulkCheckbox, firstDomainsCheckbox, secondDomainsCheckbox ] =
+		screen.getAllByRole< HTMLInputElement >( 'checkbox' );
+
+	fireEvent.click( firstDomainsCheckbox );
+
+	expect( bulkCheckbox ).toBePartiallyChecked();
+	expect( firstDomainsCheckbox ).toBeChecked();
+	expect( secondDomainsCheckbox ).not.toBeChecked();
+} );
+
+test( 'when the user selects all domains, the bulk domains checkbox becomes checked', () => {
+	render(
+		<DomainsTable
+			domains={ [
+				testPartialDomain( { domain: 'example1.com' } ),
+				testPartialDomain( { domain: 'example2.com' } ),
+			] }
+			isAllSitesView
+		/>
+	);
+
+	const [ bulkCheckbox, firstDomainsCheckbox, secondDomainsCheckbox ] =
+		screen.getAllByRole< HTMLInputElement >( 'checkbox' );
+
+	fireEvent.click( firstDomainsCheckbox );
+	fireEvent.click( secondDomainsCheckbox );
+
+	expect( bulkCheckbox ).toBeChecked();
+	expect( firstDomainsCheckbox ).toBeChecked();
+	expect( secondDomainsCheckbox ).toBeChecked();
+} );
+
+test( 'when no domains are checked and the user clicks the bulk checkbox, all domains become checked', () => {
+	render(
+		<DomainsTable
+			domains={ [
+				testPartialDomain( { domain: 'example1.com' } ),
+				testPartialDomain( { domain: 'example2.com' } ),
+			] }
+			isAllSitesView
+		/>
+	);
+
+	const [ bulkCheckbox, firstDomainsCheckbox, secondDomainsCheckbox ] =
+		screen.getAllByRole< HTMLInputElement >( 'checkbox' );
+
+	fireEvent.click( bulkCheckbox );
+
+	expect( bulkCheckbox ).toBeChecked();
+	expect( firstDomainsCheckbox ).toBeChecked();
+	expect( secondDomainsCheckbox ).toBeChecked();
+} );
+
+test( 'when a subset of domains are checked and the user clicks the bulk checkbox, all domains become checked', () => {
+	render(
+		<DomainsTable
+			domains={ [
+				testPartialDomain( { domain: 'example1.com' } ),
+				testPartialDomain( { domain: 'example2.com' } ),
+			] }
+			isAllSitesView
+		/>
+	);
+
+	const [ bulkCheckbox, firstDomainsCheckbox, secondDomainsCheckbox ] =
+		screen.getAllByRole< HTMLInputElement >( 'checkbox' );
+
+	fireEvent.click( firstDomainsCheckbox );
+
+	expect( bulkCheckbox ).toBePartiallyChecked();
+	expect( firstDomainsCheckbox ).toBeChecked();
+	expect( secondDomainsCheckbox ).not.toBeChecked();
+
+	fireEvent.click( bulkCheckbox );
+
+	expect( bulkCheckbox ).toBeChecked();
+	expect( firstDomainsCheckbox ).toBeChecked();
+	expect( secondDomainsCheckbox ).toBeChecked();
+} );
+
+test( 'when all domains are checked and the user clicks the bulk checkbox, all domains become unchecked', () => {
+	render(
+		<DomainsTable
+			domains={ [
+				testPartialDomain( { domain: 'example1.com' } ),
+				testPartialDomain( { domain: 'example2.com' } ),
+			] }
+			isAllSitesView
+		/>
+	);
+
+	const [ bulkCheckbox, firstDomainsCheckbox, secondDomainsCheckbox ] =
+		screen.getAllByRole< HTMLInputElement >( 'checkbox' );
+
+	fireEvent.click( bulkCheckbox );
+	expect( bulkCheckbox ).toBeChecked();
+	expect( firstDomainsCheckbox ).toBeChecked();
+	expect( secondDomainsCheckbox ).toBeChecked();
+
+	fireEvent.click( bulkCheckbox );
+
+	expect( bulkCheckbox ).not.toBeChecked();
+	expect( firstDomainsCheckbox ).not.toBeChecked();
+	expect( secondDomainsCheckbox ).not.toBeChecked();
+} );
+
+test( 'when the domains list changes, all domains become unchecked', () => {
+	const { rerender } = render(
+		<DomainsTable
+			domains={ [
+				testPartialDomain( { domain: 'example1.com' } ),
+				testPartialDomain( { domain: 'example2.com' } ),
+			] }
+			isAllSitesView
+		/>
+	);
+
+	const [ bulkCheckbox, firstDomainsCheckbox, secondDomainsCheckbox ] =
+		screen.getAllByRole< HTMLInputElement >( 'checkbox' );
+
+	fireEvent.click( bulkCheckbox );
+	expect( bulkCheckbox ).toBeChecked();
+	expect( firstDomainsCheckbox ).toBeChecked();
+	expect( secondDomainsCheckbox ).toBeChecked();
+
+	rerender(
+		<DomainsTable
+			domains={ [
+				testPartialDomain( { domain: 'example1.com' } ),
+				testPartialDomain( { domain: 'example2.com' } ),
+				testPartialDomain( { domain: 'example3.com' } ),
+			] }
+			isAllSitesView
+		/>
+	);
+
+	expect( bulkCheckbox ).not.toBeChecked();
+	expect( firstDomainsCheckbox ).not.toBeChecked();
+	expect( secondDomainsCheckbox ).not.toBeChecked();
 } );

--- a/packages/domains-table/src/domains-table/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/index.tsx
@@ -265,7 +265,7 @@ test( 'when all domains are checked and the user clicks the bulk checkbox, all d
 	expect( secondDomainsCheckbox ).not.toBeChecked();
 } );
 
-test( 'when the domains list changes, all domains become unchecked', () => {
+test( 'when the domains list changes, the bulk selection removes dangling domains', () => {
 	const { rerender } = render(
 		<DomainsTable
 			domains={ [
@@ -276,27 +276,22 @@ test( 'when the domains list changes, all domains become unchecked', () => {
 		/>
 	);
 
-	const bulkCheckbox = getBulkCheckbox();
-	const firstDomainsCheckbox = getDomainCheckbox( 'example1.com' );
-	const secondDomainsCheckbox = getDomainCheckbox( 'example2.com' );
-
-	fireEvent.click( bulkCheckbox );
-	expect( bulkCheckbox ).toBeChecked();
-	expect( firstDomainsCheckbox ).toBeChecked();
-	expect( secondDomainsCheckbox ).toBeChecked();
+	fireEvent.click( getBulkCheckbox() );
+	expect( getBulkCheckbox() ).toBeChecked();
+	expect( getDomainCheckbox( 'example1.com' ) ).toBeChecked();
+	expect( getDomainCheckbox( 'example2.com' ) ).toBeChecked();
 
 	rerender(
 		<DomainsTable
 			domains={ [
 				testPartialDomain( { domain: 'example1.com' } ),
-				testPartialDomain( { domain: 'example2.com' } ),
 				testPartialDomain( { domain: 'example3.com' } ),
 			] }
 			isAllSitesView
 		/>
 	);
 
-	expect( bulkCheckbox ).not.toBeChecked();
-	expect( firstDomainsCheckbox ).not.toBeChecked();
-	expect( secondDomainsCheckbox ).not.toBeChecked();
+	expect( getBulkCheckbox() ).toBePartiallyChecked();
+	expect( getDomainCheckbox( 'example1.com' ) ).toBeChecked();
+	expect( getDomainCheckbox( 'example3.com' ) ).not.toBeChecked();
 } );

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,4 +1,5 @@
 import { useSiteDomainsQuery } from '@automattic/data-stores';
+import { CheckboxControl } from '@wordpress/components';
 import { useMemo } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { PrimaryDomainLabel } from '../primary-domain-label';
@@ -7,6 +8,8 @@ import type { PartialDomainData, SiteDomainsQueryFnData } from '@automattic/data
 interface DomainsTableRowProps {
 	domain: PartialDomainData;
 	isAllSitesView: boolean;
+	isSelected: boolean;
+	onSelect( domain: PartialDomainData ): void;
 
 	fetchSiteDomains?: (
 		siteIdOrSlug: number | string | null | undefined
@@ -16,6 +19,8 @@ interface DomainsTableRowProps {
 export function DomainsTableRow( {
 	domain,
 	isAllSitesView,
+	isSelected,
+	onSelect,
 	fetchSiteDomains,
 }: DomainsTableRowProps ) {
 	const { ref, inView } = useInView( { triggerOnce: true } );
@@ -44,6 +49,13 @@ export function DomainsTableRow( {
 
 	return (
 		<tr key={ domain.domain } ref={ ref }>
+			<td>
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					checked={ isSelected }
+					onChange={ () => onSelect( domain ) }
+				/>
+			</td>
 			<td>
 				{ shouldDisplayPrimaryDomainLabel && <PrimaryDomainLabel /> }
 				{ isManageableDomain ? (

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,5 +1,7 @@
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { PrimaryDomainLabel } from '../primary-domain-label';
@@ -23,6 +25,7 @@ export function DomainsTableRow( {
 	onSelect,
 	fetchSiteDomains,
 }: DomainsTableRowProps ) {
+	const { __ } = useI18n();
 	const { ref, inView } = useInView( { triggerOnce: true } );
 
 	const { data } = useSiteDomainsQuery( domain.blog_id, {
@@ -54,6 +57,10 @@ export function DomainsTableRow( {
 					__nextHasNoMarginBottom
 					checked={ isSelected }
 					onChange={ () => onSelect( domain ) }
+					/* translators: Label for a checkbox control that selects a domain name.*/
+					aria-label={ sprintf( __( 'Tick box for %(domain)s', __i18n_text_domain__ ), {
+						domain: domain.domain,
+					} ) }
 				/>
 			</td>
 			<td>

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -28,7 +28,23 @@ export function DomainsTable( { domains, fetchSiteDomains, isAllSitesView }: Dom
 	const [ selectedDomains, setSelectedDomains ] = useState( () => new Set< string >() );
 
 	useLayoutEffect( () => {
-		setSelectedDomains( new Set() );
+		if ( ! domains ) {
+			setSelectedDomains( new Set() );
+			return;
+		}
+
+		setSelectedDomains( ( selectedDomains ) => {
+			const domainUrls = domains.map( ( { domain } ) => domain );
+			const selectedDomainsCopy = new Set( selectedDomains );
+
+			for ( const selectedDomain of selectedDomainsCopy ) {
+				if ( ! domainUrls.includes( selectedDomain ) ) {
+					selectedDomainsCopy.delete( selectedDomain );
+				}
+			}
+
+			return selectedDomainsCopy;
+		} );
 	}, [ domains ] );
 
 	const handleSelectDomain = useCallback(

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -25,21 +25,23 @@ export function DomainsTable( { domains, fetchSiteDomains, isAllSitesView }: Dom
 		sortDirection: 'asc',
 	} );
 
-	const [ selectedDomains, setSelectedDomains ] = useState< PartialDomainData[] >( [] );
+	const [ selectedDomains, setSelectedDomains ] = useState( () => new Set< string >() );
 
 	useLayoutEffect( () => {
-		setSelectedDomains( [] );
+		setSelectedDomains( new Set() );
 	}, [ domains ] );
 
 	const handleSelectDomain = useCallback(
-		( domain: PartialDomainData ) => {
-			if ( selectedDomains.includes( domain ) ) {
-				setSelectedDomains(
-					selectedDomains.filter( ( selectedDomain ) => selectedDomain !== domain )
-				);
+		( { domain }: PartialDomainData ) => {
+			const selectedDomainsCopy = new Set( selectedDomains );
+
+			if ( selectedDomainsCopy.has( domain ) ) {
+				selectedDomainsCopy.delete( domain );
 			} else {
-				setSelectedDomains( [ ...selectedDomains, domain ] );
+				selectedDomainsCopy.add( domain );
 			}
+
+			setSelectedDomains( selectedDomainsCopy );
 		},
 		[ setSelectedDomains, selectedDomains ]
 	);
@@ -66,8 +68,8 @@ export function DomainsTable( { domains, fetchSiteDomains, isAllSitesView }: Dom
 		} );
 	};
 
-	const hasSelectedDomains = selectedDomains.length > 0;
-	const areAllDomainsSelected = domains.length === selectedDomains.length;
+	const hasSelectedDomains = selectedDomains.size > 0;
+	const areAllDomainsSelected = domains.length === selectedDomains.size;
 
 	const getBulkSelectionStatus = () => {
 		if ( hasSelectedDomains && areAllDomainsSelected ) {
@@ -83,9 +85,9 @@ export function DomainsTable( { domains, fetchSiteDomains, isAllSitesView }: Dom
 
 	const changeBulkSelection = () => {
 		if ( ! hasSelectedDomains || ! areAllDomainsSelected ) {
-			setSelectedDomains( domains );
+			setSelectedDomains( new Set( domains.map( ( { domain } ) => domain ) ) );
 		} else {
-			setSelectedDomains( [] );
+			setSelectedDomains( new Set() );
 		}
 	};
 
@@ -106,7 +108,7 @@ export function DomainsTable( { domains, fetchSiteDomains, isAllSitesView }: Dom
 					<DomainsTableRow
 						key={ domain.domain }
 						domain={ domain }
-						isSelected={ selectedDomains.includes( domain ) }
+						isSelected={ selectedDomains.has( domain.domain ) }
 						onSelect={ handleSelectDomain }
 						fetchSiteDomains={ fetchSiteDomains }
 						isAllSitesView={ isAllSitesView }

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -1,12 +1,10 @@
-@import '@automattic/typography/styles/variables';
+@import "@automattic/typography/styles/variables";
 
 .domains-table {
 	th {
 		padding-bottom: 16px;
-		border-bottom: 1px solid #f0f0f0;
+		color: var(--studio-gray-60);
 		vertical-align: middle;
-
-		color: var( --studio-gray-60 );
 		font-size: $font-body-small;
 		font-style: normal;
 		font-weight: 500;
@@ -21,13 +19,14 @@
 			margin-right: 16px;
 		}
 	}
+
 	td {
 		padding: 20px 0;
-		border-bottom: 1px solid var( --studio-gray-5 );
+		border-bottom: 1px solid var(--studio-gray-5);
 		height: 44px;
 		vertical-align: middle;
 
-		color: var( --studio-gray-100 );
+		color: var(--studio-gray-100);
 		font-size: $font-body;
 		font-style: normal;
 		font-weight: 500;
@@ -35,10 +34,10 @@
 	}
 
 	.domains-table__domain-link {
-		color: var( --studio-gray-100 );
+		color: var(--studio-gray-100);
 
 		&:hover {
-			color: var( --color-link );
+			color: var(--color-link);
 		}
 	}
 

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -1,21 +1,33 @@
-@import "@automattic/typography/styles/variables";
+@import '@automattic/typography/styles/variables';
 
 .domains-table {
 	th {
 		padding-bottom: 16px;
-		color: var(--studio-gray-60);
+		border-bottom: 1px solid #f0f0f0;
+		vertical-align: middle;
+
+		color: var( --studio-gray-60 );
 		font-size: $font-body-small;
 		font-style: normal;
 		font-weight: 500;
 		line-height: 20px;
 	}
+
+	.domains-table__bulk-action-container {
+		width: 0;
+		min-width: fit-content;
+
+		.components-checkbox-control__input-container {
+			margin-right: 16px;
+		}
+	}
 	td {
 		padding: 20px 0;
-		border-bottom: 1px solid var(--studio-gray-5);
+		border-bottom: 1px solid var( --studio-gray-5 );
 		height: 44px;
 		vertical-align: middle;
 
-		color: var(--studio-gray-100);
+		color: var( --studio-gray-100 );
 		font-size: $font-body;
 		font-style: normal;
 		font-weight: 500;
@@ -23,10 +35,10 @@
 	}
 
 	.domains-table__domain-link {
-		color: var(--studio-gray-100);
+		color: var( --studio-gray-100 );
 
 		&:hover {
-			color: var(--color-link);
+			color: var( --color-link );
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3418.

## Proposed Changes

**Translators**: the translatable messages are accessible only by using a screen reader. It should activate whenever the checkboxes are focused.

This PR adds the ability to select domains by marking a checkbox. It allows domain cherry-picking as well as selecting all the domains from the table by clicking on the topmost checkbox:

https://github.com/Automattic/wp-calypso/assets/26530524/b1a2606e-6b9c-407b-b8d9-f71726dba523

I added the selected domains list inside `<DomainsTable />`. I initially added it as a dependency (prop) of the table along with the change handler, but since I figured that the bulk actions would be the same, regardless of the view (general or site-specific), I thought it would make more sense to couple it.

## Testing Instructions

1. Checkout this PR and open the `/domains/manage`
2. Verify that all domains are unchecked by default
3. Click a single row, and verify that the topmost checkbox is partially checked
4. Click the topmost checkbox and verify that it changes to checked, along with all domains becoming selected
5. Click any selected row and verify that the topmost checkbox becomes partially checked
6. Click the topmost checkbox in the partially checked state and verify that all domains became selected
7. Click the topmost checkbox again and verify that all domains became unselected

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
~- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~