### PR TITLE
Add Live Preview activation event 

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
@@ -1,4 +1,5 @@
 import { select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import { getEditorType } from '../utils';
 import tracksRecordEvent from './track-record-event';
 
@@ -12,14 +13,16 @@ export const wpcomBlockEditorSaveClick = () => ( {
 	selector:
 		'.editor-entities-saved-states__save-button, .editor-post-publish-button:not(.has-changes-dot)',
 	type: 'click',
-	handler: () => {
+	handler: ( event ) => {
 		const isSiteEditor = getEditorType() === 'site';
 		const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
 		const isEditedPostBeingScheduled = select( 'core/editor' ).isEditedPostBeingScheduled();
 		let actionType = 'publish';
 
 		if ( isSiteEditor ) {
-			const isPreviewingBlockTheme = window.location.search.includes( 'wp_theme_preview' );
+			const isPreviewingBlockTheme =
+				event.target?.textContent.includes( __( 'Activate' ) ) ||
+				event.target?.textContent.includes( __( 'Activate & Save' ) );
 			if ( isPreviewingBlockTheme ) {
 				actionType = 'activate';
 			} else {

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
@@ -12,14 +12,15 @@ export const wpcomBlockEditorSaveClick = () => ( {
 	selector:
 		'.editor-entities-saved-states__save-button, .editor-post-publish-button:not(.has-changes-dot)',
 	type: 'click',
-	handler: ( event ) => {
+	handler: () => {
 		const isSiteEditor = getEditorType() === 'site';
 		const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
 		const isEditedPostBeingScheduled = select( 'core/editor' ).isEditedPostBeingScheduled();
 		let actionType = 'publish';
 
 		if ( isSiteEditor ) {
-			if ( event.target.textContent.includes( 'Activate' ) ) {
+			const isPreviewingBlockTheme = window.location.search.includes( 'wp_theme_preview' );
+			if ( isPreviewingBlockTheme ) {
 				actionType = 'activate';
 			} else {
 				actionType = 'save';

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-save-click.js
@@ -12,14 +12,18 @@ export const wpcomBlockEditorSaveClick = () => ( {
 	selector:
 		'.editor-entities-saved-states__save-button, .editor-post-publish-button:not(.has-changes-dot)',
 	type: 'click',
-	handler: () => {
+	handler: ( event ) => {
 		const isSiteEditor = getEditorType() === 'site';
 		const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
 		const isEditedPostBeingScheduled = select( 'core/editor' ).isEditedPostBeingScheduled();
 		let actionType = 'publish';
 
 		if ( isSiteEditor ) {
-			actionType = 'save';
+			if ( event.target.textContent.includes( 'Activate' ) ) {
+				actionType = 'activate';
+			} else {
+				actionType = 'save';
+			}
 		} else if ( isEditedPostBeingScheduled ) {
 			actionType = 'schedule';
 		} else if ( isCurrentPostPublished ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3301

## Proposed Changes

This PR is a follow-up for #80953 and https://github.com/Automattic/wp-calypso/pull/80956.
Add an event that is fired when a user clicks `Activate` or `Activate & Save` when previewing a theme.

wpcom_block_editor_save_click
<img width="750" alt="Screen Shot 2023-08-24 at 14 19 40" src="https://github.com/Automattic/wp-calypso/assets/5287479/be92a711-832f-4cac-9b54-382a47bd8a06">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch this PR to your sandbox with `cd apps/wpcom-block-editor/ && yarn dev --sync`
* Sandbox widgets.wp.com and your site
* Go to the Site Editor
* See if events fire with https://github.com/Automattic/tracks-chrome-extension

UI that triggers the event

[![Image from Gyazo](https://i.gyazo.com/b59c9aad5a0e3854810f7caf60d62c05.gif)](https://gyazo.com/b59c9aad5a0e3854810f7caf60d62c05)

[![Image from Gyazo](https://i.gyazo.com/6c580580b87a002e44386fcfc11265d1.gif)](https://gyazo.com/6c580580b87a002e44386fcfc11265d1)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?