### PR TITLE
Add Live Preview-related track events

### DIFF
--- a/client/my-sites/theme/live-preview-button/index.tsx
+++ b/client/my-sites/theme/live-preview-button/index.tsx
@@ -27,7 +27,7 @@ export const LivePreviewButton: FC< Props > = ( { themeId, siteId } ) => {
 	}
 
 	return (
-		<Button onClick={ () => dispatch( livePreview( themeId, siteId ) ) }>
+		<Button onClick={ () => dispatch( livePreview( themeId, siteId, 'detail' ) ) }>
 			{ translate( 'Live preview' ) }
 		</Button>
 	);

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -340,7 +340,7 @@ class ThemeSheet extends Component {
 		return null;
 	}
 
-	previewAction = ( event, type, position ) => {
+	previewAction = ( event, type, source ) => {
 		const { demoUrl, isExternallyManagedTheme, isWpcomTheme, isLivePreviewSupported } = this.props;
 		if ( event.altKey || event.ctrlKey || event.metaKey || event.shiftKey ) {
 			return;
@@ -350,7 +350,7 @@ class ThemeSheet extends Component {
 		this.props.recordTracksEvent( 'calypso_theme_live_demo_preview_click', {
 			theme: this.props.themeId,
 			type,
-			position,
+			source,
 			/**
 			 * To see tracks as the UI changes depending on whether Live Preview is available or not.
 			 *

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -351,6 +351,11 @@ class ThemeSheet extends Component {
 			theme: this.props.themeId,
 			type,
 			position,
+			/**
+			 * To see tracks as the UI changes depending on whether Live Preview is available or not.
+			 *
+			 * @see https://github.com/Automattic/wp-calypso/pull/80540
+			 */
 			has_live_preview_cta: isLivePreviewSupported,
 		} );
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -340,8 +340,8 @@ class ThemeSheet extends Component {
 		return null;
 	}
 
-	previewAction = ( event, type ) => {
-		const { demoUrl, isExternallyManagedTheme, isWpcomTheme } = this.props;
+	previewAction = ( event, type, position ) => {
+		const { demoUrl, isExternallyManagedTheme, isWpcomTheme, isLivePreviewSupported } = this.props;
 		if ( event.altKey || event.ctrlKey || event.metaKey || event.shiftKey ) {
 			return;
 		}
@@ -350,6 +350,8 @@ class ThemeSheet extends Component {
 		this.props.recordTracksEvent( 'calypso_theme_live_demo_preview_click', {
 			theme: this.props.themeId,
 			type,
+			position,
+			has_live_preview_cta: isLivePreviewSupported,
 		} );
 
 		// The embed live demo works only for WP.com themes
@@ -466,7 +468,7 @@ class ThemeSheet extends Component {
 					className="theme__sheet-screenshot is-active"
 					href={ demoUrl }
 					onClick={ ( e ) => {
-						this.previewAction( e, 'screenshot' );
+						this.previewAction( e, 'screenshot', 'preview' );
 					} }
 					rel="noopener noreferrer"
 				>
@@ -486,7 +488,7 @@ class ThemeSheet extends Component {
 					<Button
 						className="theme__sheet-preview-demo-site"
 						onClick={ ( e ) => {
-							this.previewAction( e, 'link' );
+							this.previewAction( e, 'link', 'preview' );
 						} }
 					>
 						{ translate( 'Preview demo site' ) }
@@ -523,7 +525,7 @@ class ThemeSheet extends Component {
 					<Button
 						className="theme__sheet-preview-demo-site"
 						onClick={ ( e ) => {
-							this.previewAction( e, 'link' );
+							this.previewAction( e, 'link', 'preview' );
 						} }
 					>
 						{ translate( 'Preview demo site' ) }
@@ -609,7 +611,7 @@ class ThemeSheet extends Component {
 						{ this.shouldRenderPreviewButton() && ! isLivePreviewSupported && (
 							<Button
 								onClick={ ( e ) => {
-									this.previewAction( e, 'link' );
+									this.previewAction( e, 'link', 'actions' );
 								} }
 							>
 								{ translate( 'Demo site', {

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -251,7 +251,9 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 		label: translate( 'Live preview', {
 			comment: 'label for previewing a block theme',
 		} ),
-		action: livePreviewAction,
+		action: ( themeId, siteId ) => {
+			return livePreviewAction( themeId, siteId, 'list' );
+		},
 		hideForTheme: ( state, themeId, siteId ) =>
 			! getIsLivePreviewSupported( state, themeId, siteId ),
 	};

--- a/client/state/themes/actions/live-preview.ts
+++ b/client/state/themes/actions/live-preview.ts
@@ -10,13 +10,15 @@ import { suffixThemeIdForInstall } from './suffix-theme-id-for-install';
 
 export function livePreview( themeId: string, siteId: number, source?: 'list' | 'detail' ) {
 	return ( dispatch: CalypsoDispatch, getState: () => AppState ) => {
-		recordTracksEvent( 'calypso_block_theme_live_preview_click', {
-			active_theme: getActiveTheme( getState(), siteId ),
-			site_id: siteId,
-			source,
-			theme_type: getThemeType( getState(), themeId ),
-			theme: themeId,
-		} );
+		dispatch(
+			recordTracksEvent( 'calypso_block_theme_live_preview_click', {
+				active_theme: getActiveTheme( getState(), siteId ),
+				site_id: siteId,
+				source,
+				theme_type: getThemeType( getState(), themeId ),
+				theme: themeId,
+			} )
+		);
 
 		dispatch( { type: LIVE_PREVIEW_START } );
 		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {

--- a/client/state/themes/actions/live-preview.ts
+++ b/client/state/themes/actions/live-preview.ts
@@ -1,14 +1,23 @@
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { LIVE_PREVIEW_START } from 'calypso/state/themes/action-types';
-import { getTheme } from 'calypso/state/themes/selectors';
+import { getActiveTheme, getTheme, getThemeType } from 'calypso/state/themes/selectors';
 import { CalypsoDispatch } from 'calypso/state/types';
 import { AppState } from 'calypso/types';
 import { installAndLivePreview } from './install-and-live-preview';
 import { redirectToLivePreview } from './redirect-to-live-preview';
 import { suffixThemeIdForInstall } from './suffix-theme-id-for-install';
 
-export function livePreview( themeId: string, siteId: number ) {
+export function livePreview( themeId: string, siteId: number, source?: 'list' | 'detail' ) {
 	return ( dispatch: CalypsoDispatch, getState: () => AppState ) => {
+		recordTracksEvent( 'calypso_block_theme_live_preview_click', {
+			active_theme: getActiveTheme( getState(), siteId ),
+			site_id: siteId,
+			source,
+			theme_type: getThemeType( getState(), themeId ),
+			theme: themeId,
+		} );
+
 		dispatch( { type: LIVE_PREVIEW_START } );
 		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {
 			const installId = suffixThemeIdForInstall( getState(), siteId, themeId );

--- a/client/state/themes/actions/live-preview.ts
+++ b/client/state/themes/actions/live-preview.ts
@@ -1,4 +1,4 @@
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { LIVE_PREVIEW_START } from 'calypso/state/themes/action-types';
 import { getActiveTheme, getTheme, getThemeType } from 'calypso/state/themes/selectors';
@@ -10,17 +10,14 @@ import { suffixThemeIdForInstall } from './suffix-theme-id-for-install';
 
 export function livePreview( themeId: string, siteId: number, source?: 'list' | 'detail' ) {
 	return ( dispatch: CalypsoDispatch, getState: () => AppState ) => {
-		dispatch(
-			recordTracksEvent( 'calypso_block_theme_live_preview_click', {
-				active_theme: getActiveTheme( getState(), siteId ),
-				site_id: siteId,
-				source,
-				theme_type: getThemeType( getState(), themeId ),
-				theme: themeId,
-			} )
-		);
-
-		dispatch( { type: LIVE_PREVIEW_START } );
+		const analysis = recordTracksEvent( 'calypso_block_theme_live_preview_click', {
+			active_theme: getActiveTheme( getState(), siteId ),
+			site_id: siteId,
+			source,
+			theme_type: getThemeType( getState(), themeId ),
+			theme: themeId,
+		} );
+		dispatch( withAnalytics( analysis, { type: LIVE_PREVIEW_START } ) );
 		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {
 			const installId = suffixThemeIdForInstall( getState(), siteId, themeId );
 			// If theme is already installed, installation will silently fail, and we just switch to the Live Preview.

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -1362,6 +1362,27 @@ describe( 'actions', () => {
 				res();
 			} )
 		);
+		const analyticsAction = {
+			type: 'ANALYTICS_EVENT_RECORD',
+			meta: {
+				analytics: [
+					{
+						payload: {
+							name: 'calypso_block_theme_live_preview_click',
+							properties: {
+								active_theme: 'twentyfifteen',
+								site_id: 2211667,
+								source: 'detail',
+								theme: 'pendant',
+								theme_type: 'free',
+							},
+							service: 'tracks',
+						},
+						type: 'ANALYTICS_EVENT_RECORD',
+					},
+				],
+			},
+		};
 		describe( 'on a WordPress.com site', () => {
 			const state = () => ( {
 				sites: {
@@ -1371,10 +1392,25 @@ describe( 'actions', () => {
 						},
 					},
 				},
+				themes: {
+					activeThemes: {
+						2211667: 'twentyfifteen',
+					},
+					queries: {
+						wpcom: new ThemeQueryManager( {
+							items: {},
+						} ),
+					},
+				},
 			} );
 			test( 'should redirect users to the Live Preview', () => {
 				return new Promise( ( done ) => {
-					livePreview( 'pendant', 2211667 )( dispatch, state ).then( () => {
+					livePreview(
+						'pendant',
+						2211667,
+						'detail'
+					)( dispatch, state ).then( () => {
+						expect( dispatch ).toBeCalledWith( analyticsAction );
 						expect( dispatch ).toBeCalledWith( { type: 'LIVE_PREVIEW_START' } );
 						expect( dispatch ).toBeCalledWith(
 							expect.toMatchFunction( redirectToLivePreview( 'pendant', 2211667 ) )
@@ -1394,11 +1430,17 @@ describe( 'actions', () => {
 						},
 					},
 				},
+				themes: {
+					activeThemes: {
+						2211667: 'twentyfifteen',
+					},
+				},
 			};
 			describe( 'if the theme is already installed', () => {
 				const state = () => ( {
 					...baseState,
 					themes: {
+						...baseState.themes,
 						queries: {
 							2211667: new ThemeQueryManager( {
 								items: { pendant: {} },
@@ -1408,7 +1450,12 @@ describe( 'actions', () => {
 				} );
 				test( 'should redirect users to the Live Preview', () => {
 					return new Promise( ( done ) => {
-						livePreview( 'pendant', 2211667 )( dispatch, state ).then( () => {
+						livePreview(
+							'pendant',
+							2211667,
+							'detail'
+						)( dispatch, state ).then( () => {
+							expect( dispatch ).toBeCalledWith( analyticsAction );
 							expect( dispatch ).toBeCalledWith( { type: 'LIVE_PREVIEW_START' } );
 							expect( dispatch ).toBeCalledWith(
 								expect.toMatchFunction( redirectToLivePreview( 'pendant', 2211667 ) )
@@ -1423,12 +1470,18 @@ describe( 'actions', () => {
 				const state = () => ( {
 					...baseState,
 					themes: {
+						...baseState.themes,
 						queries: {},
 					},
 				} );
 				test( 'should install the theme and then redirect users to the Live Preview', () => {
 					return new Promise( ( done ) => {
-						livePreview( 'pendant', 2211667 )( dispatch, state ).then( () => {
+						livePreview(
+							'pendant',
+							2211667,
+							'detail'
+						)( dispatch, state ).then( () => {
+							expect( dispatch ).toBeCalledWith( analyticsAction );
 							expect( dispatch ).toBeCalledWith( { type: 'LIVE_PREVIEW_START' } );
 							expect( dispatch ).toBeCalledWith(
 								expect.toMatchFunction( installAndLivePreview( 'pendant', 2211667 ) )

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -517,6 +517,32 @@ describe( 'actions', () => {
 			test( 'should refresh the admin bar', () => {
 				themeActivated( 'pub/mayland-blocks', 2211667 )( spy, fakeGetState );
 				expect( spy ).toBeCalledWith( {
+					type: 'THEME_ACTIVATE_SUCCESS',
+					themeStylesheet: 'pub/mayland-blocks',
+					siteId: 2211667,
+					meta: {
+						analytics: [
+							{
+								payload: {
+									name: 'calypso_themeshowcase_theme_activate',
+									properties: {
+										previous_theme: 'twentyfifteen',
+										purchased: false,
+										search_taxonomies: '',
+										search_term: 'simple, white',
+										source: 'unknown',
+										style_variation_slug: '',
+										theme: 'mayland-blocks',
+										theme_type: 'free',
+									},
+									service: 'tracks',
+								},
+								type: 'ANALYTICS_EVENT_RECORD',
+							},
+						],
+					},
+				} );
+				expect( spy ).toBeCalledWith( {
 					type: 'ADMIN_MENU_REQUEST',
 					siteId: 2211667,
 				} );
@@ -551,6 +577,32 @@ describe( 'actions', () => {
 				siteId: 2211667,
 			};
 			themeActivated( 'pub/twentysixteen', 2211667 )( spy, fakeGetState );
+			expect( spy ).toBeCalledWith( {
+				type: 'THEME_ACTIVATE_SUCCESS',
+				themeStylesheet: 'pub/twentysixteen',
+				siteId: 2211667,
+				meta: {
+					analytics: [
+						{
+							payload: {
+								name: 'calypso_themeshowcase_theme_activate',
+								properties: {
+									previous_theme: 'twentyfifteen',
+									purchased: false,
+									search_taxonomies: '',
+									search_term: 'simple, white',
+									source: 'unknown',
+									style_variation_slug: '',
+									theme: 'twentysixteen',
+									theme_type: 'free',
+								},
+								service: 'tracks',
+							},
+							type: 'ANALYTICS_EVENT_RECORD',
+						},
+					],
+				},
+			} );
 			expect( spy ).toBeCalledWith( expectedActivationSuccess );
 		} );
 	} );
@@ -1362,8 +1414,8 @@ describe( 'actions', () => {
 				res();
 			} )
 		);
-		const analyticsAction = {
-			type: 'ANALYTICS_EVENT_RECORD',
+		const livePreviewStartAction = {
+			type: 'LIVE_PREVIEW_START',
 			meta: {
 				analytics: [
 					{
@@ -1410,8 +1462,7 @@ describe( 'actions', () => {
 						2211667,
 						'detail'
 					)( dispatch, state ).then( () => {
-						expect( dispatch ).toBeCalledWith( analyticsAction );
-						expect( dispatch ).toBeCalledWith( { type: 'LIVE_PREVIEW_START' } );
+						expect( dispatch ).toBeCalledWith( livePreviewStartAction );
 						expect( dispatch ).toBeCalledWith(
 							expect.toMatchFunction( redirectToLivePreview( 'pendant', 2211667 ) )
 						);
@@ -1455,8 +1506,7 @@ describe( 'actions', () => {
 							2211667,
 							'detail'
 						)( dispatch, state ).then( () => {
-							expect( dispatch ).toBeCalledWith( analyticsAction );
-							expect( dispatch ).toBeCalledWith( { type: 'LIVE_PREVIEW_START' } );
+							expect( dispatch ).toBeCalledWith( livePreviewStartAction );
 							expect( dispatch ).toBeCalledWith(
 								expect.toMatchFunction( redirectToLivePreview( 'pendant', 2211667 ) )
 							);
@@ -1481,8 +1531,7 @@ describe( 'actions', () => {
 							2211667,
 							'detail'
 						)( dispatch, state ).then( () => {
-							expect( dispatch ).toBeCalledWith( analyticsAction );
-							expect( dispatch ).toBeCalledWith( { type: 'LIVE_PREVIEW_START' } );
+							expect( dispatch ).toBeCalledWith( livePreviewStartAction );
 							expect( dispatch ).toBeCalledWith(
 								expect.toMatchFunction( installAndLivePreview( 'pendant', 2211667 ) )
 							);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3301, https://github.com/Automattic/wp-calypso/pull/80953

## Proposed Changes

This PR adds the `calypso_block_theme_live_preview_click` event when the Live Preview CTA is clicked. The overview of tracking events follows below;

| Land on the Theme Detail page | Click CTA | Site Editor interaction | Activate | 
|--------|--------|--------|--------|
| `calypso_page_view` | 🆕 `calypso_block_theme_live_preview_click` with `source = 'detail'` | https://github.com/Automattic/wp-calypso/pull/80953, https://github.com/Automattic/wp-calypso/pull/81335 | https://github.com/Automattic/wp-calypso/pull/81000 | 
| `calypso_page_view` | `calypso_theme_live_demo_preview_click` | NaN | `calypso_themeshowcase_theme_activate` with `source = 'detail'` | 

| Land on the Theme Showcase page | Click three-dots | Click CTA | Site Editor interaction | Activate | 
|--------|--------|--------|--------|--------|
| `calypso_page_view` | `calypso_themeshowcase_theme_click` with `action = popup_open` | 🆕 `calypso_block_theme_live_preview_click` with `source = 'list'` | https://github.com/Automattic/wp-calypso/pull/80953, https://github.com/Automattic/wp-calypso/pull/81335 | https://github.com/Automattic/wp-calypso/pull/81000 | 
| `calypso_page_view` | `calypso_themeshowcase_theme_click` with `action = popup_open` | `calypso_themeshowcase_theme_more_button_item_click` with `action = preview` | NaN | `calypso_themeshowcase_theme_activate` with `source = 'list'` | 

<img width="743" alt="Screen Shot 2023-08-24 at 10 57 47" src="https://github.com/Automattic/wp-calypso/assets/5287479/8c171da5-2533-42f8-acd4-81c9df46e79f">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Theme Detail page

- Go to the Theme Detail page
- Click the Live Preview button
- See if events fire with [Automattic/tracks-chrome-extension](https://github.com/Automattic/tracks-chrome-extension)

Theme Showcase page

- Go to the Theme Showcase page
- Click the three-dots on the Theme Card
- Click the Live Preview option
- See if events fire with [Automattic/tracks-chrome-extension](https://github.com/Automattic/tracks-chrome-extension)

You can use themes such as Lativ, Issue, Didone. See pdtkmj-1JP-p2#known-issues for Live Preview compatible themes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?