### PR TITLE
Hiding the upgrade CTA for 100 year plan

### DIFF
--- a/client/my-sites/earn/components/commission-fees.tsx
+++ b/client/my-sites/earn/components/commission-fees.tsx
@@ -7,6 +7,7 @@ type CommissionFeesProps = {
 	commission: number | null;
 	iconSize?: number;
 	siteSlug?: string | null;
+	isPlan100YearPlan?: boolean;
 };
 
 const CommissionFees = ( {
@@ -14,6 +15,7 @@ const CommissionFees = ( {
 	commission,
 	iconSize = 16,
 	siteSlug,
+	isPlan100YearPlan,
 }: CommissionFeesProps ) => {
 	const translate = useTranslate();
 
@@ -22,7 +24,7 @@ const CommissionFees = ( {
 	}
 
 	const upgradeLink =
-		commission === 0 ? null : (
+		commission === 0 || isPlan100YearPlan ? null : (
 			<>
 				{ ' ' }
 				<a href={ siteSlug ? `/plans/${ siteSlug }` : '/plans' }>

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -1,6 +1,7 @@
 import {
 	FEATURE_SIMPLE_PAYMENTS,
 	FEATURE_WORDADS_INSTANT,
+	PLAN_100_YEARS,
 	PLAN_JETPACK_SECURITY_DAILY,
 	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
@@ -61,6 +62,8 @@ const Home = () => {
 	const isRequestingWordAds = useSelector( ( state ) =>
 		isRequestingWordAdsApprovalForSite( state, site )
 	);
+
+	const isPlan100YearPlan = sitePlanSlug === PLAN_100_YEARS;
 
 	const hasConnectedAccount = Boolean( connectedAccountId );
 	const isNonAtomicJetpack = Boolean( isJetpack && ! isSiteTransfer );
@@ -511,6 +514,7 @@ const Home = () => {
 					commission={ commission }
 					iconSize={ 14 }
 					siteSlug={ site?.slug }
+					isPlan100YearPlan={ isPlan100YearPlan }
 				/>
 			</>
 		),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/Martech#2102

## Proposed Changes

* This will hide the upgrade CTA under Tools>Earn for hundred year plans. 
* The commission is fixed in D119735-code

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test it on a hundred year plan. You should see the commission (2% if you patch the backend code and sandbox). But in either case you won't see the upsell
* No regression for Busines, Free, etc.

![Screenshot 2023-08-24 at 12 38 26](https://github.com/Automattic/wp-calypso/assets/52675688/987f1a8d-94f1-4116-84e4-015008fbf75f)
![Screenshot 2023-08-24 at 12 37 28](https://github.com/Automattic/wp-calypso/assets/52675688/83908cf4-d341-4cce-8681-0459a996d045)
![Screenshot 2023-08-24 at 12 36 25](https://github.com/Automattic/wp-calypso/assets/52675688/cbda28d1-fb0a-46cc-be0a-d37d452acc49)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
