### PR TITLE
100 Year: Fix domain copy on domains page for a plan that has a domain credit

### DIFF
--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -1,4 +1,4 @@
-import { isFreePlan } from '@automattic/calypso-products';
+import { PLAN_100_YEARS, isFreePlan } from '@automattic/calypso-products';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -12,6 +12,8 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 
 	const siteHasPaidPlan =
 		selectedSite?.plan?.product_slug && ! isFreePlan( selectedSite.plan.product_slug );
+
+	const siteHasHundredYearPlan = selectedSite?.plan?.product_slug === PLAN_100_YEARS;
 
 	let title = translate( 'Get your domain' );
 	let line = translate(
@@ -38,9 +40,11 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 
 	if ( siteHasPaidPlan && hasDomainCredit ) {
 		title = translate( 'Claim your free domain' );
-		line = translate(
-			'You have a free one-year domain registration or transfer included with your plan.'
-		);
+		line = siteHasHundredYearPlan
+			? translate( 'You have a free domain registration or transfer included with your plan.' )
+			: translate(
+					'You have a free one-year domain registration or transfer included with your plan.'
+			  );
 		action = translate( 'Search for a domain' );
 		actionURL = domainAddNew( selectedSite.slug );
 		secondaryAction = translate( 'I have a domain' );


### PR DESCRIPTION
Closes Automattic/martech#2104

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This plan has a domain credit that lasts the whole plan term, not just the first year. This updates the copy on this page to match that.

![Screenshot 2023-08-24 at 12 23 09](https://github.com/Automattic/wp-calypso/assets/52675688/2899071d-7495-4725-acf7-c3b5673f6808)


## Testing Instructions

* With a 100y plan, click the "Domains" link in the sidebar. 
* Confirm no regression for other plans.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

cc: @dzver 