### PR TITLE
Domain Forwarding: Fixed chevron alignment

### DIFF
--- a/client/components/domains/accordion/index.tsx
+++ b/client/components/domains/accordion/index.tsx
@@ -12,6 +12,7 @@ const Accordion = ( {
 	isPlaceholder,
 	expanded = false,
 	onClose,
+	className,
 }: AccordionProps ) => {
 	const classes = classNames( {
 		'is-placeholder': isPlaceholder,
@@ -30,6 +31,7 @@ const Accordion = ( {
 		<div className="accordion">
 			<FoldableCard
 				clickableHeader
+				className={ className }
 				header={ renderHeader() }
 				expanded={ expanded }
 				disabled={ isPlaceholder }

--- a/client/components/domains/accordion/types.ts
+++ b/client/components/domains/accordion/types.ts
@@ -8,4 +8,5 @@ export type AccordionProps = {
 	onClose?: () => void;
 
 	isPlaceholder?: boolean;
+	className?: string;
 };

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -170,22 +170,40 @@
 		}
 	}
 
-	.foldable-card__content {
+	> .foldable-card__content {
 		padding: 0 !important;
 	}
 
 	.form-text-input-with-affixes {
-		padding: 0 24px;
+		padding: 0 16px;
+
+		@include break-mobile {
+			padding: 0 24px;
+		}
+
 		box-sizing: border-box;
 	}
 
 	.form-button.is-primary {
-		margin: 0 24px 24px;
+		margin: 10px 16px 16px;
+
+		@include break-mobile {
+			margin: 10px 24px 24px;
+		}
+	}
+
+	.form-fieldset {
+		margin-bottom: 0;
 	}
 
 	.accordion .foldable-card {
 		box-shadow: none;
-		padding-left: 24px;
+
+		padding-left: 16px;
+
+		@include break-mobile {
+			padding-left: 24px;
+		}
 
 		.foldable-card__header {
 			padding-left: 0;
@@ -196,6 +214,12 @@
 		}
 
 		.foldable-card__content {
+			padding-right: 16px;
+
+			@include break-mobile {
+				padding-right: 24px;
+			}
+
 			.form-label {
 				margin-top: 16px;
 				margin-bottom: 0;

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -132,7 +132,7 @@
 	}
 }
 
-.domain-forwarding-card__fields {
+.domain-forwarding-card__accordion {
 	margin-bottom: 0 !important;
 
 	.form-text-input:disabled {
@@ -140,7 +140,7 @@
 	}
 
 	.form-text-input-with-affixes__prefix,
-	.form-text-input-with-affixes__suffix, {
+	.form-text-input-with-affixes__suffix {
 		padding: 0;
 		border: 0 !important;
 
@@ -170,8 +170,22 @@
 		}
 	}
 
+	.foldable-card__content {
+		padding: 0 !important;
+	}
+
+	.form-text-input-with-affixes {
+		padding: 0 24px;
+		box-sizing: border-box;
+	}
+
+	.form-button.is-primary {
+		margin: 0 24px 24px;
+	}
+
 	.accordion .foldable-card {
 		box-shadow: none;
+		padding-left: 24px;
 
 		.foldable-card__header {
 			padding-left: 0;
@@ -208,7 +222,7 @@
 
 .domain-forwarding-card__error-field {
 	height: 35px;
-	margin-bottom: 17px;
+	margin: 0 0 17px 24px;
 }
 
 .ownership-verification-card {

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -351,6 +351,7 @@ const Settings = ( {
 
 		return (
 			<Accordion
+				className="domain-forwarding-card__accordion"
 				title={ translate( 'Domain Forwarding', { textOnly: true } ) }
 				subtitle={ translate( 'Forward your domain to another' ) }
 			>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up of https://github.com/Automattic/wp-calypso/pull/80922
More context: p1692827039722599-slack-C05CT832K2T

## Proposed Changes

* Align chevron to the far right
* Improved alignment on Advanced button
* Improved alignment on Error state

| Before | After |
|--------|--------|
| <img width="758" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/2332adee-8b00-49ec-8dc3-2e0d2be1ed13"> | <img width="756" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/33f3c140-1aa2-45dd-ba07-7b340fc09638"> |
| <img width="595" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/c8141513-087e-44e0-898a-4cbd5b76600f"> | <img width="591" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/a92008a1-42d8-4d67-af46-28a10ae1550c"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the Domain Forwarding feature and ensure the chevron is correctly aligned with Design
* Validate mobile version
* Input an invalid domain and validate the error state alignment

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?