### PR TITLE
Fix styles in reader post card actions - reblog and comments buttons.

### DIFF
--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -5,6 +5,7 @@
 	cursor: pointer;
 	display: flex;
 	height: 20px;
+	gap: 4px;
 
 	// highlight button
 	&:hover,

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -127,7 +127,12 @@ class ReaderShare extends Component {
 						} )
 					) : (
 						<>
-							<Gridicon icon="reblog" size={ this.props.iconSize } title={ reblogTitle } />
+							<Gridicon
+								icon="reblog"
+								size={ this.props.iconSize }
+								title={ reblogTitle }
+								style={ { height: this.props.iconSize, width: this.props.iconSize } }
+							/>
 							{ this.props.showReblogLabel && (
 								<span className="reader-share__reblog-label" title={ reblogTitle }>
 									{ translate( 'Reblog' ) }


### PR DESCRIPTION
… fix overwriting styles

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-17X-p2

## Proposed Changes

* Fixes the space on the comment button - adds style `gap: "4px"` similar to as we do for the likes button.
* Fixes the Reblog icon - Passes the `iconSize` prop into the reblog icon via the inline `style` attribute.  Currently, we are only passing it as `size` which sets `height` and `width` in the svg directly. But these are not inline styles and are overwritten by stylesheet rules. There are 2 general stylesheet rules for gridicon buttons that overwrite the height and width on the reblog icon this way. Using the `style` attribute ensures the elements inline styles are used for these attributes and that the proper `iconSize` is rendered.

<img width="253" alt="Screenshot 2023-08-23 at 11 10 30 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/0631874b-ce34-4ada-9753-42195f5594fa">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* visit the reader and ensure the reblog icon is 20x20 like the surrounding icons.
* verify the space between the comment icon and count mirrors that of the likes icon and count.




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p

2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
