### PR TITLE
Jetpack E2E: add Writing Prompt spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -19,6 +19,7 @@ export * from './tiled-gallery';
 export * from './youtube';
 export * from './layout-grid';
 export * from './ai-assistant';
+export * from './writing-prompt';
 
 /* Types */
 export * from './types';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/writing-prompt.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/writing-prompt.ts
@@ -1,7 +1,7 @@
 import { BlockFlow, EditorContext, PublishedPostContext } from '.';
 
 /**
- * Represents the flow of using an Ad block.
+ * Represents the flow of using a Writing Prompt block.
  */
 export class WritingPromptFlow implements BlockFlow {
 	blockSidebarName = 'Writing Prompt';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/writing-prompt.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/writing-prompt.ts
@@ -1,0 +1,61 @@
+import { BlockFlow, EditorContext, PublishedPostContext } from '.';
+
+/**
+ * Represents the flow of using an Ad block.
+ */
+export class WritingPromptFlow implements BlockFlow {
+	blockSidebarName = 'Writing Prompt';
+	blockEditorSelector = 'div[aria-label="Block: Writing Prompt"]';
+
+	private prompt: string | undefined;
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when
+	 * configuring and validating the block.
+	 */
+	constructor() {
+		this.prompt = undefined;
+	}
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of
+	 * test execution.
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		const block = editorCanvas.getByRole( 'document', {
+			name: `Block: ${ this.blockSidebarName }`,
+		} );
+
+		await block.locator( '.components-spinner' ).waitFor( { state: 'detached' } );
+
+		// Must use CSS selector here due to lack of accessible locator
+		// for the block components.
+		this.prompt = await block.locator( '.jetpack-blogging-prompt__text' ).innerText();
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at
+	 * the point of test execution.
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		// Check the prompt is the same.
+		await context.page
+			.getByRole( 'main' )
+			.getByText( this.prompt as string )
+			.waitFor();
+
+		const newPagePromise = context.page.waitForEvent( 'popup' );
+		await context.page
+			.getByRole( 'main' )
+			.getByRole( 'link', { name: 'View all responses' } )
+			.click();
+		const newPage = await newPagePromise;
+		await newPage.waitForURL( /dailyprompt/ );
+		await newPage.close();
+	}
+}

--- a/test/e2e/specs/blocks/blocks__jetpack-writing.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-writing.ts
@@ -2,7 +2,7 @@
  * @group gutenberg
  * @group jetpack-wpcom-integration
  */
-import { BlockFlow, AIAssistantFlow } from '@automattic/calypso-e2e';
+import { BlockFlow, AIAssistantFlow, WritingPromptFlow } from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
@@ -11,6 +11,7 @@ const blockFlows: BlockFlow[] = [
 		tone: 'Passionate',
 		improve: 'Make shorter',
 	} ),
+	new WritingPromptFlow(),
 ];
 
 createBlockTests( 'Blocks: Jetpack Writing', blockFlows );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80730.

## Proposed Changes

This PR adds new block smoke test for the Writing Prompt block.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
