### PR TITLE
Assembler: Add a confirmation step for newly created sites without premium styles selection

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
@@ -31,6 +31,12 @@ export const PATTERN_ASSEMBLER_EVENTS = {
 		'calypso_signup_pattern_assembler_screen_activation_activate_click',
 
 	/**
+	 * Screen Activation
+	 */
+	SCREEN_CONFIRMATION_CONFIRM_CLICK:
+		'calypso_signup_pattern_assembler_screen_confirmation_confirm_click',
+
+	/**
 	 * Pattern Panels
 	 */
 	PATTERN_SELECT_CLICK: 'calypso_signup_pattern_assembler_pattern_select_click',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
@@ -31,7 +31,7 @@ export const PATTERN_ASSEMBLER_EVENTS = {
 		'calypso_signup_pattern_assembler_screen_activation_activate_click',
 
 	/**
-	 * Screen Activation
+	 * Screen Confirmation
 	 */
 	SCREEN_CONFIRMATION_CONFIRM_CLICK:
 		'calypso_signup_pattern_assembler_screen_confirmation_confirm_click',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -411,6 +411,7 @@ const PatternAssembler = ( {
 
 		recordSelectedDesign( { flow, intent, design } );
 		submit?.();
+		trackEventContinue();
 	};
 
 	const onUpgradeLater = () => {
@@ -435,8 +436,6 @@ const PatternAssembler = ( {
 	} );
 
 	const onContinueClick = () => {
-		trackEventContinue();
-
 		if ( shouldUnlockGlobalStyles ) {
 			openGlobalStylesUpgradeModal();
 			return;
@@ -556,7 +555,7 @@ const PatternAssembler = ( {
 				</NavigatorScreen>
 
 				<NavigatorScreen path={ NAVIGATOR_PATHS.CONFIRMATION } className="screen-confirmation">
-					<ScreenConfirmation onConfirm={ onConfirm } />
+					<ScreenConfirmation onConfirm={ onConfirm } recordTracksEvent={ recordTracksEvent } />
 				</NavigatorScreen>
 			</div>
 			<div className="pattern-assembler__sidebar-panel">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -47,6 +47,7 @@ import PatternAssemblerContainer from './pattern-assembler-container';
 import PatternLargePreview from './pattern-large-preview';
 import ScreenActivation from './screen-activation';
 import ScreenColorPalettes from './screen-color-palettes';
+import ScreenConfirmation from './screen-confirmation';
 import ScreenFontPairings from './screen-font-pairings';
 import ScreenMain from './screen-main';
 import ScreenPatternListPanel from './screen-pattern-list-panel';
@@ -412,7 +413,7 @@ const PatternAssembler = ( {
 		submit?.();
 	};
 
-	const handleContinue = () => {
+	const onUpgradeLater = () => {
 		if ( isNewSite ) {
 			onSubmit();
 		} else {
@@ -429,7 +430,7 @@ const PatternAssembler = ( {
 		stepName,
 		hasSelectedColorVariation: !! colorVariation,
 		hasSelectedFontVariation: !! fontVariation,
-		onUpgradeLater: handleContinue,
+		onUpgradeLater,
 		recordTracksEvent,
 	} );
 
@@ -441,11 +442,20 @@ const PatternAssembler = ( {
 			return;
 		}
 
-		handleContinue();
+		if ( isNewSite ) {
+			navigator.goTo( NAVIGATOR_PATHS.CONFIRMATION );
+		} else {
+			navigator.goTo( NAVIGATOR_PATHS.ACTIVATION );
+		}
 	};
 
 	const onActivate = () => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_ACTIVATION_ACTIVATE_CLICK );
+		onSubmit();
+	};
+
+	const onConfirm = () => {
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_CONFIRMATION_CONFIRM_CLICK );
 		onSubmit();
 	};
 
@@ -543,6 +553,10 @@ const PatternAssembler = ( {
 
 				<NavigatorScreen path={ NAVIGATOR_PATHS.ACTIVATION } className="screen-activation">
 					<ScreenActivation onActivate={ onActivate } />
+				</NavigatorScreen>
+
+				<NavigatorScreen path={ NAVIGATOR_PATHS.CONFIRMATION } className="screen-confirmation">
+					<ScreenConfirmation onConfirm={ onConfirm } />
 				</NavigatorScreen>
 			</div>
 			<div className="pattern-assembler__sidebar-panel">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -4,7 +4,7 @@ import {
 	getVariationTitle,
 	getVariationType,
 } from '@automattic/global-styles';
-import { useLocale } from '@automattic/i18n-utils';
+import { useLocale, useIsEnglishLocale } from '@automattic/i18n-utils';
 import {
 	StepContainer,
 	isSiteAssemblerFlow,
@@ -94,6 +94,8 @@ const PatternAssembler = ( {
 	const siteId = useSiteIdParam();
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 	const locale = useLocale();
+	const isEnglishLocale = useIsEnglishLocale();
+
 	// New sites are created from 'site-setup' and 'with-site-assembler' flows
 	const isNewSite = !! useQuery().get( 'isNewSite' ) || isSiteSetupFlow( flow );
 
@@ -442,7 +444,12 @@ const PatternAssembler = ( {
 		}
 
 		if ( isNewSite ) {
-			navigator.goTo( NAVIGATOR_PATHS.CONFIRMATION );
+			if ( isEnglishLocale ) {
+				navigator.goTo( NAVIGATOR_PATHS.CONFIRMATION );
+			} else {
+				// Skip screen for other locales until translations are ready
+				onSubmit();
+			}
 		} else {
 			navigator.goTo( NAVIGATOR_PATHS.ACTIVATION );
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -4,7 +4,7 @@ import {
 	getVariationTitle,
 	getVariationType,
 } from '@automattic/global-styles';
-import { useLocale, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { useLocale } from '@automattic/i18n-utils';
 import {
 	StepContainer,
 	isSiteAssemblerFlow,
@@ -94,7 +94,6 @@ const PatternAssembler = ( {
 	const siteId = useSiteIdParam();
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 	const locale = useLocale();
-	const isEnglishLocale = useIsEnglishLocale();
 
 	// New sites are created from 'site-setup' and 'with-site-assembler' flows
 	const isNewSite = !! useQuery().get( 'isNewSite' ) || isSiteSetupFlow( flow );
@@ -444,12 +443,7 @@ const PatternAssembler = ( {
 		}
 
 		if ( isNewSite ) {
-			if ( isEnglishLocale ) {
-				navigator.goTo( NAVIGATOR_PATHS.CONFIRMATION );
-			} else {
-				// Skip screen for other locales until translations are ready
-				onSubmit();
-			}
+			navigator.goTo( NAVIGATOR_PATHS.CONFIRMATION );
 		} else {
 			navigator.goTo( NAVIGATOR_PATHS.ACTIVATION );
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.scss
@@ -21,6 +21,7 @@
 	display: flex;
 	padding-top: 2px;
 	flex-direction: column;
+	flex-grow: 1;
 	gap: 4px;
 	font-size: $font-body-small;
 	line-height: 20px;
@@ -29,5 +30,6 @@
 
 .screen-confirmation__list-item-description {
 	color: var(--studio-gray-60);
+	text-wrap: pretty;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.scss
@@ -1,0 +1,33 @@
+@import "@automattic/typography/styles/fonts";
+
+.screen-confirmation__list {
+	display: flex;
+	flex-direction: column;
+	gap: 18px;
+}
+
+.screen-confirmation__list-item-icon {
+	fill: var(--studio-gray-60);
+	height: 24px;
+	width: 24px;
+	border-radius: 2px;
+	background: var(--studio-gray-0);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.screen-confirmation__list-item-wrapper {
+	display: flex;
+	padding-top: 2px;
+	flex-direction: column;
+	gap: 4px;
+	font-size: $font-body-small;
+	line-height: 20px;
+	letter-spacing: -0.15px;
+}
+
+.screen-confirmation__list-item-description {
+	color: var(--studio-gray-60);
+}
+

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.scss
@@ -9,7 +9,7 @@
 .screen-confirmation__list-item-icon {
 	fill: var(--studio-gray-60);
 	height: 24px;
-	width: 24px;
+	min-width: 24px;
 	border-radius: 2px;
 	background: var(--studio-gray-0);
 	display: flex;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
@@ -1,11 +1,12 @@
 import { Button } from '@automattic/components';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { NavigatorHeader } from '@automattic/onboarding';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { Icon, image, verse, layout } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import NavigatorTitle from './navigator-title';
 import './screen-confirmation.scss';
@@ -17,22 +18,35 @@ interface Props {
 
 const ScreenConfirmation = ( { onConfirm, recordTracksEvent }: Props ) => {
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const list = [
 		{
 			icon: image,
 			title: translate( 'Upload images' ),
-			description: translate( 'Showcase your photos in their best light.' ),
+			description:
+				isEnglishLocale || i18n.hasTranslation( 'Showcase your photos in their best light.' )
+					? translate( 'Showcase your photos in their best light.' )
+					: null,
 		},
 		{
 			icon: verse,
 			title: translate( 'Start writing' ),
-			description: translate( 'Get things going and share your insights.' ),
+			description:
+				isEnglishLocale || i18n.hasTranslation( 'Get things going and share your insights.' )
+					? translate( 'Get things going and share your insights.' )
+					: null,
 		},
 		{
 			icon: layout,
-			title: translate( 'Customize every detail' ),
-			description: translate( 'Make your site even more unique.' ),
+			title:
+				isEnglishLocale || i18n.hasTranslation( 'Customize every detail' )
+					? translate( 'Customize every detail' )
+					: translate( 'Customize in editor' ),
+			description:
+				isEnglishLocale || i18n.hasTranslation( 'Make your site even more unique.' )
+					? translate( 'Make your site even more unique.' )
+					: null,
 		},
 	];
 
@@ -40,7 +54,12 @@ const ScreenConfirmation = ( { onConfirm, recordTracksEvent }: Props ) => {
 		<>
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Great job!' ) } /> }
-				description={ translate( 'Time to add some content and bring your site to life!' ) }
+				description={
+					isEnglishLocale ||
+					i18n.hasTranslation( 'Time to add some content and bring your site to life!' )
+						? translate( 'Time to add some content and bring your site to life!' )
+						: translate( 'Bring your site to life with some content.' )
+				}
 				onBack={ () => {
 					recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_BACK_CLICK, {
 						screen_from: 'confirmation',
@@ -65,7 +84,9 @@ const ScreenConfirmation = ( { onConfirm, recordTracksEvent }: Props ) => {
 			</div>
 			<div className="screen-container__footer">
 				<Button className="pattern-assembler__button" primary onClick={ onConfirm }>
-					{ translate( 'Start adding content' ) }
+					{ isEnglishLocale || i18n.hasTranslation( 'Start adding content' )
+						? translate( 'Start adding content' )
+						: translate( 'Continue' ) }
 				</Button>
 			</div>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
@@ -1,12 +1,12 @@
 import { Button } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { NavigatorHeader } from '@automattic/onboarding';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { Icon, image, verse, layout } from '@wordpress/icons';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import NavigatorTitle from './navigator-title';
 import './screen-confirmation.scss';
@@ -18,35 +18,31 @@ interface Props {
 
 const ScreenConfirmation = ( { onConfirm, recordTracksEvent }: Props ) => {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const list = [
 		{
 			icon: image,
 			title: translate( 'Upload images' ),
-			description:
-				isEnglishLocale || i18n.hasTranslation( 'Showcase your photos in their best light.' )
-					? translate( 'Showcase your photos in their best light.' )
-					: null,
+			description: hasEnTranslation( 'Showcase your photos in their best light.' )
+				? translate( 'Showcase your photos in their best light.' )
+				: null,
 		},
 		{
 			icon: verse,
 			title: translate( 'Start writing' ),
-			description:
-				isEnglishLocale || i18n.hasTranslation( 'Get things going and share your insights.' )
-					? translate( 'Get things going and share your insights.' )
-					: null,
+			description: hasEnTranslation( 'Get things going and share your insights.' )
+				? translate( 'Get things going and share your insights.' )
+				: null,
 		},
 		{
 			icon: layout,
-			title:
-				isEnglishLocale || i18n.hasTranslation( 'Customize every detail' )
-					? translate( 'Customize every detail' )
-					: translate( 'Customize in editor' ),
-			description:
-				isEnglishLocale || i18n.hasTranslation( 'Make your site even more unique.' )
-					? translate( 'Make your site even more unique.' )
-					: null,
+			title: hasEnTranslation( 'Customize every detail' )
+				? translate( 'Customize every detail' )
+				: translate( 'Customize in editor' ),
+			description: hasEnTranslation( 'Make your site even more unique.' )
+				? translate( 'Make your site even more unique.' )
+				: null,
 		},
 	];
 
@@ -55,8 +51,7 @@ const ScreenConfirmation = ( { onConfirm, recordTracksEvent }: Props ) => {
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Great job!' ) } /> }
 				description={
-					isEnglishLocale ||
-					i18n.hasTranslation( 'Time to add some content and bring your site to life!' )
+					hasEnTranslation( 'Time to add some content and bring your site to life!' )
 						? translate( 'Time to add some content and bring your site to life!' )
 						: translate( 'Bring your site to life with some content.' )
 				}
@@ -84,7 +79,7 @@ const ScreenConfirmation = ( { onConfirm, recordTracksEvent }: Props ) => {
 			</div>
 			<div className="screen-container__footer">
 				<Button className="pattern-assembler__button" primary onClick={ onConfirm }>
-					{ isEnglishLocale || i18n.hasTranslation( 'Start adding content' )
+					{ hasEnTranslation( 'Start adding content' )
 						? translate( 'Start adding content' )
 						: translate( 'Continue' ) }
 				</Button>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
@@ -3,80 +3,69 @@ import { NavigatorHeader } from '@automattic/onboarding';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
-	__experimentalUseNavigator as useNavigator,
 } from '@wordpress/components';
 import { Icon, image, verse, layout } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import NavigatorTitle from './navigator-title';
 import './screen-confirmation.scss';
 
 interface Props {
 	onConfirm: () => void;
+	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 }
 
-const ScreenConfirmation = ( { onConfirm }: Props ) => {
+const ScreenConfirmation = ( { onConfirm, recordTracksEvent }: Props ) => {
 	const translate = useTranslate();
-	const { goBack } = useNavigator();
+
+	const list = [
+		{
+			icon: image,
+			title: translate( 'Upload images' ),
+			description: translate( 'Showcase your photos in their best light.' ),
+		},
+		{
+			icon: verse,
+			title: translate( 'Start writing' ),
+			description: translate( 'Get things going and share your insights.' ),
+		},
+		{
+			icon: layout,
+			title: translate( 'Customize every detail' ),
+			description: translate( 'Make your site even more unique.' ),
+		},
+	];
 
 	return (
 		<>
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Great job!' ) } /> }
-				description={ translate( 'Prepare to bring your site to life with your unique content.' ) }
+				description={ translate( 'Time to add some content and bring your site to life!' ) }
 				onBack={ () => {
-					goBack();
-					// @TODO: Track back event
+					recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_BACK_CLICK, {
+						screen_from: 'confirmation',
+						screen_to: 'styles',
+					} );
 				} }
 			/>
 			<div className="screen-container__body">
 				<VStack spacing="4" className="screen-confirmation__list">
-					<HStack spacing="4" alignment="top">
-						<div className="screen-confirmation__list-item-icon">
-							<Icon icon={ image } size={ 18.6 } />
-						</div>
-						<VStack spacing="1" className="screen-confirmation__list-item-wrapper">
-							<strong className="screen-confirmation__list-item-title">
-								{ translate( 'Upload your photos' ) }
-							</strong>
-							<p className="screen-confirmation__list-item-description">
-								{ /* @TODO: Update copy */ }
-								{ translate( 'Morbi pellentesque mauris eget laoreet.' ) }
-							</p>
-						</VStack>
-					</HStack>
-					<HStack spacing="4" alignment="top">
-						<div className="screen-confirmation__list-item-icon">
-							<Icon icon={ verse } size={ 18.6 } />
-						</div>
-						<VStack spacing="1" className="screen-confirmation__list-item-wrapper">
-							<strong className="screen-confirmation__list-item-title">
-								{ translate( 'Write your content' ) }
-							</strong>
-							<p className="screen-confirmation__list-item-description">
-								{ /* @TODO: Update copy */ }
-								{ translate( 'Morbi pellentesque mauris eget laoreet.' ) }
-							</p>
-						</VStack>
-					</HStack>
-					<HStack spacing="4" alignment="top">
-						<div className="screen-confirmation__list-item-icon">
-							<Icon icon={ layout } size={ 18.6 } />
-						</div>
-						<VStack spacing="1" className="screen-confirmation__list-item-wrapper">
-							<strong className="screen-confirmation__list-item-title">
-								{ translate( 'Customize every detail' ) }
-							</strong>
-							<p className="screen-confirmation__list-item-description">
-								{ /* @TODO: Update copy */ }
-								{ translate( 'Morbi pellentesque mauris eget laoreet.' ) }
-							</p>
-						</VStack>
-					</HStack>
+					{ list.map( ( { icon, title, description } ) => (
+						<HStack spacing="4" alignment="top" key={ title }>
+							<div className="screen-confirmation__list-item-icon">
+								<Icon icon={ icon } size={ 18.6 } />
+							</div>
+							<VStack spacing="1" className="screen-confirmation__list-item-wrapper">
+								<strong className="screen-confirmation__list-item-title">{ title }</strong>
+								<p className="screen-confirmation__list-item-description">{ description }</p>
+							</VStack>
+						</HStack>
+					) ) }
 				</VStack>
 			</div>
 			<div className="screen-container__footer">
 				<Button className="pattern-assembler__button" primary onClick={ onConfirm }>
-					{ translate( 'Ready to add content' ) }
+					{ translate( 'Start adding content' ) }
 				</Button>
 			</div>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
@@ -39,6 +39,7 @@ const ScreenConfirmation = ( { onConfirm }: Props ) => {
 								{ translate( 'Upload your photos' ) }
 							</strong>
 							<p className="screen-confirmation__list-item-description">
+								{ /* @TODO: Update copy */ }
 								{ translate( 'Morbi pellentesque mauris eget laoreet.' ) }
 							</p>
 						</VStack>
@@ -52,6 +53,7 @@ const ScreenConfirmation = ( { onConfirm }: Props ) => {
 								{ translate( 'Write your content' ) }
 							</strong>
 							<p className="screen-confirmation__list-item-description">
+								{ /* @TODO: Update copy */ }
 								{ translate( 'Morbi pellentesque mauris eget laoreet.' ) }
 							</p>
 						</VStack>
@@ -65,6 +67,7 @@ const ScreenConfirmation = ( { onConfirm }: Props ) => {
 								{ translate( 'Customize every detail' ) }
 							</strong>
 							<p className="screen-confirmation__list-item-description">
+								{ /* @TODO: Update copy */ }
 								{ translate( 'Morbi pellentesque mauris eget laoreet.' ) }
 							</p>
 						</VStack>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
@@ -1,0 +1,83 @@
+import { Button } from '@automattic/components';
+import { NavigatorHeader } from '@automattic/onboarding';
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalUseNavigator as useNavigator,
+} from '@wordpress/components';
+import { Icon, image, verse, layout } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import NavigatorTitle from './navigator-title';
+import './screen-confirmation.scss';
+
+interface Props {
+	onConfirm: () => void;
+}
+
+const ScreenConfirmation = ( { onConfirm }: Props ) => {
+	const translate = useTranslate();
+	const { goBack } = useNavigator();
+
+	return (
+		<>
+			<NavigatorHeader
+				title={ <NavigatorTitle title={ translate( 'Great job!' ) } /> }
+				description={ translate( 'Prepare to bring your site to life with your unique content.' ) }
+				onBack={ () => {
+					goBack();
+					// @TODO: Track back event
+				} }
+			/>
+			<div className="screen-container__body">
+				<VStack spacing="4" className="screen-confirmation__list">
+					<HStack spacing="4" alignment="top">
+						<div className="screen-confirmation__list-item-icon">
+							<Icon icon={ image } size={ 18.6 } />
+						</div>
+						<VStack spacing="1" className="screen-confirmation__list-item-wrapper">
+							<strong className="screen-confirmation__list-item-title">
+								{ translate( 'Upload your photos' ) }
+							</strong>
+							<p className="screen-confirmation__list-item-description">
+								{ translate( 'Morbi pellentesque mauris eget laoreet.' ) }
+							</p>
+						</VStack>
+					</HStack>
+					<HStack spacing="4" alignment="top">
+						<div className="screen-confirmation__list-item-icon">
+							<Icon icon={ verse } size={ 18.6 } />
+						</div>
+						<VStack spacing="1" className="screen-confirmation__list-item-wrapper">
+							<strong className="screen-confirmation__list-item-title">
+								{ translate( 'Write your content' ) }
+							</strong>
+							<p className="screen-confirmation__list-item-description">
+								{ translate( 'Morbi pellentesque mauris eget laoreet.' ) }
+							</p>
+						</VStack>
+					</HStack>
+					<HStack spacing="4" alignment="top">
+						<div className="screen-confirmation__list-item-icon">
+							<Icon icon={ layout } size={ 18.6 } />
+						</div>
+						<VStack spacing="1" className="screen-confirmation__list-item-wrapper">
+							<strong className="screen-confirmation__list-item-title">
+								{ translate( 'Customize every detail' ) }
+							</strong>
+							<p className="screen-confirmation__list-item-description">
+								{ translate( 'Morbi pellentesque mauris eget laoreet.' ) }
+							</p>
+						</VStack>
+					</HStack>
+				</VStack>
+			</div>
+			<div className="screen-container__footer">
+				<Button className="pattern-assembler__button" primary onClick={ onConfirm }>
+					{ translate( 'Ready to add content' ) }
+				</Button>
+			</div>
+		</>
+	);
+};
+
+export default ScreenConfirmation;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes  #80679

## Proposed Changes

* Add a confirmation screen


**Important Note:** This screen is only for users who have not selected any custom styles and when the site is newly created (not a theme switch)



https://github.com/Automattic/wp-calypso/assets/1881481/88c24069-5742-414c-96b0-68229e006937

<img width="365" alt="Screenshot 2566-08-25 at 11 59 18" src="https://github.com/Automattic/wp-calypso/assets/1881481/3b73e8c6-cefe-4a12-a589-cf3f13a3c0b1">

## Testing Instructions

* Create a new site (this is required)
- Add patterns
- Click `Save and continue`
- Expect to see the new confirmation screen
- Click `Ready to add content`
- Expect to be redirected to the editor

Also, after the TODO is done, verify the back button is being tracked with props `screen_from: confirmation` and `screen_to: styles`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

