### PR TITLE
Newsletter Categories: Create useImportSiteSubscriptionsMutation

### DIFF
--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -10,6 +10,7 @@ type callApiParams = {
 	body?: object;
 	isLoggedIn?: boolean;
 	apiVersion?: string;
+	formData?: ( string | File )[][];
 };
 
 // Get cookie named subkey
@@ -25,6 +26,7 @@ async function callApi< ReturnType >( {
 	body,
 	isLoggedIn = false,
 	apiVersion = '1.1',
+	formData,
 }: callApiParams ): Promise< ReturnType > {
 	if ( isLoggedIn ) {
 		const res = await wpcomRequest( {
@@ -33,6 +35,7 @@ async function callApi< ReturnType >( {
 			apiVersion,
 			method,
 			body: method === 'POST' ? body : undefined,
+			formData,
 		} );
 		return res as ReturnType;
 	}

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -1,6 +1,7 @@
 import { SiteSubscriptionsQueryPropsProvider, useSiteSubscriptionsQueryProps } from './contexts';
 import { useCacheKey, useIsLoggedIn, useSubscriberEmailAddress } from './hooks';
 import {
+	useImportSiteSubscriptionsMutation,
 	usePendingPostConfirmMutation,
 	usePendingPostDeleteMutation,
 	usePendingSiteConfirmMutation,
@@ -30,6 +31,7 @@ export const SubscriptionManager = {
 	siteSubscriptionsQueryKeyPrefix,
 	useCacheKey,
 	useIsLoggedIn,
+	useImportSiteSubscriptionsMutation,
 	usePendingPostConfirmMutation,
 	usePendingPostDeleteMutation,
 	usePendingPostSubscriptionsQuery,

--- a/packages/data-stores/src/reader/mutations/index.ts
+++ b/packages/data-stores/src/reader/mutations/index.ts
@@ -10,3 +10,4 @@ export { default as usePendingPostDeleteMutation } from './use-pending-post-dele
 export { default as useSiteNotifyMeOfNewPostsMutation } from './use-site-notify-me-of-new-posts-mutation';
 export { default as useSiteEmailMeNewPostsMutation } from './use-site-email-me-new-posts-mutation';
 export { default as useSiteEmailMeNewCommentsMutation } from './use-site-email-me-new-comments-mutation';
+export { default as useImportSiteSubscriptionsMutation } from './use-import-site-subscriptions-mutation';

--- a/packages/data-stores/src/reader/mutations/test/use-import-site-subscriptions-mutation.test.tsx
+++ b/packages/data-stores/src/reader/mutations/test/use-import-site-subscriptions-mutation.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import React, { useEffect } from 'react';
+import { callApi } from '../../helpers';
+import useImportSiteSubscriptionsMutation from '../use-import-site-subscriptions-mutation';
+
+// Mock the useIsLoggedIn function
+jest.mock( '../../hooks', () => ( {
+	useIsLoggedIn: jest.fn().mockReturnValue( { isLoggedIn: true } ),
+} ) );
+
+// Mock the entire Helpers module
+jest.mock( '../../helpers', () => ( {
+	callApi: jest.fn(),
+} ) );
+
+const client = new QueryClient();
+const Parent = ( { children } ) => (
+	<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
+);
+
+describe( 'useImportSiteSubscriptionsMutation()', () => {
+	it( 'calls the right API', async () => {
+		const mockFile = new File( [ 'test' ], 'test.opml' );
+
+		const Skeleton = () => {
+			const { mutate } = useImportSiteSubscriptionsMutation();
+			useEffect( () => {
+				mutate( {
+					file: mockFile,
+				} );
+			}, [ mutate ] );
+
+			return <p></p>;
+		};
+
+		( callApi as jest.Mock ).mockResolvedValue( {
+			success: true,
+		} );
+
+		render(
+			<Parent>
+				<Skeleton />
+			</Parent>
+		);
+
+		await waitFor( () =>
+			expect( callApi ).toHaveBeenCalledWith( {
+				apiVersion: '1.2',
+				path: '/read/following/mine/import',
+				formData: [ [ 'import', mockFile, 'test.opml' ] ],
+				isLoggedIn: true,
+				method: 'POST',
+			} )
+		);
+	} );
+
+	it( 'calls onSuccess', async () => {
+		const mockFile = new File( [ 'test' ], 'test.opml' );
+
+		const onSuccess = jest.fn();
+
+		const Skeleton = () => {
+			const { mutate } = useImportSiteSubscriptionsMutation();
+			useEffect( () => {
+				mutate( { file: mockFile }, { onSuccess } );
+			}, [ mutate ] );
+
+			return <p></p>;
+		};
+
+		( callApi as jest.Mock ).mockResolvedValue( {
+			success: true,
+		} );
+
+		render(
+			<Parent>
+				<Skeleton />
+			</Parent>
+		);
+
+		await waitFor( () => expect( onSuccess ).toHaveBeenCalled() );
+	} );
+
+	it( 'calls onError', async () => {
+		const mockFile = new File( [ 'test' ], 'test.opml' );
+
+		const onError = jest.fn();
+
+		const Skeleton = () => {
+			const { mutate } = useImportSiteSubscriptionsMutation();
+			useEffect( () => {
+				mutate( { file: mockFile }, { onError } );
+			}, [ mutate ] );
+
+			return <p></p>;
+		};
+
+		( callApi as jest.Mock ).mockRejectedValue( {
+			success: false,
+		} );
+
+		render(
+			<Parent>
+				<Skeleton />
+			</Parent>
+		);
+
+		await waitFor( () => expect( onError ).toHaveBeenCalled() );
+	} );
+} );

--- a/packages/data-stores/src/reader/mutations/use-import-site-subscriptions-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-import-site-subscriptions-mutation.ts
@@ -1,0 +1,42 @@
+import { useMutation } from '@tanstack/react-query';
+import { callApi } from '../helpers';
+import { useIsLoggedIn } from '../hooks';
+
+type ImportSubscriptionsParams = {
+	file: File;
+	onSuccess?: () => void;
+	onError?: () => void;
+};
+
+type ImportSubscriptionsResponse = {
+	success?: boolean;
+};
+
+const useImportSiteSubscriptionsMutation = () => {
+	const { isLoggedIn } = useIsLoggedIn();
+
+	return useMutation( {
+		mutationFn: async ( params: ImportSubscriptionsParams ) => {
+			const response = await callApi< ImportSubscriptionsResponse >( {
+				path: '/read/following/mine/import',
+				method: 'POST',
+				isLoggedIn,
+				apiVersion: '1.2',
+				formData: [ [ 'import', params.file, params.file.name ] ],
+			} );
+			if ( ! response.success ) {
+				throw new Error( 'Something went wrong while importing subscriptions.' );
+			}
+
+			return response;
+		},
+		onError: ( _error, params ) => {
+			params.onError?.();
+		},
+		onSuccess: ( data, params ) => {
+			params.onSuccess?.();
+		},
+	} );
+};
+
+export default useImportSiteSubscriptionsMutation;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/79231

## Proposed Changes

* Create useImportSiteSubscriptionsMutation

## Testing Instructions

* Apply this PR to your local env
* Run `yarn test-packages packages/data-stores/src/reader/mutations/test/use-import-site-subscriptions-mutation.test.tsx` and the tests should pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
