### PR TITLE
Stats: Fetch purchases via API for consistency on Calypso and Odyssey

### DIFF
--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -2,8 +2,10 @@ import config from '@automattic/calypso-config';
 import page from 'page';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import version_compare from 'calypso/lib/version-compare';
 import useNoticeVisibilityQuery from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import { hasLoadedSitePurchasesFromServer } from 'calypso/state/purchases/selectors';
 import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
@@ -46,6 +48,9 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 
 	// TODO: Display error messages on the notice.
 	const { hasLoadedPurchases } = usePurchasesToUpdateSiteProducts( isOdysseyStats, siteId );
+	const hasLoadedSitePurchasesOnWPCom = useSelector( ( state ) =>
+		hasLoadedSitePurchasesFromServer( state )
+	);
 
 	const { data: isDoYouLoveJetpackStatsVisible } = useNoticeVisibilityQuery(
 		siteId,
@@ -71,10 +76,12 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 			showUpgradeNoticeForWpcomSites ) &&
 		// Show the notice if the site has not purchased the paid stats product.
 		! hasPaidStats &&
-		hasLoadedPurchases;
+		hasLoadedPurchases &&
+		hasLoadedSitePurchasesOnWPCom;
 
 	return (
 		<>
+			{ ! isOdysseyStats && <QuerySitePurchases siteId={ siteId } /> }
 			{ showDoYouLoveJetpackStatsNotice && (
 				<DoYouLoveJetpackStatsNotice siteId={ siteId } hasFreeStats={ hasFreeStats } />
 			) }

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -20,7 +20,7 @@ import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-succ
 import removeStatsPurchaseSuccessParam from './lib/remove-stats-purchase-success-param';
 import PaidPlanPurchaseSuccessJetpackStatsNotice from './paid-plan-purchase-success-notice';
 import { StatsNoticesProps } from './types';
-import usePurchasesToUpdateSiteProducts from './use-purchases-to-update-site-products';
+import useSitePurchasesOnOdysseyStats from './use-site-purchases-on-odyssey-stats';
 import './style.scss';
 
 const TEAM51_OWNER_ID = 70055110;
@@ -47,10 +47,8 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 	);
 
 	// TODO: Display error messages on the notice.
-	const { hasLoadedPurchases } = usePurchasesToUpdateSiteProducts( isOdysseyStats, siteId );
-	const hasLoadedSitePurchasesOnWPCom = useSelector( ( state ) =>
-		hasLoadedSitePurchasesFromServer( state )
-	);
+	useSitePurchasesOnOdysseyStats( isOdysseyStats, siteId );
+	const hasLoadedPurchases = useSelector( ( state ) => hasLoadedSitePurchasesFromServer( state ) );
 
 	const { data: isDoYouLoveJetpackStatsVisible } = useNoticeVisibilityQuery(
 		siteId,
@@ -76,11 +74,11 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 			showUpgradeNoticeForWpcomSites ) &&
 		// Show the notice if the site has not purchased the paid stats product.
 		! hasPaidStats &&
