### PR TITLE
Add sidebar click events on the Site Editor

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -22,6 +22,13 @@ import {
 } from './wpcom-site-editor-document-actions-dropdown-click';
 import wpcomSiteEditorExitClick from './wpcom-site-editor-exit-click';
 import {
+	wpcomSiteEditorSidebarNavigationClick,
+	wpcomSiteEditorSidebarPagesClick,
+	wpcomSiteEditorSidebarPatternsClick,
+	wpcomSiteEditorSidebarStylesClick,
+	wpcomSiteEditorSidebarTemplatesClick,
+} from './wpcom-site-editor-sidebar-clicks';
+import {
 	wpcomTemplatePartChooseCapture,
 	wpcomTemplatePartChooseBubble,
 	wpcomTemplatePartReplaceBubble,
@@ -70,11 +77,16 @@ const EVENTS_MAPPING = [
 	wpcomBlockEditorPostPublishAddNewClick(),
 	wpcomBlockEditorSaveClick(),
 	wpcomBlockEditorSaveDraftClick(),
-	wpcomSiteEditorExitClick(),
 	wpcomSiteEditorDocumentActionsDropdownOpen(),
-	wpcomSiteEditorDocumentActionsTemplateAreaClick(),
 	wpcomSiteEditorDocumentActionsRevertClick(),
 	wpcomSiteEditorDocumentActionsShowAllClick(),
+	wpcomSiteEditorDocumentActionsTemplateAreaClick(),
+	wpcomSiteEditorExitClick(),
+	wpcomSiteEditorSidebarNavigationClick(),
+	wpcomSiteEditorSidebarPagesClick(),
+	wpcomSiteEditorSidebarPatternsClick(),
+	wpcomSiteEditorSidebarStylesClick(),
+	wpcomSiteEditorSidebarTemplatesClick(),
 ];
 const EVENTS_MAPPING_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => capture );
 const EVENTS_MAPPING_NON_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => ! capture );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-sidebar-clicks.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-sidebar-clicks.ts
@@ -1,0 +1,51 @@
+import tracksRecordEvent from './track-record-event';
+
+export const wpcomSiteEditorSidebarNavigationClick = () => {
+	return {
+		id: 'wpcom_site_editor_sidebar_navigation_click',
+		// \2f is the encoded slash.
+		selector: '#\\2fnavigation',
+		type: 'click',
+		handler: () => tracksRecordEvent( 'wpcom_site_editor_sidebar_navigation_click' ),
+	};
+};
+
+export const wpcomSiteEditorSidebarPagesClick = () => {
+	return {
+		id: 'wpcom_site_editor_sidebar_pages_click',
+		// \2f is the encoded slash.
+		selector: '#\\2fpage',
+		type: 'click',
+		handler: () => tracksRecordEvent( 'wpcom_site_editor_sidebar_pages_click' ),
+	};
+};
+
+export const wpcomSiteEditorSidebarPatternsClick = () => {
+	return {
+		id: 'wpcom_site_editor_sidebar_patterns_click',
+		// \2f is the encoded slash.
+		selector: '#\\2fpatterns',
+		type: 'click',
+		handler: () => tracksRecordEvent( 'wpcom_site_editor_sidebar_patterns_click' ),
+	};
+};
+
+export const wpcomSiteEditorSidebarStylesClick = () => {
+	return {
+		id: 'wpcom_site_editor_sidebar_styles_click',
+		// \2f is the encoded slash.
+		selector: '#\\2fwp_global_styles',
+		type: 'click',
+		handler: () => tracksRecordEvent( 'wpcom_site_editor_sidebar_styles_click' ),
+	};
+};
+
+export const wpcomSiteEditorSidebarTemplatesClick = () => {
+	return {
+		id: 'wpcom_site_editor_sidebar_templates_click',
+		// \2f is the encoded slash.
+		selector: `#\\2fwp_template`,
+		type: 'click',
+		handler: () => tracksRecordEvent( 'wpcom_site_editor_sidebar_templates_click' ),
+	};
+};

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-sidebar-clicks.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-sidebar-clicks.ts
@@ -6,7 +6,10 @@ export const wpcomSiteEditorSidebarNavigationClick = () => {
 		// \2f is the encoded slash.
 		selector: '#\\2fnavigation',
 		type: 'click',
-		handler: () => tracksRecordEvent( 'wpcom_site_editor_sidebar_navigation_click' ),
+		handler: () =>
+			tracksRecordEvent( 'wpcom_block_editor_nav_sidebar_main_item_click', {
+				item_type: 'navigation',
+			} ),
 	};
 };
 
@@ -16,7 +19,10 @@ export const wpcomSiteEditorSidebarPagesClick = () => {
 		// \2f is the encoded slash.
 		selector: '#\\2fpage',
 		type: 'click',
-		handler: () => tracksRecordEvent( 'wpcom_site_editor_sidebar_pages_click' ),
+		handler: () =>
+			tracksRecordEvent( 'wpcom_block_editor_nav_sidebar_main_item_click', {
+				item_type: 'pages',
+			} ),
 	};
 };
 
