### PR TITLE
Fix crash when spreading action.activePromotions REST response

### DIFF
--- a/client/state/active-promotions/reducer.js
+++ b/client/state/active-promotions/reducer.js
@@ -20,7 +20,11 @@ import { itemsSchema } from './schema';
 export const items = withSchemaValidation( itemsSchema, ( state = [], action ) => {
 	switch ( action.type ) {
 		case ACTIVE_PROMOTIONS_RECEIVE:
-			return [ ...action.activePromotions ];
+			// Sometimes an empty PHP can be serialized as `{}` object, force to array in that case
+			if ( ! Array.isArray( action.activePromotions ) ) {
+				return [];
+			}
+			return action.activePromotions;
 	}
 
 	return state;

--- a/client/state/active-promotions/test/reducer.js
+++ b/client/state/active-promotions/test/reducer.js
@@ -53,6 +53,14 @@ describe( 'reducer', () => {
 			expect( newState ).toEqual( expectedState );
 		} );
 
+		test( 'should handle non-array response', () => {
+			const initialState = WPCOM_RESPONSE;
+			const action = activePromotionsReceiveAction( {} );
+
+			const newState = itemsReducer( initialState, action );
+			expect( newState ).toEqual( [] );
+		} );
+
 		test( 'should persist state', () => {
 			const activePromotions = WPCOM_RESPONSE;
 			const initialState = activePromotions;


### PR DESCRIPTION
Fixes a crash reported by Sentry as:
```
action.activePromotions is not iterable
```
The `action.activePromotions` value is coming from a REST `/me/active-promotions` response. I'm adding a guard that checks if the response is an array before storing it in state.

Apparently, for some reason, the response can be a non-array. One possibility is that the PHP server wants to send an empty PHP array (`[]`) which is however serialized to an empty JSON object (`{}`).

