### PR TITLE
Add 'Like' label to comments like button with 0 likes.

### DIFF
--- a/client/blocks/comments/comment-likes.jsx
+++ b/client/blocks/comments/comment-likes.jsx
@@ -54,6 +54,7 @@ class CommentLikeButtonContainer extends Component {
 				likedLabel={ likedLabel }
 				iconSize={ 18 }
 				icon={ likeIcon }
+				defaultLabel={ translate( 'Like' ) }
 			/>
 		);
 	}

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -25,6 +25,7 @@ class LikeButton extends PureComponent {
 		postId: PropTypes.number,
 		slug: PropTypes.string,
 		icon: PropTypes.object,
+		defaultLabel: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -37,6 +38,7 @@ class LikeButton extends PureComponent {
 		postId: null,
 		slug: null,
 		icon: null,
+		defaultLabel: '',
 	};
 
 	constructor( props ) {
@@ -68,6 +70,7 @@ class LikeButton extends PureComponent {
 			onMouseEnter,
 			onMouseLeave,
 			icon,
+			defaultLabel,
 		} = this.props;
 		const showLikeCount = likeCount > 0 || showZeroCount;
 		const isLink = containerTag === 'a';
@@ -86,7 +89,9 @@ class LikeButton extends PureComponent {
 
 		const labelElement = (
 			<span className="like-button__label">
-				<span className="like-button__label-count">{ showLikeCount ? likeCount : '' }</span>
+				<span className="like-button__label-count">
+					{ showLikeCount ? likeCount : defaultLabel }
+				</span>
 			</span>
 		);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-17X-p2

## Proposed Changes

* Adds a "Like" label to the comments likes button for when there are 0 comments.

<img width="313" alt="Screenshot 2023-08-24 at 12 10 49 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/d0865acb-bbb5-4052-9d13-295afcc50319">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test likes in reader comments. Verify there is a label saying "Like" when there are 0 likes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
