### PR TITLE
Jetpack E2E: add flow for AI Assistant block.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
@@ -40,7 +40,8 @@ export class AIAssistantFlow implements BlockFlow {
 	/**
 	 * Configure the block in the editor with the configuration data from the constructor
 	 *
-	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 * @param {EditorContext} context The current context for the editor at the point of
+	 * test execution.
 	 */
 	async configure( context: EditorContext ): Promise< void > {
 		const editorCanvas = await context.editorPage.getEditorCanvas();
@@ -90,6 +91,7 @@ export class AIAssistantFlow implements BlockFlow {
 		const changeToneButton = anchor.getByRole( 'button', { name: 'Change tone' } );
 		await changeToneButton.waitFor();
 		await changeToneButton.click();
+
 		await editorCanvas
 			.getByRole( 'menu', { name: 'Change tone' } )
 			.getByRole( 'menuitem', { name: this.configurationData.tone } )
@@ -110,6 +112,7 @@ export class AIAssistantFlow implements BlockFlow {
 		const improveButton = anchor.getByRole( 'button', { name: 'Improve' } );
 		await improveButton.waitFor();
 		await improveButton.click();
+
 		await editorCanvas
 			.getByRole( 'menu', { name: 'Improve' } )
 			.getByRole( 'menuitem', { name: this.configurationData.improve } )
@@ -142,15 +145,21 @@ export class AIAssistantFlow implements BlockFlow {
 	 * @param {Locator} anchor The root locator of the block.
 	 */
 	private async waitForQuery( anchor: Locator ) {
-		await anchor
-			.getByRole( 'button', { name: 'Stop request' } )
-			.waitFor( { state: 'detached', timeout: 15 * 1000 } );
+		await Promise.all( [
+			anchor
+				.getByRole( 'button', { name: 'Stop request' } )
+				.waitFor( { state: 'detached', timeout: 15 * 1000 } ),
+			anchor
+				.getByRole( 'textbox', { name: 'Ask Jetpack AI', disabled: true } )
+				.waitFor( { state: 'detached', timeout: 15 * 1000 } ),
+		] );
 	}
 
 	/**
 	 * Validate the block in the published post
 	 *
-	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 * @param {PublishedPostContext} context The current context for the published post at
+	 * the point of test execution.
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
 		await context.page.getByRole( 'main' ).getByText( this.generatedText ).waitFor();

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
@@ -19,7 +19,7 @@ interface ConfigurationData {
 }
 
 /**
- * Represents the flow of using an Ad block.
+ * Represents the flow of using the AI Assistant block.
  */
 export class AIAssistantFlow implements BlockFlow {
 	private configurationData: ConfigurationData;

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
@@ -1,0 +1,154 @@
+import { Locator } from 'playwright';
+import { BlockFlow, EditorContext, PublishedPostContext } from '.';
+
+interface ConfigurationData {
+	query: string;
+	tone?:
+		| 'Formal'
+		| 'Informal'
+		| 'Optimistic'
+		| 'Humorous'
+		| 'Serious'
+		| 'Skeptical'
+		| 'Empathetic'
+		| 'Confident'
+		| 'Passionate'
+		| 'Provocative';
+	improve?: 'Summarize' | 'Make longer' | 'Make shorter';
+}
+
+/**
+ * Represents the flow of using an Ad block.
+ */
+export class AIAssistantFlow implements BlockFlow {
+	private configurationData: ConfigurationData;
+	private generatedText: string;
+	/**
+	 * Constructs an instance of this block flow with data to be used when
+	 * configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData Configuration data for the block.
+	 */
+	constructor( configurationData: ConfigurationData ) {
+		this.configurationData = configurationData;
+		this.generatedText = '';
+	}
+
+	blockSidebarName = 'AI Assistant (Experimental)';
+	blockEditorSelector = 'div[aria-label="Block: AI Assistant (Experimental)"]';
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+
+		await this.initialQuery( editorCanvas );
+
+		if ( this.configurationData.tone ) {
+			await this.changeTone( editorCanvas );
+		}
+
+		if ( this.configurationData.improve ) {
+			await this.improve( editorCanvas );
+		}
+
+		await this.accept( editorCanvas );
+	}
+
+	/**
+	 * Fill the text input with the initial query and submit.
+	 *
+	 * @param {Locator} editorCanvas Locator to the editor.
+	 */
+	private async initialQuery( editorCanvas: Locator ) {
+		const anchor = editorCanvas.getByRole( 'document', {
+			name: `Block: ${ this.blockSidebarName }`,
+		} );
+
+		// Fill in the query into the input field.
+		await anchor
+			.getByRole( 'textbox', { name: 'Ask Jetpack AI' } )
+			.fill( this.configurationData.query );
+
+		await anchor.getByRole( 'button', { name: 'Send' } ).click();
+
+		// Wait for the query and text generation to complete.
+		await this.waitForQuery( anchor );
+	}
+
+	/**
+	 * Clicks on the tone specified in the configuration data.
+	 *
+	 * @param {Locator} editorCanvas Locator to the editor.
+	 */
+	private async changeTone( editorCanvas: Locator ) {
+		const anchor = editorCanvas.getByRole( 'toolbar', { name: 'Block tools' } );
+
+		await anchor.getByRole( 'button', { name: 'Change tone' } ).click();
+		await editorCanvas
+			.getByRole( 'menu', { name: 'Change tone' } )
+			.getByRole( 'menuitem', { name: this.configurationData.tone } )
+			.click();
+
+		// Wait for the query and text generation to complete.
+		await this.waitForQuery( anchor );
+	}
+
+	/**
+	 * Clicks on the improve option specified in the configuration data.
+	 *
+	 * @param {Locator} editorCanvas Locator to the editor.
+	 */
+	private async improve( editorCanvas: Locator ) {
+		const anchor = editorCanvas.getByRole( 'toolbar', { name: 'Block tools' } );
+
+		await anchor.getByRole( 'button', { name: 'Improve' } ).click();
+		await editorCanvas
+			.getByRole( 'menu', { name: 'Improve' } )
+			.getByRole( 'menuitem', { name: this.configurationData.improve } )
+			.click();
+
+		// Wait for the query and text generation to complete.
+		await this.waitForQuery( anchor );
+	}
+
+	/**
+	 * Accepts the generated text.
+	 *
+	 * @param {Locator} editorCanvas Locator to the editor.
+	 */
+	private async accept( editorCanvas: Locator ) {
+		const anchor = editorCanvas.getByRole( 'document', {
+			name: `Block: ${ this.blockSidebarName }`,
+		} );
+
+		// Accept the query and confirm the AI Assistant block is replaced.
+		await anchor.getByRole( 'button', { name: 'Accept' } ).click();
+		await anchor.waitFor( { state: 'detached' } );
+
+		this.generatedText = await editorCanvas.locator( '.is-selected' ).innerText();
+	}
+
+	/**
+	 * Helper method to wait for the query to complete.
+	 *
+	 * @param {Locator} anchor The root locator of the block.
+	 */
+	private async waitForQuery( anchor: Locator ) {
+		await anchor
+			.getByRole( 'button', { name: 'Stop request' } )
+			.waitFor( { state: 'detached', timeout: 15 * 1000 } );
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		await context.page.getByRole( 'main' ).getByText( this.generatedText ).waitFor();
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
@@ -23,6 +23,7 @@ interface ConfigurationData {
 export class AIAssistantFlow implements BlockFlow {
 	private configurationData: ConfigurationData;
 	private generatedText: string;
+
 	/**
 	 * Constructs an instance of this block flow with data to be used when
 	 * configuring and validating the block.

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
@@ -87,7 +87,9 @@ export class AIAssistantFlow implements BlockFlow {
 	private async changeTone( editorCanvas: Locator ) {
 		const anchor = editorCanvas.getByRole( 'toolbar', { name: 'Block tools' } );
 
-		await anchor.getByRole( 'button', { name: 'Change tone' } ).click();
+		const changeToneButton = anchor.getByRole( 'button', { name: 'Change tone' } );
+		await changeToneButton.waitFor();
+		await changeToneButton.click();
 		await editorCanvas
 			.getByRole( 'menu', { name: 'Change tone' } )
 			.getByRole( 'menuitem', { name: this.configurationData.tone } )

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
@@ -105,7 +105,9 @@ export class AIAssistantFlow implements BlockFlow {
 	private async improve( editorCanvas: Locator ) {
 		const anchor = editorCanvas.getByRole( 'toolbar', { name: 'Block tools' } );
 
-		await anchor.getByRole( 'button', { name: 'Improve' } ).click();
+		const improveButton = anchor.getByRole( 'button', { name: 'Improve' } );
+		await improveButton.waitFor();
+		await improveButton.click();
 		await editorCanvas
 			.getByRole( 'menu', { name: 'Improve' } )
 			.getByRole( 'menuitem', { name: this.configurationData.improve } )

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
@@ -45,113 +45,103 @@ export class AIAssistantFlow implements BlockFlow {
 	 */
 	async configure( context: EditorContext ): Promise< void > {
 		const editorCanvas = await context.editorPage.getEditorCanvas();
+		const block = editorCanvas.getByRole( 'document', {
+			name: `Block: ${ this.blockSidebarName }`,
+		} );
 
-		await this.initialQuery( editorCanvas );
+		await this.enterInput( block );
+		await this.clickButtonOnBlock( block, 'Send' );
+		await this.waitForQuery( editorCanvas );
 
 		if ( this.configurationData.tone ) {
-			await this.changeTone( editorCanvas );
+			await this.clickToolbarButton( 'Change tone', this.configurationData.tone, context );
+			await this.waitForQuery( editorCanvas );
 		}
 
 		if ( this.configurationData.improve ) {
-			await this.improve( editorCanvas );
+			await this.clickToolbarButton( 'Improve', this.configurationData.improve, context );
+			await this.waitForQuery( editorCanvas );
 		}
 
-		await this.accept( editorCanvas );
+		await this.clickButtonOnBlock( block, 'Accept' );
+		await block.waitFor( { state: 'detached' } );
+		this.generatedText = await editorCanvas.locator( '.is-selected' ).innerText();
 	}
 
 	/**
-	 * Fill the text input with the initial query and submit.
+	 * Clicks on the toolbar button, then in the dropdown that appears, clicks an option.
 	 *
-	 * @param {Locator} editorCanvas Locator to the editor.
+	 * @param {string} buttonName Name of the button to click.
+	 * @param {string} optionName Name of the option in the dropdown to click.
+	 * @param {EditorContext} context The current context for the editor at the point of
+	 * test execution.
 	 */
-	private async initialQuery( editorCanvas: Locator ) {
-		const anchor = editorCanvas.getByRole( 'document', {
-			name: `Block: ${ this.blockSidebarName }`,
-		} );
+	private async clickToolbarButton(
+		buttonName: string,
+		optionName: string,
+		context: EditorContext
+	) {
+		// Block-based and non-block-based themes strike again.
+		// For block-based themes (eg. Twenty Twenty-Three) a given block's toolbar
+		// lives "outside" of the DOM tree returned by `getEditorCanvas`.
+		// For non-block-based themes (eg. Twenty Twenty-One) a block's toolbar
+		// lives in the same DOM tree as the locator returned by `getEditorCanvas`.
+		// However, the locator returned by `getEditorParent` has the toolbar inside
+		// the DOM tree in both cases.
+		const editorParent = await context.editorPage.getEditorParent();
 
-		// Fill in the query into the input field.
-		await anchor
+		const toolbar = editorParent.getByRole( 'toolbar', { name: 'Block tools' } );
+		await toolbar.waitFor();
+		// Yes, yuck, I know. But Playwright often tries to act on the buttons sooner
+		// than it should, so we need to wait for the bounding box of the element here
+		// to be stable before attempting to click on the toolbar.
+		const elementHandle = await toolbar.elementHandle();
+		await elementHandle?.waitForElementState( 'stable' );
+
+		const button = toolbar.getByRole( 'button', { name: buttonName } );
+		await button.waitFor();
+		await button.click();
+
+		const option = editorParent.getByRole( 'menuitem', { name: optionName } );
+		await option.waitFor();
+		await option.click();
+	}
+
+	/**
+	 * Clicks on a button on the block.
+	 *
+	 * @param {Locator} block Locator to the block.
+	 * @param {string}name Name of the button to click.
+	 */
+	private async clickButtonOnBlock( block: Locator, name: string ) {
+		await block.getByRole( 'button', { name: name } ).click();
+	}
+
+	/**
+	 * Enters the query into the input on the block.
+	 *
+	 * @param {Locator} block Locator to the block.
+	 */
+	private async enterInput( block: Locator ) {
+		await block
 			.getByRole( 'textbox', { name: 'Ask Jetpack AI' } )
 			.fill( this.configurationData.query );
-
-		await anchor.getByRole( 'button', { name: 'Send' } ).click();
-
-		// Wait for the query and text generation to complete.
-		await this.waitForQuery( anchor );
-	}
-
-	/**
-	 * Clicks on the tone specified in the configuration data.
-	 *
-	 * @param {Locator} editorCanvas Locator to the editor.
-	 */
-	private async changeTone( editorCanvas: Locator ) {
-		const anchor = editorCanvas.getByRole( 'toolbar', { name: 'Block tools' } );
-
-		const changeToneButton = anchor.getByRole( 'button', { name: 'Change tone' } );
-		await changeToneButton.waitFor();
-		await changeToneButton.click();
-
-		await editorCanvas
-			.getByRole( 'menu', { name: 'Change tone' } )
-			.getByRole( 'menuitem', { name: this.configurationData.tone } )
-			.click();
-
-		// Wait for the query and text generation to complete.
-		await this.waitForQuery( anchor );
-	}
-
-	/**
-	 * Clicks on the improve option specified in the configuration data.
-	 *
-	 * @param {Locator} editorCanvas Locator to the editor.
-	 */
-	private async improve( editorCanvas: Locator ) {
-		const anchor = editorCanvas.getByRole( 'toolbar', { name: 'Block tools' } );
-
-		const improveButton = anchor.getByRole( 'button', { name: 'Improve' } );
-		await improveButton.waitFor();
-		await improveButton.click();
-
-		await editorCanvas
-			.getByRole( 'menu', { name: 'Improve' } )
-			.getByRole( 'menuitem', { name: this.configurationData.improve } )
-			.click();
-
-		// Wait for the query and text generation to complete.
-		await this.waitForQuery( anchor );
-	}
-
-	/**
-	 * Accepts the generated text.
-	 *
-	 * @param {Locator} editorCanvas Locator to the editor.
-	 */
-	private async accept( editorCanvas: Locator ) {
-		const anchor = editorCanvas.getByRole( 'document', {
-			name: `Block: ${ this.blockSidebarName }`,
-		} );
-
-		// Accept the query and confirm the AI Assistant block is replaced.
-		await anchor.getByRole( 'button', { name: 'Accept' } ).click();
-		await anchor.waitFor( { state: 'detached' } );
-
-		this.generatedText = await editorCanvas.locator( '.is-selected' ).innerText();
 	}
 
 	/**
 	 * Helper method to wait for the query to complete.
 	 *
-	 * @param {Locator} anchor The root locator of the block.
+	 * @param {Locator} block Locator to the block.
 	 */
-	private async waitForQuery( anchor: Locator ) {
+	private async waitForQuery( block: Locator ) {
 		await Promise.all( [
-			anchor
+			block
 				.getByRole( 'button', { name: 'Stop request' } )
 				.waitFor( { state: 'detached', timeout: 15 * 1000 } ),
-			anchor
+			block
 				.getByRole( 'textbox', { name: 'Ask Jetpack AI', disabled: true } )
 				.waitFor( { state: 'detached', timeout: 15 * 1000 } ),
+			block.locator( '.components-spinner' ).waitFor( { state: 'detached' } ),
 		] );
 	}
 

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -18,6 +18,7 @@ export * from './slideshow';
 export * from './tiled-gallery';
 export * from './youtube';
 export * from './layout-grid';
+export * from './ai-assistant';
 
 /* Types */
 export * from './types';

--- a/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
@@ -55,7 +55,6 @@ export class EditorBlockToolbarComponent {
 
 		if ( identifier.name ) {
 			// Accessible names don't need to have the selector built.
-			await editorParent.getByRole( 'button', { name: identifier.name } ).click( { trial: true } );
 			await editorParent.getByRole( 'button', { name: identifier.name } ).click();
 		} else {
 			// Other identifers need to have the selector built.

--- a/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
@@ -24,6 +24,7 @@ const selectors = {
 export interface BlockToolbarButtonIdentifier {
 	text?: string;
 	ariaLabel?: string;
+	name?: string;
 }
 
 /**
@@ -51,8 +52,16 @@ export class EditorBlockToolbarComponent {
 	 */
 	async clickPrimaryButton( identifier: BlockToolbarButtonIdentifier ): Promise< void > {
 		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selectors.button( identifier ) );
-		await locator.click();
+
+		if ( identifier.name ) {
+			// Accessible names don't need to have the selector built.
+			await editorParent.getByRole( 'button', { name: identifier.name } ).click( { trial: true } );
+			await editorParent.getByRole( 'button', { name: identifier.name } ).click();
+		} else {
+			// Other identifers need to have the selector built.
+			const locator = editorParent.locator( selectors.button( identifier ) );
+			await locator.click();
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
@@ -26,7 +26,6 @@ export class EditorPopoverMenuComponent {
 		const editorParent = await this.editor.parent();
 
 		const locator = editorParent.getByRole( 'menu' ).getByRole( 'menuitem', { name: name } );
-		await locator.click( { trial: true } );
 		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
@@ -1,12 +1,6 @@
 import { Page } from 'playwright';
 import { EditorComponent } from './editor-component';
 
-const popoverParentSelector = '.popover-slot .components-popover';
-
-const selectors = {
-	menuButton: ( name: string ) => `${ popoverParentSelector } :text-is("${ name }")`,
-};
-
 /**
  * Represents the popover menu that can be launched from multiple different places.
  */
@@ -30,7 +24,9 @@ export class EditorPopoverMenuComponent {
 	 */
 	async clickMenuButton( name: string ): Promise< void > {
 		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selectors.menuButton( name ) );
+
+		const locator = editorParent.getByRole( 'menu' ).getByRole( 'menuitem', { name: name } );
+		await locator.click( { trial: true } );
 		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
@@ -25,7 +25,7 @@ export class EditorPopoverMenuComponent {
 	async clickMenuButton( name: string ): Promise< void > {
 		const editorParent = await this.editor.parent();
 
-		const locator = editorParent.getByRole( 'menu' ).getByRole( 'menuitem', { name: name } );
+		const locator = editorParent.getByRole( 'menuitem', { name: name } );
 		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -16,7 +16,9 @@ import {
 	EditorWelcomeTourComponent,
 	EditorBlockToolbarComponent,
 	EditorTemplateModalComponent,
+	EditorPopoverMenuComponent,
 	TemplateCategory,
+	BlockToolbarButtonIdentifier,
 } from '../components';
 import { BlockInserter, OpenInlineInserter } from './shared-types';
 import type {
@@ -57,6 +59,7 @@ export class EditorPage {
 	private editorWelcomeTourComponent: EditorWelcomeTourComponent;
 	private editorBlockToolbarComponent: EditorBlockToolbarComponent;
 	private editorTemplateModalComponent: EditorTemplateModalComponent;
+	private editorPopoverMenuComponent: EditorPopoverMenuComponent;
 
 	/**
 	 * Constructs an instance of the component.
@@ -85,6 +88,7 @@ export class EditorPage {
 			this.editor
 		);
 		this.editorTemplateModalComponent = new EditorTemplateModalComponent( page, this.editor );
+		this.editorPopoverMenuComponent = new EditorPopoverMenuComponent( page, this.editor );
 	}
 
 	//#region Generic and Shell Methods
@@ -423,6 +427,27 @@ export class EditorPage {
 	 */
 	async moveBlockDown(): Promise< void > {
 		await this.editorBlockToolbarComponent.moveDown();
+	}
+
+	/**
+	 * Selects the matching option from the popover triggered by clicking
+	 * on a block toolbar button.
+	 *
+	 * @param {string} name Accessible name of the element.
+	 */
+	async selectFromToolbarPopover( name: string ) {
+		await this.editorPopoverMenuComponent.clickMenuButton( name );
+	}
+
+	/**
+	 * Clicks on a button with either the name or aria-label on the
+	 * editor toolbar.
+	 *
+	 * @param {BlockToolbarButtonIdentifier} name Object specifying either the
+	 * 	text label or aria-label of the button to be clicked.
+	 */
+	async clickBlockToolbarButton( name: BlockToolbarButtonIdentifier ): Promise< void > {
+		await this.editorBlockToolbarComponent.clickPrimaryButton( name );
 	}
 
 	//#endregion

--- a/test/e2e/specs/blocks/blocks__jetpack-earn.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-earn.ts
@@ -6,7 +6,6 @@ import {
 	BlockFlow,
 	PayWithPaypalBlockFlow,
 	OpenTableFlow,
-	AIAssistantFlow,
 	// PaymentsBlockFlow,
 	// envVariables,
 } from '@automattic/calypso-e2e';
@@ -20,11 +19,6 @@ const blockFlows: BlockFlow[] = [
 	} ),
 	new OpenTableFlow( {
 		restaurant: 'Miku Restaurant - Vancouver',
-	} ),
-	new AIAssistantFlow( {
-		query: 'In three sentences, tell me about Vancouver, Canada.',
-		tone: 'Passionate',
-		improve: 'Make shorter',
 	} ),
 ];
 

--- a/test/e2e/specs/blocks/blocks__jetpack-earn.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-earn.ts
@@ -6,6 +6,7 @@ import {
 	BlockFlow,
 	PayWithPaypalBlockFlow,
 	OpenTableFlow,
+	AIAssistantFlow,
 	// PaymentsBlockFlow,
 	// envVariables,
 } from '@automattic/calypso-e2e';
@@ -19,6 +20,11 @@ const blockFlows: BlockFlow[] = [
 	} ),
 	new OpenTableFlow( {
 		restaurant: 'Miku Restaurant - Vancouver',
+	} ),
+	new AIAssistantFlow( {
+		query: 'In three sentences, tell me about Vancouver, Canada.',
+		tone: 'Passionate',
+		improve: 'Make shorter',
 	} ),
 ];
 

--- a/test/e2e/specs/blocks/blocks__jetpack-writing.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-writing.ts
@@ -10,6 +10,7 @@ const blockFlows: BlockFlow[] = [
 		query: 'In two short sentences, tell me about Vancouver, Canada.',
 		tone: 'Passionate',
 		improve: 'Make shorter',
+		keywords: [ 'Vancouver, Canada' ],
 	} ),
 ];
 

--- a/test/e2e/specs/blocks/blocks__jetpack-writing.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-writing.ts
@@ -1,0 +1,16 @@
+/**
+ * @group gutenberg
+ * @group jetpack-wpcom-integration
+ */
+import { BlockFlow, AIAssistantFlow } from '@automattic/calypso-e2e';
+import { createBlockTests } from './shared/block-smoke-testing';
+
+const blockFlows: BlockFlow[] = [
+	new AIAssistantFlow( {
+		query: 'In two short sentences, tell me about Vancouver, Canada.',
+		tone: 'Passionate',
+		improve: 'Make shorter',
+	} ),
+];
+
+createBlockTests( 'Blocks: Jetpack Writing', blockFlows );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80730.

## Proposed Changes

This PR adds a new block testing flow for the AI Assistant.

Key flows:
- initial query
- change tone
- improve

This change stretches what we have done with the Block Smoke Testing/BlockFlow template. 

## Testing Instructions
Ensure the following build configurations are passing:
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E AT 
  - [x] Calypso E2E (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