@@ -26,7 +32,10 @@ export const wpcomSiteEditorSidebarPatternsClick = () => {
 		// \2f is the encoded slash.
 		selector: '#\\2fpatterns',
 		type: 'click',
-		handler: () => tracksRecordEvent( 'wpcom_site_editor_sidebar_patterns_click' ),
+		handler: () =>
+			tracksRecordEvent( 'wpcom_block_editor_nav_sidebar_main_item_click', {
+				item_type: 'patterns',
+			} ),
 	};
 };
 
@@ -36,7 +45,10 @@ export const wpcomSiteEditorSidebarStylesClick = () => {
 		// \2f is the encoded slash.
 		selector: '#\\2fwp_global_styles',
 		type: 'click',
-		handler: () => tracksRecordEvent( 'wpcom_site_editor_sidebar_styles_click' ),
+		handler: () =>
+			tracksRecordEvent( 'wpcom_block_editor_nav_sidebar_main_item_click', {
+				item_type: 'styles',
+			} ),
 	};
 };
 
@@ -46,6 +58,9 @@ export const wpcomSiteEditorSidebarTemplatesClick = () => {
 		// \2f is the encoded slash.
 		selector: `#\\2fwp_template`,
 		type: 'click',
-		handler: () => tracksRecordEvent( 'wpcom_site_editor_sidebar_templates_click' ),
+		handler: () =>
+			tracksRecordEvent( 'wpcom_block_editor_nav_sidebar_main_item_click', {
+				item_type: 'templates',
+			} ),
 	};
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3301

## Proposed Changes

This enables us to track the Site Editor-related events in the Live Preview flow.

>- If we can track from within the Site Editor, I'd like to see which options are clicked the most.
>- If there's any way to track if the user has made any changes to their site, I'd like to see the percentage of users that go the Live Preview, and change their sites, before activating it.
>https://github.com/Automattic/dotcom-forge/issues/3301

Added 🆕 track events as follows. Many of them are existing events. 

| Click any navigation | Click further navigation | Edit | 
|--------|--------|--------|
| 🆕 `wpcom_site_editor_sidebar_templates_click` | `wpcom_block_editor_nav_sidebar_item_edit` <br><br> Click any template | `wpcom_block_inserted` <br><br> We can think of this as user's edit if it has the `insert_method` property. | NaN |
| 🆕 `wpcom_site_editor_sidebar_pages_click` | `wpcom_block_editor_nav_sidebar_item_edit` <br><br> Click any page | `wpcom_block_inserted` <br><br> We can think of this as user's edit if it has the `insert_method` property. | 
| 🆕 `wpcom_site_editor_sidebar_patterns_click` | `wpcom_block_editor_nav_sidebar_item_edit` <br><br> Click any pattern | `wpcom_block_inserted` <br><br> We can think of this as user's edit if it has the `insert_method` property. | NaN |
| 🆕 `wpcom_site_editor_sidebar_styles_click` | NaN | `wpcom_block_editor_global_styles_update` <br><br> Users update global styles. | NaN | 
| 🆕 `wpcom_site_editor_sidebar_navigation_click` <br><br> For the `Navigation` menu, I don't think it's useful in the Live Preview. We can add further tracks later if we find a noticeable amount of clicks. | NaN | NaN |

<!--
<br><br> We can Identify which template is selected by `item_id` (e.g. `pub/arbutus//index`).
<br><br> We can Identify which template part is selected `item_id` (e.g. `pub/arbutus//footer`).
-->

Navigation UI

<img width="353" alt="Screen Shot 2023-08-23 at 15 11 51" src="https://github.com/Automattic/wp-calypso/assets/5287479/f39cca52-ed87-4963-932b-94c3655c7318">

Overview

```mermaid
%%{init: {"flowchart": {"htmlLabels": false}} }%%
flowchart LR
    1["calypso_page_view"]
    2["wpcom_site_editor_sidebar_pages_click
wpcom_site_editor_sidebar_patterns_click
wpcom_site_editor_sidebar_templates_click
"]
	21["wpcom_block_editor_nav_sidebar_item_edit"]
	211["wpcom_block_inserted"]
	3["wpcom_site_editor_sidebar_styles_click"]
	31["wpcom_block_editor_global_styles_update"]
	4["wpcom_site_editor_sidebar_navigation_click"]
    1 --> 2 --> 21 --> 211
	1 --> 3 --> 31
	1 --> 4
```

- [x] I'll create a follow up PR for events;
	- [x] when `Activate` is clicked.
	- [x] `wpcom_site_editor_sidebar_navigation_click` is not fired when the theme has no style variations. https://github.com/Automattic/wp-calypso/pull/81002
	- [x] ~~when global styles is updated for themes that does not have style variations.~~ -> This seems to be fired already.
	- [x] ~~that indicate a users edited other than `wpcom_block_inserted`.~~ -> We will use the [existing events](https://github.com/Automattic/wp-calypso/blob/d35f5998a903eecaa90d9dfc1ba798c2bc0b6120/apps/wpcom-block-editor/src/wpcom/features/tracking.js#L850).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch this PR to your sandbox with `cd apps/wpcom-block-editor/ && yarn dev --sync`
* Sandbox widgets.wp.com and your site
* Go to the Site Editor
* See if events fire with https://github.com/Automattic/tracks-chrome-extension

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?