### PR TITLE
Checkout: Update checkout line item key to be unique

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -90,7 +90,7 @@ export function WPOrderReviewLineItems( {
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
 			{ responseCart.products.map( ( product ) => (
 				<LineItemWrapper
-					key={ product.product_slug }
+					key={ product.uuid }
 					product={ product }
 					isSummary={ isSummary }
 					removeProductFromCart={ removeProductFromCart }


### PR DESCRIPTION
When two or more Premium Themes are added to Checkout, they mistakenly share the same React key - these keys need to be unique.

![image](https://github.com/Automattic/wp-calypso/assets/16580129/89f134b3-1b2a-412c-afd4-af1f83fd58fb)

![image](https://github.com/Automattic/wp-calypso/assets/16580129/8ebea465-03f1-40bd-b924-2bb0548687f0)

![image](https://github.com/Automattic/wp-calypso/assets/16580129/ca46b93b-19cd-4b00-9ffb-77c118145c27)

## Proposed Changes

* We already use the `product.uuid` as a unique key further down in the same file, so this PR just updates the existing `product.product_slug` to the uuid.
* This will give us unique IDs such as `premium_theme125` and `premium_theme126`

## Testing Instructions

Add your WordPress.com site URL to the links below and then follow them to add these two themes to your cart
- https://wordpress.com/checkout/[YOU_WORDPRESS_URL/premium_theme:munchies
- https://wordpress.com/checkout/[YOU_WORDPRESS_URL/premium_theme:payton
- Once both themes are in your cart, check console log for the error depicted above
- Feel free to try any other products that may have duplicates. I tried with domains but they correctly use the keys `dotblog_domain119` and `dotblog_domain120`
