### PR TITLE
Update auth header copy for Jetpack AI and Jetpack Boost A/B test

### DIFF
--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -140,30 +140,42 @@ export class AuthFormHeader extends Component {
 		}
 
 		if ( isWooCoreProfiler ) {
+			const pluginNames = {
+				'jetpack-ai': 'Jetpack AI',
+				'jetpack-boost': 'Jetpack Boost',
+				default: 'Jetpack',
+			};
+			const pluginName = pluginNames[ this.props.authQuery.plugin_name ] || pluginNames.default;
+			const translateParams = {
+				components: {
+					br: <br />,
+					a: (
+						<a
+							href={ login( {
+								isJetpack: true,
+								redirectTo: window.location.href,
+								from: this.props.authQuery.from,
+							} ) }
+						/>
+					),
+				},
+				args: { pluginName },
+				comment:
+					'Link displayed on the Jetpack Connect signup page for users to log in with a WordPress.com account',
+			};
+
 			switch ( currentState ) {
 				case 'logged-out':
 					return translate(
-						"We'll make it quick – promise. In order to take advantage of the benefits offered by Jetpack, you'll need to connect your store to your WordPress.com account. {{br/}} Already have one? {{a}}Log in{{/a}}",
-						{
-							components: {
-								br: <br />,
-								a: (
-									<a
-										href={ login( {
-											isJetpack: true,
-											redirectTo: window.location.href,
-											from: this.props.authQuery.from,
-										} ) }
-									/>
-								),
-							},
-							comment:
-								'Link displayed on the Jetpack Connect signup page for users to log in with a WordPress.com account',
-						}
+						"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to connect your store to your WordPress.com account. {{br/}} Already have one? {{a}}Log in{{/a}}",
+						translateParams
 					);
 				default:
 					return translate(
-						"We'll make it quick – promise. In order to take advantage of the benefits offered by Jetpack, you'll need to connect your store to your WordPress.com account."
+						"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to connect your store to your WordPress.com account.",
+						{
+							args: { pluginName },
+						}
 					);
 			}
 		}

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -145,6 +145,7 @@ export class AuthFormHeader extends Component {
 				'jetpack-boost': 'Jetpack Boost',
 				default: 'Jetpack',
 			};
+
 			const pluginName = pluginNames[ this.props.authQuery.plugin_name ] || pluginNames.default;
 			const translateParams = {
 				components: {

--- a/client/jetpack-connect/schema.js
+++ b/client/jetpack-connect/schema.js
@@ -42,5 +42,6 @@ export const authorizeQueryDataSchema = {
 		skip_user: { type: 'string' }, // deprecated, to be removed soon
 		allow_site_connection: { type: 'string' }, // '1' if true
 		installed_ext_success: { type: 'string' }, // '1' if true
+		plugin_name: { type: 'string' },
 	},
 };

--- a/client/jetpack-connect/test/__snapshots__/utils.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/utils.js.snap
@@ -15,6 +15,7 @@ Object {
   "isPopup": false,
   "jpVersion": null,
   "nonce": "foobar",
+  "plugin_name": null,
   "redirectAfterAuth": null,
   "redirectUri": "https://yourjetpack.blog/wp-admin/admin.php",
   "scope": "administrator:34579bf2a3185a47d1b31aab30125d",

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -48,6 +48,11 @@ export function authQueryTransformer( queryObject ) {
 		allowSiteConnection: queryObject.skip_user || queryObject.allow_site_connection || null,
 		// Used by woo core profiler flow to determine if we need to show a success notice after installing extensions or not.
 		installedExtSuccess: queryObject.installed_ext_success || null,
+
+		// This is a temporary param used for Jetpack A.I and Jetpack Boost A/B testing in WooCommerce core
+		// Related WooCommerce PR: https://github.com/woocommerce/woocommerce/pull/39799
+		// this param will be removed after the expierment is over
+		plugin_name: queryObject.plugin_name || null,
 	};
 }
 
@@ -70,6 +75,7 @@ export const authQueryPropTypes = PropTypes.shape( {
 	state: PropTypes.string.isRequired,
 	userEmail: PropTypes.string,
 	installedExtSuccess: PropTypes.string,
+	plugin_name: PropTypes.string,
 } );
 
 export function addCalypsoEnvQueryArg( url ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/woocommerce/woocommerce/issues/39629

## Proposed Changes

* Updated Auth Form Header copies for Jetpack AI and Jetpack Boost A/B test
* This PR renders `Jetpack` or `Jetpack AI` or `Jetpack Boost` depending on `plugin_name` query param. Related WooCommerce Core commit: https://github.com/woocommerce/woocommerce/pull/39799/commits/5dfce0e4380a1b3fe6516212ca9f3770828259c5

## Testing Instructions

1. Create a new JN site with WooCommerce
2. Start the core profiler and proceed to the plugins page.
3. Make sure to choose Jetpack
4. Click the continue button to install
5. You should be redirected to Jetpack connect page.
6. Copy the URL
7. Checkout this branch and open your local wp-calypso
8. Replace the copied URL and replace the host to your local wp-calypso
9. You should see Jetpack connect page
10. Append `plugin_name=jetpack-ai` query param and refresh the page
11. The copy should contain `Jetpack AI`
12. Change the param to `plugin_name=jetpack-boost` and refresh the page
13. The copy should contain `Jetpack Boost`
14. Remove `plugin_name` param and refresh the page
15. The copy should contain `Jetpack` 
16. Logout and repeat the test with `plugin_name` param


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
