### PR TITLE
Boot: Use locale from the pathname only when we cannot get the value from the server side

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -68,8 +68,8 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		// For logged out Calypso pages, set the locale from query param
 		const pathLocaleSlug = getLocaleFromQueryParam();
 		pathLocaleSlug && reduxStore.dispatch( setLocale( pathLocaleSlug, '' ) );
-	} else {
-		// For logged out Calypso pages, set the locale from slug
+	} else if ( ! window.hasOwnProperty( 'localeFromPathname' ) ) {
+		// For logged out Calypso pages, set the locale from path if we cannot get the locale from the pathname on the server side
 		const pathLocaleSlug = getLocaleFromPathname();
 		pathLocaleSlug && reduxStore.dispatch( setLocale( pathLocaleSlug, '' ) );
 	}

--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -69,8 +69,8 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		// For logged out Calypso pages, set the locale from query param
 		const pathLocaleSlug = getLocaleFromQueryParam();
 		pathLocaleSlug && reduxStore.dispatch( setLocale( pathLocaleSlug, '' ) );
-	} else if ( ! window.hasOwnProperty( 'localeFromPathname' ) ) {
-		// For logged out Calypso pages, set the locale from path if we cannot get the locale from the pathname on the server side
+	} else if ( ! window.hasOwnProperty( 'localeFromRoute' ) ) {
+		// For logged out Calypso pages, set the locale from path if we cannot get the locale from the route on the server side
 		const pathLocaleSlug = getLocaleFromPathname();
 		pathLocaleSlug && reduxStore.dispatch( setLocale( pathLocaleSlug, '' ) );
 		recordTracksEvent( 'calypso_locale_set', { path: window.location.pathname } );

--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import {
 	isDefaultLocale,
@@ -72,6 +73,7 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		// For logged out Calypso pages, set the locale from path if we cannot get the locale from the pathname on the server side
 		const pathLocaleSlug = getLocaleFromPathname();
 		pathLocaleSlug && reduxStore.dispatch( setLocale( pathLocaleSlug, '' ) );
+		recordTracksEvent( 'calypso_locale_set', { path: window.location.pathname } );
 	}
 
 	// If user is logged out and translations are not bootstrapped, we assume default locale

--- a/client/controller/ssr-setup-locale.js
+++ b/client/controller/ssr-setup-locale.js
@@ -3,6 +3,7 @@ import { readFile } from 'fs/promises';
 import { defaultI18n } from '@wordpress/i18n';
 import { I18N } from 'i18n-calypso';
 import getAssetFilePath from 'calypso/lib/get-asset-file-path';
+import { getLanguageFile } from 'calypso/lib/i18n-utils/switch-locale';
 import config from 'calypso/server/config';
 import { LOCALE_SET } from 'calypso/state/action-types';
 
@@ -44,14 +45,14 @@ export function ssrSetupLocaleMiddleware() {
 			setLocaleData( cachedTranslations );
 		} else {
 			readFile( getAssetFilePath( `languages/${ lang }-v1.1.json` ), 'utf-8' )
-				.then( ( data ) => {
-					const translations = JSON.parse( data );
+				.then( ( data ) => JSON.parse( data ) )
+				// Fall back to the remote one if the local translation file is not found.
+				.catch( () => getLanguageFile( lang ) )
+				.then( ( translations ) => {
 					translationsCache[ lang ] = translations;
 					setLocaleData( translations );
 				} )
-				.catch( () => {
-					setLocaleData( null );
-				} );
+				.catch( () => setLocaleData( null ) );
 		}
 	};
 }

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -59,6 +59,7 @@ class Document extends Component {
 			useTranslationChunks,
 			target,
 			featuresHelper,
+			params,
 		} = this.props;
 
 		const installedChunks = entrypoint.js
@@ -82,7 +83,10 @@ class Document extends Component {
 			( languageRevisions
 				? `var languageRevisions = ${ jsonStringifyForHtml( languageRevisions ) };\n`
 				: '' ) +
-			`var installedChunks = ${ jsonStringifyForHtml( installedChunks ) };\n`;
+			`var installedChunks = ${ jsonStringifyForHtml( installedChunks ) };\n` +
+			( params && params.hasOwnProperty( 'lang' )
+				? `var localeFromPathname = ${ jsonStringifyForHtml( params.lang ?? '' ) };\n`
+				: '' );
 
 		const isJetpackWooCommerceFlow =
 			'jetpack-connect' === sectionName && 'woocommerce-onboarding' === requestFrom;

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -84,8 +84,9 @@ class Document extends Component {
 				? `var languageRevisions = ${ jsonStringifyForHtml( languageRevisions ) };\n`
 				: '' ) +
 			`var installedChunks = ${ jsonStringifyForHtml( installedChunks ) };\n` +
+			// Inject the locale if we can get it from the route via `getLanguageRouteParam`
 			( params && params.hasOwnProperty( 'lang' )
-				? `var localeFromPathname = ${ jsonStringifyForHtml( params.lang ?? '' ) };\n`
+				? `var localeFromRoute = ${ jsonStringifyForHtml( params.lang ?? '' ) };\n`
 				: '' );
 
 		const isJetpackWooCommerceFlow =

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -112,7 +112,8 @@ export async function getFile( url ) {
 }
 
 export function getLanguageFile( targetLocaleSlug ) {
-	const url = getLanguageFileUrl( targetLocaleSlug, 'json', window.languageRevisions || {} );
+	const languageRevisions = typeof window !== 'undefined' ? window.languageRevisions : {};
+	const url = getLanguageFileUrl( targetLocaleSlug, 'json', languageRevisions );
 
 	return getFile( url );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80843, https://github.com/Automattic/wp-calypso/pull/80797, https://github.com/Automattic/wp-calypso/pull/80854

## Proposed Changes

* Inject the matched locale from the pathname to the client side so we don't need to parse the pathname to get the locale on the client side.
* Get the translation data from the remote if the local translation file is not found. This is only for the dev env

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/theme/snd`, and ensure that the page renders correctly with the default locale.
* Head to `/ja/theme/snd`, and ensure that the page renders correctly with the locale ja.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
