### PR TITLE
Plans 2023: Split and export plan-features and plan-comparison grids, et al

### DIFF
--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -1,10 +1,10 @@
 @import "@automattic/components/src/highlight-cards/variables.scss";
 
-$plan-features-sidebar-width: 272px;
+$plan-features-sidebar-width: 272px; // same as --sidebar-width-max
 $plan-features-header-banner-height: 20px;
 
 // Plan Features Grid Breakpoints
-$plans-2023-small-breakpoint: 780px;
+$plans-2023-small-breakpoint: 780px; // same as $break-medium
 $plans-2023-medium-breakpoint: 1200px;
 
 $minWidthToGridWidthMap: (

--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -29,7 +29,6 @@ type PlanFeaturesActionsButtonProps = {
 	canUserPurchasePlan?: boolean | null;
 	className: string;
 	currentSitePlanSlug?: string | null;
-	current: boolean;
 	freePlan: boolean;
 	manageHref: string;
 	isPopular?: boolean;
@@ -176,7 +175,6 @@ const LoggedInPlansFeatureActionButton = ( {
 	planTitle,
 	handleUpgradeButtonClick,
 	planSlug,
-	current,
 	manageHref,
 	canUserPurchasePlan,
 	currentSitePlanSlug,
@@ -192,7 +190,6 @@ const LoggedInPlansFeatureActionButton = ( {
 	planTitle: TranslateResult;
 	handleUpgradeButtonClick: () => void;
 	planSlug: string;
-	current?: boolean;
 	manageHref?: string;
 	canUserPurchasePlan?: boolean | null;
 	currentSitePlanSlug?: string | null;
@@ -201,6 +198,8 @@ const LoggedInPlansFeatureActionButton = ( {
 	planActionOverrides?: PlanActionOverrides;
 } ) => {
 	const translate = useTranslate();
+	const { gridPlansIndex } = usePlansGridContext();
+	const { current } = gridPlansIndex[ planSlug ];
 	const currentPlanBillPeriod = useSelector( ( state ) => {
 		return currentSitePlanSlug ? getPlanBillPeriod( state, currentSitePlanSlug ) : null;
 	} );
@@ -339,7 +338,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	canUserPurchasePlan,
 	className,
 	currentSitePlanSlug,
-	current = false,
 	freePlan = false,
 	manageHref,
 	isInSignup,
@@ -358,15 +356,15 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
 	const { gridPlansIndex } = usePlansGridContext();
+	const {
+		planTitle,
+		current,
+		pricing: { currencyCode, originalPrice, discountedPrice },
+	} = gridPlansIndex[ planSlug ];
 
 	const classes = classNames( 'plan-features-2023-grid__actions-button', className, {
 		'is-current-plan': current,
 	} );
-
-	const {
-		planTitle,
-		pricing: { currencyCode, originalPrice, discountedPrice },
-	} = gridPlansIndex[ planSlug ];
 
 	const handleUpgradeButtonClick = () => {
 		if ( ! freePlan ) {
@@ -466,7 +464,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			availableForPurchase={ availableForPurchase }
 			classes={ classes }
 			handleUpgradeButtonClick={ handleUpgradeButtonClick }
-			current={ current }
 			manageHref={ manageHref }
 			canUserPurchasePlan={ canUserPurchasePlan }
 			currentSitePlanSlug={ currentSitePlanSlug }

--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -36,7 +36,6 @@ type PlanFeaturesActionsButtonProps = {
 	isInSignup?: boolean;
 	isLaunchPage?: boolean | null;
 	onUpgradeClick: () => void;
-	planTitle: TranslateResult;
 	planSlug: PlanSlug;
 	flowName?: string | null;
 	buttonText?: string;
@@ -346,7 +345,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	isInSignup,
 	isLaunchPage,
 	onUpgradeClick,
-	planTitle,
 	planSlug,
 	flowName,
 	buttonText,
@@ -366,6 +364,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	} );
 
 	const {
+		planTitle,
 		pricing: { currencyCode, originalPrice, discountedPrice },
 	} = gridPlansIndex[ planSlug ];
 

--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -11,7 +11,7 @@ import {
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import styled from '@emotion/styled';
-import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../grid-context';
 
 function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
@@ -132,7 +132,6 @@ const DiscountPromotion = styled.div`
 
 interface Props {
 	planSlug: PlanSlug;
-	billingTimeframe: TranslateResult;
 }
 
 const PlanFeatures2023GridBillingTimeframe = ( { planSlug }: Props ) => {

--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -135,10 +135,10 @@ interface Props {
 	billingTimeframe: TranslateResult;
 }
 
-const PlanFeatures2023GridBillingTimeframe = ( { planSlug, billingTimeframe }: Props ) => {
+const PlanFeatures2023GridBillingTimeframe = ( { planSlug }: Props ) => {
 	const translate = useTranslate();
 	const { gridPlansIndex } = usePlansGridContext();
-	const { isMonthlyPlan } = gridPlansIndex[ planSlug ];
+	const { isMonthlyPlan, billingTimeframe } = gridPlansIndex[ planSlug ];
 	const perMonthDescription = usePerMonthDescription( { planSlug } );
 	const description = perMonthDescription || billingTimeframe;
 

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -458,7 +458,6 @@ const PlanComparisonGridHeaderCell = ( {
 				isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planSlug ) }
 				isInSignup={ isInSignup }
 				isLaunchPage={ isLaunchPage }
-				planTitle={ gridPlan.planConstantObj.getTitle() }
 				planSlug={ planSlug }
 				flowName={ flowName }
 				selectedSiteSlug={ selectedSiteSlug }

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -442,10 +442,7 @@ const PlanComparisonGridHeaderCell = ( {
 				siteId={ siteId }
 			/>
 			<div className="plan-comparison-grid__billing-info">
-				<PlanFeatures2023GridBillingTimeframe
-					planSlug={ planSlug }
-					billingTimeframe={ gridPlan.planConstantObj.getBillingTimeFrame() }
-				/>
+				<PlanFeatures2023GridBillingTimeframe planSlug={ planSlug } />
 			</div>
 			<PlanFeatures2023GridActions
 				currentSitePlanSlug={ currentSitePlanSlug }

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -412,7 +412,7 @@ const PlanComparisonGridHeaderCell = ( {
 						className="plan-comparison-grid__title-select"
 						value={ planSlug }
 					>
-						{ displayedGridPlans.map( ( { planSlug: otherPlan, planConstantObj } ) => {
+						{ displayedGridPlans.map( ( { planSlug: otherPlan, planTitle } ) => {
 							const isVisiblePlan = visibleGridPlans.find(
 								( { planSlug } ) => planSlug === otherPlan
 							);
@@ -423,14 +423,14 @@ const PlanComparisonGridHeaderCell = ( {
 
 							return (
 								<option key={ otherPlan } value={ otherPlan }>
-									{ planConstantObj.getTitle() }
+									{ planTitle }
 								</option>
 							);
 						} ) }
 					</select>
 				) }
 				<h4 className="plan-comparison-grid__title">
-					<span>{ gridPlan.planConstantObj.getTitle() }</span>
+					<span>{ gridPlan.planTitle }</span>
 					{ showPlanSelect && <DropdownIcon /> }
 				</h4>
 			</PlanSelector>

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid/index.tsx
@@ -20,7 +20,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback, useEffect, ChangeEvent } from 'react';
 import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible';
 import getPlanFeaturesObject from 'calypso/my-sites/plan-features-2023-grid/lib/get-plan-features-object';
-import PlanTypeSelector from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import { usePlansGridContext } from '../../grid-context';
 import useHighlightAdjacencyMatrix from '../../hooks/npm-ready/use-highlight-adjacency-matrix';
 import useIsLargeCurrency from '../../hooks/npm-ready/use-is-large-currency';
@@ -701,7 +700,6 @@ interface InternalPlanComparisonGridProps
 
 const PlanComparisonGrid = ( {
 	intervalType,
-	planTypeSelectorProps,
 	isInSignup,
 	isLaunchPage,
 	flowName,
@@ -875,11 +873,6 @@ const PlanComparisonGrid = ( {
 
 	return (
 		<div className="plan-comparison-grid">
-			<PlanTypeSelector
-				{ ...planTypeSelectorProps }
-				kind="interval"
-				plans={ displayedGridPlans.map( ( { planSlug } ) => planSlug ) }
-			/>
 			<Grid isInSignup={ isInSignup }>
 				<PlanComparisonGridHeader
 					siteId={ siteId }

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid/index.tsx
@@ -21,24 +21,24 @@ import { useState, useCallback, useEffect, ChangeEvent } from 'react';
 import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible';
 import getPlanFeaturesObject from 'calypso/my-sites/plan-features-2023-grid/lib/get-plan-features-object';
 import PlanTypeSelector from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
-import { usePlansGridContext } from '../grid-context';
-import useHighlightAdjacencyMatrix from '../hooks/npm-ready/use-highlight-adjacency-matrix';
-import useIsLargeCurrency from '../hooks/npm-ready/use-is-large-currency';
-import { sortPlans } from '../lib/sort-plan-properties';
-import { plansBreakSmall } from '../media-queries';
-import { getStorageStringFromFeature, usePricingBreakpoint } from '../util';
-import PlanFeatures2023GridActions from './actions';
-import PlanFeatures2023GridBillingTimeframe from './billing-timeframe';
-import PlanFeatures2023GridHeaderPrice from './header-price';
-import { Plans2023Tooltip } from './plans-2023-tooltip';
-import PopularBadge from './popular-badge';
+import { usePlansGridContext } from '../../grid-context';
+import useHighlightAdjacencyMatrix from '../../hooks/npm-ready/use-highlight-adjacency-matrix';
+import useIsLargeCurrency from '../../hooks/npm-ready/use-is-large-currency';
+import { sortPlans } from '../../lib/sort-plan-properties';
+import { plansBreakSmall } from '../../media-queries';
+import { getStorageStringFromFeature, usePricingBreakpoint } from '../../util';
+import PlanFeatures2023GridActions from '../actions';
+import PlanFeatures2023GridBillingTimeframe from '../billing-timeframe';
+import PlanFeatures2023GridHeaderPrice from '../header-price';
+import { Plans2023Tooltip } from '../plans-2023-tooltip';
+import PopularBadge from '../popular-badge';
 import type {
 	GridPlan,
 	TransformedFeatureObject,
-} from '../hooks/npm-ready/data-store/use-grid-plans';
-import type { PlanActionOverrides } from '../types';
+} from '../../hooks/npm-ready/data-store/use-grid-plans';
+import type { PlanActionOverrides, PlanComparisonGridProps } from '../../types';
 import type { FeatureObject, Feature, FeatureGroup, PlanSlug } from '@automattic/calypso-products';
-import type { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
+import '../../style.scss';
 
 function DropdownIcon() {
 	return (
@@ -58,15 +58,6 @@ const JetpackIconContainer = styled.div`
 	display: inline-block;
 	vertical-align: middle;
 	line-height: 1;
-`;
-
-const PlanComparisonHeader = styled.h1`
-	.plans .step-container .step-container__content &&,
-	&& {
-		font-size: 2rem;
-		text-align: center;
-		margin: 48px 0;
-	}
 `;
 
 const Title = styled.div< { isHiddenInMobile?: boolean } >`
@@ -301,25 +292,6 @@ const FeatureFootnote = styled.span`
 	}
 `;
 
-type PlanComparisonGridProps = {
-	intervalType?: string;
-	planTypeSelectorProps: PlanTypeSelectorProps;
-	isInSignup?: boolean;
-	isLaunchPage?: boolean | null;
-	flowName?: string | null;
-	currentSitePlanSlug?: string | null;
-	manageHref: string;
-	canUserPurchasePlan?: boolean | null;
-	selectedSiteSlug: string | null;
-	onUpgradeClick: ( planSlug: PlanSlug ) => void;
-	siteId?: number | null;
-	planActionOverrides?: PlanActionOverrides;
-	selectedPlan?: string;
-	selectedFeature?: string;
-	isGlobalStylesOnPersonal?: boolean;
-	showLegacyStorageFeature?: boolean;
-};
-
 type PlanComparisonGridHeaderProps = {
 	displayedGridPlans: GridPlan[];
 	visibleGridPlans: GridPlan[];
@@ -448,7 +420,6 @@ const PlanComparisonGridHeaderCell = ( {
 				currentSitePlanSlug={ currentSitePlanSlug }
 				manageHref={ manageHref }
 				canUserPurchasePlan={ canUserPurchasePlan }
-				current={ gridPlan.current ?? false }
 				availableForPurchase={ gridPlan.availableForPurchase }
 				className={ getPlanClass( planSlug ) }
 				freePlan={ isFreePlan( planSlug ) }
@@ -719,7 +690,16 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	);
 };
 
-export const PlanComparisonGrid = ( {
+// TODO clk: These `Internal...` props should gradually be factored out as more dependencies are moved to plans-features-main
+interface InternalPlanComparisonGridProps
+	extends Omit< PlanComparisonGridProps, 'onUpgradeClick' > {
+	onUpgradeClick: ( planSlug: PlanSlug ) => void;
+	canUserPurchasePlan: boolean | null;
+	manageHref: string;
+	selectedSiteSlug: string | null;
+}
+
+const PlanComparisonGrid = ( {
 	intervalType,
 	planTypeSelectorProps,
 	isInSignup,
@@ -734,8 +714,7 @@ export const PlanComparisonGrid = ( {
 	planActionOverrides,
 	selectedPlan,
 	selectedFeature,
-}: PlanComparisonGridProps ) => {
-	const translate = useTranslate();
+}: InternalPlanComparisonGridProps ) => {
 	const { gridPlans, allFeaturesList } = usePlansGridContext();
 
 	// Check to see if we have at least one Woo Express plan we're comparing.
@@ -896,9 +875,6 @@ export const PlanComparisonGrid = ( {
 
 	return (
 		<div className="plan-comparison-grid">
-			<PlanComparisonHeader className="wp-brand-font">
-				{ translate( 'Compare our plans and find yours' ) }
-			</PlanComparisonHeader>
 			<PlanTypeSelector
 				{ ...planTypeSelectorProps }
 				kind="interval"
@@ -1000,3 +976,5 @@ export const PlanComparisonGrid = ( {
 		</div>
 	);
 };
+
+export default PlanComparisonGrid;

--- a/client/my-sites/plan-features-2023-grid/components/plan-features-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-features-grid/index.tsx
@@ -1,0 +1,745 @@
+import {
+	getPlanClass,
+	isFreePlan,
+	isPersonalPlan,
+	isEcommercePlan,
+	isWpComFreePlan,
+	isWpcomEnterpriseGridPlan,
+	isBusinessPlan,
+	isPremiumPlan,
+	isWooExpressMediumPlan,
+	isWooExpressSmallPlan,
+	isWooExpressPlan,
+	PlanSlug,
+	isWooExpressPlusPlan,
+} from '@automattic/calypso-products';
+import {
+	JetpackLogo,
+	BloombergLogo,
+	CloudLogo,
+	CNNLogo,
+	CondenastLogo,
+	DisneyLogo,
+	FacebookLogo,
+	SalesforceLogo,
+	SlackLogo,
+	TimeLogo,
+	VIPLogo,
+	WooLogo,
+} from '@automattic/components';
+import { isAnyHostingFlow } from '@automattic/onboarding';
+import classNames from 'classnames';
+import { type LocalizeProps, useTranslate } from 'i18n-calypso';
+import { Component, createRef } from 'react';
+import FoldableCard from 'calypso/components/foldable-card';
+import { usePlansGridContext } from '../../grid-context';
+import useHighlightAdjacencyMatrix from '../../hooks/npm-ready/use-highlight-adjacency-matrix';
+import { getStorageStringFromFeature } from '../../util';
+import PlanFeatures2023GridActions from '../actions';
+import PlanFeatures2023GridBillingTimeframe from '../billing-timeframe';
+import PlanFeatures2023GridFeatures from '../features';
+import PlanFeatures2023GridHeaderPrice from '../header-price';
+import { PlanFeaturesItem } from '../item';
+import { Plans2023Tooltip } from '../plans-2023-tooltip';
+import PopularBadge from '../popular-badge';
+import { StickyContainer } from '../sticky-container';
+import StorageAddOnDropdown from '../storage-add-on-dropdown';
+import type { GridPlan } from '../../hooks/npm-ready/data-store/use-grid-plans';
+import type { PlanFeaturesGridProps } from '../../types';
+import '../../style.scss';
+
+type PlanRowOptions = {
+	isTableCell?: boolean;
+	isStuck?: boolean;
+};
+
+const Container = (
+	props: (
+		| React.HTMLAttributes< HTMLDivElement >
+		| React.HTMLAttributes< HTMLTableCellElement >
+	 ) & { isTableCell?: boolean; scope?: string }
+) => {
+	const { children, isTableCell, ...otherProps } = props;
+	return isTableCell ? (
+		<td { ...otherProps }>{ children }</td>
+	) : (
+		<div { ...otherProps }>{ children }</div>
+	);
+};
+
+const PlanLogo: React.FunctionComponent< {
+	planIndex: number;
+	planSlug: PlanSlug;
+	renderedGridPlans: GridPlan[];
+	isTableCell?: boolean;
+	isInSignup?: boolean;
+} > = ( { planIndex, planSlug, renderedGridPlans, isTableCell, isInSignup } ) => {
+	const { gridPlansIndex } = usePlansGridContext();
+	const { current } = gridPlansIndex[ planSlug ];
+	const translate = useTranslate();
+	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
+		renderedPlans: renderedGridPlans.map( ( gridPlan ) => gridPlan.planSlug ),
+	} );
+	const headerClasses = classNames(
+		'plan-features-2023-grid__header-logo',
+		getPlanClass( planSlug )
+	);
+	const tableItemClasses = classNames( 'plan-features-2023-grid__table-item', {
+		'popular-plan-parent-class': gridPlansIndex[ planSlug ]?.highlightLabel,
+		'is-left-of-highlight': highlightAdjacencyMatrix[ planSlug ]?.leftOfHighlight,
+		'is-right-of-highlight': highlightAdjacencyMatrix[ planSlug ]?.rightOfHighlight,
+		'is-only-highlight': highlightAdjacencyMatrix[ planSlug ]?.isOnlyHighlight,
+		'is-current-plan': current,
+		'is-first-in-row': planIndex === 0,
+		'is-last-in-row': planIndex === renderedGridPlans.length - 1,
+	} );
+	const popularBadgeClasses = classNames( {
+		'with-plan-logo': ! (
+			isFreePlan( planSlug ) ||
+			isPersonalPlan( planSlug ) ||
+			isPremiumPlan( planSlug )
+		),
+		'is-current-plan': current,
+	} );
+
+	const shouldShowWooLogo = isEcommercePlan( planSlug ) && ! isWooExpressPlan( planSlug );
+
+	return (
+		<Container key={ planSlug } className={ tableItemClasses } isTableCell={ isTableCell }>
+			<PopularBadge
+				isInSignup={ isInSignup }
+				planSlug={ planSlug }
+				additionalClassName={ popularBadgeClasses }
+			/>
+			<header className={ headerClasses }>
+				{ isBusinessPlan( planSlug ) && (
+					<Plans2023Tooltip
+						text={ translate(
+							'WP Cloud gives you the tools you need to add scalable, highly available, extremely fast WordPress hosting.'
+						) }
+					>
+						<CloudLogo />
+					</Plans2023Tooltip>
+				) }
+				{ shouldShowWooLogo && (
+					<Plans2023Tooltip
+						text={ translate( 'Make your online store a reality with the power of WooCommerce.' ) }
+					>
+						<WooLogo />
+					</Plans2023Tooltip>
+				) }
+				{ isWpcomEnterpriseGridPlan( planSlug ) && (
+					<Plans2023Tooltip
+						text={ translate( 'The trusted choice for enterprise WordPress hosting.' ) }
+					>
+						<VIPLogo />
+					</Plans2023Tooltip>
+				) }
+			</header>
+		</Container>
+	);
+};
+
+// TODO clk: These `Internal...` props should gradually be factored out as more dependencies are moved to plans-features-main
+export interface InternalPlanFeaturesGridProps
+	extends Omit< PlanFeaturesGridProps, 'onUpgradeClick' > {
+	onUpgradeClick: ( planSlug: PlanSlug ) => void;
+	canUserPurchasePlan: boolean | null;
+	manageHref: string;
+	selectedSiteSlug: string | null;
+	isLargeCurrency: boolean;
+	translate: LocalizeProps[ 'translate' ];
+	isPlanUpgradeCreditEligible: boolean;
+}
+
+export class FunkyHtmlTableOrCards extends Component< InternalPlanFeaturesGridProps > {
+	observer: IntersectionObserver | null = null;
+	buttonRef: React.RefObject< HTMLButtonElement > = createRef< HTMLButtonElement >();
+
+	componentDidMount() {
+		this.observer = new IntersectionObserver( ( entries ) => {
+			entries.forEach( ( entry ) => {
+				if ( entry.isIntersecting ) {
+					this.props.showOdie?.();
+					this.observer?.disconnect();
+				}
+			} );
+		} );
+
+		if ( this.buttonRef.current ) {
+			this.observer.observe( this.buttonRef.current );
+		}
+	}
+
+	componentWillUnmount() {
+		if ( this.observer ) {
+			this.observer.disconnect();
+		}
+	}
+
+	renderTable( renderedGridPlans: GridPlan[] ) {
+		const { translate, gridPlanForSpotlight, stickyRowOffset, isInSignup } = this.props;
+		// Do not render the spotlight plan if it exists
+		const gridPlansWithoutSpotlight = ! gridPlanForSpotlight
+			? renderedGridPlans
+			: renderedGridPlans.filter( ( { planSlug } ) => gridPlanForSpotlight.planSlug !== planSlug );
+		const tableClasses = classNames(
+			'plan-features-2023-grid__table',
+			`has-${ gridPlansWithoutSpotlight.length }-cols`
+		);
+
+		return (
+			<table className={ tableClasses }>
+				<caption className="plan-features-2023-grid__screen-reader-text screen-reader-text">
+					{ translate( 'Available plans to choose from' ) }
+				</caption>
+				<tbody>
+					<tr>{ this.renderPlanLogos( gridPlansWithoutSpotlight, { isTableCell: true } ) }</tr>
+					<tr>{ this.renderPlanHeaders( gridPlansWithoutSpotlight, { isTableCell: true } ) }</tr>
+					<tr>{ this.renderPlanTagline( gridPlansWithoutSpotlight, { isTableCell: true } ) }</tr>
+					<tr>{ this.renderPlanPrice( gridPlansWithoutSpotlight, { isTableCell: true } ) }</tr>
+					<tr>
+						{ this.renderBillingTimeframe( gridPlansWithoutSpotlight, { isTableCell: true } ) }
+					</tr>
+					<StickyContainer
+						stickyClass="is-sticky-top-buttons-row"
+						element="tr"
+						stickyOffset={ stickyRowOffset }
+						topOffset={ stickyRowOffset + ( isInSignup ? 0 : 20 ) }
+					>
+						{ ( isStuck: boolean ) =>
+							this.renderTopButtons( gridPlansWithoutSpotlight, { isTableCell: true, isStuck } )
+						}
+					</StickyContainer>
+					<tr>
+						{ this.maybeRenderRefundNotice( gridPlansWithoutSpotlight, { isTableCell: true } ) }
+					</tr>
+					<tr>
+						{ this.renderPreviousFeaturesIncludedTitle( gridPlansWithoutSpotlight, {
+							isTableCell: true,
+						} ) }
+					</tr>
+					<tr>
+						{ this.renderPlanFeaturesList( gridPlansWithoutSpotlight, { isTableCell: true } ) }
+					</tr>
+					<tr>
+						{ this.renderPlanStorageOptions( gridPlansWithoutSpotlight, { isTableCell: true } ) }
+					</tr>
+				</tbody>
+			</table>
+		);
+	}
+
+	renderTabletView() {
+		const { gridPlans, gridPlanForSpotlight } = this.props;
+		const gridPlansWithoutSpotlight = ! gridPlanForSpotlight
+			? gridPlans
+			: gridPlans.filter( ( { planSlug } ) => gridPlanForSpotlight.planSlug !== planSlug );
+		const numberOfPlansToShowOnTop = 4 === gridPlansWithoutSpotlight.length ? 2 : 3;
+		const plansForTopRow = gridPlansWithoutSpotlight.slice( 0, numberOfPlansToShowOnTop );
+		const plansForBottomRow = gridPlansWithoutSpotlight.slice( numberOfPlansToShowOnTop );
+
+		return (
+			<>
+				<div className="plan-features-2023-grid__table-top">
+					{ this.renderTable( plansForTopRow ) }
+				</div>
+				{ plansForBottomRow.length > 0 && (
+					<div className="plan-features-2023-grid__table-bottom">
+						{ this.renderTable( plansForBottomRow ) }
+					</div>
+				) }
+			</>
+		);
+	}
+
+	/**
+	 * Similar to `renderMobileView` above.
+	 */
+	renderSpotlightPlan() {
+		const { gridPlanForSpotlight } = this.props;
+
+		if ( ! gridPlanForSpotlight ) {
+			return null;
+		}
+
+		const spotlightPlanClasses = classNames(
+			'plan-features-2023-grid__plan-spotlight-card',
+			getPlanClass( gridPlanForSpotlight.planSlug )
+		);
+
+		return (
+			<div className="plan-features-2023-grid__plan-spotlight">
+				<div className={ spotlightPlanClasses }>
+					{ this.renderPlanLogos( [ gridPlanForSpotlight ] ) }
+					{ this.renderPlanHeaders( [ gridPlanForSpotlight ] ) }
+					{ this.renderPlanTagline( [ gridPlanForSpotlight ] ) }
+					{ this.renderPlanPrice( [ gridPlanForSpotlight ] ) }
+					{ this.renderBillingTimeframe( [ gridPlanForSpotlight ] ) }
+					{ this.renderTopButtons( [ gridPlanForSpotlight ] ) }
+				</div>
+			</div>
+		);
+	}
+
+	renderMobileView() {
+		const { translate, selectedFeature, gridPlans, gridPlanForSpotlight } = this.props;
+		const CardContainer = (
+			props: React.ComponentProps< typeof FoldableCard > & { planSlug: string }
+		) => {
+			const { children, planSlug, ...otherProps } = props;
+			return isWpcomEnterpriseGridPlan( planSlug ) ? (
+				<div { ...otherProps }>{ children }</div>
+			) : (
+				<FoldableCard { ...otherProps } compact clickableHeader>
+					{ children }
+				</FoldableCard>
+			);
+		};
+
+		return gridPlans
+			.reduce( ( acc, griPlan ) => {
+				// Bring the spotlight plan to the top
+				if ( gridPlanForSpotlight?.planSlug === griPlan.planSlug ) {
+					return [ griPlan ].concat( acc );
+				}
+				return acc.concat( griPlan );
+			}, [] as GridPlan[] )
+			.map( ( gridPlan, index ) => {
+				const planCardClasses = classNames(
+					'plan-features-2023-grid__mobile-plan-card',
+					getPlanClass( gridPlan.planSlug )
+				);
+				const planCardJsx = (
+					<div className={ planCardClasses } key={ `${ gridPlan.planSlug }-${ index }` }>
+						{ this.renderPlanLogos( [ gridPlan ] ) }
+						{ this.renderPlanHeaders( [ gridPlan ] ) }
+						{ this.renderPlanTagline( [ gridPlan ] ) }
+						{ this.renderPlanPrice( [ gridPlan ] ) }
+						{ this.renderBillingTimeframe( [ gridPlan ] ) }
+						{ this.renderMobileFreeDomain( gridPlan.planSlug, gridPlan.isMonthlyPlan ) }
+						{ this.renderTopButtons( [ gridPlan ] ) }
+						{ this.maybeRenderRefundNotice( [ gridPlan ] ) }
+						<CardContainer
+							header={ translate( 'Show all features' ) }
+							planSlug={ gridPlan.planSlug }
+							key={ `${ gridPlan.planSlug }-${ index }` }
+							expanded={
+								selectedFeature &&
+								gridPlan.features.wpcomFeatures.some(
+									( feature ) => feature.getSlug() === selectedFeature
+								)
+							}
+						>
+							{ this.renderPreviousFeaturesIncludedTitle( [ gridPlan ] ) }
+							{ this.renderPlanFeaturesList( [ gridPlan ] ) }
+							{ this.renderPlanStorageOptions( [ gridPlan ] ) }
+						</CardContainer>
+					</div>
+				);
+				return planCardJsx;
+			} );
+	}
+
+	renderMobileFreeDomain( planSlug: PlanSlug, isMonthlyPlan?: boolean ) {
+		const { translate } = this.props;
+
+		if ( isMonthlyPlan || isWpComFreePlan( planSlug ) || isWpcomEnterpriseGridPlan( planSlug ) ) {
+			return null;
+		}
+		const { paidDomainName } = this.props;
+
+		const displayText = paidDomainName
+			? translate( '%(paidDomainName)s is included', {
+					args: { paidDomainName },
+			  } )
+			: translate( 'Free domain for one year' );
+
+		return (
+			<div className="plan-features-2023-grid__highlighted-feature">
+				<PlanFeaturesItem>
+					<span className="plan-features-2023-grid__item-info is-annual-plan-feature is-available">
+						<span className="plan-features-2023-grid__item-title is-bold">{ displayText }</span>
+					</span>
+				</PlanFeaturesItem>
+			</div>
+		);
+	}
+
+	renderPlanPrice( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
+		const {
+			isReskinned,
+			isLargeCurrency,
+			translate,
+			isPlanUpgradeCreditEligible,
+			currentSitePlanSlug,
+			siteId,
+		} = this.props;
+		return renderedGridPlans.map( ( { planSlug } ) => {
+			const isWooExpressPlus = isWooExpressPlusPlan( planSlug );
+			const classes = classNames( 'plan-features-2023-grid__table-item', 'is-bottom-aligned', {
+				'has-border-top': ! isReskinned,
+			} );
+
+			return (
+				<Container
+					scope="col"
+					key={ planSlug }
+					className={ classes }
+					isTableCell={ options?.isTableCell }
+				>
+					<PlanFeatures2023GridHeaderPrice
+						planSlug={ planSlug }
+						isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
+						isLargeCurrency={ isLargeCurrency }
+						currentSitePlanSlug={ currentSitePlanSlug }
+						siteId={ siteId }
+					/>
+					{ isWooExpressPlus && (
+						<div className="plan-features-2023-grid__header-tagline">
+							{ translate( 'Speak to our team for a custom quote.' ) }
+						</div>
+					) }
+				</Container>
+			);
+		} );
+	}
+
+	renderBillingTimeframe( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
+		return renderedGridPlans.map( ( { planSlug } ) => {
+			const classes = classNames(
+				'plan-features-2023-grid__table-item',
+				'plan-features-2023-grid__header-billing-info'
+			);
+
+			return (
+				<Container className={ classes } isTableCell={ options?.isTableCell } key={ planSlug }>
+					<PlanFeatures2023GridBillingTimeframe planSlug={ planSlug } />
+				</Container>
+			);
+		} );
+	}
+
+	renderPlanLogos( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
+		const { isInSignup } = this.props;
+
+		return renderedGridPlans.map( ( { planSlug }, index ) => {
+			return (
+				<PlanLogo
+					key={ planSlug }
+					planIndex={ index }
+					planSlug={ planSlug }
+					renderedGridPlans={ renderedGridPlans }
+					isTableCell={ options?.isTableCell }
+					isInSignup={ isInSignup }
+				/>
+			);
+		} );
+	}
+
+	renderPlanHeaders( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
+		return renderedGridPlans.map( ( { planSlug, planTitle } ) => {
+			const headerClasses = classNames(
+				'plan-features-2023-grid__header',
+				getPlanClass( planSlug )
+			);
+
+			return (
+				<Container
+					key={ planSlug }
+					className="plan-features-2023-grid__table-item"
+					isTableCell={ options?.isTableCell }
+				>
+					<header className={ headerClasses }>
+						<h4 className="plan-features-2023-grid__header-title">{ planTitle }</h4>
+					</header>
+				</Container>
+			);
+		} );
+	}
+
+	renderPlanTagline( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
+		return renderedGridPlans.map( ( { planSlug, tagline } ) => {
+			return (
+				<Container
+					key={ planSlug }
+					className="plan-features-2023-grid__table-item"
+					isTableCell={ options?.isTableCell }
+				>
+					<div className="plan-features-2023-grid__header-tagline">{ tagline }</div>
+				</Container>
+			);
+		} );
+	}
+
+	renderTopButtons( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
+		const {
+			isInSignup,
+			isLaunchPage,
+			flowName,
+			canUserPurchasePlan,
+			manageHref,
+			currentSitePlanSlug,
+			selectedSiteSlug,
+			translate,
+			planActionOverrides,
+			siteId,
+			isLargeCurrency,
+			onUpgradeClick,
+		} = this.props;
+
+		return renderedGridPlans.map( ( { planSlug, availableForPurchase } ) => {
+			const classes = classNames(
+				'plan-features-2023-grid__table-item',
+				'is-top-buttons',
+				'is-bottom-aligned'
+			);
+
+			// Leaving it `undefined` makes it use the default label
+			let buttonText;
+
+			if (
+				isWooExpressMediumPlan( planSlug ) &&
+				! isWooExpressMediumPlan( currentSitePlanSlug || '' )
+			) {
+				buttonText = translate( 'Get Performance', { textOnly: true } );
+			} else if (
+				isWooExpressSmallPlan( planSlug ) &&
+				! isWooExpressSmallPlan( currentSitePlanSlug || '' )
+			) {
+				buttonText = translate( 'Get Essential', { textOnly: true } );
+			}
+
+			return (
+				<Container key={ planSlug } className={ classes } isTableCell={ options?.isTableCell }>
+					<PlanFeatures2023GridActions
+						manageHref={ manageHref }
+						canUserPurchasePlan={ canUserPurchasePlan }
+						availableForPurchase={ availableForPurchase }
+						className={ getPlanClass( planSlug ) }
+						freePlan={ isFreePlan( planSlug ) }
+						isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planSlug ) }
+						isWooExpressPlusPlan={ isWooExpressPlusPlan( planSlug ) }
+						isInSignup={ isInSignup }
+						isLaunchPage={ isLaunchPage }
+						onUpgradeClick={ () => onUpgradeClick( planSlug ) }
+						planSlug={ planSlug }
+						flowName={ flowName }
+						currentSitePlanSlug={ currentSitePlanSlug }
+						selectedSiteSlug={ selectedSiteSlug }
+						buttonText={ buttonText }
+						planActionOverrides={ planActionOverrides }
+						showMonthlyPrice={ true }
+						siteId={ siteId }
+						isStuck={ options?.isStuck || false }
+						isLargeCurrency={ isLargeCurrency }
+					/>
+				</Container>
+			);
+		} );
+	}
+
+	maybeRenderRefundNotice( gridPlan: GridPlan[], options?: PlanRowOptions ) {
+		const { translate, flowName } = this.props;
+
+		if ( ! isAnyHostingFlow( flowName ) ) {
+			return false;
+		}
+
+		return gridPlan.map( ( { planSlug, pricing: { billingPeriod } } ) => (
+			<Container
+				key={ planSlug }
+				className="plan-features-2023-grid__table-item"
+				isTableCell={ options?.isTableCell }
+			>
+				{ ! isFreePlan( planSlug ) && (
+					<div className={ `plan-features-2023-grid__refund-notice ${ getPlanClass( planSlug ) }` }>
+						{ translate( 'Refundable within %(dayCount)s days. No questions asked.', {
+							args: {
+								dayCount: billingPeriod === 365 ? 14 : 7,
+							},
+						} ) }
+					</div>
+				) }
+			</Container>
+		) );
+	}
+
+	renderEnterpriseClientLogos() {
+		return (
+			<div className="plan-features-2023-grid__item plan-features-2023-grid__enterprise-logo">
+				<TimeLogo />
+				<SlackLogo />
+				<DisneyLogo />
+				<CNNLogo />
+				<SalesforceLogo />
+				<FacebookLogo />
+				<CondenastLogo />
+				<BloombergLogo />
+			</div>
+		);
+	}
+
+	renderPreviousFeaturesIncludedTitle( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
+		const { translate, gridPlans } = this.props;
+
+		return renderedGridPlans.map( ( { planSlug } ) => {
+			const shouldRenderEnterpriseLogos =
+				isWpcomEnterpriseGridPlan( planSlug ) || isWooExpressPlusPlan( planSlug );
+			const shouldShowFeatureTitle = ! isWpComFreePlan( planSlug ) && ! shouldRenderEnterpriseLogos;
+			const indexInGridPlans = gridPlans.findIndex( ( { planSlug: slug } ) => slug === planSlug );
+			const previousProductName =
+				indexInGridPlans > 0 ? gridPlans[ indexInGridPlans - 1 ].productNameShort : null;
+			const title =
+				previousProductName &&
+				translate( 'Everything in %(planShortName)s, plus:', {
+					args: { planShortName: previousProductName },
+				} );
+			const classes = classNames(
+				'plan-features-2023-grid__common-title',
+				getPlanClass( planSlug )
+			);
+			const rowspanProp =
+				options?.isTableCell && shouldRenderEnterpriseLogos ? { rowSpan: '2' } : {};
+			return (
+				<Container
+					key={ planSlug }
+					isTableCell={ options?.isTableCell }
+					className="plan-features-2023-grid__table-item"
+					{ ...rowspanProp }
+				>
+					{ shouldShowFeatureTitle && <div className={ classes }>{ title }</div> }
+					{ shouldRenderEnterpriseLogos && this.renderEnterpriseClientLogos() }
+				</Container>
+			);
+		} );
+	}
+
+	renderPlanFeaturesList( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
+		const {
+			paidDomainName,
+			translate,
+			hideUnavailableFeatures,
+			selectedFeature,
+			wpcomFreeDomainSuggestion,
+			isCustomDomainAllowedOnFreePlan,
+		} = this.props;
+		const plansWithFeatures = renderedGridPlans.filter(
+			( gridPlan ) =>
+				! isWpcomEnterpriseGridPlan( gridPlan.planSlug ) &&
+				! isWooExpressPlusPlan( gridPlan.planSlug )
+		);
+
+		return plansWithFeatures.map(
+			( { planSlug, features: { wpcomFeatures, jetpackFeatures } }, mapIndex ) => {
+				return (
+					<Container
+						key={ `${ planSlug }-${ mapIndex }` }
+						isTableCell={ options?.isTableCell }
+						className="plan-features-2023-grid__table-item"
+					>
+						<PlanFeatures2023GridFeatures
+							features={ wpcomFeatures }
+							planSlug={ planSlug }
+							paidDomainName={ paidDomainName }
+							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+							hideUnavailableFeatures={ hideUnavailableFeatures }
+							selectedFeature={ selectedFeature }
+							isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
+						/>
+						{ jetpackFeatures.length !== 0 && (
+							<div className="plan-features-2023-grid__jp-logo" key="jp-logo">
+								<Plans2023Tooltip
+									text={ translate(
+										'Security, performance and growth tools made by the WordPress experts.'
+									) }
+								>
+									<JetpackLogo size={ 16 } />
+								</Plans2023Tooltip>
+							</div>
+						) }
+						<PlanFeatures2023GridFeatures
+							features={ jetpackFeatures }
+							planSlug={ planSlug }
+							paidDomainName={ paidDomainName }
+							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+							hideUnavailableFeatures={ hideUnavailableFeatures }
+							isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
+						/>
+					</Container>
+				);
+			}
+		);
+	}
+
+	renderPlanStorageOptions( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
+		const { translate, intervalType, showUpgradeableStorage } = this.props;
+
+		return renderedGridPlans.map( ( { planSlug, features: { storageOptions } } ) => {
+			if ( ! options?.isTableCell && isWpcomEnterpriseGridPlan( planSlug ) ) {
+				return null;
+			}
+
+			const shouldRenderStorageTitle =
+				storageOptions.length === 1 ||
+				( intervalType !== 'yearly' && storageOptions.length > 0 ) ||
+				( ! showUpgradeableStorage && storageOptions.length > 0 );
+			const canUpgradeStorageForPlan =
+				storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage;
+
+			const storageJSX = canUpgradeStorageForPlan ? (
+				<StorageAddOnDropdown planSlug={ planSlug } storageOptions={ storageOptions } />
+			) : (
+				storageOptions.map( ( storageOption ) => {
+					if ( ! storageOption?.isAddOn ) {
+						return (
+							<div className="plan-features-2023-grid__storage-buttons" key={ planSlug }>
+								{ getStorageStringFromFeature( storageOption?.slug ) }
+							</div>
+						);
+					}
+				} )
+			);
+
+			return (
+				<Container
+					key={ planSlug }
+					className="plan-features-2023-grid__table-item plan-features-2023-grid__storage"
+					isTableCell={ options?.isTableCell }
+				>
+					{ shouldRenderStorageTitle ? (
+						<div className="plan-features-2023-grid__storage-title">{ translate( 'Storage' ) }</div>
+					) : null }
+					{ storageJSX }
+				</Container>
+			);
+		} );
+	}
+
+	render() {
+		const { gridPlans } = this.props;
+
+		return (
+			<div>
+				{ this.renderSpotlightPlan() }
+				<div className="plan-features">
+					<div className="plan-features-2023-grid__content">
+						<div>
+							<div className="plan-features-2023-grid__desktop-view">
+								{ this.renderTable( gridPlans ) }
+							</div>
+							<div className="plan-features-2023-grid__tablet-view">
+								{ this.renderTabletView() }
+							</div>
+							<div className="plan-features-2023-grid__mobile-view">
+								{ this.renderMobileView() }
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default FunkyHtmlTableOrCards;

--- a/client/my-sites/plan-features-2023-grid/components/plan-features-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-features-grid/index.tsx
@@ -30,7 +30,7 @@ import {
 import { isAnyHostingFlow } from '@automattic/onboarding';
 import classNames from 'classnames';
 import { type LocalizeProps, useTranslate } from 'i18n-calypso';
-import { Component, createRef } from 'react';
+import { Component } from 'react';
 import FoldableCard from 'calypso/components/foldable-card';
 import { usePlansGridContext } from '../../grid-context';
 import useHighlightAdjacencyMatrix from '../../hooks/npm-ready/use-highlight-adjacency-matrix';
@@ -153,30 +153,6 @@ export interface InternalPlanFeaturesGridProps
 }
 
 export class FunkyHtmlTableOrCards extends Component< InternalPlanFeaturesGridProps > {
-	observer: IntersectionObserver | null = null;
-	buttonRef: React.RefObject< HTMLButtonElement > = createRef< HTMLButtonElement >();
-
-	componentDidMount() {
-		this.observer = new IntersectionObserver( ( entries ) => {
-			entries.forEach( ( entry ) => {
-				if ( entry.isIntersecting ) {
-					this.props.showOdie?.();
-					this.observer?.disconnect();
-				}
-			} );
-		} );
-
-		if ( this.buttonRef.current ) {
-			this.observer.observe( this.buttonRef.current );
-		}
-	}
-
-	componentWillUnmount() {
-		if ( this.observer ) {
-			this.observer.disconnect();
-		}
-	}
-
 	renderTable( renderedGridPlans: GridPlan[] ) {
 		const { translate, gridPlanForSpotlight, stickyRowOffset, isInSignup } = this.props;
 		// Do not render the spotlight plan if it exists

--- a/client/my-sites/plan-features-2023-grid/components/shared/README.md
+++ b/client/my-sites/plan-features-2023-grid/components/shared/README.md
@@ -1,0 +1,1 @@
+## Components that are shared

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -19,7 +19,6 @@ import {
 	type FeatureList,
 	type PlanSlug,
 	type FeatureObject,
-	type FilteredPlan,
 	type StorageOption,
 } from '@automattic/calypso-products';
 import useHighlightLabels from './use-highlight-labels';
@@ -74,7 +73,6 @@ export type UsePricingMetaForGridPlans = ( {
 export type GridPlan = {
 	planSlug: PlanSlug;
 	isVisible: boolean;
-	planConstantObj: FilteredPlan;
 	features: {
 		wpcomFeatures: TransformedFeatureObject[];
 		jetpackFeatures: TransformedFeatureObject[];
@@ -295,7 +293,6 @@ const useGridPlans = ( {
 		return {
 			planSlug,
 			isVisible: planSlugsForIntent.includes( planSlug ),
-			planConstantObj,
 			tagline,
 			availableForPurchase,
 			productNameShort,

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -85,6 +85,7 @@ export type GridPlan = {
 	availableForPurchase: boolean;
 	productNameShort?: string | null;
 	planTitle: TranslateResult;
+	billingTimeframe?: TranslateResult | null;
 	current?: boolean;
 	isMonthlyPlan?: boolean;
 	cartItemForPlan?: {
@@ -299,6 +300,7 @@ const useGridPlans = ( {
 			availableForPurchase,
 			productNameShort,
 			planTitle: planConstantObj.getTitle?.() ?? '',
+			billingTimeframe: planConstantObj.getBillingTimeFrame?.(),
 			current: sitePlanSlug === planSlug,
 			isMonthlyPlan,
 			cartItemForPlan,

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -25,6 +25,7 @@ import {
 import useHighlightLabels from './use-highlight-labels';
 import usePlansFromTypes from './use-plans-from-types';
 import type { PricedAPIPlan } from '@automattic/data-stores';
+import type { TranslateResult } from 'i18n-calypso';
 
 // TODO clk: move to plans data store
 export type TransformedFeatureObject = FeatureObject & {
@@ -83,6 +84,7 @@ export type GridPlan = {
 	tagline: string;
 	availableForPurchase: boolean;
 	productNameShort?: string | null;
+	planTitle: TranslateResult;
 	current?: boolean;
 	isMonthlyPlan?: boolean;
 	cartItemForPlan?: {
@@ -296,6 +298,7 @@ const useGridPlans = ( {
 			tagline,
 			availableForPurchase,
 			productNameShort,
+			planTitle: planConstantObj.getTitle?.() ?? '',
 			current: sitePlanSlug === planSlug,
 			isMonthlyPlan,
 			cartItemForPlan,

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -566,7 +566,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			isLargeCurrency,
 		} = this.props;
 
-		return renderedGridPlans.map( ( { planSlug, current, availableForPurchase } ) => {
+		return renderedGridPlans.map( ( { planSlug, availableForPurchase } ) => {
 			const classes = classNames(
 				'plan-features-2023-grid__table-item',
 				'is-top-buttons',
@@ -603,7 +603,6 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 						onUpgradeClick={ () => this.handleUpgradeClick( planSlug ) }
 						planSlug={ planSlug }
 						flowName={ flowName }
-						current={ current ?? false }
 						currentSitePlanSlug={ currentSitePlanSlug }
 						selectedSiteSlug={ selectedSiteSlug }
 						buttonText={ buttonText }

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -467,7 +467,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 	}
 
 	renderBillingTimeframe( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		return renderedGridPlans.map( ( { planConstantObj, planSlug } ) => {
+		return renderedGridPlans.map( ( { planSlug } ) => {
 			const classes = classNames(
 				'plan-features-2023-grid__table-item',
 				'plan-features-2023-grid__header-billing-info'
@@ -475,10 +475,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 
 			return (
 				<Container className={ classes } isTableCell={ options?.isTableCell } key={ planSlug }>
-					<PlanFeatures2023GridBillingTimeframe
-						planSlug={ planSlug }
-						billingTimeframe={ planConstantObj.getBillingTimeFrame() }
-					/>
+					<PlanFeatures2023GridBillingTimeframe planSlug={ planSlug } />
 				</Container>
 			);
 		} );

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -836,14 +836,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 					allFeaturesList={ allFeaturesList }
 				>
 					{ this.renderSpotlightPlan() }
-				</PlansGridContextProvider>
-				<div className="plan-features">
-					<PlansGridContextProvider
-						intent={ intent }
-						gridPlans={ gridPlansForFeaturesGrid }
-						usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
-						allFeaturesList={ allFeaturesList }
-					>
+					<div className="plan-features">
 						<div className="plan-features-2023-grid__content">
 							<div>
 								<div className="plan-features-2023-grid__desktop-view">
@@ -857,8 +850,9 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 								</div>
 							</div>
 						</div>
-					</PlansGridContextProvider>
-				</div>
+					</div>
+				</PlansGridContextProvider>
+
 				{ ! hidePlansFeatureComparison && (
 					<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
 						<Button onClick={ toggleShowPlansComparisonGrid } ref={ this.buttonRef }>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -502,7 +502,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 	}
 
 	renderPlanHeaders( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		return renderedGridPlans.map( ( { planSlug, planConstantObj } ) => {
+		return renderedGridPlans.map( ( { planSlug, planTitle } ) => {
 			const headerClasses = classNames(
 				'plan-features-2023-grid__header',
 				getPlanClass( planSlug )
@@ -515,9 +515,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 					isTableCell={ options?.isTableCell }
 				>
 					<header className={ headerClasses }>
-						<h4 className="plan-features-2023-grid__header-title">
-							{ planConstantObj.getTitle() }
-						</h4>
+						<h4 className="plan-features-2023-grid__header-title">{ planTitle }</h4>
 					</header>
 				</Container>
 			);

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -827,7 +827,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 		} = this.props;
 
 		return (
-			<div className="plans-wrapper">
+			<div>
 				<QueryActivePromotions />
 				<PlansGridContextProvider
 					intent={ intent }

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -1,544 +1,59 @@
-import {
-	getPlanClass,
-	isFreePlan,
-	isPersonalPlan,
-	isEcommercePlan,
-	isWpComFreePlan,
-	isWpcomEnterpriseGridPlan,
-	isBusinessPlan,
-	isPremiumPlan,
-	isWooExpressMediumPlan,
-	isWooExpressSmallPlan,
-	isWooExpressPlan,
-	PlanSlug,
-	isWooExpressPlusPlan,
-	FeatureList,
-} from '@automattic/calypso-products';
-import {
-	JetpackLogo,
-	BloombergLogo,
-	CloudLogo,
-	CNNLogo,
-	CondenastLogo,
-	DisneyLogo,
-	FacebookLogo,
-	SalesforceLogo,
-	SlackLogo,
-	TimeLogo,
-	VIPLogo,
-	WooLogo,
-} from '@automattic/components';
-import { isAnyHostingFlow } from '@automattic/onboarding';
-import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import { Button } from '@wordpress/components';
-import classNames from 'classnames';
-import { LocalizeProps, useTranslate } from 'i18n-calypso';
-import { Component, ForwardedRef, forwardRef, createRef } from 'react';
+import { isFreePlan, PlanSlug } from '@automattic/calypso-products';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
-import FoldableCard from 'calypso/components/foldable-card';
 import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible';
-import { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
 import CalypsoShoppingCartProvider from '../checkout/calypso-shopping-cart-provider';
 import { getManagePurchaseUrlFor } from '../purchases/paths';
-import PlanFeatures2023GridActions from './components/actions';
-import PlanFeatures2023GridBillingTimeframe from './components/billing-timeframe';
-import PlanFeatures2023GridFeatures from './components/features';
-import PlanFeatures2023GridHeaderPrice from './components/header-price';
-import { PlanFeaturesItem } from './components/item';
-import { PlanComparisonGrid } from './components/plan-comparison-grid';
-import { Plans2023Tooltip } from './components/plans-2023-tooltip';
-import PopularBadge from './components/popular-badge';
-import { StickyContainer } from './components/sticky-container';
-import StorageAddOnDropdown from './components/storage-add-on-dropdown';
-import PlansGridContextProvider, { usePlansGridContext } from './grid-context';
-import useHighlightAdjacencyMatrix from './hooks/npm-ready/use-highlight-adjacency-matrix';
+import PlanComparisonGrid from './components/plan-comparison-grid';
+import PlanFeaturesGrid from './components/plan-features-grid';
+import PlansGridContextProvider from './grid-context';
 import useIsLargeCurrency from './hooks/npm-ready/use-is-large-currency';
-import { DataResponse } from './types';
-import { getStorageStringFromFeature } from './util';
-import type { PlansIntent } from './grid-context';
-import type {
-	GridPlan,
-	UsePricingMetaForGridPlans,
-} from './hooks/npm-ready/data-store/use-grid-plans';
-import type { PlanActionOverrides } from './types';
-import type { DomainSuggestion } from '@automattic/data-stores';
+import type { PlanFeaturesGridProps, PlanComparisonGridProps } from './types';
 import type { IAppState } from 'calypso/state/types';
 import './style.scss';
 
-type PlanRowOptions = {
-	isTableCell?: boolean;
-	isStuck?: boolean;
-};
-
-const Container = (
-	props: (
-		| React.HTMLAttributes< HTMLDivElement >
-		| React.HTMLAttributes< HTMLTableCellElement >
-	 ) & { isTableCell?: boolean; scope?: string }
-) => {
-	const { children, isTableCell, ...otherProps } = props;
-	return isTableCell ? (
-		<td { ...otherProps }>{ children }</td>
-	) : (
-		<div { ...otherProps }>{ children }</div>
+const PlanComparisonGrid2023 = ( {
+	planTypeSelectorProps,
+	intervalType,
+	isInSignup,
+	isLaunchPage,
+	flowName,
+	currentSitePlanSlug,
+	siteId,
+	selectedPlan,
+	selectedFeature,
+	isGlobalStylesOnPersonal,
+	showLegacyStorageFeature,
+	intent,
+	gridPlans,
+	usePricingMetaForGridPlans,
+	allFeaturesList,
+	onUpgradeClick: ownPropsOnUpgradeClick,
+}: PlanComparisonGridProps ) => {
+	// TODO clk: canUserManagePlan should be passed through props instead of being calculated here
+	const canUserPurchasePlan = useSelector( ( state: IAppState ) =>
+		siteId
+			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
+			: null
 	);
-};
-
-export interface PlanFeatures2023GridProps {
-	gridPlansForFeaturesGrid: GridPlan[];
-	gridPlansForComparisonGrid: GridPlan[];
-	gridPlanForSpotlight?: GridPlan;
-	// allFeaturesList temporary until feature definitions are ported to calypso-products package
-	allFeaturesList: FeatureList;
-	isInSignup?: boolean;
-	siteId?: number | null;
-	isLaunchPage?: boolean | null;
-	isReskinned?: boolean;
-	onUpgradeClick?: ( cartItem?: MinimalRequestCartProduct | null ) => void;
-	flowName?: string | null;
-	paidDomainName?: string;
-	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >; // used to show a wpcom free domain in the Free plan column when a paid domain is picked.
-	intervalType?: string;
-	currentSitePlanSlug?: string | null;
-	hidePlansFeatureComparison?: boolean;
-	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
-	planActionOverrides?: PlanActionOverrides;
-	// Value of the `?plan=` query param, so we can highlight a given plan.
-	selectedPlan?: string;
-	// Value of the `?feature=` query param, so we can highlight a given feature and hide plans without it.
-	selectedFeature?: string;
-	intent?: PlansIntent;
-	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >; // indicate when a custom domain is allowed to be used with the Free plan.
-	isGlobalStylesOnPersonal?: boolean;
-	showLegacyStorageFeature?: boolean;
-	showUpgradeableStorage: boolean; // feature flag used to show the storage add-on dropdown
-	stickyRowOffset: number;
-	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
-	showOdie?: () => void;
-	// temporary
-	showPlansComparisonGrid: boolean;
-	// temporary
-	toggleShowPlansComparisonGrid: () => void;
-	planTypeSelectorProps: PlanTypeSelectorProps;
-}
-
-interface PlanFeatures2023GridType extends PlanFeatures2023GridProps {
-	isLargeCurrency: boolean;
-	translate: LocalizeProps[ 'translate' ];
-	canUserPurchasePlan: boolean | null;
-	manageHref: string;
-	selectedSiteSlug: string | null;
-	isPlanUpgradeCreditEligible: boolean;
-	// temporary: element ref to scroll comparison grid into view once "Compare plans" button is clicked
-	plansComparisonGridRef: ForwardedRef< HTMLDivElement >;
-}
-
-const PlanLogo: React.FunctionComponent< {
-	planIndex: number;
-	planSlug: PlanSlug;
-	renderedGridPlans: GridPlan[];
-	isTableCell?: boolean;
-	isInSignup?: boolean;
-} > = ( { planIndex, planSlug, renderedGridPlans, isTableCell, isInSignup } ) => {
-	const { gridPlansIndex } = usePlansGridContext();
-	const { current } = gridPlansIndex[ planSlug ];
-	const translate = useTranslate();
-	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
-		renderedPlans: renderedGridPlans.map( ( gridPlan ) => gridPlan.planSlug ),
-	} );
-	const headerClasses = classNames(
-		'plan-features-2023-grid__header-logo',
-		getPlanClass( planSlug )
+	const purchaseId = useSelector( ( state: IAppState ) =>
+		siteId ? getCurrentPlanPurchaseId( state, siteId ) : null
 	);
-	const tableItemClasses = classNames( 'plan-features-2023-grid__table-item', {
-		'popular-plan-parent-class': gridPlansIndex[ planSlug ]?.highlightLabel,
-		'is-left-of-highlight': highlightAdjacencyMatrix[ planSlug ]?.leftOfHighlight,
-		'is-right-of-highlight': highlightAdjacencyMatrix[ planSlug ]?.rightOfHighlight,
-		'is-only-highlight': highlightAdjacencyMatrix[ planSlug ]?.isOnlyHighlight,
-		'is-current-plan': current,
-		'is-first-in-row': planIndex === 0,
-		'is-last-in-row': planIndex === renderedGridPlans.length - 1,
-	} );
-	const popularBadgeClasses = classNames( {
-		'with-plan-logo': ! (
-			isFreePlan( planSlug ) ||
-			isPersonalPlan( planSlug ) ||
-			isPremiumPlan( planSlug )
-		),
-		'is-current-plan': current,
-	} );
+	// TODO clk: selectedSiteSlug has no other use than computing manageRef below. stop propagating it through props
+	const selectedSiteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
 
-	const shouldShowWooLogo = isEcommercePlan( planSlug ) && ! isWooExpressPlan( planSlug );
+	const manageHref =
+		purchaseId && selectedSiteSlug
+			? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
+			: `/plans/my-plan/${ siteId }`;
 
-	return (
-		<Container key={ planSlug } className={ tableItemClasses } isTableCell={ isTableCell }>
-			<PopularBadge
-				isInSignup={ isInSignup }
-				planSlug={ planSlug }
-				additionalClassName={ popularBadgeClasses }
-			/>
-			<header className={ headerClasses }>
-				{ isBusinessPlan( planSlug ) && (
-					<Plans2023Tooltip
-						text={ translate(
-							'WP Cloud gives you the tools you need to add scalable, highly available, extremely fast WordPress hosting.'
-						) }
-					>
-						<CloudLogo />
-					</Plans2023Tooltip>
-				) }
-				{ shouldShowWooLogo && (
-					<Plans2023Tooltip
-						text={ translate( 'Make your online store a reality with the power of WooCommerce.' ) }
-					>
-						<WooLogo />
-					</Plans2023Tooltip>
-				) }
-				{ isWpcomEnterpriseGridPlan( planSlug ) && (
-					<Plans2023Tooltip
-						text={ translate( 'The trusted choice for enterprise WordPress hosting.' ) }
-					>
-						<VIPLogo />
-					</Plans2023Tooltip>
-				) }
-			</header>
-		</Container>
-	);
-};
-
-export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > {
-	observer: IntersectionObserver | null = null;
-	buttonRef: React.RefObject< HTMLButtonElement > = createRef< HTMLButtonElement >();
-
-	componentDidMount() {
-		this.observer = new IntersectionObserver( ( entries ) => {
-			entries.forEach( ( entry ) => {
-				if ( entry.isIntersecting ) {
-					this.props.showOdie?.();
-					this.observer?.disconnect();
-				}
-			} );
-		} );
-
-		if ( this.buttonRef.current ) {
-			this.observer.observe( this.buttonRef.current );
-		}
-	}
-
-	componentWillUnmount() {
-		if ( this.observer ) {
-			this.observer.disconnect();
-		}
-	}
-
-	renderTable( renderedGridPlans: GridPlan[] ) {
-		const { translate, gridPlanForSpotlight, stickyRowOffset, isInSignup } = this.props;
-		// Do not render the spotlight plan if it exists
-		const gridPlansWithoutSpotlight = ! gridPlanForSpotlight
-			? renderedGridPlans
-			: renderedGridPlans.filter( ( { planSlug } ) => gridPlanForSpotlight.planSlug !== planSlug );
-		const tableClasses = classNames(
-			'plan-features-2023-grid__table',
-			`has-${ gridPlansWithoutSpotlight.length }-cols`
-		);
-
-		return (
-			<table className={ tableClasses }>
-				<caption className="plan-features-2023-grid__screen-reader-text screen-reader-text">
-					{ translate( 'Available plans to choose from' ) }
-				</caption>
-				<tbody>
-					<tr>{ this.renderPlanLogos( gridPlansWithoutSpotlight, { isTableCell: true } ) }</tr>
-					<tr>{ this.renderPlanHeaders( gridPlansWithoutSpotlight, { isTableCell: true } ) }</tr>
-					<tr>{ this.renderPlanTagline( gridPlansWithoutSpotlight, { isTableCell: true } ) }</tr>
-					<tr>{ this.renderPlanPrice( gridPlansWithoutSpotlight, { isTableCell: true } ) }</tr>
-					<tr>
-						{ this.renderBillingTimeframe( gridPlansWithoutSpotlight, { isTableCell: true } ) }
-					</tr>
-					<StickyContainer
-						stickyClass="is-sticky-top-buttons-row"
-						element="tr"
-						stickyOffset={ stickyRowOffset }
-						topOffset={ stickyRowOffset + ( isInSignup ? 0 : 20 ) }
-					>
-						{ ( isStuck: boolean ) =>
-							this.renderTopButtons( gridPlansWithoutSpotlight, { isTableCell: true, isStuck } )
-						}
-					</StickyContainer>
-					<tr>
-						{ this.maybeRenderRefundNotice( gridPlansWithoutSpotlight, { isTableCell: true } ) }
-					</tr>
-					<tr>
-						{ this.renderPreviousFeaturesIncludedTitle( gridPlansWithoutSpotlight, {
-							isTableCell: true,
-						} ) }
-					</tr>
-					<tr>
-						{ this.renderPlanFeaturesList( gridPlansWithoutSpotlight, { isTableCell: true } ) }
-					</tr>
-					<tr>
-						{ this.renderPlanStorageOptions( gridPlansWithoutSpotlight, { isTableCell: true } ) }
-					</tr>
-				</tbody>
-			</table>
-		);
-	}
-
-	renderTabletView() {
-		const { gridPlansForFeaturesGrid, gridPlanForSpotlight } = this.props;
-		const gridPlansWithoutSpotlight = ! gridPlanForSpotlight
-			? gridPlansForFeaturesGrid
-			: gridPlansForFeaturesGrid.filter(
-					( { planSlug } ) => gridPlanForSpotlight.planSlug !== planSlug
-			  );
-		const numberOfPlansToShowOnTop = 4 === gridPlansWithoutSpotlight.length ? 2 : 3;
-		const plansForTopRow = gridPlansWithoutSpotlight.slice( 0, numberOfPlansToShowOnTop );
-		const plansForBottomRow = gridPlansWithoutSpotlight.slice( numberOfPlansToShowOnTop );
-
-		return (
-			<>
-				<div className="plan-features-2023-grid__table-top">
-					{ this.renderTable( plansForTopRow ) }
-				</div>
-				{ plansForBottomRow.length > 0 && (
-					<div className="plan-features-2023-grid__table-bottom">
-						{ this.renderTable( plansForBottomRow ) }
-					</div>
-				) }
-			</>
-		);
-	}
-
-	/**
-	 * Similar to `renderMobileView` above.
-	 */
-	renderSpotlightPlan() {
-		const { gridPlanForSpotlight } = this.props;
-
-		if ( ! gridPlanForSpotlight ) {
-			return null;
-		}
-
-		const spotlightPlanClasses = classNames(
-			'plan-features-2023-grid__plan-spotlight-card',
-			getPlanClass( gridPlanForSpotlight.planSlug )
-		);
-
-		return (
-			<div className="plan-features-2023-grid__plan-spotlight">
-				<div className={ spotlightPlanClasses }>
-					{ this.renderPlanLogos( [ gridPlanForSpotlight ] ) }
-					{ this.renderPlanHeaders( [ gridPlanForSpotlight ] ) }
-					{ this.renderPlanTagline( [ gridPlanForSpotlight ] ) }
-					{ this.renderPlanPrice( [ gridPlanForSpotlight ] ) }
-					{ this.renderBillingTimeframe( [ gridPlanForSpotlight ] ) }
-					{ this.renderTopButtons( [ gridPlanForSpotlight ] ) }
-				</div>
-			</div>
-		);
-	}
-
-	renderMobileView() {
-		const { translate, selectedFeature, gridPlansForFeaturesGrid, gridPlanForSpotlight } =
-			this.props;
-		const CardContainer = (
-			props: React.ComponentProps< typeof FoldableCard > & { planSlug: string }
-		) => {
-			const { children, planSlug, ...otherProps } = props;
-			return isWpcomEnterpriseGridPlan( planSlug ) ? (
-				<div { ...otherProps }>{ children }</div>
-			) : (
-				<FoldableCard { ...otherProps } compact clickableHeader>
-					{ children }
-				</FoldableCard>
-			);
-		};
-
-		return gridPlansForFeaturesGrid
-			.reduce( ( acc, griPlan ) => {
-				// Bring the spotlight plan to the top
-				if ( gridPlanForSpotlight?.planSlug === griPlan.planSlug ) {
-					return [ griPlan ].concat( acc );
-				}
-				return acc.concat( griPlan );
-			}, [] as GridPlan[] )
-			.map( ( gridPlan, index ) => {
-				const planCardClasses = classNames(
-					'plan-features-2023-grid__mobile-plan-card',
-					getPlanClass( gridPlan.planSlug )
-				);
-				const planCardJsx = (
-					<div className={ planCardClasses } key={ `${ gridPlan.planSlug }-${ index }` }>
-						{ this.renderPlanLogos( [ gridPlan ] ) }
-						{ this.renderPlanHeaders( [ gridPlan ] ) }
-						{ this.renderPlanTagline( [ gridPlan ] ) }
-						{ this.renderPlanPrice( [ gridPlan ] ) }
-						{ this.renderBillingTimeframe( [ gridPlan ] ) }
-						{ this.renderMobileFreeDomain( gridPlan.planSlug, gridPlan.isMonthlyPlan ) }
-						{ this.renderTopButtons( [ gridPlan ] ) }
-						{ this.maybeRenderRefundNotice( [ gridPlan ] ) }
-						<CardContainer
-							header={ translate( 'Show all features' ) }
-							planSlug={ gridPlan.planSlug }
-							key={ `${ gridPlan.planSlug }-${ index }` }
-							expanded={
-								selectedFeature &&
-								gridPlan.features.wpcomFeatures.some(
-									( feature ) => feature.getSlug() === selectedFeature
-								)
-							}
-						>
-							{ this.renderPreviousFeaturesIncludedTitle( [ gridPlan ] ) }
-							{ this.renderPlanFeaturesList( [ gridPlan ] ) }
-							{ this.renderPlanStorageOptions( [ gridPlan ] ) }
-						</CardContainer>
-					</div>
-				);
-				return planCardJsx;
-			} );
-	}
-
-	renderMobileFreeDomain( planSlug: PlanSlug, isMonthlyPlan?: boolean ) {
-		const { translate } = this.props;
-
-		if ( isMonthlyPlan || isWpComFreePlan( planSlug ) || isWpcomEnterpriseGridPlan( planSlug ) ) {
-			return null;
-		}
-		const { paidDomainName } = this.props;
-
-		const displayText = paidDomainName
-			? translate( '%(paidDomainName)s is included', {
-					args: { paidDomainName },
-			  } )
-			: translate( 'Free domain for one year' );
-
-		return (
-			<div className="plan-features-2023-grid__highlighted-feature">
-				<PlanFeaturesItem>
-					<span className="plan-features-2023-grid__item-info is-annual-plan-feature is-available">
-						<span className="plan-features-2023-grid__item-title is-bold">{ displayText }</span>
-					</span>
-				</PlanFeaturesItem>
-			</div>
-		);
-	}
-
-	renderPlanPrice( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const {
-			isReskinned,
-			isLargeCurrency,
-			translate,
-			isPlanUpgradeCreditEligible,
-			currentSitePlanSlug,
-			siteId,
-		} = this.props;
-		return renderedGridPlans.map( ( { planSlug } ) => {
-			const isWooExpressPlus = isWooExpressPlusPlan( planSlug );
-			const classes = classNames( 'plan-features-2023-grid__table-item', 'is-bottom-aligned', {
-				'has-border-top': ! isReskinned,
-			} );
-
-			return (
-				<Container
-					scope="col"
-					key={ planSlug }
-					className={ classes }
-					isTableCell={ options?.isTableCell }
-				>
-					<PlanFeatures2023GridHeaderPrice
-						planSlug={ planSlug }
-						isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
-						isLargeCurrency={ isLargeCurrency }
-						currentSitePlanSlug={ currentSitePlanSlug }
-						siteId={ siteId }
-					/>
-					{ isWooExpressPlus && (
-						<div className="plan-features-2023-grid__header-tagline">
-							{ translate( 'Speak to our team for a custom quote.' ) }
-						</div>
-					) }
-				</Container>
-			);
-		} );
-	}
-
-	renderBillingTimeframe( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		return renderedGridPlans.map( ( { planSlug } ) => {
-			const classes = classNames(
-				'plan-features-2023-grid__table-item',
-				'plan-features-2023-grid__header-billing-info'
-			);
-
-			return (
-				<Container className={ classes } isTableCell={ options?.isTableCell } key={ planSlug }>
-					<PlanFeatures2023GridBillingTimeframe planSlug={ planSlug } />
-				</Container>
-			);
-		} );
-	}
-
-	renderPlanLogos( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const { isInSignup } = this.props;
-
-		return renderedGridPlans.map( ( { planSlug }, index ) => {
-			return (
-				<PlanLogo
-					key={ planSlug }
-					planIndex={ index }
-					planSlug={ planSlug }
-					renderedGridPlans={ renderedGridPlans }
-					isTableCell={ options?.isTableCell }
-					isInSignup={ isInSignup }
-				/>
-			);
-		} );
-	}
-
-	renderPlanHeaders( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		return renderedGridPlans.map( ( { planSlug, planTitle } ) => {
-			const headerClasses = classNames(
-				'plan-features-2023-grid__header',
-				getPlanClass( planSlug )
-			);
-
-			return (
-				<Container
-					key={ planSlug }
-					className="plan-features-2023-grid__table-item"
-					isTableCell={ options?.isTableCell }
-				>
-					<header className={ headerClasses }>
-						<h4 className="plan-features-2023-grid__header-title">{ planTitle }</h4>
-					</header>
-				</Container>
-			);
-		} );
-	}
-
-	renderPlanTagline( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		return renderedGridPlans.map( ( { planSlug, tagline } ) => {
-			return (
-				<Container
-					key={ planSlug }
-					className="plan-features-2023-grid__table-item"
-					isTableCell={ options?.isTableCell }
-				>
-					<div className="plan-features-2023-grid__header-tagline">{ tagline }</div>
-				</Container>
-			);
-		} );
-	}
-
-	handleUpgradeClick = ( planSlug: PlanSlug ) => {
-		const { onUpgradeClick: ownPropsOnUpgradeClick, gridPlansForFeaturesGrid } = this.props;
+	const handleUpgradeClick = ( planSlug: PlanSlug ) => {
 		const { cartItemForPlan } =
-			gridPlansForFeaturesGrid.find( ( gridPlan ) => gridPlan.planSlug === planSlug ) ?? {};
-
-		// TODO clk: Revisit. Could this suffice: `ownPropsOnUpgradeClick?.( cartItemForPlan )`
+			gridPlans.find( ( gridPlan ) => gridPlan.planSlug === planSlug ) ?? {};
 
 		if ( cartItemForPlan ) {
 			ownPropsOnUpgradeClick?.( cartItemForPlan );
@@ -551,415 +66,174 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 		}
 	};
 
-	renderTopButtons( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const {
-			isInSignup,
-			isLaunchPage,
-			flowName,
-			canUserPurchasePlan,
-			manageHref,
-			currentSitePlanSlug,
-			selectedSiteSlug,
-			translate,
-			planActionOverrides,
-			siteId,
-			isLargeCurrency,
-		} = this.props;
-
-		return renderedGridPlans.map( ( { planSlug, availableForPurchase } ) => {
-			const classes = classNames(
-				'plan-features-2023-grid__table-item',
-				'is-top-buttons',
-				'is-bottom-aligned'
-			);
-
-			// Leaving it `undefined` makes it use the default label
-			let buttonText;
-
-			if (
-				isWooExpressMediumPlan( planSlug ) &&
-				! isWooExpressMediumPlan( currentSitePlanSlug || '' )
-			) {
-				buttonText = translate( 'Get Performance', { textOnly: true } );
-			} else if (
-				isWooExpressSmallPlan( planSlug ) &&
-				! isWooExpressSmallPlan( currentSitePlanSlug || '' )
-			) {
-				buttonText = translate( 'Get Essential', { textOnly: true } );
-			}
-
-			return (
-				<Container key={ planSlug } className={ classes } isTableCell={ options?.isTableCell }>
-					<PlanFeatures2023GridActions
-						manageHref={ manageHref }
-						canUserPurchasePlan={ canUserPurchasePlan }
-						availableForPurchase={ availableForPurchase }
-						className={ getPlanClass( planSlug ) }
-						freePlan={ isFreePlan( planSlug ) }
-						isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planSlug ) }
-						isWooExpressPlusPlan={ isWooExpressPlusPlan( planSlug ) }
-						isInSignup={ isInSignup }
-						isLaunchPage={ isLaunchPage }
-						onUpgradeClick={ () => this.handleUpgradeClick( planSlug ) }
-						planSlug={ planSlug }
-						flowName={ flowName }
-						currentSitePlanSlug={ currentSitePlanSlug }
-						selectedSiteSlug={ selectedSiteSlug }
-						buttonText={ buttonText }
-						planActionOverrides={ planActionOverrides }
-						showMonthlyPrice={ true }
-						siteId={ siteId }
-						isStuck={ options?.isStuck || false }
-						isLargeCurrency={ isLargeCurrency }
-					/>
-				</Container>
-			);
-		} );
-	}
-
-	maybeRenderRefundNotice( gridPlan: GridPlan[], options?: PlanRowOptions ) {
-		const { translate, flowName } = this.props;
-
-		if ( ! isAnyHostingFlow( flowName ) ) {
-			return false;
-		}
-
-		return gridPlan.map( ( { planSlug, pricing: { billingPeriod } } ) => (
-			<Container
-				key={ planSlug }
-				className="plan-features-2023-grid__table-item"
-				isTableCell={ options?.isTableCell }
-			>
-				{ ! isFreePlan( planSlug ) && (
-					<div className={ `plan-features-2023-grid__refund-notice ${ getPlanClass( planSlug ) }` }>
-						{ translate( 'Refundable within %(dayCount)s days. No questions asked.', {
-							args: {
-								dayCount: billingPeriod === 365 ? 14 : 7,
-							},
-						} ) }
-					</div>
-				) }
-			</Container>
-		) );
-	}
-
-	renderEnterpriseClientLogos() {
+	if ( isInSignup ) {
 		return (
-			<div className="plan-features-2023-grid__item plan-features-2023-grid__enterprise-logo">
-				<TimeLogo />
-				<SlackLogo />
-				<DisneyLogo />
-				<CNNLogo />
-				<SalesforceLogo />
-				<FacebookLogo />
-				<CondenastLogo />
-				<BloombergLogo />
-			</div>
-		);
-	}
-
-	renderPreviousFeaturesIncludedTitle( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const { translate, gridPlansForFeaturesGrid } = this.props;
-
-		return renderedGridPlans.map( ( { planSlug } ) => {
-			const shouldRenderEnterpriseLogos =
-				isWpcomEnterpriseGridPlan( planSlug ) || isWooExpressPlusPlan( planSlug );
-			const shouldShowFeatureTitle = ! isWpComFreePlan( planSlug ) && ! shouldRenderEnterpriseLogos;
-			const indexInGridPlansForFeaturesGrid = gridPlansForFeaturesGrid.findIndex(
-				( { planSlug: slug } ) => slug === planSlug
-			);
-			const previousProductName =
-				indexInGridPlansForFeaturesGrid > 0
-					? gridPlansForFeaturesGrid[ indexInGridPlansForFeaturesGrid - 1 ].productNameShort
-					: null;
-			const title =
-				previousProductName &&
-				translate( 'Everything in %(planShortName)s, plus:', {
-					args: { planShortName: previousProductName },
-				} );
-			const classes = classNames(
-				'plan-features-2023-grid__common-title',
-				getPlanClass( planSlug )
-			);
-			const rowspanProp =
-				options?.isTableCell && shouldRenderEnterpriseLogos ? { rowSpan: '2' } : {};
-			return (
-				<Container
-					key={ planSlug }
-					isTableCell={ options?.isTableCell }
-					className="plan-features-2023-grid__table-item"
-					{ ...rowspanProp }
-				>
-					{ shouldShowFeatureTitle && <div className={ classes }>{ title }</div> }
-					{ shouldRenderEnterpriseLogos && this.renderEnterpriseClientLogos() }
-				</Container>
-			);
-		} );
-	}
-
-	renderPlanFeaturesList( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const {
-			paidDomainName,
-			translate,
-			hideUnavailableFeatures,
-			selectedFeature,
-			wpcomFreeDomainSuggestion,
-			isCustomDomainAllowedOnFreePlan,
-		} = this.props;
-		const plansWithFeatures = renderedGridPlans.filter(
-			( gridPlan ) =>
-				! isWpcomEnterpriseGridPlan( gridPlan.planSlug ) &&
-				! isWooExpressPlusPlan( gridPlan.planSlug )
-		);
-
-		return plansWithFeatures.map(
-			( { planSlug, features: { wpcomFeatures, jetpackFeatures } }, mapIndex ) => {
-				return (
-					<Container
-						key={ `${ planSlug }-${ mapIndex }` }
-						isTableCell={ options?.isTableCell }
-						className="plan-features-2023-grid__table-item"
-					>
-						<PlanFeatures2023GridFeatures
-							features={ wpcomFeatures }
-							planSlug={ planSlug }
-							paidDomainName={ paidDomainName }
-							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
-							hideUnavailableFeatures={ hideUnavailableFeatures }
-							selectedFeature={ selectedFeature }
-							isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-						/>
-						{ jetpackFeatures.length !== 0 && (
-							<div className="plan-features-2023-grid__jp-logo" key="jp-logo">
-								<Plans2023Tooltip
-									text={ translate(
-										'Security, performance and growth tools made by the WordPress experts.'
-									) }
-								>
-									<JetpackLogo size={ 16 } />
-								</Plans2023Tooltip>
-							</div>
-						) }
-						<PlanFeatures2023GridFeatures
-							features={ jetpackFeatures }
-							planSlug={ planSlug }
-							paidDomainName={ paidDomainName }
-							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
-							hideUnavailableFeatures={ hideUnavailableFeatures }
-							isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-						/>
-					</Container>
-				);
-			}
-		);
-	}
-
-	renderPlanStorageOptions( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const { translate, intervalType, showUpgradeableStorage } = this.props;
-
-		return renderedGridPlans.map( ( { planSlug, features: { storageOptions } } ) => {
-			if ( ! options?.isTableCell && isWpcomEnterpriseGridPlan( planSlug ) ) {
-				return null;
-			}
-
-			const shouldRenderStorageTitle =
-				storageOptions.length === 1 ||
-				( intervalType !== 'yearly' && storageOptions.length > 0 ) ||
-				( ! showUpgradeableStorage && storageOptions.length > 0 );
-			const canUpgradeStorageForPlan =
-				storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage;
-
-			const storageJSX = canUpgradeStorageForPlan ? (
-				<StorageAddOnDropdown planSlug={ planSlug } storageOptions={ storageOptions } />
-			) : (
-				storageOptions.map( ( storageOption ) => {
-					if ( ! storageOption?.isAddOn ) {
-						return (
-							<div className="plan-features-2023-grid__storage-buttons" key={ planSlug }>
-								{ getStorageStringFromFeature( storageOption?.slug ) }
-							</div>
-						);
-					}
-				} )
-			);
-
-			return (
-				<Container
-					key={ planSlug }
-					className="plan-features-2023-grid__table-item plan-features-2023-grid__storage"
-					isTableCell={ options?.isTableCell }
-				>
-					{ shouldRenderStorageTitle ? (
-						<div className="plan-features-2023-grid__storage-title">{ translate( 'Storage' ) }</div>
-					) : null }
-					{ storageJSX }
-				</Container>
-			);
-		} );
-	}
-
-	render() {
-		const {
-			isInSignup,
-			planTypeSelectorProps,
-			intervalType,
-			isLaunchPage,
-			flowName,
-			currentSitePlanSlug,
-			manageHref,
-			canUserPurchasePlan,
-			translate,
-			selectedSiteSlug,
-			hidePlansFeatureComparison,
-			siteId,
-			selectedPlan,
-			selectedFeature,
-			intent,
-			isGlobalStylesOnPersonal,
-			gridPlansForFeaturesGrid,
-			gridPlansForComparisonGrid,
-			showLegacyStorageFeature,
-			usePricingMetaForGridPlans,
-			allFeaturesList,
-			plansComparisonGridRef,
-			toggleShowPlansComparisonGrid,
-			showPlansComparisonGrid,
-		} = this.props;
-
-		return (
-			<div>
+			<>
 				<QueryActivePromotions />
 				<PlansGridContextProvider
 					intent={ intent }
-					gridPlans={ gridPlansForFeaturesGrid }
+					gridPlans={ gridPlans }
 					usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 					allFeaturesList={ allFeaturesList }
 				>
-					{ this.renderSpotlightPlan() }
-					<div className="plan-features">
-						<div className="plan-features-2023-grid__content">
-							<div>
-								<div className="plan-features-2023-grid__desktop-view">
-									{ this.renderTable( gridPlansForFeaturesGrid ) }
-								</div>
-								<div className="plan-features-2023-grid__tablet-view">
-									{ this.renderTabletView() }
-								</div>
-								<div className="plan-features-2023-grid__mobile-view">
-									{ this.renderMobileView() }
-								</div>
-							</div>
-						</div>
-					</div>
+					<PlanComparisonGrid
+						intent={ intent }
+						gridPlans={ gridPlans }
+						usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+						allFeaturesList={ allFeaturesList }
+						planTypeSelectorProps={ planTypeSelectorProps }
+						intervalType={ intervalType }
+						isInSignup={ isInSignup }
+						isLaunchPage={ isLaunchPage }
+						flowName={ flowName }
+						currentSitePlanSlug={ currentSitePlanSlug }
+						manageHref={ manageHref }
+						canUserPurchasePlan={ canUserPurchasePlan }
+						selectedSiteSlug={ selectedSiteSlug }
+						onUpgradeClick={ handleUpgradeClick }
+						siteId={ siteId }
+						selectedPlan={ selectedPlan }
+						selectedFeature={ selectedFeature }
+						isGlobalStylesOnPersonal={ isGlobalStylesOnPersonal }
+						showLegacyStorageFeature={ showLegacyStorageFeature }
+					/>
 				</PlansGridContextProvider>
-
-				{ ! hidePlansFeatureComparison && (
-					<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
-						<Button onClick={ toggleShowPlansComparisonGrid } ref={ this.buttonRef }>
-							{ showPlansComparisonGrid
-								? translate( 'Hide comparison' )
-								: translate( 'Compare plans' ) }
-						</Button>
-					</div>
-				) }
-				{ ! hidePlansFeatureComparison && showPlansComparisonGrid ? (
-					<div
-						ref={ plansComparisonGridRef }
-						className="plan-features-2023-grid__plan-comparison-grid-container"
-					>
-						<PlansGridContextProvider
-							intent={ intent }
-							gridPlans={ gridPlansForComparisonGrid }
-							usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
-							allFeaturesList={ allFeaturesList }
-						>
-							<PlanComparisonGrid
-								planTypeSelectorProps={ planTypeSelectorProps }
-								intervalType={ intervalType }
-								isInSignup={ isInSignup }
-								isLaunchPage={ isLaunchPage }
-								flowName={ flowName }
-								currentSitePlanSlug={ currentSitePlanSlug }
-								manageHref={ manageHref }
-								canUserPurchasePlan={ canUserPurchasePlan }
-								selectedSiteSlug={ selectedSiteSlug }
-								onUpgradeClick={ this.handleUpgradeClick }
-								siteId={ siteId }
-								selectedPlan={ selectedPlan }
-								selectedFeature={ selectedFeature }
-								isGlobalStylesOnPersonal={ isGlobalStylesOnPersonal }
-								showLegacyStorageFeature={ showLegacyStorageFeature }
-							/>
-							<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
-								<Button onClick={ toggleShowPlansComparisonGrid }>
-									{ translate( 'Hide comparison' ) }
-								</Button>
-							</div>
-						</PlansGridContextProvider>
-					</div>
-				) : null }
-			</div>
+			</>
 		);
 	}
-}
 
-export default forwardRef< HTMLDivElement, PlanFeatures2023GridProps >(
-	function WrappedPlanFeatures2023Grid( props, ref ) {
-		const { siteId } = props;
-		const translate = useTranslate();
-		const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible(
-			props.siteId,
-			props.gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug )
-		);
-		const isLargeCurrency = useIsLargeCurrency( {
-			gridPlans: props.gridPlansForFeaturesGrid,
-		} );
-
-		// TODO clk: canUserManagePlan should be passed through props instead of being calculated here
-		const canUserPurchasePlan = useSelector( ( state: IAppState ) =>
-			siteId
-				? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
-				: null
-		);
-		const purchaseId = useSelector( ( state: IAppState ) =>
-			siteId ? getCurrentPlanPurchaseId( state, siteId ) : null
-		);
-		// TODO clk: selectedSiteSlug has no other use than computing manageRef below. stop propagating it through props
-		const selectedSiteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
-
-		const manageHref =
-			purchaseId && selectedSiteSlug
-				? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
-				: `/plans/my-plan/${ siteId }`;
-
-		if ( props.isInSignup ) {
-			return (
-				<PlanFeatures2023Grid
-					{ ...props }
-					plansComparisonGridRef={ ref }
-					isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
-					isLargeCurrency={ isLargeCurrency }
-					canUserPurchasePlan={ canUserPurchasePlan }
+	return (
+		<CalypsoShoppingCartProvider>
+			<QueryActivePromotions />
+			<PlansGridContextProvider
+				intent={ intent }
+				gridPlans={ gridPlans }
+				usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+				allFeaturesList={ allFeaturesList }
+			>
+				<PlanComparisonGrid
+					intent={ intent }
+					gridPlans={ gridPlans }
+					usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+					allFeaturesList={ allFeaturesList }
+					planTypeSelectorProps={ planTypeSelectorProps }
+					intervalType={ intervalType }
+					isInSignup={ isInSignup }
+					isLaunchPage={ isLaunchPage }
+					flowName={ flowName }
+					currentSitePlanSlug={ currentSitePlanSlug }
 					manageHref={ manageHref }
+					canUserPurchasePlan={ canUserPurchasePlan }
 					selectedSiteSlug={ selectedSiteSlug }
-					translate={ translate }
+					onUpgradeClick={ handleUpgradeClick }
+					siteId={ siteId }
+					selectedPlan={ selectedPlan }
+					selectedFeature={ selectedFeature }
+					isGlobalStylesOnPersonal={ isGlobalStylesOnPersonal }
+					showLegacyStorageFeature={ showLegacyStorageFeature }
 				/>
-			);
+			</PlansGridContextProvider>
+		</CalypsoShoppingCartProvider>
+	);
+};
+
+const PlanFeaturesGrid2023 = ( props: PlanFeaturesGridProps ) => {
+	const {
+		siteId,
+		gridPlans,
+		usePricingMetaForGridPlans,
+		intent,
+		allFeaturesList,
+		onUpgradeClick: ownPropsOnUpgradeClick,
+	} = props;
+	const translate = useTranslate();
+	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible(
+		siteId,
+		gridPlans.map( ( gridPlan ) => gridPlan.planSlug )
+	);
+	const isLargeCurrency = useIsLargeCurrency( {
+		gridPlans,
+	} );
+
+	// TODO clk: canUserManagePlan should be passed through props instead of being calculated here
+	const canUserPurchasePlan = useSelector( ( state: IAppState ) =>
+		siteId
+			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
+			: null
+	);
+	const purchaseId = useSelector( ( state: IAppState ) =>
+		siteId ? getCurrentPlanPurchaseId( state, siteId ) : null
+	);
+	// TODO clk: selectedSiteSlug has no other use than computing manageRef below. stop propagating it through props
+	const selectedSiteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
+
+	const manageHref =
+		purchaseId && selectedSiteSlug
+			? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
+			: `/plans/my-plan/${ siteId }`;
+
+	const handleUpgradeClick = ( planSlug: PlanSlug ) => {
+		const { cartItemForPlan } =
+			gridPlans.find( ( gridPlan ) => gridPlan.planSlug === planSlug ) ?? {};
+
+		if ( cartItemForPlan ) {
+			ownPropsOnUpgradeClick?.( cartItemForPlan );
+			return;
 		}
 
+		if ( isFreePlan( planSlug ) ) {
+			ownPropsOnUpgradeClick?.( null );
+			return;
+		}
+	};
+
+	if ( props.isInSignup ) {
 		return (
-			<CalypsoShoppingCartProvider>
-				<PlanFeatures2023Grid
+			<>
+				<QueryActivePromotions />
+				<PlansGridContextProvider
+					intent={ intent }
+					gridPlans={ gridPlans }
+					usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+					allFeaturesList={ allFeaturesList }
+				>
+					<PlanFeaturesGrid
+						{ ...props }
+						isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
+						isLargeCurrency={ isLargeCurrency }
+						canUserPurchasePlan={ canUserPurchasePlan }
+						manageHref={ manageHref }
+						selectedSiteSlug={ selectedSiteSlug }
+						translate={ translate }
+						onUpgradeClick={ handleUpgradeClick }
+					/>
+				</PlansGridContextProvider>
+			</>
+		);
+	}
+
+	return (
+		<CalypsoShoppingCartProvider>
+			<QueryActivePromotions />
+			<PlansGridContextProvider
+				intent={ intent }
+				gridPlans={ gridPlans }
+				usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+				allFeaturesList={ allFeaturesList }
+			>
+				<PlanFeaturesGrid
 					{ ...props }
-					plansComparisonGridRef={ ref }
 					isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
 					isLargeCurrency={ isLargeCurrency }
 					canUserPurchasePlan={ canUserPurchasePlan }
 					manageHref={ manageHref }
 					selectedSiteSlug={ selectedSiteSlug }
 					translate={ translate }
+					onUpgradeClick={ handleUpgradeClick }
 				/>
-			</CalypsoShoppingCartProvider>
-		);
-	}
-);
+			</PlansGridContextProvider>
+		</CalypsoShoppingCartProvider>
+	);
+};
+
+export { PlanComparisonGrid2023, PlanFeaturesGrid2023 };

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -571,59 +571,56 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			isLargeCurrency,
 		} = this.props;
 
-		return renderedGridPlans.map(
-			( { planSlug, planConstantObj, current, availableForPurchase } ) => {
-				const classes = classNames(
-					'plan-features-2023-grid__table-item',
-					'is-top-buttons',
-					'is-bottom-aligned'
-				);
+		return renderedGridPlans.map( ( { planSlug, current, availableForPurchase } ) => {
+			const classes = classNames(
+				'plan-features-2023-grid__table-item',
+				'is-top-buttons',
+				'is-bottom-aligned'
+			);
 
-				// Leaving it `undefined` makes it use the default label
-				let buttonText;
+			// Leaving it `undefined` makes it use the default label
+			let buttonText;
 
-				if (
-					isWooExpressMediumPlan( planSlug ) &&
-					! isWooExpressMediumPlan( currentSitePlanSlug || '' )
-				) {
-					buttonText = translate( 'Get Performance', { textOnly: true } );
-				} else if (
-					isWooExpressSmallPlan( planSlug ) &&
-					! isWooExpressSmallPlan( currentSitePlanSlug || '' )
-				) {
-					buttonText = translate( 'Get Essential', { textOnly: true } );
-				}
-
-				return (
-					<Container key={ planSlug } className={ classes } isTableCell={ options?.isTableCell }>
-						<PlanFeatures2023GridActions
-							manageHref={ manageHref }
-							canUserPurchasePlan={ canUserPurchasePlan }
-							availableForPurchase={ availableForPurchase }
-							className={ getPlanClass( planSlug ) }
-							freePlan={ isFreePlan( planSlug ) }
-							isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planSlug ) }
-							isWooExpressPlusPlan={ isWooExpressPlusPlan( planSlug ) }
-							isInSignup={ isInSignup }
-							isLaunchPage={ isLaunchPage }
-							onUpgradeClick={ () => this.handleUpgradeClick( planSlug ) }
-							planTitle={ planConstantObj.getTitle() }
-							planSlug={ planSlug }
-							flowName={ flowName }
-							current={ current ?? false }
-							currentSitePlanSlug={ currentSitePlanSlug }
-							selectedSiteSlug={ selectedSiteSlug }
-							buttonText={ buttonText }
-							planActionOverrides={ planActionOverrides }
-							showMonthlyPrice={ true }
-							siteId={ siteId }
-							isStuck={ options?.isStuck || false }
-							isLargeCurrency={ isLargeCurrency }
-						/>
-					</Container>
-				);
+			if (
+				isWooExpressMediumPlan( planSlug ) &&
+				! isWooExpressMediumPlan( currentSitePlanSlug || '' )
+			) {
+				buttonText = translate( 'Get Performance', { textOnly: true } );
+			} else if (
+				isWooExpressSmallPlan( planSlug ) &&
+				! isWooExpressSmallPlan( currentSitePlanSlug || '' )
+			) {
+				buttonText = translate( 'Get Essential', { textOnly: true } );
 			}
-		);
+
+			return (
+				<Container key={ planSlug } className={ classes } isTableCell={ options?.isTableCell }>
+					<PlanFeatures2023GridActions
+						manageHref={ manageHref }
+						canUserPurchasePlan={ canUserPurchasePlan }
+						availableForPurchase={ availableForPurchase }
+						className={ getPlanClass( planSlug ) }
+						freePlan={ isFreePlan( planSlug ) }
+						isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planSlug ) }
+						isWooExpressPlusPlan={ isWooExpressPlusPlan( planSlug ) }
+						isInSignup={ isInSignup }
+						isLaunchPage={ isLaunchPage }
+						onUpgradeClick={ () => this.handleUpgradeClick( planSlug ) }
+						planSlug={ planSlug }
+						flowName={ flowName }
+						current={ current ?? false }
+						currentSitePlanSlug={ currentSitePlanSlug }
+						selectedSiteSlug={ selectedSiteSlug }
+						buttonText={ buttonText }
+						planActionOverrides={ planActionOverrides }
+						showMonthlyPrice={ true }
+						siteId={ siteId }
+						isStuck={ options?.isStuck || false }
+						isLargeCurrency={ isLargeCurrency }
+					/>
+				</Container>
+			);
+		} );
 	}
 
 	maybeRenderRefundNotice( gridPlan: GridPlan[], options?: PlanRowOptions ) {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -17,7 +17,6 @@ import type { IAppState } from 'calypso/state/types';
 import './style.scss';
 
 const PlanComparisonGrid2023 = ( {
-	planTypeSelectorProps,
 	intervalType,
 	isInSignup,
 	isLaunchPage,
@@ -81,7 +80,6 @@ const PlanComparisonGrid2023 = ( {
 						gridPlans={ gridPlans }
 						usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 						allFeaturesList={ allFeaturesList }
-						planTypeSelectorProps={ planTypeSelectorProps }
 						intervalType={ intervalType }
 						isInSignup={ isInSignup }
 						isLaunchPage={ isLaunchPage }
@@ -116,7 +114,6 @@ const PlanComparisonGrid2023 = ( {
 					gridPlans={ gridPlans }
 					usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 					allFeaturesList={ allFeaturesList }
-					planTypeSelectorProps={ planTypeSelectorProps }
 					intervalType={ intervalType }
 					isInSignup={ isInSignup }
 					isLaunchPage={ isLaunchPage }

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1044,27 +1044,6 @@ body.is-section-signup.is-white-signup,
 	}
 }
 
-/**
- * We auto-scroll to the plan comparison grid when it is shown.
- * However, on the /plans page, due to the presence of the masterbar on top,
- * we need to add a scroll offset.
- */
-.is-section-plans .plan-features-2023-grid__plan-comparison-grid-container {
-	scroll-margin-top: $plan-features-header-banner-height + 24px;
-	margin: auto;
-	@include plan-comparison-grid-breakpoints-with-sidebar;
-}
-
-.is-section-signup .plan-features-2023-grid__plan-comparison-grid-container {
-	margin: auto;
-	@include plan-comparison-grid-breakpoints;
-}
-
-.is-section-stepper .plan-features-2023-grid__plan-comparison-grid-container {
-	margin: auto;
-	@include plan-comparison-grid-breakpoints;
-}
-
 .formatted-header {
 	margin-bottom: 0;
 }

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -172,389 +172,337 @@ $mobile-card-max-width: 440px;
 	margin-top: 10px;
 }
 
-.is-2023-pricing-grid .plans-wrapper {
-	margin: 0 20px;
-	padding: 0 0 10px;
-	overflow-x: visible;
+.plan-features-2023-grid__mobile-view {
+	flex-direction: column;
+	align-items: stretch;
+	gap: 20px;
+	margin: 0 auto;
+	max-width: $mobile-card-max-width;
 
-	@include plans-2023-break-small {
-		padding-top: 35px; // enough to cover `plan-features-2023-grid__popular-badge` repositioning (top: -35px)
-		margin: 0;
+	.plan-features-2023-grid__mobile-plan-card {
+		background-color: var(--studio-white);
+		border: 1px solid #e0e0e0;
+		/* stylelint-disable-next-line */
+		border-radius: 5px;
+		padding: 38px 0 20px 0;
+
+		@include plans-section-custom-mobile-breakpoint {
+			margin-left: 0;
+			margin-right: 0;
+		}
+
+		&:first-of-type {
+			margin-top: 0;
+		}
+
+		.foldable-card__main .foldable-card__expand .gridicon {
+			width: 14px;
+		}
+
+		&.is-free-plan .foldable-card__main {
+			color: var(--studio-blue-50);
+
+			.foldable-card__expand .gridicon {
+				fill: var(--studio-blue-50);
+			}
+		}
+
+		&.is-personal-plan .foldable-card__main {
+			color: var(--studio-blue-60);
+
+			.foldable-card__expand .gridicon {
+				fill: var(--studio-blue-60);
+			}
+		}
+
+		&.is-premium-plan .foldable-card__main {
+			color: #004687;
+
+			.foldable-card__expand .gridicon {
+				fill: #004687;
+			}
+		}
+
+		&.is-business-plan .foldable-card__main {
+			color: #7f54b3;
+
+			.foldable-card__expand .gridicon {
+				fill: #7f54b3;
+			}
+		}
+
+		&.is-ecommerce-plan .foldable-card__main {
+			color: #55347d;
+
+			.foldable-card__expand .gridicon {
+				fill: #55347d;
+			}
+		}
 	}
 
-	@include plans-2023-break-medium {
-		margin: 0 20px;
+	.foldable-card {
+		box-shadow: unset;
+		margin-top: 24px;
+
+		.foldable-card__main {
+			color: var(--studio-blue-60);
+			font-family: Inter, $sans;
+			font-weight: 500;
+			font-size: $font-body-small;
+			letter-spacing: -0.24px;
+			line-height: 20px;
+		}
+
+		&.is-compact .foldable-card__header {
+			padding: 0 20px;
+		}
+
+		&.is-expanded .foldable-card__content {
+			border-top: none;
+			padding: 24px 0 0;
+		}
 	}
 
-	@include plans-section-break-medium {
-		margin: 0;
-	}
-
-	@include plans-2023-break-medium {
-		margin: 0 20px;
-	}
-
-	@include plans-section-break-medium {
-		margin: 0;
+	.plan-features-2023-grid__highlighted-feature .plan-features-2023-grid__item {
+		padding-bottom: 24px;
 	}
 }
 
-.is-2023-pricing-grid {
+.plan-features-2023-grid__table {
+	font-size: $font-body-small;
+	color: var(--color-text-subtle);
+	table-layout: fixed;
+	border: 1px solid #e0e0e0;
+	border-radius: 5px; /* stylelint-disable-line */
+	background-color: #fff;
 	margin: 0 auto;
+	border-spacing: 0;
+	width: 100%;
 
-	.signup__steps & {
-		width: auto;
+	&.has-1-cols {
+		max-width: $table-cell-max-width;
 	}
 
-	.is-section-stepper &,
-	.is-section-signup & {
-		@include plan-features-layout-switcher;
+	&.has-2-cols {
+		max-width: $table-cell-max-width * 2;
 	}
 
-	.is-section-plans:not(.is-sidebar-collapsed) & {
-		@include plan-features-layout-switcher-with-sidebar;
+	&.has-3-cols {
+		max-width: $table-cell-max-width * 3;
 	}
 
-	.is-section-plans.is-sidebar-collapsed & {
-		@include plan-features-layout-switcher;
+	&.has-4-cols {
+		max-width: $table-cell-max-width * 4;
 	}
 
-	.plan-features-2023-grid__mobile-view {
-		flex-direction: column;
-		align-items: stretch;
-		gap: 20px;
-		margin: 0 auto;
-		max-width: $mobile-card-max-width;
-
-		.plan-features-2023-grid__mobile-plan-card {
-			background-color: var(--studio-white);
-			border: 1px solid #e0e0e0;
-			/* stylelint-disable-next-line */
-			border-radius: 5px;
-			padding: 38px 0 20px 0;
-
-			@include plans-section-custom-mobile-breakpoint {
-				margin-left: 0;
-				margin-right: 0;
-			}
-
-			&:first-of-type {
-				margin-top: 0;
-			}
-
-			.foldable-card__main .foldable-card__expand .gridicon {
-				width: 14px;
-			}
-
-			&.is-free-plan .foldable-card__main {
-				color: var(--studio-blue-50);
-
-				.foldable-card__expand .gridicon {
-					fill: var(--studio-blue-50);
-				}
-			}
-
-			&.is-personal-plan .foldable-card__main {
-				color: var(--studio-blue-60);
-
-				.foldable-card__expand .gridicon {
-					fill: var(--studio-blue-60);
-				}
-			}
-
-			&.is-premium-plan .foldable-card__main {
-				color: #004687;
-
-				.foldable-card__expand .gridicon {
-					fill: #004687;
-				}
-			}
-
-			&.is-business-plan .foldable-card__main {
-				color: #7f54b3;
-
-				.foldable-card__expand .gridicon {
-					fill: #7f54b3;
-				}
-			}
-
-			&.is-ecommerce-plan .foldable-card__main {
-				color: #55347d;
-
-				.foldable-card__expand .gridicon {
-					fill: #55347d;
-				}
-			}
-		}
-
-		.foldable-card {
-			box-shadow: unset;
-			margin-top: 24px;
-
-			.foldable-card__main {
-				color: var(--studio-blue-60);
-				font-family: Inter, $sans;
-				font-weight: 500;
-				font-size: $font-body-small;
-				letter-spacing: -0.24px;
-				line-height: 20px;
-			}
-
-			&.is-compact .foldable-card__header {
-				padding: 0 20px;
-			}
-
-			&.is-expanded .foldable-card__content {
-				border-top: none;
-				padding: 24px 0 0;
-			}
-		}
-
-		.plan-features-2023-grid__highlighted-feature .plan-features-2023-grid__item {
-			padding-bottom: 24px;
-		}
-	}
-
-	.signup__steps .plans-features-main__group.is-scrollable & {
-		max-width: 100%;
-	}
-
-	.plan-features-2023-grid__table {
-		font-size: $font-body-small;
-		color: var(--color-text-subtle);
-		table-layout: fixed;
-		border: 1px solid #e0e0e0;
-		border-radius: 5px; /* stylelint-disable-line */
-		background-color: #fff;
-		margin: 0 auto;
-		border-spacing: 0;
-		width: 100%;
-
-		&.has-1-cols {
-			max-width: $table-cell-max-width;
-		}
-
-		&.has-2-cols {
-			max-width: $table-cell-max-width * 2;
-		}
-
-		&.has-3-cols {
-			max-width: $table-cell-max-width * 3;
-		}
-
-		&.has-4-cols {
-			max-width: $table-cell-max-width * 4;
-		}
-
-		.components-custom-select-control__label {
-			color: var(--studio-gray-100);
-		}
-
-		.components-custom-select-control__menu {
-			margin-left: 0;
-		}
-	}
-
-	.plan-features-2023-grid__header-title {
-		margin-top: 0;
-		margin-bottom: 5px;
-		font-size: $font-title-large;
-		line-height: 0.7;
+	.components-custom-select-control__label {
 		color: var(--studio-gray-100);
-		font-weight: 400;
-		@include onboarding-font-recoleta;
-		letter-spacing: 0;
 	}
 
-	.plan-features-2023-grid__header-tagline {
-		font-size: $font-body;
-		line-height: 24px;
-		color: var(--studio-gray-80);
-		font-weight: 400;
-		padding: 0 20px 24px 20px;
+	.components-custom-select-control__menu {
+		margin-left: 0;
+	}
+}
 
+.plan-features-2023-grid__header-title {
+	margin-top: 0;
+	margin-bottom: 5px;
+	font-size: $font-title-large;
+	line-height: 0.7;
+	color: var(--studio-gray-100);
+	font-weight: 400;
+	@include onboarding-font-recoleta;
+	letter-spacing: 0;
+}
+
+.plan-features-2023-grid__header-tagline {
+	font-size: $font-body;
+	line-height: 24px;
+	color: var(--studio-gray-80);
+	font-weight: 400;
+	padding: 0 20px 24px 20px;
+
+	@include plans-2023-break-small {
+		font-size: $font-body-small;
+		line-height: 20px;
+	}
+
+	@include plans-2023-break-medium {
+		font-size: 0.813rem; /* stylelint-disable-line */
+		line-height: 16px;
+		padding-bottom: 8px;
+		min-height: 50px;
+	}
+}
+
+.plan-features-2023-grid__table-item {
+	text-align: left;
+	transition: opacity 0.05s;
+	border: none;
+	background-color: var(--color-surface);
+	position: relative;
+	vertical-align: baseline;
+
+	.is-bold {
+		font-weight: 600;
+	}
+
+	&.is-bottom-aligned {
+		vertical-align: bottom;
+	}
+
+
+	&.is-top-buttons {
+		padding: 0 20px;
+		vertical-align: bottom;
 		@include plans-2023-break-small {
-			font-size: $font-body-small;
-			line-height: 20px;
-		}
-
-		@include plans-2023-break-medium {
-			font-size: 0.813rem; /* stylelint-disable-line */
-			line-height: 16px;
-			padding-bottom: 8px;
-			min-height: 50px;
+			padding-top: 16px;
+			padding-bottom: 16px;
 		}
 	}
 
+	@include plans-2023-break-small {
+		border-left: solid 1px #e0e0e0;
+	}
+}
+
+.plan-features-2023-grid__desktop-view,
+.plan-features-2023-grid__tablet-view {
 	.plan-features-2023-grid__table-item {
-		text-align: left;
-		transition: opacity 0.05s;
-		border: none;
-		background-color: var(--color-surface);
-		position: relative;
-		vertical-align: baseline;
+		max-width: $table-cell-max-width;
+	}
+}
 
-		.is-bold {
-			font-weight: 600;
-		}
+.plan-features-2023-grid__plan-spotlight {
+	background-color: var(--studio-white);
+	.plan-features-2023-grid__plan-spotlight-card {
+		max-width: 100%;
+		margin-bottom: 64px;
+		border: 1px solid #e0e0e0;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 0 0 5px 5px;
+		div.plan-features-2023-grid__table-item {
+			border: none;
+			&.is-top-buttons {
+				position: absolute;
+				top: 46px;
+				right: 0;
+				border-left: 0;
+			}
 
-		&.is-bottom-aligned {
-			vertical-align: bottom;
-		}
+			&.plan-features-2023-grid__header-billing-info {
+				padding-bottom: 32px;
+				@include plans-2023-break-small {
+					padding-bottom: 32px;
+				}
+			}
 
+			&.popular-plan-parent-class .plan-features-2023-grid__popular-badge {
+				padding-bottom: 23px;
+			}
 
-		&.is-top-buttons {
-			padding: 0 20px;
-			vertical-align: bottom;
-			@include plans-2023-break-small {
-				padding-top: 16px;
+			.plan-features-2023-grid__header-title {
+				margin-top: 24px;
+			}
+
+			.plan-features-2023-grid__header-tagline {
+				min-height: 0;
 				padding-bottom: 16px;
 			}
-		}
 
-		@include plans-2023-break-small {
-			border-left: solid 1px #e0e0e0;
-		}
-	}
-
-	.plan-features-2023-grid__desktop-view,
-	.plan-features-2023-grid__tablet-view {
-		.plan-features-2023-grid__table-item {
-			max-width: $table-cell-max-width;
-		}
-	}
-
-	.plan-features-2023-grid__plan-spotlight {
-		background-color: var(--studio-white);
-		.plan-features-2023-grid__plan-spotlight-card {
-			max-width: 100%;
-			margin-bottom: 64px;
-			border: 1px solid #e0e0e0;
-			/* stylelint-disable-next-line scales/radii */
-			border-radius: 0 0 5px 5px;
-			div.plan-features-2023-grid__table-item {
-				border: none;
-				&.is-top-buttons {
-					position: absolute;
-					top: 46px;
-					right: 0;
-					border-left: 0;
-				}
-
-				&.plan-features-2023-grid__header-billing-info {
-					padding-bottom: 32px;
-					@include plans-2023-break-small {
-						padding-bottom: 32px;
-					}
-				}
-
-				&.popular-plan-parent-class .plan-features-2023-grid__popular-badge {
-					padding-bottom: 23px;
-				}
-
-				.plan-features-2023-grid__header-title {
-					margin-top: 24px;
-				}
-
-				.plan-features-2023-grid__header-tagline {
-					min-height: 0;
-					padding-bottom: 16px;
-				}
-
-				.plan-features-2023-grid__header-logo {
-					display: none;
-				}
+			.plan-features-2023-grid__header-logo {
+				display: none;
 			}
 		}
 	}
+}
 
-	.plan-features-2023-grid__header-annual-discount {
-		color: var(--studio-green-60);
-		&-is-loading {
-			@include placeholder();
-		}
+.plan-features-2023-grid__header-annual-discount {
+	color: var(--studio-green-60);
+	&-is-loading {
+		@include placeholder();
 	}
+}
 
-	.plan-features-2023-grid__item-info {
-		display: flex;
-		flex-direction: column;
+.plan-features-2023-grid__item-info {
+	display: flex;
+	flex-direction: column;
+	flex: 1 0 0;
+	width: 100%;
+
+	.plan-features-2023-grid__item-title {
+		color: var(--studio-gray-80);
+		font-size: $font-body-small;
+		font-weight: 400;
+		line-height: 20px;
+		overflow-wrap: break-word;
+		margin: 0;
 		flex: 1 0 0;
 		width: 100%;
 
+		&.is-bold {
+			font-weight: 600;
+		}
+
+		@include plans-2023-break-small {
+			font-size: $font-body-extra-small;
+			line-height: 16px;
+		}
+	}
+
+	&:not(.is-available) {
+		color: var(--studio-gray-20);
+
 		.plan-features-2023-grid__item-title {
-			color: var(--studio-gray-80);
-			font-size: $font-body-small;
-			font-weight: 400;
-			line-height: 20px;
-			overflow-wrap: break-word;
+			text-decoration: line-through;
+		}
+	}
+}
+
+.plan-features-2023-grid__actions-button {
+	width: 100%;
+
+	&.disabled,
+	&[disabled] {
+		color: var(--color-neutral-light);
+	}
+}
+
+.plan-features-2023-grid__row:last-of-type .plan-features-2023-grid__table-item {
+	border-bottom: solid 1px var(--color-neutral-5);
+
+	&.is-last-feature {
+		.plan-features-2023-grid__item-info {
+			padding-bottom: 30px;
+		}
+	}
+}
+
+.plan-features-2023-grid__item {
+	padding: 0 20px 12px;
+	text-align: left;
+
+	&.plan-features-2023-grid__item-available {
+		display: flex;
+		flex-direction: column;
+		position: relative;
+
+		& .plan-features-2023-grid__item-info-container {
+			display: flex;
+		}
+	}
+
+	&.plan-features-2023-grid__enterprise-logo {
+		display: flex;
+		flex-wrap: wrap;
+		column-gap: 20px;
+		row-gap: 14px;
+		position: relative;
+		margin: 32px 0 0;
+
+		@include plans-2023-break-small {
 			margin: 0;
-			flex: 1 0 0;
-			width: 100%;
-
-			&.is-bold {
-				font-weight: 600;
-			}
-
-			@include plans-2023-break-small {
-				font-size: $font-body-extra-small;
-				line-height: 16px;
-			}
-		}
-
-		&:not(.is-available) {
-			color: var(--studio-gray-20);
-
-			.plan-features-2023-grid__item-title {
-				text-decoration: line-through;
-			}
-		}
-	}
-
-	.plan-features-2023-grid__actions-button {
-		width: 100%;
-
-		&.disabled,
-		&[disabled] {
-			color: var(--color-neutral-light);
-		}
-	}
-
-	.plan-features-2023-grid__row:last-of-type .plan-features-2023-grid__table-item {
-		border-bottom: solid 1px var(--color-neutral-5);
-
-		&.is-last-feature {
-			.plan-features-2023-grid__item-info {
-				padding-bottom: 30px;
-			}
-		}
-	}
-
-	.plan-features-2023-grid__item {
-		padding: 0 20px 12px;
-		text-align: left;
-
-		&.plan-features-2023-grid__item-available {
-			display: flex;
-			flex-direction: column;
-			position: relative;
-
-			& .plan-features-2023-grid__item-info-container {
-				display: flex;
-			}
-		}
-
-		&.plan-features-2023-grid__enterprise-logo {
-			display: flex;
-			flex-wrap: wrap;
-			column-gap: 20px;
-			row-gap: 14px;
-			position: relative;
-			margin: 32px 0 0;
-
-			@include plans-2023-break-small {
-				margin: 0;
-				top: 14px;
-			}
+			top: 14px;
 		}
 	}
 }
@@ -1063,8 +1011,8 @@ body.is-section-signup.is-white-signup,
 	margin-right: 20px;
 
 	@include plans-section-custom-mobile-breakpoint {
-		margin-left: 0;
-		margin-right: 0;
+		// margin-left: 0;
+		// margin-right: 0;
 	}
 
 	button {

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -1,4 +1,12 @@
-import { FeatureObject } from 'calypso/lib/plans/features-list';
+import type { PlansIntent } from './grid-context';
+import type {
+	GridPlan,
+	UsePricingMetaForGridPlans,
+} from './hooks/npm-ready/data-store/use-grid-plans';
+import type { FeatureObject, FeatureList } from '@automattic/calypso-products';
+import type { DomainSuggestion } from '@automattic/data-stores';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import type { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import type { TranslateResult } from 'i18n-calypso';
 
 export type TransformedFeatureObject = FeatureObject & {
@@ -20,3 +28,45 @@ export type DataResponse< T > = {
 	isLoading: boolean;
 	result?: T;
 };
+
+/** The various Grid (Features/Comparison) props below */
+interface ContextProps {
+	intent?: PlansIntent;
+	gridPlans: GridPlan[];
+	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
+	// allFeaturesList temporary until feature definitions are ported to calypso-products package
+	allFeaturesList: FeatureList;
+}
+
+interface SharedPlansGridProps extends ContextProps {
+	intervalType?: string;
+	isInSignup?: boolean;
+	isLaunchPage?: boolean | null;
+	flowName?: string | null;
+	currentSitePlanSlug?: string | null;
+	onUpgradeClick?: ( cartItem?: MinimalRequestCartProduct | null ) => void;
+	siteId?: number | null;
+	planActionOverrides?: PlanActionOverrides;
+	// Value of the `?plan=` query param, so we can highlight a given plan.
+	selectedPlan?: string;
+	// Value of the `?feature=` query param, so we can highlight a given feature and hide plans without it.
+	selectedFeature?: string;
+	isGlobalStylesOnPersonal?: boolean;
+	showLegacyStorageFeature?: boolean;
+}
+
+export interface PlanComparisonGridProps extends SharedPlansGridProps {
+	planTypeSelectorProps: PlanTypeSelectorProps;
+}
+
+export interface PlanFeaturesGridProps extends SharedPlansGridProps {
+	gridPlanForSpotlight?: GridPlan;
+	isReskinned?: boolean;
+	paidDomainName?: string;
+	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >; // used to show a wpcom free domain in the Free plan column when a paid domain is picked.
+	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
+	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >; // indicate when a custom domain is allowed to be used with the Free plan.
+	showUpgradeableStorage: boolean; // feature flag used to show the storage add-on dropdown
+	stickyRowOffset: number;
+	showOdie?: () => void;
+}

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -6,7 +6,6 @@ import type {
 import type { FeatureObject, FeatureList } from '@automattic/calypso-products';
 import type { DomainSuggestion } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import type { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import type { TranslateResult } from 'i18n-calypso';
 
 export type TransformedFeatureObject = FeatureObject & {
@@ -55,9 +54,7 @@ interface SharedPlansGridProps extends ContextProps {
 	showLegacyStorageFeature?: boolean;
 }
 
-export interface PlanComparisonGridProps extends SharedPlansGridProps {
-	planTypeSelectorProps: PlanTypeSelectorProps;
-}
+export type PlanComparisonGridProps = SharedPlansGridProps;
 
 export interface PlanFeaturesGridProps extends SharedPlansGridProps {
 	gridPlanForSpotlight?: GridPlan;

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -65,5 +65,4 @@ export interface PlanFeaturesGridProps extends SharedPlansGridProps {
 	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >; // indicate when a custom domain is allowed to be used with the Free plan.
 	showUpgradeableStorage: boolean; // feature flag used to show the storage add-on dropdown
 	stickyRowOffset: number;
-	showOdie?: () => void;
 }

--- a/client/my-sites/plans-features-main/components/comparison-grid-toggle.tsx
+++ b/client/my-sites/plans-features-main/components/comparison-grid-toggle.tsx
@@ -1,0 +1,60 @@
+import { Button } from '@automattic/components';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { type TranslateResult } from 'i18n-calypso';
+import { plansBreakSmall } from 'calypso/my-sites/plan-features-2023-grid/media-queries';
+import '../style.scss';
+
+const ComparisonGridToggle = ( {
+	onClick,
+	label,
+}: {
+	onClick: () => void;
+	label: TranslateResult;
+} ) => {
+	const Container = styled.div`
+		display: flex;
+		justify-content: center;
+		margin-top: 32px;
+		margin-left: 20px;
+		margin-right: 20px;
+
+		button {
+			background: var( --studio-white );
+			border: 1px solid var( --studio-gray-10 );
+			border-radius: 4px;
+			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
+			color: var( --studio-gray-100 );
+			font-size: var( --scss-font-body-small );
+			font-weight: 500;
+			height: 48px;
+			justify-content: center;
+			line-height: 20px;
+			padding: 0 24px;
+			width: 100%;
+			transition: border-color 0.15s ease-out;
+
+			${ plansBreakSmall( css`
+				width: initial;
+				height: 40px;
+			` ) }
+
+			&:not( [disabled] ):hover,
+			&:not( [disabled] ):focus {
+				border-color: var( --studio-gray-100 );
+				box-shadow: none;
+				color: inherit;
+			}
+		}
+	`;
+
+	return (
+		<Container>
+			<Button onClick={ onClick } ref={ null }>
+				{ label }
+			</Button>
+		</Container>
+	);
+};
+
+export default ComparisonGridToggle;

--- a/client/my-sites/plans-features-main/components/comparison-grid-toggle.tsx
+++ b/client/my-sites/plans-features-main/components/comparison-grid-toggle.tsx
@@ -2,16 +2,17 @@ import { Button } from '@automattic/components';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { type TranslateResult } from 'i18n-calypso';
+import { forwardRef } from 'react';
 import { plansBreakSmall } from 'calypso/my-sites/plan-features-2023-grid/media-queries';
 import '../style.scss';
 
-const ComparisonGridToggle = ( {
-	onClick,
-	label,
-}: {
-	onClick: () => void;
-	label: TranslateResult;
-} ) => {
+const ComparisonGridToggle = forwardRef<
+	HTMLAnchorElement | HTMLButtonElement,
+	{
+		onClick: () => void;
+		label: TranslateResult;
+	}
+>( ( { onClick, label }, ref ) => {
 	const Container = styled.div`
 		display: flex;
 		justify-content: center;
@@ -50,11 +51,11 @@ const ComparisonGridToggle = ( {
 
 	return (
 		<Container>
-			<Button onClick={ onClick } ref={ null }>
+			<Button onClick={ onClick } ref={ ref }>
 				{ label }
 			</Button>
 		</Container>
 	);
-};
+} );
 
 export default ComparisonGridToggle;

--- a/client/my-sites/plans-features-main/hooks/use-observable-for-oddie.ts
+++ b/client/my-sites/plans-features-main/hooks/use-observable-for-oddie.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useOdieAssistantContext } from 'calypso/odie/context';
+
+/**
+ * Returns a callback for setting an observable node to show the Odie AI assistant
+ * when it's intersected in view
+ */
+const useObservableForOddie = () => {
+	const {
+		isVisible: isOdieVisible,
+		setIsVisible: setIsOdieVisible,
+		trackEvent: trackOdieEvent,
+	} = useOdieAssistantContext();
+
+	const observer = useRef< IntersectionObserver | null >( null );
+
+	useEffect( () => {
+		if ( ! window.IntersectionObserver ) {
+			return;
+		}
+
+		observer.current = new IntersectionObserver( ( entries ) => {
+			entries.forEach( ( entry ) => {
+				if ( entry.isIntersecting ) {
+					if ( ! isOdieVisible ) {
+						trackOdieEvent( 'calypso_odie_chat_toggle_visibility', {
+							visibility: true,
+							trigger: 'scroll',
+						} );
+						setIsOdieVisible( true );
+					}
+
+					observer.current?.disconnect();
+				}
+			} );
+		} );
+
+		return () => {
+			observer.current?.disconnect();
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	return useCallback( ( observableElement: Element | null ) => {
+		if ( null !== observableElement ) {
+			observer?.current?.observe( observableElement );
+		}
+	}, [] );
+};
+
+export default useObservableForOddie;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -27,7 +27,10 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
 import { isValidFeatureKey, FEATURES_LIST } from 'calypso/lib/plans/features-list';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
-import PlanFeatures2023Grid from 'calypso/my-sites/plan-features-2023-grid';
+import {
+	PlanComparisonGrid2023,
+	PlanFeaturesGrid2023,
+} from 'calypso/my-sites/plan-features-2023-grid';
 import useGridPlans from 'calypso/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans';
 import usePlanFeaturesForGridPlans from 'calypso/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans';
 import useRestructuredPlanFeaturesForComparisonGrid from 'calypso/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-restructured-plan-features-for-comparison-grid';
@@ -170,6 +173,15 @@ const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) 
 		/>
 	);
 };
+
+const PlanComparisonHeader = styled.h1`
+	.plans .step-container .step-container__content &&,
+	&& {
+		font-size: 2rem;
+		text-align: center;
+		margin: 48px 0;
+	}
+`;
 
 const PlansFeaturesMain = ( {
 	paidDomainName,
@@ -634,9 +646,8 @@ const PlansFeaturesMain = ( {
 						data-e2e-plans="wpcom"
 					>
 						<div className="plans-wrapper">
-							<PlanFeatures2023Grid
-								gridPlansForFeaturesGrid={ gridPlansForFeaturesGrid }
-								gridPlansForComparisonGrid={ gridPlansForComparisonGrid }
+							<PlanFeaturesGrid2023
+								gridPlans={ gridPlansForFeaturesGrid }
 								gridPlanForSpotlight={ gridPlanForSpotlight }
 								paidDomainName={ paidDomainName }
 								wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
@@ -650,7 +661,6 @@ const PlansFeaturesMain = ( {
 								siteId={ siteId }
 								isReskinned={ isReskinned }
 								intervalType={ intervalType }
-								hidePlansFeatureComparison={ hidePlansFeatureComparison }
 								hideUnavailableFeatures={ hideUnavailableFeatures }
 								currentSitePlanSlug={ sitePlanSlug }
 								planActionOverrides={ planActionOverrides }
@@ -670,19 +680,50 @@ const PlansFeaturesMain = ( {
 										setIsVisible( true );
 									}
 								} }
-								showPlansComparisonGrid={ showPlansComparisonGrid }
-								toggleShowPlansComparisonGrid={ toggleShowPlansComparisonGrid }
-								planTypeSelectorProps={ planTypeSelectorProps }
-								ref={ plansComparisonGridRef }
 							/>
-							<ComparisonGridToggle
-								onClick={ toggleShowPlansComparisonGrid }
-								label={
-									showPlansComparisonGrid
-										? translate( 'Hide comparison' )
-										: translate( 'Compare plans' )
-								}
-							/>
+							{ ! hidePlansFeatureComparison && (
+								<ComparisonGridToggle
+									onClick={ toggleShowPlansComparisonGrid }
+									label={
+										showPlansComparisonGrid
+											? translate( 'Hide comparison' )
+											: translate( 'Compare plans' )
+									}
+								/>
+							) }
+							{ ! hidePlansFeatureComparison && showPlansComparisonGrid ? (
+								<div
+									ref={ plansComparisonGridRef }
+									className="plan-features-2023-grid__plan-comparison-grid-container"
+								>
+									<PlanComparisonHeader className="wp-brand-font">
+										{ translate( 'Compare our plans and find yours' ) }
+									</PlanComparisonHeader>
+									<PlanComparisonGrid2023
+										gridPlans={ gridPlansForComparisonGrid }
+										isInSignup={ isInSignup }
+										isLaunchPage={ isLaunchPage }
+										onUpgradeClick={ handleUpgradeClick }
+										flowName={ flowName }
+										selectedFeature={ selectedFeature }
+										selectedPlan={ selectedPlan }
+										siteId={ siteId }
+										intervalType={ intervalType }
+										currentSitePlanSlug={ sitePlanSlug }
+										planActionOverrides={ planActionOverrides }
+										intent={ intent }
+										isGlobalStylesOnPersonal={ globalStylesInPersonalPlan }
+										showLegacyStorageFeature={ showLegacyStorageFeature }
+										usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+										allFeaturesList={ FEATURES_LIST }
+										planTypeSelectorProps={ planTypeSelectorProps }
+									/>
+									<ComparisonGridToggle
+										onClick={ toggleShowPlansComparisonGrid }
+										label={ translate( 'Hide comparison' ) }
+									/>
+								</div>
+							) : null }
 						</div>
 					</div>
 				</>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -699,6 +699,7 @@ const PlansFeaturesMain = ( {
 									<PlanComparisonHeader className="wp-brand-font">
 										{ translate( 'Compare our plans and find yours' ) }
 									</PlanComparisonHeader>
+									{ ! hidePlanSelector && <PlanTypeSelector { ...planTypeSelectorProps } /> }
 									<PlanComparisonGrid2023
 										gridPlans={ gridPlansForComparisonGrid }
 										isInSignup={ isInSignup }
@@ -716,7 +717,6 @@ const PlansFeaturesMain = ( {
 										showLegacyStorageFeature={ showLegacyStorageFeature }
 										usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 										allFeaturesList={ FEATURES_LIST }
-										planTypeSelectorProps={ planTypeSelectorProps }
 									/>
 									<ComparisonGridToggle
 										onClick={ toggleShowPlansComparisonGrid }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -694,7 +694,7 @@ const PlansFeaturesMain = ( {
 							{ ! hidePlansFeatureComparison && showPlansComparisonGrid ? (
 								<div
 									ref={ plansComparisonGridRef }
-									className="plan-features-2023-grid__plan-comparison-grid-container"
+									className="plans-features-main__plan-comparison-grid-container"
 								>
 									<PlanComparisonHeader className="wp-brand-font">
 										{ translate( 'Compare our plans and find yours' ) }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -42,6 +42,7 @@ import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-f
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSitePlanSlug, getSiteSlug } from 'calypso/state/sites/selectors';
+import ComparisonGridToggle from './components/comparison-grid-toggle';
 import { FreePlanFreeDomainDialog } from './components/free-plan-free-domain-dialog';
 import { FreePlanPaidDomainDialog } from './components/free-plan-paid-domain-dialog';
 import usePricedAPIPlans from './hooks/data-store/use-priced-api-plans';
@@ -66,7 +67,6 @@ import type {
 	PlanActionOverrides,
 } from 'calypso/my-sites/plan-features-2023-grid/types';
 import type { IAppState } from 'calypso/state/types';
-
 import './style.scss';
 
 const SPOTLIGHT_ENABLED_INTENTS = [ 'plans-default-wpcom' ];
@@ -633,47 +633,57 @@ const PlansFeaturesMain = ( {
 						) }
 						data-e2e-plans="wpcom"
 					>
-						<PlanFeatures2023Grid
-							gridPlansForFeaturesGrid={ gridPlansForFeaturesGrid }
-							gridPlansForComparisonGrid={ gridPlansForComparisonGrid }
-							gridPlanForSpotlight={ gridPlanForSpotlight }
-							paidDomainName={ paidDomainName }
-							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
-							isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-							isInSignup={ isInSignup }
-							isLaunchPage={ isLaunchPage }
-							onUpgradeClick={ handleUpgradeClick }
-							flowName={ flowName }
-							selectedFeature={ selectedFeature }
-							selectedPlan={ selectedPlan }
-							siteId={ siteId }
-							isReskinned={ isReskinned }
-							intervalType={ intervalType }
-							hidePlansFeatureComparison={ hidePlansFeatureComparison }
-							hideUnavailableFeatures={ hideUnavailableFeatures }
-							currentSitePlanSlug={ sitePlanSlug }
-							planActionOverrides={ planActionOverrides }
-							intent={ intent }
-							isGlobalStylesOnPersonal={ globalStylesInPersonalPlan }
-							showLegacyStorageFeature={ showLegacyStorageFeature }
-							showUpgradeableStorage={ showUpgradeableStorage }
-							stickyRowOffset={ masterbarHeight }
-							usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
-							allFeaturesList={ FEATURES_LIST }
-							showOdie={ () => {
-								if ( ! isVisible ) {
-									trackEvent( 'calypso_odie_chat_toggle_visibility', {
-										visibility: true,
-										trigger: 'scroll',
-									} );
-									setIsVisible( true );
+						<div className="plans-wrapper">
+							<PlanFeatures2023Grid
+								gridPlansForFeaturesGrid={ gridPlansForFeaturesGrid }
+								gridPlansForComparisonGrid={ gridPlansForComparisonGrid }
+								gridPlanForSpotlight={ gridPlanForSpotlight }
+								paidDomainName={ paidDomainName }
+								wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+								isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
+								isInSignup={ isInSignup }
+								isLaunchPage={ isLaunchPage }
+								onUpgradeClick={ handleUpgradeClick }
+								flowName={ flowName }
+								selectedFeature={ selectedFeature }
+								selectedPlan={ selectedPlan }
+								siteId={ siteId }
+								isReskinned={ isReskinned }
+								intervalType={ intervalType }
+								hidePlansFeatureComparison={ hidePlansFeatureComparison }
+								hideUnavailableFeatures={ hideUnavailableFeatures }
+								currentSitePlanSlug={ sitePlanSlug }
+								planActionOverrides={ planActionOverrides }
+								intent={ intent }
+								isGlobalStylesOnPersonal={ globalStylesInPersonalPlan }
+								showLegacyStorageFeature={ showLegacyStorageFeature }
+								showUpgradeableStorage={ showUpgradeableStorage }
+								stickyRowOffset={ masterbarHeight }
+								usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+								allFeaturesList={ FEATURES_LIST }
+								showOdie={ () => {
+									if ( ! isVisible ) {
+										trackEvent( 'calypso_odie_chat_toggle_visibility', {
+											visibility: true,
+											trigger: 'scroll',
+										} );
+										setIsVisible( true );
+									}
+								} }
+								showPlansComparisonGrid={ showPlansComparisonGrid }
+								toggleShowPlansComparisonGrid={ toggleShowPlansComparisonGrid }
+								planTypeSelectorProps={ planTypeSelectorProps }
+								ref={ plansComparisonGridRef }
+							/>
+							<ComparisonGridToggle
+								onClick={ toggleShowPlansComparisonGrid }
+								label={
+									showPlansComparisonGrid
+										? translate( 'Hide comparison' )
+										: translate( 'Compare plans' )
 								}
-							} }
-							showPlansComparisonGrid={ showPlansComparisonGrid }
-							toggleShowPlansComparisonGrid={ toggleShowPlansComparisonGrid }
-							planTypeSelectorProps={ planTypeSelectorProps }
-							ref={ plansComparisonGridRef }
-						/>
+							/>
+						</div>
 					</div>
 				</>
 			) }

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -59,6 +59,27 @@
 	}
 }
 
+/**
+ * We auto-scroll to the plan comparison grid when it is shown.
+ * However, on the /plans page, due to the presence of the masterbar on top,
+ * we need to add a scroll offset.
+ */
+.is-section-plans .plan-features-2023-grid__plan-comparison-grid-container {
+	scroll-margin-top: $plan-features-header-banner-height + 24px;
+	margin: auto;
+	@include plan-comparison-grid-breakpoints-with-sidebar;
+}
+
+.is-section-signup .plan-features-2023-grid__plan-comparison-grid-container {
+	margin: auto;
+	@include plan-comparison-grid-breakpoints;
+}
+
+.is-section-stepper .plan-features-2023-grid__plan-comparison-grid-container {
+	margin: auto;
+	@include plan-comparison-grid-breakpoints;
+}
+
 // Content group
 .plans-features-main__group {
 	& + & {

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -1,6 +1,63 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 @import "calypso/my-sites/plan-features-2023-grid/media-queries";
+
+:root {
+	--scss-font-body-small: #{$font-body-small};
+}
+
+.is-2023-pricing-grid {
+	margin: 0 auto;
+
+	.signup__steps & {
+		width: auto;
+	}
+
+	.is-section-stepper &,
+	.is-section-signup & {
+		@include plan-features-layout-switcher;
+	}
+
+	.is-section-plans:not(.is-sidebar-collapsed) & {
+		@include plan-features-layout-switcher-with-sidebar;
+	}
+
+	.is-section-plans.is-sidebar-collapsed & {
+		@include plan-features-layout-switcher;
+	}
+
+	.signup__steps .plans-features-main__group.is-scrollable & {
+		max-width: 100%;
+	}
+
+	.plans-wrapper {
+		margin: 0 20px;
+		padding: 0 0 10px;
+		overflow-x: visible;
+
+		@include plans-2023-break-small {
+			padding-top: 35px; // enough to cover `plan-features-2023-grid__popular-badge` repositioning (top: -35px)
+			margin: 0;
+		}
+
+		@include plans-2023-break-medium {
+			margin: 0 20px;
+		}
+
+		@include plans-section-break-medium {
+			margin: 0;
+		}
+
+		@include plans-2023-break-medium {
+			margin: 0 20px;
+		}
+
+		@include plans-section-break-medium {
+			margin: 0;
+		}
+	}
+}
 
 // Content group
 .plans-features-main__group {

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -64,18 +64,18 @@
  * However, on the /plans page, due to the presence of the masterbar on top,
  * we need to add a scroll offset.
  */
-.is-section-plans .plan-features-2023-grid__plan-comparison-grid-container {
+.is-section-plans .plans-features-main__plan-comparison-grid-container {
 	scroll-margin-top: $plan-features-header-banner-height + 24px;
 	margin: auto;
 	@include plan-comparison-grid-breakpoints-with-sidebar;
 }
 
-.is-section-signup .plan-features-2023-grid__plan-comparison-grid-container {
+.is-section-signup .plans-features-main__plan-comparison-grid-container {
 	margin: auto;
 	@include plan-comparison-grid-breakpoints;
 }
 
-.is-section-stepper .plan-features-2023-grid__plan-comparison-grid-container {
+.is-section-stepper .plans-features-main__plan-comparison-grid-container {
 	margin: auto;
 	@include plan-comparison-grid-breakpoints;
 }

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
@@ -30,7 +30,7 @@
 	}
 
 	.plan-features-2023-grid__content .plan-features-2023-grid__table-item .plan-price,
-	.plan-features-2023-grid__plan-comparison-grid-container .plan-comparison-grid .plan-price {
+	.plans-features-main__plan-comparison-grid-container .plan-comparison-grid .plan-price {
 		font-family: $sans;
 	}
 
@@ -38,7 +38,7 @@
 		font-size: $woo-font-title-medium;
 	}
 
-	.plan-features-2023-grid__plan-comparison-grid-container .plan-comparison-grid .wp-brand-font {
+	.plans-features-main__plan-comparison-grid-container .plan-comparison-grid .wp-brand-font {
 		display: none;
 	}
 

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -13,11 +13,11 @@
 	@include pricing-grid-breakpoints;
 }
 
-.is-section-plans:not(.is-sidebar-collapsed) .is-2023-pricing-grid .plan-features-2023-grid__plan-comparison-grid-container {
+.is-section-plans:not(.is-sidebar-collapsed) .is-2023-pricing-grid .plans-features-main__plan-comparison-grid-container {
 	@include plan-comparison-grid-breakpoints-with-sidebar;
 }
 
-.is-section-plans.is-sidebar-collapsed .is-2023-pricing-grid .plan-features-2023-grid__plan-comparison-grid-container {
+.is-section-plans.is-sidebar-collapsed .is-2023-pricing-grid .plans-features-main__plan-comparison-grid-container {
 	@include plan-comparison-grid-breakpoints;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78266

## Proposed Changes

* Converts the main package component `plans-features-2023-grid` into an index of individual parts, exported and assembled at consuming end
* `ComparisonGrid` and `FeaturesGrid` are moved into respective folders and exported. No title and plan-type-selector embedded
* A "shared" folder is introduced to start moving shared components into

## Testing Instructions

- Confirm `/start` and `/plans/[ paid | free ]` render as before
- Confirm tailored flows (newsletter, wooexpress) work as before
- Confirm plan-term toggle works correctly
- Confirm Odie AI assistant works like before.
    - Visit `/plans` with `?flags=odie`
    - Scroll to the bottom until `Compare Plans` shows. Odie widget should slide in from the side (and stay present until reload - as per original)
- Confirm no performance degradation, or minimal (some might be perceived due to more selectors moving to `plans-features-main`). Confirm over live-image vs staging, or trunk vs this-branch. If not critical, we handle improvements in a follow-up

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?