### PR TITLE
Jetpack Pro Dashboard: fix the downtime monitoring test case failure

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/test/toggle-activate-monitoring.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/test/toggle-activate-monitoring.tsx
@@ -136,7 +136,7 @@ describe( 'ToggleActivateMonitoring', () => {
 			...defaultProps,
 			settings: {
 				...defaultProps.settings,
-				monitor_deferment_time: 60,
+				check_interval: 60,
 			},
 		};
 		render( <ToggleActivateMonitoring { ...props } />, {


### PR DESCRIPTION
## Proposed Changes

This PR fixes the failing test case related to the downtime monitoring.

## Testing Instructions

- Run `git checkout fix/downtime-monitoring-test-case && git pull`
- Run `yarn run test-client client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/` to run the tests.
- Verify the tests are passing and code changes make sense

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
