### PR TITLE
Support: Ensure availability check is run on presales chat

### DIFF
--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -69,7 +69,7 @@ class DomainManagementData extends Component {
 }
 
 export function UsePresalesChat() {
-	usePresalesChat( 'wpcom', true, true );
+	usePresalesChat( 'wpcom' );
 	return null;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -13,7 +13,7 @@ const Intro: Step = function Intro( { navigation, flow, variantSlug } ) {
 	const { submit, goBack } = navigation;
 	const { __ } = useI18n();
 
-	usePresalesChat( 'wpcom', true, true );
+	usePresalesChat( 'wpcom' );
 
 	const handleSubmit = () => {
 		submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
@@ -13,7 +13,7 @@ const Intro: Step = function Intro( { navigation, variantSlug } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
 
-	usePresalesChat( 'wpcom', true, true );
+	usePresalesChat( 'wpcom' );
 
 	const handleSubmit = () => {
 		submit?.();

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -660,7 +660,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 }
 
 export function UsePresalesChat() {
-	usePresalesChat( 'wpcom', true, true );
+	usePresalesChat( 'wpcom' );
 }
 
 export default connect(

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -246,7 +246,7 @@ export default function WPCheckout( {
 	const couponFieldStateProps = useCouponFieldState( applyCoupon );
 	const total = useTotal();
 	const reduxDispatch = useReduxDispatch();
-	usePresalesChat( 'wpcom', true, true );
+	usePresalesChat( 'wpcom' );
 
 	const areThereDomainProductsInCart =
 		hasDomainRegistration( responseCart ) || hasTransferProduct( responseCart );


### PR DESCRIPTION
This way, presales chats don't skip the queue. Otherwise, support users will have a hard time getting an available live chat slot.

pbvpgB-3CR-p2#comment-9926

## Proposed Changes

* Enable availability checks for WPCOM presales chats. It seems they were disabled by @ebinnion in https://github.com/Automattic/wp-calypso/pull/80018#issuecomment-1659069371, which introduced this issue.

## Testing Instructions

Visit places that have presales chat enabled (for example, Domains Management), verify there's an API call to `is-available` endpoint being made. Mock the API results to verify that if there's no availability, the presales chat is not shown.

<img width="465" alt="Screenshot 2023-08-22 at 10 06 58" src="https://github.com/Automattic/wp-calypso/assets/3392497/601fb179-4d5e-45f8-93d2-a5f5d49fb00e">
