### PR TITLE
Fix overflowing text on VideoPress "choose a domain" results

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -143,6 +143,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 					onSkip={ onSkip }
 					products={ productsList }
 					useProvidedProductsList={ true }
+					isReskinned={ true }
 				/>
 				<div className="aside-sections">
 					<div className="aside-section">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
@@ -228,6 +228,11 @@ $videopress-background: #010101;
 			background: none;
 		}
 	}
+
+	.featured-domain-suggestion.card .domain-product-price {
+		align-items: flex-start;
+		margin-top: 12px;
+	}
 }
 
 .is-videopress-stepper {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
@@ -179,6 +179,7 @@ $videopress-background: #010101;
 
 		.domain-registration-suggestion__badges,
 		.domain-registration-suggestion__match-reasons {
+			flex: 1 1 0%;
 			background-color: rgba(255, 255, 255, 0.2);
 		}
 	}
@@ -227,6 +228,17 @@ $videopress-background: #010101;
 			color: #fff;
 			background: none;
 		}
+	}
+
+	.domain-registration-suggestion__title {
+		align-self: baseline;
+		flex: 0 1 auto;
+	}
+
+	.domain-registration-suggestion__badges {
+		align-self: baseline;
+		flex: 1;
+		white-space: nowrap;
 	}
 
 	.featured-domain-suggestion.card .domain-product-price {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
@@ -239,7 +239,12 @@ $videopress-background: #010101;
 		align-self: baseline;
 		flex: 1;
 		white-space: nowrap;
+
+		@media (max-width: 1080px) {
+			margin-left: 0;
+		}
 	}
+
 
 	.featured-domain-suggestion.card .domain-product-price {
 		align-items: flex-start;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
@@ -245,7 +245,6 @@ $videopress-background: #010101;
 		}
 	}
 
-
 	.featured-domain-suggestion.card .domain-product-price {
 		align-items: flex-start;
 		margin-top: 12px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

This PR updates the layout of the VideoPress "Choose a Domain" step to match the same step on the wordpress.com "choose a domain" step for new sites. The VideoPress version seems to not be used by any other flows anymore, so its possible it has been left out from updates that have been given to dotcom.

| before | after | wordpress.com equivalent |
| -- | -- | -- |
| <img width="2079" alt="SCR-20230821-mtta" src="https://github.com/Automattic/wp-calypso/assets/4081020/7fd4128b-8552-4a7b-87eb-74885963c8c2"> | <img width="1647" alt="SCR-20230821-mtnt" src="https://github.com/Automattic/wp-calypso/assets/4081020/dda55d44-0e68-4686-b1db-659ee3aa0527"> | <img width="2074" alt="SCR-20230821-mtqv" src="https://github.com/Automattic/wp-calypso/assets/4081020/053354f7-8993-41ef-be87-28fffc0b8f5a"> |

## Proposed Changes

* use the `isReskinned` layout for videopress "choose a domain" screen

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* load the `/setup/videopress` signup flow
* go through the flow until you reach the "Choose a Domain" step
* search for a domain with a long-ish name ex: "videoflow testing"
* the badge shouldn't overlap with the pricing text
* also test in responsive mode to ensure it still looks OK on a mobile device

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
