### PR TITLE
Assembler: Move recipe states to URL as query params

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
@@ -12,7 +12,6 @@ interface Props {
 	stepName: string;
 	hasSelectedColorVariation?: boolean;
 	hasSelectedFontVariation?: boolean;
-	onCheckout?: () => void;
 	onUpgradeLater?: () => void;
 	recordTracksEvent: ( eventName: string, eventProps?: { [ key: string ]: unknown } ) => void;
 }
@@ -22,7 +21,6 @@ const useGlobalStylesUpgradeModal = ( {
 	stepName,
 	hasSelectedColorVariation = false,
 	hasSelectedFontVariation = false,
-	onCheckout,
 	onUpgradeLater,
 	recordTracksEvent,
 }: Props ) => {
@@ -50,7 +48,6 @@ const useGlobalStylesUpgradeModal = ( {
 
 	const checkout = () => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.GLOBAL_STYLES_GATING_MODAL_CHECKOUT_BUTTON_CLICK );
-		onCheckout?.();
 
 		// When the user is done with checkout, send them back to the current url
 		const redirectUrl = window.location.href.replace( window.location.origin, '' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -1,7 +1,7 @@
 import { useColorPaletteVariations, useFontPairingVariations } from '@automattic/global-styles';
 import { keyBy } from '@automattic/js-utils';
 import { useSelect } from '@wordpress/data';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { ONBOARD_STORE } from '../../../../../stores';
 import { decodePatternId } from '../utils';
@@ -28,17 +28,55 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 	const header = header_pattern_id ? patternsById[ decodePatternId( header_pattern_id ) ] : null;
 	const footer = footer_pattern_id ? patternsById[ decodePatternId( footer_pattern_id ) ] : null;
 
-	const sections = section_pattern_ids
-		.map( ( patternId ) => patternsById[ decodePatternId( patternId ) ] )
-		.filter( Boolean )
-		.map( ( pattern: Pattern ) => {
-			const [ firstCategory ] = Object.keys( pattern.categories );
-			const category = categoriesByName[ firstCategory ];
-			return {
-				...pattern,
-				category,
-			};
-		} );
+	/* Adds a unique "key" prop to each section pattern,
+	   so that when the patterns are rendered in a list,
+	   they are not re-rendered unnecessarily when the list
+	   is manipulated (some elements get appended / removed).
+	*/
+	const [ keyedSections, setKeyedSections ] = useState< Pattern[] >( [] );
+
+	/* To sync the keyed sections with the search params,
+	   we first initialize the sections from the search params.
+	*/
+	const initialSections = useMemo(
+		() =>
+			section_pattern_ids
+				.map( ( patternId ) => patternsById[ decodePatternId( patternId ) ] )
+				.filter( Boolean )
+				.map( ( pattern: Pattern ) => {
+					const [ firstCategory ] = Object.keys( pattern.categories );
+					const category = categoriesByName[ firstCategory ];
+					return {
+						...pattern,
+						category,
+					};
+				} ),
+		/* We initialize the sections (at most) once when the patterns and categories are finally loaded
+		   (hence the ".length"s in the dependency array).
+
+		   We are ignoring the changes from the search params (section_pattern_ids),
+	       since after this point, the changes will be handled by setSections().
+	    */
+		[ patterns.length, categories.length ] // eslint-disable-line react-hooks/exhaustive-deps
+	);
+
+	const uniqueSectionPatternKeyRef = useRef( 0 );
+	const generateSectionPatternKey = ( pattern: Pattern ) => {
+		uniqueSectionPatternKeyRef.current++;
+		return `${ uniqueSectionPatternKeyRef.current }-${ pattern.ID }`;
+	};
+
+	/* Generates the keys to the initial sections and set them as the initial value of keyedSections.
+	   After this point, the changes will be handled by setSections().
+    */
+	useEffect( () => {
+		const initialKeyedSections = initialSections.map( ( pattern ) => ( {
+			...pattern,
+			key: generateSectionPatternKey( pattern ),
+		} ) );
+
+		setKeyedSections( initialKeyedSections );
+	}, [ initialSections ] );
 
 	const selectedDesign = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
@@ -88,29 +126,6 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 		);
 	};
 
-	const incrementIndexRef = useRef( 0 );
-	const generateKey = ( pattern: Pattern ) => {
-		incrementIndexRef.current++;
-		return `${ incrementIndexRef.current }-${ pattern.ID }`;
-	};
-
-	// Adds a unique "key" prop to each section pattern,
-	// so that when the patterns are rendered in a list,
-	// they are not re-rendered unnecessarily when the list
-	// is manipulated (some elements get appended / removed).
-	const [ keyedSections, setKeyedSections ] = useState< Pattern[] >( [] );
-
-	// Initializes the keys once,
-	// when the patterns and categories are finally loaded.
-	useEffect( () => {
-		const initialKeyedSections = sections.map( ( pattern ) => ( {
-			...pattern,
-			key: generateKey( pattern ),
-		} ) );
-
-		setKeyedSections( initialKeyedSections );
-	}, [ patterns.length, categories.length ] );
-
 	const setSections = ( patterns: Pattern[] ) => {
 		setSearchParams(
 			( currentSearchParams ) => {
@@ -130,7 +145,7 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 					? pattern
 					: {
 							...pattern,
-							key: generateKey( pattern ),
+							key: generateSectionPatternKey( pattern ),
 					  }
 			)
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -12,13 +12,8 @@ import type { GlobalStylesObject } from '@automattic/global-styles';
 const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) => {
 	const [ searchParams, setSearchParams ] = useSearchParams();
 
-	const header_pattern_ids = ( searchParams.get( 'header_pattern_ids' ) || '' )
-		.split( ',' )
-		.filter( Boolean );
-
-	const footer_pattern_ids = ( searchParams.get( 'footer_pattern_ids' ) || '' )
-		.split( ',' )
-		.filter( Boolean );
+	const header_pattern_id = searchParams.get( 'header_pattern_id' );
+	const footer_pattern_id = searchParams.get( 'footer_pattern_id' );
 
 	const section_pattern_ids = ( searchParams.get( 'pattern_ids' ) || '' )
 		.split( ',' )
@@ -30,15 +25,8 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 	const patternsById = keyBy( patterns, 'ID' );
 	const categoriesByName = keyBy( categories, 'name' );
 
-	const header =
-		header_pattern_ids.length === 0
-			? null
-			: patternsById[ decodePatternId( header_pattern_ids[ 0 ] ) ];
-
-	const footer =
-		footer_pattern_ids.length === 0
-			? null
-			: patternsById[ decodePatternId( footer_pattern_ids[ 0 ] ) ];
+	const header = header_pattern_id ? patternsById[ decodePatternId( header_pattern_id ) ] : null;
+	const footer = footer_pattern_id ? patternsById[ decodePatternId( footer_pattern_id ) ] : null;
 
 	const sections = section_pattern_ids
 		.map( ( patternId ) => patternsById[ decodePatternId( patternId ) ] )
@@ -76,9 +64,9 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 		setSearchParams(
 			( currentSearchParams ) => {
 				if ( pattern === null ) {
-					currentSearchParams.delete( 'header_pattern_ids' );
+					currentSearchParams.delete( 'header_pattern_id' );
 				} else {
-					currentSearchParams.set( 'header_pattern_ids', '' + pattern.ID );
+					currentSearchParams.set( 'header_pattern_id', '' + pattern.ID );
 				}
 				return currentSearchParams;
 			},
@@ -90,9 +78,9 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 		setSearchParams(
 			( currentSearchParams ) => {
 				if ( pattern === null ) {
-					currentSearchParams.delete( 'footer_pattern_ids' );
+					currentSearchParams.delete( 'footer_pattern_id' );
 				} else {
-					currentSearchParams.set( 'footer_pattern_ids', '' + pattern.ID );
+					currentSearchParams.set( 'footer_pattern_id', '' + pattern.ID );
 				}
 				return currentSearchParams;
 			},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -22,8 +22,9 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 	const color_variation_title = searchParams.get( 'color_variation_title' );
 	const font_variation_title = searchParams.get( 'font_variation_title' );
 
-	const patternsById = keyBy( patterns, 'ID' );
-	const categoriesByName = keyBy( categories, 'name' );
+	// Initialize the mappings once, when the patterns and categories are finally loaded
+	const patternsById = useMemo( () => keyBy( patterns, 'ID' ), [ patterns.length ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	const categoriesByName = useMemo( () => keyBy( categories, 'name' ), [ categories.length ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const header = header_pattern_id ? patternsById[ decodePatternId( header_pattern_id ) ] : null;
 	const footer = footer_pattern_id ? patternsById[ decodePatternId( footer_pattern_id ) ] : null;
@@ -51,13 +52,10 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 						category,
 					};
 				} ),
-		/* We initialize the sections (at most) once when the patterns and categories are finally loaded
-		   (hence the ".length"s in the dependency array).
-
-		   We are ignoring the changes from the search params (section_pattern_ids),
+		/* We are ignoring the changes from the search params (section_pattern_ids),
 	       since after this point, the changes will be handled by setSections().
 	    */
-		[ patterns.length, categories.length ] // eslint-disable-line react-hooks/exhaustive-deps
+		[ patternsById, categoriesByName ] // eslint-disable-line react-hooks/exhaustive-deps
 	);
 
 	const uniqueSectionPatternKeyRef = useRef( 0 );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -1,34 +1,62 @@
 import { useColorPaletteVariations, useFontPairingVariations } from '@automattic/global-styles';
 import { keyBy } from '@automattic/js-utils';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useSelect } from '@wordpress/data';
+import { useState, useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { ONBOARD_STORE } from '../../../../../stores';
 import { decodePatternId } from '../utils';
 import type { Pattern, Category } from '../types';
 import type { OnboardSelect } from '@automattic/data-stores';
-import type { Design } from '@automattic/design-picker/src/types';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 
 const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) => {
-	const incrementIndexRef = useRef( 0 );
-	const [ header, setHeader ] = useState< Pattern | null >( null );
-	const [ footer, setFooter ] = useState< Pattern | null >( null );
-	const [ sections, setSections ] = useState< Pattern[] >( [] );
-	const [ colorVariation, setColorVariation ] = useState< GlobalStylesObject | null >( null );
-	const [ fontVariation, setFontVariation ] = useState< GlobalStylesObject | null >( null );
+	const [ searchParams, setSearchParams ] = useSearchParams();
+
+	const header_pattern_ids = ( searchParams.get( 'header_pattern_ids' ) || '' )
+		.split( ',' )
+		.filter( Boolean );
+
+	const footer_pattern_ids = ( searchParams.get( 'footer_pattern_ids' ) || '' )
+		.split( ',' )
+		.filter( Boolean );
+
+	const section_pattern_ids = ( searchParams.get( 'pattern_ids' ) || '' )
+		.split( ',' )
+		.filter( Boolean );
+
+	const color_variation_title = searchParams.get( 'color_variation_title' );
+	const font_variation_title = searchParams.get( 'font_variation_title' );
+
+	const patternsById = keyBy( patterns, 'ID' );
+	const categoriesByName = keyBy( categories, 'name' );
+
+	const header =
+		header_pattern_ids.length === 0
+			? null
+			: patternsById[ decodePatternId( header_pattern_ids[ 0 ] ) ];
+
+	const footer =
+		footer_pattern_ids.length === 0
+			? null
+			: patternsById[ decodePatternId( footer_pattern_ids[ 0 ] ) ];
+
+	const sections = section_pattern_ids
+		.map( ( patternId ) => patternsById[ decodePatternId( patternId ) ] )
+		.filter( Boolean )
+		.map( ( pattern: Pattern ) => {
+			const [ firstCategory ] = Object.keys( pattern.categories );
+			const category = categoriesByName[ firstCategory ];
+			return {
+				...pattern,
+				category,
+			};
+		} );
+
 	const selectedDesign = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
 		[]
 	);
-
-	const {
-		stylesheet = '',
-		header_pattern_ids = [],
-		footer_pattern_ids = [],
-		pattern_ids = [],
-		color_variation_title = '',
-		font_variation_title = '',
-	} = selectedDesign?.recipe || {};
+	const { stylesheet = '' } = selectedDesign?.recipe || {};
 
 	const colorVariations = useColorPaletteVariations( siteId, stylesheet, {
 		enabled: !! color_variation_title,
@@ -38,96 +66,113 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 		enabled: !! font_variation_title,
 	} );
 
-	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
+	const colorVariation =
+		( colorVariations || [] ).find( ( { title } ) => title === color_variation_title ) || null;
 
-	const selectedDesignRef = useRef< Design | undefined >( selectedDesign );
+	const fontVariation =
+		( fontVariations || [] ).find( ( { title } ) => title === font_variation_title ) || null;
 
-	selectedDesignRef.current = {
-		...selectedDesign,
-		recipe: {
-			...selectedDesign?.recipe,
-			header_pattern_ids: header ? [ header.ID ] : [],
-			footer_pattern_ids: footer ? [ footer.ID ] : [],
-			pattern_ids: sections.map( ( section ) => section.ID ),
-			color_variation_title: colorVariation?.title,
-			font_variation_title: fontVariation?.title,
-		},
-	} as Design;
+	const setHeader = ( pattern: Pattern | null ) => {
+		setSearchParams(
+			( currentSearchParams ) => {
+				if ( pattern === null ) {
+					currentSearchParams.delete( 'header_pattern_ids' );
+				} else {
+					currentSearchParams.set( 'header_pattern_ids', '' + pattern.ID );
+				}
+				return currentSearchParams;
+			},
+			{ replace: true }
+		);
+	};
 
+	const setFooter = ( pattern: Pattern | null ) => {
+		setSearchParams(
+			( currentSearchParams ) => {
+				if ( pattern === null ) {
+					currentSearchParams.delete( 'footer_pattern_ids' );
+				} else {
+					currentSearchParams.set( 'footer_pattern_ids', '' + pattern.ID );
+				}
+				return currentSearchParams;
+			},
+			{ replace: true }
+		);
+	};
+
+	const incrementIndexRef = useRef( 0 );
 	const generateKey = ( pattern: Pattern ) => {
 		incrementIndexRef.current++;
 		return `${ incrementIndexRef.current }-${ pattern.ID }`;
 	};
 
-	const snapshotRecipe = useCallback( () => setSelectedDesign( selectedDesignRef.current ), [] );
-
-	/**
-	 * Initialize the default value from the recipe of the selected design when both patterns and categories are ready
-	 */
+	const [ keyedSections, setKeyedSections ] = useState< Pattern[] >( [] );
 	useEffect( () => {
-		if ( patterns.length === 0 || categories.length === 0 || ! selectedDesignRef.current?.recipe ) {
-			return;
-		}
+		const initialKeyedSections = sections.map( ( pattern ) => ( {
+			...pattern,
+			key: generateKey( pattern ),
+		} ) );
 
-		const patternsById = keyBy( patterns, 'ID' );
-		const categoriesByName = keyBy( categories, 'name' );
-		const selectedHeader = patternsById[ decodePatternId( header_pattern_ids[ 0 ] ) ];
-		const selectedFooter = patternsById[ decodePatternId( footer_pattern_ids[ 0 ] ) ];
-
-		if ( selectedHeader ) {
-			setHeader( selectedHeader );
-		}
-
-		if ( selectedFooter ) {
-			setFooter( selectedFooter );
-		}
-
-		setSections(
-			pattern_ids
-				.map( ( patternId: string | number ) => patternsById[ decodePatternId( patternId ) ] )
-				.filter( Boolean )
-				.map( ( pattern: Pattern ) => {
-					const [ firstCategory ] = Object.keys( pattern.categories );
-					const category = categoriesByName[ firstCategory ];
-					return {
-						...pattern,
-						key: generateKey( pattern ),
-						category,
-					};
-				} )
-		);
+		setKeyedSections( initialKeyedSections );
 	}, [ patterns.length, categories.length ] );
 
-	useEffect( () => {
-		if ( ! colorVariations || ! color_variation_title ) {
-			return;
-		}
-
-		const initialColorVariation = colorVariations.find(
-			( { title } ) => title === color_variation_title
+	const setSections = ( patterns: Pattern[] ) => {
+		setSearchParams(
+			( currentSearchParams ) => {
+				if ( patterns.length === 0 ) {
+					currentSearchParams.delete( 'pattern_ids' );
+				} else {
+					currentSearchParams.set( 'pattern_ids', patterns.map( ( p ) => p.ID ).join( ',' ) );
+				}
+				return currentSearchParams;
+			},
+			{ replace: true }
 		);
-		if ( initialColorVariation ) {
-			setColorVariation( initialColorVariation );
-		}
-	}, [ colorVariations ] );
 
-	useEffect( () => {
-		if ( ! fontVariations || ! font_variation_title ) {
-			return;
-		}
-
-		const initialFontVariation = fontVariations.find(
-			( { title } ) => title === font_variation_title
+		setKeyedSections(
+			patterns.map( ( pattern ) =>
+				pattern.key
+					? pattern
+					: {
+							...pattern,
+							key: generateKey( pattern ),
+					  }
+			)
 		);
-		if ( initialFontVariation ) {
-			setFontVariation( initialFontVariation );
-		}
-	}, [ fontVariations ] );
+	};
+
+	const setColorVariation = ( variation: GlobalStylesObject | null ) => {
+		setSearchParams(
+			( currentSearchParams ) => {
+				if ( variation?.title ) {
+					currentSearchParams.set( 'color_variation_title', variation?.title );
+				} else {
+					currentSearchParams.delete( 'color_variation_title' );
+				}
+				return currentSearchParams;
+			},
+			{ replace: true }
+		);
+	};
+
+	const setFontVariation = ( variation: GlobalStylesObject | null ) => {
+		setSearchParams(
+			( currentSearchParams ) => {
+				if ( variation?.title ) {
+					currentSearchParams.set( 'font_variation_title', variation?.title );
+				} else {
+					currentSearchParams.delete( 'font_variation_title' );
+				}
+				return currentSearchParams;
+			},
+			{ replace: true }
+		);
+	};
 
 	return {
 		header,
 		footer,
-		sections,
+		sections: keyedSections,
 		colorVariation,
 		fontVariation,
 		setHeader,
@@ -135,8 +180,6 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 		setSections,
 		setColorVariation,
 		setFontVariation,
-		generateKey,
-		snapshotRecipe,
 	};
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -106,7 +106,14 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 		return `${ incrementIndexRef.current }-${ pattern.ID }`;
 	};
 
+	// Adds a unique "key" prop to each section pattern,
+	// so that when the patterns are rendered in a list,
+	// they are not re-rendered unnecessarily when the list
+	// is manipulated (some elements get appended / removed).
 	const [ keyedSections, setKeyedSections ] = useState< Pattern[] >( [] );
+
+	// Initializes the keys once,
+	// when the patterns and categories are finally loaded.
 	useEffect( () => {
 		const initialKeyedSections = sections.map( ( pattern ) => ( {
 			...pattern,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -110,8 +110,6 @@ const PatternAssembler = ( {
 		setSections,
 		setColorVariation,
 		setFontVariation,
-		generateKey,
-		snapshotRecipe,
 	} = useRecipe( site?.ID, allPatterns, categories );
 
 	const stylesheet = selectedDesign?.recipe?.stylesheet || '';
@@ -249,10 +247,7 @@ const PatternAssembler = ( {
 		if ( position !== null ) {
 			setSections( [
 				...sections.slice( 0, position ),
-				{
-					...pattern,
-					key: sections[ position ].key,
-				},
+				pattern,
 				...sections.slice( position + 1 ),
 			] );
 			updateActivePatternPosition( position );
@@ -261,13 +256,7 @@ const PatternAssembler = ( {
 	};
 
 	const addSection = ( pattern: Pattern ) => {
-		setSections( [
-			...( sections as Pattern[] ),
-			{
-				...pattern,
-				key: generateKey( pattern ),
-			},
-		] );
+		setSections( [ ...( sections as Pattern[] ), pattern ] );
 		updateActivePatternPosition( sections.length );
 		noticeOperations.showPatternInsertedNotice( pattern );
 	};
@@ -408,7 +397,6 @@ const PatternAssembler = ( {
 		stepName,
 		hasSelectedColorVariation: !! colorVariation,
 		hasSelectedFontVariation: !! fontVariation,
-		onCheckout: snapshotRecipe,
 		onUpgradeLater: handleContinue,
 		recordTracksEvent,
 	} );

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -118,8 +118,8 @@ function getChecklistThemeDestination( {
 	flowName,
 	siteSlug,
 	themeParameter,
-	headerPatternIds,
-	footerPatternIds,
+	headerPatternId,
+	footerPatternId,
 	sectionPatternIds,
 } ) {
 	if ( isSiteAssemblerFlow( flowName ) ) {
@@ -130,8 +130,8 @@ function getChecklistThemeDestination( {
 					theme: themeParameter,
 					siteSlug: siteSlug,
 					isNewSite: true,
-					header_pattern_ids: headerPatternIds,
-					footer_pattern_ids: footerPatternIds,
+					header_pattern_id: headerPatternId,
+					footer_pattern_id: footerPatternId,
 					pattern_ids: sectionPatternIds,
 				},
 				`/setup/with-theme-assembler`

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -114,7 +114,14 @@ function getThankYouNoSiteDestination() {
 	return `/checkout/thank-you/no-site`;
 }
 
-function getChecklistThemeDestination( { flowName, siteSlug, themeParameter } ) {
+function getChecklistThemeDestination( {
+	flowName,
+	siteSlug,
+	themeParameter,
+	headerPatternIds,
+	footerPatternIds,
+	sectionPatternIds,
+} ) {
 	if ( isSiteAssemblerFlow( flowName ) ) {
 		// Check whether to go to the assembler. If not, go to the site editor directly
 		if ( isAssemblerSupported() ) {
@@ -123,6 +130,9 @@ function getChecklistThemeDestination( { flowName, siteSlug, themeParameter } ) 
 					theme: themeParameter,
 					siteSlug: siteSlug,
 					isNewSite: true,
+					header_pattern_ids: headerPatternIds,
+					footer_pattern_ids: footerPatternIds,
+					pattern_ids: sectionPatternIds,
 				},
 				`/setup/with-theme-assembler`
 			);

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -301,8 +301,8 @@ export default {
 		const themeParameter = query && query.theme;
 		const themeType = query && query.theme_type;
 		const styleVariation = query && query.style_variation;
-		const headerPatternIds = query && query.header_pattern_ids;
-		const footerPatternIds = query && query.footer_pattern_ids;
+		const headerPatternId = query && query.header_pattern_id;
+		const footerPatternId = query && query.footer_pattern_id;
 		const sectionPatternIds = query && query.pattern_ids;
 		// Set plugin parameter in signup dependency store so we can retrieve it in getWithPluginDestination().
 		const pluginParameter = query && query.plugin;
@@ -313,8 +313,8 @@ export default {
 			...( themeParameter && { themeParameter } ),
 			...( themeType && { themeType } ),
 			...( styleVariation && { styleVariation } ),
-			...( headerPatternIds && { headerPatternIds } ),
-			...( footerPatternIds && { footerPatternIds } ),
+			...( headerPatternId && { headerPatternId } ),
+			...( footerPatternId && { footerPatternId } ),
 			...( sectionPatternIds && { sectionPatternIds } ),
 			...( pluginParameter && { pluginParameter } ),
 			...( pluginBillingPeriod && { pluginBillingPeriod } ),

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -297,10 +297,13 @@ export default {
 
 		// Set referral parameter in signup dependency store so we can retrieve it in getSignupDestination().
 		const refParameter = query && query.ref;
-		// Set theme parameter in signup depencency store so we can retrieve it in getChecklistThemeDestination().
+		// Set design parameters in signup depencency store so we can retrieve it in getChecklistThemeDestination().
 		const themeParameter = query && query.theme;
 		const themeType = query && query.theme_type;
 		const styleVariation = query && query.style_variation;
+		const headerPatternIds = query && query.header_pattern_ids;
+		const footerPatternIds = query && query.footer_pattern_ids;
+		const sectionPatternIds = query && query.pattern_ids;
 		// Set plugin parameter in signup dependency store so we can retrieve it in getWithPluginDestination().
 		const pluginParameter = query && query.plugin;
 		const pluginBillingPeriod = query && query.billing_period;
@@ -310,6 +313,9 @@ export default {
 			...( themeParameter && { themeParameter } ),
 			...( themeType && { themeType } ),
 			...( styleVariation && { styleVariation } ),
+			...( headerPatternIds && { headerPatternIds } ),
+			...( footerPatternIds && { footerPatternIds } ),
+			...( sectionPatternIds && { sectionPatternIds } ),
 			...( pluginParameter && { pluginParameter } ),
 			...( pluginBillingPeriod && { pluginBillingPeriod } ),
 		};


### PR DESCRIPTION
Related to:

- #80668 

## Proposed Changes

Currently, in the Site Assembler flow, we store the current recipe in the `selectedDesign.recipe` object in the onboard store. We store the following:

- `header_pattern_ids`
- `footer_pattern_ids`
- `pattern_ids`
- `color_variation_title`
- `footer_variation_title`

This PR proposes to move the above recipe states to the URL instead. The benefits:

- To allow pre-selection required on #80668.
- The URL becomes single source of truth of the recipe.
- We don't need to "snapshot" the recipe anymore in the Global Styles checkout flow (see #75057)

This PR also moves the logic of generating section keys to `useRecipe()` so that we don't have to export it.

## Testing Instructions

### A. Free flow

1. Go to the Site Assembler flow (`/setup/with-theme-assembler?siteSlug=<SITE_SLUG>`)
2. Add header, sections, footer.
3. Refresh the page, verify that the patterns are preserved.
4. Finish the flow, verify that we land in the Site Editor with the correct patterns.

### B. Premium flow

1. Go to the Site Assembler flow (`/setup/with-theme-assembler?siteSlug=<SITE_SLUG>`)
2. Add header, sections, footer.
3. Pick custom color, font.
4. Refresh the page, verify that the patterns, color, and font are preserved.
5. Click Save & Continue -> Upgrade plan
6. On checkout page: click back button, verify that everything is preserved.
7. Go to checkout page again.
8. Finish the checkout, verify that we're redirected to the assembler flow and everything is preserved.
4. Finish the flow, verify that we land in the Site Editor with the correct patterns, color, and font.

### C. Pattern pre-selection flow

1. Open incognito.
2. Go to `/start/with-theme-assembler?header_pattern_id=5588&pattern_ids=7156`
3. Log in, select domain etc. 
4. Verify that you land in the Site Assembler flow, with the following header and pattern pre-selected:

    <img width="960" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/44e22d06-508f-4e0e-8f6b-bda9be634f15">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
