### PR TITLE
display selected text in reblog editor

### DIFF
--- a/apps/wpcom-block-editor/src/default/features/press-this.js
+++ b/apps/wpcom-block-editor/src/default/features/press-this.js
@@ -12,7 +12,7 @@ if ( url ) {
 
 		const blocks = [];
 
-		if ( text ) {
+		if ( text && text !== title ) {
 			const link = `<a href="${ url }">${ title }</a>`;
 			blocks.push(
 				createBlock( 'core/quote', {

--- a/apps/wpcom-block-editor/src/default/features/press-this.js
+++ b/apps/wpcom-block-editor/src/default/features/press-this.js
@@ -3,7 +3,7 @@ import { dispatch } from '@wordpress/data';
 import { getQueryArgs } from '@wordpress/url';
 import { isEditorReady } from '../../utils';
 
-const { url, comment_content, comment_author } = getQueryArgs( window.location.href );
+const { url, title, text, comment_content, comment_author } = getQueryArgs( window.location.href );
 
 if ( url ) {
 	( async () => {
@@ -12,12 +12,21 @@ if ( url ) {
 
 		const blocks = [];
 
+		if ( text ) {
+			const link = `<a href="${ url }">${ title }</a>`;
+			blocks.push(
+				createBlock( 'core/quote', {
+					value: `<p>${ text }</p>`,
+					citation: link,
+				} )
+			);
+		}
+
 		if ( comment_content ) {
 			blocks.push(
 				createBlock( 'core/quote', { value: comment_content, citation: comment_author } )
 			);
 		}
-
 		blocks.push( createBlock( 'core/embed', { url, type: 'wp-embed' } ) );
 
 		dispatch( 'core/editor' ).resetEditorBlocks( blocks );

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -227,8 +227,8 @@ export const redirect = async ( context, next ) => {
 };
 
 function getPressThisData( query ) {
-	const { url, comment_content, comment_author } = query;
-	return url ? { url, comment_content, comment_author } : null;
+	const { url, text, title, comment_content, comment_author } = query;
+	return url ? { url, text, title, comment_content, comment_author } : null;
 }
 
 function getAnchorFmData( query ) {

--- a/client/my-sites/site-settings/press-this/link.jsx
+++ b/client/my-sites/site-settings/press-this/link.jsx
@@ -26,10 +26,6 @@ const pressThis = function ( postURL ) {
 		sel = docSel ? docSel.createRange().text : '';
 	}
 
-	if ( ! encodeURIComponent( sel ) ) {
-		sel = doc.title;
-	}
-
 	const url =
 		postURL +
 		'?url=' +


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/80742

Passes `text` and `title` along to the reblog editor and displays a quote to support the pressThis parameteres as described in https://github.com/Automattic/wp-calypso/issues/80742

Note that this updates the pressThis bookmarklet to not pass `text` if there is no text selection. The editor code will also be backwards compatible with old versions of the bookmarklet by comparing `text` with its default value of the page `title`.

https://github.com/Automattic/wp-calypso/assets/22446385/c2fa46be-818b-46a9-ad82-024157236464



### Test instructions

Sandbox your test site
start the app. 
`yarn start`
sync the wpcom-block-editor in another tab
`cd apps/wpcom-block-editor && yarn dev --sync`
Install the pressThis bookmarklet from `http://calypso.localhost:3000/settings/writing/$blog_slug`
use the pressThis bookmarklet with quoted text and the text should appear as a quote block before the embed link.