### PR TITLE
Assembler - UX - Improve the sections step by keeping visible the next steps

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-category-list.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-category-list.scss
@@ -1,8 +1,12 @@
 .pattern-category-list {
-	margin-top: 10px;
-	margin-right: -22px;
+	margin: 10px -11px 0 -11px;
+	// Keep the other steps visible (Footer, Colors, and Fonts)
+	// 655px is the height reserved in sidebar
+	max-height: calc(100vh - 655px);
+	overflow-y: auto;
 
 	.components-item.navigator-item {
 		padding-left: 42px;
+		margin: 0;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80673

## Proposed Changes

* Always keep the next steps (Footer, Colors, and Fonts) visible when pattern categories are open

|BEFORE|AFTER|
|--|--|
|<img width="348" alt="Screenshot 2566-08-22 at 09 25 56" src="https://github.com/Automattic/wp-calypso/assets/1881481/6fcbbd83-fb22-4d58-b319-1d1964360472">|<img width="349" alt="Screenshot 2566-08-22 at 09 27 00" src="https://github.com/Automattic/wp-calypso/assets/1881481/87bc9603-dac2-4a50-8082-29b64d64cefe">|

|BEFORE|AFTER|
|--|--|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/21319305-e442-4c33-982c-5c8b70f74936">|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/82eb06f8-0fb8-4c04-b2b2-0b2bc582fb5b">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }`
* Click `Sections`
* Verify you can scroll the category list and add patterns
* Verify the next steps are always visible at the bottom of the category list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
