### PR TITLE
Jetpack E2E: increase coverage of the existing Stats spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -1,4 +1,5 @@
 import { Locator, Page } from 'playwright';
+import { envVariables } from '../..';
 import { getCalypsoURL } from '../../data-helper';
 import { clickNavTab } from '../../element-helper';
 
@@ -121,12 +122,14 @@ export class StatsPage {
 		await target.waitFor();
 		await target.click();
 
-		// The chart legend will update.
-		await this.anchor
-			.locator( '.chart__legend-options' )
-			.getByRole( 'listitem' )
-			.filter( { hasText: activityType.type } )
-			.waitFor();
+		// The chart legend will update, but this only happens on Desktop viewports.
+		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
+			await this.anchor
+				.locator( '.chart__legend-options' )
+				.getByRole( 'listitem' )
+				.filter( { hasText: activityType.type } )
+				.waitFor();
+		}
 
 		// Query param changes when the stats type is changed, but only for the Traffic tab.
 		// Selecting different stats types in the Store tab does not add query params.

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -16,6 +16,8 @@ type SubscriberOrigin = 'WordPress.com' | 'Email';
 
 const selectors = {
 	highlightPeriodSelectButton: '.highlight-cards-heading__settings-action',
+	graph: '.chart__bars',
+	statsTabs: '.stats-tabs',
 };
 
 /**
@@ -111,12 +113,12 @@ export class StatsPage {
 		// Wait for the charts to load first, even if no activity is present.
 		// CSS selector has to be used here because there is no a11y selector
 		// for this element.
-		await this.page.locator( '.chart__bars' ).waitFor();
+		await this.page.locator( selectors.graph ).waitFor();
 
 		// CSS selector is used to narrow down to the Stats Activity tab for
 		// similar reason to above.
 		const target = this.anchor
-			.locator( '.stats-tabs' )
+			.locator( selectors.statsTabs )
 			.getByRole( 'listitem' )
 			.filter( { hasText: activityType.type } );
 		await target.waitFor();
@@ -131,17 +133,14 @@ export class StatsPage {
 				.waitFor();
 		}
 
-		// Query param changes when the stats type is changed, but only for the Traffic tab.
-		// Selecting different stats types in the Store tab does not add query params.
-		if ( activityType.tab === 'Traffic' ) {
-			await this.page.waitForURL( new RegExp( `tab=${ activityType.type }`, 'i' ) );
-		}
-
 		// Verify the selected stats type is now active.
-		const classes = await target.getAttribute( 'class' );
-		if ( ! classes?.includes( 'is-selected' ) ) {
-			throw new Error( `Failed to click and filter traffic data category to ${ activityType }.` );
-		}
+		// A slightly different selector has to be used because the active tab
+		// is not reported using accessible selectors but a CSS class.
+		await this.anchor
+			.locator( selectors.statsTabs )
+			.locator( '.is-selected' )
+			.filter( { hasText: activityType.type } )
+			.waitFor();
 	}
 
 	// Traffic

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -1,13 +1,22 @@
-import { Page } from 'playwright';
+import { Locator, Page } from 'playwright';
+import { getCalypsoURL } from '../../data-helper';
 import { clickNavTab } from '../../element-helper';
 
-export type StatsTabs = 'Traffic' | 'Insights' | 'Store';
+export type StatsTabs = 'Traffic' | 'Insights' | 'Subscribers';
+type StatsTrafficActivityCategory = 'Views' | 'Visitors' | 'Likes' | 'Comments';
+type HighlightStatsPeriod = '7-day' | '30-day';
+type StatsPeriod = 'Days' | 'Weeks' | 'Months' | 'Years';
+
+const selectors = {
+	highlightPeriodSelectButton: '.highlight-cards-heading__settings-action',
+};
 
 /**
  * Represents the Statistics page.
  */
 export class StatsPage {
 	private page: Page;
+	private anchor: Locator;
 
 	/**
 	 * Constructs an instance of the page.
@@ -16,6 +25,28 @@ export class StatsPage {
 	 */
 	constructor( page: Page ) {
 		this.page = page;
+		this.anchor = this.page.getByRole( 'main' );
+	}
+
+	/**
+	 *
+	 * @param siteSlug
+	 */
+	async visit( siteSlug?: string ) {
+		await this.page.goto( getCalypsoURL( `/stats/${ siteSlug }` ) );
+	}
+
+	/**
+	 *
+	 */
+	private async dismissModal() {
+		// Sometimes a modal appears when accessing Stats > Traffic.
+		const dismissModalButton = this.page.getByRole( 'button', { name: 'Got it' } );
+
+		if ( ( await dismissModalButton.count() ) > 0 ) {
+			await dismissModalButton.click();
+			await dismissModalButton.waitFor( { state: 'hidden' } );
+		}
 	}
 
 	/**
@@ -25,12 +56,113 @@ export class StatsPage {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickTab( name: StatsTabs ): Promise< void > {
-		const dismissModalButton = this.page.getByRole( 'button', { name: 'Got it' } );
-
-		if ( ( await dismissModalButton.count() ) > 0 ) {
-			await dismissModalButton.click();
-			await dismissModalButton.waitFor( { state: 'hidden' } );
-		}
+		await this.dismissModal();
 		await clickNavTab( this.page, name );
+
+		// Wait for the expected URL scheme to load.
+		if ( name === 'Traffic' ) {
+			await this.page.waitForURL( /stats\/day/ );
+		}
+		if ( name === 'Insights' ) {
+			await this.page.waitForURL( /stats\/insights/ );
+		}
+		if ( name === 'Subscribers' ) {
+			await this.page.waitForURL( /stats\/subscribers/ );
+		}
+	}
+
+	// Traffic
+
+	/**
+	 *
+	 * @param period
+	 */
+	async selectHighlightPeriod( period: HighlightStatsPeriod ): Promise< void > {
+		await this.dismissModal();
+
+		const switcherButton = this.anchor.locator( selectors.highlightPeriodSelectButton );
+		await switcherButton.click();
+
+		// Tooltips live outside the normal DOM tree.
+		const tooltip = this.page.getByRole( 'tooltip', { name: /highlights/ } );
+		await tooltip.waitFor();
+		await tooltip.getByRole( 'button', { name: period } ).click();
+
+		// Dismiss.
+		await switcherButton.click();
+	}
+
+	/**
+	 *
+	 * @param period
+	 */
+	async selectStatsPeriod( period: StatsPeriod ) {
+		const target = this.anchor.getByRole( 'radiogroup' ).getByRole( 'radio', { name: period } );
+		await target.click();
+
+		if ( ! ( await target.isChecked() ) ) {
+			throw new Error( `Failed to select the Stats Period ${ period }` );
+		}
+	}
+
+	/**
+	 *
+	 * @param category
+	 */
+	async showTrafficOfType( category: StatsTrafficActivityCategory ): Promise< void > {
+		await this.page.locator( '.chart__bars' ).waitFor();
+
+		const target = this.anchor
+			.locator( '.stats-tabs' )
+			.getByRole( 'listitem' )
+			.filter( { hasText: category } );
+		await target.waitFor();
+		await target.click();
+
+		await this.page.waitForURL( new RegExp( `tab=${ category }`, 'i' ) );
+
+		const classes = await target.getAttribute( 'class' );
+		if ( ! classes?.includes( 'is-selected' ) ) {
+			throw new Error( `Failed to click and filter traffic data category to ${ category }.` );
+		}
+	}
+
+	// Insights
+
+	/**
+	 *
+	 */
+	async clickViewAllAnnualInsights() {
+		await this.anchor.getByRole( 'link', { name: 'View all annual insights' } ).click();
+
+		await this.page.waitForURL( /annualstats/ );
+	}
+
+	/**
+	 *
+	 * @param year
+	 */
+	async annualInsightPresentForYear( year: number ) {
+		await this.page
+			.getByRole( 'main' )
+			.getByRole( 'table' )
+			.getByRole( 'rowheader' )
+			.filter( { hasText: year.toString() } )
+			.waitFor();
+	}
+
+	// Subscribers
+
+	/**
+	 *
+	 * @param type
+	 */
+	async selectSubscriberType( type: 'WordPress.com' | 'Email' ) {
+		const target = this.anchor.getByRole( 'radiogroup' ).getByRole( 'radio', { name: type } );
+		await target.click();
+
+		if ( ! ( await target.isChecked() ) ) {
+			throw new Error( `Failed to select the Subscriber type ${ type }` );
+		}
 	}
 }

