### PR TITLE
Stats - Address Subscribers Stats Page Responsiveness For Small Viewports

### DIFF
--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -85,6 +85,7 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 				( highlight ) =>
 					highlight.show && (
 						<CountComparisonCard
+							compact={ true }
 							key={ highlight.heading }
 							heading={ highlight.heading }
 							count={ highlight.count }

--- a/client/my-sites/stats/stats-subscribers-highlight-section/style.scss
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/style.scss
@@ -14,7 +14,7 @@
 
 		// make it more compact for is-compact
 		&.is-compact {
-			min-width: 0;
+			min-width: 90px;
 			padding: 0;
 		}
 	}

--- a/client/my-sites/stats/stats-subscribers-highlight-section/style.scss
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/style.scss
@@ -11,6 +11,12 @@
 	// Override the default minimum width.
 	.highlight-card {
 		min-width: 240px;
+
+		// make it more compact for is-compact
+		&.is-compact {
+			min-width: 0;
+			padding: 0;
+		}
 	}
 
 	// Hide unused icon div.

--- a/client/my-sites/stats/stats-subscribers-highlight-section/style.scss
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/style.scss
@@ -12,6 +12,7 @@
 	.highlight-card {
 		min-width: 240px;
 	}
+
 	// Hide unused icon div.
 	.highlight-card-icon {
 		display: none;

--- a/packages/components/src/highlight-cards/count-comparison-card.tsx
+++ b/packages/components/src/highlight-cards/count-comparison-card.tsx
@@ -12,6 +12,7 @@ type CountComparisonCardProps = {
 	previousCount?: number | null;
 	showValueTooltip?: boolean | null;
 	note?: string;
+	compact?: boolean;
 };
 
 function subtract( a: number | null, b: number | null | undefined ): number | null {
@@ -38,6 +39,7 @@ export default function CountComparisonCard( {
 	heading,
 	showValueTooltip,
 	note = '',
+	compact = false,
 }: CountComparisonCardProps ) {
 	const difference = subtract( count, previousCount );
 	const differenceMagnitude = Math.abs( difference as number );
@@ -48,7 +50,7 @@ export default function CountComparisonCard( {
 	const [ isTooltipVisible, setTooltipVisible ] = useState( false );
 
 	return (
-		<Card className="highlight-card">
+		<Card className="highlight-card" compact={ compact }>
 			{ icon && <div className="highlight-card-icon">{ icon }</div> }
 			{ heading && <div className="highlight-card-heading">{ heading }</div> }
 			<div

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -207,7 +207,7 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 
 .highlight-card.is-compact .highlight-card-count-value,
 .highlight-card.is-compact .highlight-card-difference {
-	flex: 1 0 100%; /* Flex grow, flex shrink, flex basis */
+	flex: 1 0 100%;
 }
 
 .highlight-card.is-compact div.highlight-card-icon {

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -200,18 +200,10 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 	margin-right: 2px;
 }
 
-.highlight-card.is-compact .highlight-card-count.is-pointer {
-	display: flex;
-	flex-wrap: wrap;
-}
-
-.highlight-card.is-compact .highlight-card-count-value,
-.highlight-card.is-compact .highlight-card-difference {
-	flex: 1 0 100%;
-}
-
-.highlight-card.is-compact div.highlight-card-icon {
-	margin-bottom: 0;
+// Remove the border and background from the compact highlight cards
+.highlight-card.is-compact {
+	box-shadow: 0 0 0 0;
+	background: none;
 }
 
 

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -199,6 +199,22 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 .highlight-card-difference-absolute-value {
 	margin-right: 2px;
 }
+
+.highlight-card.is-compact .highlight-card-count.is-pointer {
+	display: flex;
+	flex-wrap: wrap;
+}
+
+.highlight-card.is-compact .highlight-card-count-value,
+.highlight-card.is-compact .highlight-card-difference {
+	flex: 1 0 100%; /* Flex grow, flex shrink, flex basis */
+}
+
+.highlight-card.is-compact div.highlight-card-icon {
+	margin-bottom: 0;
+}
+
+
 .highlight-year-navigation {
 	display: flex;
 	justify-content: space-between;

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -229,7 +229,6 @@ export default function WeeklyHighlightCards( {
 
 			<div className="highlight-cards-list">
 				<CountComparisonCard
-					compact={ true }
 					heading={ translate( 'Visitors' ) }
 					icon={ <Icon icon={ people } /> }
 					count={ counts?.visitors ?? null }
@@ -238,7 +237,6 @@ export default function WeeklyHighlightCards( {
 					onClick={ onClickVisitors }
 				/>
 				<CountComparisonCard
-					compact={ true }
 					heading={ translate( 'Views' ) }
 					icon={ <Icon icon={ eye } /> }
 					count={ counts?.views ?? null }
@@ -247,7 +245,6 @@ export default function WeeklyHighlightCards( {
 					onClick={ onClickViews }
 				/>
 				<CountComparisonCard
-					compact={ true }
 					heading={ translate( 'Likes' ) }
 					icon={ <Icon icon={ starEmpty } /> }
 					count={ counts?.likes ?? null }
@@ -256,7 +253,6 @@ export default function WeeklyHighlightCards( {
 					onClick={ onClickLikes }
 				/>
 				<CountComparisonCard
-					compact={ true }
 					heading={ translate( 'Comments' ) }
 					icon={ <Icon icon={ commentContent } /> }
 					count={ counts?.comments ?? null }

--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -229,6 +229,7 @@ export default function WeeklyHighlightCards( {
 
 			<div className="highlight-cards-list">
 				<CountComparisonCard
+					compact={ true }
 					heading={ translate( 'Visitors' ) }
 					icon={ <Icon icon={ people } /> }
 					count={ counts?.visitors ?? null }
@@ -237,6 +238,7 @@ export default function WeeklyHighlightCards( {
 					onClick={ onClickVisitors }
 				/>
 				<CountComparisonCard
+					compact={ true }
 					heading={ translate( 'Views' ) }
 					icon={ <Icon icon={ eye } /> }
 					count={ counts?.views ?? null }
@@ -245,6 +247,7 @@ export default function WeeklyHighlightCards( {
 					onClick={ onClickViews }
 				/>
 				<CountComparisonCard
+					compact={ true }
 					heading={ translate( 'Likes' ) }
 					icon={ <Icon icon={ starEmpty } /> }
 					count={ counts?.likes ?? null }
@@ -253,6 +256,7 @@ export default function WeeklyHighlightCards( {
 					onClick={ onClickLikes }
 				/>
 				<CountComparisonCard
+					compact={ true }
 					heading={ translate( 'Comments' ) }
 					icon={ <Icon icon={ commentContent } /> }
 					count={ counts?.comments ?? null }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80590

## Proposed Changes

* This PR addresses the issue with the Subscribers page in Jetpack stats not being responsive for small viewports. This has been done by modifying the cards to be compact cards with a new and different design. In addition to code review, I'd love design feedback on this direction. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live branch 
* Navigate to the Subscribers tab at `/stats/subscribers/{URL}`
* Check the new condensed styling of the highlights under the `All-time stats` heading
* Use or resize to a narrow viewport and check how it resizes and fits the window

![Screen Capture on 2023-08-22 at 18-58-52](https://github.com/Automattic/wp-calypso/assets/30754158/3a4f58f4-2712-4747-b9cc-e7616ed9a9dd)




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
