### PR TITLE
Newsletter: add tracks event for goal step clicks

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-goals/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Onboard } from '@automattic/data-stores';
 import { StepContainer } from '@automattic/onboarding';
 import { __experimentalVStack as VStack } from '@wordpress/components';
@@ -5,7 +6,6 @@ import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import FlowCard from '../components/flow-card';
 import { IconPaid, IconFree, IconImport } from './icons';
 import type { Step } from '../../types';
@@ -25,6 +25,10 @@ const NewsletterGoals: Step = ( { navigation } ) => {
 			// We could instead just avoid doing anything if nothing wasn't set ever.
 			resetGoals();
 		}
+
+		recordTracksEvent( 'calypso_signup_newsletter_goal_click', {
+			goal: goal?.toString() ?? 'free',
+		} );
 
 		submit?.();
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Add a simple click event to goal step

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go /setup/newsletter
* At goal step, try each option
* Note track event getting tracked

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
