### PR TITLE
Align universal-header-navigation-ui with the rest of the LP page header

### DIFF
--- a/packages/wpcom-template-parts/src/types.ts
+++ b/packages/wpcom-template-parts/src/types.ts
@@ -24,7 +24,7 @@ export interface PureFooterProps extends FooterProps {
 }
 
 export interface MenuItemProps {
-	content: string;
+	content: string | React.ReactNode;
 	className?: string;
 }
 

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -380,13 +380,23 @@ const UniversalNavbarHeader = ( {
 									<ul className="x-menu-grid">
 										<ClickableItem
 											titleValue=""
-											content={ __( 'Sign Up', __i18n_text_domain__ ) }
+											content={
+												<>
+													{ __( 'Sign Up', __i18n_text_domain__ ) }{ ' ' }
+													<span className="x-menu-link-chevron" />
+												</>
+											}
 											urlValue={ startUrl }
 											type="menu"
 										/>
 										<ClickableItem
 											titleValue=""
-											content={ __( 'Log In', __i18n_text_domain__ ) }
+											content={
+												<>
+													{ __( 'Log In', __i18n_text_domain__ ) }{ ' ' }
+													<span className="x-menu-link-chevron" />
+												</>
+											}
 											urlValue={ localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn, true ) }
 											type="menu"
 										/>
@@ -496,8 +506,6 @@ const UniversalNavbarHeader = ( {
 												urlValue={ localizeUrl( '//wordpress.com/features/' ) }
 												type="menu"
 											/>
-										</ul>
-										<ul className="x-menu-grid">
 											<ClickableItem
 												titleValue=""
 												content={ __( 'WordPress Themes', __i18n_text_domain__ ) }

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -98,6 +98,10 @@ $studio-blue-30: #0675c4;
 	padding-top: 10px;
 }
 
+.x-icon__menu span + span {
+	margin-top: 4px;
+}
+
 .x-icon,
 .x-icon span {
 	color: inherit;
@@ -119,7 +123,6 @@ $studio-blue-30: #0675c4;
 	height: 2px;
 	background: currentcolor;
 	color: inherit;
-	margin-bottom: 6px;
 }
 
 /**
@@ -130,7 +133,7 @@ $lp-content-width-center-minus: 480px;
 $lp-content-width-center: 576px;
 $lp-content-width-center-plus: 672px;
 $lp-content-width-wide-minus: 960px;
-$lp-content-width-wide: 1056px;
+$lp-content-width-wide: 1152px;
 
 /**
  * Responsive web design
@@ -170,7 +173,7 @@ $x-nav-breakpoint-small: $lp-breakpoint-S;
 
 $x-nav-padding-top: 9px;
 $x-nav-padding-x-narrow: 18px;
-$x-nav-padding-x-wide: 10px;
+$x-nav-padding-x-wide: 24px;
 
 $x-nav-item-padding-x-narrow: 9px;
 $x-nav-item-padding-x-wide: 12px;
@@ -205,10 +208,10 @@ $x-nav-height: $x-nav-padding-top + $x-nav-item-height + $x-nav-item-padding-x-w
 	color: $studio-blue-90;
 
 	.cta-btn-nav {
-		padding: 10px 24px 10px 24px !important;
 		border-radius: 4px;
 		background: $studio-blue-30 !important;
-		margin: 11px 14px 0 8px;
+		margin: 11px 18px 0 9px;
+		padding: 8px 9px !important;
 		text-decoration: none !important;
 	}
 }
@@ -244,7 +247,7 @@ button.x-nav-link.x-link {
 
 	&.x-nav-link { /* 2 */
 		border: none;
-		background: none;
+		background: 0 0;
 		box-shadow: none;
 		overflow: unset;
 	}
@@ -454,7 +457,7 @@ $x-dropdown-item-line-height: 19px;
 	opacity: 0;
 	left: -60px;
 	background: #fff;
-	border-radius: 4px;
+	border-radius: 9px; /* stylelint-disable-line scales/radii */
 	box-shadow: 0 9px 48px rgb(16 21 23 / 25%);
 	width: 210px;
 	pointer-events: none;
@@ -543,7 +546,7 @@ $x-menu-width-narrow: 408px;
 $x-menu-width-wide: 480px;
 
 $x-menu-outer-offset: 12px;
-$x-menu-border-radius: 4px;
+$x-menu-border-radius: 9px; /* stylelint-disable-line scales/radii */
 
 $x-menu-item-font-size-narrow: 13px;
 $x-menu-item-font-size-wide: 14px;
@@ -745,6 +748,13 @@ $x-menu-heading-line-height-wide: $x-menu-heading-font-size-wide + 7px; /* 1 */
 }
 
 @media ( min-width: $x-nav-breakpoint-wide ) {
+	.x-nav-item {
+		.cta-btn-nav {
+			padding: 8px 12px !important;
+			margin: 11px 24px 0 12px;
+		}
+	}
+
 	.x-nav-link:not(.x-nav-link__logo):not(.x-nav-link__menu) {
 		padding-right: $x-nav-item-padding-x-wide;
 		padding-left: $x-nav-item-padding-x-wide;


### PR DESCRIPTION
## Proposed Changes

As discussed in p1692214789060709-slack-C9EJ7KSGH, currently the page header of `/themes` and `/plugins` are not aligned with other logged-out pages, such as https://wordpress.com/. This is because only the page header of `/themes` and `/plugins` are implemented in Calypso. This PR updates the package `universal-header-navigation-ui` so that it's more aligned with other logged-out pages.

| wordpress.com | wordpress.com/themes (before) | wordpress.com/themes (after) |
| --- | --- | --- |
| ![Screenshot 2023-08-23 at 5 38 15 PM](https://github.com/Automattic/wp-calypso/assets/797888/18b32296-1193-4ec9-b9d4-5cafbe93d3e1)| ![Screenshot 2023-08-23 at 5 38 54 PM](https://github.com/Automattic/wp-calypso/assets/797888/35d6a248-a486-432b-8fef-8adb6a4c3cbe) | ![Screenshot 2023-08-23 at 5 38 38 PM](https://github.com/Automattic/wp-calypso/assets/797888/9e5572db-71a1-4296-a6ab-ac207bbaf4a1) | 
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/themes` and `/plugins` while logged out.
* Compare them to other logged-out pages, such as https://wordpress.com/, and ensure that they are visually aligned.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
