### PR TITLE
Add ceil function to migration expiration date

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -155,7 +155,7 @@ export class SiteNotice extends Component {
 	}
 
 	daysRemaining( { endsAt } ) {
-		return moment( endsAt ).diff( moment(), 'days' );
+		return Math.ceil( moment( endsAt ).diff( moment(), 'days', true ) );
 	}
 
 	render() {

--- a/client/my-sites/plans/trials/trial-banner/index.tsx
+++ b/client/my-sites/plans/trials/trial-banner/index.tsx
@@ -26,7 +26,7 @@ const TrialBanner = ( props: TrialBannerProps ) => {
 		( state ) => ( {
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
 			trialExpired: isTrialExpired( state, selectedSiteId ),
-			trialDaysLeft: Math.floor( getTrialDaysLeft( state, selectedSiteId ) || 0 ),
+			trialDaysLeft: Math.ceil( getTrialDaysLeft( state, selectedSiteId ) || 0 ),
 			trialExpiration: getTrialExpiration( state, selectedSiteId ),
 		} )
 	);


### PR DESCRIPTION
Expiration date is now +1 day.

## Proposed Changes

* Add ceil to dates

![image](https://github.com/Automattic/wp-calypso/assets/167611/0c4b1ba8-396b-450b-abde-41c4872d002b)

## Testing Instructions

1. Open a site with a free migration trial
2. From the store admin set the date to seven days from now minus some minutes, one day from now and in the past
3. Check if the countdown are ok on `http://calypso.localhost:3000/plans/__BLOG__` and on the left sidebar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