-		hasLoadedPurchases &&
-		hasLoadedSitePurchasesOnWPCom;
+		hasLoadedPurchases;
 
 	return (
 		<>
+			{ /* Only query site purchases on Calypso via existing data component */ }
 			{ ! isOdysseyStats && <QuerySitePurchases siteId={ siteId } /> }
 			{ showDoYouLoveJetpackStatsNotice && (
 				<DoYouLoveJetpackStatsNotice siteId={ siteId } hasFreeStats={ hasFreeStats } />

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -1,10 +1,11 @@
 import config from '@automattic/calypso-config';
 import page from 'page';
-import { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useState, useEffect } from 'react';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import version_compare from 'calypso/lib/version-compare';
 import useNoticeVisibilityQuery from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import { useSelector, useDispatch } from 'calypso/state';
+import { resetSiteState } from 'calypso/state/purchases/actions';
 import { hasLoadedSitePurchasesFromServer } from 'calypso/state/purchases/selectors';
 import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -30,6 +31,9 @@ const TEAM51_OWNER_ID = 70055110;
  * New notices are based on async API call and hence is faster than the old notices.
  */
 const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
+	const dispatch = useDispatch();
+
+	const [ currentSiteId, setCurrentSiteId ] = useState( siteId );
 	const hasPaidStats = useSelector( ( state ) => hasSiteProductJetpackStatsPaid( state, siteId ) );
 	const hasFreeStats = useSelector( ( state ) => hasSiteProductJetpackStatsFree( state, siteId ) );
 	// `is_vip` is not correctly placed in Odyssey, so we need to check `options.is_vip` as well.
@@ -75,6 +79,14 @@ const NewStatsNotices = ( { siteId, isOdysseyStats }: StatsNoticesProps ) => {
 		// Show the notice if the site has not purchased the paid stats product.
 		! hasPaidStats &&
 		hasLoadedPurchases;
+
+	// Clear loaded flag when switching sites on Calypso.
+	useEffect( () => {
+		if ( siteId !== currentSiteId ) {
+			setCurrentSiteId( siteId );
+			dispatch( resetSiteState() );
+		}
+	}, [ siteId, currentSiteId, setCurrentSiteId, dispatch ] );
 
 	return (
 		<>

--- a/client/my-sites/stats/stats-notices/use-purchases-to-update-site-products.tsx
+++ b/client/my-sites/stats/stats-notices/use-purchases-to-update-site-products.tsx
@@ -1,22 +1,8 @@
 import { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import wpcom from 'calypso/lib/wp';
-import { SITE_PURCHASES_UPDATE } from 'calypso/state/action-types';
-import type { RawSiteProduct } from 'calypso/state/sites/selectors/get-site-products';
-
-const formatPurchasesToSiteProducts = (
-	purchases: Record< string, string >[]
-): RawSiteProduct[] => {
-	return purchases.map( ( purchase ) => ( {
-		product_id: purchase.product_id,
-		product_slug: purchase.product_slug,
-		product_name: purchase.product_name,
-		// `product_name_short`, `expired`, and `user_is_owner` are not available in the purchase object.
-		product_name_short: purchase.product_name_short || null,
-		expired: !! purchase.expired,
-		user_is_owner: !! purchase.user_is_owner,
-	} ) );
-};
+import { PURCHASES_SITE_FETCH_COMPLETED } from 'calypso/state/action-types';
+import type { RawPurchase } from 'calypso/lib/purchases/types';
 
 /**
  * Update site products in the Redux store by fetching purchases via API for Odyssey Stats.
@@ -37,11 +23,11 @@ export default function usePurchasesToUpdateSiteProducts(
 			wpcom.req
 				.get( { path: '/site/purchases', apiNamespace: 'jetpack/v4' } )
 				.then( ( res: { data: string } ) => JSON.parse( res.data ) )
-				.then( ( purchases: Record< string, string >[] ) => {
+				.then( ( purchases: RawPurchase[] ) => {
 					reduxDispatch( {
-						type: SITE_PURCHASES_UPDATE,
+						type: PURCHASES_SITE_FETCH_COMPLETED,
 						siteId,
-						purchases: formatPurchasesToSiteProducts( purchases ),
+						purchases: purchases,
 					} );
 				} )
 				.catch( ( error: Error ) => setError( error ) )

--- a/client/my-sites/stats/stats-notices/use-site-purchases-on-odyssey-stats.tsx
+++ b/client/my-sites/stats/stats-notices/use-site-purchases-on-odyssey-stats.tsx
@@ -7,15 +7,12 @@ import type { RawPurchase } from 'calypso/lib/purchases/types';
 /**
  * Update site products in the Redux store by fetching purchases via API for Odyssey Stats.
  */
-export default function usePurchasesToUpdateSiteProducts(
+export default function useSitePurchasesOnOdysseyStats(
 	isOdysseyStats: boolean | undefined,
 	siteId: number | null
 ) {
 	const reduxDispatch = useDispatch();
 
-	const [ hasLoadedPurchases, setHasLoadedPurchases ] = useState< boolean | undefined >(
-		! isOdysseyStats
-	);
 	const [ error, setError ] = useState< Error | null >( null );
 
 	useEffect( () => {
@@ -24,19 +21,18 @@ export default function usePurchasesToUpdateSiteProducts(
 				.get( { path: '/site/purchases', apiNamespace: 'jetpack/v4' } )
 				.then( ( res: { data: string } ) => JSON.parse( res.data ) )
 				.then( ( purchases: RawPurchase[] ) => {
+					// Dispatch to the Purchases reducer for consistent requesting status
 					reduxDispatch( {
 						type: PURCHASES_SITE_FETCH_COMPLETED,
 						siteId,
 						purchases: purchases,
 					} );
 				} )
-				.catch( ( error: Error ) => setError( error ) )
-				.finally( () => setHasLoadedPurchases( true ) );
+				.catch( ( error: Error ) => setError( error ) );
 		}
 	}, [ isOdysseyStats, reduxDispatch, siteId ] );
 
 	return {
-		hasLoadedPurchases,
 		error,
 	};
 }

--- a/client/state/sites/selectors/has-site-product-jetpack-stats.ts
+++ b/client/state/sites/selectors/has-site-product-jetpack-stats.ts
@@ -5,6 +5,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
 import getSitePlan from './get-site-plan';
 
+// TODO: Move this selector outside of state/sites since we now use state/purchases to check the Stats product.
 const hasSiteProductJetpackStats = (
 	state: AppState,
 	onlyPaid = false,

--- a/client/state/sites/selectors/has-site-product-jetpack-stats.ts
+++ b/client/state/sites/selectors/has-site-product-jetpack-stats.ts
@@ -1,17 +1,18 @@
 import { camelOrSnakeSlug } from '@automattic/calypso-products';
 import { productHasStats } from 'calypso/blocks/jetpack-benefits/feature-checks';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
 import getSitePlan from './get-site-plan';
-import getSiteProducts from './get-site-products';
 
 const hasSiteProductJetpackStats = (
 	state: AppState,
 	onlyPaid = false,
 	siteId = getSelectedSiteId( state )
 ): boolean => {
-	const siteHasStatsProduct = getSiteProducts( state, siteId )?.some(
-		( product ) => productHasStats( camelOrSnakeSlug( product ), onlyPaid ) && ! product.expired
+	const siteHasStatsProduct = getSitePurchases( state, siteId )?.some(
+		( product ) =>
+			productHasStats( camelOrSnakeSlug( product ), onlyPaid ) && product.expiryStatus !== 'expired'
 	);
 	const sitePlan = getSitePlan( state, siteId );
 	const siteHasStatsPlan = productHasStats( sitePlan?.product_slug as string, onlyPaid );

--- a/client/state/sites/selectors/test/has-site-product-jetpack-stats.js
+++ b/client/state/sites/selectors/test/has-site-product-jetpack-stats.js
@@ -7,14 +7,18 @@ describe( 'hasSiteProductJetpackStats()', () => {
 				items: {
 					2916288: {
 						plan: {},
-						products: [
-							{
-								product_slug: 'jetpack_stats_free_yearly',
-								expired: false,
-							},
-						],
+						products: [],
 					},
 				},
+			},
+			purchases: {
+				data: [
+					{
+						blog_id: 2916288,
+						product_slug: 'jetpack_stats_free_yearly',
+						expiry_status: 'manual-renew',
+					},
+				],
 			},
 		};
 		const hasPaidJetpackStats = hasSiteProductJetpackStats( stateWithFreeStats, true, 2916288 );
@@ -28,14 +32,18 @@ describe( 'hasSiteProductJetpackStats()', () => {
 				items: {
 					2916288: {
 						plan: {},
-						products: [
-							{
-								product_slug: 'jetpack_stats_free_yearly',
-								expired: false,
-							},
-						],
+						products: [],
 					},
 				},
+			},
+			purchases: {
+				data: [
+					{
+						blog_id: 2916288,
+						product_slug: 'jetpack_stats_free_yearly',
+						expiry_status: 'manual-renew',
+					},
+				],
 			},
 		};
 		const hasJetpackStats = hasSiteProductJetpackStats( stateWithFreeStats, false, 2916288 );
@@ -49,14 +57,18 @@ describe( 'hasSiteProductJetpackStats()', () => {
 				items: {
 					2916288: {
 						plan: {},
-						products: [
-							{
-								product_slug: 'jetpack_stats_monthly',
-								expired: false,
-							},
-						],
+						products: [],
 					},
 				},
+			},
+			purchases: {
+				data: [
+					{
+						blog_id: 2916288,
+						product_slug: 'jetpack_stats_monthly',
+						expiry_status: 'manual-renew',
+					},
+				],
 			},
 		};
 		const hasPaidJetpackStats = hasSiteProductJetpackStats( stateWithPaidStats, true, 2916288 );
@@ -70,14 +82,18 @@ describe( 'hasSiteProductJetpackStats()', () => {
 				items: {
 					2916288: {
 						plan: {},
-						products: [
-							{
-								product_slug: 'jetpack_stats_monthly',
-								expired: true,
-							},
-						],
+						products: [],
 					},
 				},
+			},
+			purchases: {
+				data: [
+					{
+						blog_id: 2916288,
+						product_slug: 'jetpack_stats_monthly',
+						expiry_status: 'expired',
+					},
+				],
 			},
 		};
 		const hasJetpackStats = hasSiteProductJetpackStats( stateWithExpiredStats, false, 2916288 );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79880 

## Proposed Changes

* Use purchases rather than site products for data resource consistency on Calypso and Odyssey Stats.
* Show the upsell notice according to the site purchases correctly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Calypso Stats
* Spin up the change with the Calypso Live link.
* Navigate to Stats > `Traffic` page with the feature flag: `/stats/day/{site-slug}?flags=stats/paid-wpcom-stats`.
* Ensure the upsell notice displays correctly according to the purchased Stats products for Simple, Atomic, and Jetpack sites.

#### Odyssey Stats
* Spin up the change with the local Jetpack site: `cd apps/odyssey-stats && STATS_PACKAGE_PATH=/{my-path}/jetpack/projects/packages/stats-admin yarn dev`
* Navigate to Stats > `Traffic` page.
* Ensure the upsell notice displays correctly according to the purchased Stats products.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
