### PR TITLE
Add links to reader pages 

### DIFF
--- a/apps/happy-blocks/block-library/universal-header-v2/index.php
+++ b/apps/happy-blocks/block-library/universal-header-v2/index.php
@@ -273,7 +273,13 @@ if ( isset( $args['website'] ) ) {
 								<?php esc_html_e( 'Logo Maker', 'happy-blocks' ); ?>
 							</a>
 						</li>
-						<?php if ( $happy_blocks_is_english ) : ?>
+						<li>
+							<a role="menuitem" class="x-dropdown-link x-link"
+								href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/discover/' ) ); ?>"
+								tabindex="-1">
+							<?php esc_html_e( 'Discover New Posts', 'happy-blocks' ); ?>
+							</a>
+						</li>
 						<li>
 							<a role="menuitem" class="x-dropdown-link x-link"
 								href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/tags/' ) ); ?>"
@@ -281,7 +287,13 @@ if ( isset( $args['website'] ) ) {
 							<?php esc_html_e( 'Popular Tags', 'happy-blocks' ); ?>
 							</a>
 						</li>
-						<?php endif; ?>
+						<li>
+							<a role="menuitem" class="x-dropdown-link x-link"
+								href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/read/search/' ) ); ?>"
+								tabindex="-1">
+							<?php esc_html_e( 'Blog Search', 'happy-blocks' ); ?>
+							</a>
+						</li>
 					</ul>
 				</div>
 				<div class="x-dropdown-content" data-dropdown-name="learn" role="menu"
@@ -529,7 +541,13 @@ if ( isset( $args['website'] ) ) {
 									<?php esc_html_e( 'Logo Maker', 'happy-blocks' ); ?>
 								</a>
 							</li>
-							<?php if ( $happy_blocks_is_english ) : ?>
+							<li class="x-menu-grid-item">
+								<a role="menuitem" class="x-menu-link x-link"
+									href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/discover/' ) ); ?>"
+									tabindex="-1">
+								<?php esc_html_e( 'Discover New Posts', 'happy-blocks' ); ?>
+								</a>
+							</li>
 							<li class="x-menu-grid-item">
 								<a role="menuitem" class="x-menu-link x-link"
 									href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/tags/' ) ); ?>"
@@ -537,7 +555,13 @@ if ( isset( $args['website'] ) ) {
 								<?php esc_html_e( 'Popular Tags', 'happy-blocks' ); ?>
 								</a>
 							</li>
-							<?php endif; ?>
+							<li class="x-menu-grid-item">
+								<a role="menuitem" class="x-menu-link x-link"
+									href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/read/search/' ) ); ?>"
+									tabindex="-1">
+								<?php esc_html_e( 'Blog Search', 'happy-blocks' ); ?>
+								</a>
+							</li>
 						</ul>
 					</div>
 					<div class="x-menu-list">

--- a/apps/happy-blocks/block-library/universal-header/index.php
+++ b/apps/happy-blocks/block-library/universal-header/index.php
@@ -273,7 +273,13 @@ if ( isset( $args['website'] ) ) {
 								<?php esc_html_e( 'Logo Maker', 'happy-blocks' ); ?>
 							</a>
 						</li>
-						<?php if ( $happy_blocks_is_english ) : ?>
+						<li>
+							<a role="menuitem" class="x-dropdown-link x-link"
+								href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/discover/' ) ); ?>"
+								tabindex="-1">
+							<?php esc_html_e( 'Discover New Posts', 'happy-blocks' ); ?>
+							</a>
+						</li>
 						<li>
 							<a role="menuitem" class="x-dropdown-link x-link"
 								href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/tags/' ) ); ?>"
@@ -281,7 +287,13 @@ if ( isset( $args['website'] ) ) {
 							<?php esc_html_e( 'Popular Tags', 'happy-blocks' ); ?>
 							</a>
 						</li>
-						<?php endif; ?>
+						<li>
+							<a role="menuitem" class="x-dropdown-link x-link"
+								href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/read/search/' ) ); ?>"
+								tabindex="-1">
+							<?php esc_html_e( 'Blog Search', 'happy-blocks' ); ?>
+							</a>
+						</li>
 						<?php if ( time() >= strtotime( '2021-02-17' ) ) : ?>
 						<li>
 							<a role="menuitem" class="x-dropdown-link x-link"
@@ -511,7 +523,13 @@ if ( isset( $args['website'] ) ) {
 									<?php esc_html_e( 'Logo Maker', 'happy-blocks' ); ?>
 								</a>
 							</li>
-							<?php if ( $happy_blocks_is_english ) : ?>
+							<li class="x-menu-grid-item">
+								<a role="menuitem" class="x-menu-link x-link"
+									href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/discover/' ) ); ?>"
+									tabindex="-1">
+								<?php esc_html_e( 'Discover New Posts', 'happy-blocks' ); ?>
+								</a>
+							</li>
 							<li class="x-menu-grid-item">
 								<a role="menuitem" class="x-menu-link x-link"
 									href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/tags/' ) ); ?>"
@@ -519,7 +537,13 @@ if ( isset( $args['website'] ) ) {
 								<?php esc_html_e( 'Popular Tags', 'happy-blocks' ); ?>
 								</a>
 							</li>
-							<?php endif; ?>
+							<li class="x-menu-grid-item">
+								<a role="menuitem" class="x-menu-link x-link"
+									href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/read/search/' ) ); ?>"
+									tabindex="-1">
+								<?php esc_html_e( 'Blog Search', 'happy-blocks' ); ?>
+								</a>
+							</li>
 							<?php if ( time() >= strtotime( '2021-02-17' ) ) : ?>
 							<li class="x-menu-grid-item">
 								<a role="menuitem" class="x-menu-link x-link"

--- a/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
@@ -215,11 +215,19 @@ export const PureUniversalNavbarFooter = ( {
 									</a>
 								</li>
 								<li>
-									{ isEnglishLocale && (
-										<a href={ localizeUrl( 'https://wordpress.com/tags/' ) } target="_self">
-											{ __( 'Popular Tags', __i18n_text_domain__ ) }
-										</a>
-									) }
+									<a href={ localizeUrl( 'https://wordpress.com/discover/' ) } target="_self">
+										{ __( 'Discover New Posts', __i18n_text_domain__ ) }
+									</a>
+								</li>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/tags/' ) } target="_self">
+										{ __( 'Popular Tags', __i18n_text_domain__ ) }
+									</a>
+								</li>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/read/search/' ) } target="_self">
+										{ __( 'Blog Search', __i18n_text_domain__ ) }
+									</a>
 								</li>
 								<li>
 									<a href={ localizeUrl( 'https://wordpress.com/webinars/' ) } target="_self">

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -266,15 +266,27 @@ const UniversalNavbarHeader = ( {
 															type="dropdown"
 															target="_self"
 														/>
-														{ isEnglishLocale && (
-															<ClickableItem
-																titleValue=""
-																content={ __( 'Popular Tags', __i18n_text_domain__ ) }
-																urlValue={ localizeUrl( '//wordpress.com/tags/' ) }
-																type="dropdown"
-																target="_self"
-															/>
-														) }
+														<ClickableItem
+															titleValue=""
+															content={ __( 'Discover New Posts', __i18n_text_domain__ ) }
+															urlValue={ localizeUrl( '//wordpress.com/discover/' ) }
+															type="dropdown"
+															target="_self"
+														/>
+														<ClickableItem
+															titleValue=""
+															content={ __( 'Popular Tags', __i18n_text_domain__ ) }
+															urlValue={ localizeUrl( '//wordpress.com/tags/' ) }
+															type="dropdown"
+															target="_self"
+														/>
+														<ClickableItem
+															titleValue=""
+															content={ __( 'Blog Search', __i18n_text_domain__ ) }
+															urlValue={ localizeUrl( '//wordpress.com/read/search/' ) }
+															type="dropdown"
+															target="_self"
+														/>
 														<ClickableItem
 															titleValue=""
 															content={ __( 'Daily Webinars', __i18n_text_domain__ ) }
@@ -571,14 +583,24 @@ const UniversalNavbarHeader = ( {
 												urlValue={ localizeUrl( '//wordpress.com/logo-maker/' ) }
 												type="menu"
 											/>
-											{ isEnglishLocale && (
-												<ClickableItem
-													titleValue=""
-													content={ __( 'Popular Tags', __i18n_text_domain__ ) }
-													urlValue={ localizeUrl( '//wordpress.com/tags/' ) }
-													type="menu"
-												/>
-											) }
+											<ClickableItem
+												titleValue=""
+												content={ __( 'Discover New Posts', __i18n_text_domain__ ) }
+												urlValue={ localizeUrl( '//wordpress.com/discover/' ) }
+												type="menu"
+											/>
+											<ClickableItem
+												titleValue=""
+												content={ __( 'Popular Tags', __i18n_text_domain__ ) }
+												urlValue={ localizeUrl( '//wordpress.com/tags/' ) }
+												type="menu"
+											/>
+											<ClickableItem
+												titleValue=""
+												content={ __( 'Blog Search', __i18n_text_domain__ ) }
+												urlValue={ localizeUrl( '//wordpress.com/read/search/' ) }
+												type="menu"
+											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Daily Webinars', __i18n_text_domain__ ) }


### PR DESCRIPTION
Part of pe7F0s-18c-p2.

Adds links to /discover and /read/search.

<img width="848" alt="Screen Shot 2023-08-24 at 11 53 12 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/50e710b9-42fb-4621-a4b6-1dd61dfd419c">
<img width="1177" alt="Screen Shot 2023-08-24 at 11 52 53 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/58ba4a71-408d-4854-a747-60f8861fd183">



### Testing Instructions
`cd apps/happy-blocks`
`yarn dev --sync`
The new links should be on the /themes and /plugins pages when logged out.