### PR TITLE
Design Picker: Allow Marketplace plugins to be displayed as selected Theme

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -727,6 +727,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					siteId={ site.ID }
 					stylesheet={ selectedDesign.recipe?.stylesheet }
 					isVirtual={ selectedDesign.is_virtual }
+					isExternallyManaged={ selectedDesign.is_externally_managed }
 					selectedColorVariation={ selectedColorVariation }
 					onSelectColorVariation={ handleSelectColorVariation }
 					selectedFontVariation={ selectedFontVariation }

--- a/client/landing/stepper/hooks/use-theme-details.ts
+++ b/client/landing/stepper/hooks/use-theme-details.ts
@@ -11,6 +11,7 @@ type Theme = {
 	date_updated: string;
 	price: string;
 	taxonomies: Record< string, [] >;
+	theme_type?: string;
 };
 
 export function useThemeDetails( slug = '' ): UseQueryResult< Theme > {

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -27,6 +27,8 @@ interface DesignPreviewProps {
 	siteId: number;
 	stylesheet: string;
 	isVirtual?: boolean;
+	screenshot?: string;
+	isExternallyManaged?: boolean;
 	selectedColorVariation: GlobalStylesObject | null;
 	onSelectColorVariation: ( variation: GlobalStylesObject | null ) => void;
 	selectedFontVariation: GlobalStylesObject | null;
@@ -144,6 +146,7 @@ const DesignPreview = ( props: DesignPreviewProps ) => (
 		siteId={ props.siteId }
 		stylesheet={ props.stylesheet }
 		placeholder={ null }
+		isContextOptional={ !! props.isExternallyManaged }
 	>
 		<Preview { ...props } />
 	</GlobalStylesProvider>

--- a/packages/global-styles/src/constants.ts
+++ b/packages/global-styles/src/constants.ts
@@ -12,5 +12,5 @@ export const SYSTEM_FONT_SLUG = 'system-font';
 
 export const DEFAULT_GLOBAL_STYLES = {
 	settings: {},
-	styles: {},
+	styles: { blocks: {} },
 };

--- a/packages/global-styles/src/types.ts
+++ b/packages/global-styles/src/types.ts
@@ -49,6 +49,7 @@ export interface GlobalStylesObject {
 			};
 		};
 		typography?: Typography;
+		blocks?: object;
 	};
 }
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/80571

## Proposed Changes

Allow Marketplace plugins to be displayed as selected Theme by making the stylesheet retrieval optional for Marketplace Themes. This is needed because Marketplace stylesheets cannot be retrieved on all sites.

---

This page still needs more work to select to properly display Marketplace Themes: 
* https://github.com/Automattic/wp-calypso/issues/80836
*  https://github.com/Automattic/dotcom-forge/issues/2956

But this PR is needed to be used as a base for the following changes and can be merged as this area is inaccessible for Marketplace Themes until D118900-code is merged.

## Testing Instructions
* Apply the diff D118900-code to your sandbox and direct requests to the sandbox


**On this branch**
* Go to the Design Picker page with a Marketplace theme selected `/setup/update-design/designSetup?siteSlug=:site&theme=:theme_slug`. Theme slugs such as `makoney` and `olsen-fse` can be used.
* You should see the title and excerpt displayed

![CleanShot 2023-08-19 at 16 00 17@2x](https://github.com/Automattic/wp-calypso/assets/5039531/4ac790b6-2159-47ad-9b72-28ff5d79625c)

* On production, go to the same route.
* You should see a never-ending loading state
<img width="1213" alt="CleanShot 2023-08-19 at 16 29 06@2x" src="https://github.com/Automattic/wp-calypso/assets/5039531/c0a21352-0313-4fd6-8be9-6bffab3f2278">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
