### PR TITLE
`useMigrationEnabled`: remove `on*` handlers from `useQuery` usage

### DIFF
--- a/client/blocks/importer/hooks/use-site-can-migrate.ts
+++ b/client/blocks/importer/hooks/use-site-can-migrate.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useMigrationEnabledInfoQuery } from 'calypso/data/site-migration/use-migration-enabled';
 import { useDispatch, useSelector } from 'calypso/state';
 import { requestSites } from 'calypso/state/sites/actions';
@@ -14,6 +14,7 @@ export function useSiteMigrateInfo(
 		refetch,
 		isFetching: isMigrationEnabledFetching,
 		data,
+		status,
 	} = useMigrationEnabledInfoQuery( targetSiteId, sourceSiteSlug, fetchMigrationEnabledOnMount );
 
 	const isRequestingAllSites = useSelector( ( state ) => isRequestingSites( state ) );
@@ -27,10 +28,21 @@ export function useSiteMigrateInfo(
 		}
 	}, [ data?.source_blog_id, sourceSite, isRequestingAllSites, dispatch ] );
 
+	// use an effect that sets `siteCanMigrate` depending on whether the request ran to `true` or `false`, it should stay undefined until it's fetched the first time
+	const [ siteCanMigrate, setSiteCanMigrate ] = useState< boolean | undefined >( undefined );
+
+	useEffect( () => {
+		if ( status === 'success' ) {
+			setSiteCanMigrate( data?.can_migrate );
+		} else if ( status === 'error' ) {
+			setSiteCanMigrate( false );
+		}
+	}, [ status, data?.can_migrate ] );
+
 	return {
 		sourceSiteId: data?.source_blog_id,
 		sourceSite,
-		siteCanMigrate: data?.can_migrate,
+		siteCanMigrate,
 		fetchMigrationEnabledStatus: refetch,
 		isFetchingData: isMigrationEnabledFetching || isRequestingAllSites,
 	};

--- a/client/blocks/importer/hooks/use-site-can-migrate.ts
+++ b/client/blocks/importer/hooks/use-site-can-migrate.ts
@@ -1,5 +1,4 @@
-import { useEffect, useState } from 'react';
-import { MigrationEnabledResponse } from 'calypso/data/site-migration/types';
+import { useEffect } from 'react';
 import { useMigrationEnabledInfoQuery } from 'calypso/data/site-migration/use-migration-enabled';
 import { useDispatch, useSelector } from 'calypso/state';
 import { requestSites } from 'calypso/state/sites/actions';
@@ -9,72 +8,29 @@ import { SiteId } from 'calypso/types';
 export function useSiteMigrateInfo(
 	targetSiteId: SiteId,
 	sourceSiteSlug: string,
-	fetchMigrationEnabledOnMount: boolean,
-	onfetchCallback?: ( checkCanSiteMigrate: boolean ) => void
+	fetchMigrationEnabledOnMount: boolean
 ) {
-	const [ sourceSiteId, setSourceSiteId ] = useState( 0 );
-	const [ siteCanMigrate, setSiteCanMigrate ] = useState( false );
-	const isRequestingAllSites = useSelector( ( state ) => isRequestingSites( state ) );
-	const sourceSite = useSelector( ( state ) => getSite( state, sourceSiteId ) );
-	const dispatch = useDispatch();
-
-	const resetMigrationEnabled = () => {
-		setSiteCanMigrate( false );
-		setSourceSiteId( 0 );
-	};
-
-	const checkCanSiteMigrate = ( data: MigrationEnabledResponse ) => {
-		if ( ! data ) {
-			return false;
-		}
-		const { jetpack_activated, jetpack_compatible, migration_activated, migration_compatible } =
-			data as MigrationEnabledResponse;
-
-		return (
-			( migration_activated && migration_compatible ) || ( jetpack_activated && jetpack_compatible )
-		);
-	};
-
 	const {
 		refetch,
 		isFetching: isMigrationEnabledFetching,
-		isError,
-		isSuccess,
 		data,
 	} = useMigrationEnabledInfoQuery( targetSiteId, sourceSiteSlug, fetchMigrationEnabledOnMount );
 
-	useEffect( () => {
-		if ( isSuccess && data ) {
-			const canMigrate = checkCanSiteMigrate( data );
-			if ( canMigrate ) {
-				setSiteCanMigrate( true );
-				setSourceSiteId( data.source_blog_id );
-			} else {
-				resetMigrationEnabled();
-			}
-			onfetchCallback?.( canMigrate );
-		}
-	}, [ data, isSuccess, onfetchCallback ] );
-
-	useEffect( () => {
-		if ( isError ) {
-			resetMigrationEnabled();
-			const canMigrate = false;
-			onfetchCallback && onfetchCallback( canMigrate );
-		}
-	}, [ isError, onfetchCallback ] );
+	const isRequestingAllSites = useSelector( ( state ) => isRequestingSites( state ) );
+	const sourceSite = useSelector( ( state ) => getSite( state, data?.source_blog_id ) );
+	const dispatch = useDispatch();
 
 	useEffect( () => {
 		// If has source site id and we do not have the source site, it means the data is not up to date, so we request the site
-		if ( sourceSiteId && ! sourceSite && ! isRequestingAllSites ) {
+		if ( data?.source_blog_id && ! sourceSite && ! isRequestingAllSites ) {
 			dispatch( requestSites() );
 		}
-	}, [ sourceSiteId, sourceSite, isRequestingAllSites, dispatch ] );
+	}, [ data?.source_blog_id, sourceSite, isRequestingAllSites, dispatch ] );
 
 	return {
-		sourceSiteId,
+		sourceSiteId: data?.source_blog_id,
 		sourceSite,
-		siteCanMigrate,
+		siteCanMigrate: data?.can_migrate,
 		fetchMigrationEnabledStatus: refetch,
 		isFetchingData: isMigrationEnabledFetching || isRequestingAllSites,
 	};

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -76,7 +76,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		siteCanMigrate,
 	} = useSiteMigrateInfo( targetSite.ID, sourceSiteSlug, isTargetSitePlanCompatible );
 
