### PR TITLE
Domain forwarding: Update form style

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -271,7 +271,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 								} ) }
 								onClick={ handleDelete }
 							>
-								<Icon icon={ trash } size={ 18 } />
+								<Icon icon={ trash } size={ 18 } fill="currentColor" />
 							</Button>
 						}
 					/>

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -135,25 +135,38 @@
 .domain-forwarding-card__fields {
 	margin-bottom: 0 !important;
 
+	.form-text-input:disabled {
+		border: 1px solid var(--color-neutral-5) !important;
+	}
+
 	.form-text-input-with-affixes__prefix,
-	.form-text-input-with-affixes__suffix {
+	.form-text-input-with-affixes__suffix, {
 		padding: 0;
-		border: 0;
+		border: 0 !important;
 
 		.form-select {
 			border-right: 0;
 			height: 100%;
+			border-radius: 2px 0 0 2px;
+		}
+		.form-select:disabled {
+			cursor: default;
+			border-color: var(--color-neutral-5);
+		}
+		.form-select:hover:enabled {
+			border-color: var(--color-neutral-20);
 		}
 		.domain-forwarding-card__delete {
 			border-left: 0;
+			border-radius: 0 2px 2px 0;
 
 			svg {
 				margin-top: 5px;
 			}
-
-			&.is-disabled {
-				background: var(--color-neutral-0);
-			}
+		}
+		.domain-forwarding-card__delete:disabled {
+			background: var(--color-neutral-0);
+			border-color: var(--color-neutral-5);
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3549

## Proposed Changes

* This PR makes several CSS tweaks to the domain forwarding form
* The trash icon is made lighter when the form is disabled.
* When the form is disabled, we force the default cursor so it doesn't look to be interactable.
* The border color and radius are unified to match across the 3 inputs and their enabled/disabled states.

ENABLED
Before | After
--|--
![enabled-before](https://github.com/Automattic/wp-calypso/assets/140841/dfdc4a13-b9a7-468e-9b9a-a9b98cb667e6)  | ![enabled-after](https://github.com/Automattic/wp-calypso/assets/140841/2edb1530-b56b-4a72-987e-8ab2217c0d3a)

DISABLED
Before | After
--|--
![disabled-before](https://github.com/Automattic/wp-calypso/assets/140841/1cad5338-984d-411f-8054-e177dc09de83) |  ![disabled-after](https://github.com/Automattic/wp-calypso/assets/140841/c39ce5ce-9e86-4653-8c01-b30fa2f1b7ac)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Test a domain that is set as the primary site address, and ensure the form looks good while disabled.
* Test a domain that is not set as the primary site address, and ensure the form looks good while enabled.
* Pay special attention to the form field borders and the trash icon.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