--- a/test/e2e/specs/stats/stats.ts
+++ b/test/e2e/specs/stats/stats.ts
@@ -13,6 +13,7 @@ import {
 	envVariables,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
+import { skipDescribeIf } from '../../jest-helpers';
 
 declare const browser: Browser;
 
@@ -102,7 +103,10 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 		} );
 	} );
 
-	describe( 'Store', function () {
+	// While not strictly true (there can be AT sites without stores enabled),
+	// for the purpose of test accounts this is a sufficient comparison.
+	// The Store tab is only available to those on Business and higher plans.
+	skipDescribeIf( envVariables.TEST_ON_ATOMIC === false )( 'Store', function () {
 		it( 'Click on the Store tab', async function () {
 			await statsPage.clickTab( 'Store' );
 		} );

--- a/test/e2e/specs/stats/stats.ts
+++ b/test/e2e/specs/stats/stats.ts
@@ -16,6 +16,11 @@ import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
+/**
+ * Shallowly tests the Stats feature, including Jetpack/Odyssey stats.
+ *
+ * Keywords: Stats, Jetpack, Odyssey Stats
+ */
 describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 	let page: Page;
 	let testAccount: TestAccount;
@@ -38,10 +43,15 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 	} );
 
 	it( 'Navigate to Stats', async function () {
+		statsPage = new StatsPage( page );
+
+		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
+			return await statsPage.visit(
+				DataHelper.getAccountSiteURL( accountName, { protocol: false } )
+			);
+		}
 		const sidebarComponent = new SidebarComponent( page );
 		await sidebarComponent.navigate( 'Stats' );
-
-		statsPage = new StatsPage( page );
 	} );
 
 	describe( 'Traffic', function () {
@@ -58,11 +68,11 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 		} );
 
 		it( 'Filter traffic activity to Likes', async function () {
-			await statsPage.showTrafficOfType( 'Likes' );
+			await statsPage.showStatsOfType( { tab: 'Traffic', type: 'Likes' } );
 		} );
 
 		it( 'Filter traffic activity to Comments', async function () {
-			await statsPage.showTrafficOfType( 'Views' );
+			await statsPage.showStatsOfType( { tab: 'Traffic', type: 'Visitors' } );
 		} );
 	} );
 
