### PR TITLE
Domain forwarding: Add warning disallowing redirects to wordpress.com URLs

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -122,6 +122,17 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 				setIsValidUrl( false );
 				return;
 			}
+
+			// Disallow wordpress.com urls.
+			if ( url.hostname.match( /\.wordpress\.com/i ) ) {
+				setErrorMessage(
+					translate(
+						'WordPress.com domains are not allowed. Use the "Set as primary" option above to make this domain your main site address.'
+					)
+				);
+				setIsValidUrl( false );
+				return;
+			}
 		} catch ( e ) {
 			setErrorMessage( translate( 'Please enter a valid URL.' ) );
 			setIsValidUrl( false );

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -160,7 +160,7 @@
 
 .domain-forwarding-card__error-field {
 	margin-bottom: 0;
-	height: 35px;
+	min-height: 35px;
 }
 
 .ownership-verification-card {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80835

## Proposed Changes

* This PR add an error message if the user tries to redirect to a *wordpress.com domain.


![no-wpcom-domains](https://github.com/Automattic/wp-calypso/assets/140841/df7b43d9-1934-460e-9ec5-3044ba6a3b84)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Try to add a redirect to a domain pointing to *.wordpress.com url.
* You should see the error message.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
