### PR TITLE
Migration trial: Handle UpgradeConfirmation case for sites upgraded from the Migration Trial plan to Business

### DIFF
--- a/client/my-sites/plans/current-plan/trials/business-trial-included.tsx
+++ b/client/my-sites/plans/current-plan/trials/business-trial-included.tsx
@@ -1,106 +1,23 @@
-import { localizeUrl } from '@automattic/i18n-utils';
 import { localize, translate } from 'i18n-calypso';
-import page from 'page';
 import { FunctionComponent } from 'react';
-import advancedDesignTools from 'calypso/assets/images/plans/wpcom/business-trial/advanced-design-tools.svg';
-import beautifulThemes from 'calypso/assets/images/plans/wpcom/business-trial/beautiful-themes.svg';
-import bestInClassHosting from 'calypso/assets/images/plans/wpcom/business-trial/best-in-class-hosting.svg';
-import googleAnalytics from 'calypso/assets/images/plans/wpcom/business-trial/google-analytics.svg';
-import jetpackBackupsAndRestores from 'calypso/assets/images/plans/wpcom/business-trial/jetpack-backups-and-restores.svg';
-import newsletters from 'calypso/assets/images/plans/wpcom/business-trial/newsletters.svg';
-import seoTools from 'calypso/assets/images/plans/wpcom/business-trial/seo-tools.svg';
-import spamProtection from 'calypso/assets/images/plans/wpcom/business-trial/spam-protection.svg';
 import { useSelector } from 'calypso/state';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import FeatureIncludedCard from '../feature-included-card';
