### PR TITLE
Migration Trial : fix date calculation on expire notice

### DIFF
--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -1038,29 +1038,42 @@ class PurchaseNotice extends Component<
 		const onClick = () => {
 			return page( `/plans/${ selectedSite?.slug }` );
 		};
-		const expiry = moment( purchase.expiryDate );
-		const daysToExpiry = moment( expiry.diff( moment() ) ).format( 'D' );
+		const expiry = moment.utc( purchase.expiryDate );
+		const daysToExpiry = isExpired( purchase )
+			? 0
+			: Math.floor( expiry.diff( moment().utc(), 'days', true ) );
 		const productType =
 			productSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY
 				? translate( 'ecommerce' )
 				: getPlan( PLAN_BUSINESS )?.getTitle();
-		return (
-			<Notice
-				showDismiss={ false }
-				status="is-info"
-				text={
-					// translators: %expiry is the number of days remaining on the trial, %productType is the type of product (e.g. ecommerce)
-					translate(
-						'You have %(expiry)s days remaining on your free trial. Upgrade your plan to keep your %(productType)s features.',
-						{
-							args: {
-								expiry: daysToExpiry,
-								productType: productType as string,
-							},
-						}
-					)
+		let noticeText;
+		if ( ! daysToExpiry ) {
+			// translators: %productType is the type of product (e.g. ecommerce)
+			noticeText = translate(
+				'Your free trial has expired. Upgrade your plan to keep your %(productType)s features.',
+				{
+					args: {
+						productType: productType as string,
+					},
 				}
-			>
+			);
+		} else {
+			// translators: %expiry is the number of days remaining on the trial, %productType is the type of product (e.g. ecommerce)
+			noticeText = translate(
+				'You have %(expiry)s day remaining on your free trial. Upgrade your plan to keep your %(productType)s features.',
+				'You have %(expiry)s days remaining on your free trial. Upgrade your plan to keep your %(productType)s features.',
+				{
+					count: daysToExpiry,
+					args: {
+						expiry: daysToExpiry,
+						productType: productType as string,
+					},
+				}
+			);
+		}
+
+		return (
+			<Notice showDismiss={ false } status="is-info" text={ noticeText }>
 				<NoticeAction onClick={ onClick }>{ translate( 'Upgrade Now' ) }</NoticeAction>
 			</Notice>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #Automattic/dotcom-forge#3558

## Proposed Changes

*  If the trial plan is expired, we shouldn't show days count on the expired notice.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use one of your expired trial site.
* Navigate to `http://calypso.localhost:3000/purchases/subscriptions/:site_slug`
* Click on the expired plan.
* See if the messages shows correctly as below.

![Screen Shot 2023-08-22 at 2 43 56 PM](https://github.com/Automattic/wp-calypso/assets/4074459/449546d8-b7de-40eb-8217-8c0a498c0253)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
