### PR TITLE
Make sure the event fires when a theme has no style variations

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-sidebar-clicks.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-sidebar-clicks.ts
@@ -45,19 +45,16 @@ export const wpcomSiteEditorSidebarStylesClick = (): DelegateEventHandler => {
 		id: 'wpcom_site_editor_sidebar_styles_click',
 		/**
 		 * There is no id attribute (`#/wp_global_styles`) for themes that do not have style variations.
-		 * Make this selector generic so as to not depend on the DOM structure.
+		 *
+		 * @see https://github.com/okmttdhr/gutenberg/blob/70ccdefe1fd0b02638f5a8ae4f1c03e6f7fe27cc/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js#L63-L83
 		 */
-		selector: '.edit-site-sidebar-navigation-item',
+		selector:
+			'.edit-site-sidebar-navigation-screen__content [role=listitem]:nth-child(2) .edit-site-sidebar-navigation-item',
 		type: 'click',
-		handler: ( event ) => {
-			const target = event.target as HTMLElement | null;
-			if ( target?.textContent !== 'Styles' ) {
-				return;
-			}
+		handler: () =>
 			tracksRecordEvent( 'wpcom_block_editor_nav_sidebar_main_item_click', {
 				item_type: 'styles',
-			} );
-		},
+			} ),
 	};
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-sidebar-clicks.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-sidebar-clicks.ts
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import tracksRecordEvent from './track-record-event';
 import { DelegateEventHandler } from './types';
 
@@ -45,16 +46,19 @@ export const wpcomSiteEditorSidebarStylesClick = (): DelegateEventHandler => {
 		id: 'wpcom_site_editor_sidebar_styles_click',
 		/**
 		 * There is no id attribute (`#/wp_global_styles`) for themes that do not have style variations.
-		 *
-		 * @see https://github.com/okmttdhr/gutenberg/blob/70ccdefe1fd0b02638f5a8ae4f1c03e6f7fe27cc/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js#L63-L83
+		 * Make this selector generic so as to not depend on the DOM structure.
 		 */
-		selector:
-			'.edit-site-sidebar-navigation-screen__content [role=listitem]:nth-child(2) .edit-site-sidebar-navigation-item',
+		selector: '.edit-site-sidebar-navigation-item',
 		type: 'click',
-		handler: () =>
+		handler: ( event ) => {
+			const target = event.target as HTMLElement | null;
+			if ( target?.textContent !== __( 'Styles' ) ) {
+				return;
+			}
 			tracksRecordEvent( 'wpcom_block_editor_nav_sidebar_main_item_click', {
 				item_type: 'styles',
-			} ),
+			} );
+		},
 	};
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-sidebar-clicks.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-sidebar-clicks.ts
@@ -1,4 +1,5 @@
 import tracksRecordEvent from './track-record-event';
+import { DelegateEventHandler } from './types';
 
 export const wpcomSiteEditorSidebarNavigationClick = () => {
 	return {
@@ -39,16 +40,24 @@ export const wpcomSiteEditorSidebarPatternsClick = () => {
 	};
 };
 
-export const wpcomSiteEditorSidebarStylesClick = () => {
+export const wpcomSiteEditorSidebarStylesClick = (): DelegateEventHandler => {
 	return {
 		id: 'wpcom_site_editor_sidebar_styles_click',
-		// \2f is the encoded slash.
-		selector: '#\\2fwp_global_styles',
+		/**
+		 * There is no id attribute (`#/wp_global_styles`) for themes that do not have style variations.
+		 * Make this selector generic so as to not depend on the DOM structure.
+		 */
+		selector: '.edit-site-sidebar-navigation-item',
 		type: 'click',
-		handler: () =>
+		handler: ( event ) => {
+			const target = event.target as HTMLElement | null;
+			if ( target?.textContent !== 'Styles' ) {
+				return;
+			}
 			tracksRecordEvent( 'wpcom_block_editor_nav_sidebar_main_item_click', {
 				item_type: 'styles',
-			} ),
+			} );
+		},
 	};
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-sidebar-clicks.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-sidebar-clicks.ts
@@ -1,7 +1,7 @@
 import tracksRecordEvent from './track-record-event';
 import { DelegateEventHandler } from './types';
 
-export const wpcomSiteEditorSidebarNavigationClick = () => {
+export const wpcomSiteEditorSidebarNavigationClick = (): DelegateEventHandler => {
 	return {
 		id: 'wpcom_site_editor_sidebar_navigation_click',
 		// \2f is the encoded slash.
@@ -14,7 +14,7 @@ export const wpcomSiteEditorSidebarNavigationClick = () => {
 	};
 };
 
-export const wpcomSiteEditorSidebarPagesClick = () => {
+export const wpcomSiteEditorSidebarPagesClick = (): DelegateEventHandler => {
 	return {
 		id: 'wpcom_site_editor_sidebar_pages_click',
 		// \2f is the encoded slash.
@@ -27,7 +27,7 @@ export const wpcomSiteEditorSidebarPagesClick = () => {
 	};
 };
 
-export const wpcomSiteEditorSidebarPatternsClick = () => {
+export const wpcomSiteEditorSidebarPatternsClick = (): DelegateEventHandler => {
 	return {
 		id: 'wpcom_site_editor_sidebar_patterns_click',
 		// \2f is the encoded slash.
@@ -61,7 +61,7 @@ export const wpcomSiteEditorSidebarStylesClick = (): DelegateEventHandler => {
 	};
 };
 
-export const wpcomSiteEditorSidebarTemplatesClick = () => {
+export const wpcomSiteEditorSidebarTemplatesClick = (): DelegateEventHandler => {
 	return {
 		id: 'wpcom_site_editor_sidebar_templates_click',
 		// \2f is the encoded slash.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3301

## Proposed Changes

This PR fixes https://github.com/Automattic/wp-calypso/pull/80953#issuecomment-1691042020 by making sure the "`wpcom_block_editor_nav_sidebar_main_item_click` with `item_type=styles`" event fires even when a theme has no style variations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch this PR to your sandbox with `cd apps/wpcom-block-editor/ && yarn dev --sync`
* Sandbox widgets.wp.com and your site
* Go to horizon.wordpress.com
* Go to the Theme Detail page of a theme without style variations (e.g. Poesis) 
* Click the `Live Preview` button
* Click the `Styles` navigation
* See if events fire with https://github.com/Automattic/tracks-chrome-extension

<img width="746" alt="Screen Shot 2023-08-24 at 16 11 51" src="https://github.com/Automattic/wp-calypso/assets/5287479/03fd4343-9630-4fa8-b2bf-0a894e77f371">

UI that triggers this event

<img width="391" alt="Screen Shot 2023-08-24 at 16 16 21" src="https://github.com/Automattic/wp-calypso/assets/5287479/82a753f5-c918-46fe-9816-3553eaec83ac">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