+import useBusinessTrialIncludedFeatures from './use-business-trial-included-features';
 
 interface Props {
 	translate: typeof translate;
 	displayAll: boolean;
 }
 const BusinessTrialIncluded: FunctionComponent< Props > = ( props ) => {
-	const { translate, displayAll = true } = props;
+	const { displayAll = true } = props;
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || -1;
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 
-	const allIncludedFeatures = [
-		{
-			title: translate( 'Beautiful themes' ),
-			text: translate( 'Set your site apart with professionally designed themes and layouts.' ),
-			illustration: beautifulThemes,
-			showButton: true,
-			buttonText: translate( 'Browse themes' ),
-			buttonClick: () => page.redirect( `/themes/${ siteSlug }` ),
-		},
-		{
-			title: translate( 'Advanced Design Tools' ),
-			text: translate(
-				'Make your site even more unique with extended color schemes, typography, and control over your site’s CSS.'
-			),
-			illustration: advancedDesignTools,
-			showButton: true,
-			buttonText: translate( 'Design your blog' ),
-			buttonClick: () => ( location.href = siteAdminUrl + 'site-editor.php' ),
-		},
-		{
-			title: translate( 'Newsletters' ),
-			text: translate(
-				'Send your new posts directly to your subscriber’s inbox, add monetization options, and create a community.'
-			),
-			illustration: newsletters,
-			showButton: true,
-			buttonText: translate( 'Setup a newsletter' ),
-			buttonClick: () => ( location.href = `/setup/newsletter/intro?siteSlug=${ siteSlug }` ),
-		},
-		{
-			title: translate( 'Jetpack backups and restores' ),
-			text: translate(
-				'Easily restore or download a backup of your site from any moment in time.'
-			),
-			illustration: jetpackBackupsAndRestores,
-			showButton: true,
-			buttonText: 'View your backup activity',
-			buttonClick: () => page.redirect( `/backup/${ siteSlug }` ),
-		},
-		{
-			title: translate( 'Spam protection' ),
-			text: translate(
-				'Keep your site free of unwelcome comment, form, and text spam with Akismet.'
-			),
-			illustration: spamProtection,
-			showButton: true,
-			buttonText: translate( 'Keep your site safe' ),
-			buttonClick: () =>
-				( location.href = localizeUrl( 'https://jetpack.com/blog/what-is-spam/' ) ),
-		},
-		{
-			title: translate( 'SEO tools' ),
-			text: translate( 'Boost traffic by making your content more findable on search engines.' ),
-			illustration: seoTools,
-			showButton: true,
-			buttonText: translate( 'Increase visibility' ),
-			buttonClick: () =>
-				( location.href = localizeUrl( 'https://wordpress.com/support/seo-tools/' ) ),
-		},
-		{
-			title: translate( 'Google Analytics' ),
-			text: translate( 'Access in-depth data on how and why people come to your site.' ),
-			illustration: googleAnalytics,
-			showButton: true,
-			buttonText: translate( 'Connect Google Analytics' ),
-			buttonClick: () =>
-				( location.href = localizeUrl( 'https://wordpress.com/support/google-analytics/' ) ),
-		},
-		{
-			title: translate( 'Best-in-class hosting' ),
-			text: translate( 'We take care of hosting your store so you can focus on selling.' ),
-			illustration: bestInClassHosting,
-			showButton: false,
-		},
-	];
+	const allIncludedFeatures = useBusinessTrialIncludedFeatures( siteSlug, siteAdminUrl || '' );
 
 	const whatsIncluded = displayAll
 		? allIncludedFeatures

--- a/client/my-sites/plans/current-plan/trials/use-business-trial-included-features.ts
+++ b/client/my-sites/plans/current-plan/trials/use-business-trial-included-features.ts
@@ -1,0 +1,103 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import advancedDesignTools from 'calypso/assets/images/plans/wpcom/business-trial/advanced-design-tools.svg';
+import beautifulThemes from 'calypso/assets/images/plans/wpcom/business-trial/beautiful-themes.svg';
+import bestInClassHosting from 'calypso/assets/images/plans/wpcom/business-trial/best-in-class-hosting.svg';
+import googleAnalytics from 'calypso/assets/images/plans/wpcom/business-trial/google-analytics.svg';
+import jetpackBackupsAndRestores from 'calypso/assets/images/plans/wpcom/business-trial/jetpack-backups-and-restores.svg';
+import newsletters from 'calypso/assets/images/plans/wpcom/business-trial/newsletters.svg';
+import seoTools from 'calypso/assets/images/plans/wpcom/business-trial/seo-tools.svg';
+import spamProtection from 'calypso/assets/images/plans/wpcom/business-trial/spam-protection.svg';
+import type { SiteSlug } from 'calypso/types';
+
+export default function useBusinessTrialIncludedFeatures(
+	siteSlug: SiteSlug,
+	siteAdminUrl: string
+) {
+	const translate = useTranslate();
+
+	return [
+		{
+			id: 'themes',
+			title: translate( 'Beautiful themes' ),
+			text: translate( 'Set your site apart with professionally designed themes and layouts.' ),
+			illustration: beautifulThemes,
+			showButton: true,
+			buttonText: translate( 'Browse themes' ),
+			buttonClick: () => page.redirect( `/themes/${ siteSlug }` ),
+		},
+		{
+			id: 'advanced-design-tools',
+			title: translate( 'Advanced Design Tools' ),
+			text: translate(
+				'Make your site even more unique with extended color schemes, typography, and control over your site’s CSS.'
+			),
+			illustration: advancedDesignTools,
+			showButton: true,
+			buttonText: translate( 'Design your blog' ),
+			buttonClick: () => ( location.href = siteAdminUrl + 'site-editor.php' ),
+		},
+		{
+			id: 'newsletters',
+			title: translate( 'Newsletters' ),
+			text: translate(
+				'Send your new posts directly to your subscriber’s inbox, add monetization options, and create a community.'
+			),
+			illustration: newsletters,
+			showButton: true,
+			buttonText: translate( 'Setup a newsletter' ),
+			buttonClick: () => ( location.href = `/setup/newsletter/intro?siteSlug=${ siteSlug }` ),
+		},
+		{
+			id: 'jetpack-backups-and-restores',
+			title: translate( 'Jetpack backups and restores' ),
+			text: translate(
+				'Easily restore or download a backup of your site from any moment in time.'
+			),
+			illustration: jetpackBackupsAndRestores,
+			showButton: true,
+			buttonText: 'View your backup activity',
+			buttonClick: () => page.redirect( `/backup/${ siteSlug }` ),
+		},
+		{
+			id: 'spam-protection',
+			title: translate( 'Spam protection' ),
+			text: translate(
+				'Keep your site free of unwelcome comment, form, and text spam with Akismet.'
+			),
+			illustration: spamProtection,
+			showButton: true,
+			buttonText: translate( 'Keep your site safe' ),
+			buttonClick: () =>
+				( location.href = localizeUrl( 'https://jetpack.com/blog/what-is-spam/' ) ),
+		},
+		{
+			id: 'seo-tools',
+			title: translate( 'SEO tools' ),
+			text: translate( 'Boost traffic by making your content more findable on search engines.' ),
+			illustration: seoTools,
+			showButton: true,
+			buttonText: translate( 'Increase visibility' ),
+			buttonClick: () =>
+				( location.href = localizeUrl( 'https://wordpress.com/support/seo-tools/' ) ),
+		},
+		{
+			id: 'google-analytics',
+			title: translate( 'Google Analytics' ),
+			text: translate( 'Access in-depth data on how and why people come to your site.' ),
+			illustration: googleAnalytics,
+			showButton: true,
+			buttonText: translate( 'Connect Google Analytics' ),
+			buttonClick: () =>
+				( location.href = localizeUrl( 'https://wordpress.com/support/google-analytics/' ) ),
+		},
+		{
+			id: 'hosting',
+			title: translate( 'Best-in-class hosting' ),
+			text: translate( 'We take care of hosting your store so you can focus on selling.' ),
+			illustration: bestInClassHosting,
+			showButton: false,
+		},
+	];
+}

--- a/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
@@ -1,0 +1,81 @@
+import { useTranslate } from 'i18n-calypso';
+import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import Main from 'calypso/components/main';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useSelector } from 'calypso/state';
+import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import useBusinessTrialIncludedFeatures from '../../current-plan/trials/use-business-trial-included-features';
+import ConfirmationTask from '../upgrade-confirmation/confirmation-task';
+import type { AppState } from 'calypso/types';
+
+import './style.scss';
+
+const BusinessUpgradeConfirmation = () => {
+	const selectedSite = useSelector( getSelectedSite );
+	const translate = useTranslate();
+	const wpAdminUrl = selectedSite?.URL ? selectedSite.URL + '/wp-admin/' : '';
+	const includedFeatures = useBusinessTrialIncludedFeatures(
+		selectedSite?.slug ?? '',
+		wpAdminUrl ?? ''
+	);
+
+	const isFetchingSitePlan = useSelector( ( state: AppState ) => {
+		if ( ! selectedSite?.ID ) {
+			return false;
+		}
+		return isRequestingSitePlans( state, selectedSite.ID );
+	} );
+
+	const currentPlanName = isFetchingSitePlan ? '' : selectedSite?.plan?.product_name_short ?? '';
+
+	return (
+		<>
+			<BodySectionCssClass bodyClass={ [ 'business-trial-upgraded' ] } />
+			<QuerySitePlans siteId={ selectedSite?.ID ?? 0 } />
+			<QueryJetpackPlugins siteIds={ [ selectedSite?.ID ?? 0 ] } />
+			<Main wideLayout>
+				<PageViewTracker
+					path="/plans/my-plan/trial-upgraded/:site"
+					title="Plans > Business Trial Post Upgrade Actions"
+				/>
+				<div className="trial-upgrade-confirmation__header">
+					<h1 className="trial-upgrade-confirmation__title">
+						{ translate( 'Welcome to Business plan' ) }
+					</h1>
+					<div className="trial-upgrade-confirmation__subtitle">
+						<span className="trial-upgrade-confirmation__subtitle-line">
+							{ currentPlanName &&
+								translate(
+									"Your purchase is complete and you're now on the {{strong}}%(planName)s plan{{/strong}}. Now it's time to take your website to the next level. What would you like to do next?",
+									{
+										args: { planName: currentPlanName },
+										components: { strong: <strong /> },
+									}
+								) }
+						</span>
+					</div>
+				</div>
+				<div className="trial-upgrade-confirmation__tasks">
+					{ includedFeatures
+						.filter( ( x ) => x.showButton )
+						.map( ( feature ) => (
+							<ConfirmationTask
+								id={ feature.id }
+								key={ feature.id }
+								context="business_trial"
+								title={ feature.title }
+								subtitle={ feature.text }
+								illustration={ feature.illustration }
+								onCardClick={ feature.buttonClick }
+							/>
+						) ) }
+				</div>
+			</Main>
+		</>
+	);
+};
+
+export default BusinessUpgradeConfirmation;

