### PR TITLE
line clamp comment content in collapsed mode

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -541,6 +541,8 @@ class PostCommentList extends Component {
 			<div
 				className={ classnames( 'comments__comment-list', {
 					'has-double-actions': showManageCommentsButton && showConversationFollowButton,
+					'is-inline': expandableView,
+					'is-collapsed': isCollapsedInline,
 				} ) }
 			>
 				{ ( this.props.showCommentCount || showViewMoreComments ) && (

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -226,6 +226,9 @@ class PostCommentList extends Component {
 				commentText={ this.state.commentText }
 				onUpdateCommentText={ this.onUpdateCommentText }
 				onCommentSubmit={ this.resetActiveReplyComment }
+				onCommentClick={
+					this.props.expandableView && ! this.state.isExpanded && this.toggleExpanded
+				}
 				depth={ 0 }
 				maxDepth={ this.props.maxDepth }
 				showNestingReplyArrow={ this.props.showNestingReplyArrow }

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -40,6 +40,13 @@
 			}
 		}
 	}
+
+	&.is-inline.is-collapsed .comments__comment-content {
+		display: -webkit-box;
+		overflow: hidden;
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: 2;
+	}
 }
 
 .comments__info-bar {

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -394,11 +394,12 @@ class PostComment extends PureComponent {
 		const postCommentClassnames = classnames( 'comments__comment', {
 			[ 'depth-' + depth ]: depth <= maxDepth && depth <= 3, // only indent up to 3
 			'is-highlighted': isHighlighted,
+			'is-clickable': this.props.onCommentClick,
 		} );
 
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		return (
-			<li className={ postCommentClassnames }>
+			<li className={ postCommentClassnames } onClick={ this.props.onCommentClick }>
 				<div className="comments__comment-author">
 					{ commentAuthorUrl ? (
 						<a href={ commentAuthorUrl } onClick={ this.handleAuthorClick }>

--- a/client/blocks/comments/post-comment.scss
+++ b/client/blocks/comments/post-comment.scss
@@ -3,6 +3,10 @@
 	margin-top: 20px;
 	position: relative;
 
+	&.is-clickable {
+		cursor: pointer;
+	}
+
 	&.depth-0,
 	&.depth-1,
 	&.depth-2 {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Line-clamps inline comments in collapsed mode similar to how we do for post content on compact reader cards.
* Explores the idea of making the collapsed comment always clickable to expand the comments section. While this seems jumpy currently as a way to see more of a line-clamped comment, it may feel much better once we re-order comments with the newest at the top as is in our planned CANI project. 
** Note - I have explored this route since line-clamped comments need a way to be expanded, and the 'view more comments' link isn't and shouldn't be there when there is only 1 comment. Similarly, there doesn't seem to be a good way in JS to tell if our CSS rules are actually line-clamping a comment to do anything conditional from that end. Adding a click behavior to the collapsed inline comments section in general seems like a good work around and a good experience once comments are reordered.

There would still be some cleaning up to do for a11y, interactions with other links in here, etc. But I wanted to share early to see if this is the path we should explore.

![comments-changes](https://github.com/Automattic/wp-calypso/assets/28742426/9147be08-eb06-40e7-963c-a12d9dad0eb1)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
