### PR TITLE
Domain Management i1: Fix issue where selecting a redirect also selects a domain

### DIFF
--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useLayoutEffect } from 'react';
 import { DomainsTableColumn, DomainsTableHeader } from '../domains-table-header';
 import { domainsTableColumns } from '../domains-table-header/columns';
+import { getDomainId } from '../get-domain-id';
 import { DomainsTableRow } from './domains-table-row';
 import type {
 	PartialDomainData,
@@ -44,11 +45,11 @@ export function DomainsTable( {
 		}
 
 		setSelectedDomains( ( selectedDomains ) => {
-			const domainUrls = domains.map( ( { domain } ) => domain );
+			const domainIds = domains.map( getDomainId );
 			const selectedDomainsCopy = new Set( selectedDomains );
 
 			for ( const selectedDomain of selectedDomainsCopy ) {
-				if ( ! domainUrls.includes( selectedDomain ) ) {
+				if ( ! domainIds.includes( selectedDomain ) ) {
 					selectedDomainsCopy.delete( selectedDomain );
 				}
 			}
@@ -58,13 +59,14 @@ export function DomainsTable( {
 	}, [ domains ] );
 
 	const handleSelectDomain = useCallback(
-		( { domain }: PartialDomainData ) => {
+		( domain: PartialDomainData ) => {
+			const domainId = getDomainId( domain );
 			const selectedDomainsCopy = new Set( selectedDomains );
 
-			if ( selectedDomainsCopy.has( domain ) ) {
-				selectedDomainsCopy.delete( domain );
+			if ( selectedDomainsCopy.has( domainId ) ) {
+				selectedDomainsCopy.delete( domainId );
 			} else {
-				selectedDomainsCopy.add( domain );
+				selectedDomainsCopy.add( domainId );
 			}
 
 			setSelectedDomains( selectedDomainsCopy );
@@ -111,7 +113,7 @@ export function DomainsTable( {
 
 	const changeBulkSelection = () => {
 		if ( ! hasSelectedDomains || ! areAllDomainsSelected ) {
-			setSelectedDomains( new Set( domains.map( ( { domain } ) => domain ) ) );
+			setSelectedDomains( new Set( domains.map( getDomainId ) ) );
 		} else {
 			setSelectedDomains( new Set() );
 		}
@@ -132,9 +134,9 @@ export function DomainsTable( {
 			<tbody>
 				{ domains.map( ( domain ) => (
 					<DomainsTableRow
-						key={ domain.domain }
+						key={ getDomainId( domain ) }
 						domain={ domain }
-						isSelected={ selectedDomains.has( domain.domain ) }
+						isSelected={ selectedDomains.has( getDomainId( domain ) ) }
 						onSelect={ handleSelectDomain }
 						fetchSiteDomains={ fetchSiteDomains }
 						fetchSite={ fetchSite }

--- a/packages/domains-table/src/get-domain-id.ts
+++ b/packages/domains-table/src/get-domain-id.ts
@@ -1,0 +1,12 @@
+import type { DomainData, PartialDomainData } from '@automattic/data-stores';
+
+/**
+ * Returns a synthetic ID for a domain.
+ *
+ * Using the domain name isn't unique enough: redirect domains uses the redirect
+ * destination as their `domain` field, meaning if the user owns the redirect
+ * destination too, then both can appear in the domains table at the same time.
+ */
+export function getDomainId( domain: PartialDomainData | DomainData ): string {
+	return domain.domain + domain.blog_id;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* The `domain` field is not a unique enough identifier. Use a new unique identifier to represent each row.

If the user owns domain `my-domain.com`, and they also have a redirect domain set up which redirects one of their other sites to `my-domain.com`, then both of those domains appear as `my-domain.com` in the table. Two rows with the same `domain` field!

Once the table is complete this will be fine because there's labels etc. to identify redirects. However it's an issue because we've been using `domain` as the unique identifier for a row. This PR uses a new composite of `domain` + `blog_id`, which I think should be unique enough.

I asked here D119262-code#2359612 whether there's a real domain ID we can use instead. But I think this should be unique enough for now.

**Before**


https://github.com/Automattic/wp-calypso/assets/1500769/2b97ebb2-b085-4761-a106-623e2b1822d4



**After**


https://github.com/Automattic/wp-calypso/assets/1500769/e6872f5c-5ba8-430b-aeef-2e8b2b35645a



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a redirect domain to point to one of your other domains
* `/domains/manage?flags=domains/management`
* There should be no "duplicate key" warnings in the console
* Multi-select should work as expected

The unit tests also pass. As I was writing the PR I had watch mode running. Tests failed as I updated things. Tests passed once the refactor was complete. 👌

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
