### PR TITLE
Fix breakpoints for trial features page

### DIFF
--- a/client/my-sites/plans/current-plan/trials/trial-current-plan.scss
+++ b/client/my-sites/plans/current-plan/trials/trial-current-plan.scss
@@ -57,11 +57,15 @@ body.is-section-plans.is-business-trial-plan {
 
 		@media (min-width: $break-large) {
 			flex-direction: column;
-			width: calc(25% - 24px);
+			width: calc(50% - 24px);
 			margin-right: 12px;
 			margin-left: 12px;
 			margin-bottom: 24px;
 			padding: 48px 24px 24px;
+		}
+
+		@media (min-width: $break-wide) {
+			width: calc(25% - 24px);
 		}
 
 		.feature-included-card__content {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, to avoid
using the "fixes" keyword and instead, attach the [Status] Fix Inbound label to
the linked issue.
-->

The breakpoints on the `/plans/my-plan/<site-id>` cause the columns to be very narrow when the screen is smaller.

<img width="842" alt="CleanShot 2566-08-22 at 18 38 57@2x" src="https://github.com/Automattic/wp-calypso/assets/10244734/dffc6973-afb3-4bdd-8f76-03e54e10f880">

This makes the page looks quite cramped.

## Proposed Changes

As suggested, we only display 4 columns at the 1280px breakpoint.

## Testing Instructions

1. Open an active migration or woo trial site.
2. Navigate to `plans/my-plan/<site-id>`
3. Resize the screen and verify that before the 1280px breakpoint, we display the features in two columns.
4. Verify that before the 960px breakpoint we display 1 column.

<img width="807" alt="CleanShot 2566-08-22 at 18 42 06@2x" src="https://github.com/Automattic/wp-calypso/assets/10244734/7f6fc017-9a60-4f87-a8f8-acb2288722b5">

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