@@ -89,6 +99,20 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 
 		it( 'Click link to see all annual insights', async function () {
 			await statsPage.selectSubscriberType( 'Email' );
+		} );
+	} );
+
+	describe( 'Store', function () {
+		it( 'Click on the Store tab', async function () {
+			await statsPage.clickTab( 'Store' );
+		} );
+
+		it( 'Select "Years" stats period', async function () {
+			await statsPage.selectStatsPeriod( 'Years' );
+		} );
+
+		it( 'Select "Gross sales" stats type', async function () {
+			await statsPage.showStatsOfType( { tab: 'Store', type: 'Gross Sales' } );
 		} );
 	} );
 } );

--- a/test/e2e/specs/stats/stats.ts
+++ b/test/e2e/specs/stats/stats.ts
@@ -33,7 +33,7 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
+		if ( testAccount.accountName === 'jetpackAtomicEcommPlanUser' ) {
 			// eCommerce plan sites attempt to load Calypso, but with
 			// third-party cookies disabled the fallback route to WP-Admin
 			// kicks in after some time.
@@ -103,10 +103,9 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 		} );
 	} );
 
-	// While not strictly true (there can be AT sites without stores enabled),
-	// for the purpose of test accounts this is a sufficient comparison.
-	// The Store tab is only available to those on Business and higher plans.
-	skipDescribeIf( envVariables.TEST_ON_ATOMIC === false )( 'Store', function () {
+	// The Store tab is not present unless Business or higher plan is on the site and the
+	// site has gone AT.
+	skipDescribeIf( accountName !== 'jetpackAtomicEcommPlanUser' )( 'Store', function () {
 		it( 'Click on the Store tab', async function () {
 			await statsPage.clickTab( 'Store' );
 		} );

--- a/test/e2e/specs/stats/stats__insights.ts
+++ b/test/e2e/specs/stats/stats__insights.ts
@@ -1,34 +1,94 @@
 /**
  * @group calypso-pr
+ * @group jetpack-wpcom-integration
  */
 
-import { DataHelper, StatsPage, SidebarComponent, TestAccount } from '@automattic/calypso-e2e';
+import {
+	DataHelper,
+	StatsPage,
+	SidebarComponent,
+	TestAccount,
+	getTestAccountByFeature,
+	envToFeatureKey,
+	envVariables,
+} from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 	let page: Page;
+	let testAccount: TestAccount;
+	let statsPage: StatsPage;
 
-	describe.each`
-		siteType      | accountName
-		${ 'Atomic' } | ${ 'atomicUser' }
-	`( 'View Insights ($siteType)', function ( { accountName } ) {
-		beforeAll( async () => {
-			page = await browser.newPage();
+	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 
-			const testAccount = new TestAccount( accountName );
+	beforeAll( async () => {
+		page = await browser.newPage();
+
+		testAccount = new TestAccount( accountName );
+		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
+			// eCommerce plan sites attempt to load Calypso, but with
+			// third-party cookies disabled the fallback route to WP-Admin
+			// kicks in after some time.
+			await testAccount.authenticate( page, { url: /wp-admin/ } );
+		} else {
 			await testAccount.authenticate( page );
+		}
+	} );
+
+	it( 'Navigate to Stats', async function () {
+		const sidebarComponent = new SidebarComponent( page );
+		await sidebarComponent.navigate( 'Stats' );
+
+		statsPage = new StatsPage( page );
+	} );
+
+	describe( 'Traffic', function () {
+		it( 'Click on the Traffic tab', async function () {
+			await statsPage.clickTab( 'Traffic' );
 		} );
 
-		it( 'Navigate to Stats', async function () {
-			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.navigate( 'Stats' );
+		it( 'View 30-day highlights', async function () {
+			await statsPage.selectHighlightPeriod( '30-day' );
 		} );
 
+		it( 'Select "Months" stats period', async function () {
+			await statsPage.selectStatsPeriod( 'Months' );
+		} );
+
+		it( 'Filter traffic activity to Likes', async function () {
+			await statsPage.showTrafficOfType( 'Likes' );
+		} );
+
+		it( 'Filter traffic activity to Comments', async function () {
+			await statsPage.showTrafficOfType( 'Views' );
+		} );
+	} );
+
+	describe( 'Insights', function () {
 		it( 'Click on Insights tab', async function () {
-			const statsPage = new StatsPage( page );
 			await statsPage.clickTab( 'Insights' );
+		} );
+
+		it( 'Click link to see all annual insights', async function () {
+			await statsPage.clickViewAllAnnualInsights();
+
+			await statsPage.annualInsightPresentForYear( 2023 );
+		} );
+
+		it( 'Go back', async function () {
+			await page.goBack();
+		} );
+	} );
+
+	describe( 'Subscribers', function () {
+		it( 'Click on Subscribers tab', async function () {
+			await statsPage.clickTab( 'Subscribers' );
+		} );
+
+		it( 'Click link to see all annual insights', async function () {
+			await statsPage.selectSubscriberType( 'Email' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80730.

## Proposed Changes

This PR adds coverage for the rest of the Stats module, powered by Jetpack.

Key changes:
- significantly increase coverage of the existing Stats E2E to all major features of the Stats module.
- add significant number of new POM methods.

## Testing Instructions

  sEnsure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

**Jetpack AT**
![image](https://github.com/Automattic/wp-calypso/assets/6549265/03c11440-abd2-4254-9ee4-7a9bdb4ba61d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
