### PR TITLE
Connected Account: Remove product.connected_destination_account_id

### DIFF
--- a/client/state/data-layer/wpcom/sites/memberships/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/index.js
@@ -20,7 +20,6 @@ export const membershipProductFromApi = ( product ) => ( {
 	formatted_price: product.price,
 	price: product.price,
 	title: product.title,
-	stripe_account: product.connected_destination_account_id,
 	renewal_schedule: product.interval,
 	buyer_can_change_amount: product.buyer_can_change_amount,
 	multiple_per_user: product.multiple_per_user,

--- a/client/state/memberships/product-list/schema.js
+++ b/client/state/memberships/product-list/schema.js
@@ -8,7 +8,6 @@ export const metadataSchema = {
 	status: { type: 'string', metaKey: 'spay_status' },
 	email: { type: 'string', metaKey: 'spay_email' },
 	formatted_price: { type: 'string', metaKey: 'spay_formatted_price' },
-	stripe_account: { type: 'string' },
 	renewal_schedule: { type: 'string' },
 	type: { type: 'string' },
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 115-gh-Automattic/gold

## Proposed Changes

* Remove `product.connected_destination_account_id`
* Remove `product.stripe_account`

## Testing Instructions

* Verify there are no other uses of `connected_destination_account_id` in the codebase
* Verify there are no other uses of `stripe_account` in the codebase