### PR TITLE
Assembler: Remove the Add a header button since it's not available

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -1,16 +1,15 @@
 import { PatternRenderer } from '@automattic/block-renderer';
-import { Button, DeviceSwitcher } from '@automattic/components';
+import { DeviceSwitcher } from '@automattic/components';
 import { useGlobalStyle } from '@automattic/global-styles';
 import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useEffect, useState, CSSProperties } from 'react';
-import { NAVIGATOR_PATHS, STYLES_PATHS } from './constants';
+import { STYLES_PATHS } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import PatternActionBar from './pattern-action-bar';
 import { encodePatternId } from './utils';
 import type { Pattern } from './types';
-import type { MouseEvent } from 'react';
 import './pattern-large-preview.scss';
 
 interface Props {
@@ -60,16 +59,6 @@ const PatternLargePreview = ( {
 		'--pattern-large-preview-background': backgroundColor,
 	} as CSSProperties );
 
-	const goToSelectHeaderPattern = () => {
-		navigator.goTo( NAVIGATOR_PATHS.HEADER );
-	};
-
-	const handleAddHeaderClick = ( event: MouseEvent ) => {
-		event.preventDefault();
-		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.LARGE_PREVIEW_ADD_HEADER_BUTTON_CLICK );
-		goToSelectHeaderPattern();
-	};
-
 	const getTitle = () => {
 		if ( ! shouldShowSelectPatternHint ) {
 			return translate( 'Welcome to your homepage.' );
@@ -84,14 +73,6 @@ const PatternLargePreview = ( {
 		}
 
 		return translate( 'You can view your color and font selections after you select a pattern.' );
-	};
-
-	const getAction = () => {
-		if ( ! shouldShowSelectPatternHint ) {
-			return null;
-		}
-
-		return <Button onClick={ handleAddHeaderClick }>{ translate( 'Add header' ) }</Button>;
 	};
 
 	const renderPattern = ( type: string, pattern: Pattern, position = -1 ) => {
@@ -212,7 +193,6 @@ const PatternLargePreview = ( {
 				<div className="pattern-large-preview__placeholder">
 					<h2>{ getTitle() }</h2>
 					<span>{ getDescription() }</span>
-					{ getAction() }
 				</div>
 			) }
 		</DeviceSwitcher>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1692624522965699-slack-C048CUFRGFQ

## Proposed Changes

* Remove the `Add header` button

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/aa16e1ee-7e01-46eb-bc5f-c54012fd9bcd) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/6ce0d286-ca64-4049-90f0-640e942ffda7) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase
* Scroll down to select the Assembler CTA
* On the Assembler screen, pick Colors/Fonts first
* Ensure you won't see the `Add header` button on the placeholder of the large preview

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
