### PR TITLE
Pricing page: Improve appearance when US locale is displayed with currency symbol (US$ vs $).

### DIFF
--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -231,10 +231,9 @@ function FlatPriceDisplay( {
 	className?: string;
 	isSmallestUnit?: boolean;
 } ) {
-	const { symbol: currencySymbol, symbolPosition } = getCurrencyObject(
-		smallerPrice,
-		currencyCode
-	);
+	const { symbol, symbolPosition } = getCurrencyObject( smallerPrice, currencyCode );
+	const currencySymbol = symbol.replace( /^US/, '' );
+
 	const translate = useTranslate();
 
 	if ( ! higherPrice ) {

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -305,15 +305,23 @@ function MultiPriceDisplay( {
 		smallerPrice,
 		currencyCode
 	);
+
+	// Sometimes the US currency symbol is displayed as `US$` instead of just `$`
+	// See: packages/format-currency/README.md (## geolocateCurrencySymbol()) for further details.
+	const hasUslocaleInSymbol = /^US\$$/.test( currencySymbol );
+
 	const translate = useTranslate();
 
 	return createElement(
 		tagName,
 		{ className },
 		<>
-			{ symbolPosition === 'before' ? (
-				<sup className="plan-price__currency-symbol">{ currencySymbol }</sup>
-			) : null }
+			{ symbolPosition === 'before' && (
+				<CurrencySymbolDisplay
+					currencySymbol={ currencySymbol }
+					hasUslocaleInSymbol={ hasUslocaleInSymbol }
+				/>
+			) }
 
 			{ ! higherPrice && (
 				<HtmlPriceDisplay
@@ -346,9 +354,12 @@ function MultiPriceDisplay( {
 					comment: 'The price range for a particular product',
 				} ) }
 
-			{ symbolPosition === 'after' ? (
-				<sup className="plan-price__currency-symbol">{ currencySymbol }</sup>
-			) : null }
+			{ symbolPosition === 'after' && (
+				<CurrencySymbolDisplay
+					currencySymbol={ currencySymbol }
+					hasUslocaleInSymbol={ hasUslocaleInSymbol }
+				/>
+			) }
 
 			{ taxText && (
 				<sup className="plan-price__tax-amount">
@@ -372,6 +383,23 @@ function MultiPriceDisplay( {
 				</Badge>
 			) }
 		</>
+	);
+}
+
+function CurrencySymbolDisplay( {
+	currencySymbol,
+	hasUslocaleInSymbol,
+}: {
+	currencySymbol: string;
+	hasUslocaleInSymbol: boolean;
+} ) {
+	return hasUslocaleInSymbol ? (
+		<>
+			<sup className="plan-price__symbol-locale">US</sup>
+			<sup className="plan-price__currency-symbol">$</sup>
+		</>
+	) : (
+		<sup className="plan-price__currency-symbol">{ currencySymbol }</sup>
 	);
 }
 

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -73,3 +73,8 @@
 	line-height: 1rem;
 	margin-left: 5px;
 }
+
+.plan-price__symbol-locale {
+	font-size: 0.65rem; /* stylelint-disable-line scales/font-sizes */
+	letter-spacing: -0.08em;
+}

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -66,6 +66,10 @@
 		max-height: 24px;
 	}
 
+	.plan-price {
+		font-weight: 700;
+	}
+
 	.plan-price.is-original {
 		color: var(--studio-gray-50);
 		font-weight: 600;
@@ -87,7 +91,6 @@
 
 	.plan-price.is-discounted {
 		color: var(--studio-gray-100);
-		font-weight: 700;
 	}
 
 	.plan-price.is-discounted .plan-price__fraction {

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -4,6 +4,13 @@
 .item-price .display-price {
 	display: block;
 
+	.display-price__prices {
+		flex: 0 1 auto;
+	}
+	.display-price__details {
+		flex: 1;
+	}
+
 	.plan-price__currency-symbol,
 	.plan-price__integer,
 	.plan-price__fraction {
@@ -43,7 +50,8 @@
 	&__expiration-date {
 		color: var(--studio-gray-50);
 		font-size: 0.75rem;
-		line-height: 24px;
+		//Mimic line-height: 24px, but with padding instead, so that the text can wrap to a new line correctly.
+		padding: 0.301rem 0 0.3rem;
 	}
 
 	@include break-mobile {
@@ -54,7 +62,9 @@
 }
 
 .item-price .display-price:not(.is-placeholder) {
-	max-height: 24px;
+	@include break-mobile {
+		max-height: 24px;
+	}
 
 	.plan-price.is-original {
 		color: var(--studio-gray-50);

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
@@ -49,6 +49,7 @@
 	.featured-item-card .item-price .display-price .display-price__billing-time-frame {
 		@media screen and (min-width: 320px) {
 			margin-top: 0;
+			padding-left: 3px;
 		}
 	}
 }

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
@@ -42,6 +42,7 @@
 		@media screen and (min-width: 320px) {
 			display: flex;
 			min-height: 24px;
+			align-items: center;
 		}
 	}
 


### PR DESCRIPTION
Sometimes the US currency symbol is displayed as `US$` versus just `$`.  This is to prevent confusion for users who are located outside the US, but have their locale set to English. See [geolocateCurrencySymbol()](https://github.com/Automattic/wp-calypso/tree/trunk/packages/format-currency#geolocatecurrencysymbol) for more detailed explanation. 

This PR improves how the`US$` currency symbol (when shown) is displayed and also improves the vertical spacing of the prices when the prices have any significant length to them.
(See Screenshots, before & after, below).

Maintenance task: https://github.com/orgs/Automattic/projects/724/views/2?sortedBy%5Bdirection%5D=desc&sortedBy%5BcolumnId%5D=53020304&pane=issue&itemId=35361597

Issue originated in Slack discussion: p1682508012934699-slack-C01264051NE

#### Screenshots

DESKTOP (Jetpack Cloud)

BEFORE | AFTER
----- | -----
![Markup 2023-08-24 at 14 13 04](https://github.com/Automattic/wp-calypso/assets/11078128/3fae84a8-b540-4602-8abb-ce686ce1c87e) | ![Markup 2023-08-22 at 16 22 17](https://github.com/Automattic/wp-calypso/assets/11078128/940b89a2-ec42-4420-b21e-8dc6227c18e1)


MOBILE (WordPress.com)

BEFORE | AFTER
----- | -----
![Markup 2023-08-22 at 16 35 55](https://github.com/Automattic/wp-calypso/assets/11078128/65141362-1a30-4591-b1f5-6b64557700f5) | ![Markup 2023-08-22 at 16 36 45](https://github.com/Automattic/wp-calypso/assets/11078128/7c22813d-8861-4af3-bdcd-fd4af5456e47)



## Testing Instructions

If you're currently located in the US, follow these steps:
- First you'll need to sandbox `public-api.sandbox.com`.
- Then in WPCOM edit file, `public.api/geo.php`, line 20.  - Return a non-US locale in the `country_short` property.
    - For Example: `'country_short'   => 'FR', //$location->country_short, 

Then:
1. Make sure you're currency is set to `USD` in Store Admin.
2. Go to https://cloud.jetpack.com/pricing and/or https://wordpress.com/jetpack/connect/store and verify the currency is displaying as `US$`, as opposed to just `$`.
3. Checkout this PR/branch and spin up Calypso blue and green concurrently. ( `yarn start` and `yarn start-jetpack-cloud-p` (in another terminal)).
4. Go to http://jetpack.cloud.localhost:3001/pricing
5. Verify the appearance of the prices (with the currency symbol) look better, spacing is better, etc.  (See before & after screenshots).
6. View the pricing cards in Mobile view and verify things still look better. (See before & after screenshots).
7. Go to http://calypso.localhost:3000/jetpack/connect/store and verify the same changes appear here and everything looks good/better.  Inspect the Mobile view too.
8. Also go to http://calypso.localhost:3000/plans/:SITE and verify the same changes appear here and everything looks good/better.  Inspect the Mobile view too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
