### PR TITLE
Checkout: Simplify code for rendering line item sublabel

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -81,7 +81,6 @@ export function WPOrderReviewLineItems( {
 	const isDisabled = formStatus !== FormStatus.READY;
 	const hasPartnerCoupon = getPartnerCoupon( {
 		coupon: responseCart.coupon,
-		products: responseCart.products,
 	} );
 
 	const [ initialProducts ] = useState( () => responseCart.products );

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -24,34 +24,32 @@ export function DefaultLineItemSublabel( { product }: { product: ResponseCartPro
 
 	if ( isDotComPlan( product ) ) {
 		if ( isRenewalItem ) {
-			return String( translate( 'Plan Renewal' ) );
+			return translate( 'Plan Renewal' );
 		}
 	}
 
 	if ( isPlan( product ) || isJetpackProductSlug( productSlug ) ) {
 		if ( isP2Plus( product ) ) {
-			return String( translate( 'Monthly subscription' ) );
+			return translate( 'Monthly subscription' );
 		}
 
-		return isRenewalItem
-			? String( translate( 'Plan Renewal' ) )
-			: String( translate( 'Plan Subscription' ) );
+		return isRenewalItem ? translate( 'Plan Renewal' ) : translate( 'Plan Subscription' );
 	}
 
 	if ( isGoogleWorkspace( product ) || isGSuiteOrExtraLicenseProductSlug( productSlug ) ) {
 		if ( isRenewalItem ) {
-			return String( translate( 'Mailboxes and Productivity Tools Renewal' ) );
+			return translate( 'Mailboxes and Productivity Tools Renewal' );
 		}
 
-		return String( translate( 'Mailboxes and Productivity Tools' ) );
+		return translate( 'Mailboxes and Productivity Tools' );
 	}
 
 	if ( isTitanMail( product ) ) {
 		if ( isRenewalItem ) {
-			return String( translate( 'Mailboxes Renewal' ) );
+			return translate( 'Mailboxes Renewal' );
 		}
 
-		return String( translate( 'Mailboxes' ) );
+		return translate( 'Mailboxes' );
 	}
 
 	if ( meta && ( isDomainProduct( product ) || isDomainTransfer( product ) ) ) {
@@ -60,32 +58,32 @@ export function DefaultLineItemSublabel( { product }: { product: ResponseCartPro
 		}
 
 		if ( productName ) {
-			return String( translate( '%(productName)s Renewal', { args: { productName } } ) );
+			return translate( '%(productName)s Renewal', { args: { productName } } );
 		}
 	}
 
 	if ( isAddOn( product ) && ! isRenewalItem ) {
-		return String( translate( 'Add-On' ) );
+		return translate( 'Add-On' );
 	}
 
 	if ( isRenewalItem ) {
-		return String( translate( 'Renewal' ) );
+		return translate( 'Renewal' );
 	}
 
 	if ( isMonthlyProduct( product ) ) {
-		return String( translate( 'Billed monthly' ) );
+		return translate( 'Billed monthly' );
 	}
 
 	if ( isYearly( product ) ) {
-		return String( translate( 'Billed annually' ) );
+		return translate( 'Billed annually' );
 	}
 
 	if ( isBiennially( product ) ) {
-		return String( translate( 'Billed every two years' ) );
+		return translate( 'Billed every two years' );
 	}
 
 	if ( isTriennially( product ) ) {
-		return String( translate( 'Billed every three years' ) );
+		return translate( 'Billed every three years' );
 	}
 
 	return null;

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -18,18 +18,18 @@ import { translate } from 'i18n-calypso';
 import { isWpComProductRenewal as isRenewal } from './is-wpcom-product-renewal';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
-export function getSublabel( serverCartItem: ResponseCartProduct ): string {
-	const isRenewalItem = isRenewal( serverCartItem );
-	const { meta, product_name: productName, product_slug: productSlug } = serverCartItem;
+export function DefaultLineItemSublabel( { product }: { product: ResponseCartProduct } ) {
+	const isRenewalItem = isRenewal( product );
+	const { meta, product_name: productName, product_slug: productSlug } = product;
 
-	if ( isDotComPlan( serverCartItem ) ) {
+	if ( isDotComPlan( product ) ) {
 		if ( isRenewalItem ) {
 			return String( translate( 'Plan Renewal' ) );
 		}
 	}
 
-	if ( isPlan( serverCartItem ) || isJetpackProductSlug( productSlug ) ) {
-		if ( isP2Plus( serverCartItem ) ) {
+	if ( isPlan( product ) || isJetpackProductSlug( productSlug ) ) {
+		if ( isP2Plus( product ) ) {
 			return String( translate( 'Monthly subscription' ) );
 		}
 
@@ -38,7 +38,7 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 			: String( translate( 'Plan Subscription' ) );
 	}
 
-	if ( isGoogleWorkspace( serverCartItem ) || isGSuiteOrExtraLicenseProductSlug( productSlug ) ) {
+	if ( isGoogleWorkspace( product ) || isGSuiteOrExtraLicenseProductSlug( productSlug ) ) {
 		if ( isRenewalItem ) {
 			return String( translate( 'Mailboxes and Productivity Tools Renewal' ) );
 		}
@@ -46,7 +46,7 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 		return String( translate( 'Mailboxes and Productivity Tools' ) );
 	}
 
-	if ( isTitanMail( serverCartItem ) ) {
+	if ( isTitanMail( product ) ) {
 		if ( isRenewalItem ) {
 			return String( translate( 'Mailboxes Renewal' ) );
 		}
@@ -54,7 +54,7 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 		return String( translate( 'Mailboxes' ) );
 	}
 
-	if ( meta && ( isDomainProduct( serverCartItem ) || isDomainTransfer( serverCartItem ) ) ) {
+	if ( meta && ( isDomainProduct( product ) || isDomainTransfer( product ) ) ) {
 		if ( ! isRenewalItem ) {
 			return productName || '';
 		}
@@ -64,7 +64,7 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 		}
 	}
 
-	if ( isAddOn( serverCartItem ) && ! isRenewalItem ) {
+	if ( isAddOn( product ) && ! isRenewalItem ) {
 		return String( translate( 'Add-On' ) );
 	}
 
@@ -72,31 +72,28 @@ export function getSublabel( serverCartItem: ResponseCartProduct ): string {
 		return String( translate( 'Renewal' ) );
 	}
 
-	if ( isMonthlyProduct( serverCartItem ) ) {
+	if ( isMonthlyProduct( product ) ) {
 		return String( translate( 'Billed monthly' ) );
 	}
 
-	if ( isYearly( serverCartItem ) ) {
+	if ( isYearly( product ) ) {
 		return String( translate( 'Billed annually' ) );
 	}
 
-	if ( isBiennially( serverCartItem ) ) {
+	if ( isBiennially( product ) ) {
 		return String( translate( 'Billed every two years' ) );
 	}
 
-	if ( isTriennially( serverCartItem ) ) {
+	if ( isTriennially( product ) ) {
 		return String( translate( 'Billed every three years' ) );
 	}
 
-	return '';
+	return null;
 }
 
-export function getLabel( serverCartItem: ResponseCartProduct ): string {
-	if (
-		serverCartItem.meta &&
-		( isDomainProduct( serverCartItem ) || isDomainTransfer( serverCartItem ) )
-	) {
-		return serverCartItem.meta;
+export function getLabel( product: ResponseCartProduct ): string {
+	if ( product.meta && ( isDomainProduct( product ) || isDomainTransfer( product ) ) ) {
+		return product.meta;
 	}
-	return serverCartItem.product_name || '';
+	return product.product_name || '';
 }

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -620,18 +620,18 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		);
 	}
 
-	if ( isPlan( product ) || isAddOn( product ) || isJetpackProductSlug( productSlug ) ) {
-		if ( isTieredVolumeSpaceAddon( product ) ) {
-			const spaceQuantity = product?.quantity ?? 1;
-			return (
-				<>
-					{ translate( '%(quantity)s GB extra space, %(price)s per year', {
-						args: { quantity: spaceQuantity, price },
-					} ) }
-				</>
-			);
-		}
+	if ( isTieredVolumeSpaceAddon( product ) ) {
+		const spaceQuantity = product?.quantity ?? 1;
+		return (
+			<>
+				{ translate( '%(quantity)s GB extra space, %(price)s per year', {
+					args: { quantity: spaceQuantity, price },
+				} ) }
+			</>
+		);
+	}
 
+	if ( isPlan( product ) || isAddOn( product ) || isJetpackProductSlug( productSlug ) ) {
 		if ( isMonthlyProduct( product ) ) {
 			return (
 				<>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1016,7 +1016,6 @@ function CheckoutLineItem( {
 
 	const containsPartnerCoupon = getPartnerCoupon( {
 		coupon: responseCart.coupon,
-		products: [ product ],
 	} );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -593,34 +593,34 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		stripZeros: true,
 	} );
 
+	if ( isP2Plus( product ) ) {
+		// This is the price for one item for products with a quantity (eg. seats in a license).
+		const itemPrice = formatCurrency(
+			product.item_original_cost_for_quantity_one_integer,
+			product.currency,
+			{ isSmallestUnit: true, stripZeros: true }
+		);
+		const members = product?.current_quantity || 1;
+		const p2Options = {
+			args: {
+				itemPrice,
+				members,
+			},
+			count: members,
+		};
+
+		return (
+			<>
+				{ translate(
+					'Monthly subscription: %(itemPrice)s x %(members)s member',
+					'Monthly subscription: %(itemPrice)s x %(members)s members',
+					p2Options
+				) }
+			</>
+		);
+	}
+
 	if ( isPlan( product ) || isAddOn( product ) || isJetpackProductSlug( productSlug ) ) {
-		if ( isP2Plus( product ) ) {
-			// This is the price for one item for products with a quantity (eg. seats in a license).
-			const itemPrice = formatCurrency(
-				product.item_original_cost_for_quantity_one_integer,
-				product.currency,
-				{ isSmallestUnit: true, stripZeros: true }
-			);
-			const members = product?.current_quantity || 1;
-			const p2Options = {
-				args: {
-					itemPrice,
-					members,
-				},
-				count: members,
-			};
-
-			return (
-				<>
-					{ translate(
-						'Monthly subscription: %(itemPrice)s x %(members)s member',
-						'Monthly subscription: %(itemPrice)s x %(members)s members',
-						p2Options
-					) }
-				</>
-			);
-		}
-
 		if ( isTieredVolumeSpaceAddon( product ) ) {
 			const spaceQuantity = product?.quantity ?? 1;
 			return (

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -27,7 +27,7 @@ import {
 } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import styled from '@emotion/styled';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useState, PropsWithChildren } from 'react';
 import { getLabel, DefaultLineItemSublabel } from './checkout-labels';
 import { getItemIntroductoryOfferDisplay } from './introductory-offer';
@@ -731,7 +731,12 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		return (
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
-				{ translate( '%(price)s per month', { args: { price } } ) }
+				{ getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( '%(price)s per month' )
+					? translate( '%(price)s per month', { args: { price } } )
+					: translate( '%(sublabel)s: %(price)s per month', {
+							textOnly: true,
+							args: { sublabel: '_', price },
+					  } ).replace( '_:', '' ) }
 			</>
 		);
 	}
@@ -740,7 +745,12 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		return (
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
-				{ translate( '%(price)s per year', { args: { price } } ) }
+				{ getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( '%(price)s per year' )
+					? translate( '%(price)s per year', { args: { price } } )
+					: translate( '%(sublabel)s: %(price)s per year', {
+							textOnly: true,
+							args: { sublabel: '_', price },
+					  } ).replace( '_:', '' ) }
 			</>
 		);
 	}
@@ -749,7 +759,12 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		return (
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
-				{ translate( '%(price)s per two years', { args: { price } } ) }
+				{ getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( '%(price)s per two years' )
+					? translate( '%(price)s per two years', { args: { price } } )
+					: translate( '%(sublabel)s: %(price)s per two years', {
+							textOnly: true,
+							args: { sublabel: '_', price },
+					  } ).replace( '_:', '' ) }
 			</>
 		);
 	}
@@ -758,7 +773,12 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		return (
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
-				{ translate( '%(price)s per three years', { args: { price } } ) }
+				{ getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( '%(price)s per three years' )
+					? translate( '%(price)s per three years', { args: { price } } )
+					: translate( '%(sublabel)s: %(price)s per three years', {
+							textOnly: true,
+							args: { sublabel: '_', price },
+					  } ).replace( '_:', '' ) }
 			</>
 		);
 	}

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -72,7 +72,7 @@ export const NonProductLineItem = styled( WPNonProductLineItem )< {
 	}
 `;
 
-export const LineItem = styled( WPLineItem )< {
+export const LineItem = styled( CheckoutLineItem )< {
 	theme?: Theme;
 } >`
 	display: flex;
@@ -937,7 +937,7 @@ const DesktopGiftWrapper = styled.div`
 	}
 `;
 
-function WPLineItem( {
+function CheckoutLineItem( {
 	children,
 	product,
 	className,

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -631,44 +631,6 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		);
 	}
 
-	if ( isPlan( product ) || isAddOn( product ) || isJetpackProductSlug( productSlug ) ) {
-		if ( isMonthlyProduct( product ) ) {
-			return (
-				<>
-					<DefaultLineItemSublabel product={ product } />:{ ' ' }
-					{ translate( '%(price)s per month', { args: { price } } ) }
-				</>
-			);
-		}
-
-		if ( isYearly( product ) ) {
-			return (
-				<>
-					<DefaultLineItemSublabel product={ product } />:{ ' ' }
-					{ translate( '%(price)s per year', { args: { price } } ) }
-				</>
-			);
-		}
-
-		if ( isBiennially( product ) ) {
-			return (
-				<>
-					<DefaultLineItemSublabel product={ product } />:{ ' ' }
-					{ translate( '%(price)s per two years', { args: { price } } ) }
-				</>
-			);
-		}
-
-		if ( isTriennially( product ) ) {
-			return (
-				<>
-					<DefaultLineItemSublabel product={ product } />:{ ' ' }
-					{ translate( '%(price)s per three years', { args: { price } } ) }
-				</>
-			);
-		}
-	}
-
 	if (
 		isGoogleWorkspaceProductSlug( productSlug ) ||
 		isGSuiteOrExtraLicenseProductSlug( productSlug ) ||
@@ -759,6 +721,44 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 			<>
 				<DefaultLineItemSublabel product={ product } />: { translate( 'billed annually' ) }{ ' ' }
 				{ price }
+			</>
+		);
+	}
+
+	const shouldRenderBasicTermSublabel =
+		isPlan( product ) || isAddOn( product ) || isJetpackProductSlug( productSlug );
+	if ( shouldRenderBasicTermSublabel && isMonthlyProduct( product ) ) {
+		return (
+			<>
+				<DefaultLineItemSublabel product={ product } />:{ ' ' }
+				{ translate( '%(price)s per month', { args: { price } } ) }
+			</>
+		);
+	}
+
+	if ( shouldRenderBasicTermSublabel && isYearly( product ) ) {
+		return (
+			<>
+				<DefaultLineItemSublabel product={ product } />:{ ' ' }
+				{ translate( '%(price)s per year', { args: { price } } ) }
+			</>
+		);
+	}
+
+	if ( shouldRenderBasicTermSublabel && isBiennially( product ) ) {
+		return (
+			<>
+				<DefaultLineItemSublabel product={ product } />:{ ' ' }
+				{ translate( '%(price)s per two years', { args: { price } } ) }
+			</>
+		);
+	}
+
+	if ( shouldRenderBasicTermSublabel && isTriennially( product ) ) {
+		return (
+			<>
+				<DefaultLineItemSublabel product={ product } />:{ ' ' }
+				{ translate( '%(price)s per three years', { args: { price } } ) }
 			</>
 		);
 	}

--- a/packages/wpcom-checkout/src/partner-coupon.ts
+++ b/packages/wpcom-checkout/src/partner-coupon.ts
@@ -1,4 +1,19 @@
-import { getSublabel } from './checkout-labels';
+import {
+	isAddOn,
+	isPlan,
+	isDomainTransfer,
+	isDomainProduct,
+	isDotComPlan,
+	isGoogleWorkspace,
+	isGSuiteOrExtraLicenseProductSlug,
+	isTitanMail,
+	isJetpackProductSlug,
+	isMonthlyProduct,
+	isYearly,
+	isBiennially,
+	isTriennially,
+} from '@automattic/calypso-products';
+import { isWpComProductRenewal as isRenewal } from './is-wpcom-product-renewal';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 /**
@@ -15,9 +30,70 @@ export function getPartnerCoupon( {
 	coupon: string;
 	products?: ResponseCartProduct[];
 } ): boolean {
-	const productHasSublabel =
-		products && products.some( ( product: ResponseCartProduct ) => !! getSublabel( product ) );
+	const isAllowed =
+		products &&
+		products.some( ( product: ResponseCartProduct ) => !! isAllowedPartnerProduct( product ) );
 	const isPartnerCoupon = coupon.startsWith( 'IONOS_' );
 
-	return ( productHasSublabel && isPartnerCoupon ) || false;
+	return ( isAllowed && isPartnerCoupon ) || false;
+}
+
+function isAllowedPartnerProduct( product: ResponseCartProduct ): boolean {
+	const isRenewalItem = isRenewal( product );
+	const { meta, product_name: productName, product_slug: productSlug } = product;
+
+	if ( isDotComPlan( product ) && isRenewalItem ) {
+		return true;
+	}
+
+	if ( isPlan( product ) || isJetpackProductSlug( productSlug ) ) {
+		return true;
+	}
+
+	if ( isGoogleWorkspace( product ) || isGSuiteOrExtraLicenseProductSlug( productSlug ) ) {
+		return true;
+	}
+
+	if ( isTitanMail( product ) ) {
+		return true;
+	}
+
+	if ( meta && ( isDomainProduct( product ) || isDomainTransfer( product ) ) ) {
+		if ( ! isRenewalItem ) {
+			if ( productName ) {
+				return true;
+			}
+			return false;
+		}
+
+		if ( productName ) {
+			return true;
+		}
+	}
+
+	if ( isAddOn( product ) && ! isRenewalItem ) {
+		return true;
+	}
+
+	if ( isRenewalItem ) {
+		return true;
+	}
+
+	if ( isMonthlyProduct( product ) ) {
+		return true;
+	}
+
+	if ( isYearly( product ) ) {
+		return true;
+	}
+
+	if ( isBiennially( product ) ) {
+		return true;
+	}
+
+	if ( isTriennially( product ) ) {
+		return true;
+	}
+
+	return false;
 }

--- a/packages/wpcom-checkout/src/partner-coupon.ts
+++ b/packages/wpcom-checkout/src/partner-coupon.ts
@@ -1,21 +1,3 @@
-import {
-	isAddOn,
-	isPlan,
-	isDomainTransfer,
-	isDomainProduct,
-	isDotComPlan,
-	isGoogleWorkspace,
-	isGSuiteOrExtraLicenseProductSlug,
-	isTitanMail,
-	isJetpackProductSlug,
-	isMonthlyProduct,
-	isYearly,
-	isBiennially,
-	isTriennially,
-} from '@automattic/calypso-products';
-import { isWpComProductRenewal as isRenewal } from './is-wpcom-product-renewal';
-import type { ResponseCartProduct } from '@automattic/shopping-cart';
-
 /**
  * Get Partner Coupon
  *
@@ -23,77 +5,6 @@ import type { ResponseCartProduct } from '@automattic/shopping-cart';
  * the Connection controller, and future improvements should probably unify the two
  * code bases to "generic utility functions".
  */
-export function getPartnerCoupon( {
-	coupon,
-	products,
-}: {
-	coupon: string;
-	products?: ResponseCartProduct[];
-} ): boolean {
-	const isAllowed =
-		products &&
-		products.some( ( product: ResponseCartProduct ) => !! isAllowedPartnerProduct( product ) );
-	const isPartnerCoupon = coupon.startsWith( 'IONOS_' );
-
-	return ( isAllowed && isPartnerCoupon ) || false;
-}
-
-function isAllowedPartnerProduct( product: ResponseCartProduct ): boolean {
-	const isRenewalItem = isRenewal( product );
-	const { meta, product_name: productName, product_slug: productSlug } = product;
-
-	if ( isDotComPlan( product ) && isRenewalItem ) {
-		return true;
-	}
-
-	if ( isPlan( product ) || isJetpackProductSlug( productSlug ) ) {
-		return true;
-	}
-
-	if ( isGoogleWorkspace( product ) || isGSuiteOrExtraLicenseProductSlug( productSlug ) ) {
-		return true;
-	}
-
-	if ( isTitanMail( product ) ) {
-		return true;
-	}
-
-	if ( meta && ( isDomainProduct( product ) || isDomainTransfer( product ) ) ) {
-		if ( ! isRenewalItem ) {
-			if ( productName ) {
-				return true;
-			}
-			return false;
-		}
-
-		if ( productName ) {
-			return true;
-		}
-	}
-
-	if ( isAddOn( product ) && ! isRenewalItem ) {
-		return true;
-	}
-
-	if ( isRenewalItem ) {
-		return true;
-	}
-
-	if ( isMonthlyProduct( product ) ) {
-		return true;
-	}
-
-	if ( isYearly( product ) ) {
-		return true;
-	}
-
-	if ( isBiennially( product ) ) {
-		return true;
-	}
-
-	if ( isTriennially( product ) ) {
-		return true;
-	}
-
-	return false;
+export function getPartnerCoupon( { coupon }: { coupon: string } ): boolean {
+	return coupon.startsWith( 'IONOS_' );
 }


### PR DESCRIPTION
Line items in checkout are rendered by the `CheckoutLineItem` component (previously `WPLineItem`). They consist of several parts:

1. A product title.
2. An item sublabel that may explain the product (eg: "Mailboxes and Productivity Tools") or the price breakdown (eg: "Plan Subscription: $48 per year").
3. A price, possibly with a crossed-out amount.
4. Additional lines for certain discounts or products.

<img width="605" alt="Screenshot 2023-08-23 at 4 38 03 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/96d43c8a-9944-4ec1-a62c-ea8b628ae438">


In this list the item sublabel is rendered in the following way:

- The `getSublabel()` function is called to generate the general text.
- Using a `translate()` function, the general text is combined with other text after a colon, like the billing interval.

This is a slightly strange use of a translated string since its primary purpose is layout (eg: `%(premiumLabel)s %(sublabel)s: %(interval)s` contains nothing really to translate). It also creates a fair amount of complexity when reading or trying to alter the sublabel since it is combined in so many different ways. This has led to confusion when devs are attempting to fix bugs or add new subtext. It's also inflexible since it means that the general text must be a string only.

## Proposed Changes

In this PR we rename `getSublabel()` to turn it into a React component instead.

This change allows us to render it combined with other information using HTML for layout and makes its behavior more explicit.

## Testing Instructions

This PR should not change how line items are rendered, so testing involves adding various products to your shopping cart and verifying that they render the same way in checkout as before this PR.