### PR TITLE
Jetpack Error UX: Add tests for site indicator

### DIFF
--- a/client/my-sites/site-indicator/index.jsx
+++ b/client/my-sites/site-indicator/index.jsx
@@ -23,7 +23,7 @@ import './style.scss';
 
 const WPAdminLink = ( props ) => <ExternalLink icon iconSize={ 12 } target="_blank" { ...props } />;
 
-class SiteIndicator extends Component {
+export class SiteIndicator extends Component {
 	static propTypes = {
 		site: PropTypes.object,
 
@@ -263,7 +263,11 @@ class SiteIndicator extends Component {
 			<div className={ indicatorClass }>
 				{ ! this.state.expand && (
 					<Animate type="appear">
-						<button className="site-indicator__button" onClick={ this.toggleExpand }>
+						<button
+							data-testid="site-indicator-button"
+							className="site-indicator__button"
+							onClick={ this.toggleExpand }
+						>
 							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 							<Gridicon icon={ this.getIcon() } size={ 16 } />
 							{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
@@ -271,7 +275,7 @@ class SiteIndicator extends Component {
 					</Animate>
 				) }
 				{ this.state.expand && (
-					<div className="site-indicator__message">
+					<div data-testid="site-indicator-message" className="site-indicator__message">
 						<div className="site-indicator__action">{ this.getText() }</div>
 						<button className="site-indicator__button" onClick={ this.toggleExpand }>
 							<Animate type="appear">

--- a/client/my-sites/site-indicator/test/index.js
+++ b/client/my-sites/site-indicator/test/index.js
@@ -1,0 +1,153 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { SiteIndicator } from '..';
+
+const INITIAL_STATE = {
+	sites: {
+		items: {},
+	},
+};
+const mockStore = configureStore();
+jest.mock( 'calypso/components/data/query-site-connection-status', () => () => {
+	return <></>;
+} );
+
+const store = mockStore( INITIAL_STATE );
+
+const defaultProps = {
+	site: {
+		ID: 123,
+		canUpdateFiles: true,
+		slug: 'example.com',
+		options: {
+			admin_url: 'https://example.com/wp-admin/',
+		},
+	},
+	recordGoogleEvent: jest.fn(),
+	recordTracksEvent: jest.fn(),
+	trackSiteDisconnect: jest.fn(),
+	translate: ( text ) => text,
+};
+
+describe( 'SiteIndicator component', () => {
+	beforeAll( () => {
+		// Mock the missing `window.matchMedia` function that's not even in JSDOM
+		Object.defineProperty( window, 'matchMedia', {
+			writable: true,
+			value: jest.fn().mockImplementation( ( query ) => ( {
+				matches: false,
+				media: query,
+				onchange: null,
+				addListener: jest.fn(), // deprecated
+				removeListener: jest.fn(), // deprecated
+				addEventListener: jest.fn(),
+				removeEventListener: jest.fn(),
+				dispatchEvent: jest.fn(),
+			} ) ),
+		} );
+		jest.clearAllMocks();
+	} );
+	it( 'should show update indicator if site is not atomic and has updates', () => {
+		const { container } = render(
+			<SiteIndicator
+				{ ...{
+					...defaultProps,
+					...{
+						userCanManage: true,
+						siteIsJetpack: true,
+
+						siteIsConnected: true,
+						siteIsAutomatedTransfer: false,
+
+						siteUpdates: { total: 1 },
+					},
+				} }
+			/>
+		);
+
+		const errorIndicator = container.getElementsByClassName( 'is-error' );
+		const updateIndicator = container.getElementsByClassName( 'is-update' );
+
+		expect( errorIndicator.length ).toBe( 0 );
+		expect( updateIndicator.length ).toBe( 1 );
+	} );
+	it( 'should not show upates for atomic sites', () => {
+		const { container } = render(
+			<SiteIndicator
+				{ ...{
+					...defaultProps,
+					...{
+						userCanManage: true,
+						siteIsJetpack: true,
+
+						siteIsConnected: true,
+						siteIsAutomatedTransfer: true,
+
+						siteUpdates: { total: 1 },
+					},
+				} }
+			/>
+		);
+
+		const errorIndicator = container.getElementsByClassName( 'is-error' );
+		const updateIndicator = container.getElementsByClassName( 'is-update' );
+
+		expect( errorIndicator.length ).toBe( 0 );
+		expect( updateIndicator.length ).toBe( 0 );
+	} );
+
+	it( 'should show error indicator if the Jetpack connection is malfunctioning', () => {
+		const { container } = render(
+			<SiteIndicator
+				{ ...{
+					...defaultProps,
+					...{
+						userCanManage: true,
+						siteIsJetpack: true,
+
+						siteIsConnected: false,
+						siteIsAutomatedTransfer: false,
+
+						siteUpdates: { total: 1 },
+					},
+				} }
+			/>
+		);
+
+		const errorIndicator = container.getElementsByClassName( 'is-error' );
+		const updateIndicator = container.getElementsByClassName( 'is-update' );
+
+		expect( errorIndicator.length ).toBe( 1 );
+		expect( updateIndicator.length ).toBe( 0 );
+	} );
+
+	it( 'should show indicator message on expand', () => {
+		render(
+			<Provider store={ store }>
+				<SiteIndicator
+					{ ...{
+						...defaultProps,
+						...{
+							userCanManage: true,
+							siteIsJetpack: true,
+
+							siteIsConnected: false,
+							siteIsAutomatedTransfer: false,
+
+							siteUpdates: { total: 1 },
+						},
+					} }
+				/>
+			</Provider>
+		);
+
+		expect( screen.queryByTestId( 'site-indicator-message' ) ).not.toBeInTheDocument();
+		const button = screen.getByTestId( 'site-indicator-button' );
+		fireEvent.click( button );
+		expect( screen.queryByTestId( 'site-indicator-message' ) ).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3532

## Proposed Changes

Recently we pushed a pr that updates indicator was mistakenly shown for atomic sites. This pr adds some tests to avoid breaking the site indicator in the future.


## Testing Instructions
- Checkout the branch
- Run `yarn test-client -- client/my-sites/site-indicator/test/index.js`
- Make sure tests are passing.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
