### PR TITLE
Jetpack E2E: enable Paid Contents block for AT environments.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
@@ -62,14 +62,15 @@ export class PaidContentBlockFlow implements BlockFlow {
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
 		// Since we're viewing as the publishing user, we should see the subscriber version of the content.
-		const expectedTitle = context.page.locator(
-			`text="${ this.configurationData.subscriberTitle }"`
-		);
-		await expectedTitle.waitFor();
+		await context.page
+			.getByRole( 'heading', {
+				name: this.configurationData.subscriberTitle,
+			} )
+			.waitFor();
 
-		const expectedText = context.page.locator(
-			`text="${ this.configurationData.subscriberText }"`
-		);
-		await expectedText.waitFor();
+		await context.page
+			.getByRole( 'paragraph' )
+			.filter( { hasText: this.configurationData.subscriberText } )
+			.waitFor();
 	}
 }

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
@@ -7,11 +7,6 @@ interface ConfigurationData {
 }
 
 const blockParentSelector = '[aria-label="Block: Paid Content"]';
-const selectors = {
-	subscriberViewButton: 'button:has-text("Subscriber View")',
-	subscriberHeader: '[aria-label="Block: Subscriber View"] [aria-label="Block: Heading"]',
-	subscriberParagraph: '[aria-label="Block: Subscriber View"] [aria-label="Paragraph block"]',
-};
 
 /**
  * Class representing the flow of using a Paid Content block in the editor.
@@ -38,6 +33,11 @@ export class PaidContentBlockFlow implements BlockFlow {
 	 */
 	async configure( context: EditorContext ): Promise< void > {
 		const editorParent = await context.editorPage.getEditorParent();
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		const block = editorCanvas.getByRole( 'document', { name: 'Block: Paid Content' } );
+
+		// The Guest View will load by default. Wait for this view to fully render.
+		await block.getByRole( 'document', { name: 'Block: Guest View' } ).waitFor();
 
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
 			// Mobile viewport hides the Subscriber/Guest view
@@ -45,14 +45,17 @@ export class PaidContentBlockFlow implements BlockFlow {
 			await editorParent.getByRole( 'button', { name: 'Change view' } ).click();
 		}
 
-		const subscriberViewButtonLocator = editorParent.locator( selectors.subscriberViewButton );
-		await subscriberViewButtonLocator.click();
+		// Using the Block Toolbar, change to the Subscriber view.
+		await context.editorPage.clickBlockToolbarButton( { name: 'Subscriber View' } );
+		await block.getByRole( 'document', { name: 'Block: Subscriber View' } ).waitFor();
 
-		const subscriberHeaderLocator = editorParent.locator( selectors.subscriberHeader );
-		await subscriberHeaderLocator.fill( this.configurationData.subscriberTitle );
-
-		const subscriberParagraphLocator = editorParent.locator( selectors.subscriberParagraph );
-		await subscriberParagraphLocator.fill( this.configurationData.subscriberText );
+		// Fill the title and text for subscribers.
+		await block
+			.getByRole( 'document', { name: 'Block: Heading' } )
+			.fill( this.configurationData.subscriberTitle );
+		await block
+			.getByRole( 'document', { name: 'Paragraph block' } )
+			.fill( this.configurationData.subscriberText );
 	}
 
 	/**

--- a/test/e2e/specs/blocks/blocks__jetpack-grow.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-grow.ts
@@ -11,7 +11,6 @@ import {
 	SubscribeFlow,
 	ContactInfoBlockFlow,
 	DataHelper,
-	envVariables,
 } from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared/block-smoke-testing';
 
@@ -21,16 +20,10 @@ const blockFlows: BlockFlow[] = [
 	new SubscribeFlow(),
 	new ContactInfoBlockFlow( { email: 'foo@example.com', phoneNumber: '(213) 621-0002' } ),
 	new WhatsAppButtonFlow( { phoneNumber: 1234567890, buttonText: 'Porpoises swim happily' } ),
+	new PaidContentBlockFlow( {
+		subscriberTitle: DataHelper.getRandomPhrase(),
+		subscriberText: DataHelper.getRandomPhrase(),
+	} ),
 ];
-
-// Stripe is not connected to this WordPress.com account, so skipping on Atomic
-if ( ! envVariables.TEST_ON_ATOMIC ) {
-	blockFlows.push(
-		new PaidContentBlockFlow( {
-			subscriberTitle: DataHelper.getRandomPhrase(),
-			subscriberText: DataHelper.getRandomPhrase(),
-		} )
-	);
-}
 
 createBlockTests( 'Blocks: Jetpack Grow', blockFlows );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80730.

## Proposed Changes

This PR enables the Premium Contents block for AT environments as I have connected a test Stripe account for all of our test accounts.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
