### PR TITLE
Design Picker: Fix the virtual theme cannot be previewed

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -1,6 +1,10 @@
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
-import { PatternAssemblerCta, usePatternAssemblerCtaData } from '@automattic/design-picker';
+import {
+	PatternAssemblerCta,
+	usePatternAssemblerCtaData,
+	isAssemblerSupported,
+} from '@automattic/design-picker';
 import { WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { Icon, addTemplate, brush, cloudUpload } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
@@ -94,7 +98,8 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 		[ props.fetchNextPage ]
 	);
 
-	const goToSiteAssemblerFlow = ( shouldGoToAssemblerStep ) => {
+	const goToSiteAssemblerFlow = () => {
+		const shouldGoToAssemblerStep = isAssemblerSupported();
 		props.recordTracksEvent( 'calypso_themeshowcase_pattern_assembler_cta_click', {
 			goes_to_assembler_step: shouldGoToAssemblerStep,
 		} );

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Design, isAssemblerDesign } from '@automattic/design-picker';
+import { Design, isAssemblerDesign, isAssemblerSupported } from '@automattic/design-picker';
 import { IMPORT_FOCUSED_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
@@ -149,8 +149,8 @@ const importFlow: Flow = {
 				}
 
 				case 'designSetup': {
-					const { selectedDesign: _selectedDesign, shouldGoToAssembler } = providedDependencies;
-					if ( isAssemblerDesign( _selectedDesign as Design ) && shouldGoToAssembler ) {
+					const { selectedDesign: _selectedDesign } = providedDependencies;
+					if ( isAssemblerDesign( _selectedDesign as Design ) && isAssemblerSupported() ) {
 						return navigate( 'patternAssembler' );
 					}
 

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -2,7 +2,7 @@ import {
 	Design,
 	StyleVariation,
 	isAssemblerDesign,
-	shouldGoToAssembler,
+	isAssemblerSupported,
 } from '@automattic/design-picker';
 import { getVariationTitle, getVariationType } from '@automattic/global-styles';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
@@ -81,7 +81,7 @@ export function recordSelectedDesign( {
 
 export function getDesignTypeProps( design?: Design ) {
 	return {
-		goes_to_assembler_step: isAssemblerDesign( design ) && shouldGoToAssembler(),
+		goes_to_assembler_step: isAssemblerDesign( design ) && isAssemblerSupported(),
 		assembler_source: getAssemblerSource( design ),
 	};
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
@@ -1,6 +1,9 @@
-import { isDefaultGlobalStylesVariationSlug, isAssemblerDesign } from '@automattic/design-picker';
+import {
+	isDefaultGlobalStylesVariationSlug,
+	isAssemblerDesign,
+	isAssemblerSupported,
+} from '@automattic/design-picker';
 import { useColorPaletteVariations, useFontPairingVariations } from '@automattic/global-styles';
-import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -12,12 +15,11 @@ import type { GlobalStylesObject } from '@automattic/global-styles';
 const useRecipe = (
 	siteId = 0,
 	allDesigns: StarterDesigns | undefined,
-	pickDesign: ( design?: Design ) => void,
+	pickDesign: ( design?: Design, options?: { shouldGoToAssembler: boolean } ) => void,
 	recordPreviewDesign: ( design: Design, styleVariation?: StyleVariation ) => void,
 	recordPreviewStyleVariation: ( design: Design, styleVariation?: StyleVariation ) => void
 ) => {
 	const [ searchParams, setSearchParams ] = useSearchParams();
-	const isDesktop = useViewportMatch( 'large' );
 	const [ isPreviewingDesign, setIsPreviewingDesign ] = useState( false );
 	const { selectedDesign, selectedStyleVariation } = useSelect( ( select ) => {
 		const { getSelectedDesign, getSelectedStyleVariation } = select(
@@ -138,12 +140,10 @@ const useRecipe = (
 	};
 
 	const previewDesign = ( design: Design, styleVariation?: StyleVariation ) => {
-		// Redirect to Site Assembler if the design_type is set to "assembler".
-		const shouldGoToAssembler = isDesktop && isAssemblerDesign( design );
-
 		recordPreviewDesign( design, styleVariation );
 
-		if ( shouldGoToAssembler ) {
+		// Redirect to Site Assembler if the design_type is set to "assembler".
+		if ( isAssemblerDesign( design ) && isAssemblerSupported() ) {
 			pickDesign( design );
 			return;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -15,6 +15,7 @@ import {
 	getDesignPreviewUrl,
 	isBlankCanvasDesign,
 	isAssemblerDesign,
+	isAssemblerSupported,
 } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
@@ -550,7 +551,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		}
 	}
 
-	function designYourOwn( design: Design, shouldGoToAssembler: boolean ) {
+	function designYourOwn( design: Design ) {
+		const shouldGoToAssembler = isAssemblerSupported();
 		if ( shouldGoToAssembler ) {
 			const _selectedDesign = {
 				...design,
@@ -580,7 +582,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			'calypso_signup_design_picker_design_your_own_top_button_click',
 			getDesignEventProps( { flow, intent, design } )
 		);
-		designYourOwn( design, true );
+		designYourOwn( design );
 	}
 
 	function handleSubmit( providedDependencies?: ProvidedDependencies, optionalProps?: object ) {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
-import { Design, isAssemblerDesign } from '@automattic/design-picker';
+import { Design, isAssemblerDesign, isAssemblerSupported } from '@automattic/design-picker';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
@@ -273,8 +273,8 @@ const siteSetupFlow: Flow = {
 				}
 
 				case 'designSetup': {
-					const { selectedDesign: _selectedDesign, shouldGoToAssembler } = providedDependencies;
-					if ( isAssemblerDesign( _selectedDesign as Design ) && shouldGoToAssembler ) {
+					const { selectedDesign: _selectedDesign } = providedDependencies;
+					if ( isAssemblerDesign( _selectedDesign as Design ) && isAssemblerSupported() ) {
 						return navigate( 'patternAssembler' );
 					}
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -3,8 +3,7 @@ import {
 	DOT_ORG_THEME,
 	WOOCOMMERCE_THEME,
 	MARKETPLACE_THEME,
-	// eslint-disable-next-line import/named
-	shouldGoToAssembler,
+	isAssemblerSupported,
 } from '@automattic/design-picker';
 import { isSiteAssemblerFlow } from '@automattic/onboarding';
 import { get, includes, reject } from 'lodash';
@@ -118,7 +117,7 @@ function getThankYouNoSiteDestination() {
 function getChecklistThemeDestination( { flowName, siteSlug, themeParameter } ) {
 	if ( isSiteAssemblerFlow( flowName ) ) {
 		// Check whether to go to the assembler. If not, go to the site editor directly
-		if ( shouldGoToAssembler() ) {
+		if ( isAssemblerSupported() ) {
 			return addQueryArgs(
 				{
 					theme: themeParameter,

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -12,7 +12,7 @@ type PatternAssemblerCtaData = {
 };
 
 type PatternAssemblerCtaProps = {
-	onButtonClick: ( shouldGoToAssemblerStep: boolean ) => void;
+	onButtonClick: () => void;
 };
 
 export function usePatternAssemblerCtaData(): PatternAssemblerCtaData {
@@ -38,10 +38,6 @@ export function usePatternAssemblerCtaData(): PatternAssemblerCtaData {
 const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 	const data = usePatternAssemblerCtaData();
 
-	const handleButtonClick = () => {
-		onButtonClick( data.shouldGoToAssemblerStep );
-	};
-
 	return (
 		<div className="pattern-assembler-cta-wrapper">
 			<div className="pattern-assembler-cta__image-wrapper">
@@ -49,7 +45,7 @@ const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 			</div>
 			<h3 className="pattern-assembler-cta__title">{ data.title }</h3>
 			<p className="pattern-assembler-cta__subtitle">{ data.subtitle }</p>
-			<Button className="pattern-assembler-cta__button" onClick={ handleButtonClick } primary>
+			<Button className="pattern-assembler-cta__button" onClick={ onButtonClick } primary>
 				{ data.buttonText }
 			</Button>
 		</div>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -203,7 +203,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 
 interface DesignPickerProps {
 	locale: string;
-	onDesignYourOwn: ( design: Design, shouldGoToAssemblerStep: boolean ) => void;
+	onDesignYourOwn: ( design: Design ) => void;
 	onClickDesignYourOwnTopButton: ( design: Design ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
@@ -280,11 +280,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						/>
 					);
 				} ) }
-				<PatternAssemblerCta
-					onButtonClick={ ( shouldGoToAssemblerStep ) =>
-						onDesignYourOwn( DEFAULT_ASSEMBLER_DESIGN, shouldGoToAssemblerStep )
-					}
-				/>
+				<PatternAssemblerCta onButtonClick={ () => onDesignYourOwn( DEFAULT_ASSEMBLER_DESIGN ) } />
 			</div>
 		</div>
 	);
@@ -292,7 +288,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 
 export interface UnifiedDesignPickerProps {
 	locale: string;
-	onDesignYourOwn: ( design: Design, shouldGoToAssemblerStep: boolean ) => void;
+	onDesignYourOwn: ( design: Design ) => void;
 	onClickDesignYourOwnTopButton: ( design: Design ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -22,7 +22,7 @@ export {
 	isBlankCanvasDesign,
 	isDefaultGlobalStylesVariationSlug,
 	getMShotOptions,
-	shouldGoToAssembler,
+	isAssemblerSupported,
 } from './utils';
 export {
 	FONT_PAIRINGS,

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -70,4 +70,4 @@ export const isAssemblerDesign = ( design?: Design ) => design?.design_type === 
 
 // Go to the assembler only when the viewport width >= 960px as the it doesn't support small
 // screen for now.
-export const shouldGoToAssembler = () => isWithinBreakpoint( '>=960px' );
+export const isAssemblerSupported = () => isWithinBreakpoint( '>=960px' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Resolved the issue that the virtual theme with the `design_type=assembler` won't go to the Assembler screen since we don't provide the `shouldGoToAssembler` property when previewing a virtual theme 🥲
* To avoid the above behavior, I assume we can call `isAssemblerSupported` on demand so we don't need to rely on the props

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D119597-code to your sandbox
* Go to `/setup?siteSlug=<your_site>`
* Continue to Design Picker
* Select a virtual theme that is available for the assembler preview, e.g.: Artfolio Detail
* Ensure you're able to preview the virtual theme on the Assembler screen
* Select a virtual theme that is not available for the assembler preview
* Ensure you're able to preview the virtual theme on the Design Preview screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
