### PR TITLE
Hosting Metrics: Refactor HTML structure and use pretty links

### DIFF
--- a/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/index.tsx
@@ -36,12 +36,15 @@ export const SiteMonitoringTabPanel = ( {
 							key={ name }
 							path={
 								name === 'metrics'
-									? `/site-monitoring/${ siteSlug }`
-									: `/site-monitoring/${ siteSlug }/${ name }`
+									? `/site-monitoring/${ siteSlug }${ new URL( window.location.href ).search }`
+									: `/site-monitoring/${ siteSlug }/${ name }${
+											new URL( window.location.href ).search
+									  }`
 							}
 							selected={ selectedTab === name }
-							children={ title }
-						/>
+						>
+							{ title }
+						</NavItem>
 					);
 				} ) }
 			</NavTabs>

--- a/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/index.tsx
@@ -1,7 +1,10 @@
-import { TabPanel } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-import { updatePageQueryParam } from '../../site-monitoring-filter-params';
+import { useSelector } from 'react-redux';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import type { SiteMonitoringTab } from '../../site-monitoring-filter-params';
 import './style.scss';
 
@@ -12,29 +15,32 @@ export const tabs = [
 ];
 
 interface SiteMonitoringTabPanelProps {
-	children: React.ComponentProps< typeof TabPanel >[ 'children' ];
 	selectedTab?: SiteMonitoringTab;
 	className?: string;
-	onSelected?: ( tabName: SiteMonitoringTab ) => void;
 }
 
 export const SiteMonitoringTabPanel = ( {
-	children: renderContents,
 	selectedTab = 'metrics',
 	className,
-	onSelected,
 }: SiteMonitoringTabPanelProps ) => {
+	const siteSlug = useSelector( getSelectedSiteSlug ) as string;
 	return (
-		<TabPanel
-			initialTabName={ selectedTab }
+		<SectionNav
+			selectedText={ selectedTab }
 			className={ classnames( 'site-monitoring-tab-panel', className ) }
-			tabs={ tabs }
-			onSelect={ ( tabName ) => {
-				updatePageQueryParam( tabName as SiteMonitoringTab );
-				onSelected?.( tabName as SiteMonitoringTab );
-			} }
 		>
-			{ ( tab ) => renderContents( tab ) }
-		</TabPanel>
+			<NavTabs>
+				{ tabs.map( ( { name, title } ) => {
+					return (
+						<NavItem
+							key={ name }
+							path={ `/site-monitoring/${ siteSlug }/${ name }` }
+							selected={ selectedTab === name }
+							children={ title }
+						/>
+					);
+				} ) }
+			</NavTabs>
+		</SectionNav>
 	);
 };

