### PR TITLE
Update monitor time drop down

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
@@ -34,7 +34,7 @@ export default function NotificationDuration( {
 	return (
 		<div className="notification-settings__content-block">
 			<div className="notification-settings__content-heading">
-				{ translate( 'Notify me about downtime:' ) }
+				{ translate( 'Monitor my site every:' ) }
 			</div>
 			<SelectDropdown
 				onToggle={ ( { open: isOpen }: { open: boolean } ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/notification-duration.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/notification-duration.tsx
@@ -57,21 +57,21 @@ describe( 'NotificationDuration', () => {
 	it( 'renders the component with selected duration and no restriction', () => {
 		render(
 			<NotificationDuration
-				selectedDuration={ { time: 15, label: 'After 15 minutes' } }
+				selectedDuration={ { time: 15, label: '15 minutes' } }
 				{ ...defaultProps }
 			/>
 		);
 
-		expect( screen.getByText( 'Notify me about downtime:' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Monitor my site every:' ) ).toBeInTheDocument();
 
 		const selectedText = screen.getByRole( 'img', { name: 'Schedules' } );
-		expect( selectedText.parentElement ).toHaveTextContent( 'After 15 minutes' );
+		expect( selectedText.parentElement ).toHaveTextContent( '15 minutes' );
 	} );
 
 	it( 'handles dropdown toggle and clicks', () => {
 		render( <NotificationDuration { ...defaultProps } /> );
 
-		fireEvent.click( screen.getByRole( 'menuitem', { name: /after 30 minutes/i } ) );
+		fireEvent.click( screen.getByRole( 'menuitem', { name: /30 minutes/i } ) );
 		expect( defaultProps.recordEvent ).toHaveBeenCalledWith( 'notification_duration_toggle' );
 		expect( defaultProps.selectDuration ).toHaveBeenCalledWith( {
 			time: 30,
@@ -91,7 +91,7 @@ describe( 'NotificationDuration', () => {
 
 		const dropdownToggle = screen.getByRole( 'menuitem', { name: /after 1 minute/i } );
 		expect( dropdownToggle ).toHaveClass( 'is-disabled' );
-		expect( dropdownToggle ).toHaveTextContent( 'After 1 minute' );
+		expect( dropdownToggle ).toHaveTextContent( '1 minute' );
 		expect( dropdownToggle ).toHaveTextContent( 'Upgrade' );
 		expect( dropdownToggle ).toHaveTextContent( 'Upgrade ($1.00/m)' );
 	} );

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
@@ -46,6 +46,7 @@ export default function useUpdateMonitorSettings(
 									monitor_user_wp_note_notifications: data.settings.wp_note_notifications,
 									monitor_notify_additional_user_emails: data.settings.contacts?.emails ?? [],
 									monitor_notify_additional_user_sms: data.settings.contacts?.sms_numbers ?? [],
+									monitor_urls: data.settings.urls,
 								},
 							};
 						}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/test-utils/constants.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/test-utils/constants.ts
@@ -27,6 +27,7 @@ const site: Site = {
 		monitor_user_sms_notifications: false,
 		monitor_notify_additional_user_emails: [],
 		monitor_notify_additional_user_sms: [],
+		monitor_urls: [],
 		is_over_limit: false,
 		sms_sent_count: 10,
 		sms_monthly_limit: 20,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -40,6 +40,11 @@ interface MonitorContacts {
 	emails?: Array< MonitorContactEmail >;
 	sms_numbers?: Array< MonitorContactSMS >;
 }
+interface MonitorURLS {
+	monitor_url: string;
+	options: Array< string >;
+	check_interval: number;
+}
 
 export interface MonitorSettings {
 	monitor_active: boolean;
@@ -52,6 +57,7 @@ export interface MonitorSettings {
 	monitor_user_wp_note_notifications: boolean;
 	monitor_notify_additional_user_emails: Array< MonitorContactEmail >;
 	monitor_notify_additional_user_sms: Array< MonitorContactSMS >;
+	monitor_urls: Array< MonitorURLS >;
 	is_over_limit: boolean;
 	sms_sent_count: number;
 	sms_monthly_limit: number;
@@ -265,6 +271,7 @@ export interface UpdateMonitorSettingsAPIResponse {
 		wp_note_notifications: boolean;
 		jetmon_defer_status_down_minutes: number;
 		contacts?: MonitorContacts;
+		urls?: MonitorURLS[];
 	};
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -500,28 +500,28 @@ export const getProductSlugFromProductType = ( type: string ): string | undefine
 export const availableNotificationDurations = [
 	{
 		time: 1,
-		label: translate( 'After 1 minute' ),
+		label: translate( '1 minute' ),
 		isPaid: true,
 	},
 	{
 		time: 5,
-		label: translate( 'After 5 minutes' ),
+		label: translate( '5 minutes' ),
 	},
 	{
 		time: 15,
-		label: translate( 'After 15 minutes' ),
+		label: translate( '15 minutes' ),
 	},
 	{
 		time: 30,
-		label: translate( 'After 30 minutes' ),
+		label: translate( '30 minutes' ),
 	},
 	{
 		time: 45,
-		label: translate( 'After 45 minutes' ),
+		label: translate( '45 minutes' ),
 	},
 	{
 		time: 60,
-		label: translate( 'After 1 hour' ),
+		label: translate( '1 hour' ),
 	},
 ];
 


### PR DESCRIPTION
Update the monitor time drop down to use check intervals in place of a deferred time after which to send notifications

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* In place of using a deferred time for notifications with the message `Notify me about downtime:` we'll be updating this to use a check interval with the message `Monitor my site every:`. The deferment option will be replaced with this for now and the check interval will be saved instead of a deferment time

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
