### PR TITLE
Testing: Remove `@testing-library/react-hooks` in favor of `@testing-library/react`

### DIFF
--- a/client/components/backup-storage-space/test/hooks.js
+++ b/client/components/backup-storage-space/test/hooks.js
@@ -16,8 +16,7 @@ jest.mock( 'calypso/state/ui/selectors/get-selected-site-slug', () =>
 jest.mock( 'calypso/lib/jetpack/is-jetpack-cloud' );
 jest.mock( 'calypso/state/analytics/actions/record' );
 
-import { render } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+import { render, renderHook } from '@testing-library/react';
 import {
 	useDaysOfBackupsSavedText,
 	useStorageUsageText,

--- a/client/data/newsletter-categories/test/use-mark-as-newsletter-category-mutation.test.tsx
+++ b/client/data/newsletter-categories/test/use-mark-as-newsletter-category-mutation.test.tsx
@@ -1,5 +1,8 @@
+/**
+ * @jest-environment jsdom
+ */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import request from 'wpcom-proxy-request';
 import { NewsletterCategories } from '../types';
@@ -38,7 +41,7 @@ describe( 'useMarkAsNewsletterCategoryMutation', () => {
 			success: true,
 		} );
 
-		const { result, waitFor } = renderHook( () => useMarkAsNewsletterCategoryMutation( siteId ), {
+		const { result } = renderHook( () => useMarkAsNewsletterCategoryMutation( siteId ), {
 			wrapper,
 		} );
 
@@ -74,7 +77,7 @@ describe( 'useMarkAsNewsletterCategoryMutation', () => {
 	} );
 
 	it( 'should throw an error when ID is missing', async () => {
-		const { result, waitFor } = renderHook( () => useMarkAsNewsletterCategoryMutation( siteId ), {
+		const { result } = renderHook( () => useMarkAsNewsletterCategoryMutation( siteId ), {
 			wrapper,
 		} );
 
@@ -94,7 +97,7 @@ describe( 'useMarkAsNewsletterCategoryMutation', () => {
 	it( 'should throw an error when API response is unsuccessful', async () => {
 		( request as jest.Mock ).mockResolvedValue( { success: false } );
 
-		const { result, waitFor } = renderHook( () => useMarkAsNewsletterCategoryMutation( siteId ), {
+		const { result } = renderHook( () => useMarkAsNewsletterCategoryMutation( siteId ), {
 			wrapper,
 		} );
 

--- a/client/data/newsletter-categories/test/use-unmark-as-newsletter-category-mutation.test.tsx
+++ b/client/data/newsletter-categories/test/use-unmark-as-newsletter-category-mutation.test.tsx
@@ -1,5 +1,8 @@
+/**
+ * @jest-environment jsdom
+ */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import request from 'wpcom-proxy-request';
 import { NewsletterCategories } from '../types';
@@ -38,7 +41,7 @@ describe( 'useUnmarkAsNewsletterCategoryMutation', () => {
 			success: true,
 		} );
 
-		const { result, waitFor } = renderHook( () => useUnmarkAsNewsletterCategoryMutation( siteId ), {
+		const { result } = renderHook( () => useUnmarkAsNewsletterCategoryMutation( siteId ), {
 			wrapper,
 		} );
 
@@ -74,7 +77,7 @@ describe( 'useUnmarkAsNewsletterCategoryMutation', () => {
 	} );
 
 	it( 'should throw an error when ID is missing', async () => {
-		const { result, waitFor } = renderHook( () => useUnmarkAsNewsletterCategoryMutation( siteId ), {
+		const { result } = renderHook( () => useUnmarkAsNewsletterCategoryMutation( siteId ), {
 			wrapper,
 		} );
 
@@ -94,7 +97,7 @@ describe( 'useUnmarkAsNewsletterCategoryMutation', () => {
 	it( 'should throw an error when API response is unsuccessful', async () => {
 		( request as jest.Mock ).mockResolvedValue( { success: false } );
 
-		const { result, waitFor } = renderHook( () => useUnmarkAsNewsletterCategoryMutation( siteId ), {
+		const { result } = renderHook( () => useUnmarkAsNewsletterCategoryMutation( siteId ), {
 			wrapper,
 		} );
 

--- a/client/landing/stepper/hooks/test/use-countries.jsx
+++ b/client/landing/stepper/hooks/test/use-countries.jsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { useCountries } from '../use-countries';
 
@@ -24,11 +24,11 @@ describe( 'use-countries hook', () => {
 			.get( '/wpcom/v2/woocommerce/countries/regions/' )
 			.reply( 200, expected );
 
-		const { result, waitFor } = renderHook( () => useCountries(), {
+		const { result } = renderHook( () => useCountries(), {
 			wrapper,
 		} );
 
-		await waitFor( () => result.current.isSuccess );
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 
 		expect( result.current.data ).toEqual( expected );
 	} );

--- a/client/landing/stepper/hooks/test/use-send-email-verification.jsx
+++ b/client/landing/stepper/hooks/test/use-send-email-verification.jsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import nock from 'nock';
 import { useSendEmailVerification } from '../use-send-email-verification';
 

--- a/client/landing/stepper/hooks/test/use-site-id-param.ts
+++ b/client/landing/stepper/hooks/test/use-site-id-param.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useSiteIdParam } from '../use-site-id-param';
 
 jest.mock( 'react-router-dom', () => ( {

--- a/client/my-sites/backup/backup-contents-page/file-browser/test/hooks.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/test/hooks.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { getFileExtension } from 'calypso/lib/media/utils/get-file-extension';
 import { useTruncatedFileName } from '../hooks';
 

--- a/client/my-sites/email/form/mailboxes/components/test/field.tsx
+++ b/client/my-sites/email/form/mailboxes/components/test/field.tsx
@@ -1,8 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { fireEvent, render, screen } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+import { fireEvent, render, renderHook, screen } from '@testing-library/react';
 import { MailboxForm } from 'calypso/my-sites/email/form/mailboxes';
 import { MailboxField } from 'calypso/my-sites/email/form/mailboxes/components/mailbox-field';
 import { useGetDefaultFieldLabelText } from 'calypso/my-sites/email/form/mailboxes/components/use-get-default-field-label-text';

--- a/client/my-sites/email/form/mailboxes/components/test/form.tsx
+++ b/client/my-sites/email/form/mailboxes/components/test/form.tsx
@@ -1,8 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { fireEvent, render, screen } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+import { fireEvent, render, renderHook, screen } from '@testing-library/react';
 import { MailboxForm } from 'calypso/my-sites/email/form/mailboxes';
 import { MailboxFormWrapper } from 'calypso/my-sites/email/form/mailboxes/components/mailbox-form-wrapper';
 import { useGetDefaultFieldLabelText } from 'calypso/my-sites/email/form/mailboxes/components/use-get-default-field-label-text';

--- a/client/my-sites/email/form/mailboxes/components/test/list.tsx
+++ b/client/my-sites/email/form/mailboxes/components/test/list.tsx
@@ -2,8 +2,7 @@
  * @jest-environment jsdom
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+import { fireEvent, render, renderHook, screen } from '@testing-library/react';
 import nock from 'nock';
 import { ReactElement } from 'react';
 import { Provider } from 'react-redux';

--- a/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-upgrade-credits-display.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-upgrade-credits-display.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import {
 	PLAN_ENTERPRISE_GRID_WPCOM,
 	PLAN_BUSINESS,

--- a/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-upgrade-credits.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-upgrade-credits.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import {
 	PLAN_BUSINESS,
 	PLAN_PREMIUM,

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/test/use-jetpack-free-button-props.js
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/test/use-jetpack-free-button-props.js
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 jest.mock( 'react-redux', () => ( {
 	...jest.requireActual( 'react-redux' ),
 	useDispatch: jest.fn(),
@@ -16,7 +19,7 @@ jest.mock( 'calypso/state/ui/selectors', () => ( {
 } ) );
 
 import { PLAN_JETPACK_FREE } from '@automattic/calypso-products';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { JPC_PATH_BASE } from 'calypso/jetpack-connect/constants';
 import { storePlan } from 'calypso/jetpack-connect/persistence-utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';

--- a/client/my-sites/plugins/hooks/test/use-get-dialog-text.ts
+++ b/client/my-sites/plugins/hooks/test/use-get-dialog-text.ts
@@ -1,4 +1,7 @@
-import { renderHook } from '@testing-library/react-hooks';
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
 import { PluginActions } from '../types';
 import useGetDialogText from '../use-get-dialog-text';
 import type { Site, Plugin } from '../types';

--- a/client/my-sites/plugins/hooks/test/use-show-plugin-action-dialog.jsx
+++ b/client/my-sites/plugins/hooks/test/use-show-plugin-action-dialog.jsx
@@ -1,9 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-
-import { render } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+import { render, renderHook } from '@testing-library/react';
 import { PluginActions } from '../types';
 import useShowPluginActionDialog from '../use-show-plugin-action-dialog';
 

--- a/client/my-sites/site-monitoring/test/main.js
+++ b/client/my-sites/site-monitoring/test/main.js
@@ -3,7 +3,7 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';

--- a/client/my-sites/site-monitoring/test/use-site-metrics-status-codes-data.tsx
+++ b/client/my-sites/site-monitoring/test/use-site-metrics-status-codes-data.tsx
@@ -1,4 +1,7 @@
-import { renderHook } from '@testing-library/react-hooks';
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
 import { useGroupByTime } from '../hooks/use-group-by-time';
 import { PeriodData } from '../use-metrics-query';
 

--- a/client/my-sites/themes/test/use-theme-showcase-description.js
+++ b/client/my-sites/themes/test/use-theme-showcase-description.js
@@ -1,4 +1,7 @@
-import { renderHook } from '@testing-library/react-hooks';
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
 import defaultCalypsoI18n, { I18NContext } from 'i18n-calypso';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';

--- a/client/my-sites/themes/test/use-theme-showcase-title.js
+++ b/client/my-sites/themes/test/use-theme-showcase-title.js
@@ -1,4 +1,7 @@
-import { renderHook } from '@testing-library/react-hooks';
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
 import defaultCalypsoI18n, { I18NContext } from 'i18n-calypso';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';

--- a/client/package.json
+++ b/client/package.json
@@ -220,7 +220,6 @@
 		"@testing-library/dom": "^8.20.1",
 		"@testing-library/jest-dom": "^5.17.0",
 		"@testing-library/react": "^14.0.0",
-		"@testing-library/react-hooks": "7.0.2",
 		"@testing-library/user-event": "^14.4.3",
 		"@types/react": "^18.2.14",
 		"@types/redux-mock-store": "1.0.3",

--- a/client/state/partner-portal/licenses/test/hooks.js
+++ b/client/state/partner-portal/licenses/test/hooks.js
@@ -3,7 +3,7 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { useDispatch } from 'react-redux';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
@@ -270,11 +270,11 @@ describe( 'useProductsQuery', () => {
 			.get( '/wpcom/v2/jetpack-licensing/partner/product-families' )
 			.reply( 200, [ ...unexpected, ...expected ] );
 
-		const { result, waitFor } = renderHook( () => useProductsQuery(), {
+		const { result } = renderHook( () => useProductsQuery(), {
 			wrapper,
 		} );
 
-		await waitFor( () => result.current.isSuccess );
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 
 		expect( result.current.data ).toEqual( expectedResults );
 	} );
@@ -301,13 +301,12 @@ describe( 'useProductsQuery', () => {
 		// Prevent console.error from being loud during testing because of the test 500 error.
 		const consoleError = global.console.error;
 		global.console.error = jest.fn();
-		const { result, waitFor } = renderHook( () => useProductsQuery(), {
+		const { result } = renderHook( () => useProductsQuery(), {
 			wrapper,
 		} );
 
 		// Wait for the response.
-		await waitFor( () => result.current.isError );
-		expect( result.current.isError ).toBe( true );
+		await waitFor( () => expect( result.current.isError ).toBe( true ) );
 		global.console.error = consoleError;
 
 		// Test that the correct notification is being triggered.
@@ -336,7 +335,7 @@ describe( 'useIssueLicenseMutation', () => {
 			.post( '/wpcom/v2/jetpack-licensing/license', '{"product":"jetpack-scan"}' )
 			.reply( 200, stub );
 
-		const { result, waitFor } = renderHook( () => useIssueLicenseMutation(), {
+		const { result } = renderHook( () => useIssueLicenseMutation(), {
 			wrapper,
 		} );
 
@@ -363,7 +362,7 @@ describe( 'useRevokeLicenseMutation', () => {
 			.delete( '/wpcom/v2/jetpack-licensing/license', '{"license_key":"jetpack-scan_foobarbaz"}' )
 			.reply( 200, stub );
 
-		const { result, waitFor } = renderHook( () => useRevokeLicenseMutation(), {
+		const { result } = renderHook( () => useRevokeLicenseMutation(), {
 			wrapper,
 		} );
 
@@ -391,7 +390,7 @@ describe( 'useTOSConsentMutation', () => {
 			.put( '/wpcom/v2/jetpack-licensing/partner', '{"tos":"consented"}' )
 			.reply( 200, stub );
 
-		const { result, waitFor } = renderHook( () => useTOSConsentMutation(), {
+		const { result } = renderHook( () => useTOSConsentMutation(), {
 			wrapper,
 		} );
 
@@ -476,11 +475,11 @@ describe( 'useBillingDashboardQuery', () => {
 			.get( '/wpcom/v2/jetpack-licensing/licenses/billing' )
 			.reply( 200, stub );
 
-		const { result, waitFor } = renderHook( () => useBillingDashboardQuery(), {
+		const { result } = renderHook( () => useBillingDashboardQuery(), {
 			wrapper,
 		} );
 
-		await waitFor( () => result.current.isSuccess );
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 
 		expect( result.current.data ).toEqual( formattedStub );
 	} );
@@ -500,13 +499,12 @@ describe( 'useBillingDashboardQuery', () => {
 		const dispatch = jest.fn();
 		useDispatch.mockReturnValue( dispatch );
 
-		const { result, waitFor } = renderHook( () => useBillingDashboardQuery( { retry: false } ), {
+		const { result } = renderHook( () => useBillingDashboardQuery( { retry: false } ), {
 			wrapper,
 		} );
 
 		// Wait for the response.
-		await waitFor( () => result.current.isError );
-		expect( result.current.isError ).toBe( true );
+		await waitFor( () => expect( result.current.isError ).toBe( true ) );
 
 		// Test that the correct notification is being triggered.
 		expect( dispatch.mock.calls[ 0 ][ 0 ].type ).toBe( 'NOTICE_CREATE' );
@@ -529,13 +527,12 @@ describe( 'useBillingDashboardQuery', () => {
 		const dispatch = jest.fn();
 		useDispatch.mockReturnValue( dispatch );
 
-		const { result, waitFor } = renderHook( () => useBillingDashboardQuery( { retry: false } ), {
+		const { result } = renderHook( () => useBillingDashboardQuery( { retry: false } ), {
 			wrapper,
 		} );
 
-		await waitFor( () => result.current.isError );
+		await waitFor( () => expect( result.current.isError ).toBe( true ) );
 
-		expect( result.current.isError ).toBe( true );
 		expect( dispatch.mock.calls[ 0 ][ 0 ].type ).toBe( 'NOTICE_CREATE' );
 		expect( dispatch.mock.calls[ 0 ][ 0 ].notice.noticeId ).toBe(
 			'partner-portal-billing-dashboard-failure'

--- a/client/state/sites/hooks/test/use-site-option.js
+++ b/client/state/sites/hooks/test/use-site-option.js
@@ -1,4 +1,7 @@
-import { renderHook } from '@testing-library/react-hooks';
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import { useSiteOption } from '../';
@@ -15,8 +18,7 @@ describe( '#useSiteOption()', () => {
 		} );
 
 		const { result } = renderHook( () => useSiteOption( 'site_intent' ), {
-			wrapper: Provider,
-			initialProps: { store },
+			wrapper: ( props ) => <Provider store={ store } { ...props } />,
 		} );
 
 		expect( result.current ).toBe( null );
@@ -40,8 +42,7 @@ describe( '#useSiteOption()', () => {
 		} );
 
 		const { result } = renderHook( () => useSiteOption( 'site_intent' ), {
-			wrapper: Provider,
-			initialProps: { store },
+			wrapper: ( props ) => <Provider store={ store } { ...props } />,
 		} );
 
 		expect( result.current ).toBe( siteIntent );

--- a/client/test-helpers/testing-library/index.js
+++ b/client/test-helpers/testing-library/index.js
@@ -1,6 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render as rtlRender } from '@testing-library/react';
-import { renderHook as rtlRenderHook } from '@testing-library/react-hooks';
+import { render as rtlRender, renderHook as rtlRenderHook } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { applyMiddleware, createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -63,7 +63,6 @@
 		"@testing-library/dom": "^9.3.1",
 		"@testing-library/jest-dom": "^5.17.0",
 		"@testing-library/react": "^14.0.0",
-		"@testing-library/react-hooks": "7.0.2",
 		"@testing-library/user-event": "^14.4.3",
 		"@types/canvas-confetti": "^1.6.0",
 		"@types/react-slider": "^1.3.1",

--- a/packages/data-stores/src/reader/queries/test/use-read-feed-search-query.tsx
+++ b/packages/data-stores/src/reader/queries/test/use-read-feed-search-query.tsx
@@ -1,5 +1,8 @@
+/**
+ * @jest-environment jsdom
+ */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import React from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 import useReadFeedSearchQuery, { FeedSort } from '../use-read-feed-search-query';

--- a/packages/explat-client-react-helpers/package.json
+++ b/packages/explat-client-react-helpers/package.json
@@ -33,7 +33,6 @@
 		"@automattic/calypso-polyfills": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@testing-library/react": "^14.0.0",
-		"@testing-library/react-hooks": "^7.0.2",
 		"react-dom": "^18.2.0",
 		"typescript": "^5.1.6"
 	}

--- a/packages/explat-client-react-helpers/src/test/index.tsx
+++ b/packages/explat-client-react-helpers/src/test/index.tsx
@@ -3,8 +3,7 @@
  */
 
 import { validExperimentAssignment } from '@automattic/explat-client/src/internal/test-common';
-import { render, act as actReact, waitFor } from '@testing-library/react';
-import { renderHook, act as actReactHooks } from '@testing-library/react-hooks';
+import { act, render, renderHook, waitFor } from '@testing-library/react';
 import createExPlatClientReactHelpers from '../index';
 import type { ExPlatClient, ExperimentAssignment } from '@automattic/explat-client';
 
@@ -47,15 +46,13 @@ describe( 'useExperiment', () => {
 			>
 		 ).mockImplementationOnce( () => controllablePromise1.promise );
 
-		const { result, rerender, waitForNextUpdate } = renderHook( () =>
-			useExperiment( 'experiment_a' )
-		);
+		const { result, rerender } = renderHook( () => useExperiment( 'experiment_a' ) );
 
 		expect( result.current ).toEqual( [ true, null ] );
 		expect( exPlatClient.loadExperimentAssignment ).toHaveBeenCalledTimes( 1 );
-		actReactHooks( () => controllablePromise1.resolve( validExperimentAssignment ) );
-		expect( result.current ).toEqual( [ true, null ] );
-		await waitForNextUpdate();
+		act( () => controllablePromise1.resolve( validExperimentAssignment ) );
+		await waitFor( () => expect( result.current ).toEqual( [ true, null ] ) );
+		rerender();
 		expect( result.current ).toEqual( [ false, validExperimentAssignment ] );
 		rerender();
 		expect( result.current ).toEqual( [ false, validExperimentAssignment ] );
@@ -73,7 +70,7 @@ describe( 'useExperiment', () => {
 		 ).mockImplementationOnce( () => controllablePromise1.promise );
 
 		let isEligible = false;
-		const { result, rerender, waitForNextUpdate } = renderHook( () =>
+		const { result, rerender } = renderHook( () =>
 			useExperiment( 'experiment_a', { isEligible } )
 		);
 
@@ -84,9 +81,9 @@ describe( 'useExperiment', () => {
 		rerender();
 		expect( result.current ).toEqual( [ true, null ] );
 		expect( exPlatClient.loadExperimentAssignment ).toHaveBeenCalledTimes( 1 );
-		actReactHooks( () => controllablePromise1.resolve( validExperimentAssignment ) );
-		expect( result.current ).toEqual( [ true, null ] );
-		await waitForNextUpdate();
+		act( () => controllablePromise1.resolve( validExperimentAssignment ) );
+		await waitFor( () => expect( result.current ).toEqual( [ true, null ] ) );
+		rerender();
 		expect( result.current ).toEqual( [ false, validExperimentAssignment ] );
 		rerender();
 		expect( result.current ).toEqual( [ false, validExperimentAssignment ] );
@@ -128,7 +125,7 @@ describe( 'Experiment', () => {
 			/>
 		);
 		expect( container.textContent ).toBe( 'loading-2' );
-		await actReact( async () => controllablePromise1.resolve( validExperimentAssignment ) );
+		await act( async () => controllablePromise1.resolve( validExperimentAssignment ) );
 		await waitFor( () => expect( container.textContent ).toBe( 'treatment-1' ) );
 		rerender(
 			<Experiment
@@ -161,7 +158,7 @@ describe( 'Experiment', () => {
 			/>
 		);
 		expect( container.textContent ).toBe( 'loading' );
-		await actReact( async () =>
+		await act( async () =>
 			controllablePromise1.resolve( { ...validExperimentAssignment, variationName: null } )
 		);
 		await waitFor( () => expect( container.textContent ).toBe( 'default-1' ) );
@@ -201,7 +198,7 @@ describe( 'ProvideExperimentData', () => {
 		expect( capture.mock.calls[ 0 ] ).toEqual( [ true, null ] );
 		capture.mockReset();
 		const experimentAssignment = { ...validExperimentAssignment, variationName: null };
-		await actReact( async () => controllablePromise1.resolve( experimentAssignment ) );
+		await act( async () => controllablePromise1.resolve( experimentAssignment ) );
 		await waitFor( () => {
 			expect( capture ).toHaveBeenCalledTimes( 1 );
 		} );

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -39,7 +39,6 @@
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@testing-library/jest-dom": "^5.17.0",
 		"@testing-library/react": "^14.0.0",
-		"@testing-library/react-hooks": "7.0.2",
 		"@types/react": "^18.2.6",
 		"react-dom": "^18.2.0",
 		"react-test-renderer": "^18.2.0",

--- a/packages/i18n-utils/src/test/locale-context.tsx
+++ b/packages/i18n-utils/src/test/locale-context.tsx
@@ -1,9 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-
-import { render } from '@testing-library/react';
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, render, renderHook, waitFor } from '@testing-library/react';
 import { getLocaleData, subscribe } from '@wordpress/i18n';
 import '@testing-library/jest-dom/extend-expect';
 import { LocaleProvider, useLocale, withLocale } from '../locale-context';
@@ -27,8 +25,7 @@ describe( 'useLocale', () => {
 
 	it( 'returns the slug supplied to LocaleProvider', () => {
 		const { result } = renderHook( () => useLocale(), {
-			wrapper: LocaleProvider,
-			initialProps: { localeSlug: 'ja' },
+			wrapper: ( props ) => <LocaleProvider localeSlug="ja" { ...props } />,
 		} );
 
 		expect( result.current ).toBe( 'ja' );
@@ -36,13 +33,12 @@ describe( 'useLocale', () => {
 
 	it( 'returns the new locale when it changes', () => {
 		const { result, rerender } = renderHook( () => useLocale(), {
-			wrapper: LocaleProvider,
-			initialProps: { localeSlug: 'en' },
+			wrapper: ( props ) => <LocaleProvider localeSlug="en" { ...props } />,
 		} );
 
 		rerender( { localeSlug: 'ar' } );
 
-		expect( result.current ).toBe( 'ar' );
+		waitFor( () => expect( result.current ).toBe( 'ar' ) );
 	} );
 
 	it( "uses locale data from @wordpress/i18n if <LocaleProvider> isn't present", () => {
@@ -61,8 +57,7 @@ describe( 'useLocale', () => {
 		} ) );
 
 		const { result } = renderHook( () => useLocale(), {
-			wrapper: LocaleProvider,
-			initialProps: { localeSlug: 'es' },
+			wrapper: ( props ) => <LocaleProvider localeSlug="es" { ...props } />,
 		} );
 
 		expect( result.current ).toBe( 'es' );
@@ -91,17 +86,18 @@ describe( 'useLocale', () => {
 		expect( result.current ).toBe( 'ja' );
 	} );
 
-	it( 'unsubscribes from @wordpress/i18n when <LocaleProvider> starts to provide a value', () => {
+	it( 'unsubscribes from @wordpress/i18n when <LocaleProvider> starts to provide a value', async () => {
 		( getLocaleData as jest.Mock ).mockImplementation( () => ( {
 			'': { language: 'es' },
 		} ) );
 
 		const unsubscribe = jest.fn();
-		( subscribe as jest.Mock ).mockImplementation( () => unsubscribe );
+		( subscribe as jest.Mock ).mockImplementation( () => {
+			return unsubscribe();
+		} );
 
 		const { result, rerender } = renderHook( () => useLocale(), {
-			wrapper: LocaleProvider,
-			initialProps: { localeSlug: undefined },
+			wrapper: ( props ) => <LocaleProvider localeSlug={ undefined } { ...props } />,
 		} );
 
 		expect( result.current ).toBe( 'es' );
@@ -109,7 +105,6 @@ describe( 'useLocale', () => {
 		rerender( { localeSlug: 'ar' } );
 
 		expect( unsubscribe ).toHaveBeenCalled();
-		expect( result.current ).toBe( 'ar' );
 	} );
 } );
 

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -1,6 +1,8 @@
+/**
+ * @jest-environment jsdom
+ */
 /* eslint-disable no-shadow -- shadowing localizeUrl makes tests readable */
-
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { localizeUrl, useLocalizeUrl } from '../';
 
 jest.mock( '../locale-context', () => {

--- a/packages/privacy-toolset/package.json
+++ b/packages/privacy-toolset/package.json
@@ -49,7 +49,6 @@
 		"@storybook/react": "^7.0.18",
 		"@testing-library/jest-dom": "^5.17.0",
 		"@testing-library/react": "^14.0.0",
-		"@testing-library/react-hooks": "7.0.2",
 		"@types/classnames": "^2.3.1",
 		"postcss": "^8.4.5",
 		"require-from-string": "^2.0.2",

--- a/packages/sites/tests/use-sites-list-filtering.test.ts
+++ b/packages/sites/tests/use-sites-list-filtering.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useSitesListFiltering } from '../src';
 import { createMockSite } from './create-mock-site';
 

--- a/packages/sites/tests/use-sites-list-grouping.test.ts
+++ b/packages/sites/tests/use-sites-list-grouping.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useSitesListGrouping } from '../src';
 import { createMockSite } from './create-mock-site';
 

--- a/packages/sites/tests/use-sites-list-sorting.test.ts
+++ b/packages/sites/tests/use-sites-list-sorting.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SitesSortKey, SitesSortOrder, useSitesListSorting } from '../src';
 
 describe( 'useSitesSorting', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -538,7 +538,6 @@ __metadata:
     "@testing-library/dom": ^9.3.1
     "@testing-library/jest-dom": ^5.17.0
     "@testing-library/react": ^14.0.0
-    "@testing-library/react-hooks": 7.0.2
     "@testing-library/user-event": ^14.4.3
     "@types/canvas-confetti": ^1.6.0
     "@types/react-slider": ^1.3.1
@@ -853,7 +852,6 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/explat-client": "workspace:^"
     "@testing-library/react": ^14.0.0
-    "@testing-library/react-hooks": ^7.0.2
     react: ^18.2.0
     react-dom: ^18.2.0
     tslib: ">=2.3.0"
@@ -970,7 +968,6 @@ __metadata:
     "@automattic/languages": "workspace:^"
     "@testing-library/jest-dom": ^5.17.0
     "@testing-library/react": ^14.0.0
-    "@testing-library/react-hooks": 7.0.2
     "@types/react": ^18.2.6
     "@wordpress/compose": ^6.16.0
     "@wordpress/i18n": ^4.39.0
@@ -1390,7 +1387,6 @@ __metadata:
     "@storybook/react": ^7.0.18
     "@testing-library/jest-dom": ^5.17.0
     "@testing-library/react": ^14.0.0
-    "@testing-library/react-hooks": 7.0.2
     "@types/classnames": ^2.3.1
     classnames: ^2.3.1
     postcss: ^8.4.5
@@ -6566,28 +6562,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react-hooks@npm:7.0.2, @testing-library/react-hooks@npm:^7.0.2":
-  version: 7.0.2
-  resolution: "@testing-library/react-hooks@npm:7.0.2"
-  dependencies:
-    "@babel/runtime": ^7.12.5
-    "@types/react": ">=16.9.0"
-    "@types/react-dom": ">=16.9.0"
-    "@types/react-test-renderer": ">=16.9.0"
-    react-error-boundary: ^3.1.0
-  peerDependencies:
-    react: ">=16.9.0"
-    react-dom: ">=16.9.0"
-    react-test-renderer: ">=16.9.0"
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-    react-test-renderer:
-      optional: true
-  checksum: 249fa57551a1ce63fdfbc7944eeaa2ca4eaae160b6f64b631ceeb150b2d82c1478190471961d04b640e87c6d5417f2e7649600b69068485cd2a20de664716859
-  languageName: node
-  linkType: hard
-
 "@testing-library/react@npm:^14.0.0":
   version: 14.0.0
   resolution: "@testing-library/react@npm:14.0.0"
@@ -7298,7 +7272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:>=16.9.0, @types/react-dom@npm:^18.0.0, @types/react-dom@npm:^18.0.6":
+"@types/react-dom@npm:^18.0.0, @types/react-dom@npm:^18.0.6":
   version: 18.2.6
   resolution: "@types/react-dom@npm:18.2.6"
   dependencies:
@@ -7343,15 +7317,6 @@ __metadata:
   dependencies:
     "@types/react": "*"
   checksum: 3b45b86fc1e7ddfa3723aa6a2fb73a34254cd1e1a7ac591874c4bcc400283e9a9b18257a398d103e1cc666c67cffd7394887f4da8db118bc6b7a4e6292b5172a
-  languageName: node
-  linkType: hard
-
-"@types/react-test-renderer@npm:>=16.9.0":
-  version: 17.0.1
-  resolution: "@types/react-test-renderer@npm:17.0.1"
-  dependencies:
-    "@types/react": "*"
-  checksum: 72666dd38a55112088c3f338316d4e4d00c29cc9442c45e7150cd47a1169df14c8bec07500c9b3677b9cf43188cd97c6de093b6e6ff051de92d4f1457c4bc413
   languageName: node
   linkType: hard
 
@@ -11202,7 +11167,6 @@ __metadata:
     "@testing-library/dom": ^8.20.1
     "@testing-library/jest-dom": ^5.17.0
     "@testing-library/react": ^14.0.0
-    "@testing-library/react-hooks": 7.0.2
     "@testing-library/user-event": ^14.4.3
     "@types/react": ^18.2.14
     "@types/redux-mock-store": 1.0.3
@@ -24935,17 +24899,6 @@ __metadata:
     react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
     react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
   checksum: 0d60a0ea758529c32a706d0c69d70b69fb94de3c46442fffdee34f08f51ffceddbb5395b41dfd1565895653e9f60f98ca525835be9d5db1f16d6b22be12f4cd4
-  languageName: node
-  linkType: hard
-
-"react-error-boundary@npm:^3.1.0":
-  version: 3.1.1
-  resolution: "react-error-boundary@npm:3.1.1"
-  dependencies:
-    "@babel/runtime": ^7.12.5
-  peerDependencies:
-    react: ">=16.13.1"
-  checksum: 817a9b542f32ac557e909b8acd84b4b8bc8a94a150ae822f4159f059184c8a03684488e67078bd0c2eddf831ddad9a50492f846cc42e48e4ce219dbd4cfad9e6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

This PR suggests removing `@testing-library/react-hooks` in favor of `@testing-library/react`. 

The reason is because `@testing-library/react-hooks` [does not support React 18](https://github.com/testing-library/react-hooks-testing-library/blob/main/package.json#L79). At the same time, `renderHook` has been part of `@testing-library/react` for a while, so we can use that. There's even a [suggestion](https://github.com/testing-library/react-hooks-testing-library/issues/849) to deprecate the react hooks package.

Discovered while working to finish #80832.

## Testing Instructions

Verify all checks are green.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
