### PR TITLE
Limited GS: Show only one notice

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
@@ -2,7 +2,13 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { ExternalLink, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { createInterpolateElement, render, useCallback, useEffect } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	render,
+	useCallback,
+	useEffect,
+	useState,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useCanvas } from './use-canvas';
 import { useGlobalStylesConfig } from './use-global-styles-config';
@@ -63,8 +69,10 @@ function GlobalStylesWarningNotice() {
 function GlobalStylesViewNotice() {
 	const { canvas } = useCanvas();
 
+	const [ isRendered, setIsRendered ] = useState( false );
+
 	useEffect( () => {
-		if ( canvas !== 'view' ) {
+		if ( isRendered || canvas !== 'view' ) {
 			return;
 		}
 
@@ -81,7 +89,9 @@ function GlobalStylesViewNotice() {
 		container.insertBefore( noticeContainer, saveHub );
 
 		render( <GlobalStylesWarningNotice />, noticeContainer );
-	}, [ canvas ] );
+
+		setIsRendered( true );
+	}, [ isRendered, canvas ] );
 
 	return null;
 }


### PR DESCRIPTION
## Proposed Changes

Fixes a bug that was causing the Limited Global Styles notice to appear multiple times in the left sidebar of the site editor.

Before | After
--- | ---
<img width="1276" alt="Screenshot 2023-08-24 at 13 22 07" src="https://github.com/Automattic/wp-calypso/assets/1233880/e43ba042-824d-481b-90f9-44aaa0858940"> | <img width="1273" alt="Screenshot 2023-08-24 at 13 25 09" src="https://github.com/Automattic/wp-calypso/assets/1233880/1009d7f4-3c85-4bb2-80c2-1e220156a630">


## Testing Instructions

- Apply these changes to your sandbox
- Sandbox a site with Limited Global Styles
- Go to `wp-admin/site-editor.php`
- Make sure the Limited GS notice shows up at the bottom of the left sidebar
- Switch to the edit mode by clicking on the site preview
- Switch back to the view mode by clicking on the top left site icon
- Make sure the Limited GS notice has not been duplicated