### PR TITLE
Issue in the free plan button  inside the /plans page

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -439,18 +439,19 @@ const PlansFeaturesMain = ( {
 		plans: gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ),
 	};
 
-	const planActionOverrides: PlanActionOverrides | undefined = {
-		loggedInFreePlan: {
-			status: isPlanUpsellEnabledOnFreeDomain.isLoading ? 'blocked' : 'enabled',
-		},
-	};
+	/**
+	 * The effects on /plans page need to be checked if this variable is initialized
+	 */
+	let planActionOverrides: PlanActionOverrides | undefined = undefined;
 	if ( sitePlanSlug && isFreePlan( sitePlanSlug ) ) {
-		planActionOverrides.loggedInFreePlan = {
-			...planActionOverrides.loggedInFreePlan,
-			callback: () => {
-				page.redirect( `/add-ons/${ siteSlug }` );
+		planActionOverrides = {
+			loggedInFreePlan: {
+				status: isPlanUpsellEnabledOnFreeDomain.isLoading ? 'blocked' : 'enabled',
+				callback: () => {
+					page.redirect( `/add-ons/${ siteSlug }` );
+				},
+				text: translate( 'Manage add-ons', { context: 'verb' } ),
 			},
-			text: translate( 'Manage add-ons', { context: 'verb' } ),
 		};
 		if ( domainFromHomeUpsellFlow ) {
 			planActionOverrides.loggedInFreePlan = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Bug fix in the `/plans` page after Purchasing any plan is fixed.
* We seem to be doing things based on whether the override is available or not
* So the override was only initialised in signup for now
* A warning was also put up for future developers.

![image](https://github.com/Automattic/wp-calypso/assets/3422709/99893f0a-0c1f-45ca-9279-0b6b6cc1cbac)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase any plan
* Go to the `/plans` page
* The free button shouldn't be broken

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
