### PR TITLE
Jetpack Manage: Move the backup addon cards to the bottom of the issue license screen

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -246,14 +246,14 @@ export default function IssueMultipleLicensesForm( {
 					</div>
 				</>
 			) }
-			{ backupAddons.length > 0 && (
+			{ wooExtensions.length > 0 && (
 				<>
 					<hr className="issue-multiple-licenses-form__separator" />
 					<p className="issue-multiple-licenses-form__description">
-						{ translate( 'VaultPress Backup Add-on Storage:' ) }
+						{ translate( 'WooCommerce Extensions:' ) }
 					</p>
 					<div className="issue-multiple-licenses-form__bottom">
-						{ backupAddons.map( ( productOption, i ) => (
+						{ wooExtensions.map( ( productOption, i ) => (
 							<LicenseProductCard
 								isMultiSelect
 								key={ productOption.slug }
@@ -268,14 +268,14 @@ export default function IssueMultipleLicensesForm( {
 					</div>
 				</>
 			) }
-			{ wooExtensions.length > 0 && (
+			{ backupAddons.length > 0 && (
 				<>
 					<hr className="issue-multiple-licenses-form__separator" />
 					<p className="issue-multiple-licenses-form__description">
-						{ translate( 'WooCommerce Extensions:' ) }
+						{ translate( 'VaultPress Backup Add-on Storage:' ) }
 					</p>
 					<div className="issue-multiple-licenses-form__bottom">
-						{ wooExtensions.map( ( productOption, i ) => (
+						{ backupAddons.map( ( productOption, i ) => (
 							<LicenseProductCard
 								isMultiSelect
 								key={ productOption.slug }


### PR DESCRIPTION
## Proposed Changes

* Jetpack Manage: Move the backup addon cards to the bottom of the issue license screen

## Testing Instructions

* Open up http://jetpack.cloud.localhost:3000/partner-portal/issue-license
* Confirm the "WooCommerce Extensions" section appears above the "VaultPress Backup Add-on Storage" section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
