### PR TITLE
WIP/Explore - making inline comments more condensed in collapsed mode.

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -328,10 +328,7 @@ class PostCommentList extends Component {
 		// the tree. We need to use commentsTreeAvailable to determine whether to show
 		// expand/collapse toggle for inline comments, but actualCommentsCount to determine whether
 		// to show the link to view all comments (including pingbacks) on the post page.
-		const shouldShowExpandToggle =
-			this.props.expandableView &&
-			( displayedCommentsCount < this.getCommentsCount( commentsTreeAvailable.children ) ||
-				this.state.isExpanded );
+		const shouldShowExpandToggle = this.props.expandableView && actualCommentsCount > 0;
 		const shouldShowLinkToFullPost =
 			this.props.expandableView &&
 			( this.state.isExpanded || ! shouldShowExpandToggle ) &&
@@ -344,8 +341,8 @@ class PostCommentList extends Component {
 				{ shouldShowExpandToggle && (
 					<button className="comments__toggle-expand" onClick={ this.toggleExpanded }>
 						{ this.state.isExpanded
-							? translate( 'View less comments' )
-							: translate( 'View more comments' ) }
+							? translate( 'Collapse comments' )
+							: translate( 'Expand comments' ) }
 					</button>
 				) }
 				{ shouldShowLinkToFullPost && (
@@ -443,21 +440,21 @@ class PostCommentList extends Component {
 			children: [],
 		};
 
-		// Go through the children of the last comment to find replies by the current user.
-		const authorReplies = commentsTree[ lastComment ]?.children.filter( ( replyId ) => {
-			return commentsTree[ replyId ]?.data.author?.ID === this.props.currentUserId;
-		} );
+		// // Go through the children of the last comment to find replies by the current user.
+		// const authorReplies = commentsTree[ lastComment ]?.children.filter( ( replyId ) => {
+		// 	return commentsTree[ replyId ]?.data.author?.ID === this.props.currentUserId;
+		// } );
 
-		// Add the latest reply of the current user to the comments children array and comment tree.
-		if ( authorReplies?.length ) {
-			const lastReply = authorReplies.pop();
-			newCommentTree[ lastComment ].children.push( lastReply );
-			newCommentTree[ lastReply ] = {
-				data: commentsTree[ lastReply ].data,
-				// Ensure no children since this is the last reply we want rendered.
-				children: [],
-			};
-		}
+		// // Add the latest reply of the current user to the comments children array and comment tree.
+		// if ( authorReplies?.length ) {
+		// 	const lastReply = authorReplies.pop();
+		// 	newCommentTree[ lastComment ].children.push( lastReply );
+		// 	newCommentTree[ lastReply ] = {
+		// 		data: commentsTree[ lastReply ].data,
+		// 		// Ensure no children since this is the last reply we want rendered.
+		// 		children: [],
+		// 	};
+		// }
 
 		return {
 			displayedComments: lastCommentArr,
@@ -541,6 +538,8 @@ class PostCommentList extends Component {
 			<div
 				className={ classnames( 'comments__comment-list', {
 					'has-double-actions': showManageCommentsButton && showConversationFollowButton,
+					'is-inline': expandableView,
+					'is-collapsed': isCollapsedInline,
 				} ) }
 			>
 				{ ( this.props.showCommentCount ||

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -338,6 +338,9 @@ class PostCommentList extends Component {
 			displayedCommentsCount < actualCommentsCount;
 		return (
 			<>
+				<ol className="comments__list is-root">
+					{ commentIds.map( ( commentId ) => this.renderComment( commentId, commentsTreeToShow ) ) }
+				</ol>
 				{ shouldShowExpandToggle && (
 					<button className="comments__toggle-expand" onClick={ this.toggleExpanded }>
 						{ this.state.isExpanded
@@ -351,9 +354,6 @@ class PostCommentList extends Component {
 						{ translate( 'View more comments on the full post' ) }
 					</button>
 				) }
-				<ol className="comments__list is-root">
-					{ commentIds.map( ( commentId ) => this.renderComment( commentId, commentsTreeToShow ) ) }
-				</ol>
 			</>
 		);
 	};
@@ -543,7 +543,8 @@ class PostCommentList extends Component {
 					'has-double-actions': showManageCommentsButton && showConversationFollowButton,
 				} ) }
 			>
-				{ ( this.props.showCommentCount || showViewMoreComments ) && (
+				{ ( this.props.showCommentCount ||
+					( showViewMoreComments && this.props.startingCommentId ) ) && (
 					<div className="comments__info-bar">
 						<div className="comments__info-bar-title-links">
 							{ this.props.showCommentCount && <CommentCount count={ actualCommentsCount } /> }
@@ -562,8 +563,8 @@ class PostCommentList extends Component {
 								) }
 							</div>
 						</div>
-						{ showViewMoreComments && (
-							<button className="comments__view-more" onClick={ this.viewEarlierCommentsHandler }>
+						{ showViewMoreComments && this.props.startingCommentId && (
+							<button className="comments__view-more" onClick={ this.viewLaterCommentsHandler }>
 								{ translate( 'Load more comments (Showing %(shown)d of %(total)d)', {
 									args: {
 										shown: displayedCommentsCount,
@@ -608,23 +609,6 @@ class PostCommentList extends Component {
 						</SegmentedControl.Item>
 					</SegmentedControl>
 				) }
-				{ this.renderCommentsList(
-					displayedComments,
-					displayedCommentsCount,
-					actualCommentsCount,
-					commentsTreeToUse,
-					commentsTree
-				) }
-				{ showViewMoreComments && this.props.startingCommentId && (
-					<button className="comments__view-more" onClick={ this.viewLaterCommentsHandler }>
-						{ translate( 'Load more comments (Showing %(shown)d of %(total)d)', {
-							args: {
-								shown: displayedCommentsCount,
-								total: actualCommentsCount,
-							},
-						} ) }
-					</button>
-				) }
 				<PostCommentFormRoot
 					post={ this.props.post }
 					commentsTree={ commentsTreeToUse }
@@ -633,6 +617,26 @@ class PostCommentList extends Component {
 					activeReplyCommentId={ this.props.activeReplyCommentId }
 					isInlineComment={ this.props.expandableView }
 				/>
+				{ this.renderCommentsList(
+					displayedComments,
+					displayedCommentsCount,
+					actualCommentsCount,
+					commentsTreeToUse,
+					commentsTree
+				) }
+				{ showViewMoreComments && (
+					<button
+						className="comments__view-more comments__view-more-last"
+						onClick={ this.viewEarlierCommentsHandler }
+					>
+						{ translate( 'Load more comments (Showing %(shown)d of %(total)d)', {
+							args: {
+								shown: displayedCommentsCount,
+								total: actualCommentsCount,
+							},
+						} ) }
+					</button>
+				) }
 			</div>
 		);
 	}

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -60,13 +60,13 @@
 	&.is-inline.is-collapsed {
 		.comments__toggle-expand {
 			margin-top: 8px;
-			margin-left: 48px;
+			margin-left: 64px;
 		}
 
 		.comments__comment {
 			display: flex;
 			align-items: center;
-			padding-left: 16px;
+			padding-left: 32px;
 			margin-top: 10px;
 
 			.comments__comment-author {

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -46,6 +46,11 @@
 			}
 		}
 	}
+
+	.comments__list.is-root {
+		display: flex;
+		flex-direction: column-reverse;
+	}
 }
 
 .comments__info-bar {

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -9,6 +9,7 @@
 	.comments__toggle-expand,
 	.comments__open-post {
 		cursor: pointer;
+		margin-top: 16px;
 		&:hover {
 			color: var(--color-link);
 		}
@@ -51,6 +52,10 @@
 		display: flex;
 		flex-direction: column-reverse;
 	}
+
+	.comments__form .form-fieldset {
+		margin: 0;
+	}
 }
 
 .comments__info-bar {
@@ -89,6 +94,10 @@
 	font-size: $font-body-small;
 	line-height: 1;
 	margin-bottom: 15px !important; // to overwrite 10px value
+
+	&.comments__view-more-last {
+		margin-top: 16px;
+	}
 
 	&:hover {
 		color: var(--color-primary-light);

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -56,6 +56,59 @@
 	.comments__form .form-fieldset {
 		margin: 0;
 	}
+
+	&.is-inline.is-collapsed {
+		.comments__toggle-expand {
+			margin-top: 8px;
+			margin-left: 48px;
+		}
+
+		.comments__comment {
+			display: flex;
+			align-items: center;
+			padding-left: 16px;
+			margin-top: 10px;
+
+			.comments__comment-author {
+				display: flex;
+				align-items: center;
+				flex-wrap: nowrap;
+
+				a {
+					display: flex;
+					align-items: center;
+				}
+
+				.gravatar {
+					position: static;
+					width: 24px;
+					height: 24px;
+					min-width: 24px;
+				}
+
+				.comments__comment-username {
+					margin-left: 7px;
+					text-wrap: nowrap;
+				}
+
+				.comments__comment-timestamp {
+					margin-right: 7px;
+					text-wrap: nowrap;
+				}
+			}
+
+			.comments__comment-content {
+				display: -webkit-box;
+				overflow: hidden;
+				-webkit-box-orient: vertical;
+				-webkit-line-clamp: 1;
+			}
+
+			.comments__comment-actions {
+				display: none;
+			}
+		}
+	}
 }
 
 .comments__info-bar {

--- a/client/blocks/comments/post-comment.scss
+++ b/client/blocks/comments/post-comment.scss
@@ -37,10 +37,6 @@
 .comments__list {
 	list-style: none;
 	margin: 0;
-
-	&.is-root {
-		margin-top: 20px;
-	}
 }
 
 .comments__view-replies-btn {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR is intended to aid brainstorm and discussion on how to handle inline comments better given recent feedback.

* Branches off of https://github.com/Automattic/wp-calypso/pull/81028 to reverse comment order for newest first.
* Explores changes to inline comments by updating the styles of 'collapsed' mode.
    * Hides comment actions - reply, like, etc.
    * line-clamps comment content at 1 line
    * updates styles to make the comment and author info all 1 line
    * no longer shows the readers response to the displayed comment
    * shows an "Expand comments" at all times when comments exist in place of "view more" if there were more than the displayed comment / reply.

![inline-comments-idea](https://github.com/Automattic/wp-calypso/assets/28742426/be810dd4-92c1-4dec-9903-2a65afc1b9fc)

Thoughts on what people think of this idea, or what other ideas folks may have.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
