### PR TITLE
Newsletter Categories: Fix typo on Enable Newsletter Categories toggle

### DIFF
--- a/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-toggle.tsx
+++ b/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-toggle.tsx
@@ -27,7 +27,7 @@ const NewsletterCategoriesToggle = ( {
 			/>
 			<FormSettingExplanation>
 				{ translate(
-					'This will allow your visitors to specifically subscribed to the selected categories. When this is enabled, only posts published under the created newsletter categories will be send out to your subscribers.'
+					'This will allow your visitors to specifically subscribe to the selected categories. When this is enabled, only posts published under the created newsletter categories will be sent out to your subscribers.'
 				) }
 			</FormSettingExplanation>
 		</div>


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80728

## Proposed Changes

* Fix typo on Enable Newsletter Categories toggle, as requested by translation reviewers
  * Changes: subscribed → subscribe, send → sent
<img width="512" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/271ef5c2-adb4-4e22-a55f-9700a4fa2936">

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/settings/newsletter/{site-slug}
* Verify if the text was updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
