### PR TITLE
Domain forwarding: Update DNS A name warning copy and CSS

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -18,7 +18,6 @@ import useDeleteDomainForwardingMutation from 'calypso/data/domains/forwarding/u
 import useDomainForwardingQuery from 'calypso/data/domains/forwarding/use-domain-forwarding-query';
 import useUpdateDomainForwardingMutation from 'calypso/data/domains/forwarding/use-update-domain-forwarding-mutation';
 import { withoutHttp } from 'calypso/lib/url';
-import { MAP_EXISTING_DOMAIN } from 'calypso/lib/url/support';
 import { useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
@@ -204,10 +203,16 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 		}
 
 		const noticeText = translate(
-			'Connect your domain to WordPress.com to enable domain forwarding. {{a}}Learn more{{/a}}.',
+			'To enable domain forwarding please "restore default A records." {{a}}Learn more{{/a}}.',
 			{
 				components: {
-					a: <a href={ localizeUrl( MAP_EXISTING_DOMAIN ) } />,
+					a: (
+						<a
+							href={ localizeUrl(
+								'https://wordpress.com/support/domains/custom-dns/#default-records'
+							) }
+						/>
+					),
 				},
 			}
 		);

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -1,5 +1,6 @@
 import { Button, FormInputValidation } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { hasTranslation } from '@wordpress/i18n';
 import { Icon, trash, info } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -18,6 +19,7 @@ import useDeleteDomainForwardingMutation from 'calypso/data/domains/forwarding/u
 import useDomainForwardingQuery from 'calypso/data/domains/forwarding/use-domain-forwarding-query';
 import useUpdateDomainForwardingMutation from 'calypso/data/domains/forwarding/use-update-domain-forwarding-mutation';
 import { withoutHttp } from 'calypso/lib/url';
+import { MAP_EXISTING_DOMAIN } from 'calypso/lib/url/support';
 import { useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
@@ -32,6 +34,7 @@ const noticeOptions = {
 export default function DomainForwardingCard( { domain }: { domain: ResponseDomain } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const { data: forwarding, isLoading, isError } = useDomainForwardingQuery( domain.name );
 
@@ -202,20 +205,35 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 			return null;
 		}
 
-		const noticeText = translate(
-			'To enable domain forwarding please "restore default A records." {{a}}Learn more{{/a}}.',
-			{
-				components: {
-					a: (
-						<a
-							href={ localizeUrl(
-								'https://wordpress.com/support/domains/custom-dns/#default-records'
-							) }
-						/>
-					),
-				},
-			}
-		);
+		const newNoticeText =
+			'To enable domain forwarding please "restore default A records." {{a}}Learn more{{/a}}.';
+
+		let noticeText;
+		if ( hasTranslation( newNoticeText ) || isEnglishLocale ) {
+			noticeText = translate(
+				'To enable domain forwarding please "restore default A records." {{a}}Learn more{{/a}}.',
+				{
+					components: {
+						a: (
+							<a
+								href={ localizeUrl(
+									'https://wordpress.com/support/domains/custom-dns/#default-records'
+								) }
+							/>
+						),
+					},
+				}
+			);
+		} else {
+			noticeText = translate(
+				'Connect your domain to WordPress.com to enable domain forwarding. {{a}}Learn more{{/a}}.',
+				{
+					components: {
+						a: <a href={ localizeUrl( MAP_EXISTING_DOMAIN ) } />,
+					},
+				}
+			);
+		}
 
 		return (
 			<div className="domain-forwarding-card-notice">

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -115,7 +115,7 @@
 }
 
 .domain-forwarding-card-notice {
-	margin-bottom: 16px;
+	margin: 0 24px 16px 24px;
 }
 
 .site-redirect-card__explanation,

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -115,7 +115,11 @@
 }
 
 .domain-forwarding-card-notice {
-	margin: 0 24px 16px 24px;
+	margin: 0 16px 16px;
+
+	@include break-mobile {
+		margin: 0 24px 16px 24px;
+	}
 }
 
 .site-redirect-card__explanation,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3551

## Proposed Changes

* Update the copy on the domain forwarding when the A records don't match.

Before | After
--|--
![warn-before](https://github.com/Automattic/wp-calypso/assets/140841/50525a90-0dc6-4ee9-94a2-9dd48e74f2d3)  | ![warn-after](https://github.com/Automattic/wp-calypso/assets/140841/c724aef2-e04b-4bff-b0fa-6e6ef1c42fc9)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* On a test domain change the A record so it doesn't point to WordPress.com
* Observe the new warning.
* Double check the old copy translation will show until the new copy is translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
