### PR TITLE
Jetpack E2E: add Donations Form flow.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/donations-form.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/donations-form.ts
@@ -91,9 +91,19 @@ export class DonationsFormFlow implements BlockFlow {
 			.click();
 
 		// Verify the donation popup.
-		await context.page
-			.frameLocator( 'iframe[id=TB_iframeContent]' )
-			.locator( '.wpsm-modal' )
-			.waitFor();
+		// For sitse with plans Premium or lower, the block cannot be used and so the popup modal
+		// states as such.
+		// For sites where sales are allowed, ther are two variants in how this flow can behave:
+		// 	1. on normal, user-controlled browsers, a Stripe-powered overlay appears.
+		// 	2. on Playwright-controlled browsers, the page navigates to show a similar
+		//     Stripe-powered overlay as 1.
+		// Since this is used for automated E2E testing, we're disregarding and not checking for
+		// variant 1.
+		await Promise.race( [
+			context.page.getByRole( 'button', { name: /pay now/i } ).waitFor(),
+			context.page
+				.frameLocator( 'iframe[id=TB_iframeContent]' )
+				.getByRole( 'heading', { name: 'Sales disabled' } ),
+		] );
 	}
 }

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/donations-form.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/donations-form.ts
@@ -1,0 +1,99 @@
+import { BlockFlow, EditorContext, PublishedPostContext } from '.';
+
+type DonationFrequency = 'One-Time' | 'Monthly' | 'Yearly';
+
+interface ConfigurationData {
+	frequency?: DonationFrequency;
+	currency: string;
+}
+
+interface ValidationData {
+	frequency: DonationFrequency;
+	customAmount: number;
+	predefinedAmount: number;
+}
+
+const blockParentSelector = 'div[aria-label="Block: Donations Form"]';
+
+/**
+ * Represents the flow of using the Donations Form block.
+ */
+export class DonationsFormFlow implements BlockFlow {
+	private configurationData: ConfigurationData;
+	private validationData: ValidationData;
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData data with which to configure and validate the block
+	 */
+	constructor( configurationData: ConfigurationData, validationData: ValidationData ) {
+		this.configurationData = configurationData;
+		this.validationData = validationData;
+	}
+
+	blockSidebarName = 'Donations Form';
+	blockEditorSelector = blockParentSelector;
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		const block = editorCanvas.getByRole( 'document', { name: 'Block: Donations Form' } );
+
+		if ( this.configurationData.currency ) {
+			await context.editorPage.clickBlockToolbarButton( { name: 'Change currency' } );
+			await context.editorPage.selectFromToolbarPopover(
+				this.configurationData.currency.toUpperCase()
+			);
+		}
+
+		if ( this.configurationData.frequency ) {
+			await block.getByRole( 'button', { name: this.configurationData.frequency } ).click();
+		}
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		// Another frequency can be selectd.
+		await context.page
+			.getByRole( 'main' )
+			.getByRole( 'button', { name: this.validationData.frequency } )
+			.click();
+
+		// Custom donation amount can be entered.
+		await context.page
+			.getByRole( 'main' )
+			.locator( '.donations__amount-value' )
+			.fill( this.validationData.customAmount.toString() );
+		await context.page
+			.getByRole( 'main' )
+			.getByRole( 'heading', { name: this.validationData.frequency } )
+			.waitFor();
+
+		// Select one of the tiers.
+		await context.page
+			.getByRole( 'main' )
+			.locator( `[data-amount="${ this.validationData.predefinedAmount }"]:visible` )
+			.click();
+
+		// Click on donate.
+		await context.page
+			.getByRole( 'main' )
+			.getByRole( 'link', { name: /Donate/, disabled: false } )
+			.click();
+
+		// Verify the donation popup.
+		await context.page
+			.frameLocator( 'iframe[id=TB_iframeContent]' )
+			.locator( '.wpsm-modal' )
+			.waitFor();
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -19,6 +19,7 @@ export * from './tiled-gallery';
 export * from './youtube';
 export * from './layout-grid';
 export * from './ai-assistant';
+export * from './donations-form';
 
 /* Types */
 export * from './types';

--- a/test/e2e/specs/blocks/blocks__jetpack-earn.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-earn.ts
@@ -6,6 +6,7 @@ import {
 	BlockFlow,
 	PayWithPaypalBlockFlow,
 	OpenTableFlow,
+	DonationsFormFlow,
 	// PaymentsBlockFlow,
 	// envVariables,
 } from '@automattic/calypso-e2e';
@@ -20,6 +21,17 @@ const blockFlows: BlockFlow[] = [
 	new OpenTableFlow( {
 		restaurant: 'Miku Restaurant - Vancouver',
 	} ),
+	new DonationsFormFlow(
+		{
+			frequency: 'Yearly',
+			currency: 'CAD',
+		},
+		{
+			frequency: 'Yearly',
+			customAmount: 50,
+			predefinedAmount: 5,
+		}
+	),
 ];
 
 // We're just skipping the Payments Button test for now due to this bug:


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80730.

## Proposed Changes

This PR adds a smoke test flow for the Donation Forms block.

Key flows
- add block
- change currency
- interact with published block

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
