### PR TITLE
Update custom name servers info notice copy (Dns Records setting and card)

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -127,7 +127,7 @@ class DnsRecords extends Component {
 		if (
 			( ! englishLocales.includes( getLocaleSlug() ) &&
 				! i18n.hasTranslation(
-					'DNS records requires using WordPress.com nameservers. {{a}}Update your nameservers now{{/a}}.'
+					"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers {{a}}Update your nameservers now{{/a}}."
 				) ) ||
 			this.hasWpcomNameservers() ||
 			! nameservers ||
@@ -146,7 +146,7 @@ class DnsRecords extends Component {
 				/>
 				<div className="dns-records-notice__message">
 					{ translate(
-						'DNS records requires using WordPress.com nameservers. {{a}}Update your nameservers now{{/a}}.',
+						"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers {{a}}Update your nameservers now{{/a}}.",
 						{
 							components: {
 								a: (

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -127,7 +127,7 @@ class DnsRecords extends Component {
 		if (
 			( ! englishLocales.includes( getLocaleSlug() ) &&
 				! i18n.hasTranslation(
-					"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers {{a}}Update your nameservers now{{/a}}."
+					"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers. {{a}}Update your name servers now{{/a}}."
 				) ) ||
 			this.hasWpcomNameservers() ||
 			! nameservers ||
@@ -146,7 +146,7 @@ class DnsRecords extends Component {
 				/>
 				<div className="dns-records-notice__message">
 					{ translate(
-						"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers {{a}}Update your nameservers now{{/a}}.",
+						"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers. {{a}}Update your name servers now{{/a}}.",
 						{
 							components: {
 								a: (

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -214,3 +214,26 @@
 		}
 	}
 }
+
+.dns-records-card-notice {
+	flex-basis: 100%;
+	background-color: var(--studio-gray-0);
+	display: flex;
+	align-items: center;
+	padding: 8px;
+	gap: 8px;
+	border-radius: 2px;
+	margin-bottom: 24px;
+
+	&__icon.gridicon {
+		min-width: 18px;
+		fill: var(--studio-orange-40);
+	}
+
+	&__message {
+		font-weight: 400;
+		font-size: $font-body-small;
+		color: var(--studio-gray-80);
+	}
+}
+

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,7 +1,9 @@
 import { Button } from '@automattic/components';
+import { englishLocales } from '@automattic/i18n-utils';
 import { useEffect } from '@wordpress/element';
+import { Icon, info } from '@wordpress/icons';
 import { removeQueryArgs } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { connect } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
@@ -22,6 +24,7 @@ import DomainHeader from 'calypso/my-sites/domains/domain-management/components/
 import { WPCOM_DEFAULT_NAMESERVERS_REGEX } from 'calypso/my-sites/domains/domain-management/name-servers/constants';
 import withDomainNameservers from 'calypso/my-sites/domains/domain-management/name-servers/with-domain-nameservers';
 import {
+	domainManagementEdit,
 	domainManagementEditContactInfo,
 	domainManagementList,
 	domainUseMyDomain,
@@ -310,6 +313,48 @@ const Settings = ( {
 		);
 	};
 
+	const renderDnsRecordsNotice = () => {
+		if (
+			( ! englishLocales.includes( getLocaleSlug() || '' ) &&
+				! i18n.hasTranslation(
+					"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers {{a}}Update your nameservers now{{/a}}."
+				) ) ||
+			areAllWpcomNameServers()
+		) {
+			return null;
+		}
+
+		return (
+			<div className="dns-records-card-notice">
+				<Icon
+					icon={ info }
+					size={ 18 }
+					className="dns-records-card-notice__icon gridicon"
+					viewBox="2 2 20 20"
+				/>
+				<div className="dns-records-card-notice__message">
+					{ translate(
+						"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers {{a}}Update your nameservers now{{/a}}.",
+						{
+							components: {
+								a: (
+									<a
+										href={ domainManagementEdit(
+											selectedSite.slug,
+											selectedDomainName,
+											currentRoute,
+											{ nameservers: true }
+										) }
+									/>
+								),
+							},
+						}
+					) }
+				</div>
+			</div>
+		);
+	};
+
 	const renderDnsRecords = () => {
 		if (
 			! domain ||
@@ -321,21 +366,26 @@ const Settings = ( {
 		}
 
 		return (
-			<Accordion
-				title={ translate( 'DNS records', { textOnly: true } ) }
-				subtitle={ translate( 'Connect your domain to other services', { textOnly: true } ) }
-			>
-				{ domain.canManageDnsRecords ? (
-					<DnsRecords
-						dns={ dns }
-						selectedDomainName={ selectedDomainName }
-						selectedSite={ selectedSite }
-						currentRoute={ currentRoute }
-					/>
-				) : (
-					<InfoNotice redesigned text={ domain.cannotManageDnsRecordsReason } />
-				) }
-			</Accordion>
+			<div className="dns-records-card">
+				<Accordion
+					title={ translate( 'DNS records', { textOnly: true } ) }
+					subtitle={ translate( 'Connect your domain to other services', { textOnly: true } ) }
+				>
+					{ domain.canManageDnsRecords ? (
+						<>
+							{ renderDnsRecordsNotice() }
+							<DnsRecords
+								dns={ dns }
+								selectedDomainName={ selectedDomainName }
+								selectedSite={ selectedSite }
+								currentRoute={ currentRoute }
+							/>
+						</>
+					) : (
+						<InfoNotice redesigned text={ domain.cannotManageDnsRecordsReason } />
+					) }
+				</Accordion>
+			</div>
 		);
 	};
 

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -317,7 +317,7 @@ const Settings = ( {
 		if (
 			( ! englishLocales.includes( getLocaleSlug() || '' ) &&
 				! i18n.hasTranslation(
-					"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers {{a}}Update your nameservers now{{/a}}."
+					"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers. {{a}}Update your name servers now{{/a}}."
 				) ) ||
 			areAllWpcomNameServers()
 		) {
@@ -334,7 +334,7 @@ const Settings = ( {
 				/>
 				<div className="dns-records-card-notice__message">
 					{ translate(
-						"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers {{a}}Update your nameservers now{{/a}}.",
+						"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers. {{a}}Update your name servers now{{/a}}.",
 						{
 							components: {
 								a: (


### PR DESCRIPTION
## Proposed Changes

This [PR](https://github.com/Automattic/wp-calypso/pull/80655) added a notice in DNS records page when the user is using custom dns. This PR modify the copy and also add the notice in domain settings page (DNS records card)

![PR1](https://github.com/Automattic/wp-calypso/assets/2797601/5f6ed7fd-cc26-4113-a442-9397c4d82152)
![PR2](https://github.com/Automattic/wp-calypso/assets/2797601/64b14d01-101e-4dd8-bcdf-123dbeb1bba6)ì

## Testing Instructions

Apply this patch locally and verify that the notice is showed when custom name servers are set for a registered domain.

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
