### PR TITLE
Storage Add Ons: Make storage options naming conventions consistent

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
@@ -15,7 +15,7 @@ export const StorageAddOnDropdown = ( { planSlug, storageOptions }: StorageAddOn
 	const { setSelectedStorageOptionForPlan } = useDispatch( WpcomPlansUI.store );
 	const selectedStorage = useSelect(
 		( select ) => {
-			return select( WpcomPlansUI.store ).getSelectedStorageOptionsForPlan( planSlug );
+			return select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug );
 		},
 		[ planSlug ]
 	);

--- a/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
@@ -15,7 +15,7 @@ export const StorageAddOnDropdown = ( { planSlug, storageOptions }: StorageAddOn
 	const { setSelectedStorageOptionForPlan } = useDispatch( WpcomPlansUI.store );
 	const selectedStorage = useSelect(
 		( select ) => {
-			return select( WpcomPlansUI.store ).getStorageAddOnForPlan( planSlug );
+			return select( WpcomPlansUI.store ).getSelectedStorageOptionsForPlan( planSlug );
 		},
 		[ planSlug ]
 	);

--- a/packages/data-stores/src/wpcom-plans-ui/actions.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/actions.ts
@@ -19,7 +19,7 @@ export const setSelectedStorageOptionForPlan = ( {
 	planSlug: PlanSlug;
 } ) =>
 	( {
-		type: 'WPCOM_PLANS_UI_SET_STORAGE_ADD_ON_FOR_PLAN',
+		type: 'WPCOM_PLANS_UI_SET_SELECTED_STORAGE_OPTIONS_FOR_PLAN',
 		addOnSlug,
 		planSlug,
 	} as const );

--- a/packages/data-stores/src/wpcom-plans-ui/actions.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/actions.ts
@@ -19,7 +19,7 @@ export const setSelectedStorageOptionForPlan = ( {
 	planSlug: PlanSlug;
 } ) =>
 	( {
-		type: 'WPCOM_PLANS_UI_SET_SELECTED_STORAGE_OPTIONS_FOR_PLAN',
+		type: 'WPCOM_PLANS_UI_SET_SELECTED_STORAGE_OPTION_FOR_PLAN',
 		addOnSlug,
 		planSlug,
 	} as const );

--- a/packages/data-stores/src/wpcom-plans-ui/reducer.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/reducer.ts
@@ -19,7 +19,7 @@ const selectedStorageOptionForPlans: Reducer<
 	selectedStorageOptionForPlans | undefined,
 	WpcomPlansUIAction
 > = ( state, action ) => {
-	if ( action.type === 'WPCOM_PLANS_UI_SET_SELECTED_STORAGE_OPTIONS_FOR_PLAN' ) {
+	if ( action.type === 'WPCOM_PLANS_UI_SET_SELECTED_STORAGE_OPTION_FOR_PLAN' ) {
 		return { ...state, [ action.planSlug ]: action.addOnSlug };
 	}
 	return state;

--- a/packages/data-stores/src/wpcom-plans-ui/reducer.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/reducer.ts
@@ -1,6 +1,6 @@
 import { combineReducers } from '@wordpress/data';
 import type { WpcomPlansUIAction } from './actions';
-import type { selectedStorageAddOnsForPlans } from './types';
+import type { selectedStorageOptionForPlans } from './types';
 import type { Reducer } from 'redux';
 
 const showDomainUpsellDialog: Reducer< boolean | undefined, WpcomPlansUIAction > = (
@@ -15,11 +15,11 @@ const showDomainUpsellDialog: Reducer< boolean | undefined, WpcomPlansUIAction >
 	return state;
 };
 
-const selectedStorageAddOnsForPlans: Reducer<
-	selectedStorageAddOnsForPlans | undefined,
+const selectedStorageOptionForPlans: Reducer<
+	selectedStorageOptionForPlans | undefined,
 	WpcomPlansUIAction
 > = ( state, action ) => {
-	if ( action.type === 'WPCOM_PLANS_UI_SET_STORAGE_ADD_ON_FOR_PLAN' ) {
+	if ( action.type === 'WPCOM_PLANS_UI_SET_SELECTED_STORAGE_OPTIONS_FOR_PLAN' ) {
 		return { ...state, [ action.planSlug ]: action.addOnSlug };
 	}
 	return state;
@@ -27,7 +27,7 @@ const selectedStorageAddOnsForPlans: Reducer<
 
 const reducer = combineReducers( {
 	showDomainUpsellDialog,
-	selectedStorageAddOnsForPlans,
+	selectedStorageOptionForPlans,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/wpcom-plans-ui/selectors.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/selectors.ts
@@ -2,5 +2,5 @@ import { PlanSlug } from '@automattic/calypso-products';
 import type { State } from './reducer';
 
 export const isDomainUpsellDialogShown = ( state: State ) => !! state.showDomainUpsellDialog;
-export const getStorageAddOnForPlan = ( state: State, planSlug: PlanSlug ) =>
-	state.selectedStorageAddOnsForPlans?.[ planSlug ];
+export const getSelectedStorageOptionsForPlan = ( state: State, planSlug: PlanSlug ) =>
+	state.selectedStorageOptionForPlans?.[ planSlug ];

--- a/packages/data-stores/src/wpcom-plans-ui/selectors.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/selectors.ts
@@ -2,5 +2,5 @@ import { PlanSlug } from '@automattic/calypso-products';
 import type { State } from './reducer';
 
 export const isDomainUpsellDialogShown = ( state: State ) => !! state.showDomainUpsellDialog;
-export const getSelectedStorageOptionsForPlan = ( state: State, planSlug: PlanSlug ) =>
+export const getSelectedStorageOptionForPlan = ( state: State, planSlug: PlanSlug ) =>
 	state.selectedStorageOptionForPlans?.[ planSlug ];

--- a/packages/data-stores/src/wpcom-plans-ui/types.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/types.ts
@@ -4,6 +4,6 @@ export interface DomainUpsellDialog {
 	show: boolean;
 }
 
-export interface selectedStorageAddOnsForPlans {
+export interface selectedStorageOptionForPlans {
 	[ key: string ]: WPComStorageAddOnSlug;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/80777#discussion_r1298795883

## Proposed Changes

* Make naming consistent for storage add ons in the wpcom-plans-ui data store
* Switch references from `storageAddOn` to `storageOptions`

## GIF
![2023-08-02 17 37 45](https://github.com/Automattic/wp-calypso/assets/5414230/b82d131f-d50d-470b-bf82-825ff4130e30)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a local dev environment or use calypso live
* Navigate to `/start/plans?flags=plans/upgradeable-storage`
* Verify that selecting items in the storage add ons dropdown continues to behave as expected. To be clear, all we're checking is that dropdown selections persist. No other functionality is wired up at this point
* Do the same for /plans

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
