### PR TITLE
Domain Management i1: Update client so it can support domain test data

### DIFF
--- a/client/data/sites/use-site-query.ts
+++ b/client/data/sites/use-site-query.ts
@@ -1,10 +1,10 @@
-import { SiteDetails } from '@automattic/data-stores/src/site';
+import { getSiteQueryKey, SiteDetails } from '@automattic/data-stores';
 import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
 export const useSiteQuery = ( sourceSiteSlug: string, enabled = true ) => {
 	return useQuery( {
-		queryKey: [ 'site-details', sourceSiteSlug ],
+		queryKey: getSiteQueryKey( sourceSiteSlug ),
 		queryFn: (): Promise< SiteDetails > =>
 			wp.req.get( {
 				path: '/sites/' + encodeURIComponent( sourceSiteSlug as string ),

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -24,6 +24,7 @@ export * from './user/types';
 export * from './queries/use-launchpad';
 export * from './queries/use-all-domains-query';
 export * from './queries/use-site-domains-query';
+export * from './queries/use-site-query';
 
 const { SubscriptionManager } = Reader;
 

--- a/packages/data-stores/src/queries/use-site-domains-query.ts
+++ b/packages/data-stores/src/queries/use-site-domains-query.ts
@@ -103,7 +103,7 @@ export function useSiteDomainsQuery(
 				path: `/sites/${ siteIdOrSlug }/domains`,
 				apiVersion: '1.2',
 			} ),
-		enabled: Boolean( siteIdOrSlug ) && options.enabled,
 		...options,
+		enabled: Boolean( siteIdOrSlug ) && options.enabled,
 	} );
 }

--- a/packages/data-stores/src/queries/use-site-query.ts
+++ b/packages/data-stores/src/queries/use-site-query.ts
@@ -1,0 +1,25 @@
+import { SiteDetails } from '@automattic/data-stores/src/site';
+import { UseQueryOptions, useQuery } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+
+export const useSiteQuery = (
+	sourceSiteSlug: string | number | null | undefined,
+	options: UseQueryOptions< SiteDetails > = {}
+) => {
+	return useQuery( {
+		queryKey: getSiteQueryKey( sourceSiteSlug ),
+		queryFn: () =>
+			wpcomRequest< SiteDetails >( {
+				path: '/sites/' + encodeURIComponent( sourceSiteSlug ?? '' ),
+			} ),
+		meta: {
+			persist: false,
+		},
+		...options,
+		enabled: Boolean( sourceSiteSlug ) && options.enabled,
+	} );
+};
+
+export function getSiteQueryKey( sourceSiteSlug: string | number | null | undefined ) {
+	return [ 'site-details', sourceSiteSlug ];
+}

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,11 +1,15 @@
-import { useSiteDomainsQuery } from '@automattic/data-stores';
+import { useSiteDomainsQuery, useSiteQuery } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { PrimaryDomainLabel } from '../primary-domain-label';
-import type { PartialDomainData, SiteDomainsQueryFnData } from '@automattic/data-stores';
+import type {
+	PartialDomainData,
+	SiteDomainsQueryFnData,
+	SiteDetails,
+} from '@automattic/data-stores';
 
 interface DomainsTableRowProps {
 	domain: PartialDomainData;
@@ -16,6 +20,7 @@ interface DomainsTableRowProps {
 	fetchSiteDomains?: (
 		siteIdOrSlug: number | string | null | undefined
 	) => Promise< SiteDomainsQueryFnData >;
+	fetchSite?: ( siteIdOrSlug: number | string | null | undefined ) => Promise< SiteDetails >;
 }
 
 export function DomainsTableRow( {
@@ -24,29 +29,39 @@ export function DomainsTableRow( {
 	isSelected,
 	onSelect,
 	fetchSiteDomains,
+	fetchSite,
 }: DomainsTableRowProps ) {
 	const { __ } = useI18n();
 	const { ref, inView } = useInView( { triggerOnce: true } );
 
-	const { data } = useSiteDomainsQuery( domain.blog_id, {
+	const { data: allSiteDomains } = useSiteDomainsQuery( domain.blog_id, {
 		enabled: inView,
 		...( fetchSiteDomains && { queryFn: () => fetchSiteDomains( domain.blog_id ) } ),
 	} );
 
-	const { siteSlug, primaryDomain } = useMemo( () => {
-		const primaryDomain = data?.domains?.find( ( d ) => d.primary_domain );
-		const unmappedDomain = data?.domains?.find( ( d ) => d.wpcom_domain );
-		const siteSlug =
-			primaryDomain?.type === 'redirect' ? unmappedDomain?.domain : primaryDomain?.domain;
+	const isPrimaryDomain = useMemo(
+		() => allSiteDomains?.domains?.find( ( d ) => d.primary_domain )?.domain === domain.domain,
+		[ allSiteDomains, domain.domain ]
+	);
 
-		return {
-			// Fall back to the site's ID if we're still loading detailed domain data
-			siteSlug: siteSlug || domain.blog_id.toString( 10 ),
-			primaryDomain,
-		};
-	}, [ data, domain.blog_id ] );
+	const { data: site } = useSiteQuery( domain.blog_id, {
+		enabled: inView,
+		...( fetchSite && { queryFn: () => fetchSite( domain.blog_id ) } ),
+	} );
 
-	const isPrimaryDomain = primaryDomain?.domain === domain.domain;
+	const siteSlug = useMemo( () => {
+		if ( ! site?.URL ) {
+			// Fall back to the site's ID if we're still loading detailed site data
+			return domain.blog_id.toString( 10 );
+		}
+
+		if ( site.options.is_redirect && site.options.unmapped_url ) {
+			return new URL( site.options.unmapped_url ).host;
+		}
+
+		return new URL( site.URL ).host.replace( /\//g, '::' );
+	}, [ site, domain.blog_id ] );
+
 	const isManageableDomain = ! domain.wpcom_domain;
 	const shouldDisplayPrimaryDomainLabel = ! isAllSitesView && isPrimaryDomain;
 

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -2,7 +2,11 @@ import { useState, useCallback, useLayoutEffect } from 'react';
 import { DomainsTableColumn, DomainsTableHeader } from '../domains-table-header';
 import { domainsTableColumns } from '../domains-table-header/columns';
 import { DomainsTableRow } from './domains-table-row';
-import type { PartialDomainData, SiteDomainsQueryFnData } from '@automattic/data-stores';
+import type {
+	PartialDomainData,
+	SiteDomainsQueryFnData,
+	SiteDetails,
+} from '@automattic/data-stores';
 import './style.scss';
 
 interface DomainsTableProps {
@@ -14,9 +18,15 @@ interface DomainsTableProps {
 	fetchSiteDomains?: (
 		siteIdOrSlug: number | string | null | undefined
 	) => Promise< SiteDomainsQueryFnData >;
+	fetchSite?: ( siteIdOrSlug: number | string | null | undefined ) => Promise< SiteDetails >;
 }
 
-export function DomainsTable( { domains, fetchSiteDomains, isAllSitesView }: DomainsTableProps ) {
+export function DomainsTable( {
+	domains,
+	fetchSiteDomains,
+	fetchSite,
+	isAllSitesView,
+}: DomainsTableProps ) {
 	const [ { sortKey, sortDirection }, setSort ] = useState< {
 		sortKey: string;
 		sortDirection: 'asc' | 'desc';
@@ -127,6 +137,7 @@ export function DomainsTable( { domains, fetchSiteDomains, isAllSitesView }: Dom
 						isSelected={ selectedDomains.has( domain.domain ) }
 						onSelect={ handleSelectDomain }
 						fetchSiteDomains={ fetchSiteDomains }
+						fetchSite={ fetchSite }
 						isAllSitesView={ isAllSitesView }
 					/>
 				) ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3420

## Proposed Changes

* Adds a `window.localStorage` flag that can be used to fetch domain test data
* Fixes the way `<DomainsTableRow>` is calculating the site slug
* A quick unrelated fix to `useSiteDomainsQuery` so that the `options.enabled` flag gets merged correctly

While testing D119028-code I discovered that the way I was calculating the site slug was incorrect. I had just assumed that the site's primary domain would be what's used. However when using the test data I discovered that this wasn't the case. `primary-domain.com` is the primary domain, however that site's slug is actually `redirectsitetest.wordpress.com` 🤷‍♂️ This broken Calypso navigation. Unfortunately we've got to fetch the slug from the

There's an existing `useSiteQuery` hook in `client/data` which we can't use unfortunately. I made sure that we're at least using the same query key so that we'll at least be able to grab it from the cache if it's there. I thought about moving the hook from `client/data` to `@automattic/data-stores` and then simply re-exporting it from `client/data` so it would continue to work for existing code. However I'm too nervous about changing the fetch method from `wp.req.get` to `wpcomRequest` in case it breaks something.

This video shows how navigating in an out of domains using test data now works.


https://github.com/Automattic/wp-calypso/assets/1500769/de6c0b5a-db22-414c-aaf8-8b9bc09a2ab5



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Define `USE_STORE_SANDBOX ` and `USE_MOCKED_DOMAINS_LIST` as described in D119028-code
* In the JS console enter `window.localStorage.setItem('test-domains', true)`
* Test `/domains/manage?flags=domains/management`
* Test `/domains/manage/{{ SITE }}?flags=domains/management`
   * When using test data the exact site you're using doesn't matter

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