-	const showUpdatePluginInfo = ! siteCanMigrate;
+	const showUpdatePluginInfo = typeof siteCanMigrate === 'boolean' ? ! siteCanMigrate : false;
 
 	const migrationTrackingProps = {
 		source_site_id: sourceSiteId,

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -63,31 +63,20 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	const [ selectedHost, setSelectedHost ] = useState( 'generic' );
 	const [ selectedProtocol, setSelectedProtocol ] = useState< 'ftp' | 'ssh' >( 'ftp' );
 	const [ hasLoaded, setHasLoaded ] = useState( false );
-	const [ showUpdatePluginInfo, setShowUpdatePluginInfo ] = useState( false );
 	const [ continueImport, setContinueImport ] = useState( false );
 	const urlQueryParams = useQuery();
 	const sourceSiteSlug = urlQueryParams.get( 'from' ) ?? '';
 	const sourceSiteUrl = formatSlugToURL( sourceSiteSlug );
-
-	const onfetchCallback = ( siteCanMigrate: boolean ) => {
-		if ( ! siteCanMigrate ) {
-			setShowUpdatePluginInfo( true );
-		} else {
-			setShowUpdatePluginInfo( false );
-		}
-	};
 
 	const {
 		sourceSiteId,
 		sourceSite,
 		fetchMigrationEnabledStatus,
 		isFetchingData: isFetchingMigrationData,
-	} = useSiteMigrateInfo(
-		targetSite.ID,
-		sourceSiteSlug,
-		isTargetSitePlanCompatible,
-		onfetchCallback
-	);
+		siteCanMigrate,
+	} = useSiteMigrateInfo( targetSite.ID, sourceSiteSlug, isTargetSitePlanCompatible );
+
+	const showUpdatePluginInfo = ! siteCanMigrate;
 
 	const migrationTrackingProps = {
 		source_site_id: sourceSiteId,

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
@@ -85,6 +85,7 @@ describe( 'PreMigration', () => {
 			sourceSite: sourceSite as SiteDetails,
 			fetchMigrationEnabledStatus: jest.fn(),
 			isFetchingData: false,
+			siteCanMigrate: true,
 		} );
 
 		renderPreMigrationScreen( {
@@ -107,18 +108,12 @@ describe( 'PreMigration', () => {
 	test( 'should show "Move to wordpress.com" plugin update', () => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
-		useSiteMigrateInfo.mockImplementationOnce(
-			( targetSiteId, sourceSiteSlug, fetchMigrationEnabledOnMount, onfetchCallback ) => {
-				onfetchCallback( false );
-
-				return {
-					sourceSiteId: 777712,
-					sourceSite: sourceSite as SiteDetails,
-					fetchMigrationEnabledStatus: jest.fn(),
-					isFetchingData: false,
-				};
-			}
-		);
+		useSiteMigrateInfo.mockImplementationOnce( () => ( {
+			sourceSiteId: 777712,
+			sourceSite: sourceSite as SiteDetails,
+			fetchMigrationEnabledStatus: jest.fn(),
+			isFetchingData: false,
+		} ) );
 
 		renderPreMigrationScreen( {
 			targetSite: targetSite,
@@ -134,18 +129,12 @@ describe( 'PreMigration', () => {
 	test( 'should show "Jetpack" plugin update', () => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
-		useSiteMigrateInfo.mockImplementationOnce(
-			( targetSiteId, sourceSiteSlug, fetchMigrationEnabledOnMount, onfetchCallback ) => {
-				onfetchCallback( false );
-
-				return {
-					sourceSiteId: 777712,
-					sourceSite: sourceSite as SiteDetails,
-					fetchMigrationEnabledStatus: jest.fn(),
-					isFetchingData: false,
-				};
-			}
-		);
+		useSiteMigrateInfo.mockImplementationOnce( () => ( {
+			sourceSiteId: 777712,
+			sourceSite: sourceSite as SiteDetails,
+			fetchMigrationEnabledStatus: jest.fn(),
+			isFetchingData: false,
+		} ) );
 
 		renderPreMigrationScreen( {
 			targetSite: targetSite,
@@ -167,6 +156,7 @@ describe( 'PreMigration', () => {
 			sourceSite: sourceSite as SiteDetails,
 			fetchMigrationEnabledStatus: jest.fn(),
 			isFetchingData: false,
+			siteCanMigrate: true,
 		} );
 
 		renderPreMigrationScreen( {

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
@@ -113,6 +113,7 @@ describe( 'PreMigration', () => {
 			sourceSite: sourceSite as SiteDetails,
 			fetchMigrationEnabledStatus: jest.fn(),
 			isFetchingData: false,
+			siteCanMigrate: false,
 		} ) );
 
 		renderPreMigrationScreen( {
@@ -134,6 +135,7 @@ describe( 'PreMigration', () => {
 			sourceSite: sourceSite as SiteDetails,
 			fetchMigrationEnabledStatus: jest.fn(),
 			isFetchingData: false,
+			siteCanMigrate: false,
 		} ) );
 
 		renderPreMigrationScreen( {

--- a/client/data/site-migration/types.ts
+++ b/client/data/site-migration/types.ts
@@ -4,4 +4,5 @@ export interface MigrationEnabledResponse {
 	jetpack_compatible: boolean;
 	migration_activated: boolean;
 	migration_compatible: boolean;
+	can_migrate: boolean;
 }

--- a/client/data/site-migration/use-migration-enabled.ts
+++ b/client/data/site-migration/use-migration-enabled.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { MigrationEnabledResponse } from './types';
 import type { SiteId, URL } from 'calypso/types';
@@ -13,11 +13,8 @@ import type { SiteId, URL } from 'calypso/types';
 export const useMigrationEnabledInfoQuery = (
 	targetSiteId: SiteId,
 	sourcSite: SiteId | URL,
-	enabled = true,
-	onSuccessCallback?: ( data: MigrationEnabledResponse ) => void,
-	onErrorCallback?: () => void
+	enabled = true
 ) => {
-	const queryClient = useQueryClient();
 	const queryKey = [
 		'migration-enabled',
 		{
@@ -38,11 +35,5 @@ export const useMigrationEnabledInfoQuery = (
 		},
 		enabled: !! ( enabled && targetSiteId && sourcSite ),
 		retry: false,
-		onSuccess: onSuccessCallback,
-		onError: () => {
-			// Clear data on error
-			queryClient.setQueryData( queryKey, null );
-			onErrorCallback && onErrorCallback();
-		},
 	} );
 };

--- a/client/data/site-migration/use-migration-enabled.ts
+++ b/client/data/site-migration/use-migration-enabled.ts
@@ -1,39 +1,47 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
-import { MigrationEnabledResponse } from './types';
+import type { MigrationEnabledResponse } from './types';
 import type { SiteId, URL } from 'calypso/types';
+
 /**
  * Fetches migration enabled information for a specific target site and source site.
  *
  * @param targetSiteId - The ID of the target site.
- * @param sourcSite - The ID or URL of the source site.
+ * @param sourceSite - The ID or URL of the source site.
  * @param enabled - Optional flag to enable/disable the query. Default is true.
  * @returns The migration enabled information query result.
  */
 export const useMigrationEnabledInfoQuery = (
 	targetSiteId: SiteId,
-	sourcSite: SiteId | URL,
+	sourceSite: SiteId | URL,
 	enabled = true
 ) => {
-	const queryKey = [
-		'migration-enabled',
-		{
-			sourcSite,
-			targetSiteId,
-		},
-	];
-
-	return useQuery( {
-		queryKey,
-		queryFn: (): Promise< MigrationEnabledResponse > =>
+	return useQuery< MigrationEnabledResponse >( {
+		queryKey: [
+			'migration-enabled',
+			{
+				sourceSite,
+				targetSiteId,
+			},
+		],
+		queryFn: () =>
 			wpcom.req.get( {
 				apiNamespace: 'wpcom/v2/',
-				path: `sites/${ targetSiteId }/migration-enabled/${ encodeURIComponent( sourcSite ) }`,
+				path: `sites/${ targetSiteId }/migration-enabled/${ encodeURIComponent( sourceSite ) }`,
 			} ),
 		meta: {
 			persist: false,
 		},
-		enabled: !! ( enabled && targetSiteId && sourcSite ),
+		enabled: !! ( enabled && targetSiteId && sourceSite ),
 		retry: false,
+		select( data ) {
+			return {
+				...data,
+				can_migrate: !! (
+					( data.migration_activated && data.migration_compatible ) ||
+					( data.jetpack_activated && data.jetpack_compatible )
+				),
+			};
+		},
 	} );
 };


### PR DESCRIPTION
## Proposed Changes

* Remove `on*` handlers from `useQuery` usage to prepare for the upcoming v5 release of `@tanstack/query`.

## Testing Instructions

* Follow testing instructions from https://github.com/Automattic/wp-calypso/pull/77364

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
