### PR TITLE
GF Signup:Fix preloading conditions

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -283,30 +283,24 @@ class DomainsStep extends Component {
 			  } )
 			: undefined;
 
-		/**
-		 * If we do not select a paid domain.
-		 * We want to pre load an experiment to show a plan upsell modal in the plans step
-		 */
-		if ( ! isPurchasingItem ) {
-			switch ( flowName ) {
-				case 'onboarding':
-					if ( isPurchasingItem ) {
-						loadExperimentAssignment( 'calypso_onboarding_plans_paid_domain_on_free_plan' );
-					} else {
-						loadExperimentAssignment(
-							'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3'
-						);
-					}
-					break;
-				case 'onboarding-pm':
-					if ( isPurchasingItem ) {
-						loadExperimentAssignment( 'calypso_onboardingpm_plans_paid_domain_on_free_plan' );
-					} else {
-						loadExperimentAssignment(
-							'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3'
-						);
-					}
-			}
+		switch ( flowName ) {
+			case 'onboarding':
+				if ( isPurchasingItem ) {
+					loadExperimentAssignment( 'calypso_onboarding_plans_paid_domain_on_free_plan' );
+				} else {
+					loadExperimentAssignment(
+						'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3'
+					);
+				}
+				break;
+			case 'onboarding-pm':
+				if ( isPurchasingItem ) {
+					loadExperimentAssignment( 'calypso_onboardingpm_plans_paid_domain_on_free_plan' );
+				} else {
+					loadExperimentAssignment(
+						'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3'
+					);
+				}
 		}
 
 		suggestion && this.props.submitDomainStepSelection( suggestion, this.getAnalyticsSection() );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -290,16 +290,22 @@ class DomainsStep extends Component {
 		if ( ! isPurchasingItem ) {
 			switch ( flowName ) {
 				case 'onboarding':
-					loadExperimentAssignment(
-						'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3'
-					);
-					loadExperimentAssignment( 'calypso_onboarding_plans_paid_domain_on_free_plan' );
+					if ( isPurchasingItem ) {
+						loadExperimentAssignment( 'calypso_onboarding_plans_paid_domain_on_free_plan' );
+					} else {
+						loadExperimentAssignment(
+							'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3'
+						);
+					}
 					break;
 				case 'onboarding-pm':
-					loadExperimentAssignment(
-						'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3'
-					);
-					loadExperimentAssignment( 'calypso_onboardingpm_plans_paid_domain_on_free_plan' );
+					if ( isPurchasingItem ) {
+						loadExperimentAssignment( 'calypso_onboardingpm_plans_paid_domain_on_free_plan' );
+					} else {
+						loadExperimentAssignment(
+							'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3'
+						);
+					}
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related 
- https://github.com/Automattic/growth-foundations/issues/159

## Proposed Changes
* Fix preloading conditions for the relevant plans modal experiment.
* The conditions for preloading the experiment were incorrect. All experiments were pre loaded only when there was a free subdomain. But two of these experiments actually are activated when there is a paid domain. So the code was changed to fix this conditional errors.

## Testing Instructions
* Run a few confidence checks from https://github.com/Automattic/wp-calypso/pull/80647

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
