### PR TITLE
Show newest comments at the top of the comments list, and reposition the default form and pagination links.

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -344,7 +344,7 @@ class PostCommentList extends Component {
 				{ shouldShowExpandToggle && (
 					<button className="comments__toggle-expand" onClick={ this.toggleExpanded }>
 						{ this.state.isExpanded
-							? translate( 'View less comments' )
+							? translate( 'View fewer comments' )
 							: translate( 'View more comments' ) }
 					</button>
 				) }

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -518,6 +518,8 @@ class PostCommentList extends Component {
 			expandableView,
 		} = this.props;
 
+		const shouldShowFilters = showFilters && ! expandableView;
+
 		const commentsTree = expandableView
 			? this.removePingAndTrackbacks( this.props.commentsTree )
 			: this.props.commentsTree;
@@ -571,7 +573,8 @@ class PostCommentList extends Component {
 				ref={ this.listRef }
 			>
 				{ ( this.props.showCommentCount ||
-					( showViewMoreComments && this.props.startingCommentId ) ) && (
+					showManageCommentsButton ||
+					showConversationFollowButton ) && (
 					<div className="comments__info-bar">
 						<div className="comments__info-bar-title-links">
 							{ this.props.showCommentCount && <CommentCount count={ actualCommentsCount } /> }
@@ -590,19 +593,17 @@ class PostCommentList extends Component {
 								) }
 							</div>
 						</div>
-						{ showViewMoreComments && this.props.startingCommentId && (
-							<button className="comments__view-more" onClick={ this.viewLaterCommentsHandler }>
-								{ translate( 'Load more comments (Showing %(shown)d of %(total)d)', {
-									args: {
-										shown: displayedCommentsCount,
-										total: actualCommentsCount,
-									},
-								} ) }
-							</button>
-						) }
 					</div>
 				) }
-				{ showFilters && (
+				<PostCommentFormRoot
+					post={ this.props.post }
+					commentsTree={ commentsTreeToUse }
+					commentText={ this.state.commentText }
+					onUpdateCommentText={ this.onUpdateCommentText }
+					activeReplyCommentId={ this.props.activeReplyCommentId }
+					isInlineComment={ this.props.expandableView }
+				/>
+				{ shouldShowFilters && (
 					<SegmentedControl compact primary>
 						<SegmentedControl.Item
 							selected={ commentsFilter === 'all' }
@@ -636,14 +637,16 @@ class PostCommentList extends Component {
 						</SegmentedControl.Item>
 					</SegmentedControl>
 				) }
-				<PostCommentFormRoot
-					post={ this.props.post }
-					commentsTree={ commentsTreeToUse }
-					commentText={ this.state.commentText }
-					onUpdateCommentText={ this.onUpdateCommentText }
-					activeReplyCommentId={ this.props.activeReplyCommentId }
-					isInlineComment={ this.props.expandableView }
-				/>
+				{ showViewMoreComments && this.props.startingCommentId && (
+					<button className="comments__view-more" onClick={ this.viewLaterCommentsHandler }>
+						{ translate( 'Load more comments (Showing %(shown)d of %(total)d)', {
+							args: {
+								shown: displayedCommentsCount,
+								total: actualCommentsCount,
+							},
+						} ) }
+					</button>
+				) }
 				{ this.renderCommentsList(
 					displayedComments,
 					displayedCommentsCount,

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -338,6 +338,9 @@ class PostCommentList extends Component {
 			displayedCommentsCount < actualCommentsCount;
 		return (
 			<>
+				<ol className="comments__list is-root">
+					{ commentIds.map( ( commentId ) => this.renderComment( commentId, commentsTreeToShow ) ) }
+				</ol>
 				{ shouldShowExpandToggle && (
 					<button className="comments__toggle-expand" onClick={ this.toggleExpanded }>
 						{ this.state.isExpanded
@@ -351,9 +354,6 @@ class PostCommentList extends Component {
 						{ translate( 'View more comments on the full post' ) }
 					</button>
 				) }
-				<ol className="comments__list is-root">
-					{ commentIds.map( ( commentId ) => this.renderComment( commentId, commentsTreeToShow ) ) }
-				</ol>
 			</>
 		);
 	};
@@ -543,7 +543,8 @@ class PostCommentList extends Component {
 					'has-double-actions': showManageCommentsButton && showConversationFollowButton,
 				} ) }
 			>
-				{ ( this.props.showCommentCount || showViewMoreComments ) && (
+				{ ( this.props.showCommentCount ||
+					( showViewMoreComments && this.props.startingCommentId ) ) && (
 					<div className="comments__info-bar">
 						<div className="comments__info-bar-title-links">
 							{ this.props.showCommentCount && <CommentCount count={ actualCommentsCount } /> }
@@ -562,8 +563,8 @@ class PostCommentList extends Component {
 								) }
 							</div>
 						</div>
-						{ showViewMoreComments && (
-							<button className="comments__view-more" onClick={ this.viewEarlierCommentsHandler }>
+						{ showViewMoreComments && this.props.startingCommentId && (
+							<button className="comments__view-more" onClick={ this.viewLaterCommentsHandler }>
 								{ translate( 'Load more comments (Showing %(shown)d of %(total)d)', {
 									args: {
 										shown: displayedCommentsCount,
@@ -608,23 +609,6 @@ class PostCommentList extends Component {
 						</SegmentedControl.Item>
 					</SegmentedControl>
 				) }
-				{ this.renderCommentsList(
-					displayedComments,
-					displayedCommentsCount,
-					actualCommentsCount,
-					commentsTreeToUse,
-					commentsTree
-				) }
-				{ showViewMoreComments && this.props.startingCommentId && (
-					<button className="comments__view-more" onClick={ this.viewLaterCommentsHandler }>
-						{ translate( 'Load more comments (Showing %(shown)d of %(total)d)', {
-							args: {
-								shown: displayedCommentsCount,
-								total: actualCommentsCount,
-							},
-						} ) }
-					</button>
-				) }
 				<PostCommentFormRoot
 					post={ this.props.post }
 					commentsTree={ commentsTreeToUse }
@@ -633,6 +617,26 @@ class PostCommentList extends Component {
 					activeReplyCommentId={ this.props.activeReplyCommentId }
 					isInlineComment={ this.props.expandableView }
 				/>
+				{ this.renderCommentsList(
+					displayedComments,
+					displayedCommentsCount,
+					actualCommentsCount,
+					commentsTreeToUse,
+					commentsTree
+				) }
+				{ showViewMoreComments && (
+					<button
+						className="comments__view-more comments__view-more-last"
+						onClick={ this.viewEarlierCommentsHandler }
+					>
+						{ translate( 'Load more comments (Showing %(shown)d of %(total)d)', {
+							args: {
+								shown: displayedCommentsCount,
+								total: actualCommentsCount,
+							},
+						} ) }
+					</button>
+				) }
 			</div>
 		);
 	}

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -65,6 +65,7 @@ class PostCommentList extends Component {
 		showConversationFollowButton: PropTypes.bool,
 		commentsFilter: PropTypes.string,
 		followSource: PropTypes.string,
+		fixedHeaderHeight: PropTypes.number,
 
 		// To show only the most recent comment by default, and allow expanding to see the longer
 		// list.
@@ -334,8 +335,10 @@ class PostCommentList extends Component {
 		if ( this.listRef.current ) {
 			const listEle = this.listRef.current;
 			const rect = listEle.getBoundingClientRect();
-			if ( rect.top < 0 ) {
+			const visualCutoff = this.props.fixedHeaderHeight || 0;
+			if ( rect.top < visualCutoff ) {
 				listEle.scrollIntoView( true );
+				window.scrollBy( 0, -1 * visualCutoff );
 			}
 		}
 	};

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -46,6 +46,11 @@
 			}
 		}
 	}
+
+	.comments__list.is-root {
+		display: flex;
+		flex-direction: column-reverse;
+	}
 }
 
 .comments__info-bar {

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -9,6 +9,7 @@
 	.comments__toggle-expand,
 	.comments__open-post {
 		cursor: pointer;
+		margin-top: 16px;
 		&:hover {
 			color: var(--color-link);
 		}
@@ -51,6 +52,10 @@
 		display: flex;
 		flex-direction: column-reverse;
 	}
+
+	.comments__form .form-fieldset {
+		margin: 0;
+	}
 }
 
 .comments__info-bar {
@@ -89,6 +94,10 @@
 	font-size: $font-body-small;
 	line-height: 1;
 	margin-bottom: 15px !important; // to overwrite 10px value
+
+	&.comments__view-more-last {
+		margin-top: 16px;
+	}
 
 	&:hover {
 		color: var(--color-primary-light);

--- a/client/blocks/comments/post-comment.scss
+++ b/client/blocks/comments/post-comment.scss
@@ -37,10 +37,6 @@
 .comments__list {
 	list-style: none;
 	margin: 0;
-
-	&.is-root {
-		margin-top: 20px;
-	}
 }
 
 .comments__view-replies-btn {

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -48,6 +48,7 @@ class ReaderPostCard extends Component {
 		teams: PropTypes.array,
 		hasOrganization: PropTypes.bool,
 		showFollowButton: PropTypes.bool,
+		fixedHeaderHeight: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -282,7 +283,11 @@ class ReaderPostCard extends Component {
 				{ readerPostCard }
 				{ this.props.children }
 				{ shouldShowPostCardComments && (
-					<PostCardComments post={ post } handleClick={ this.props.handleClick } />
+					<PostCardComments
+						post={ post }
+						handleClick={ this.props.handleClick }
+						fixedHeaderHeight={ this.props.fixedHeaderHeight }
+					/>
 				) }
 			</Card>
 		);

--- a/client/blocks/reader-post-card/post-card-comments.jsx
+++ b/client/blocks/reader-post-card/post-card-comments.jsx
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { requestPostComments } from 'calypso/state/comments/actions';
 import { commentsFetchingStatus } from 'calypso/state/comments/selectors';
 
-const PostCardComments = ( { post, handleClick } ) => {
+const PostCardComments = ( { post, handleClick, fixedHeaderHeight } ) => {
 	const dispatch = useDispatch();
 	const fetchStatus = useSelector( ( state ) =>
 		commentsFetchingStatus( state, post.site_ID, post.ID )
@@ -56,6 +56,7 @@ const PostCardComments = ( { post, handleClick } ) => {
 			initialSize={ 5 }
 			maxDepth={ 1 }
 			openPostPageAtComments={ onOpenPostPageAtCommentsClick }
+			fixedHeaderHeight={ fixedHeaderHeight }
 		/>
 	);
 };

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -168,6 +168,8 @@ class SearchStream extends React.Component {
 			', ',
 		] ).slice( 0, -1 );
 
+		const fixedAreaHeight = this.fixedAreaRef && this.fixedAreaRef.clientHeight;
+
 		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
 			<div>
@@ -230,7 +232,7 @@ class SearchStream extends React.Component {
 				{ ! hidePostsAndSites && wideDisplay && (
 					<div className={ searchStreamResultsClasses }>
 						<div className="search-stream__post-results">
-							<PostResults { ...this.props } />
+							<PostResults { ...this.props } fixedHeaderHeight={ fixedAreaHeight } />
 						</div>
 						<div className="search-stream__site-results">
 							{ query && (
@@ -251,7 +253,9 @@ class SearchStream extends React.Component {
 				) }
 				{ ! hidePostsAndSites && ! wideDisplay && (
 					<div className={ singleColumnResultsClasses }>
-						{ ( searchType === SEARCH_TYPES.POSTS && <PostResults { ...this.props } /> ) ||
+						{ ( searchType === SEARCH_TYPES.POSTS && (
+							<PostResults { ...this.props } fixedHeaderHeight={ fixedAreaHeight } />
+						) ) ||
 							( query && (
 								<SiteResults
 									query={ query }

--- a/client/reader/search-stream/post-results.jsx
+++ b/client/reader/search-stream/post-results.jsx
@@ -13,6 +13,7 @@ class PostResults extends Component {
 	static propTypes = {
 		query: PropTypes.string,
 		streamKey: PropTypes.string,
+		fixedHeaderHeight: PropTypes.number,
 	};
 
 	placeholderFactory = ( { key, ...rest } ) => {
@@ -33,6 +34,7 @@ class PostResults extends Component {
 			! query || query === ''
 				? ( postKey ) => ( { ...postKey, isRecommendation: true } )
 				: defaultTransform;
+
 		return (
 			<Stream
 				{ ...this.props }
@@ -42,6 +44,7 @@ class PostResults extends Component {
 				placeholderFactory={ this.placeholderFactory }
 				transformStreamItems={ transformStreamItems }
 				isMain={ false }
+				fixedHeaderHeight={ this.props.fixedHeaderHeight }
 			>
 				{ this.props.showBack && <HeaderBack /> }
 				<div ref={ this.handleStreamMounted } />

--- a/client/reader/stream/empty-search-recommended-post.jsx
+++ b/client/reader/stream/empty-search-recommended-post.jsx
@@ -3,7 +3,12 @@ import { recordTrackForPost, recordAction } from 'calypso/reader/stats';
 import { showSelectedPost } from 'calypso/reader/utils';
 import Post from './post';
 
-export default function EmptySearchRecommendedPost( { post, postKey, streamKey } ) {
+export default function EmptySearchRecommendedPost( {
+	post,
+	postKey,
+	streamKey,
+	fixedHeaderHeight,
+} ) {
 	const dispatch = useDispatch();
 
 	function handlePostClick() {
@@ -22,5 +27,7 @@ export default function EmptySearchRecommendedPost( { post, postKey, streamKey }
 		return null;
 	}
 
-	return <Post post={ post } handleClick={ handlePostClick } />;
+	return (
+		<Post post={ post } handleClick={ handlePostClick } fixedHeaderHeight={ fixedHeaderHeight } />
+	);
 }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -77,6 +77,7 @@ class ReaderStream extends Component {
 		trackScrollPage: PropTypes.func.isRequired,
 		translate: PropTypes.func,
 		useCompactCards: PropTypes.bool,
+		fixedHeaderHeight: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -443,6 +444,7 @@ class ReaderStream extends Component {
 					compact={ this.props.useCompactCards }
 					siteId={ primarySiteId }
 					showFollowButton={ this.props.showFollowButton }
+					fixedHeaderHeight={ this.props.fixedHeaderHeight }
 				/>
 				{ index === 0 && <ReaderPerformanceTrackerStop /> }
 			</Fragment>

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -23,6 +23,7 @@ class PostLifecycle extends Component {
 		isDiscoverStream: PropTypes.bool,
 		handleClick: PropTypes.func,
 		recStreamKey: PropTypes.string,
+		fixedHeaderHeight: PropTypes.number,
 	};
 
 	render() {
@@ -54,7 +55,12 @@ class PostLifecycle extends Component {
 			);
 		} else if ( ! isDiscoverStream && streamKey.indexOf( 'rec' ) > -1 ) {
 			return (
-				<EmptySearchRecommendedPost post={ post } postKey={ postKey } streamKey={ streamKey } />
+				<EmptySearchRecommendedPost
+					post={ post }
+					postKey={ postKey }
+					streamKey={ streamKey }
+					fixedHeaderHeight={ this.props.fixedHeaderHeight }
+				/>
 			);
 		} else if ( postKey.isGap ) {
 			return (

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -52,6 +52,7 @@ class ReaderPostCardAdapter extends Component {
 				postKey={ this.props.postKey }
 				compact={ this.props.compact }
 				showFollowButton={ this.props.showFollowButton }
+				fixedHeaderHeight={ this.props.fixedHeaderHeight }
 			>
 				{ feedId && <QueryReaderFeed feedId={ feedId } /> }
 				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-17X-p2

## Proposed Changes

Updates how comments are displayed from the comments list component (used for inline commments and the reader full post comments section).

* Reorders comments to be newest first.
* Repositions the default comment form to be above the comment list instead of below.
* Switches locations of the 'load earlier' and 'load later' pagination links to match the new comment order.
* moves the 'view more comments' link in inline-comments to the bottom.

Note, this does not yet impact conversations feeds comments threads. I wasn't sure if we wanted to do the same there and am happy to address it in a follow up if so.

Inline comments:
![inline-backwards](https://github.com/Automattic/wp-calypso/assets/28742426/c1fb1288-684e-4830-9568-fade70895b99)

Post page:
![postpagecommentsbackwards](https://github.com/Automattic/wp-calypso/assets/28742426/aae2d219-e979-46a3-b92a-b91db1b5d7a3)
(oops, apologies for the window on the right - but you get the idea 😁 )

### Questions:
* In moving the comment form above the listed comments, I wasn't sure where it should sit WRT some conditional items the component displays near the top (specifically the comments filter bar and load newer pagination links).  I set the form below these two items for the time being, but am unsure if it should be just above the "Load more comments" link. Thoughts?

<img width="801" alt="Screenshot 2023-08-24 at 11 01 00 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/db34ffe6-09bd-4598-a54c-14ea6ea5deab">

* For the inline comments section we moved "view more comments" to the bottom. I think this works well in the collapsed view, but in the expanded view it feels weird to me that i have to scroll down to collapse the section again. Im wondering if we should show the 'view less comments' link at both the top and bottom of the section when expanded or something. Wondering if others have thoughts, other ideas, or if they don't feel like its even an issue?

<img width="675" alt="Screenshot 2023-08-24 at 11 19 17 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/92db11e1-7e83-40bf-b2e3-ff39a8864299">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch of calypso
* test comments in inline comments and full post reader pages
* verify conversations are unaffected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
