### PR TITLE
Mailing Lists: Remove category for Jetpack agency onboarding notifications

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -114,8 +114,6 @@ class MainComponent extends Component {
 			return this.props.translate( 'Jetpack Newsletter' );
 		} else if ( 'jetpack_reports' === category ) {
 			return this.props.translate( 'Jetpack Reports' );
-		} else if ( 'jetpack_agencies_pro_onboarding' === category ) {
-			return this.props.translate( 'Jetpack Agencies Pro Onboarding' );
 		} else if ( 'akismet_marketing' === category ) {
 			return this.props.translate( 'Akismet Marketing' );
 		} else if ( 'woopay_marketing' === category ) {
@@ -161,8 +159,6 @@ class MainComponent extends Component {
 			return this.props.translate( 'Jetpack news, announcements, and product spotlights.' );
 		} else if ( 'jetpack_reports' === category ) {
 			return this.props.translate( 'Jetpack security and performance reports.' );
-		} else if ( 'jetpack_agencies_pro_onboarding' === category ) {
-			return this.props.translate( 'Jetpack Agency & Pro program setup and onboarding.' );
 		} else if ( 'akismet_marketing' === category ) {
 			return this.props.translate(
 				'Relevant tips and new features to get the most out of Akismet'


### PR DESCRIPTION
This change removes Calypso (UI) support for the mailing list category 'Jetpack Agencies Pro Onboarding' used for Jetpack agency onboarding notifications.

## Testing Instructions

The backend work on removing the mailing list category for Jetpack Agency Pro Onboarding has been completed via D116519.

- Visit [this unsubscribe URL](http://calypso.localhost:3000/mailing-lists/unsubscribe?category=jetpack_agency_pro_onboarding&email=codepoet%40gmail.com&hmac=881715be29d92ad76d1cd4f1d9bd8756). Confirm that the category name is no longer prettify and the description no longer appears.

![CleanShot 2023-08-23 at 12 40 59@2x](https://github.com/Automattic/wp-calypso/assets/135139690/3414aad4-e86b-4420-a635-da51b71e6969)
