### PR TITLE
Theme Detail page: Update banner copy for Partner themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1018,11 +1018,11 @@ class ThemeSheet extends Component {
 
 		if ( isBundledSoftwareSet && ! isExternallyManagedTheme ) {
 			return translate( 'Access this WooCommerce theme with a Business plan!' );
-		} else if ( isExternallyManagedTheme ) {
-			if ( ! isMarketplaceThemeSubscribed && ! isSiteEligibleForManagedExternalThemes ) {
+		} else if ( isExternallyManagedTheme && ! isMarketplaceThemeSubscribed ) {
+			if ( ! isSiteEligibleForManagedExternalThemes ) {
 				return translate( 'Upgrade to a Business plan and subscribe to this theme!' );
 			}
-			return translate( 'Subscribe to this premium theme!' );
+			return translate( 'Subscribe to this theme!' );
 		}
 
 		return translate( 'Access this theme for FREE with a Premium or Business plan!' );
@@ -1041,13 +1041,13 @@ class ThemeSheet extends Component {
 			return translate(
 				'This theme comes bundled with the WooCommerce plugin. Upgrade to a Business plan to select this theme and unlock all its features.'
 			);
-		} else if ( isExternallyManagedTheme ) {
-			if ( ! isMarketplaceThemeSubscribed && ! isSiteEligibleForManagedExternalThemes ) {
+		} else if ( isExternallyManagedTheme && ! isMarketplaceThemeSubscribed ) {
+			if ( ! isSiteEligibleForManagedExternalThemes ) {
 				return translate(
-					'Unlock this theme by upgrading to a Business plan and subscribing to this premium theme.'
+					'Unlock this theme by upgrading to a Business plan and subscribing to this theme.'
 				);
 			}
-			return translate( 'Subscribe to this premium theme and unlock all its features.' );
+			return translate( 'Subscribe to this theme and unlock all its features.' );
 		}
 
 		return translate(


### PR DESCRIPTION
## Proposed Changes

Currently, the upsell banner for Partner theme contains the word "premium "in its copy, which can be confused with Premium themes. This PR proposed to remove the word "premium" from the banner.

Simple sites:
| Before | After |
| --- | --- |
| ![Screenshot 2023-08-22 at 2 57 22 PM](https://github.com/Automattic/wp-calypso/assets/797888/103828e4-cf7c-4e35-bb91-e1d78a1f0159)| ![Screenshot 2023-08-22 at 2 57 40 PM](https://github.com/Automattic/wp-calypso/assets/797888/36aac850-aa8f-4bb6-837b-2aba9c5ed613)|

Atomic sites:
| Before | After |
| --- | --- |
|![Screenshot 2023-08-22 at 2 57 05 PM](https://github.com/Automattic/wp-calypso/assets/797888/c8ab37d6-ce41-49a0-90ca-32653d362e2c)| ![Screenshot 2023-08-22 at 2 56 23 PM](https://github.com/Automattic/wp-calypso/assets/797888/58fecb19-3707-49e7-a150-c4a58ed425ae)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Pick a Partner theme.
* Ensure that the banner copy is updated as described above.
* Test this for Simple and Atomic sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
