### PR TITLE
Earn: Remove connect() from Referrals component 

### DIFF
--- a/client/my-sites/earn/refer-a-friend/index.tsx
+++ b/client/my-sites/earn/refer-a-friend/index.tsx
@@ -1,39 +1,36 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { compact } from 'lodash';
-import { FunctionComponent, Fragment, useState, useEffect } from 'react';
-import { connect } from 'react-redux';
+import { Fragment, useState, useEffect } from 'react';
 import earnSectionImage from 'calypso/assets/images/earn/earn-section.svg';
 import referralImage from 'calypso/assets/images/earn/referral.svg';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
 import { CtaButton } from 'calypso/components/promo-section/promo-card/cta';
 import wp from 'calypso/lib/wp';
+import { useDispatch, useSelector } from 'calypso/state';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import getSiteBySlug from 'calypso/state/sites/selectors/get-site-by-slug';
-import { IAppState } from 'calypso/state/types';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import type { SiteSlug } from 'calypso/types';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
-interface ConnectedProps {
-	siteId: number | undefined;
-	selectedSiteSlug: SiteSlug;
-	isJetpack: boolean;
-	isAtomicSite: boolean;
-	trackCtaButton: ( feature: string ) => void;
-}
-
-const ReferAFriendSection: FunctionComponent< ConnectedProps > = ( {
-	isJetpack,
-	isAtomicSite,
-	trackCtaButton,
-} ) => {
+const ReferAFriendSection = () => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const [ peerReferralLink, setPeerReferralLink ] = useState( '' );
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
+	const isAtomicSite = useSelector( ( state ) => isSiteAutomatedTransfer( state, site?.ID ) );
+
+	const trackCtaButton = ( feature: string ) =>
+		dispatch(
+			composeAnalytics(
+				recordTracksEvent( 'calypso_earn_page_cta_button_click', { feature } ),
+				bumpStat( 'calypso_earn_page', 'cta-button-' + feature )
+			)
+		);
 
 	useEffect( () => {
 		if ( peerReferralLink ) {
@@ -133,23 +130,4 @@ const ReferAFriendSection: FunctionComponent< ConnectedProps > = ( {
 	);
 };
 
-export default connect(
-	( state: IAppState ) => {
-		const selectedSiteSlug = getSelectedSiteSlug( state );
-		const site = getSiteBySlug( state, selectedSiteSlug );
-		return {
-			siteId: site?.ID,
-			isJetpack: Boolean( isJetpackSite( state, site?.ID ?? null ) ),
-			isAtomicSite: Boolean( isSiteAutomatedTransfer( state, site?.ID ?? null ) ),
-		};
-	},
-	( dispatch ) => ( {
-		trackCtaButton: ( feature: string ) =>
-			dispatch(
-				composeAnalytics(
-					recordTracksEvent( 'calypso_earn_page_cta_button_click', { feature } ),
-					bumpStat( 'calypso_earn_page', 'cta-button-' + feature )
-				)
-			),
-	} )
-)( ReferAFriendSection );
+export default ReferAFriendSection;

--- a/client/my-sites/earn/refer-a-friend/index.tsx
+++ b/client/my-sites/earn/refer-a-friend/index.tsx
@@ -8,7 +8,7 @@ import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
 import { CtaButton } from 'calypso/components/promo-section/promo-card/cta';
 import wp from 'calypso/lib/wp';
-import { useDispatch, useSelector } from 'calypso/state';
+import { useSelector } from 'calypso/state';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -18,19 +18,17 @@ import './style.scss';
 
 const ReferAFriendSection = () => {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 	const [ peerReferralLink, setPeerReferralLink ] = useState( '' );
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
 	const isAtomicSite = useSelector( ( state ) => isSiteAutomatedTransfer( state, site?.ID ) );
 
-	const trackCtaButton = ( feature: string ) =>
-		dispatch(
-			composeAnalytics(
-				recordTracksEvent( 'calypso_earn_page_cta_button_click', { feature } ),
-				bumpStat( 'calypso_earn_page', 'cta-button-' + feature )
-			)
+	const trackCtaButton = ( feature: string ) => {
+		composeAnalytics(
+			recordTracksEvent( 'calypso_earn_page_cta_button_click', { feature } ),
+			bumpStat( 'calypso_earn_page', 'cta-button-' + feature )
 		);
+	};
 
 	useEffect( () => {
 		if ( peerReferralLink ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Refactors the Earn > Refer a Friend component to stop using the connect() method and just rely on hooks instead. Part of a bigger effort to refactor all Earn pages and components to functional react with hooks and TypeScript.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Check out this branch and go to http://calypso.localhost:3000/earn/ericktesting1565.wordpress.com
2) Confirm the page generally loads and behaves as before. 
3) Find the Refer a Friend card, and if you have not yet clicked the button to start earning referrals, do so. It should then show a referral link. If you have done this, confirm the referral link still loads. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
