### PR TITLE
Migration trial: Improve "Hosting Configuration" page

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -5,6 +5,7 @@ import {
 	FEATURE_SITE_STAGING_SITES,
 	WPCOM_FEATURES_ATOMIC,
 } from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import wrapWithClickOutside from 'react-click-outside';
@@ -24,6 +25,7 @@ import { ScrollToAnchorOnMount } from 'calypso/components/scroll-to-anchor-on-mo
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { GitHubCard } from 'calypso/my-sites/hosting/github';
+import TrialBanner from 'calypso/my-sites/plans/trials/trial-banner';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
@@ -37,7 +39,10 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
-import { isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
+import {
+	isSiteOnECommerceTrial,
+	isSiteOnMigrationTrial,
+} from 'calypso/state/sites/plans/selectors';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import CacheCard from './cache-card';
@@ -195,6 +200,7 @@ class Hosting extends Component {
 			isAdvancedHostingDisabled,
 			isBasicHostingDisabled,
 			isECommerceTrial,
+			isMigrationTrial,
 			isSiteAtomic,
 			isTransferring,
 			isWpcomStagingSite,
@@ -344,7 +350,16 @@ class Hosting extends Component {
 					) }
 					align="left"
 				/>
-				{ banner }
+				{ ! isMigrationTrial && banner }
+				{ isMigrationTrial && (
+					<TrialBanner
+						callToAction={
+							<Button primary href={ `/plans/${ siteSlug }` }>
+								{ translate( 'Upgrade plan' ) }
+							</Button>
+						}
+					/>
+				) }
 				{ getContent() }
 				<QueryReaderTeams />
 			</Main>
@@ -366,6 +381,7 @@ export default connect(
 		return {
 			teams: getReaderTeams( state ),
 			isECommerceTrial: isSiteOnECommerceTrial( state, siteId ),
+			isMigrationTrial: isSiteOnMigrationTrial( state, siteId ),
 			transferState: getAutomatedTransferStatus( state, siteId ),
 			isTransferring: isAutomatedTransferActive( state, siteId ),
 			isAdvancedHostingDisabled: ! hasSftpFeature || ! isSiteAtomic,

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -59,7 +59,7 @@ import './style.scss';
 
 const HEADING_OFFSET = 30;
 
-const ShowEnabledFeatureCards = ( { availableTypes, cards } ) => {
+const ShowEnabledFeatureCards = ( { availableTypes, cards, showDisabledCards = true } ) => {
 	const enabledCards = cards.filter(
 		( card ) => ! card.type || availableTypes.includes( card.type )
 	);
@@ -72,7 +72,7 @@ const ShowEnabledFeatureCards = ( { availableTypes, cards } ) => {
 			{ enabledCards.map( ( card ) => {
 				return <Fragment key={ card.feature }>{ card.content }</Fragment>;
 			} ) }
-			{ disabledCards.length > 0 && (
+			{ showDisabledCards && disabledCards.length > 0 && (
 				<FeatureExample>
 					{ disabledCards.map( ( card ) => {
 						return <Fragment key={ card.feature }>{ card.content }</Fragment>;
@@ -89,6 +89,7 @@ const MainCards = ( {
 	isBasicHostingDisabled,
 	isGithubIntegrationEnabled,
 	isWpcomStagingSite,
+	isMigrationTrial,
 	siteId,
 } ) => {
 	const mainCards = [
@@ -147,7 +148,13 @@ const MainCards = ( {
 		! isBasicHostingDisabled ? 'basic' : null,
 	].filter( ( type ) => type !== null );
 
-	return <ShowEnabledFeatureCards cards={ mainCards } availableTypes={ availableTypes } />;
+	return (
+		<ShowEnabledFeatureCards
+			cards={ mainCards }
+			availableTypes={ availableTypes }
+			showDisabledCards={ ! isMigrationTrial }
+		/>
+	);
 };
 
 const SidebarCards = ( { isBasicHostingDisabled } ) => {
@@ -313,6 +320,7 @@ class Hosting extends Component {
 								isBasicHostingDisabled={ isBasicHostingDisabled }
 								isGithubIntegrationEnabled={ isGithubIntegrationEnabled }
 								isWpcomStagingSite={ isWpcomStagingSite }
+								isMigrationTrial={ isMigrationTrial }
 								siteId={ siteId }
 							/>
 						</Column>

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -26,8 +26,20 @@
 		background: var(--color-surface);
 		box-shadow: 0 0 0 1px var(--color-border-subtle);
 
-		@include breakpoint-deprecated( "<480px" ) {
+	}
+
+	@include breakpoint-deprecated( "<480px" ) {
+		.card.trial-banner {
 			margin: 0 auto 0.625rem;
+
+			.trial-banner__content .trial-banner__title {
+				font-size: 1.25rem;
+				font-weight: normal;
+			}
+
+			.trial-banner__content .trial-banner__subtitle {
+				font-size: 1rem;
+			}
 		}
 	}
 

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -23,9 +23,27 @@
 	}
 
 	.card.trial-banner {
+		padding: 1.5rem;
 		background: var(--color-surface);
 		box-shadow: 0 0 0 1px var(--color-border-subtle);
 
+		.trial-banner__content {
+			padding-right: 0;
+		}
+
+		.trial-banner__content .trial-banner__title {
+			font-size: 2rem;
+			font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		}
+
+		.trial-banner__content .trial-banner__subtitle {
+			color: var(--color-text);
+		}
+
+		.trial-banner__chart-wrapper .trial-banner__chart-label {
+			font-size: 0.875rem;
+			color: var(--color-text);
+		}
 	}
 
 	@include breakpoint-deprecated( "<480px" ) {

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -25,6 +25,10 @@
 	.card.trial-banner {
 		background: var(--color-surface);
 		box-shadow: 0 0 0 1px var(--color-border-subtle);
+
+		@include breakpoint-deprecated( "<480px" ) {
+			margin: 0 auto 0.625rem;
+		}
 	}
 
 	@include breakpoint-deprecated( ">1280px" ) {

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -22,6 +22,11 @@
 		line-height: 32px;
 	}
 
+	.card.trial-banner {
+		background: var(--color-surface);
+		box-shadow: 0 0 0 1px var(--color-border-subtle);
+	}
+
 	@include breakpoint-deprecated( ">1280px" ) {
 		&__main-layout-col {
 			.card {


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3528

## Proposed Changes

* Hosting configuration page:
  * Show the "Upgrade plan" banner for Migration trial plan sites
  * Hide disabled features cards for Migration trial plan sites

## Testing Instructions

* Open a site with a Migration Trial plan
* Go to `Settings -> Hosting configuration` page
* Check if there is an "Upgrade plan" banner (see screenshot)
* Check if the "Upgrade plan" button leads to the plans page
* Check if the bottom of the page is without disabled features card


<img width="1090" alt="Screenshot 2023-08-21 at 00 19 59" src="https://github.com/Automattic/wp-calypso/assets/1241413/d0290b7b-69d8-4bf2-b3e9-0067e049d7ab">

<img width="1143" alt="Screenshot 2023-08-21 at 00 24 41" src="https://github.com/Automattic/wp-calypso/assets/1241413/9b336865-8b89-466c-8819-e3eed97b1d08">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
