### PR TITLE
Earn: Refactor ads > payments to function component

### DIFF
--- a/client/my-sites/earn/ads/payments.jsx
+++ b/client/my-sites/earn/ads/payments.jsx
@@ -1,41 +1,22 @@
 import { Badge, Card } from '@automattic/components';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
 import QueryWordadsPayments from 'calypso/components/data/query-wordads-payments';
 import QueryWordadsSettings from 'calypso/components/data/query-wordads-settings';
 import Notice from 'calypso/components/notice';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import { useSelector } from 'calypso/state';
 import { getWordadsSettings } from 'calypso/state/selectors/get-wordads-settings';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getWordAdsPayments } from 'calypso/state/wordads/payments/selectors';
 
-class WordAdsPayments extends Component {
-	static propTypes = {
-		siteId: PropTypes.number,
-		payments: PropTypes.arrayOf(
-			PropTypes.shape( {
-				id: PropTypes.number.isRequired,
-				paymentDate: PropTypes.string,
-				amount: PropTypes.string,
-				status: PropTypes.string,
-				paypalEmail: PropTypes.string.isRequired,
-				description: PropTypes.string,
-			} )
-		).isRequired,
-	};
+const WordAdsPayments = ( { numberFormat } ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const payments = useSelector( ( state ) => getWordAdsPayments( state, siteId ) );
+	const wordAdsSettings = useSelector( ( state ) => getWordadsSettings( state, siteId ) );
 
-	checkSize( obj ) {
-		if ( ! obj ) {
-			return 0;
-		}
-
-		return Object.keys( obj ).length;
-	}
-
-	statusToType( status ) {
+	function statusToType( status ) {
 		const map = {
 			paid: 'success',
 			pending: 'info',
@@ -44,12 +25,11 @@ class WordAdsPayments extends Component {
 		return map[ status ] || 'warning';
 	}
 
-	paymentsTable( payments, type ) {
-		const { numberFormat, translate } = this.props;
+	function paymentsTable( currentPayments, type ) {
 		const rows = [];
 		const classes = classNames( 'payments_history' );
 
-		payments.forEach( ( payment ) => {
+		currentPayments.forEach( ( payment ) => {
 			rows.push(
 				<tr key={ type + '-' + payment.id }>
 					<td className="ads__payments-history-value">
@@ -63,10 +43,7 @@ class WordAdsPayments extends Component {
 					</td>
 					<td className="ads__payments-history-value">${ numberFormat( payment.amount, 2 ) }</td>
 					<td className="ads__payments-history-value">
-						<Badge
-							className="ads__payments-history-badge"
-							type={ this.statusToType( payment.status ) }
-						>
+						<Badge className="ads__payments-history-badge" type={ statusToType( payment.status ) }>
 							{ payment.status }
 						</Badge>
 					</td>
@@ -101,21 +78,19 @@ class WordAdsPayments extends Component {
 		);
 	}
 
-	notices( payments, wordAdsSettings ) {
-		const { translate } = this.props;
-
-		if ( ! payments || ! wordAdsSettings ) {
+	function notices( currentPayments, currentWordAdsSettings ) {
+		if ( ! currentPayments || ! currentWordAdsSettings ) {
 			return null;
 		}
 
-		if ( ! wordAdsSettings.paypal ) {
+		if ( ! currentWordAdsSettings.paypal ) {
 			return null;
 		}
 
 		let hasMismatch = false;
 
-		payments.forEach( ( payment ) => {
-			if ( payment.status === 'pending' && payment.paypalEmail !== wordAdsSettings.paypal ) {
+		currentPayments.forEach( ( payment ) => {
+			if ( payment.status === 'pending' && payment.paypalEmail !== currentWordAdsSettings.paypal ) {
 				hasMismatch = true;
 			}
 		} );
@@ -137,9 +112,7 @@ class WordAdsPayments extends Component {
 		) : null;
 	}
 
-	empty() {
-		const { translate } = this.props;
-
+	function empty() {
 		return (
 			<Card>
 				{ translate(
@@ -149,28 +122,14 @@ class WordAdsPayments extends Component {
 		);
 	}
 
-	render() {
-		const { siteId, payments, wordAdsSettings } = this.props;
-		return (
-			<div>
-				<QueryWordadsSettings siteId={ siteId } />
-				<QueryWordadsPayments siteId={ siteId } />
-				{ this.notices( payments, wordAdsSettings ) }
-				{ payments && payments.length > 0
-					? this.paymentsTable( payments, 'wordads' )
-					: this.empty() }
-			</div>
-		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
-	}
-}
+	return (
+		<div>
+			<QueryWordadsSettings siteId={ siteId } />
+			<QueryWordadsPayments siteId={ siteId } />
+			{ notices( payments, wordAdsSettings ) }
+			{ payments && payments.length > 0 ? paymentsTable( payments, 'wordads' ) : empty() }
+		</div>
+	);
+};
 
-export default connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
-
-	return {
-		siteId,
-		payments: getWordAdsPayments( state, siteId ),
-		wordAdsSettings: getWordadsSettings( state, siteId ),
-	};
-} )( localize( WordAdsPayments ) );
+export default WordAdsPayments;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Refactors the Earn > Ads > Payments component from class to functional component. This is part of an effort to update all earn code. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Checkout this branch and go to `http://calypso.localhost:3000/earn/YOURDOMAIN`
2) Test Ads pages to confirm they look and behave the same as before: 
   - If you haven't yet, find the Ads card and enable Ads. 
   - Click around on the ads dashboard and confirm everything loads as expect. 
   - Trying to Ads Dashboard > Settings and saving settings to confirm that works. 
3) Bonus: I don't have a personal site with ad revenue to check earning stats. I tested this by using the Switch to User functionality. I went to an active WordPress.com site with ads and confirmed totals still show. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
