### PR TITLE
100 year: Update plan title and descriptions in calypso products

### DIFF
--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -2718,16 +2718,16 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		group: GROUP_WPCOM,
 		type: TYPE_100_YEAR,
 		// Todo: ¯\_(ツ)_/¯ on the copy.
-		getTitle: () => i18n.translate( '100 Year Plan' ),
+		getTitle: () => i18n.translate( '100-Year Plan' ),
 		getAudience: () => i18n.translate( 'Best for long-term thinkers' ),
 		getBlogAudience: () => i18n.translate( 'Best for long-term thinkers' ),
 		getPortfolioAudience: () => i18n.translate( 'Best for long-term thinkers' ),
 		getStoreAudience: () => i18n.translate( 'Best for long-term thinkers' ),
-		getPlanTagline: () => i18n.translate( 'A plan for the future of your website.' ),
-		getDescription: () => i18n.translate( 'A plan for the future of your website.' ),
-		getShortDescription: () => i18n.translate( 'A plan for the future of your website.' ),
-		getTagline: () => i18n.translate( 'A plan for the future of your website.' ),
-		getBlogOnboardingTagLine: () => i18n.translate( 'A plan for the future of your website.' ),
+		getPlanTagline: () => i18n.translate( 'A plan to leave a lasting mark on the web.' ),
+		getDescription: () => i18n.translate( 'A plan to leave a lasting mark on the web.' ),
+		getShortDescription: () => i18n.translate( 'A plan to leave a lasting mark on the web.' ),
+		getTagline: () => i18n.translate( 'A plan to leave a lasting mark on the web.' ),
+		getBlogOnboardingTagLine: () => i18n.translate( 'A plan to leave a lasting mark on the web.' ),
 		getBillingTimeFrame: WPComGetBillingTimeframe,
 		availableFor: ( plan ) =>
 			[


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Updating the title to title case and hyphenation, to match backend. 
* Some tweaks on descriptions. We can always re-visit these.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check for typos in the object.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
