### PR TITLE
Earn: Convert products component to typescript

### DIFF
--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -23,36 +23,41 @@ import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import RecurringPaymentsPlanAddEditModal from '../components/add-edit-plan-modal';
+import { Product } from '../types';
 import { ADD_NEW_PAYMENT_PLAN_HASH, ADD_NEWSLETTER_PAYMENT_PLAN_HASH } from './constants';
 import RecurringPaymentsPlanDeleteModal from './delete-plan-modal';
 import MembershipsSection from './';
 import './style.scss';
 
+type MembersProductsSectionProps = {
+	section: any;
+	query: any;
+};
 const showAddEditDialogInitially =
 	window.location.hash === ADD_NEW_PAYMENT_PLAN_HASH ||
 	window.location.hash === ADD_NEWSLETTER_PAYMENT_PLAN_HASH;
 
-function MembershipsProductsSection( { section, query } ) {
+function MembershipsProductsSection( { section, query }: MembersProductsSectionProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const [ showAddEditDialog, setShowAddEditDialog ] = useState( showAddEditDialogInitially );
 	const [ showDeleteDialog, setShowDeleteDialog ] = useState( false );
-	const [ product, setProduct ] = useState( null );
+	const [ product, setProduct ] = useState< Product | null >( null );
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const features = useSelector( ( state ) => getFeaturesBySiteId( state, site?.ID ) );
 	const hasLoadedFeatures = features?.active.length > 0;
-	const products = useSelector( ( state ) => getProductsForSiteId( state, site?.ID ) );
+	const products: Product[] = useSelector( ( state ) => getProductsForSiteId( state, site?.ID ) );
 	const connectedAccountId = useSelector( ( state ) =>
 		getConnectedAccountIdForSiteId( state, site?.ID )
 	);
 	const hasDonationsFeature = useSelector( ( state ) =>
-		siteHasFeature( state, site?.ID, FEATURE_DONATIONS )
+		siteHasFeature( state, site?.ID ?? null, FEATURE_DONATIONS )
 	);
 	const hasPremiumContentFeature = useSelector( ( state ) =>
-		siteHasFeature( state, site?.ID, FEATURE_PREMIUM_CONTENT_CONTAINER )
+		siteHasFeature( state, site?.ID ?? null, FEATURE_PREMIUM_CONTENT_CONTAINER )
 	);
 	const hasRecurringPaymentsFeature = useSelector( ( state ) =>
-		siteHasFeature( state, site?.ID, FEATURE_RECURRING_PAYMENTS )
+		siteHasFeature( state, site?.ID ?? null, FEATURE_RECURRING_PAYMENTS )
 	);
 	const hasStripeFeature =
 		hasDonationsFeature || hasPremiumContentFeature || hasRecurringPaymentsFeature;
@@ -64,7 +69,7 @@ function MembershipsProductsSection( { section, query } ) {
 	const trackUpgrade = () =>
 		dispatch( bumpStat( 'calypso_earn_page', 'payment-plans-upgrade-button' ) );
 
-	function renderEllipsisMenu( productId ) {
+	function renderEllipsisMenu( productId: string | null ) {
 		return (
 			<EllipsisMenu position="bottom left">
 				{ hasStripeFeature && (
@@ -81,22 +86,22 @@ function MembershipsProductsSection( { section, query } ) {
 		);
 	}
 
-	function openAddEditDialog( productId ) {
+	function openAddEditDialog( productId: string | null ) {
 		if ( productId ) {
-			const currentProduct = products.find( ( prod ) => prod.ID === productId );
+			const currentProduct = products.find( ( currentProduct ) => currentProduct.ID === productId );
 			setShowAddEditDialog( true );
-			setProduct( currentProduct );
+			setProduct( currentProduct ?? null );
 		} else {
 			setShowAddEditDialog( true );
 			setProduct( null );
 		}
 	}
 
-	function openDeleteDialog( productId ) {
+	function openDeleteDialog( productId: string | null ) {
 		if ( productId ) {
-			const currentProduct = products.find( ( prod ) => prod.ID === productId );
+			const currentProduct = products.find( ( currentProduct ) => currentProduct.ID === productId );
 			setShowDeleteDialog( true );
-			setProduct( currentProduct );
+			setProduct( currentProduct ?? null );
 		}
 	}
 
@@ -107,8 +112,8 @@ function MembershipsProductsSection( { section, query } ) {
 
 	return (
 		<div>
-			<QueryMembershipsSettings siteId={ site?.ID } />
-			<QueryMembershipProducts siteId={ site?.ID } />
+			<QueryMembershipsSettings siteId={ site?.ID ?? 0 } />
+			<QueryMembershipProducts siteId={ site?.ID ?? 0 } />
 			<HeaderCake backHref={ '/earn/payments/' + site?.slug }>
 				{ translate( 'Payment plans' ) }
 			</HeaderCake>
@@ -155,7 +160,7 @@ function MembershipsProductsSection( { section, query } ) {
 							) }
 						</div>
 
-						{ renderEllipsisMenu( currentProduct?.ID ) }
+						{ renderEllipsisMenu( currentProduct?.ID ?? null ) }
 					</CompactCard>
 				) ) }
 			{ hasLoadedFeatures && showAddEditDialog && hasStripeFeature && connectedAccountId && (
@@ -166,7 +171,7 @@ function MembershipsProductsSection( { section, query } ) {
 					} ) }
 				/>
 			) }
-			{ hasLoadedFeatures && showDeleteDialog && (
+			{ hasLoadedFeatures && showDeleteDialog && product && (
 				<RecurringPaymentsPlanDeleteModal closeDialog={ closeDialog } product={ product } />
 			) }
 			{ ! hasLoadedFeatures && (

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -30,7 +30,6 @@ import MembershipsSection from './';
 import './style.scss';
 
 type MembersProductsSectionProps = {
-	section: string;
 	query?: {
 		[ key: string ]: string;
 	};
@@ -40,7 +39,7 @@ const showAddEditDialogInitially =
 	window.location.hash === ADD_NEW_PAYMENT_PLAN_HASH ||
 	window.location.hash === ADD_NEWSLETTER_PAYMENT_PLAN_HASH;
 
-function MembershipsProductsSection( { section, query }: MembersProductsSectionProps ) {
+function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const [ showAddEditDialog, setShowAddEditDialog ] = useState( showAddEditDialogInitially );
@@ -138,9 +137,7 @@ function MembershipsProductsSection( { section, query }: MembersProductsSectionP
 				/>
 			) }
 
-			{ hasLoadedFeatures && ! connectedAccountId && (
-				<MembershipsSection section={ section } query={ query } />
-			) }
+			{ hasLoadedFeatures && ! connectedAccountId && <MembershipsSection query={ query } /> }
 			{ hasLoadedFeatures && hasStripeFeature && connectedAccountId && (
 				<SectionHeader>
 					<Button primary compact onClick={ () => openAddEditDialog( null ) }>

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -30,9 +30,12 @@ import MembershipsSection from './';
 import './style.scss';
 
 type MembersProductsSectionProps = {
-	section: any;
-	query: any;
+	section: string;
+	query?: {
+		[ key: string ]: string;
+	};
 };
+
 const showAddEditDialogInitially =
 	window.location.hash === ADD_NEW_PAYMENT_PLAN_HASH ||
 	window.location.hash === ADD_NEWSLETTER_PAYMENT_PLAN_HASH;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Convert the Earn > MembershipsProductsSection component to TypeScript. This is a follow up to https://github.com/Automattic/wp-calypso/pull/80764, which refactored the component from class to functional component with hooks. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Earn page functionality should be the exact same before and after this PR. So we are testing to confirm everything still works as expected. 

1) You will need a stripe connected site to test. 
   - If your site is not stripe Connected, you should see a button to connect at `http://calypso.localhost:3000/earn/payments/YOURDOMAIN`. Click the button to connect. To avoid fully connecting Stripe, add `define( 'USE_STORE_SANDBOX', true );` to wp-content/mu-plugins/0-sandbox.php in your sandbox, and sandbox public-api.wordpress.com and the domain of your test site. Then click the link to go to Stripe and you'll see a button to skip the setup.
2) Go to http://calypso.localhost:3000/earn/payments-plans/YOURDOMAIN.
3) Confirm you can create, edit, and deleted products like normal. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