--- a/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/index.tsx
@@ -34,7 +34,11 @@ export const SiteMonitoringTabPanel = ( {
 					return (
 						<NavItem
 							key={ name }
-							path={ `/site-monitoring/${ siteSlug }/${ name }` }
+							path={
+								name === 'metrics'
+									? `/site-monitoring/${ siteSlug }`
+									: `/site-monitoring/${ siteSlug }/${ name }`
+							}
 							selected={ selectedTab === name }
 							children={ title }
 						/>

--- a/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/style.scss
+++ b/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/style.scss
@@ -1,46 +1,61 @@
-.site-monitoring-tab-panel {
-	margin-left: 16px;
-	margin-right: 16px;
+@use "sass:math";
 
-	@include breakpoint-deprecated( ">660px" ) {
-		margin-left: 0;
-		margin-right: 0;
+$section-max-width: 1224px;
+
+.is-section-site-monitoring {
+	& .section-nav {
+		box-shadow: rgba(0, 0, 0, 0.05) 0 -1px 0 inset;
+		margin-bottom: 32px;
+		padding: 0 max(calc(50% - #{math.div( $section-max-width, 2 )}), 32px);
 	}
 
-	.components-tab-panel__tabs {
-		margin-bottom: 32px;
-
-		position: relative;
-
-		&::before {
-			content: "";
-			position: absolute;
-			background-color: var(--studio-white);
-			top: -50px;
-			left: -1000px;
-			right: -1000px;
-			bottom: 0;
-			z-index: -1;
-			box-shadow: inset 0 -1px 0 #eee;
+	& .section-nav.is-open {
+		@media ( max-width: 481px ) {
+			box-shadow: rgba(0, 0, 0, 0.05) 0 -1px 0 inset;
 		}
 	}
 
-	.components-tab-panel__tabs-item {
+	& .section-nav-tab {
 		--wp-admin-theme-color: var(--studio-gray-100);
-		color: var(--color-neutral-60);
-		margin-right: 16px;
-		font-size: rem(14px);
-		line-height: 20px;
-		flex-shrink: 0;
+		font-size: 0.875rem;
 		font-weight: 400;
-		padding: 8px 12px;
+		border: 0;
+		&.is-selected .section-nav-tab__link {
+			box-shadow: inset 0 -2px 0 0 var(--wp-admin-theme-color);
+			color: var(--studio-gray-100);
+			@media ( max-width: 481px ) {
+				background-color: var(--color-primary);
+				color: var(--color-text-inverted);
+			}
+		}
 	}
 
-	.components-tab-panel__tabs-item:hover,
-	.components-tab-panel__tabs-item.is-active,
-	.components-tab-panel__tabs-item.is-active:focus,
-	.components-tab-panel__tabs-item:focus:not(:disabled) {
-		box-shadow: inset 0 -2px 0 0 var(--wp-admin-theme-color);
+	& .section-nav__mobile-header-text {
+		width: 100%;
+	}
+
+	& .section-nav-tab__link {
+		color: var(--color-neutral-60);
+		flex-shrink: 0;
+		padding: 8px 12px;
+		font-size: rem(14px);
+		line-height: 32px;
+		margin-right: 16px;
+	}
+
+	& .section-nav-tab__text {
+		height: 48px;
+		line-height: 20px;
+		position: relative;
+		@media ( max-width: 481px ) {
+			height: initial;
+			line-height: 20px;
+		}
+	}
+	& .section-nav-tab__link:hover {
 		color: var(--studio-gray-100);
+		background-color: var(--color-surface);
+		box-shadow: inset 0 -2px 0 0 var(--wp-admin-theme-color);
+		border: 0;
 	}
 }

--- a/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/style.scss
+++ b/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/style.scss
@@ -22,7 +22,7 @@ $section-max-width: 1224px;
 		border: 0;
 		&.is-selected .section-nav-tab__link {
 			box-shadow: inset 0 -2px 0 0 var(--wp-admin-theme-color);
-			color: var(--studio-gray-100);
+			color: var(--color-neutral-100);
 			@media ( max-width: 481px ) {
 				background-color: var(--color-primary);
 				color: var(--color-text-inverted);
@@ -52,10 +52,12 @@ $section-max-width: 1224px;
 			line-height: 20px;
 		}
 	}
-	& .section-nav-tab__link:hover {
-		color: var(--studio-gray-100);
+
+	& .notouch .section-nav-tab__link:hover,
+	.section-nav-tab__link:hover {
+		color: var(--color-neutral-60);
 		background-color: var(--color-surface);
-		box-shadow: inset 0 -2px 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 -2px 0 0 var(--color-primary-0);
 		border: 0;
 	}
 }

--- a/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/style.scss
+++ b/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/style.scss
@@ -2,6 +2,13 @@
 
 $section-max-width: 1224px;
 
+.notouch .is-section-site-monitoring .section-nav-tab__link:hover {
+	color: var(--color-neutral-60);
+	background-color: var(--color-surface);
+	box-shadow: inset 0 -2px 0 0 var(--color-primary-0);
+	border: 0;
+}
+
 .is-section-site-monitoring {
 	& .section-nav {
 		box-shadow: rgba(0, 0, 0, 0.05) 0 -1px 0 inset;
@@ -53,7 +60,6 @@ $section-max-width: 1224px;
 		}
 	}
 
-	& .notouch .section-nav-tab__link:hover,
 	.section-nav-tab__link:hover {
 		color: var(--color-neutral-60);
 		background-color: var(--color-surface);

--- a/client/my-sites/site-monitoring/controller.tsx
+++ b/client/my-sites/site-monitoring/controller.tsx
@@ -9,7 +9,7 @@ export const siteMetrics: PageJS.Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker path="/site-monitoring/:site" title="Site Monitoring" delay={ 500 } />
-			<SiteMetrics />
+			<SiteMetrics tab={ context.params.tab } />
 		</>
 	);
 	next();

--- a/client/my-sites/site-monitoring/index.ts
+++ b/client/my-sites/site-monitoring/index.ts
@@ -7,7 +7,7 @@ export default function () {
 	page( '/site-monitoring', siteSelection, sites, makeLayout, clientRender );
 
 	page(
-		'/site-monitoring/:siteId/:tab(php|web|metrics)?',
+		'/site-monitoring/:siteId/:tab(php|web|null)?',
 		siteSelection,
 		redirectHomeIfIneligible,
 		navigation,

--- a/client/my-sites/site-monitoring/index.ts
+++ b/client/my-sites/site-monitoring/index.ts
@@ -7,7 +7,7 @@ export default function () {
 	page( '/site-monitoring', siteSelection, sites, makeLayout, clientRender );
 
 	page(
-		'/site-monitoring/:siteId',
+		'/site-monitoring/:siteId/:tab(php|web|metrics)?',
 		siteSelection,
 		redirectHomeIfIneligible,
 		navigation,

--- a/client/my-sites/site-monitoring/index.ts
+++ b/client/my-sites/site-monitoring/index.ts
@@ -7,7 +7,7 @@ export default function () {
 	page( '/site-monitoring', siteSelection, sites, makeLayout, clientRender );
 
 	page(
-		'/site-monitoring/:siteId/:tab(php|web|null)?',
+		'/site-monitoring/:siteId/:tab(php|web)?',
 		siteSelection,
 		redirectHomeIfIneligible,
 		navigation,

--- a/client/my-sites/site-monitoring/logs-tab.tsx
+++ b/client/my-sites/site-monitoring/logs-tab.tsx
@@ -116,7 +116,7 @@ export const LogsTab = ( {
 	};
 
 	return (
-		<div class="site-logs-container">
+		<div className="site-logs-container">
 			<SiteLogsToolbar
 				logType={ logType }
 				startDateTime={ dateRange.startTime }

--- a/client/my-sites/site-monitoring/logs-tab.tsx
+++ b/client/my-sites/site-monitoring/logs-tab.tsx
@@ -116,7 +116,7 @@ export const LogsTab = ( {
 	};
 
 	return (
-		<>
+		<div class="site-logs-container">
 			<SiteLogsToolbar
 				logType={ logType }
 				startDateTime={ dateRange.startTime }
@@ -144,6 +144,6 @@ export const LogsTab = ( {
 					/>
 				</div>
 			) }
-		</>
+		</div>
 	);
 };

--- a/client/my-sites/site-monitoring/main.tsx
+++ b/client/my-sites/site-monitoring/main.tsx
@@ -1,6 +1,5 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { translate } from 'i18n-calypso';
-import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -9,18 +8,13 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { SiteMonitoringTabPanel } from './components/site-monitoring-tab-panel';
 import { LogsTab } from './logs-tab';
 import { MetricsTab } from './metrics-tab';
-import { SiteMonitoringTab, getPageQueryParam } from './site-monitoring-filter-params';
+import { SiteMonitoringTab } from './site-monitoring-filter-params';
 
 import './style.scss';
 
-export function SiteMetrics() {
+export function SiteMetrics( { tab = 'metrics' }: { tab: SiteMonitoringTab } ) {
 	const { __ } = useI18n();
 	const titleHeader = __( 'Site Monitoring' );
-	const [ page, setPage ] = useState< SiteMonitoringTab >( () => getPageQueryParam() || 'metrics' );
-
-	const handleTabSelected = ( tabName: SiteMonitoringTab ) => {
-		setPage( tabName );
-	};
 
 	return (
 		<Main className="site-monitoring" fullWidthLayout>
@@ -45,14 +39,11 @@ export function SiteMetrics() {
 					}
 				) }
 			></FormattedHeader>
-			<SiteMonitoringTabPanel selectedTab={ page } onSelected={ handleTabSelected }>
-				{ () => (
-					<>
-						{ page === 'metrics' && <MetricsTab /> }
-						{ page !== 'metrics' && <LogsTab logType={ page } /> }
-					</>
-				) }
-			</SiteMonitoringTabPanel>
+			<SiteMonitoringTabPanel selectedTab={ tab }></SiteMonitoringTabPanel>
+			<div>
+				{ tab === 'metrics' && <MetricsTab /> }
+				{ tab !== 'metrics' && <LogsTab logType={ tab } /> }
+			</div>
 		</Main>
 	);
 }

--- a/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
+++ b/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
@@ -10,16 +10,6 @@ export function getPageQueryParam(): SiteMonitoringTab | null {
 		: null;
 }
 
-export function updatePageQueryParam( tabName: SiteMonitoringTab ) {
-	const url = new URL( window.location.href );
-	if ( tabName === 'metrics' ) {
-		url.searchParams.delete( 'page' );
-	} else {
-		url.searchParams.set( 'page', tabName );
-	}
-	page.replace( url.pathname + url.search );
-}
-
 export function getDateRangeQueryParam( moment: typeof import('moment') ): {
 	startTime: Moment | null;
 	endTime: Moment | null;

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -1,12 +1,36 @@
+@use "sass:math";
 @import "uplot/dist/uPlot.min.css";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+$section-max-width: 1224px;
+
 .is-section-site-monitoring.theme-default {
 	background-color: var(--studio-white);
 	.focus-content:not(.has-no-sidebar) .layout__content {
-		@media screen and (max-width: 782px) {
+		@media screen and ( max-width: 782px ) {
 			padding-top: 71px;
+		}
+	}
+}
+
+.is-section-site-monitoring {
+	// this overrides the default .layout__content that adds unwanted padding
+	& .layout__content,
+	&.theme-default .focus-content .layout__content {
+		padding: 0;
+		padding-block-start: 79px;
+
+		@media ( min-width: 782px ) {
+			padding-inline-start: calc(var(--sidebar-width-max) + 1px);
+		}
+	}
+	& .site-logs-container {
+		padding: 0 max(calc(50% - #{math.div( $section-max-width, 2 )}), 32px);
+		@media screen and ( max-width: 782px ) {
+			padding: 0;
+			margin-left: 16px;
+			margin-right: 16px;
 		}
 	}
 }
@@ -32,25 +56,25 @@
 	}
 }
 
-.site-monitoring__formatted-header.formatted-header.modernized-header.is-left-align,
 .site-monitoring .components-tab-panel__tab-content,
 .site-monitoring .components-tab-panel__tabs {
+	margin-left: 16px;
+	margin-right: 16px;
 	max-width: 1224px;
-	margin-left: auto;
-	margin-right: auto;
 }
 
 .site-monitoring__formatted-header.formatted-header.modernized-header.is-left-align {
 	padding-bottom: 24px;
-	margin-left: 16px;
-	margin-right: 16px;
-	@include break-medium {
-		margin-left: 0;
-		margin-right: 0;
+	margin-left: 32px;
+	margin-right: 32px;
+	@media screen and ( max-width: 782px ) {
+		margin-left: 16px;
+		margin-right: 16px;
 	}
 }
 
 .site-monitoring-metrics-tab {
+	padding: 0 max(calc(50% - #{math.div( $section-max-width, 2 )}), 32px);
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
@@ -126,7 +150,6 @@
 	.pie-chart__chart-section-cache-miss,
 	.pie-chart__legend-sample-cache-miss {
 		fill: #bae0f9;
-
 	}
 	.pie-chart__chart-section-cache-hit,
 	.pie-chart__legend-sample-cache-hit {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3498

## Proposed Changes

This PR introduces refactoring on the current code, removing unwanted CSS rules, and making the URLs used in the hosting-metrics section more user-friendly.

## Testing Instructions

1. Make sure that the page looks the same as before
2. Ensure that the URLs are not having `?page=<tab>` parameter anymore, but using the `site-monitoring/<site>/<tab>` format instead

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
