### PR TITLE
Jetpack E2E: add step to check Social Sharing icons on published page.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -142,10 +142,9 @@ export class PublishedPostPage {
 	 * @param {string} name Name of the social sharing button.
 	 */
 	async validateSocialButton( name: string, { click }: { click?: boolean } = {} ) {
-		const button = this.anchor
-			.getByRole( 'list' )
-			.getByRole( 'listitem' )
-			.filter( { hasText: new RegExp( name, 'i' ) } );
+		const button = this.anchor.getByRole( 'link', { name: name } );
+
+		await button.waitFor();
 
 		if ( click ) {
 			const popupPromise = this.page.waitForEvent( 'popup' );

--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -132,4 +132,27 @@ export class PublishedPostPage {
 	async validateTags( tag: string ): Promise< void > {
 		await this.page.waitForSelector( `a:text-is("${ tag }")` );
 	}
+
+	/**
+	 * Validates the presence of a social sharing button on the published content.
+	 *
+	 * If optional parameter `click` is set, the button will be clicked to verify
+	 * functionality.
+	 *
+	 * @param {string} name Name of the social sharing button.
+	 */
+	async validateSocialButton( name: string, { click }: { click?: boolean } = {} ) {
+		const button = this.anchor
+			.getByRole( 'list' )
+			.getByRole( 'listitem' )
+			.filter( { hasText: new RegExp( name, 'i' ) } );
+
+		if ( click ) {
+			const popupPromise = this.page.waitForEvent( 'popup' );
+			await button.click();
+			const popup = await popupPromise;
+			await popup.waitForLoadState( 'load' );
+			await popup.close();
+		}
+	}
 }

--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -3,6 +3,9 @@ import { Locator, Page } from 'playwright';
 const selectors = {
 	// Post body
 	postPasswordInput: 'input[name="post_password"]',
+
+	// Published content
+	socialShareSection: '.sharedaddy',
 };
 
 /**
@@ -142,7 +145,11 @@ export class PublishedPostPage {
 	 * @param {string} name Name of the social sharing button.
 	 */
 	async validateSocialButton( name: string, { click }: { click?: boolean } = {} ) {
-		const button = this.anchor.getByRole( 'link', { name: name } );
+		// CSS selector have to be used due to no accessible locator for narrowing
+		// to the social icons.
+		const button = this.anchor
+			.locator( selectors.socialShareSection )
+			.getByRole( 'link', { name: name } );
 
 		await button.waitFor();
 

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -125,5 +125,15 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			await publishedPostPage.validateCategory( category );
 			await publishedPostPage.validateTags( tag );
 		} );
+
+		// Press This button is not available in AT.
+		// @see: paYJgx-1lp-p2
+		it.each( [ { name: 'Twitter' }, { name: 'Facebook' } ] )(
+			'Social sharing button for $name can be clicked',
+			async function ( { name } ) {
+				publishedPostPage = new PublishedPostPage( page );
+				await publishedPostPage.validateSocialButton( name, { click: true } );
+			}
+		);
 	} );
 } );

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -126,14 +126,15 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			await publishedPostPage.validateTags( tag );
 		} );
 
-		// Press This button is not available in AT.
+		// Not checking the `Press This` button as it is not available on AT.
 		// @see: paYJgx-1lp-p2
-		it.each( [ { name: 'Twitter' }, { name: 'Facebook' } ] )(
-			'Social sharing button for $name can be clicked',
-			async function ( { name } ) {
-				publishedPostPage = new PublishedPostPage( page );
-				await publishedPostPage.validateSocialButton( name, { click: true } );
-			}
-		);
+		// Skip test on Private user because social sharing only works on public sites.
+		skipItIf( accountName === 'jetpackAtomicPrivateUser' ).each( [
+			{ name: 'Twitter' },
+			{ name: 'Facebook' },
+		] )( 'Social sharing button for $name can be clicked', async function ( { name } ) {
+			publishedPostPage = new PublishedPostPage( page );
+			await publishedPostPage.validateSocialButton( name, { click: true } );
+		} );
 	} );
 } );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80730.

## Proposed Changes

This PR adds a test step at the end of `Editor: Basic Post Flow` to iterate through a pre-defined list of Social Sharing services, and check actionability on the buttons.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Jetpack E2E Simple
  - [x] Jetpack E2E AT
  - [x] Calypso E2E (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
