### PR TITLE
Jetpack Pro Dashboard: add UI test cases for downtime monitoring changes(all /downtime-monitoring components)

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/feature-restriction-badge/test/feature-restriction-badge.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/feature-restriction-badge/test/feature-restriction-badge.tsx
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import FeatureRestrictionBadge from '../index';
+
+describe( 'FeatureRestrictionBadge', () => {
+	const initialState = {};
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'renders the "Upgrade" badge when restriction is "upgrade_required', () => {
+		render( <FeatureRestrictionBadge restriction="upgrade_required" />, { wrapper: Wrapper } );
+		expect( screen.getByText( 'Upgrade' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders "Not Available" badge when restriction is "free_site_selected"', () => {
+		render( <FeatureRestrictionBadge restriction="free_site_selected" />, { wrapper: Wrapper } );
+		expect( screen.getByText( 'Not Available' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders nothing when restriction is undefined', () => {
+		render( <FeatureRestrictionBadge /> );
+		expect( screen.queryByText( 'Upgrade' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Not Available' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/not-available-badge/test/not-available-badge.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/not-available-badge/test/not-available-badge.tsx
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import NotAvailableBadge from '../index';
+
+describe( 'NotAvailableBadge', () => {
+	it( 'renders the badge text', () => {
+		render( <NotAvailableBadge /> );
+		const badge = screen.getByText( 'Not Available' );
+		expect( badge ).toBeInTheDocument();
+	} );
+
+	it( 'shows tooltip on mouse hover', () => {
+		render( <NotAvailableBadge /> );
+
+		const badgeWrapper = screen.getByRole( 'button', { name: 'Not Available' } );
+		act( () => {
+			userEvent.hover( badgeWrapper );
+		} );
+		waitFor( () => {
+			expect(
+				screen.getByText( 'One of the selected sites does not have a Basic plan.' )
+			).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/test/toggle-activate-monitoring.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/test/toggle-activate-monitoring.tsx
@@ -1,0 +1,152 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { site } from '../../../sites-overview/test/test-utils/constants';
+import ToggleActivateMonitoring from '../index';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const config = () => 'development';
+	config.isEnabled = ( property: string ) => property === 'jetpack/pro-dashboard-monitor-paid-tier';
+	return config;
+} );
+
+describe( 'ToggleActivateMonitoring', () => {
+	const defaultProps = {
+		site,
+		status: 'success',
+		settings: site.monitor_settings,
+		tooltip: 'Tooltip content',
+		tooltipId: 'tooltip123',
+		siteError: false,
+		isLargeScreen: false,
+	};
+
+	const initialState = {};
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'renders the component with toggle content when checked', () => {
+		render( <ToggleActivateMonitoring { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+
+		const checkbox = screen.getByRole( 'checkbox', { name: /current schedule/i } );
+		expect( checkbox ).toBeInTheDocument();
+		expect( checkbox ).toBeChecked();
+	} );
+
+	it( 'renders the component with toggle content when unchecked', () => {
+		render( <ToggleActivateMonitoring { ...defaultProps } status="disabled" />, {
+			wrapper: Wrapper,
+		} );
+
+		const checkbox = screen.getByRole( 'checkbox' );
+		expect( checkbox ).toBeInTheDocument();
+		expect( checkbox ).not.toBeChecked();
+	} );
+
+	it( 'renders the component with toggle content and shows the default tooltip', () => {
+		render( <ToggleActivateMonitoring { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+
+		const button = screen.getByRole( 'button', { name: /current schedule/i } );
+		expect( button ).toBeInTheDocument();
+		act( () => {
+			userEvent.hover( button );
+		} );
+		waitFor( () => {
+			expect( screen.getByText( defaultProps.tooltip ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders the component with toggle content and shows the SMS overlimit tooltip', () => {
+		const props = {
+			...defaultProps,
+			settings: {
+				...defaultProps.settings,
+				is_over_limit: true,
+			},
+		};
+		render( <ToggleActivateMonitoring { ...props } />, {
+			wrapper: Wrapper,
+		} );
+
+		const button = screen.getByRole( 'button', { name: /alert/i } );
+		expect( button ).toBeInTheDocument();
+		act( () => {
+			userEvent.hover( button );
+		} );
+		waitFor( () => {
+			expect( screen.getByText( 'You have reached the SMS limit' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders the component with toggle content and shows the upgrade tooltip', () => {
+		const props = {
+			...defaultProps,
+			site: {
+				...defaultProps.site,
+				has_paid_agency_monitor: false,
+			},
+		};
+		render( <ToggleActivateMonitoring { ...props } />, {
+			wrapper: Wrapper,
+		} );
+
+		const button = screen.getByRole( 'button', { name: /current schedule/i } );
+		expect( button ).toBeInTheDocument();
+		act( () => {
+			userEvent.hover( button );
+		} );
+		waitFor( () => {
+			expect( screen.getByText( 'Maximise uptime' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders the component with correct aria label for notification schedule in minutes', () => {
+		render( <ToggleActivateMonitoring { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+
+		expect(
+			screen.getByRole( 'button', {
+				name: 'The current notification schedule is set to 5 minutes. Click here to update the settings',
+			} )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders the component with correct aria label for notification schedule in hours', () => {
+		const props = {
+			...defaultProps,
+			settings: {
+				...defaultProps.settings,
+				monitor_deferment_time: 60,
+			},
+		};
+		render( <ToggleActivateMonitoring { ...props } />, {
+			wrapper: Wrapper,
+		} );
+
+		expect(
+			screen.getByRole( 'button', {
+				name: 'The current notification schedule is set to 1 hour. Click here to update the settings',
+			} )
+		).toBeInTheDocument();
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-badge/test/upgrade-badge.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-badge/test/upgrade-badge.tsx
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import UpgradeBadge from '../index';
+
+describe( 'UpgradeBadge', () => {
+	const initialState = {};
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'renders the badge text', () => {
+		render( <UpgradeBadge />, { wrapper: Wrapper } );
+		const badge = screen.getByText( 'Upgrade' );
+		expect( badge ).toBeInTheDocument();
+	} );
+
+	it( 'shows tooltip on mouse hover', () => {
+		render( <UpgradeBadge />, { wrapper: Wrapper } );
+
+		const badgeWrapper = screen.getByRole( 'button', { name: 'Upgrade' } );
+		act( () => {
+			userEvent.hover( badgeWrapper );
+		} );
+		waitFor( () => {
+			expect( screen.getByText( 'Maximise uptime' ) ).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/test/upgrade-link.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/test/upgrade-link.tsx
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import SitesOverviewContext from '../../../sites-overview/context';
+import DashboardDataContext from '../../../sites-overview/dashboard-data-context';
+import UpgradeLink from '../index';
+
+describe( 'UpgradeLink', () => {
+	const dashboardContextValue = {
+		verifiedContacts: {
+			emails: [],
+			phoneNumbers: [],
+			refetchIfFailed: jest.fn(),
+		},
+		products: [
+			{
+				name: 'Jetpack Monitor',
+				slug: 'jetpack-monitor',
+				product_id: 123,
+				currency: 'USD',
+				amount: 1,
+				price_interval: 'month',
+				family_slug: 'jetpack-monitor',
+			},
+		],
+		isLargeScreen: true,
+	};
+
+	const initialState = {};
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'renders the upgrade link text', () => {
+		render(
+			<DashboardDataContext.Provider value={ dashboardContextValue }>
+				<UpgradeLink />
+			</DashboardDataContext.Provider>,
+			{ wrapper: Wrapper }
+		);
+		const upgradeLink = screen.getByText( 'Upgrade ($1.00/m)' );
+		expect( upgradeLink ).toBeInTheDocument();
+	} );
+
+	it( 'renders the upgrade link text and onclick works', () => {
+		const mockShowLicenseInfo = jest.fn();
+
+		render(
+			// We need only the showLicenseInfo function from the context
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			<SitesOverviewContext.Provider value={ { showLicenseInfo: mockShowLicenseInfo } }>
+				<DashboardDataContext.Provider value={ dashboardContextValue }>
+					<UpgradeLink />
+				</DashboardDataContext.Provider>
+			</SitesOverviewContext.Provider>,
+			{ wrapper: Wrapper }
+		);
+		const upgradeLink = screen.getByText( 'Upgrade ($1.00/m)' );
+		expect( upgradeLink ).toBeInTheDocument();
+		fireEvent.click( upgradeLink );
+		expect( mockShowLicenseInfo ).toHaveBeenCalledWith( 'monitor' );
+	} );
+
+	it( 'renders the upgrade link text inline', () => {
+		render(
+			<DashboardDataContext.Provider value={ dashboardContextValue }>
+				<UpgradeLink isInline />
+			</DashboardDataContext.Provider>,
+			{ wrapper: Wrapper }
+		);
+
+		const upgradeLink = screen.getByText( 'Upgrade ($1.00/m)' );
+		expect( upgradeLink.parentElement ).toHaveClass( 'is-inline' );
+	} );
+
+	it( 'renders the upgrade link text when the price is undefined', () => {
+		render(
+			<DashboardDataContext.Provider value={ { ...dashboardContextValue, products: [] } }>
+				<UpgradeLink />
+			</DashboardDataContext.Provider>,
+			{ wrapper: Wrapper }
+		);
+		const upgradeLink = screen.getByText( 'Upgrade' );
+		expect( upgradeLink ).toBeInTheDocument();
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/index.tsx
@@ -86,8 +86,13 @@ export default function UpgradePopover( {
 		>
 			<h2 className="upgrade-popover__heading">{ translate( 'Maximise uptime' ) }</h2>
 			{ dismissibleWithPreference && (
-				<Button borderless className="upgrade-popover__close-button">
-					<Icon icon={ close } onClick={ handleClose } size={ 16 } />
+				<Button
+					borderless
+					className="upgrade-popover__close-button"
+					aria-label={ translate( 'Close' ) }
+					onClick={ handleClose }
+				>
+					<Icon icon={ close } size={ 16 } />
 				</Button>
 			) }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/test/upgrade-popover.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/test/upgrade-popover.tsx
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import SitesOverviewContext from '../../../sites-overview/context';
+import UpgradePopover from '../index';
+
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useDispatch: jest.fn().mockImplementation( () => jest.fn() ),
+} ) );
+
+describe( 'UpgradePopover', () => {
+	const initialState = {};
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	const defaultProps = {
+		context: document.createElement( 'div' ),
+		isVisible: true,
+	};
+
+	it( 'renders the component when the popover is visible and not dismissible', () => {
+		render( <UpgradePopover { ...defaultProps } />, { wrapper: Wrapper } );
+
+		expect( screen.getByText( 'Maximise uptime' ) ).toBeInTheDocument();
+		expect( screen.getByText( '1 minute monitoring interval' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'SMS Notifications' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Multiple email recipients' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Explore' } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Close' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'calls the right methods when Explore button is clicked', () => {
+		const mockShowLicenseInfo = jest.fn();
+		const onClose = jest.fn();
+
+		render(
+			// We need only the showLicenseInfo function from the context
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			<SitesOverviewContext.Provider value={ { showLicenseInfo: mockShowLicenseInfo } }>
+				<UpgradePopover { ...defaultProps } onClose={ onClose } />
+			</SitesOverviewContext.Provider>,
+			{ wrapper: Wrapper }
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Explore' } ) );
+		expect( mockShowLicenseInfo ).toHaveBeenCalledWith( 'monitor' );
+		expect( onClose ).toHaveBeenCalled();
+	} );
+
+	it( 'renders an empty component when the popover is not visible', () => {
+		render( <UpgradePopover { ...defaultProps } isVisible={ false } />, { wrapper: Wrapper } );
+		expect( screen.queryByText( 'Maximise uptime' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the component when the popover is dismissible and show close button', () => {
+		const onClose = jest.fn();
+		render( <UpgradePopover dismissibleWithPreference onClose={ onClose } { ...defaultProps } />, {
+			wrapper: Wrapper,
+		} );
+
+		expect( screen.getByText( 'Maximise uptime' ) ).toBeInTheDocument();
+		const closeButton = screen.getByRole( 'button', { name: 'Close' } );
+		expect( closeButton ).toBeInTheDocument();
+		fireEvent.click( closeButton );
+		expect( onClose ).toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Related to 

- 1202619025189113-as-1205290901768401
- 1202619025189113-as-1205290901768402
- 1202619025189113-as-1205290901768403
- 1202619025189113-as-1205290901768404
- 1202619025189113-as-1205290901768405
- 1202619025189113-as-1205290901768406 

## Proposed Changes

This PR adds test cases to the remaining /downtime-monitoring components added as a part of the downtime-monitoring changes.

## Testing Instructions

- Run `git checkout add/test-cases-for-downtime-monitoring-changes-4 && git pull`
- Run `yarn run test-client client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/` to run the tests.
- Verify the tests are passing and code changes make sense

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
