### PR TITLE
Add Jetpack Instant Search E2E Test

### DIFF
--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -35,6 +35,7 @@ export * from './template-part-list-component';
 export * from './template-part-modal-component';
 export * from './full-side-editor-nav-sidebar-component';
 export * from './editor-dimensions-component';
+export * from './jetpack-instant-search-modal-component';
 
 export * from './me';
 

--- a/packages/calypso-e2e/src/lib/components/jetpack-instant-search-modal-component.ts
+++ b/packages/calypso-e2e/src/lib/components/jetpack-instant-search-modal-component.ts
@@ -16,40 +16,48 @@ export class JetpackInstantSearchModalComponent {
 	}
 
 	/**
-	 *
+	 * A locator to the parent modal dialog.
 	 */
 	get modalLocator(): Locator {
 		return this.page.getByRole( 'dialog', { name: 'Search results' } );
 	}
 
 	/**
-	 *
+	 * A locator to the parent element for the list of search results.
 	 */
 	get resultsListLocator(): Locator {
-		// No good accessible differentiator for the ol element.
+		// No good accessible differentiator for the ol element, so we need CSS.
 		return this.modalLocator.locator( '.jetpack-instant-search__search-results-list' );
 	}
 
 	/**
+	 * Gets the current value of the search input field.
 	 *
-	 * @returns
+	 * @returns {Promise<string>} The current value of the search input field.
 	 */
 	async getSearchTerm(): Promise< string > {
-		// The name of this is messed up -- we're pulling in some icon text. So we do a partial match.
+		// The name of this is messed up -- we're pulling in some icon text. So we do a partial name RegEx match.
 		const searchTermLocator = this.modalLocator.getByRole( 'searchbox', { name: /Search/ } );
-		searchTermLocator.waitFor();
+		await searchTermLocator.waitFor();
 		return await searchTermLocator.inputValue();
 	}
 
 	/**
-	 *
+	 * Clears the search input field using the Clear button.
 	 */
 	async clearSearchTerm(): Promise< void > {
 		await this.modalLocator.getByRole( 'button', { name: 'Clear' } ).click();
 	}
 
 	/**
+	 * Waits for a search to start and complete by keying off of DOM changes.
+	 * This should wrap other actions that trigger a search.
+	 * E.g.:
 	 *
+	 * await Promise.all( [
+	 *  searchModalComponent.expectAndWaitForSearch(),
+	 *  <some action that triggers a search>(),
+	 * ] );
 	 */
 	async expectAndWaitForSearch(): Promise< void > {
 		// This is currently the safest and most reliable way to wait for a search action to complete.
@@ -57,6 +65,7 @@ export class JetpackInstantSearchModalComponent {
 		// The loading header is reliable, but it takes a quick moment to show up, allowing for a race condition.
 		// Therefore, we take a wrapped approach. We wait for the loading header to show up, then wait for it to go away.
 		// Then we wrap the search-triggering action in this promise.
+		// Also, the header text changes depending on whether there's a search term or not.
 		const withTermLocator = this.modalLocator.getByRole( 'heading', {
 			name: 'Searching…',
 			includeHidden: true, // these are aria-hidden while search is underway
@@ -73,29 +82,36 @@ export class JetpackInstantSearchModalComponent {
 	}
 
 	/**
+	 * Gets the number of search results items.
 	 *
-	 * @returns
+	 * @returns {Promise<number>} The number of search results items.
 	 */
 	async getNumberOfResults(): Promise< number > {
 		return await this.resultsListLocator.getByRole( 'listitem' ).count();
 	}
 
 	/**
+	 * Validates that there is a highlighted match with given text in the search results.
 	 *
+	 * @throws If no highlted match is found.
 	 */
 	async validateHighlightedMatch( text: string ): Promise< void > {
 		return await this.resultsListLocator.locator( `mark:has-text("${ text }")` ).first().waitFor();
 	}
 
 	/**
+	 * Gets the number of highlighted matches in the search results. Useful for validating
+	 * that there are no highlighted matches.
 	 *
-	 * @returns
+	 * @returns {Promise<number>} The number of highlighted matches in the search results.
 	 */
 	async getNumberOfHighlightedMatches(): Promise< number > {
 		return await this.resultsListLocator.locator( 'mark' ).count();
 	}
 
-	/** */
+	/**
+	 * Closes the modal and validates that it actually goes away.
+	 */
 	async closeModal(): Promise< void > {
 		await this.modalLocator.getByRole( 'button', { name: 'Close search results' } ).click();
 		await this.modalLocator.waitFor( { state: 'detached' } );

--- a/packages/calypso-e2e/src/lib/components/jetpack-instant-search-modal-component.ts
+++ b/packages/calypso-e2e/src/lib/components/jetpack-instant-search-modal-component.ts
@@ -96,7 +96,11 @@ export class JetpackInstantSearchModalComponent {
 	 * @throws If no highlted match is found.
 	 */
 	async validateHighlightedMatch( text: string ): Promise< void > {
-		return await this.resultsListLocator.locator( `mark:has-text("${ text }")` ).first().waitFor();
+		return await this.resultsListLocator
+			.locator( 'mark' )
+			.filter( { hasText: text } )
+			.first()
+			.waitFor();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/jetpack-instant-search-modal-component.ts
+++ b/packages/calypso-e2e/src/lib/components/jetpack-instant-search-modal-component.ts
@@ -1,0 +1,103 @@
+import { Locator, Page } from 'playwright';
+
+/**
+ * Component representing the modal popup for Jetpack Instant Search.
+ */
+export class JetpackInstantSearchModalComponent {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 *
+	 */
+	get modalLocator(): Locator {
+		return this.page.getByRole( 'dialog', { name: 'Search results' } );
+	}
+
+	/**
+	 *
+	 */
+	get resultsListLocator(): Locator {
+		// No good accessible differentiator for the ol element.
+		return this.modalLocator.locator( '.jetpack-instant-search__search-results-list' );
+	}
+
+	/**
+	 *
+	 * @returns
+	 */
+	async getSearchTerm(): Promise< string > {
+		// The name of this is messed up -- we're pulling in some icon text. So we do a partial match.
+		const searchTermLocator = this.modalLocator.getByRole( 'searchbox', { name: /Search/ } );
+		searchTermLocator.waitFor();
+		return await searchTermLocator.inputValue();
+	}
+
+	/**
+	 *
+	 */
+	async clearSearchTerm(): Promise< void > {
+		await this.modalLocator.getByRole( 'button', { name: 'Clear' } ).click();
+	}
+
+	/**
+	 *
+	 */
+	async expectAndWaitForSearch(): Promise< void > {
+		// This is currently the safest and most reliable way to wait for a search action to complete.
+		// Keying off of web requests is a bit squirrely because it's always the same route with a ton of different args.
+		// The loading header is reliable, but it takes a quick moment to show up, allowing for a race condition.
+		// Therefore, we take a wrapped approach. We wait for the loading header to show up, then wait for it to go away.
+		// Then we wrap the search-triggering action in this promise.
+		const withTermLocator = this.modalLocator.getByRole( 'heading', {
+			name: 'Searching…',
+			includeHidden: true, // these are aria-hidden while search is underway
+		} );
+		const withoutTermLocator = this.modalLocator.getByRole( 'heading', {
+			name: 'Loading popular results…',
+			includeHidden: true, // these are aria-hidden while search is underway
+		} );
+		await Promise.race( [ withTermLocator.waitFor(), withoutTermLocator.waitFor() ] );
+		await Promise.all( [
+			withTermLocator.waitFor( { state: 'detached', timeout: 20 * 1000 } ),
+			withoutTermLocator.waitFor( { state: 'detached', timeout: 20 * 1000 } ),
+		] );
+	}
+
+	/**
+	 *
+	 * @returns
+	 */
+	async getNumberOfResults(): Promise< number > {
+		return await this.resultsListLocator.getByRole( 'listitem' ).count();
+	}
+
+	/**
+	 *
+	 */
+	async validateHighlightedMatch( text: string ): Promise< void > {
+		return await this.resultsListLocator.locator( `mark:has-text("${ text }")` ).first().waitFor();
+	}
+
+	/**
+	 *
+	 * @returns
+	 */
+	async getNumberOfHighlightedMatches(): Promise< number > {
+		return await this.resultsListLocator.locator( 'mark' ).count();
+	}
+
+	/** */
+	async closeModal(): Promise< void > {
+		await this.modalLocator.getByRole( 'button', { name: 'Close search results' } ).click();
+		await this.modalLocator.waitFor( { state: 'detached' } );
+	}
+}

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -37,6 +37,7 @@ import type {
 	AllWidgetsResponse,
 	CommentLikeResponse,
 	JetpackSearchResponse,
+	JetpackSearchParams,
 } from './types';
 import type { BodyInit, HeadersInit, RequestInit } from 'node-fetch';
 
@@ -1097,23 +1098,29 @@ export class RestAPIClient {
 	 * Useful for checking if something has been indexed yet.
 	 *
 	 * @param {number} siteId ID of the target site.
-	 * @param {string} query The search query.
+	 * @param {JetpackSearchParams} searchParams The search parameters.
 	 */
-	async jetpackSearch( siteId: number, query: string ): Promise< JetpackSearchResponse > {
+	async jetpackSearch(
+		siteId: number,
+		searchParams: JetpackSearchParams
+	): Promise< JetpackSearchResponse > {
 		// Private sites require auth, so always auth!
-		const params: RequestParams = {
+		const requestParams: RequestParams = {
 			method: 'get',
 			headers: {
 				Authorization: await this.getAuthorizationHeader( 'bearer' ),
 			},
 		};
 
-		const requestUrl = this.getRequestURL(
-			'1.3',
-			`/sites/${ siteId }/search?query=${ encodeURIComponent( query ) }`
-		);
+		const requestUrl = this.getRequestURL( '1.3', `/sites/${ siteId }/search` );
 
-		const response = await this.sendRequest( requestUrl, params );
+		const { query, size } = searchParams;
+		requestUrl.searchParams.append( 'query', query );
+		if ( size ) {
+			requestUrl.searchParams.append( 'size', size.toString() );
+		}
+
+		const response = await this.sendRequest( requestUrl, requestParams );
 
 		if ( response.hasOwnProperty( 'error' ) ) {
 			throw new Error(

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -1113,8 +1113,6 @@ export class RestAPIClient {
 			`/sites/${ siteId }/search?query=${ encodeURIComponent( query ) }`
 		);
 
-		console.log( requestUrl.href );
-
 		const response = await this.sendRequest( requestUrl, params );
 
 		if ( response.hasOwnProperty( 'error' ) ) {

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -1093,8 +1093,10 @@ export class RestAPIClient {
 		widgets.map( async ( widget ) => await this.deleteWidget( siteID, widget.id ) );
 	}
 
+	/* Search */
+
 	/**
-	 * Execute a primitive Jetpack site search request. Right now, only the query is supported.
+	 * Execute a primitive Jetpack site search request.
 	 * Useful for checking if something has been indexed yet.
 	 *
 	 * @param {number} siteId ID of the target site.

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -187,9 +187,15 @@ export interface PluginRemovalResponse {
 	log: string[];
 }
 
+export interface JetpackSearchParams {
+	query: string;
+	size?: number;
+	// Lots more of course -- add as needed!
+}
+
 export interface JetpackSearchResponse {
-	total: number;
-	// Right now we just need count, there's more we can add later.
+	results: unknown[];
+	// Lots more of course -- add as needed!
 }
 
 /* Error Responses */

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -187,6 +187,11 @@ export interface PluginRemovalResponse {
 	log: string[];
 }
 
+export interface JetpackSearchResponse {
+	total: number;
+	// Right now we just need count, there's more we can add later.
+}
+
 /* Error Responses */
 
 export interface BearerTokenErrorResponse {

--- a/test/e2e/specs/search/search__jetpack-instant.ts
+++ b/test/e2e/specs/search/search__jetpack-instant.ts
@@ -86,8 +86,14 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Instant Search' ), function () {
 	} );
 
 	it( 'Enter search term and launch search modal', async function () {
-		const inputLocator = page.getByRole( 'search' ).getByRole( 'searchbox', { name: 'Search' } );
-		const buttonLocator = page.getByRole( 'search' ).getByRole( 'button', { name: 'Search' } );
+		const inputLocator = page
+			.getByRole( 'search' )
+			.getByRole( 'searchbox', { name: 'Search' } )
+			.first();
+		const buttonLocator = page
+			.getByRole( 'search' )
+			.getByRole( 'button', { name: 'Search' } )
+			.first();
 
 		await inputLocator.fill( searchString );
 		await Promise.all( [ searchModalComponent.expectAndWaitForSearch(), buttonLocator.click() ] );

--- a/test/e2e/specs/search/search__jetpack-instant.ts
+++ b/test/e2e/specs/search/search__jetpack-instant.ts
@@ -12,42 +12,21 @@ import {
 	JetpackInstantSearchModalComponent,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
+import { skipItIf } from '../../jest-helpers';
 
 declare const browser: Browser;
 
-async function waitForIndexToUpdate(
-	restAPIClient: RestAPIClient,
-	siteId: number,
-	expectedSearch: string
-) {
-	const sleep = ( ms: number ) => new Promise( ( resolve ) => setTimeout( resolve, ms ) );
-	const MAX_RETRIES = 10;
-	const RETRY_INTERVAL_MS = 2000;
-	for ( let i = 0; i < MAX_RETRIES; i++ ) {
-		// We start with the sleep because, c'mon, it's not going to index immediately!
-		// So puting the polling delay upfront makes the most sense. The test is still very fast!
-		await sleep( RETRY_INTERVAL_MS );
-		const response = await restAPIClient.jetpackSearch( siteId, {
-			query: expectedSearch,
-			// We are incrementing size here to bust the ElasticSearch cache.
-			// Otherwise, if it hasn't indexed the post by the first search request, the ES cache will
-			// continue to return NO results, even after the post has been indexed!!!!
-			// We just need there to be any hit for the post name, so we can just keep bumping the size
-			// to do the cache busting.
-			size: i + 1,
-		} );
-		if ( response.results.length > 0 ) {
-			return;
-		}
-	}
-
-	throw new Error(
-		`Could not find any Jetpack Search results for query ${ expectedSearch } after 15 seconds. The index may not be updating.`
-	);
-}
+/* 
+	Unfortunately, we can't test Search as thoroughly on Atomic as we can on Simple sites.
+	Indexing of new posts on Simple site is REALLY fast, usually seconds.
+	On Atomic, it's more variable and usually on the scale of a few minutes.
+	This means we can't create reliable data conditions to validate the actual search result content.
+	So on atomic, we're limited to validating the integtity and interactability of the search modal.
+*/
 
 describe( DataHelper.createSuiteTitle( 'Jetpack Instant Search' ), function () {
 	const searchString = DataHelper.getRandomPhrase();
+
 	let page: Page;
 	let testAccount: TestAccount;
 	let restAPIClient: RestAPIClient;
@@ -66,19 +45,42 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Instant Search' ), function () {
 		restAPIClient = new RestAPIClient( testAccount.credentials );
 	} );
 
-	it( 'Create a new post using the REST API', async function () {
-		await restAPIClient.createPost( siteId, {
-			title: searchString,
-			content: searchString,
-		} );
-	} );
+	skipItIf( envVariables.TEST_ON_ATOMIC )(
+		'Create a new post using the REST API',
+		async function () {
+			const postResponse = await restAPIClient.createPost( siteId, {
+				title: searchString,
+				content: searchString,
+			} );
 
-	it( 'Wait for index to update using the REST API', async function () {
-		await waitForIndexToUpdate( restAPIClient, siteId, searchString );
-	} );
+			console.log( postResponse );
+		}
+	);
+
+	skipItIf( envVariables.TEST_ON_ATOMIC )(
+		'Wait for index to update using the REST API',
+		async function () {
+			await waitForIndexToUpdate( restAPIClient, siteId, searchString );
+		}
+	);
 
 	it( 'Navigate to site homepage', async function () {
+		const isPrivateAtomicSite =
+			envVariables.TEST_ON_ATOMIC && envVariables.ATOMIC_VARIATION === 'private';
+
+		if ( isPrivateAtomicSite ) {
+			// First, get a fresh cookie.
+			await testAccount.authenticate( page );
+		}
+
 		await page.goto( testAccount.getSiteURL( { protocol: true } ) );
+
+		if ( isPrivateAtomicSite ) {
+			// On private Atomic sites, still have to click the blue Log In button to use your cookie.
+			await page.getByRole( 'link', { name: 'Log in' } ).click();
+			// Then let all the redirects settle.
+			await page.waitForURL( testAccount.getSiteURL( { protocol: true } ), { timeout: 20 * 1000 } );
+		}
 
 		searchModalComponent = new JetpackInstantSearchModalComponent( page );
 	} );
@@ -95,13 +97,16 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Instant Search' ), function () {
 		expect( await searchModalComponent.getSearchTerm() ).toEqual( searchString );
 	} );
 
-	it( 'There are search results', async function () {
+	skipItIf( envVariables.TEST_ON_ATOMIC )( 'There are search results', async function () {
 		expect( await searchModalComponent.getNumberOfResults() ).toBeGreaterThanOrEqual( 1 );
 	} );
 
-	it( 'The search term is present in the results as a highlighted match', async function () {
-		await searchModalComponent.validateHighlightedMatch( searchString );
-	} );
+	skipItIf( envVariables.TEST_ON_ATOMIC )(
+		'The search term is present in the results as a highlighted match',
+		async function () {
+			await searchModalComponent.validateHighlightedMatch( searchString );
+		}
+	);
 
 	it( 'Clear the search term', async function () {
 		await Promise.all( [
@@ -112,15 +117,52 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Instant Search' ), function () {
 		expect( await searchModalComponent.getSearchTerm() ).toEqual( '' );
 	} );
 
-	it( 'There are still default popular results', async function () {
-		expect( await searchModalComponent.getNumberOfResults() ).toBeGreaterThanOrEqual( 1 );
-	} );
+	skipItIf( envVariables.TEST_ON_ATOMIC )(
+		'There are still default popular results',
+		async function () {
+			expect( await searchModalComponent.getNumberOfResults() ).toBeGreaterThanOrEqual( 1 );
+		}
+	);
 
-	it( 'There are no highlighted matches in the results', async function () {
-		expect( await searchModalComponent.getNumberOfHighlightedMatches() ).toBe( 0 );
-	} );
+	skipItIf( envVariables.TEST_ON_ATOMIC )(
+		'There are no highlighted matches in the results',
+		async function () {
+			expect( await searchModalComponent.getNumberOfHighlightedMatches() ).toBe( 0 );
+		}
+	);
 
 	it( 'Close the modal', async function () {
 		await searchModalComponent.closeModal();
 	} );
 } );
+
+async function waitForIndexToUpdate(
+	restAPIClient: RestAPIClient,
+	siteId: number,
+	expectedSearch: string
+) {
+	const sleep = ( ms: number ) => new Promise( ( resolve ) => setTimeout( resolve, ms ) );
+	const MAX_RETRIES = 15;
+	const RETRY_INTERVAL_MS = 3000;
+	for ( let i = 0; i < MAX_RETRIES; i++ ) {
+		// We start with the sleep because, c'mon, it's not going to re-index instantly!
+		// So puting the polling delay upfront makes the most sense. The test is still very fast!
+		await sleep( RETRY_INTERVAL_MS );
+		const response = await restAPIClient.jetpackSearch( siteId, {
+			query: expectedSearch,
+			// We are incrementing size here to bust the ElasticSearch cache.
+			// Otherwise, if it hasn't indexed the post by the first search request, the ES cache will
+			// continue to return no results, even after the post has been indexed!!!!
+			// We just need there to be any hit for the post name, so we can just keep bumping the size
+			// to do the cache busting.
+			size: i + 1,
+		} );
+		if ( response.results.length > 0 ) {
+			return;
+		}
+	}
+
+	throw new Error(
+		`Could not find any Jetpack Search results for query ${ expectedSearch } after 45 seconds. The index may not be updating.`
+	);
+}

--- a/test/e2e/specs/search/search__jetpack-instant.ts
+++ b/test/e2e/specs/search/search__jetpack-instant.ts
@@ -73,7 +73,7 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Instant Search' ), function () {
 			await testAccount.authenticate( page );
 		}
 
-		await page.goto( testAccount.getSiteURL( { protocol: true } ) );
+		await page.goto( testAccount.getSiteURL( { protocol: true } ), { timeout: 20 * 1000 } );
 
 		if ( isPrivateAtomicSite ) {
 			// On private Atomic sites, still have to click the blue Log In button to use your cookie.

--- a/test/e2e/specs/search/search__jetpack-instant.ts
+++ b/test/e2e/specs/search/search__jetpack-instant.ts
@@ -1,0 +1,116 @@
+/**
+ * @group jetpack-wpcom-integration
+ */
+
+import {
+	DataHelper,
+	envVariables,
+	TestAccount,
+	getTestAccountByFeature,
+	envToFeatureKey,
+	RestAPIClient,
+	JetpackInstantSearchModalComponent,
+} from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+async function waitForIndexToUpdate(
+	restAPIClient: RestAPIClient,
+	siteId: number,
+	expectedQuery: string
+) {
+	const sleep = ( ms: number ) => new Promise( ( resolve ) => setTimeout( resolve, ms ) );
+	const MAX_RETRIES = 5;
+	const RETRY_INTERVAL_MS = 3000;
+	for ( let i = 0; i < MAX_RETRIES; i++ ) {
+		const response = await restAPIClient.jetpackSearch( siteId, expectedQuery );
+		console.log( response );
+		if ( response.total > 0 ) {
+			return;
+		}
+		// Only sleep if it's not the last iteration
+		if ( i < MAX_RETRIES - 1 ) {
+			await sleep( RETRY_INTERVAL_MS );
+		}
+	}
+
+	throw new Error(
+		`Could not find any Jetpack Search results for query ${ expectedQuery } after 15 seconds. The index may not be updating.`
+	);
+}
+
+describe( DataHelper.createSuiteTitle( 'Jetpack Instant Search' ), function () {
+	const searchString = 'bazbatquxbigword';
+	let page: Page;
+	let testAccount: TestAccount;
+
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( features );
+
+	let searchModalComponent: JetpackInstantSearchModalComponent;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+
+		testAccount = new TestAccount( accountName );
+		const siteId = testAccount.credentials.testSites?.primary.id as number;
+
+		const restAPIClient = new RestAPIClient( testAccount.credentials );
+
+		await restAPIClient.createPost( siteId, {
+			title: searchString,
+			content: searchString,
+		} );
+
+		// TODO: this check isn't working -- something's messed up in the index query.
+		await waitForIndexToUpdate( restAPIClient, siteId, searchString );
+	} );
+
+	it( 'Navigate to site homepage', async function () {
+		await page.goto( testAccount.getSiteURL( { protocol: true } ) );
+
+		searchModalComponent = new JetpackInstantSearchModalComponent( page );
+	} );
+
+	it( 'Enter search term and launch search modal', async function () {
+		const inputLocator = page.getByRole( 'search' ).getByRole( 'searchbox', { name: 'Search' } );
+		const buttonLocator = page.getByRole( 'search' ).getByRole( 'button', { name: 'Search' } );
+
+		await inputLocator.fill( searchString );
+		await Promise.all( [ searchModalComponent.expectAndWaitForSearch(), buttonLocator.click() ] );
+	} );
+
+	it( 'The search term pulls into the modal', async function () {
+		expect( await searchModalComponent.getSearchTerm() ).toEqual( searchString );
+	} );
+
+	it( 'There are search results', async function () {
+		expect( await searchModalComponent.getNumberOfResults() ).toBeGreaterThanOrEqual( 1 );
+	} );
+
+	it( 'The search term is present in the results as a highlighted match', async function () {
+		await searchModalComponent.validateHighlightedMatch( searchString );
+	} );
+
+	it( 'Clear the search term', async function () {
+		await Promise.all( [
+			searchModalComponent.expectAndWaitForSearch(),
+			searchModalComponent.clearSearchTerm(),
+		] );
+
+		expect( await searchModalComponent.getSearchTerm() ).toEqual( '' );
+	} );
+
+	it( 'There are still default popular results', async function () {
+		expect( await searchModalComponent.getNumberOfResults() ).toBeGreaterThanOrEqual( 1 );
+	} );
+
+	it( 'There are no highlighted matches in the results', async function () {
+		expect( await searchModalComponent.getNumberOfHighlightedMatches() ).toBe( 0 );
+	} );
+
+	it( 'Close the modal', async function () {
+		await searchModalComponent.closeModal();
+	} );
+} );

--- a/test/e2e/specs/search/search__jetpack-instant.ts
+++ b/test/e2e/specs/search/search__jetpack-instant.ts
@@ -25,7 +25,6 @@ async function waitForIndexToUpdate(
 	const RETRY_INTERVAL_MS = 3000;
 	for ( let i = 0; i < MAX_RETRIES; i++ ) {
 		const response = await restAPIClient.jetpackSearch( siteId, expectedQuery );
-		console.log( response );
 		if ( response.total > 0 ) {
 			return;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80730 

## Proposed Changes

This adds an E2E test covering Jetpack Instant Search (the modal) on sites.

### Simple vs Atomic

The scope of coverage is slightly different for Simple vs Atomic.

The most test-data-stable and comprehensive way to design this test is by making a new post, letting it get indexed, then targeting it with Jetpack Instant Search. Not only is this resilient to new blogs or recently-emptied blogs, but it also puts the indexing process under test!

Unfortunately though, while indexing takes mere seconds on Simple sites, it can be more erratic and way longer for Atomic sites (matter of minutes).

So, to try to maximize both stability and coverage:
- Simple sites make a fresh post, wait for it to index, then run the test actually validating the search result content.
- Atomic sites don't make a post and just focus on the integrity and interaction with the search modal, skipping any content validation.

## Testing Instructions

- [x] Jetpack Simple Deploy Desktop
- [x] Jetpack Simple Deploy Mobile
- [x] Jetpack Atomic Deploy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
