### PR TITLE
Updating copy on domains page (not incl checkout)

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -1,3 +1,4 @@
+import { PLAN_100_YEARS } from '@automattic/calypso-products';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -5,6 +6,8 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -17,6 +20,7 @@ class DomainProductPrice extends Component {
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
 		isMappingProduct: PropTypes.bool,
 		salePrice: PropTypes.string,
+		isCurrentPlan100YearPlan: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -58,7 +62,7 @@ class DomainProductPrice extends Component {
 	}
 
 	renderReskinFreeWithPlanText() {
-		const { isMappingProduct, translate } = this.props;
+		const { isMappingProduct, translate, isCurrentPlan100YearPlan } = this.props;
 
 		const domainPriceElement = ( message ) => (
 			<div className="domain-product-price__free-text">{ message }</div>
@@ -66,6 +70,10 @@ class DomainProductPrice extends Component {
 
 		if ( isMappingProduct ) {
 			return domainPriceElement( translate( 'Included in paid plans' ) );
+		}
+
+		if ( isCurrentPlan100YearPlan ) {
+			return domainPriceElement( translate( 'Free with your plan' ) );
 		}
 
 		const message = translate( '{{span}}Free for the first year with annual paid plans{{/span}}', {
@@ -206,4 +214,6 @@ export default connect( ( state ) => ( {
 	domainsWithPlansOnly: getCurrentUser( state )
 		? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
 		: true,
+	isCurrentPlan100YearPlan:
+		getSitePlanSlug( state, getSelectedSiteId( state ) ) === PLAN_100_YEARS ?? false,
 } ) )( localize( DomainProductPrice ) );

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -214,6 +214,5 @@ export default connect( ( state ) => ( {
 	domainsWithPlansOnly: getCurrentUser( state )
 		? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
 		: true,
-	isCurrentPlan100YearPlan:
-		getSitePlanSlug( state, getSelectedSiteId( state ) ) === PLAN_100_YEARS ?? false,
+	isCurrentPlan100YearPlan: getSitePlanSlug( state, getSelectedSiteId( state ) ) === PLAN_100_YEARS,
 } ) )( localize( DomainProductPrice ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/Martech#2093 cc: @dzver 

## Proposed Changes

* For the hundred year plan, the text on the domain search is misleading. This will make it clear what's included.

Before:
<img width="1076" alt="262667637-946a2c27-b3a1-4d86-96fc-5273d243487a" src="https://github.com/Automattic/wp-calypso/assets/52675688/dc31f1ed-5b4c-484d-afde-728f6cd3a27a">


After:
![Screenshot 2023-08-23 at 14 45 49](https://github.com/Automattic/wp-calypso/assets/52675688/c819a785-c7c1-4d48-a89e-3e83fc80b522)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a site with a hundred year plan, go to the domains page  `http://calypso.localhost:3000/domains/add/:site`
* Search for a domain, and confirm that the text on what's included is updated (ref screenshots above)
* Make sure that there's no regressions for other plans.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