--- a/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
@@ -43,13 +43,13 @@ const BusinessUpgradeConfirmation = () => {
 				/>
 				<div className="trial-upgrade-confirmation__header">
 					<h1 className="trial-upgrade-confirmation__title">
-						{ translate( 'Welcome to Business plan' ) }
+						{ translate( 'Welcome to the Business plan' ) }
 					</h1>
 					<div className="trial-upgrade-confirmation__subtitle">
 						<span className="trial-upgrade-confirmation__subtitle-line">
 							{ currentPlanName &&
 								translate(
-									"Your purchase is complete and you're now on the {{strong}}%(planName)s plan{{/strong}}. Now it's time to take your website to the next level. What would you like to do next?",
+									"Your purchase is complete, and you're now on the {{strong}}%(planName)s plan{{/strong}}. It's time to take your website to the next level. What would you like to do next?",
 									{
 										args: { planName: currentPlanName },
 										components: { strong: <strong /> },

--- a/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
@@ -69,7 +69,8 @@ const BusinessUpgradeConfirmation = () => {
 								title={ feature.title }
 								subtitle={ feature.text }
 								illustration={ feature.illustration }
-								onCardClick={ feature.buttonClick }
+								buttonText={ feature.buttonText }
+								onButtonClick={ feature.buttonClick }
 							/>
 						) ) }
 				</div>

--- a/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
@@ -4,11 +4,10 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import BusinessTrialIncluded from 'calypso/my-sites/plans/current-plan/trials/business-trial-included';
 import { useSelector } from 'calypso/state';
 import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import useBusinessTrialIncludedFeatures from '../../current-plan/trials/use-business-trial-included-features';
-import ConfirmationTask from '../upgrade-confirmation/confirmation-task';
 import type { AppState } from 'calypso/types';
 
 import './style.scss';
@@ -16,11 +15,6 @@ import './style.scss';
 const BusinessUpgradeConfirmation = () => {
 	const selectedSite = useSelector( getSelectedSite );
 	const translate = useTranslate();
-	const wpAdminUrl = selectedSite?.URL ? selectedSite.URL + '/wp-admin/' : '';
-	const includedFeatures = useBusinessTrialIncludedFeatures(
-		selectedSite?.slug ?? '',
-		wpAdminUrl ?? ''
-	);
 
 	const isFetchingSitePlan = useSelector( ( state: AppState ) => {
 		if ( ! selectedSite?.ID ) {
@@ -59,20 +53,7 @@ const BusinessUpgradeConfirmation = () => {
 					</div>
 				</div>
 				<div className="trial-upgrade-confirmation__tasks">
-					{ includedFeatures
-						.filter( ( x ) => x.showButton )
-						.map( ( feature ) => (
-							<ConfirmationTask
-								id={ feature.id }
-								key={ feature.id }
-								context="business_trial"
-								title={ feature.title }
-								subtitle={ feature.text }
-								illustration={ feature.illustration }
-								buttonText={ feature.buttonText }
-								onButtonClick={ feature.buttonClick }
-							/>
-						) ) }
+					<BusinessTrialIncluded displayAll={ true } />
 				</div>
 			</Main>
 		</>

--- a/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/style.scss
@@ -1,0 +1,1 @@
+@import "../upgrade-confirmation/style";

--- a/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/style.scss
@@ -1,7 +1,22 @@
 @import "../upgrade-confirmation/style";
 
-.business-trial-upgraded {
-	.confirmation-task__illustration {
-		width: 60px;
+body.business-trial-upgraded {
+	.feature-included-card__card {
+		text-align: center;
+		margin-bottom: 0;
+	}
+
+	.feature-included-card__illustration {
+		margin: auto;
+	}
+
+	.feature-included-card__link {
+		text-align: center !important;
+	}
+
+	.trial-upgrade-confirmation__tasks {
+		grid-template-columns: repeat(auto-fill, 240px) !important;
+		grid-column-gap: 28px !important;
+		grid-row-gap: 28px !important;
 	}
 }

--- a/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/style.scss
@@ -1,1 +1,7 @@
 @import "../upgrade-confirmation/style";
+
+.business-trial-upgraded {
+	.confirmation-task__illustration {
+		width: 60px;
+	}
+}

--- a/client/my-sites/plans/ecommerce-trial/controller.jsx
+++ b/client/my-sites/plans/ecommerce-trial/controller.jsx
@@ -2,6 +2,7 @@ import wasBusinessTrialSite from 'calypso/state/selectors/was-business-trial-sit
 import wasEcommerceTrialSite from 'calypso/state/selectors/was-ecommerce-trial-site';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import BusinessTrialExpired from '../trials/business-trial-expired';
+import BusinessUpgradeConfirmation from './business-upgrade-confirmation';
 import ECommerceTrialExpired from './ecommerce-trial-expired';
 import TrialUpgradeConfirmation from './upgrade-confirmation';
 
@@ -19,6 +20,14 @@ export function trialExpired( context, next ) {
 }
 
 export function trialUpgradeConfirmation( context, next ) {
-	context.primary = <TrialUpgradeConfirmation />;
+	const state = context.store.getState();
+	const selectedSite = getSelectedSite( state );
+
+	if ( wasEcommerceTrialSite( state, selectedSite.ID ) ) {
+		context.primary = <TrialUpgradeConfirmation />;
+	} else if ( wasBusinessTrialSite( state, selectedSite.ID ) ) {
+		context.primary = <BusinessUpgradeConfirmation />;
+	}
+
 	next();
 }

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/index.tsx
@@ -1,4 +1,5 @@
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
+import classnames from 'classnames';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { GetActionUrlProps } from '../confirmation-tasks';
@@ -12,9 +13,10 @@ interface ConfirmationTaskProps {
 	title: TranslateResult;
 	subtitle: TranslateResult;
 	illustration: string;
-	onCardClick?: () => void;
 	getActionUrl?: ( actionUrlProps: GetActionUrlProps ) => string;
 	taskActionUrlProps?: GetActionUrlProps;
+	buttonText?: string;
+	onButtonClick?: () => void;
 }
 
 const ConfirmationTask = ( props: ConfirmationTaskProps ) => {
@@ -24,23 +26,24 @@ const ConfirmationTask = ( props: ConfirmationTaskProps ) => {
 		title,
 		subtitle,
 		illustration,
-		onCardClick,
 		getActionUrl,
 		taskActionUrlProps,
+		buttonText,
+		onButtonClick,
 	} = props;
 
 	const dispatch = useDispatch();
 
 	return (
 		<Card
-			className="confirmation-task__card"
+			className={ classnames( 'confirmation-task__card', {
+				'confirmation-task__card-with-cta': !! onButtonClick,
+			} ) }
 			href={ taskActionUrlProps ? getActionUrl?.( taskActionUrlProps ) : null }
-			onClick={ () => {
-				onCardClick && onCardClick();
-				dispatch(
-					recordTracksEvent( `calypso_${ context }_upgraded_card_click`, { card_id: id } )
-				);
-			} }
+			onClick={ () =>
+				taskActionUrlProps &&
+				dispatch( recordTracksEvent( `calypso_${ context }_upgraded_card_click`, { card_id: id } ) )
+			}
 		>
 			<img
 				className="confirmation-task__illustration"
@@ -49,6 +52,22 @@ const ConfirmationTask = ( props: ConfirmationTaskProps ) => {
 			/>
 			<div className="confirmation-task__title">{ title }</div>
 			<div className="confirmation-task__subtitle">{ subtitle }</div>
+			{ buttonText && onButtonClick && (
+				<div className="confirmation-task__action">
+					<Button
+						borderless={ true }
+						primary={ true }
+						onClick={ () => {
+							dispatch(
+								recordTracksEvent( `calypso_${ context }_upgraded_card_click`, { card_id: id } )
+							);
+							onButtonClick();
+						} }
+					>
+						{ buttonText }
+					</Button>
+				</div>
+			) }
 		</Card>
 	);
 };

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/index.tsx
@@ -8,27 +8,39 @@ import './style.scss';
 
 interface ConfirmationTaskProps {
 	id: string;
+	context: string;
 	title: TranslateResult;
 	subtitle: TranslateResult;
 	illustration: string;
-	getActionUrl: ( actionUrlProps: GetActionUrlProps ) => string;
-	taskActionUrlProps: GetActionUrlProps;
+	onCardClick?: () => void;
+	getActionUrl?: ( actionUrlProps: GetActionUrlProps ) => string;
+	taskActionUrlProps?: GetActionUrlProps;
 }
 
 const ConfirmationTask = ( props: ConfirmationTaskProps ) => {
-	const { id, title, subtitle, illustration, getActionUrl, taskActionUrlProps } = props;
+	const {
+		id,
+		context,
+		title,
+		subtitle,
+		illustration,
+		onCardClick,
+		getActionUrl,
+		taskActionUrlProps,
+	} = props;
 
 	const dispatch = useDispatch();
 
 	return (
 		<Card
 			className="confirmation-task__card"
-			href={ getActionUrl( taskActionUrlProps ) }
-			onClick={ () =>
+			href={ taskActionUrlProps ? getActionUrl?.( taskActionUrlProps ) : null }
+			onClick={ () => {
+				onCardClick && onCardClick();
 				dispatch(
-					recordTracksEvent( 'calypso_wooexpress_trial_upgraded_card_click', { card_id: id } )
-				)
-			}
+					recordTracksEvent( `calypso_${ context }_upgraded_card_click`, { card_id: id } )
+				);
+			} }
 		>
 			<img
 				className="confirmation-task__illustration"

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/style.scss
@@ -16,7 +16,11 @@
 		}
 	}
 
-	&:hover {
+	&.confirmation-task__card-with-cta {
+		cursor: inherit;
+	}
+
+	&:hover:not(.confirmation-task__card-with-cta) {
 		box-shadow: 0 0 0 2px var(--color-accent-50);
 	}
 

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -74,6 +74,7 @@ const TrialUpgradeConfirmation = () => {
 					{ tasks.map( ( task ) => (
 						<ConfirmationTask
 							key={ task.id }
+							context="wooexpress_trial"
 							{ ...task }
 							taskActionUrlProps={ taskActionUrlProps }
 						/>

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
@@ -1,7 +1,8 @@
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/breakpoints";
 
-body.ecommerce-trial-upgraded {
+body.ecommerce-trial-upgraded,
+body.business-trial-upgraded {
 	background-color: var(--color-surface);
 	font-family: $font-sf-pro-text;
 


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3560

## Proposed Changes

* Created a reusable hook for getting the Business plan feature list configuration
* Created and adapted the UpgradeConfirmation component for the Migration trial case

## Testing Instructions

* Open a site with the Migration trial plan
* Upgrade the plan to the Business (use credits)
* After the successful checkout
* Check if there is a "Welcome to Business plan" page with a feature list

<img width="1193" alt="Screenshot 2023-08-22 at 14 56 41" src="https://github.com/Automattic/wp-calypso/assets/1241413/a87db0a4-5f77-4d7f-bc29-bebfc5881cf3">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
