### PR TITLE
[2nd try] Onboarding: Get rid of the headstart

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -1,4 +1,12 @@
-export const WRITE_INTENT_DEFAULT_DESIGN = {
+import type { Design } from '@automattic/design-picker';
+
+export const WRITE_INTENT_DEFAULT_DESIGN: Design = {
+	slug: 'livro',
+	title: 'Livro',
+	is_premium: false,
+	categories: [],
+	features: [],
+	template: 'livro',
 	theme: 'livro',
 };
 

--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -53,7 +53,7 @@ export function activateTheme(
 		} );
 
 		return wpcom.req
-			.post( `/sites/${ siteId }/themes/mine`, {
+			.post( `/sites/${ siteId }/themes/mine?_locale=user`, {
 				theme: themeId,
 				...( dontChangeHomepage && { dont_change_homepage: true } ),
 				...( isEnabled( 'themes/theme-switch-persist-template' ) && {

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -599,9 +599,9 @@ describe( 'actions', () => {
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.post( '/rest/v1.1/sites/2211667/themes/mine', { theme: 'twentysixteen' } )
+				.post( '/rest/v1.1/sites/2211667/themes/mine?_locale=user', { theme: 'twentysixteen' } )
 				.reply( 200, { id: 'karuna', version: '1.0.3' } )
-				.post( '/rest/v1.1/sites/2211667/themes/mine', { theme: 'badTheme' } )
+				.post( '/rest/v1.1/sites/2211667/themes/mine?_locale=user', { theme: 'badTheme' } )
 				.reply( 404, {
 					error: 'theme_not_found',
 					message: 'The specified theme was not found',

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -381,15 +381,17 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		selectedDesign: Design,
 		options: DesignOptions = {}
 	) {
-		const shouldRunThemeSetup = THEME_SLUGS_THAT_SHOULD_RUN_THEME_SETUP.includes(
-			selectedDesign.slug
-		);
+		const themeSlug =
+			selectedDesign.slug ||
+			selectedDesign.recipe?.stylesheet?.split( '/' )[ 1 ] ||
+			selectedDesign.theme;
+		const shouldRunThemeSetup = THEME_SLUGS_THAT_SHOULD_RUN_THEME_SETUP.includes( themeSlug );
 		const { keepHomepage = shouldRunThemeSetup, styleVariation, globalStyles } = options;
 		const activatedTheme: ActiveTheme = yield wpcomRequest( {
 			path: `/sites/${ siteSlug }/themes/mine?_locale=user`,
 			apiVersion: '1.1',
 			body: {
-				theme: selectedDesign.slug,
+				theme: themeSlug,
 				dont_change_homepage: keepHomepage,
 			},
 			method: 'POST',

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -397,7 +397,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 
 		// @todo Always use the global styles for consistency
 		if ( styleVariation?.slug ) {
-			const variations: GlobalStyles[] = yield getGlobalStylesVariations(
+			const variations: GlobalStyles[] = yield* getGlobalStylesVariations(
 				siteSlug,
 				activatedTheme.stylesheet
 			);
@@ -408,7 +408,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			);
 
 			if ( currentVariation ) {
-				yield setGlobalStyles(
+				yield* setGlobalStyles(
 					siteSlug,
 					activatedTheme.stylesheet,
 					currentVariation,
@@ -418,11 +418,11 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		}
 
 		if ( globalStyles ) {
-			yield setGlobalStyles( siteSlug, activatedTheme.stylesheet, globalStyles, activatedTheme );
+			yield* setGlobalStyles( siteSlug, activatedTheme.stylesheet, globalStyles, activatedTheme );
 		}
 
 		if ( shouldRunThemeSetup ) {
-			yield runThemeSetupOnSite( siteSlug );
+			yield* runThemeSetupOnSite( siteSlug );
 		}
 
 		return activatedTheme;

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -371,7 +371,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 	) {
 		const { keepHomepage = false, styleVariation, globalStyles } = options;
 		const activatedTheme: ActiveTheme = yield wpcomRequest( {
-			path: `/sites/${ siteSlug }/themes/mine`,
+			path: `/sites/${ siteSlug }/themes/mine?_locale=user`,
 			apiVersion: '1.1',
 			body: {
 				theme: selectedDesign.recipe?.stylesheet?.split( '/' )[ 1 ] || selectedDesign.theme,

--- a/packages/data-stores/src/site/constants.ts
+++ b/packages/data-stores/src/site/constants.ts
@@ -1,3 +1,5 @@
 export const STORE_KEY = 'automattic/site';
 
 export const PLACEHOLDER_SITE_ID = 220580624; // creatiodemo.wordpress.com
+
+export const THEME_SLUGS_THAT_SHOULD_RUN_THEME_SETUP = [ 'arbutus', 'byrne', 'geologist' ];

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -438,18 +438,8 @@ describe( 'Site Actions', () => {
 		const createMockedThemeSwitchApiRequest = ( payload ) => ( {
 			type: 'WPCOM_REQUEST',
 			request: {
-				path: `/sites/${ siteSlug }/themes/mine`,
+				path: `/sites/${ siteSlug }/themes/mine?_locale=user`,
 				apiVersion: '1.1',
-				body: payload,
-				method: 'POST',
-			},
-		} );
-
-		const createMockedThemeSetupApiRequest = ( payload ) => ( {
-			type: 'WPCOM_REQUEST',
-			request: {
-				path: `/sites/${ siteSlug }/theme-setup/?_locale=user`,
-				apiNamespace: 'wpcom/v2',
 				body: payload,
 				method: 'POST',
 			},
@@ -465,112 +455,9 @@ describe( 'Site Actions', () => {
 			expect( generator.next().value ).toEqual(
 				createMockedThemeSwitchApiRequest( {
 					theme: 'zoologist',
-					dont_change_homepage: true,
+					dont_change_homepage: false,
 				} )
 			);
-		} );
-
-		it( 'should send pattern_ids to theme-setup API if the recipe of the design has this property', () => {
-			const { setDesignOnSite } = createActions( mockedClientCredentials );
-			const patternIds = [ 1, 2, 3 ];
-			const generator = setDesignOnSite( siteSlug, {
-				...mockedDesign,
-				recipe: {
-					...mockedRecipe,
-					pattern_ids: patternIds,
-				},
-			} );
-
-			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
-			expect( generator.next().value ).toEqual(
-				createMockedThemeSwitchApiRequest( {
-					theme: 'zoologist',
-					dont_change_homepage: true,
-				} )
-			);
-
-			// Second iteration: WP_COM_REQUEST to /sites/${ siteSlug }/theme-setup is fired
-			expect( generator.next().value ).toEqual(
-				createMockedThemeSetupApiRequest( {
-					trim_content: true,
-					pattern_ids: patternIds,
-				} )
-			);
-		} );
-
-		it( 'should send header_pattern_ids to theme-setup API if the recipe of the design has this property', () => {
-			const { setDesignOnSite } = createActions( mockedClientCredentials );
-			const headerPatternIds = [ 1, 2, 3 ];
-			const generator = setDesignOnSite( siteSlug, {
-				...mockedDesign,
-				recipe: {
-					...mockedRecipe,
-					header_pattern_ids: headerPatternIds,
-				},
-			} );
-
-			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
-			expect( generator.next().value ).toEqual(
-				createMockedThemeSwitchApiRequest( {
-					theme: 'zoologist',
-					dont_change_homepage: true,
-				} )
-			);
-
-			// Second iteration: WP_COM_REQUEST to /sites/${ siteSlug }/theme-setup is fired
-			expect( generator.next().value ).toEqual(
-				createMockedThemeSetupApiRequest( {
-					trim_content: true,
-					header_pattern_ids: headerPatternIds,
-				} )
-			);
-		} );
-
-		it( 'should send footer_pattern_ids to theme-setup API if the recipe of the design has this property', () => {
-			const { setDesignOnSite } = createActions( mockedClientCredentials );
-			const footerPatternIds = [ 1, 2, 3 ];
-			const generator = setDesignOnSite( siteSlug, {
-				...mockedDesign,
-				recipe: {
-					...mockedRecipe,
-					footer_pattern_ids: footerPatternIds,
-				},
-			} );
-
-			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
-			expect( generator.next().value ).toEqual(
-				createMockedThemeSwitchApiRequest( {
-					theme: 'zoologist',
-					dont_change_homepage: true,
-				} )
-			);
-
-			// Second iteration: WP_COM_REQUEST to /sites/${ siteSlug }/theme-setup is fired
-			expect( generator.next().value ).toEqual(
-				createMockedThemeSetupApiRequest( {
-					trim_content: true,
-					footer_pattern_ids: footerPatternIds,
-				} )
-			);
-		} );
-
-		it( 'should not call theme-setup api if the design is any of the anchor designs', () => {
-			const { setDesignOnSite } = createActions( mockedClientCredentials );
-			const generator = setDesignOnSite( siteSlug, {
-				...mockedDesign,
-				template: 'hannah',
-			} );
-
-			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
-			expect( generator.next().value ).toEqual(
-				createMockedThemeSwitchApiRequest( {
-					theme: 'zoologist',
-					dont_change_homepage: true,
-				} )
-			);
-
-			// Second iteration: Complete the cycle
-			expect( generator.next().done ).toEqual( true );
 		} );
 	} );
 } );

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -481,15 +481,6 @@ export interface LaunchPadCheckListTasksStatuses {
 	plan_completed?: boolean;
 }
 
-export interface ThemeSetupOptions {
-	trim_content?: boolean;
-	vertical_id?: string;
-	pattern_ids?: number[] | string[];
-	header_pattern_ids?: number[] | string[];
-	footer_pattern_ids?: number[] | string[];
-	posts_source_site_id?: number;
-}
-
 export interface ActiveTheme {
 	stylesheet: string;
 	_links: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80732, D119166-code

## Proposed Changes

* As the title, we want to get rid of the headstart during the onboarding. Hence, this PR is focusing on avoid calling the theme-setup endpoint during the onboarding

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_site>
* Continue until you land on the Design Picker
* Pick the following themes that have a static homepage
  * byrne
  * arbutus
  * attar
  * geologist
  * marl
* Ensure the homepage after the onboarding is the same as the theme
* Repeat the above steps, and now pick the themes that are using the template as their homepage
* Ensure the homepage is still correct after the onboarding

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
