### PR TITLE
Gutenberg E2E: close WhatsApp block settings pane before moving on to other actions.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/whatsapp-button.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/whatsapp-button.ts
@@ -7,7 +7,6 @@ interface ConfigurationData {
 
 const selectors = {
 	// Editor
-	settings: 'button[aria-label="WhatsApp Button Settings"]',
 	phoneNumberInput: 'input[placeholder="Your phone number…"]',
 	buttonLabel: 'a.whatsapp-block__button',
 
@@ -43,17 +42,30 @@ export class WhatsAppButtonFlow implements BlockFlow {
 	async configure( context: EditorContext ): Promise< void > {
 		const editorCanvas = await context.editorPage.getEditorCanvas();
 
+		// Update the button text if config data is present.
 		if ( this.configurationData.buttonText ) {
 			const buttonLabelLocator = editorCanvas.locator( selectors.buttonLabel );
+			// First clear the text.
+			await buttonLabelLocator.fill( '' );
 			await buttonLabelLocator.fill( this.configurationData.buttonText );
 		}
 
 		const editorParent = await context.editorPage.getEditorParent();
-		const settingsLocator = editorParent.locator( selectors.settings );
+		const settingsLocator = editorParent.getByRole( 'button', {
+			name: 'WhatsApp Button Settings',
+		} );
+
+		// Open the block settings dialog.
 		await settingsLocator.click();
 
+		// Enter phone number.
 		const phoneInputLocator = editorParent.locator( selectors.phoneNumberInput );
 		await phoneInputLocator.fill( this.configurationData.phoneNumber.toString() );
+
+		// Dismiss the block settings dialog.
+		await settingsLocator.click();
+
+		await phoneInputLocator.waitFor( { state: 'detached' } );
 	}
 
 	/**


### PR DESCRIPTION
Context: p1692639188443899-slack-CBTN58FTJ

## Proposed Changes

This PR adds a step to close the block settings panel/dialog for the WhatsApp block.

One selector has also been changed to be a11y-compatible. 

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E Simple edge (mobile)
  - [x] Gutenberg E2E AT edge (mobile)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
