### PR TITLE
update reader subscription sidebar 'load more sites' link colors

### DIFF
--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -105,7 +105,7 @@
 	}
 
 	.sidebar-streams__following-load-more {
-		color: var(--color-sidebar-text-alternative);
+		color: var(--color-link);
 		cursor: pointer;
 		font-size: $font-body-extra-small;
 		text-align: center;
@@ -114,7 +114,7 @@
 		width: 100%;
 
 		&:hover {
-			color: var(--color-sidebar-menu-hover-text);
+			color: var(--color-link-dark);
 		}
 	}
 }


### PR DESCRIPTION
…ave better visibility

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-17X-p2

## Proposed Changes

* Updates colors on the reader subscriptions sidebar's "load more sites" link.

Before:
![load-more](https://github.com/Automattic/wp-calypso/assets/28742426/74c29560-d83a-46a8-8b18-883dbfa14ec6)

After:
![load-more-sites-updates](https://github.com/Automattic/wp-calypso/assets/28742426/8d4f092c-1579-43f6-a157-12d8281e443f)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* go to the readers recent section
* scroll down on the subscriptions sidebar to view the "load more sites" link. verify we use the blue and dark blue link colors similar to "Manage" at the top.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
