### PR TITLE
All sites domains table sorts its rows on the server

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -1,4 +1,4 @@
-import { DomainsTable, useDomainsTable } from '@automattic/domains-table';
+import { DomainsTable, useAllDomainsTable } from '@automattic/domains-table';
 import { useTranslate } from 'i18n-calypso';
 import { UsePresalesChat } from 'calypso/components/data/domain-management';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -14,7 +14,7 @@ interface BulkAllDomainsProps {
 }
 
 export default function BulkAllDomains( props: BulkAllDomainsProps ) {
-	const { domains } = useDomainsTable();
+	const domainsTable = useAllDomainsTable();
 	const translate = useTranslate();
 
 	const item = {
@@ -47,7 +47,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			<Main wideLayout>
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
-				<DomainsTable domains={ domains } isAllSitesView />
+				<DomainsTable { ...domainsTable } />
 			</Main>
 			<UsePresalesChat />
 		</>

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -1,5 +1,4 @@
-import { useSiteDomainsQuery } from '@automattic/data-stores';
-import { DomainsTable } from '@automattic/domains-table';
+import { DomainsTable, useSiteDomainsTable } from '@automattic/domains-table';
 import { useTranslate } from 'i18n-calypso';
 import { UsePresalesChat } from 'calypso/components/data/domain-management';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -18,7 +17,7 @@ interface BulkSiteDomainsProps {
 
 export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 	const siteSlug = useSelector( getSelectedSiteSlug );
-	const { data } = useSiteDomainsQuery( siteSlug );
+	const domainsTable = useSiteDomainsTable( siteSlug );
 	const translate = useTranslate();
 
 	const item = {
@@ -43,7 +42,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 			<Main wideLayout>
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
-				<DomainsTable domains={ data?.domains } isAllSitesView={ false } />
+				<DomainsTable { ...domainsTable } />
 			</Main>
 			<UsePresalesChat />
 		</>

--- a/packages/data-stores/src/queries/use-all-domains-query.ts
+++ b/packages/data-stores/src/queries/use-all-domains-query.ts
@@ -1,4 +1,5 @@
 import { UseQueryOptions, useQuery } from '@tanstack/react-query';
+import { addQueryArgs } from '@wordpress/url';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { DomainData } from './use-site-domains-query';
 
@@ -17,15 +18,29 @@ export type PartialDomainData = Pick<
 	| 'current_user_is_owner'
 >;
 
+export interface AllDomainsQueryParams {
+	sortKey?: 'domain' | 'site' | 'status' | 'registered-until';
+	sortOrder?: 'asc' | 'desc';
+}
+
 export interface AllDomainsQueryFnData {
 	domains: PartialDomainData[];
 }
 
-export function useAllDomainsQuery( options: UseQueryOptions< AllDomainsQueryFnData > = {} ) {
+export function useAllDomainsQuery(
+	{ sortKey, sortOrder }: AllDomainsQueryParams = {},
+	options: UseQueryOptions< AllDomainsQueryFnData > = {}
+) {
 	return useQuery( {
-		queryKey: [ 'all-domains' ],
+		queryKey: [ 'all-domains', sortKey, sortOrder ],
 		queryFn: () =>
-			wpcomRequest< AllDomainsQueryFnData >( { path: '/all-domains', apiVersion: '1.1' } ),
+			wpcomRequest< AllDomainsQueryFnData >( {
+				path: addQueryArgs( '/all-domains', {
+					sort_key: sortKey,
+					sort_order: sortOrder,
+				} ),
+				apiVersion: '1.1',
+			} ),
 		...options,
 	} );
 }

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/components';
-import { DomainData, SiteDetails } from '@automattic/data-stores';
+import { AllDomainsQueryParams, DomainData, SiteDetails } from '@automattic/data-stores';
 import { CheckboxControl, Icon } from '@wordpress/components';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -10,7 +10,7 @@ export type DomainsTableBulkSelectionStatus = 'no-domains' | 'some-domains' | 'a
 
 export type DomainsTableColumn =
 	| {
-			name: string;
+			name: Exclude< AllDomainsQueryParams[ 'sortKey' ], undefined >;
 			label: string;
 			isSortable: true;
 			initialSortDirection: 'asc' | 'desc';

--- a/packages/domains-table/src/index.ts
+++ b/packages/domains-table/src/index.ts
@@ -1,3 +1,4 @@
 export { DomainsTable } from './domains-table';
 export { PrimaryDomainLabel } from './primary-domain-label';
-export { useDomainsTable } from './use-domains-table';
+export { useAllDomainsTable } from './use-all-domains-table';
+export { useSiteDomainsTable } from './use-site-domains-table';

--- a/packages/domains-table/src/use-all-domains-table.ts
+++ b/packages/domains-table/src/use-all-domains-table.ts
@@ -1,0 +1,13 @@
+import { useAllManagableDomains } from './use-all-managable-domains';
+import { useSortState } from './use-sort-state';
+import type { DomainsTableProps } from './domains-table';
+
+export function useAllDomainsTable(): DomainsTableProps {
+	const [ sorting, setSortState ] = useSortState();
+	const { data: domains } = useAllManagableDomains( {
+		sortKey: sorting.sortKey,
+		sortOrder: sorting.sortDirection,
+	} );
+
+	return { domains, sorting, onSortChange: setSortState, isAllSitesView: true };
+}

--- a/packages/domains-table/src/use-all-managable-domains.ts
+++ b/packages/domains-table/src/use-all-managable-domains.ts
@@ -1,17 +1,24 @@
-import { useAllDomainsQuery, AllDomainsQueryFnData } from '@automattic/data-stores';
+import {
+	useAllDomainsQuery,
+	type AllDomainsQueryFnData,
+	type AllDomainsQueryParams,
+} from '@automattic/data-stores';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import type { UseQueryOptions } from '@tanstack/react-query';
 
 const EMPTY_STATE = Object.freeze( {} );
 
-export function useDomainsTable( queryOptions: UseQueryOptions< AllDomainsQueryFnData > = {} ) {
+export function useAllManagableDomains(
+	params: AllDomainsQueryParams = {},
+	queryOptions: UseQueryOptions< AllDomainsQueryFnData > = {}
+) {
 	const { capabilities, sites } = useSelector( ( state: any ) => ( {
 		capabilities: state?.currentUser?.capabilities || EMPTY_STATE,
 		sites: state?.sites?.items || EMPTY_STATE,
 	} ) );
 
-	const { data: allDomains, ...queryResult } = useAllDomainsQuery( queryOptions );
+	const { data: allDomains, ...queryResult } = useAllDomainsQuery( params, queryOptions );
 
 	const filteredDomains = useMemo( () => {
 		const sitesUserCanManage = new Set(
@@ -26,5 +33,5 @@ export function useDomainsTable( queryOptions: UseQueryOptions< AllDomainsQueryF
 		);
 	}, [ allDomains, capabilities, sites ] );
 
-	return { ...queryResult, domains: filteredDomains };
+	return { ...queryResult, data: filteredDomains };
 }

--- a/packages/domains-table/src/use-site-domains-table.ts
+++ b/packages/domains-table/src/use-site-domains-table.ts
@@ -1,0 +1,34 @@
+import { useSiteDomainsQuery } from '@automattic/data-stores';
+import { useMemo } from 'react';
+import { domainsTableColumns } from './domains-table-header/columns';
+import { useSortState } from './use-sort-state';
+import type { DomainsTableProps } from './domains-table';
+
+export function useSiteDomainsTable(
+	siteIdOrSlug: number | string | null | undefined
+): DomainsTableProps {
+	const [ sorting, setSortState ] = useSortState();
+	const { sortKey, sortDirection } = sorting;
+	const { data } = useSiteDomainsQuery( siteIdOrSlug );
+
+	const domains = useMemo( () => {
+		const selectedColumnDefinition = domainsTableColumns.find(
+			( column ) => column.name === sortKey
+		);
+
+		return data?.domains.sort( ( first, second ) => {
+			let result = 0;
+
+			for ( const sortFunction of selectedColumnDefinition?.sortFunctions || [] ) {
+				result = sortFunction( first, second, sortDirection === 'asc' ? 1 : -1 );
+				if ( result !== 0 ) {
+					break;
+				}
+			}
+
+			return result;
+		} );
+	}, [ data, sortKey, sortDirection ] );
+
+	return { domains, sorting, onSortChange: setSortState, isAllSitesView: false };
+}

--- a/packages/domains-table/src/use-sort-state.ts
+++ b/packages/domains-table/src/use-sort-state.ts
@@ -1,0 +1,37 @@
+import { useCallback, useState } from 'react';
+import { DomainsTableColumn } from './domains-table-header';
+import type { AllDomainsQueryParams } from '@automattic/data-stores';
+
+export interface Sorting {
+	sortKey: Exclude< AllDomainsQueryParams[ 'sortKey' ], undefined >;
+	sortDirection: 'asc' | 'desc';
+}
+
+export function useSortState() {
+	const [ sortState, innerSetSortState ] = useState< Sorting >( {
+		sortKey: 'domain',
+		sortDirection: 'asc',
+	} );
+
+	const setSortState = useCallback( ( selectedColumn: DomainsTableColumn ) => {
+		if ( ! selectedColumn.isSortable ) {
+			return;
+		}
+
+		innerSetSortState( ( { sortKey, sortDirection } ) => {
+			const newSortDirection =
+				selectedColumn.name === sortKey &&
+				selectedColumn.supportsOrderSwitching &&
+				sortDirection === 'asc'
+					? 'desc'
+					: selectedColumn.initialSortDirection;
+
+			return {
+				sortKey: selectedColumn.name,
+				sortDirection: newSortDirection,
+			};
+		} );
+	}, [] );
+
+	return [ sortState, setSortState ] as const;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

A WIP
Depends on D119599-code for backend sorting.

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
