### PR TITLE
Jetpack Pro Dashboard: add UI test cases for downtime monitoring changes (hooks & utils)

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/hooks.tsx
@@ -1,0 +1,84 @@
+import { renderHook } from '@testing-library/react-hooks';
+import {
+	useContactModalTitleAndSubtitle,
+	useContactFormInputHelpText,
+	useGetSupportedSMSCountries,
+} from '../hooks';
+
+describe( 'useContactModalTitleAndSubtitle', () => {
+	it( 'returns correct title and subtitle for email type and add action', () => {
+		const { result } = renderHook( () => useContactModalTitleAndSubtitle( 'email', 'add' ) );
+
+		expect( result.current ).toEqual( {
+			title: 'Add new email address',
+			subtitle: 'Please use an email address that is accessible. Only alerts will be sent.',
+		} );
+	} );
+
+	it( 'returns correct title and subtitle for email type and edit action', () => {
+		const { result } = renderHook( () => useContactModalTitleAndSubtitle( 'email', 'edit' ) );
+
+		expect( result.current ).toEqual( {
+			title: 'Edit your email address',
+			subtitle: 'If you update your email address, you’ll need to verify it.',
+		} );
+	} );
+
+	it( 'returns correct title and subtitle for sms type and remove action', () => {
+		const { result } = renderHook( () => useContactModalTitleAndSubtitle( 'sms', 'remove' ) );
+		expect( result.current ).toEqual( {
+			title: 'Remove Phone Number',
+			subtitle: 'Are you sure you want to remove this phone number?',
+		} );
+	} );
+
+	it( 'returns correct title and subtitle for sms type and verify action', () => {
+		const { result } = renderHook( () => useContactModalTitleAndSubtitle( 'sms', 'verify' ) );
+		expect( result.current ).toEqual( {
+			title: 'Verify your phone number',
+			subtitle: 'We’ll send a code to verify your phone number.',
+		} );
+	} );
+} );
+
+describe( 'useContactFormInputHelpText', () => {
+	it( 'returns correct input help text for email type', () => {
+		const { result } = renderHook( () => useContactFormInputHelpText( 'email' ) );
+
+		expect( result.current ).toEqual( {
+			name: 'Give this email a nickname for your personal reference.',
+			email: 'We’ll send a code to verify your email address.',
+			verificationCode: 'Please enter the code you received via email',
+		} );
+	} );
+
+	it( 'returns correct input help text for sms type', () => {
+		const { result } = renderHook( () => useContactFormInputHelpText( 'sms' ) );
+
+		expect( result.current ).toEqual( {
+			name: 'Give this number a nickname for your personal reference.',
+			phoneNumber: 'We’ll send a code to verify your phone number.',
+			verificationCode: 'Please enter the code you received via SMS',
+		} );
+	} );
+} );
+
+jest.mock( 'calypso/data/geo/use-geolocation-query', () => ( {
+	useGeoLocationQuery: jest.fn( () => ( { data: { country_short: 'US' } } ) ),
+} ) );
+
+describe( 'useGetSupportedSMSCountries', () => {
+	it( 'returns supported SMS countries with user country at the top', () => {
+		const countries = [
+			{ code: 'US', name: 'United States' },
+			{ code: 'CA', name: 'Canada' },
+		];
+
+		// Mock the useSelector function to return the countries
+		jest.spyOn( require( 'calypso/state' ), 'useSelector' ).mockReturnValue( countries );
+
+		const { result } = renderHook( () => useGetSupportedSMSCountries() );
+
+		expect( result.current ).toEqual( countries );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/hooks.tsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { renderHook } from '@testing-library/react';
 import {
 	useContactModalTitleAndSubtitle,

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/hooks.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import {
 	useContactModalTitleAndSubtitle,
 	useContactFormInputHelpText,

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/utils.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/test/utils.tsx
@@ -1,0 +1,301 @@
+import {
+	isCompleteContactInfo,
+	getDefaultContactInfo,
+	getContactInfoValue,
+	getContactInfoPayload,
+	isMatchingContactInfo,
+	isContactAlreadyExists,
+	removeFromContactList,
+	addToContactList,
+	isValidContactInfo,
+} from '../utils';
+
+const emailContact = {
+	name: 'John Doe',
+	email: 'johndoe@example.com',
+};
+
+const emailContactWithVerifiedKey = {
+	...emailContact,
+	verified: false,
+};
+
+const smsContact = {
+	name: 'Jane Smith',
+	countryCode: 'US',
+	countryNumericCode: '+1',
+	phoneNumber: '1234567890',
+	phoneNumberFull: '+11234567890',
+};
+
+const smsContactWithVerifiedKey = {
+	...smsContact,
+	verified: true,
+};
+
+const nonExistingEmailContact = {
+	name: 'Jane Smith',
+	email: 'janesmith@example.com',
+	verified: true,
+};
+
+describe( 'isCompleteContactInfo', () => {
+	it( 'returns true for complete email contact with verification code', () => {
+		const contact = {
+			...emailContact,
+			verificationCode: '123456',
+		};
+		expect( isCompleteContactInfo( 'email', contact, true ) ).toBe( true );
+	} );
+
+	it( 'returns false for incomplete email contact without verification code', () => {
+		expect( isCompleteContactInfo( 'email', emailContact, true ) ).toBe( false );
+	} );
+
+	it( 'returns true for complete SMS contact with verification code', () => {
+		const contact = {
+			...smsContact,
+			verificationCode: '123456',
+		};
+		expect( isCompleteContactInfo( 'sms', contact, true ) ).toBe( true );
+	} );
+
+	it( 'returns false for incomplete SMS contact without verification code', () => {
+		expect( isCompleteContactInfo( 'sms', smsContact, true ) ).toBe( false );
+	} );
+
+	it( 'returns false for unknown contact type', () => {
+		const unknownContact = {
+			name: 'John Doe',
+		};
+		// We want to test the case where the contact type is not known
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		expect( isCompleteContactInfo( 'unknownType', unknownContact, true ) ).toBe( false );
+	} );
+} );
+
+describe( 'getDefaultContactInfo', () => {
+	it( 'returns default email contact when type is email', () => {
+		const contact = {
+			...emailContact,
+			verified: true,
+		};
+		const result = getDefaultContactInfo( 'email', contact );
+		expect( result ).toEqual( {
+			name: 'John Doe',
+			email: 'johndoe@example.com',
+			id: 'johndoe@example.com',
+		} );
+	} );
+
+	it( 'returns default SMS contact when type is sms', () => {
+		const result = getDefaultContactInfo( 'sms', smsContactWithVerifiedKey );
+		expect( result ).toEqual( {
+			name: 'Jane Smith',
+			countryCode: 'US',
+			countryNumericCode: '+1',
+			phoneNumber: '1234567890',
+			phoneNumberFull: '+11234567890',
+			id: '+11234567890',
+		} );
+	} );
+
+	it( 'returns default contact with empty values for unknown type', () => {
+		// We want to test the case where the contact type is not known
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		const result = getDefaultContactInfo( 'unknownType' );
+		expect( result ).toEqual( {
+			name: '',
+		} );
+	} );
+
+	it( 'returns default contact with empty values when no contact provided', () => {
+		const result = getDefaultContactInfo( 'email' );
+		expect( result ).toEqual( {
+			name: '',
+		} );
+	} );
+} );
+
+describe( 'getContactInfoValue', () => {
+	it( 'returns email address from contact info when type is email', () => {
+		const result = getContactInfoValue( 'email', emailContact );
+		expect( result ).toBe( 'johndoe@example.com' );
+	} );
+
+	it( 'returns phone number from contact info when type is sms', () => {
+		const result = getContactInfoValue( 'sms', smsContact );
+		expect( result ).toBe( '+11234567890' );
+	} );
+
+	it( 'returns name from contact info for unknown type', () => {
+		const contactInfo = {
+			name: 'John Doe',
+		};
+		// We want to test the case where the contact type is not known
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		const result = getContactInfoValue( 'unknownType', contactInfo );
+		expect( result ).toBe( 'John Doe' );
+	} );
+
+	it( 'returns empty string when no contact info provided', () => {
+		const result = getContactInfoValue( 'email', {} );
+		expect( result ).toBe( '' );
+	} );
+} );
+
+describe( 'getContactInfoPayload', () => {
+	it( 'returns payload for email contact', () => {
+		const result = getContactInfoPayload( 'email', emailContact );
+		expect( result ).toEqual( {
+			type: 'email',
+			value: 'johndoe@example.com',
+			site_ids: [],
+		} );
+	} );
+
+	it( 'returns payload for SMS contact', () => {
+		const result = getContactInfoPayload( 'sms', smsContact );
+		expect( result ).toEqual( {
+			type: 'sms',
+			value: '+11234567890',
+			number: '1234567890',
+			country_code: 'US',
+			country_numeric_code: '+1',
+			site_ids: [],
+		} );
+	} );
+
+	it( 'returns empty payload for unknown type', () => {
+		const contactInfo = {
+			name: 'John Doe',
+		};
+		// We want to test the case where the contact type is not known
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		const result = getContactInfoPayload( 'unknownType', contactInfo );
+		expect( result ).toEqual( {
+			type: 'unknownType',
+			value: '',
+			site_ids: [],
+		} );
+	} );
+} );
+
+describe( 'isMatchingContactInfo', () => {
+	it( 'returns true for matching email contact info', () => {
+		const result = isMatchingContactInfo(
+			'email',
+			emailContactWithVerifiedKey,
+			emailContactWithVerifiedKey
+		);
+		expect( result ).toBe( true );
+	} );
+
+	it( 'returns true for matching SMS contact info', () => {
+		const result = isMatchingContactInfo(
+			'sms',
+			smsContactWithVerifiedKey,
+			smsContactWithVerifiedKey
+		);
+		expect( result ).toBe( true );
+	} );
+
+	it( 'returns false for non-matching contact info', () => {
+		const result = isMatchingContactInfo(
+			'email',
+			emailContactWithVerifiedKey,
+			nonExistingEmailContact
+		);
+		expect( result ).toBe( false );
+	} );
+} );
+
+describe( 'isContactAlreadyExists', () => {
+	it( 'returns true for existing email contact in the list', () => {
+		const contacts = [ emailContactWithVerifiedKey ];
+		const result = isContactAlreadyExists( 'email', contacts, emailContact );
+		expect( result ).toBe( emailContactWithVerifiedKey );
+	} );
+
+	it( 'returns true for existing SMS contact in the list', () => {
+		const contacts = [ smsContactWithVerifiedKey ];
+		const result = isContactAlreadyExists( 'sms', contacts, smsContact );
+		expect( result ).toBe( smsContactWithVerifiedKey );
+	} );
+
+	it( 'returns false for non-existing contact in the list', () => {
+		const contacts = [ emailContactWithVerifiedKey ];
+		const contactInfo = {
+			name: 'Jane Smith',
+			email: 'janesmith@example.com',
+		};
+		const result = isContactAlreadyExists( 'email', contacts, contactInfo );
+		expect( result ).toBeUndefined();
+	} );
+} );
+
+describe( 'removeFromContactList', () => {
+	it( 'removes existing email contact from the list', () => {
+		const contacts = [ emailContactWithVerifiedKey ];
+		const updatedContacts = removeFromContactList( 'email', contacts, emailContactWithVerifiedKey );
+		expect( updatedContacts ).toEqual( [] );
+	} );
+
+	it( 'removes existing SMS contact from the list', () => {
+		const contacts = [ smsContactWithVerifiedKey ];
+		const updatedContacts = removeFromContactList( 'sms', contacts, smsContactWithVerifiedKey );
+		expect( updatedContacts ).toEqual( [] );
+	} );
+
+	it( 'does not remove non-existing contact from the list', () => {
+		const contacts = [ emailContactWithVerifiedKey ];
+		const updatedContacts = removeFromContactList( 'email', contacts, nonExistingEmailContact );
+		expect( updatedContacts ).toEqual( contacts );
+	} );
+} );
+
+describe( 'addToContactList', () => {
+	it( 'adds a new email contact to the list as verified', () => {
+		const contacts = [];
+		const asVerified = true;
+		const updatedContacts = addToContactList( 'email', contacts, emailContact, asVerified );
+		expect( updatedContacts ).toContainEqual( { ...emailContact, verified: true } );
+	} );
+
+	it( 'adds a new SMS contact to the list as not verified', () => {
+		const contacts = [];
+		const asVerified = false;
+		const updatedContacts = addToContactList( 'sms', contacts, smsContact, asVerified );
+		expect( updatedContacts ).toContainEqual( { ...smsContact, verified: false } );
+	} );
+
+	it( 'updates an existing email contact to verified', () => {
+		const contacts = [ emailContactWithVerifiedKey ];
+		const asVerified = true;
+		const updatedContacts = addToContactList(
+			'email',
+			contacts,
+			emailContactWithVerifiedKey,
+			asVerified
+		);
+		expect( updatedContacts ).toContainEqual( { ...emailContactWithVerifiedKey, verified: true } );
+	} );
+} );
+
+describe( 'isValidContactInfo', () => {
+	it( 'returns true for valid email', () => {
+		expect( isValidContactInfo( 'email', emailContact ) ).toBe( true );
+	} );
+	const invalidEmailContact = {
+		name: 'John Doe',
+		email: 'invalid-email',
+		id: 'invalid-email',
+	};
+	it( 'returns false for invalid email', () => {
+		expect( isValidContactInfo( 'email', invalidEmailContact ) ).toBe( false );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/test/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/test/utils.ts
@@ -1,0 +1,84 @@
+import { getContactItemValue, getContactActionEventName } from '../utils';
+
+describe( 'getContactItemValue', () => {
+	it( 'gets the email value from an email contact item', () => {
+		const emailContact = {
+			name: 'Jane Smith',
+			email: 'janesmith@example.com',
+			verified: true,
+		};
+		const type = 'email';
+		const value = getContactItemValue( type, emailContact );
+		expect( value ).toBe( emailContact.email );
+	} );
+
+	it( 'gets the phone number value from an SMS contact item', () => {
+		const smsContact = {
+			name: 'Jane Smith',
+			countryCode: 'US',
+			countryNumericCode: '1',
+			phoneNumber: '1234567890',
+			phoneNumberFull: '+11234567890',
+			verified: true,
+		};
+		const type = 'sms';
+		const value = getContactItemValue( type, smsContact );
+		expect( value ).toBe( smsContact.phoneNumberFull );
+	} );
+
+	it( 'returns null for an unknown contact type', () => {
+		const unknownContact = {
+			name: 'John Doe',
+			id: 'johndoe@example.com',
+		};
+		const type = 'unknown';
+		// We want to test the case where the contact type is not known
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		const value = getContactItemValue( type, unknownContact );
+		expect( value ).toBe( null );
+	} );
+} );
+
+describe( 'getContactActionEventName', () => {
+	it( 'gets the correct event name for adding an email contact', () => {
+		const type = 'email';
+		const action = 'add';
+		const eventName = getContactActionEventName( type, action );
+		expect( eventName ).toBe( 'downtime_monitoring_email_address_add_click' );
+	} );
+
+	it( 'gets the correct event name for editing an SMS contact', () => {
+		const type = 'sms';
+		const action = 'edit';
+		const eventName = getContactActionEventName( type, action );
+		expect( eventName ).toBe( 'downtime_monitoring_phone_number_edit_click' );
+	} );
+
+	it( 'gets the correct event name for removing a contact', () => {
+		const type = 'email';
+		const action = 'remove';
+		const eventName = getContactActionEventName( type, action );
+		expect( eventName ).toBe( 'downtime_monitoring_email_address_remove_click' );
+	} );
+
+	it( 'gets the correct event name for unknown action to email contact', () => {
+		const type = 'email';
+		const action = 'unknown	';
+		// We want to test the case where the contact type is not known
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		const eventName = getContactActionEventName( type, action );
+		expect( eventName ).toBe( undefined );
+	} );
+
+	it( 'gets the correct event name for verifying an unknown contact type', () => {
+		const type = 'unknown';
+		const action = 'verify';
+		// We want to test the case where the contact type is not known
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		const eventName = getContactActionEventName( type, action );
+		expect( eventName ).toBe( undefined );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/utils.ts
@@ -40,5 +40,5 @@ export const getContactActionEventName = (
 		},
 	};
 
-	return EVENT_NAMES[ type as keyof typeof EVENT_NAMES ][ action ];
+	return EVENT_NAMES[ type as keyof typeof EVENT_NAMES ]?.[ action ];
 };


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-genesis/issues/20


## Proposed Changes

This PR adds test cases to the /downtime-monitoring hooks & utils added as a part of the downtime-monitoring changes.

## Testing Instructions

- Run `git checkout add/test-cases-for-downtime-monitoring-changes-5 && git pull`
- Run `yarn run test-client client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/` to run the tests.
- Verify the tests are passing and code changes make sense

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
