### PR TITLE
Domain management: fill site and expiry cells

### DIFF
--- a/packages/domains-table/src/domains-table/__tests__/domains-table-registered-until-cell.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-registered-until-cell.tsx
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import React from 'react';
+import { renderWithProvider, testPartialDomain } from '../../test-utils';
+import { DomainsTableRegisteredUntilCell } from '../domains-table-registered-until-cell';
+
+describe( 'DomainsTable registered until cell', () => {
+	let dateTimeFormatSpy;
+
+	beforeAll( () => {
+		const OriginalTimeFormat = Intl.DateTimeFormat;
+		dateTimeFormatSpy = jest.spyOn( global.Intl, 'DateTimeFormat' );
+		dateTimeFormatSpy.mockImplementation(
+			( locale, options ) => new OriginalTimeFormat( locale, { ...options, timeZone: 'UTC' } )
+		);
+	} );
+
+	afterAll( () => {
+		dateTimeFormatSpy.mockClear();
+	} );
+
+	test( 'when a domain is registered, display its expiration date', () => {
+		const partialDomain = testPartialDomain( {
+			domain: 'example.com',
+			blog_id: 123,
+			wpcom_domain: false,
+			has_registration: true,
+			expiry: '2024-08-01T00:00:00+00:00',
+		} );
+
+		renderWithProvider( <DomainsTableRegisteredUntilCell domain={ partialDomain } /> );
+
+		expect( screen.getByText( 'Aug 1, 2024' ) ).toBeInTheDocument();
+	} );
+
+	test( 'when its not a registered domain, do not display an expiration date', () => {
+		const partialDomain = testPartialDomain( {
+			domain: 'example.wordpress.com',
+			blog_id: 123,
+			wpcom_domain: true,
+			has_registration: false,
+		} );
+
+		renderWithProvider( <DomainsTableRegisteredUntilCell domain={ partialDomain } /> );
+
+		expect( screen.getByText( '-' ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -3,7 +3,7 @@
  */
 import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { renderWithProvider, testDomain, testPartialDomain, testSite } from '../../test-utils';
+import { renderWithProvider, testDomain, testPartialDomain } from '../../test-utils';
 import { DomainsTableRow } from '../domains-table-row';
 
 const noop = jest.fn();
@@ -219,90 +219,4 @@ test( 'transfer domains link to the transfer management interface', async () => 
 		'href',
 		'/domains/manage/example.com/transfer/in/example.com'
 	);
-} );
-
-describe( 'columns', () => {
-	test( 'when a site is associated with a domain, display its name', async () => {
-		const [ primaryPartial, primaryFull ] = testDomain( {
-			domain: 'primary-domain.blog',
-			blog_id: 123,
-			primary_domain: true,
-		} );
-
-		const fetchSiteDomains = jest.fn().mockImplementation( () =>
-			Promise.resolve( {
-				domains: [ primaryFull ],
-			} )
-		);
-
-		const fetchSite = jest
-			.fn()
-			.mockImplementation( () =>
-				Promise.resolve( testSite( { ID: 123, name: 'Primary Domain Blog' } ) )
-			);
-
-		render(
-			<DomainsTableRow
-				domain={ primaryPartial }
-				isAllSitesView
-				fetchSite={ fetchSite }
-				fetchSiteDomains={ fetchSiteDomains }
-				isSelected={ false }
-				onSelect={ noop }
-			/>
-		);
-
-		await waitFor( () =>
-			expect( screen.queryByText( 'Primary Domain Blog' ) ).toBeInTheDocument()
-		);
-	} );
-
-	test( 'when a site is not associated with a domain, display site linking ctas', async () => {
-		const [ primaryPartial, primaryFull ] = testDomain( {
-			domain: 'primary-domain.blog',
-			blog_id: 123,
-			primary_domain: true,
-			current_user_can_create_site_from_domain_only: true,
-		} );
-
-		const fetchSiteDomains = jest.fn().mockImplementation( () =>
-			Promise.resolve( {
-				domains: [ primaryFull ],
-			} )
-		);
-
-		const fetchSite = jest
-			.fn()
-			.mockImplementation( () =>
-				Promise.resolve( testSite( { URL: 'https://primary-domain.blog', ID: 123 } ) )
-			);
-
-		render(
-			<DomainsTableRow
-				domain={ primaryPartial }
-				isAllSitesView
-				fetchSite={ fetchSite }
-				fetchSiteDomains={ fetchSiteDomains }
-				isSelected={ false }
-				onSelect={ noop }
-			/>
-		);
-
-		await waitFor( () => {
-			const createLink = screen.queryByText( 'Create' );
-			const connectLink = screen.queryByText( 'connect' );
-
-			expect( createLink ).toBeInTheDocument();
-			expect( createLink ).toHaveAttribute(
-				'href',
-				'/start/site-selected/?siteSlug=primary-domain.blog&siteId=123'
-			);
-
-			expect( connectLink ).toBeInTheDocument();
-			expect( connectLink ).toHaveAttribute(
-				'href',
-				'/domains/manage/all/primary-domain.blog/transfer/other-site/primary-domain.blog'
-			);
-		} );
-	} );
 } );

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -3,7 +3,7 @@
  */
 import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { renderWithProvider, testDomain, testPartialDomain } from '../../test-utils';
+import { renderWithProvider, testDomain, testPartialDomain, testSite } from '../../test-utils';
 import { DomainsTableRow } from '../domains-table-row';
 
 const noop = jest.fn();
@@ -219,4 +219,90 @@ test( 'transfer domains link to the transfer management interface', async () => 
 		'href',
 		'/domains/manage/example.com/transfer/in/example.com'
 	);
+} );
+
+describe( 'columns', () => {
+	test( 'when a site is associated with a domain, display its name', async () => {
+		const [ primaryPartial, primaryFull ] = testDomain( {
+			domain: 'primary-domain.blog',
+			blog_id: 123,
+			primary_domain: true,
+		} );
+
+		const fetchSiteDomains = jest.fn().mockImplementation( () =>
+			Promise.resolve( {
+				domains: [ primaryFull ],
+			} )
+		);
+
+		const fetchSite = jest
+			.fn()
+			.mockImplementation( () =>
+				Promise.resolve( testSite( { ID: 123, name: 'Primary Domain Blog' } ) )
+			);
+
+		render(
+			<DomainsTableRow
+				domain={ primaryPartial }
+				isAllSitesView
+				fetchSite={ fetchSite }
+				fetchSiteDomains={ fetchSiteDomains }
+				isSelected={ false }
+				onSelect={ noop }
+			/>
+		);
+
+		await waitFor( () =>
+			expect( screen.queryByText( 'Primary Domain Blog' ) ).toBeInTheDocument()
+		);
+	} );
+
+	test( 'when a site is not associated with a domain, display site linking ctas', async () => {
+		const [ primaryPartial, primaryFull ] = testDomain( {
+			domain: 'primary-domain.blog',
+			blog_id: 123,
+			primary_domain: true,
+			current_user_can_create_site_from_domain_only: true,
+		} );
+
+		const fetchSiteDomains = jest.fn().mockImplementation( () =>
+			Promise.resolve( {
+				domains: [ primaryFull ],
+			} )
+		);
+
+		const fetchSite = jest
+			.fn()
+			.mockImplementation( () =>
+				Promise.resolve( testSite( { URL: 'https://primary-domain.blog', ID: 123 } ) )
+			);
+
+		render(
+			<DomainsTableRow
+				domain={ primaryPartial }
+				isAllSitesView
+				fetchSite={ fetchSite }
+				fetchSiteDomains={ fetchSiteDomains }
+				isSelected={ false }
+				onSelect={ noop }
+			/>
+		);
+
+		await waitFor( () => {
+			const createLink = screen.queryByText( 'Create' );
+			const connectLink = screen.queryByText( 'connect' );
+
+			expect( createLink ).toBeInTheDocument();
+			expect( createLink ).toHaveAttribute(
+				'href',
+				'/start/site-selected/?siteSlug=primary-domain.blog&siteId=123'
+			);
+
+			expect( connectLink ).toBeInTheDocument();
+			expect( connectLink ).toHaveAttribute(
+				'href',
+				'/domains/manage/all/primary-domain.blog/transfer/other-site/primary-domain.blog'
+			);
+		} );
+	} );
 } );

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-site-cell.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-site-cell.tsx
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { renderWithProvider, testDomain } from '../../test-utils';
+import { DomainsTableSiteCell } from '../domains-table-site-cell';
+
+test( 'when a site is associated with a domain, display its name', async () => {
+	const [ , primaryFull ] = testDomain( {
+		domain: 'primary-domain.blog',
+		blog_id: 123,
+		primary_domain: true,
+	} );
+
+	const site = { ID: 123, name: 'Primary Domain Blog' };
+
+	renderWithProvider(
+		<DomainsTableSiteCell
+			site={ site }
+			currentDomainData={ primaryFull }
+			siteSlug="primary-domain.blog"
+		/>
+	);
+
+	await waitFor( () => expect( screen.queryByText( 'Primary Domain Blog' ) ).toBeInTheDocument() );
+} );
+
+test( 'when a site is not associated with a domain, display site linking ctas', async () => {
+	const [ , primaryFull ] = testDomain( {
+		domain: 'primary-domain.blog',
+		blog_id: 123,
+		primary_domain: true,
+		current_user_can_create_site_from_domain_only: true,
+	} );
+
+	const site = { ID: 123, name: 'primarydomainblog.wordpress.com' };
+
+	renderWithProvider(
+		<DomainsTableSiteCell
+			site={ site }
+			currentDomainData={ primaryFull }
+			siteSlug="primary-domain.blog"
+		/>
+	);
+
+	await waitFor( () => {
+		const createLink = screen.queryByText( 'Create' );
+		const connectLink = screen.queryByText( 'connect' );
+
+		expect( createLink ).toBeInTheDocument();
+		expect( createLink ).toHaveAttribute(
+			'href',
+			'/start/site-selected/?siteSlug=primary-domain.blog&siteId=123'
+		);
+
+		expect( connectLink ).toBeInTheDocument();
+		expect( connectLink ).toHaveAttribute(
+			'href',
+			'/domains/manage/all/primary-domain.blog/transfer/other-site/primary-domain.blog'
+		);
+	} );
+} );

--- a/packages/domains-table/src/domains-table/domains-table-registered-until-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-registered-until-cell.tsx
@@ -1,0 +1,18 @@
+import { PartialDomainData } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
+
+interface DomainsTableRegisteredUntilCellProps {
+	domain: PartialDomainData;
+}
+
+export const DomainsTableRegisteredUntilCell = ( {
+	domain,
+}: DomainsTableRegisteredUntilCellProps ) => {
+	const localeSlug = useLocale();
+
+	return domain.has_registration
+		? new Intl.DateTimeFormat( localeSlug, { dateStyle: 'medium' } ).format(
+				new Date( domain.expiry )
+		  )
+		: '-';
+};

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,5 +1,6 @@
 import { LoadingPlaceholder } from '@automattic/components';
 import { useSiteDomainsQuery, useSiteQuery } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
 import { CheckboxControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -33,6 +34,7 @@ export function DomainsTableRow( {
 	fetchSite,
 }: DomainsTableRowProps ) {
 	const { __ } = useI18n();
+	const localeSlug = useLocale();
 	const { ref, inView } = useInView( { triggerOnce: true } );
 
 	const { data: allSiteDomains } = useSiteDomainsQuery( domain.blog_id, {
@@ -107,6 +109,12 @@ export function DomainsTableRow( {
 				) : (
 					siteColumn
 				) }
+			</td>
+			<td></td>
+			<td>
+				{ domain.has_registration
+					? new Date( domain.expiry ).toLocaleDateString( localeSlug, { dateStyle: 'medium' } )
+					: '-' }
 			</td>
 		</tr>
 	);

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,13 +1,13 @@
 import { LoadingPlaceholder } from '@automattic/components';
 import { useSiteDomainsQuery, useSiteQuery } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { PrimaryDomainLabel } from '../primary-domain-label';
 import { DomainsTableRegisteredUntilCell } from './domains-table-registered-until-cell';
+import { DomainsTableSiteCell } from './domains-table-site-cell';
 import type {
 	PartialDomainData,
 	SiteDomainsQueryFnData,
@@ -82,38 +82,6 @@ export function DomainsTableRow( {
 		return Math.floor( Math.random() * ( MAX - MIN + 1 ) ) + MIN;
 	}, [] );
 
-	const getSiteColumn = () => {
-		if ( ! site || ! currentDomainData ) {
-			return null;
-		}
-
-		if ( currentDomainData.current_user_can_create_site_from_domain_only ) {
-			return createInterpolateElement(
-				/* translators: ariaHidden means that the component will be skipped by screen readers. */
-				__(
-					'<create>Create</create> <ariaHidden>or</ariaHidden> <connect>connect</connect> <ariaHidden>a site</ariaHidden>'
-				),
-				{
-					create: (
-						<a
-							href={ domainOnlySiteCreationLink( siteSlug, site?.ID ) }
-							aria-label={ __( 'Create a site for this domain' ) }
-						/>
-					),
-					connect: (
-						<a
-							href={ domainManagementTransferToOtherSiteLink( siteSlug, domain.domain ) }
-							aria-label={ __( 'Connect this domain to an existing site' ) }
-						/>
-					),
-					ariaHidden: <span aria-hidden={ true } />,
-				}
-			);
-		}
-
-		return site.name ?? '-';
-	};
-
 	return (
 		<tr key={ domain.domain } ref={ ref }>
 			<td>
@@ -144,7 +112,11 @@ export function DomainsTableRow( {
 				{ isLoadingSiteDetails || isLoadingSiteDomainsDetails ? (
 					<LoadingPlaceholder style={ { width: `${ placeholderWidth }%` } } />
 				) : (
-					getSiteColumn()
+					<DomainsTableSiteCell
+						site={ site }
+						siteSlug={ siteSlug }
+						currentDomainData={ currentDomainData }
+					/>
 				) }
 			</td>
 			<td></td>
@@ -153,16 +125,6 @@ export function DomainsTableRow( {
 			</td>
 		</tr>
 	);
-}
-
-export function domainOnlySiteCreationLink( siteSlug: string, siteId: number ) {
-	return `/start/site-selected/?siteSlug=${ encodeURIComponent(
-		siteSlug
-	) }&siteId=${ encodeURIComponent( siteId ) }`;
-}
-
-export function domainManagementTransferToOtherSiteLink( siteSlug: string, domainName: string ) {
-	return `/domains/manage/all/${ domainName }/transfer/other-site/${ siteSlug }`;
 }
 
 function domainManagementLink(

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,6 +1,5 @@
 import { LoadingPlaceholder } from '@automattic/components';
 import { useSiteDomainsQuery, useSiteQuery } from '@automattic/data-stores';
-import { useLocale } from '@automattic/i18n-utils';
 import { CheckboxControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -8,6 +7,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { PrimaryDomainLabel } from '../primary-domain-label';
+import { DomainsTableRegisteredUntilCell } from './domains-table-registered-until-cell';
 import type {
 	PartialDomainData,
 	SiteDomainsQueryFnData,
@@ -35,7 +35,6 @@ export function DomainsTableRow( {
 	fetchSite,
 }: DomainsTableRowProps ) {
 	const { __ } = useI18n();
-	const localeSlug = useLocale();
 	const { ref, inView } = useInView( { triggerOnce: true } );
 
 	const { data: allSiteDomains, isLoading: isLoadingSiteDomainsDetails } = useSiteDomainsQuery(
@@ -150,9 +149,7 @@ export function DomainsTableRow( {
 			</td>
 			<td></td>
 			<td>
-				{ domain.has_registration
-					? new Date( domain.expiry ).toLocaleDateString( localeSlug, { dateStyle: 'medium' } )
-					: '-' }
+				<DomainsTableRegisteredUntilCell domain={ domain } />
 			</td>
 		</tr>
 	);

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -46,7 +46,7 @@ export function DomainsTableRow( {
 		}
 	);
 
-	const currentSiteDomains = useMemo( () => {
+	const currentDomainData = useMemo( () => {
 		return allSiteDomains?.domains.find( ( d ) => d.domain === domain.domain );
 	}, [ allSiteDomains, domain.domain ] );
 
@@ -84,11 +84,11 @@ export function DomainsTableRow( {
 	}, [] );
 
 	const getSiteColumn = () => {
-		if ( ! site || ! currentSiteDomains ) {
+		if ( ! site || ! currentDomainData ) {
 			return null;
 		}
 
-		if ( currentSiteDomains.current_user_can_create_site_from_domain_only ) {
+		if ( currentDomainData.current_user_can_create_site_from_domain_only ) {
 			return createInterpolateElement(
 				/* translators: ariaHidden means that the component will be skipped by screen readers. */
 				__(

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,3 +1,4 @@
+import { LoadingPlaceholder } from '@automattic/components';
 import { useSiteDomainsQuery, useSiteQuery } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
@@ -44,7 +45,7 @@ export function DomainsTableRow( {
 		[ allSiteDomains, domain.domain ]
 	);
 
-	const { data: site } = useSiteQuery( domain.blog_id, {
+	const { data: site, isLoading: isLoadingSiteDetails } = useSiteQuery( domain.blog_id, {
 		enabled: inView,
 		...( fetchSite && { queryFn: () => fetchSite( domain.blog_id ) } ),
 	} );
@@ -64,6 +65,15 @@ export function DomainsTableRow( {
 
 	const isManageableDomain = ! domain.wpcom_domain;
 	const shouldDisplayPrimaryDomainLabel = ! isAllSitesView && isPrimaryDomain;
+
+	const placeholderWidth = useMemo( () => {
+		const MIN = 70;
+		const MAX = 100;
+
+		return Math.floor( Math.random() * ( MAX - MIN + 1 ) ) + MIN;
+	}, [] );
+
+	const siteColumn = site?.name;
 
 	return (
 		<tr key={ domain.domain } ref={ ref }>
@@ -91,7 +101,13 @@ export function DomainsTableRow( {
 					<span className="domains-table__domain-name">{ domain.domain }</span>
 				) }
 			</td>
-			<td>{ site?.name }</td>
+			<td>
+				{ isLoadingSiteDetails ? (
+					<LoadingPlaceholder style={ { width: `${ placeholderWidth }%` } } />
+				) : (
+					siteColumn
+				) }
+			</td>
 		</tr>
 	);
 }

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -82,15 +82,16 @@ export function DomainsTableRow( {
 				{ shouldDisplayPrimaryDomainLabel && <PrimaryDomainLabel /> }
 				{ isManageableDomain ? (
 					<a
-						className="domains-table__domain-link"
+						className="domains-table__domain-name"
 						href={ domainManagementLink( domain, siteSlug, isAllSitesView ) }
 					>
 						{ domain.domain }
 					</a>
 				) : (
-					domain.domain
+					<span className="domains-table__domain-name">{ domain.domain }</span>
 				) }
 			</td>
+			<td>{ site?.name }</td>
 		</tr>
 	);
 }

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -3,7 +3,7 @@ import { useSiteDomainsQuery, useSiteQuery } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { PrimaryDomainLabel } from '../primary-domain-label';
 import { DomainsTableRegisteredUntilCell } from './domains-table-registered-until-cell';
@@ -75,12 +75,12 @@ export function DomainsTableRow( {
 	const isManageableDomain = ! domain.wpcom_domain;
 	const shouldDisplayPrimaryDomainLabel = ! isAllSitesView && isPrimaryDomain;
 
-	const placeholderWidth = useMemo( () => {
+	const [ placeholderWidth ] = useState( () => {
 		const MIN = 40;
 		const MAX = 100;
 
 		return Math.floor( Math.random() * ( MAX - MIN + 1 ) ) + MIN;
-	}, [] );
+	} );
 
 	return (
 		<tr key={ domain.domain } ref={ ref }>

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -92,10 +92,10 @@ export function DomainsTableRow( {
 			return createInterpolateElement(
 				/* translators: ariaHidden means that the component will be skipped by screen readers. */
 				__(
-					'<add>Create</add> <ariaHidden>or</ariaHidden> <connect>connect</connect> <ariaHidden>a site</ariaHidden>'
+					'<create>Create</create> <ariaHidden>or</ariaHidden> <connect>connect</connect> <ariaHidden>a site</ariaHidden>'
 				),
 				{
-					add: (
+					create: (
 						<a
 							href={ domainOnlySiteCreationLink( siteSlug, site?.ID ) }
 							aria-label={ __( 'Create a site for this domain' ) }

--- a/packages/domains-table/src/domains-table/domains-table-site-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-site-cell.tsx
@@ -1,0 +1,57 @@
+import { DomainData, SiteDetails } from '@automattic/data-stores';
+import { createInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
+
+interface DomainsTableSiteCellProps {
+	site?: Pick< SiteDetails, 'ID' | 'name' >;
+	currentDomainData?: DomainData;
+	siteSlug: string;
+}
+
+export const DomainsTableSiteCell = ( {
+	site,
+	currentDomainData,
+	siteSlug,
+}: DomainsTableSiteCellProps ) => {
+	const { __ } = useI18n();
+
+	if ( ! site || ! currentDomainData ) {
+		return null;
+	}
+
+	if ( currentDomainData.current_user_can_create_site_from_domain_only ) {
+		return createInterpolateElement(
+			/* translators: ariaHidden means that the component will be skipped by screen readers. */
+			__(
+				'<create>Create</create> <ariaHidden>or</ariaHidden> <connect>connect</connect> <ariaHidden>a site</ariaHidden>'
+			),
+			{
+				create: (
+					<a
+						href={ domainOnlySiteCreationLink( siteSlug, site.ID ) }
+						aria-label={ __( 'Create a site for this domain' ) }
+					/>
+				),
+				connect: (
+					<a
+						href={ domainManagementTransferToOtherSiteLink( siteSlug, currentDomainData.domain ) }
+						aria-label={ __( 'Connect this domain to an existing site' ) }
+					/>
+				),
+				ariaHidden: <span aria-hidden={ true } />,
+			}
+		);
+	}
+
+	return site.name ?? '-';
+};
+
+export function domainOnlySiteCreationLink( siteSlug: string, siteId: number ) {
+	return `/start/site-selected/?siteSlug=${ encodeURIComponent(
+		siteSlug
+	) }&siteId=${ encodeURIComponent( siteId ) }`;
+}
+
+export function domainManagementTransferToOtherSiteLink( siteSlug: string, domainName: string ) {
+	return `/domains/manage/all/${ domainName }/transfer/other-site/${ siteSlug }`;
+}

--- a/packages/domains-table/src/domains-table/index.stories.tsx
+++ b/packages/domains-table/src/domains-table/index.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/react';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import React from 'react';
-import { testDomain } from '../test-utils';
+import { testDomain, testSite } from '../test-utils';
 import { DomainsTable } from './index';
 
 const queryClient = new QueryClient();
@@ -32,15 +32,27 @@ const testDomains = [
 		wpcom_domain: true,
 	} ),
 	testDomain( { domain: 'example3.com', blog_id: 2, primary_domain: true } ),
+	testDomain( {
+		domain: 'domainonly.com',
+		blog_id: 4,
+		current_user_can_create_site_from_domain_only: true,
+	} ),
+];
+
+const testSites = [
+	testSite( { blog_id: 1, name: 'Example 1' } ),
+	testSite( { blog_id: 2 } ),
+	testSite( { blog_id: 4, name: 'domainonly' } ),
 ];
 
 const defaultArgs = {
 	domains: testDomains.map( ( [ partial ] ) => partial ),
 	isAllSitesView: true,
-	fetchSiteDomains: ( siteId ) =>
+	fetchSiteDomains: ( siteId: number ) =>
 		Promise.resolve( {
 			domains: testDomains.map( ( [ , full ] ) => full ).filter( ( d ) => d.blog_id === siteId ),
 		} ),
+	fetchSite: ( siteId: number ) => Promise.resolve( testSites.find( ( s ) => s.ID === siteId ) ),
 };
 
 const storyDefaults = {

--- a/packages/domains-table/src/domains-table/index.stories.tsx
+++ b/packages/domains-table/src/domains-table/index.stories.tsx
@@ -40,9 +40,9 @@ const testDomains = [
 ];
 
 const testSites = [
-	testSite( { blog_id: 1, name: 'Example 1' } ),
-	testSite( { blog_id: 2 } ),
-	testSite( { blog_id: 4, name: 'domainonly' } ),
+	testSite( { ID: 1, name: 'Example 1' } ),
+	testSite( { ID: 2 } ),
+	testSite( { ID: 4, name: 'domainonly' } ),
 ];
 
 const defaultArgs = {

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -35,19 +35,21 @@
 		height: 44px;
 		vertical-align: middle;
 
-		color: var(--studio-gray-100);
-		font-size: $font-body;
+		color: var(--studio-gray-50);
+		font-size: $font-body-small;
+		line-height: 20px;
 		font-style: normal;
-		font-weight: 500;
-		line-height: 24px;
-	}
 
-	.domains-table__domain-link {
-		color: var(--studio-gray-100);
-
-		&:hover {
+		a:hover {
 			color: var(--color-link);
 		}
+	}
+
+	.domains-table__domain-name {
+		color: var(--studio-gray-100);
+		font-size: $font-body;
+		line-height: 24px;
+		font-weight: 500;
 	}
 
 	.domains-table__primary-domain-label {

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -40,12 +40,15 @@
 		line-height: 20px;
 		font-style: normal;
 
+		a,
 		a:hover {
+			text-decoration: underline;
 			color: var(--color-link);
 		}
 	}
 
 	.domains-table__domain-name {
+		text-decoration: none;
 		color: var(--studio-gray-100);
 		font-size: $font-body;
 		line-height: 24px;

--- a/packages/domains-table/src/test-utils.tsx
+++ b/packages/domains-table/src/test-utils.tsx
@@ -19,6 +19,13 @@ export function renderWithProvider(
 	return rtlRender( ui, { ...renderOptions, wrapper: Wrapper } );
 }
 
+export function testSite( { blog_id = 0, name }: { blog_id: number; name?: string } ) {
+	return {
+		ID: blog_id,
+		name,
+	};
+}
+
 export function testDomain(
 	defaults: Partial< DomainData > = {}
 ): [ PartialDomainData, DomainData ] {

--- a/packages/domains-table/src/test-utils.tsx
+++ b/packages/domains-table/src/test-utils.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render as rtlRender, RenderResult, RenderOptions } from '@testing-library/react';
 import React from 'react';
-import type { PartialDomainData, DomainData } from '@automattic/data-stores';
+import type { PartialDomainData, DomainData, SiteDetails } from '@automattic/data-stores';
 
 export function renderWithProvider(
 	ui: React.ReactElement,
@@ -19,10 +19,12 @@ export function renderWithProvider(
 	return rtlRender( ui, { ...renderOptions, wrapper: Wrapper } );
 }
 
-export function testSite( { blog_id = 0, name }: { blog_id: number; name?: string } ) {
+export function testSite( defaults: Partial< SiteDetails > ) {
 	return {
-		ID: blog_id,
-		name,
+		...defaults,
+		options: {
+			...defaults.options,
+		},
 	};
 }
 


### PR DESCRIPTION
## Proposed Changes

This PR fills the "Site" and "Registered until" cells of the new DomainsTable:

![image](https://github.com/Automattic/wp-calypso/assets/26530524/a39e1fc2-a0dd-4143-8e4a-1901ca1d0293)

I extracted the logic of each cell into its own component so that the `DomainsTableRow` stops growing bigger. Another reason for that is that testing was getting harder because it's difficult to assert the `-` string for multiple places, and we'd need to rely on test IDs.

One thing that I did not test was the placement of the cells (cell order). But I think this might be a tinfoil hat moment from my side.

## Testing Instructions

With the `domains/management` feature flag disabled, note down domains with an expiry date (registered) and ones that do not have one (free, WPCOM ones). Also, note down domain-only entries.

Enable the feature flag and refresh the page. The domain entries should be consistent with the new version of the table.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
~- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~