### PR TITLE
Assembler: Add the Upsell screen

### DIFF
--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -6,7 +6,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
-
+import useGlobalStylesUpgradeTranslations from './use-global-styles-upgrade-translations';
 import './style.scss';
 
 export interface PremiumGlobalStylesUpgradeModalProps {
@@ -29,21 +29,14 @@ export default function PremiumGlobalStylesUpgradeModal( {
 }: PremiumGlobalStylesUpgradeModalProps ) {
 	const translate = useTranslate();
 	const premiumPlanProduct = useSelector( ( state ) => getProductBySlug( state, PLAN_PREMIUM ) );
+	const translations = useGlobalStylesUpgradeTranslations( { numOfSelectedGlobalStyles } );
 	const isLoading = ! premiumPlanProduct;
-	const features = [
-		<strong>{ translate( 'Free domain for one year' ) }</strong>,
-		<strong>{ translate( 'Premium themes' ) }</strong>,
-		translate( 'Style customization' ),
-		translate( 'Live chat support' ),
-		translate( 'Ad-free experience' ),
-		translate( 'Earn with WordAds' ),
-	];
 
 	const featureList = (
 		<div className="upgrade-modal__included">
-			<h2>{ translate( 'Included with your Premium plan' ) }</h2>
+			<h2>{ translations.featuresTitle }</h2>
 			<ul>
-				{ features.map( ( feature, i ) => (
+				{ translations.features.map( ( feature, i ) => (
 					<li key={ i } className="upgrade-modal__included-item">
 						<Gridicon icon="checkmark" size={ 16 } />
 						{ feature }
@@ -71,33 +64,21 @@ export default function PremiumGlobalStylesUpgradeModal( {
 							<h1 className="upgrade-modal__heading">{ translate( 'Unlock custom styles' ) }</h1>
 							{ description ?? (
 								<>
-									<p>
-										{ translate(
-											'You’ve selected a custom style that will only be visible to visitors after upgrading to the Premium plan or higher.',
-											'You’ve selected custom styles that will only be visible to visitors after upgrading to the Premium plan or higher.',
-											{ count: numOfSelectedGlobalStyles }
-										) }
-									</p>
-									<p>
-										{ translate(
-											'Upgrade now to unlock your custom style and get access to tons of other features. Or you can decide later and try it out first.',
-											'Upgrade now to unlock your custom styles and get access to tons of other features. Or you can decide later and try them out first.',
-											{ count: numOfSelectedGlobalStyles }
-										) }
-									</p>
+									<p>{ translations.description }</p>
+									<p>{ translations.promotion }</p>
 								</>
 							) }
 							{ featureList }
 							<div className="upgrade-modal__actions bundle">
 								<Button className="upgrade-modal__cancel" onClick={ () => tryStyle() }>
-									{ translate( 'Decide later' ) }
+									{ translations.cancel }
 								</Button>
 								<Button
 									className="upgrade-modal__upgrade-plan"
 									primary
 									onClick={ () => checkout() }
 								>
-									{ translate( 'Upgrade plan' ) }
+									{ translations.upgrade }
 								</Button>
 							</div>
 						</div>

--- a/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
@@ -1,7 +1,5 @@
 import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'calypso/state';
-import { getProductBySlug } from 'calypso/state/products-list/selectors';
 
 interface Props {
 	numOfSelectedGlobalStyles?: number;
@@ -9,8 +7,8 @@ interface Props {
 
 const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: Props ) => {
 	const translate = useTranslate();
-	const planProduct = useSelector( ( state ) => getProductBySlug( state, PLAN_PREMIUM ) );
 	const plan = getPlan( PLAN_PREMIUM );
+	const planTitle = plan?.getTitle() ?? '';
 	const features = [
 		<strong>{ translate( 'Free domain for one year' ) }</strong>,
 		<strong>{ translate( 'Premium themes' ) }</strong>,
@@ -24,9 +22,12 @@ const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: 
 		featuresTitle: translate( 'Included with your Premium plan' ),
 		features: features,
 		description: translate(
-			'You’ve selected a custom style that will only be visible to visitors after upgrading to the Premium plan or higher.',
-			'You’ve selected custom styles that will only be visible to visitors after upgrading to the Premium plan or higher.',
-			{ count: numOfSelectedGlobalStyles }
+			'You’ve selected a custom style that will only be visible to visitors after upgrading to the %(planTitle)s plan or higher.',
+			'You’ve selected custom styles that will only be visible to visitors after upgrading to the %(planTitle)s plan or higher.',
+			{
+				count: numOfSelectedGlobalStyles,
+				args: { planTitle },
+			}
 		),
 		promotion: translate(
 			'Upgrade now to unlock your custom style and get access to tons of other features. Or you can decide later and try it out first.',
@@ -35,11 +36,8 @@ const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: 
 		),
 		cancel: translate( 'Decide later' ),
 		upgrade: translate( 'Upgrade plan' ),
-		upgradeWithPlan: translate( 'Get %(planTitle)s for %(displayPrice)s/month', {
-			args: {
-				planTitle: plan?.getTitle() ?? '',
-				displayPrice: planProduct?.cost_per_month_display ?? '',
-			},
+		upgradeWithPlan: translate( 'Get %(planTitle)s', {
+			args: { planTitle },
 		} ),
 	};
 };

--- a/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
@@ -1,0 +1,47 @@
+import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
+
+interface Props {
+	numOfSelectedGlobalStyles?: number;
+}
+
+const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: Props ) => {
+	const translate = useTranslate();
+	const planProduct = useSelector( ( state ) => getProductBySlug( state, PLAN_PREMIUM ) );
+	const plan = getPlan( PLAN_PREMIUM );
+	const features = [
+		<strong>{ translate( 'Free domain for one year' ) }</strong>,
+		<strong>{ translate( 'Premium themes' ) }</strong>,
+		translate( 'Style customization' ),
+		translate( 'Live chat support' ),
+		translate( 'Ad-free experience' ),
+		translate( 'Earn with WordAds' ),
+	];
+
+	return {
+		featuresTitle: translate( 'Included with your Premium plan' ),
+		features: features,
+		description: translate(
+			'You’ve selected a custom style that will only be visible to visitors after upgrading to the Premium plan or higher.',
+			'You’ve selected custom styles that will only be visible to visitors after upgrading to the Premium plan or higher.',
+			{ count: numOfSelectedGlobalStyles }
+		),
+		promotion: translate(
+			'Upgrade now to unlock your custom style and get access to tons of other features. Or you can decide later and try it out first.',
+			'Upgrade now to unlock your custom styles and get access to tons of other features. Or you can decide later and try them out first.',
+			{ count: numOfSelectedGlobalStyles }
+		),
+		cancel: translate( 'Decide later' ),
+		upgrade: translate( 'Upgrade plan' ),
+		upgradeWithPlan: translate( 'Get %(planTitle)s for %(displayPrice)s/month', {
+			args: {
+				planTitle: plan?.getTitle() ?? '',
+				displayPrice: planProduct?.cost_per_month_display ?? '',
+			},
+		} ),
+	};
+};
+
+export default useGlobalStylesUpgradeTranslations;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -12,6 +12,7 @@ export const NAVIGATOR_PATHS = {
 	STYLES_FONTS: '/styles/fonts',
 	ACTIVATION: '/activation',
 	CONFIRMATION: '/confirmation',
+	UPSELL: '/upsell',
 };
 
 export const INITIAL_PATH = NAVIGATOR_PATHS.MAIN_HEADER;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
@@ -36,6 +36,16 @@ export const PATTERN_ASSEMBLER_EVENTS = {
 	SCREEN_CONFIRMATION_CONFIRM_CLICK:
 		'calypso_signup_pattern_assembler_screen_confirmation_confirm_click',
 
+	/*
+	 * Screen Upsell
+	 */
+	SCREEN_UPSELL_CHECKOUT_BUTTON_CLICK:
+		'calypso_signup_pattern_assembler_screen_upsell_checkout_button_click',
+	SCREEN_UPSELL_UPGRADE_LATER_BUTTON_CLICK:
+		'calypso_signup_pattern_assembler_screen_upsell_upgrade_later_button_click',
+	SCREEN_UPSELL_EDIT_YOUR_CONTENT_BUTTON_CLICK:
+		'calypso_signup_pattern_assembler_screen_upsell_edit_your_content_button_click',
+
 	/**
 	 * Pattern Panels
 	 */
@@ -51,18 +61,6 @@ export const PATTERN_ASSEMBLER_EVENTS = {
 	PATTERN_SHUFFLE_CLICK: 'calypso_signup_pattern_assembler_pattern_shuffle_click',
 
 	PREVIEW_DEVICE_CLICK: 'calypso_signup_pattern_assembler_preview_device_click',
-
-	/**
-	 * Global Styles Gating Modal
-	 */
-	GLOBAL_STYLES_GATING_MODAL_SHOW:
-		'calypso_signup_pattern_assembler_global_styles_gating_modal_show',
-	GLOBAL_STYLES_GATING_MODAL_CLOSE_BUTTON_CLICK:
-		'calypso_signup_pattern_assembler_global_styles_gating_modal_close_button_click',
-	GLOBAL_STYLES_GATING_MODAL_CHECKOUT_BUTTON_CLICK:
-		'calypso_signup_pattern_assembler_global_styles_gating_modal_checkout_button_click',
-	GLOBAL_STYLES_GATING_MODAL_UPGRADE_LATER_BUTTON_CLICK:
-		'calypso_signup_pattern_assembler_global_styles_gating_modal_upgrade_later_button_click',
 
 	/**
 	 * Large Preview

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/index.ts
@@ -1,5 +1,6 @@
 export { default as useCategoriesOrder } from './use-categories-order';
 export { default as useCurrentScreen } from './use-current-screen';
+export { default as useCustomStyles } from './use-custom-styles';
 export { default as useDotcomPatterns } from './use-dotcom-patterns';
 export { default as useGlobalStylesUpgradeProps } from './use-global-styles-upgrade-props';
 export { default as useInitialPath } from './use-initial-path';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/index.ts
@@ -1,7 +1,7 @@
 export { default as useCategoriesOrder } from './use-categories-order';
 export { default as useCurrentScreen } from './use-current-screen';
 export { default as useDotcomPatterns } from './use-dotcom-patterns';
-export { default as useGlobalStylesUpgradeModal } from './use-global-styles-upgrade-modal';
+export { default as useGlobalStylesUpgradeProps } from './use-global-styles-upgrade-props';
 export { default as useInitialPath } from './use-initial-path';
 export { default as usePatternCategories } from './use-pattern-categories';
 export { default as usePatternsMapByCategory } from './use-patterns-map-by-category';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-current-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-current-screen.tsx
@@ -1,12 +1,12 @@
 import { useSearchParams } from 'react-router-dom';
 import { INITIAL_SCREEN } from '../constants';
-import useScreen from './use-screen';
+import useScreen, { UseScreenOptions } from './use-screen';
 import type { ScreenName } from '../types';
 
-const useCurrentScreen = ( shouldUnlockGlobalStyles = false ) => {
+const useCurrentScreen = ( options: UseScreenOptions ) => {
 	const [ searchParams ] = useSearchParams();
 	const currentScreenName = ( searchParams.get( 'screen' ) ?? INITIAL_SCREEN ) as ScreenName;
-	const currentScreen = useScreen( currentScreenName, shouldUnlockGlobalStyles );
+	const currentScreen = useScreen( currentScreenName, options );
 
 	return currentScreen;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-current-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-current-screen.tsx
@@ -3,10 +3,10 @@ import { INITIAL_SCREEN } from '../constants';
 import useScreen from './use-screen';
 import type { ScreenName } from '../types';
 
-const useCurrentScreen = () => {
+const useCurrentScreen = ( shouldUnlockGlobalStyles = false ) => {
 	const [ searchParams ] = useSearchParams();
 	const currentScreenName = ( searchParams.get( 'screen' ) ?? INITIAL_SCREEN ) as ScreenName;
-	const currentScreen = useScreen( currentScreenName );
+	const currentScreen = useScreen( currentScreenName, shouldUnlockGlobalStyles );
 
 	return currentScreen;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-custom-styles.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-custom-styles.tsx
@@ -1,0 +1,41 @@
+import { useSearchParams } from 'react-router-dom';
+import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
+
+interface Props {
+	siteID?: number | string;
+	hasColor: boolean;
+	hasFont: boolean;
+}
+
+const useCustomStyles = ( { siteID = 0, hasColor, hasFont }: Props ) => {
+	const [ searchParams, setSearchParams ] = useSearchParams();
+
+	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteID );
+
+	const numOfSelectedGlobalStyles = [ hasColor, hasFont ].filter( Boolean ).length;
+
+	const resetCustomStyles = !! searchParams.get( 'reset_custom_styles' );
+
+	const setResetCustomStyles = ( value: boolean ) => {
+		setSearchParams(
+			( currentSearchParams ) => {
+				if ( value ) {
+					currentSearchParams.set( 'reset_custom_styles', String( value ) );
+				} else {
+					currentSearchParams.delete( 'reset_custom_styles' );
+				}
+				return currentSearchParams;
+			},
+			{ replace: true }
+		);
+	};
+
+	return {
+		shouldUnlockGlobalStyles: numOfSelectedGlobalStyles > 0 && shouldLimitGlobalStyles,
+		numOfSelectedGlobalStyles,
+		resetCustomStyles,
+		setResetCustomStyles,
+	};
+};
+
+export default useCustomStyles;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-props.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-props.tsx
@@ -4,6 +4,7 @@ import useCheckout from '../../../../../hooks/use-checkout';
 import { useSite } from '../../../../../hooks/use-site';
 import { useSiteSlugParam } from '../../../../../hooks/use-site-slug-param';
 import { PATTERN_ASSEMBLER_EVENTS } from '../events';
+import type { ScreenName } from '../types';
 
 interface Props {
 	flowName: string;
@@ -11,6 +12,7 @@ interface Props {
 	hasSelectedColorVariation?: boolean;
 	hasSelectedFontVariation?: boolean;
 	resetCustomStyles?: boolean;
+	nextScreenName: ScreenName;
 	onUpgradeLater?: () => void;
 	onContinue?: () => void;
 	recordTracksEvent: ( eventName: string, eventProps?: { [ key: string ]: unknown } ) => void;
@@ -22,6 +24,7 @@ const useGlobalStylesUpgradeProps = ( {
 	hasSelectedColorVariation = false,
 	hasSelectedFontVariation = false,
 	resetCustomStyles,
+	nextScreenName,
 	onUpgradeLater,
 	onContinue,
 	recordTracksEvent,
@@ -38,8 +41,10 @@ const useGlobalStylesUpgradeProps = ( {
 	const handleCheckout = () => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_UPSELL_CHECKOUT_BUTTON_CLICK );
 
-		// When the user is done with checkout, send them back to the current url
-		const redirectUrl = window.location.href.replace( window.location.origin, '' );
+		// When the user is done with checkout, send them back to the next screen
+		const searchParams = new URLSearchParams( window.location.search );
+		searchParams.set( 'screen', nextScreenName );
+		const redirectUrl = `${ window.location.pathname }?${ searchParams }`;
 
 		goToCheckout( {
 			flowName,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-props.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-props.tsx
@@ -11,7 +11,6 @@ interface Props {
 	stepName: string;
 	hasSelectedColorVariation?: boolean;
 	hasSelectedFontVariation?: boolean;
-	resetCustomStyles?: boolean;
 	nextScreenName: ScreenName;
 	onUpgradeLater?: () => void;
 	onContinue?: () => void;
@@ -23,7 +22,6 @@ const useGlobalStylesUpgradeProps = ( {
 	stepName,
 	hasSelectedColorVariation = false,
 	hasSelectedFontVariation = false,
-	resetCustomStyles,
 	nextScreenName,
 	onUpgradeLater,
 	onContinue,
@@ -66,8 +64,7 @@ const useGlobalStylesUpgradeProps = ( {
 	};
 
 	return {
-		shouldUnlockGlobalStyles:
-			numOfSelectedGlobalStyles > 0 && shouldLimitGlobalStyles && ! resetCustomStyles,
+		shouldUnlockGlobalStyles: numOfSelectedGlobalStyles > 0 && shouldLimitGlobalStyles,
 		globalStylesInPersonalPlan,
 		numOfSelectedGlobalStyles,
 		onCheckout: handleCheckout,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-props.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-props.tsx
@@ -1,5 +1,4 @@
 import { urlToSlug } from 'calypso/lib/url';
-import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import useCheckout from '../../../../../hooks/use-checkout';
 import { useSite } from '../../../../../hooks/use-site';
 import { useSiteSlugParam } from '../../../../../hooks/use-site-slug-param';
@@ -9,8 +8,6 @@ import type { ScreenName } from '../types';
 interface Props {
 	flowName: string;
 	stepName: string;
-	hasSelectedColorVariation?: boolean;
-	hasSelectedFontVariation?: boolean;
 	nextScreenName: ScreenName;
 	onUpgradeLater?: () => void;
 	onContinue?: () => void;
@@ -20,8 +17,6 @@ interface Props {
 const useGlobalStylesUpgradeProps = ( {
 	flowName,
 	stepName,
-	hasSelectedColorVariation = false,
-	hasSelectedFontVariation = false,
 	nextScreenName,
 	onUpgradeLater,
 	onContinue,
@@ -30,11 +25,7 @@ const useGlobalStylesUpgradeProps = ( {
 	const site = useSite();
 	const siteSlug = useSiteSlugParam();
 	const siteUrl = siteSlug || urlToSlug( site?.URL || '' ) || '';
-	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
 	const { goToCheckout } = useCheckout();
-	const numOfSelectedGlobalStyles = [ hasSelectedColorVariation, hasSelectedFontVariation ].filter(
-		Boolean
-	).length;
 
 	const handleCheckout = () => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_UPSELL_CHECKOUT_BUTTON_CLICK );
@@ -64,9 +55,6 @@ const useGlobalStylesUpgradeProps = ( {
 	};
 
 	return {
-		shouldUnlockGlobalStyles: numOfSelectedGlobalStyles > 0 && shouldLimitGlobalStyles,
-		globalStylesInPersonalPlan,
-		numOfSelectedGlobalStyles,
 		onCheckout: handleCheckout,
 		onTryStyle: handleTryStyle,
 		onContinue: handleContinue,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-props.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-props.tsx
@@ -1,30 +1,31 @@
-import { useState } from 'react';
 import { urlToSlug } from 'calypso/lib/url';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import useCheckout from '../../../../../hooks/use-checkout';
 import { useSite } from '../../../../../hooks/use-site';
 import { useSiteSlugParam } from '../../../../../hooks/use-site-slug-param';
 import { PATTERN_ASSEMBLER_EVENTS } from '../events';
-import type { PremiumGlobalStylesUpgradeModalProps } from 'calypso/components/premium-global-styles-upgrade-modal';
 
 interface Props {
 	flowName: string;
 	stepName: string;
 	hasSelectedColorVariation?: boolean;
 	hasSelectedFontVariation?: boolean;
+	resetCustomStyles?: boolean;
 	onUpgradeLater?: () => void;
+	onContinue?: () => void;
 	recordTracksEvent: ( eventName: string, eventProps?: { [ key: string ]: unknown } ) => void;
 }
 
-const useGlobalStylesUpgradeModal = ( {
+const useGlobalStylesUpgradeProps = ( {
 	flowName,
 	stepName,
 	hasSelectedColorVariation = false,
 	hasSelectedFontVariation = false,
+	resetCustomStyles,
 	onUpgradeLater,
+	onContinue,
 	recordTracksEvent,
 }: Props ) => {
-	const [ isOpen, setIsOpen ] = useState( false );
 	const site = useSite();
 	const siteSlug = useSiteSlugParam();
 	const siteUrl = siteSlug || urlToSlug( site?.URL || '' ) || '';
@@ -34,18 +35,8 @@ const useGlobalStylesUpgradeModal = ( {
 		Boolean
 	).length;
 
-	const openModal = () => {
-		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.GLOBAL_STYLES_GATING_MODAL_SHOW );
-		setIsOpen( true );
-	};
-
-	const closeModal = () => {
-		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.GLOBAL_STYLES_GATING_MODAL_CLOSE_BUTTON_CLICK );
-		setIsOpen( false );
-	};
-
-	const checkout = () => {
-		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.GLOBAL_STYLES_GATING_MODAL_CHECKOUT_BUTTON_CLICK );
+	const handleCheckout = () => {
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_UPSELL_CHECKOUT_BUTTON_CLICK );
 
 		// When the user is done with checkout, send them back to the current url
 		const redirectUrl = window.location.href.replace( window.location.origin, '' );
@@ -57,29 +48,27 @@ const useGlobalStylesUpgradeModal = ( {
 			destination: redirectUrl,
 			plan: 'premium',
 		} );
-
-		setIsOpen( false );
 	};
 
-	const upgradeLater = () => {
-		recordTracksEvent(
-			PATTERN_ASSEMBLER_EVENTS.GLOBAL_STYLES_GATING_MODAL_UPGRADE_LATER_BUTTON_CLICK
-		);
+	const handleTryStyle = () => {
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_UPSELL_UPGRADE_LATER_BUTTON_CLICK );
 		onUpgradeLater?.();
-		setIsOpen( false );
+	};
+
+	const handleContinue = () => {
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_UPSELL_EDIT_YOUR_CONTENT_BUTTON_CLICK );
+		onContinue?.();
 	};
 
 	return {
-		shouldUnlockGlobalStyles: numOfSelectedGlobalStyles > 0 && shouldLimitGlobalStyles,
-		globalStylesUpgradeModalProps: {
-			isOpen,
-			numOfSelectedGlobalStyles,
-			closeModal,
-			checkout,
-			tryStyle: upgradeLater,
-		} as PremiumGlobalStylesUpgradeModalProps,
-		openModal,
+		shouldUnlockGlobalStyles:
+			numOfSelectedGlobalStyles > 0 && shouldLimitGlobalStyles && ! resetCustomStyles,
+		globalStylesInPersonalPlan,
+		numOfSelectedGlobalStyles,
+		onCheckout: handleCheckout,
+		onTryStyle: handleTryStyle,
+		onContinue: handleContinue,
 	};
 };
 
-export default useGlobalStylesUpgradeModal;
+export default useGlobalStylesUpgradeProps;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -183,7 +183,7 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 		setSearchParams(
 			( currentSearchParams ) => {
 				if ( value ) {
-					currentSearchParams.set( 'reset_custom_styles', value );
+					currentSearchParams.set( 'reset_custom_styles', String( value ) );
 				} else {
 					currentSearchParams.delete( 'reset_custom_styles' );
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -96,6 +96,8 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 	const fontVariation =
 		( fontVariations || [] ).find( ( { title } ) => title === font_variation_title ) || null;
 
+	const resetCustomStyles = !! searchParams.get( 'reset_custom_styles' );
+
 	const setHeader = ( pattern: Pattern | null ) => {
 		setSearchParams(
 			( currentSearchParams ) => {
@@ -177,17 +179,33 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 		);
 	};
 
+	const setResetCustomStyles = ( value: boolean ) => {
+		setSearchParams(
+			( currentSearchParams ) => {
+				if ( value ) {
+					currentSearchParams.set( 'reset_custom_styles', value );
+				} else {
+					currentSearchParams.delete( 'reset_custom_styles' );
+				}
+				return currentSearchParams;
+			},
+			{ replace: true }
+		);
+	};
+
 	return {
 		header,
 		footer,
 		sections: keyedSections,
 		colorVariation,
 		fontVariation,
+		resetCustomStyles,
 		setHeader,
 		setFooter,
 		setSections,
 		setColorVariation,
 		setFontVariation,
+		setResetCustomStyles,
 	};
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -96,8 +96,6 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 	const fontVariation =
 		( fontVariations || [] ).find( ( { title } ) => title === font_variation_title ) || null;
 
-	const resetCustomStyles = !! searchParams.get( 'reset_custom_styles' );
-
 	const setHeader = ( pattern: Pattern | null ) => {
 		setSearchParams(
 			( currentSearchParams ) => {
@@ -179,33 +177,17 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 		);
 	};
 
-	const setResetCustomStyles = ( value: boolean ) => {
-		setSearchParams(
-			( currentSearchParams ) => {
-				if ( value ) {
-					currentSearchParams.set( 'reset_custom_styles', String( value ) );
-				} else {
-					currentSearchParams.delete( 'reset_custom_styles' );
-				}
-				return currentSearchParams;
-			},
-			{ replace: true }
-		);
-	};
-
 	return {
 		header,
 		footer,
 		sections: keyedSections,
 		colorVariation,
 		fontVariation,
-		resetCustomStyles,
 		setHeader,
 		setFooter,
 		setSections,
 		setColorVariation,
 		setFontVariation,
-		setResetCustomStyles,
 	};
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
@@ -3,7 +3,12 @@ import { useTranslate } from 'i18n-calypso';
 import { NAVIGATOR_PATHS } from '../constants';
 import type { ScreenName } from '../types';
 
-const useScreen = ( screenName: ScreenName, shouldUnlockGlobalStyles = false ) => {
+export type UseScreenOptions = {
+	isNewSite?: boolean;
+	shouldUnlockGlobalStyles?: boolean;
+};
+
+const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ) => {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 	const screens = {
@@ -40,13 +45,28 @@ const useScreen = ( screenName: ScreenName, shouldUnlockGlobalStyles = false ) =
 		main: null,
 		styles: screens.main,
 		upsell: screens.styles,
-		activation: shouldUnlockGlobalStyles ? screens.upsell : screens.styles,
-		confirmation: shouldUnlockGlobalStyles ? screens.upsell : screens.styles,
+		activation: options.shouldUnlockGlobalStyles ? screens.upsell : screens.styles,
+		confirmation: options.shouldUnlockGlobalStyles ? screens.upsell : screens.styles,
+	};
+
+	const nextScreens = {
+		main: screens.styles,
+		styles: ( () => {
+			if ( options.shouldUnlockGlobalStyles ) {
+				return screens.upsell;
+			}
+
+			return options.isNewSite ? screens.confirmation : screens.activation;
+		} )(),
+		upsell: options.isNewSite ? screens.confirmation : screens.activation,
+		activation: null,
+		confirmation: null,
 	};
 
 	return {
 		...screens[ screenName ],
 		previousScreen: previousScreens[ screenName ],
+		nextScreen: nextScreens[ screenName ],
 	};
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { NAVIGATOR_PATHS } from '../constants';
 import type { ScreenName } from '../types';
 
-const useScreen = ( screenName: ScreenName ) => {
+const useScreen = ( screenName: ScreenName, shouldUnlockGlobalStyles = false ) => {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 	const screens = {
@@ -22,6 +22,7 @@ const useScreen = ( screenName: ScreenName ) => {
 		upsell: {
 			name: 'upsell',
 			title: translate( 'Custom styles' ),
+			initialPath: NAVIGATOR_PATHS.UPSELL,
 		},
 		activation: {
 			name: 'activation',
@@ -35,13 +36,12 @@ const useScreen = ( screenName: ScreenName ) => {
 		},
 	};
 
-	/** @todo Handle the upsell screen in the following PR */
 	const previousScreens = {
 		main: null,
 		styles: screens.main,
 		upsell: screens.styles,
-		activation: screens.styles,
-		confirmation: screens.styles,
+		activation: shouldUnlockGlobalStyles ? screens.upsell : screens.styles,
+		confirmation: shouldUnlockGlobalStyles ? screens.upsell : screens.styles,
 	};
 
 	return {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -194,7 +194,7 @@ const PatternAssembler = ( {
 		} );
 	};
 
-	const trackEventContinue = () => {
+	const trackSubmit = () => {
 		const patterns = getPatterns();
 		const categories = Array.from( new Set( patterns.map( ( { category } ) => category?.name ) ) );
 
@@ -416,8 +416,8 @@ const PatternAssembler = ( {
 		);
 
 		recordSelectedDesign( { flow, intent, design } );
+		trackSubmit();
 		submit?.();
-		trackEventContinue();
 	};
 
 	const onUpgradeLater = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -21,7 +21,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useRef, useMemo } from 'react';
 import { createRecordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useDispatch as useReduxDispatch } from 'calypso/state';
-import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { activateOrInstallThenActivate } from 'calypso/state/themes/actions';
 import { useQuery } from '../../../../hooks/use-query';
 import { useSite } from '../../../../hooks/use-site';
@@ -33,6 +32,7 @@ import { SITE_TAGLINE, NAVIGATOR_PATHS, INITIAL_SCREEN } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import {
 	useCurrentScreen,
+	useCustomStyles,
 	useDotcomPatterns,
 	useGlobalStylesUpgradeProps,
 	useInitialPath,
@@ -95,7 +95,6 @@ const PatternAssembler = ( {
 	const siteId = useSiteIdParam();
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 	const locale = useLocale();
-	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
 
 	// New sites are created from 'site-setup' and 'with-site-assembler' flows
 	const isNewSite = !! useQuery().get( 'isNewSite' ) || isSiteSetupFlow( flow );
@@ -115,18 +114,23 @@ const PatternAssembler = ( {
 		sections,
 		colorVariation,
 		fontVariation,
-		resetCustomStyles,
 		setHeader,
 		setFooter,
 		setSections,
 		setColorVariation,
 		setFontVariation,
-		setResetCustomStyles,
 	} = useRecipe( site?.ID, dotcomPatterns, categories );
 
-	const numOfSelectedGlobalStyles = [ colorVariation, fontVariation ].filter( Boolean ).length;
-
-	const shouldUnlockGlobalStyles = numOfSelectedGlobalStyles > 0 && shouldLimitGlobalStyles;
+	const {
+		shouldUnlockGlobalStyles,
+		numOfSelectedGlobalStyles,
+		resetCustomStyles,
+		setResetCustomStyles,
+	} = useCustomStyles( {
+		siteID: site?.ID,
+		hasColor: !! colorVariation,
+		hasFont: !! fontVariation,
+	} );
 
 	const currentScreen = useCurrentScreen( { isNewSite, shouldUnlockGlobalStyles } );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -207,6 +207,7 @@ const PatternAssembler = ( {
 			pattern_categories: categories.join( ',' ),
 			category_count: categories.length,
 			pattern_count: patterns.length,
+			reset_custom_styles: resetCustomStyles,
 		} );
 		patterns.forEach( ( { ID, name, category } ) => {
 			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_FINAL_SELECT, {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -425,36 +425,34 @@ const PatternAssembler = ( {
 		submit?.();
 	};
 
-	const onUpgradeLater = () => {
+	const onContinue = () => {
 		if ( isNewSite ) {
 			navigator.goTo( NAVIGATOR_PATHS.CONFIRMATION );
 		} else {
 			navigator.goTo( NAVIGATOR_PATHS.ACTIVATION );
 		}
 	};
+
+	const onContinueWithUpsell = () => {
+		if ( shouldUnlockGlobalStyles ) {
+			navigator.goTo( NAVIGATOR_PATHS.UPSELL );
+			return;
+		}
+
+		onContinue();
+	}
 
 	const { shouldUnlockGlobalStyles, ...globalStylesUpgradeProps } = useGlobalStylesUpgradeProps( {
 		flowName: flow,
 		stepName,
 		hasSelectedColorVariation: !! colorVariation,
 		hasSelectedFontVariation: !! fontVariation,
-		onUpgradeLater,
 		resetCustomStyles,
+		nextScreenName: isNewSite ? 'confirmation' : 'activation',
+		onUpgradeLater: onContinue,
+		onContinue,
 		recordTracksEvent,
 	} );
-
-	const onContinueClick = () => {
-		if ( shouldUnlockGlobalStyles ) {
-			navigator.goTo( NAVIGATOR_PATHS.UPSELL );
-			return;
-		}
-
-		if ( isNewSite ) {
-			navigator.goTo( NAVIGATOR_PATHS.CONFIRMATION );
-		} else {
-			navigator.goTo( NAVIGATOR_PATHS.ACTIVATION );
-		}
-	};
 
 	const onActivate = () => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_ACTIVATION_ACTIVATE_CLICK );
@@ -536,7 +534,7 @@ const PatternAssembler = ( {
 				<NavigatorScreen path={ NAVIGATOR_PATHS.MAIN } partialMatch>
 					<ScreenMain
 						onMainItemSelect={ onMainItemSelect }
-						onContinueClick={ onContinueClick }
+						onContinueClick={ onContinueWithUpsell }
 						recordTracksEvent={ recordTracksEvent }
 						surveyDismissed={ surveyDismissed }
 						setSurveyDismissed={ setSurveyDismissed }
@@ -551,7 +549,7 @@ const PatternAssembler = ( {
 				<NavigatorScreen path={ NAVIGATOR_PATHS.STYLES } partialMatch>
 					<ScreenStyles
 						onMainItemSelect={ onMainItemSelect }
-						onContinueClick={ onContinueClick }
+						onContinueClick={ onContinueWithUpsell }
 						recordTracksEvent={ recordTracksEvent }
 						hasColor={ !! colorVariation }
 						hasFont={ !! fontVariation }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -352,6 +352,11 @@ const PatternAssembler = ( {
 	};
 
 	const onBack = () => {
+		// Turn off the resetting custom styles when going back from the upsell screen
+		if ( resetCustomStyles ) {
+			setResetCustomStyles( false );
+		}
+
 		if ( currentScreen.previousScreen ) {
 			if ( navigator.location.isInitial && currentScreen.name !== INITIAL_SCREEN ) {
 				navigator.goTo( currentScreen.previousScreen.initialPath, { replace: true } );
@@ -566,7 +571,6 @@ const PatternAssembler = ( {
 						{ ...globalStylesUpgradeProps }
 						resetCustomStyles={ resetCustomStyles }
 						setResetCustomStyles={ setResetCustomStyles }
-						recordTracksEvent={ recordTracksEvent }
 					/>
 				</NavigatorScreen>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -77,7 +77,6 @@ const PatternAssembler = ( {
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
 	const [ activePosition, setActivePosition ] = useState( -1 );
 	const [ surveyDismissed, setSurveyDismissed ] = useState( false );
-	const [ resetCustomStyles, setResetCustomStyles ] = useState( false );
 	const { goBack, goNext, submit } = navigation;
 	const { assembleSite } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
@@ -114,11 +113,13 @@ const PatternAssembler = ( {
 		sections,
 		colorVariation,
 		fontVariation,
+		resetCustomStyles,
 		setHeader,
 		setFooter,
 		setSections,
 		setColorVariation,
 		setFontVariation,
+		setResetCustomStyles,
 	} = useRecipe( site?.ID, dotcomPatterns, categories );
 
 	const stylesheet = selectedDesign?.recipe?.stylesheet || '';
@@ -148,8 +149,6 @@ const PatternAssembler = ( {
 	);
 
 	const syncedGlobalStylesUserConfig = useSyncGlobalStylesUserConfig( selectedVariations );
-
-	const currentScreen = useCurrentScreen();
 
 	useSyncNavigatorScreen();
 	usePrefetchImages();
@@ -337,49 +336,6 @@ const PatternAssembler = ( {
 		}
 	};
 
-	const getBackLabel = () => {
-		if ( ! currentScreen.previousScreen ) {
-			return undefined;
-		}
-
-		// Commit the following string for the translation
-		// translate( 'Back to %(pageTitle)s' );
-		return translate( 'Back to %(clientTitle)s', {
-			args: {
-				clientTitle: currentScreen.previousScreen.title,
-			},
-		} );
-	};
-
-	const onBack = () => {
-		// Turn off the resetting custom styles when going back from the upsell screen
-		if ( resetCustomStyles ) {
-			setResetCustomStyles( false );
-		}
-
-		if ( currentScreen.previousScreen ) {
-			if ( navigator.location.isInitial && currentScreen.name !== INITIAL_SCREEN ) {
-				navigator.goTo( currentScreen.previousScreen.initialPath, { replace: true } );
-			} else {
-				navigator.goBack();
-			}
-
-			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_BACK_CLICK, {
-				screen_from: currentScreen.name,
-				screen_to: currentScreen.previousScreen.name,
-			} );
-			return;
-		}
-
-		const patterns = getPatterns();
-		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.BACK_CLICK, {
-			has_selected_patterns: patterns.length > 0,
-			pattern_count: patterns.length,
-		} );
-
-		goBack?.();
-	};
-
 	const onSubmit = () => {
 		const design = getDesign();
 		const stylesheet = design.recipe?.stylesheet ?? '';
@@ -453,6 +409,51 @@ const PatternAssembler = ( {
 		onContinue,
 		recordTracksEvent,
 	} );
+
+	const currentScreen = useCurrentScreen( shouldUnlockGlobalStyles );
+
+	const getBackLabel = () => {
+		if ( ! currentScreen.previousScreen ) {
+			return undefined;
+		}
+
+		// Commit the following string for the translation
+		// translate( 'Back to %(pageTitle)s' );
+		return translate( 'Back to %(clientTitle)s', {
+			args: {
+				clientTitle: currentScreen.previousScreen.title,
+			},
+		} );
+	};
+
+	const onBack = () => {
+		// Turn off the resetting custom styles when going back from the upsell screen
+		if ( resetCustomStyles ) {
+			setResetCustomStyles( false );
+		}
+
+		if ( currentScreen.previousScreen ) {
+			if ( navigator.location.isInitial && currentScreen.name !== INITIAL_SCREEN ) {
+				navigator.goTo( currentScreen.previousScreen.initialPath, { replace: true } );
+			} else {
+				navigator.goBack();
+			}
+
+			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_BACK_CLICK, {
+				screen_from: currentScreen.name,
+				screen_to: currentScreen.previousScreen.name,
+			} );
+			return;
+		}
+
+		const patterns = getPatterns();
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.BACK_CLICK, {
+			has_selected_patterns: patterns.length > 0,
+			pattern_count: patterns.length,
+		} );
+
+		goBack?.();
+	};
 
 	const onActivate = () => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_ACTIVATION_ACTIVATE_CLICK );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -403,7 +403,6 @@ const PatternAssembler = ( {
 		stepName,
 		hasSelectedColorVariation: !! colorVariation,
 		hasSelectedFontVariation: !! fontVariation,
-		resetCustomStyles,
 		nextScreenName: isNewSite ? 'confirmation' : 'activation',
 		onUpgradeLater: onContinue,
 		onContinue,
@@ -428,7 +427,7 @@ const PatternAssembler = ( {
 
 	const onBack = () => {
 		// Turn off the resetting custom styles when going back from the upsell screen
-		if ( resetCustomStyles ) {
+		if ( currentScreen.name === 'upsell' && resetCustomStyles ) {
 			setResetCustomStyles( false );
 		}
 
@@ -535,7 +534,6 @@ const PatternAssembler = ( {
 				<NavigatorScreen path={ NAVIGATOR_PATHS.MAIN } partialMatch>
 					<ScreenMain
 						onMainItemSelect={ onMainItemSelect }
-						onContinueClick={ onContinueWithUpsell }
 						recordTracksEvent={ recordTracksEvent }
 						surveyDismissed={ surveyDismissed }
 						setSurveyDismissed={ setSurveyDismissed }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -26,6 +26,7 @@ interface Props {
 	hasFooter: boolean;
 	categories: Category[];
 	patternsMapByCategory: { [ key: string ]: Pattern[] };
+	onContinueClick: () => void;
 }
 
 const ScreenMain = ( {
@@ -38,6 +39,7 @@ const ScreenMain = ( {
 	hasFooter,
 	categories,
 	patternsMapByCategory,
+	onContinueClick,
 }: Props ) => {
 	const translate = useTranslate();
 	const { title } = useScreen( 'main' );
@@ -53,14 +55,6 @@ const ScreenMain = ( {
 		isEnglishLocale || i18n.hasTranslation( 'Pick your style' )
 			? translate( 'Pick your style' )
 			: translate( 'Save and continue' );
-
-	const handleClick = () => {
-		goTo( NAVIGATOR_PATHS.STYLES_COLORS );
-		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_CONTINUE_CLICK, {
-			screen_from: 'main',
-			screen_to: 'styles',
-		} );
-	};
 
 	const handleNavigatorItemSelect = ( type: string, category: string ) => {
 		const nextPath =
@@ -138,7 +132,7 @@ const ScreenMain = ( {
 					className="pattern-assembler__button"
 					disabled={ isButtonDisabled }
 					showTooltip={ isButtonDisabled }
-					onClick={ handleClick }
+					onClick={ onContinueClick }
 					label={
 						isButtonDisabled ? translate( 'Add your first pattern to get started.' ) : buttonText
 					}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -18,7 +18,6 @@ import { Pattern, Category } from './types';
 
 interface Props {
 	onMainItemSelect: ( name: string ) => void;
-	onContinueClick: ( callback?: () => void ) => void;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 	surveyDismissed: boolean;
 	setSurveyDismissed: ( dismissed: boolean ) => void;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-styles.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-styles.tsx
@@ -14,7 +14,7 @@ import NavigatorTitle from './navigator-title';
 
 interface Props {
 	onMainItemSelect: ( name: string ) => void;
-	onContinueClick: ( callback?: () => void ) => void;
+	onContinueClick: () => void;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 	hasColor: boolean;
 	hasFont: boolean;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.scss
@@ -6,7 +6,7 @@
 	}
 
 	.screen-upsell__description {
-		margin-bottom: 12px;
+		margin-bottom: 32px;
 		font-size: $font-body-small;
 
 		p {
@@ -22,7 +22,7 @@
 		li {
 			display: flex;
 			align-items: center;
-			margin-top: 16px;
+			margin-top: 8px;
 			gap: 16px;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.scss
@@ -1,0 +1,41 @@
+@import "@automattic/typography/styles/fonts";
+
+.screen-upsell {
+	.screen-upsell__heading {
+		margin-bottom: 4px;
+	}
+
+	.screen-upsell__description {
+		margin-bottom: 12px;
+		font-size: $font-body-small;
+
+		p {
+			margin-bottom: 16px;
+		}
+	}
+
+	ul.screen-upsell__features {
+		margin: 0;
+		font-size: $font-body-small;
+		list-style: none;
+
+		li {
+			display: flex;
+			align-items: center;
+			margin-top: 16px;
+			gap: 16px;
+		}
+
+		strong {
+			font-weight: normal;
+		}
+
+		svg {
+			color: var(--studio-blue-50);
+		}
+	}
+
+	.pattern-assembler__button + .pattern-assembler__button {
+		margin-top: 8px;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -3,7 +3,7 @@ import { NavigatorHeader } from '@automattic/onboarding';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import useGlobalStylesUpgradeTranslations from 'calypso/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations';
-import { PATTERN_ASSEMBLER_EVENTS } from './events';
+import { useScreen } from './hooks';
 import NavigatorTitle from './navigator-title';
 import './screen-upsell.scss';
 
@@ -15,7 +15,6 @@ interface Props {
 	onCheckout: () => void;
 	onTryStyle: () => void;
 	onContinue: () => void;
-	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 }
 
 const ScreenUpsell = ( {
@@ -26,28 +25,20 @@ const ScreenUpsell = ( {
 	onCheckout,
 	onTryStyle,
 	onContinue,
-	recordTracksEvent,
 }: Props ) => {
 	const translate = useTranslate();
+	const { title } = useScreen( 'upsell' );
 	const translations = useGlobalStylesUpgradeTranslations( {
 		globalStylesInPersonalPlan,
 		numOfSelectedGlobalStyles,
 	} );
 
-	const handleBackClick = () => {
-		setResetCustomStyles( false );
-		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_BACK_CLICK, {
-			screen_from: 'upsell',
-			screen_to: 'styles',
-		} );
-	};
-
 	return (
 		<>
 			<NavigatorHeader
-				title={ <NavigatorTitle title={ translate( 'Custom styles' ) } /> }
+				title={ <NavigatorTitle title={ title } /> }
 				description={ translate( "You've chosen a custom style and action is required." ) }
-				onBack={ handleBackClick }
+				hideBack
 			/>
 			<div className="screen-container__body">
 				<strong className="screen-upsell__heading">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -59,7 +59,7 @@ const ScreenUpsell = ( {
 				</div>
 				<strong>{ translations.featuresTitle }</strong>
 				<ul className="screen-upsell__features">
-					{ translations.features.map( ( feature: JSX.Element, i: number ) => (
+					{ translations.features.map( ( feature, i ) => (
 						<li key={ i }>
 							<Gridicon icon="checkmark" size={ 16 } />
 							{ feature }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -2,7 +2,6 @@ import { Button, Gridicon, PremiumBadge } from '@automattic/components';
 import { NavigatorHeader } from '@automattic/onboarding';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import QueryProductsList from 'calypso/components/data/query-products-list';
 import useGlobalStylesUpgradeTranslations from 'calypso/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import NavigatorTitle from './navigator-title';
@@ -45,7 +44,6 @@ const ScreenUpsell = ( {
 
 	return (
 		<>
-			<QueryProductsList />
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ translate( 'Custom styles' ) } /> }
 				description={ translate( "You've chosen a custom style and action is required." ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -1,0 +1,99 @@
+import { Button, Gridicon, PremiumBadge } from '@automattic/components';
+import { NavigatorHeader } from '@automattic/onboarding';
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import QueryProductsList from 'calypso/components/data/query-products-list';
+import useGlobalStylesUpgradeTranslations from 'calypso/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations';
+import { PATTERN_ASSEMBLER_EVENTS } from './events';
+import NavigatorTitle from './navigator-title';
+import './screen-upsell.scss';
+
+interface Props {
+	resetCustomStyles: boolean;
+	globalStylesInPersonalPlan?: boolean;
+	numOfSelectedGlobalStyles?: number;
+	setResetCustomStyles: React.Dispatch< React.SetStateAction< boolean > >;
+	onCheckout: () => void;
+	onTryStyle: () => void;
+	onContinue: () => void;
+	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
+}
+
+const ScreenUpsell = ( {
+	resetCustomStyles,
+	globalStylesInPersonalPlan,
+	numOfSelectedGlobalStyles = 1,
+	setResetCustomStyles,
+	onCheckout,
+	onTryStyle,
+	onContinue,
+	recordTracksEvent,
+}: Props ) => {
+	const translate = useTranslate();
+	const translations = useGlobalStylesUpgradeTranslations( {
+		globalStylesInPersonalPlan,
+		numOfSelectedGlobalStyles,
+	} );
+
+	const handleBackClick = () => {
+		setResetCustomStyles( false );
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_BACK_CLICK, {
+			screen_from: 'upsell',
+			screen_to: 'styles',
+		} );
+	};
+
+	return (
+		<>
+			<QueryProductsList />
+			<NavigatorHeader
+				title={ <NavigatorTitle title={ translate( 'Custom styles' ) } /> }
+				description={ translate( "You've chosen a custom style and action is required." ) }
+				onBack={ handleBackClick }
+			/>
+			<div className="screen-container__body">
+				<strong className="screen-upsell__heading">
+					{ translate( 'Custom styles' ) }
+					<PremiumBadge
+						shouldHideTooltip
+						shouldCompactWithAnimation
+						labelText={ translate( 'Upgrade' ) }
+					/>
+				</strong>
+				<div className="screen-upsell__description">
+					<p>{ translations.description }</p>
+					<ToggleControl
+						label={ translate( 'Reset custom styles' ) }
+						checked={ resetCustomStyles }
+						onChange={ () => setResetCustomStyles( ( value ) => ! value ) }
+					/>
+				</div>
+				<strong>{ translations.featuresTitle }</strong>
+				<ul className="screen-upsell__features">
+					{ translations.features.map( ( feature, i ) => (
+						<li key={ i }>
+							<Gridicon icon="checkmark" size={ 16 } />
+							{ feature }
+						</li>
+					) ) }
+				</ul>
+			</div>
+			<div className="screen-container__footer">
+				{ ! resetCustomStyles && (
+					<Button className="pattern-assembler__button" onClick={ onTryStyle }>
+						{ translations.cancel }
+					</Button>
+				) }
+				<Button
+					className="pattern-assembler__button"
+					primary
+					onClick={ ! resetCustomStyles ? onCheckout : onContinue }
+				>
+					{ ! resetCustomStyles ? translations.upgradeWithPlan : translate( 'Edit your content' ) }
+				</Button>
+			</div>
+		</>
+	);
+};
+
+export default ScreenUpsell;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -11,7 +11,7 @@ interface Props {
 	resetCustomStyles: boolean;
 	globalStylesInPersonalPlan?: boolean;
 	numOfSelectedGlobalStyles?: number;
-	setResetCustomStyles: React.Dispatch< React.SetStateAction< boolean > >;
+	setResetCustomStyles: ( value: boolean ) => void;
 	onCheckout: () => void;
 	onTryStyle: () => void;
 	onContinue: () => void;
@@ -54,7 +54,7 @@ const ScreenUpsell = ( {
 					<ToggleControl
 						label={ translate( 'Reset custom styles' ) }
 						checked={ resetCustomStyles }
-						onChange={ () => setResetCustomStyles( ( value ) => ! value ) }
+						onChange={ () => setResetCustomStyles( ! resetCustomStyles ) }
 					/>
 				</div>
 				<strong>{ translations.featuresTitle }</strong>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -78,7 +78,7 @@ const ScreenUpsell = ( {
 					primary
 					onClick={ ! resetCustomStyles ? onCheckout : onContinue }
 				>
-					{ ! resetCustomStyles ? translations.upgradeWithPlan : translate( 'Edit your content' ) }
+					{ ! resetCustomStyles ? translations.upgradeWithPlan : translate( 'Continue' ) }
 				</Button>
 			</div>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -9,7 +9,6 @@ import './screen-upsell.scss';
 
 interface Props {
 	resetCustomStyles: boolean;
-	globalStylesInPersonalPlan?: boolean;
 	numOfSelectedGlobalStyles?: number;
 	setResetCustomStyles: ( value: boolean ) => void;
 	onCheckout: () => void;
@@ -19,7 +18,6 @@ interface Props {
 
 const ScreenUpsell = ( {
 	resetCustomStyles,
-	globalStylesInPersonalPlan,
 	numOfSelectedGlobalStyles = 1,
 	setResetCustomStyles,
 	onCheckout,
@@ -28,10 +26,7 @@ const ScreenUpsell = ( {
 }: Props ) => {
 	const translate = useTranslate();
 	const { title } = useScreen( 'upsell' );
-	const translations = useGlobalStylesUpgradeTranslations( {
-		globalStylesInPersonalPlan,
-		numOfSelectedGlobalStyles,
-	} );
+	const translations = useGlobalStylesUpgradeTranslations( { numOfSelectedGlobalStyles } );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -70,7 +70,7 @@ const ScreenUpsell = ( {
 				</div>
 				<strong>{ translations.featuresTitle }</strong>
 				<ul className="screen-upsell__features">
-					{ translations.features.map( ( feature, i ) => (
+					{ translations.features.map( ( feature: JSX.Element, i: number ) => (
 						<li key={ i }>
 							<Gridicon icon="checkmark" size={ 16 } />
 							{ feature }

--- a/client/state/products-list/selectors/get-products-list.ts
+++ b/client/state/products-list/selectors/get-products-list.ts
@@ -22,6 +22,7 @@ export interface ProductListItem {
 	available: boolean;
 	is_domain_registration: boolean;
 	cost_display: string;
+	cost_per_month_display: string;
 	cost: number;
 	cost_smallest_unit: number;
 	currency_code: string;

--- a/client/state/products-list/selectors/get-products-list.ts
+++ b/client/state/products-list/selectors/get-products-list.ts
@@ -22,7 +22,6 @@ export interface ProductListItem {
 	available: boolean;
 	is_domain_registration: boolean;
 	cost_display: string;
-	cost_per_month_display: string;
 	cost: number;
 	cost_smallest_unit: number;
 	currency_code: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80682

## Proposed Changes

* Added the Upsell screen

| Without resetting custom styles | With resetting custom styles |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/784f7d9a-7617-44ed-a9e9-6d29aea9e4ed) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/b794adc1-8d6d-4207-bb7d-fc75bb440b7d) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>` on your free site
* Continue to Design Picker
* Pick “Design your own”
* On the Assembler screen
  * Pick patterns
  * Pick styles
  * Ensure you can see the Upsell screen
  * Toggle the “Reset custom styles”
  * Ensure the global styles won't be applied and you can see the “Edit your content” button now

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
