### PR TITLE
Migration trial banner: Update subtitle copy for Migration trial plan

### DIFF
--- a/client/my-sites/plans/trials/trial-banner/index.tsx
+++ b/client/my-sites/plans/trials/trial-banner/index.tsx
@@ -1,5 +1,4 @@
 import { Card } from '@automattic/components';
-import { useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useSelector } from 'calypso/state';
@@ -11,6 +10,7 @@ import {
 } from 'calypso/state/sites/plans/selectors/trials/trials-expiration';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import DoughnutChart from '../../doughnut-chart';
+import useBannerSubtitle from './use-banner-subtitle';
 
 import './style.scss';
 
@@ -31,7 +31,6 @@ const TrialBanner = ( props: TrialBannerProps ) => {
 		} )
 	);
 
-	const locale = useLocale();
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 
@@ -45,35 +44,18 @@ const TrialBanner = ( props: TrialBannerProps ) => {
 	let trialProgress = Math.min( trialDaysLeft / trialDuration, 1 );
 	trialProgress = Math.max( trialProgress, 0 );
 	const trialDaysLeftToDisplay = trialExpired ? 0 : trialDaysLeft;
-
-	// moment.js doesn't have a format option to display the long form in a localized way without the year
-	// https://github.com/moment/moment/issues/3341
-	const readableExpirationDate = trialExpiration?.toDate().toLocaleDateString( locale, {
-		month: 'long',
-		day: 'numeric',
-	} );
+	const bannerSubtitle = useBannerSubtitle(
+		currentPlan?.productSlug,
+		trialExpired,
+		trialDaysLeftToDisplay,
+		trialExpiration
+	);
 
 	return (
 		<Card className="trial-banner">
 			<div className="trial-banner__content">
 				<p className="trial-banner__title">{ translate( 'You’re in a free trial' ) }</p>
-				<p className="trial-banner__subtitle">
-					{ trialExpired
-						? translate(
-								'Your free trial has expired. Upgrade to a plan to unlock new features and start selling.'
-						  )
-						: translate(
-								'Your free trial will end in %(daysLeft)d day. Upgrade to a plan by %(expirationdate)s to unlock new features and start selling.',
-								'Your free trial will end in %(daysLeft)d days. Upgrade to a plan by %(expirationdate)s to unlock new features and start selling.',
-								{
-									count: trialDaysLeftToDisplay,
-									args: {
-										daysLeft: trialDaysLeftToDisplay,
-										expirationdate: readableExpirationDate as string,
-									},
-								}
-						  ) }
-				</p>
+				<p className="trial-banner__subtitle">{ bannerSubtitle }</p>
 				{ callToAction }
 			</div>
 			<div className="trial-banner__chart-wrapper">

--- a/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
+++ b/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
@@ -1,0 +1,68 @@
+import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { useLocale } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useEffect } from 'react';
+import type { Moment } from 'moment/moment';
+
+export default function useBannerSubtitle(
+	currentPlanSlug: string | null,
+	trialExpired: boolean | null,
+	trialDaysLeftToDisplay: number,
+	trialExpiration: Moment | null
+): string {
+	const locale = useLocale();
+	const translate = useTranslate();
+	const [ bannerSubtitle, setBannerSubtitle ] = useState( '' );
+
+	// moment.js doesn't have a format option to display the long form in a localized way without the year
+	// https://github.com/moment/moment/issues/3341
+	const readableExpirationDate = trialExpiration?.toDate().toLocaleDateString( locale, {
+		month: 'long',
+		day: 'numeric',
+	} );
+
+	useEffect( () => {
+		let subtitle;
+
+		switch ( currentPlanSlug ) {
+			case PLAN_MIGRATION_TRIAL_MONTHLY:
+				subtitle = trialExpired
+					? translate(
+							'Your free trial has expired. Upgrade to a plan to unlock new features and launch your migrated website.'
+					  )
+					: translate(
+							'Your free trial will end in %(daysLeft)d day. Upgrade to a plan by %(expirationdate)s to unlock new features and launch your migrated website.',
+							'Your free trial will end in %(daysLeft)d days. Upgrade to a plan by %(expirationdate)s to unlock new features and launch your migrated website.',
+							{
+								count: trialDaysLeftToDisplay,
+								args: {
+									daysLeft: trialDaysLeftToDisplay,
+									expirationdate: readableExpirationDate as string,
+								},
+							}
+					  );
+				break;
+			default:
+				subtitle = trialExpired
+					? translate(
+							'Your free trial has expired. Upgrade to a plan to unlock new features and start selling.'
+					  )
+					: translate(
+							'Your free trial will end in %(daysLeft)d day. Upgrade to a plan by %(expirationdate)s to unlock new features and start selling.',
+							'Your free trial will end in %(daysLeft)d days. Upgrade to a plan by %(expirationdate)s to unlock new features and start selling.',
+							{
+								count: trialDaysLeftToDisplay,
+								args: {
+									daysLeft: trialDaysLeftToDisplay,
+									expirationdate: readableExpirationDate as string,
+								},
+							}
+					  );
+				break;
+		}
+
+		setBannerSubtitle( subtitle as string );
+	}, [ currentPlanSlug, trialExpired, trialDaysLeftToDisplay, readableExpirationDate ] );
+
+	return bannerSubtitle;
+}


### PR DESCRIPTION
Closes #80694

## Proposed Changes

* Update copy for migration trial plan

## Testing Instructions

* Pick a site with the Migration trial plan
* Go to `/plans/{SITE_SLUG}`
* Check the banner subtitle copy; for more details, see #80694

**Before:**
<img width="1265" alt="Screenshot 2023-08-21 at 15 52 43" src="https://github.com/Automattic/wp-calypso/assets/1241413/14f563b9-362d-44d5-8aed-df275a9693e0">

**Now:**
<img width="1286" alt="Screenshot 2023-08-21 at 15 52 15" src="https://github.com/Automattic/wp-calypso/assets/1241413/636fa502-af50-4dc0-a021-8a4f755b6d2b">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
