### PR TITLE
Update Forms block smoke testing for broader coverage

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
@@ -130,8 +130,13 @@ export class AllFormFieldsFlow implements BlockFlow {
 	 */
 	private async addFieldBlockToForm( context: EditorContext, blockName: string ) {
 		const openInlineInserter: OpenInlineInserter = async ( editorCanvas ) => {
-			await context.editorPage.selectBlockParent();
-			await editorCanvas.getByRole( 'button', { name: 'Add block' } ).click();
+			await context.editorPage.selectBlockParent( 'Form' );
+			const addBlockLocater = await editorCanvas.getByRole( 'button', { name: 'Add block' } );
+			// See: https://github.com/Automattic/jetpack/issues/32695
+			// On mobile, we can't click the inline button directly due to an overlay z-index bug.
+			// So we force the click via dispatchEvent.
+			await addBlockLocater.waitFor();
+			await addBlockLocater.dispatchEvent( 'click' );
 		};
 		await context.editorPage.addBlockInline(
 			blockName,

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
@@ -142,8 +142,8 @@ export class AllFormFieldsFlow implements BlockFlow {
 
 	/** */
 	private async labelFieldBlock( context: EditorContext, blockName: string ) {
-		const editorCanvas = await context.editorPage.getEditorCanvas();
-		await editorCanvas
+		const parentFormBlock = context.addedBlockLocator;
+		await parentFormBlock
 			.locator( this.makeBlockSelector( blockName ) )
 			.getByRole( 'textbox', { name: 'Add label…' } )
 			.fill( this.addLabelPrefix( blockName ) );
@@ -154,8 +154,8 @@ export class AllFormFieldsFlow implements BlockFlow {
 	 * @param context
 	 */
 	private async configureSingleChoiceOption( context: EditorContext ) {
-		const editorCanvas = await context.editorPage.getEditorCanvas();
-		await editorCanvas
+		const parentFormBlock = context.addedBlockLocator;
+		await parentFormBlock
 			.locator( this.makeBlockSelector( 'Single Choice (Radio)' ) )
 			.getByRole( 'textbox', { name: 'Add option…' } )
 			.fill( this.addLabelPrefix( 'Single Option' ) );
@@ -166,8 +166,8 @@ export class AllFormFieldsFlow implements BlockFlow {
 	 * @param context
 	 */
 	private async configureMultipleChoiceOption( context: EditorContext ) {
-		const editorCanvas = await context.editorPage.getEditorCanvas();
-		await editorCanvas
+		const parentFormBlock = context.addedBlockLocator;
+		await parentFormBlock
 			.locator( this.makeBlockSelector( 'Multiple Choice (Checkbox)' ) )
 			.getByRole( 'textbox', { name: 'Add option…' } )
 			.fill( this.addLabelPrefix( 'Multiple Option' ) );
@@ -178,8 +178,8 @@ export class AllFormFieldsFlow implements BlockFlow {
 	 * @param context
 	 */
 	private async configureTermsConsent( context: EditorContext ) {
-		const editorCanvas = await context.editorPage.getEditorCanvas();
-		await editorCanvas
+		const parentFormBlock = context.addedBlockLocator;
+		await parentFormBlock
 			.locator( this.makeBlockSelector( 'Terms Consent' ) )
 			.getByRole( 'textbox', { name: 'Add implicit consent message…' } )
 			.fill( this.addLabelPrefix( 'Terms Consent Message' ) );
@@ -190,8 +190,8 @@ export class AllFormFieldsFlow implements BlockFlow {
 	 * @param context
 	 */
 	private async configureSubmitButton( context: EditorContext ) {
-		const editorCanvas = await context.editorPage.getEditorCanvas();
-		await editorCanvas
+		const parentFormBlock = context.addedBlockLocator;
+		await parentFormBlock
 			.locator( this.makeBlockSelector( 'Button' ) )
 			.getByRole( 'textbox', { name: 'Add text…' } )
 			.fill( `${ this.configurationData.labelPrefix } Submit` );

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
@@ -1,0 +1,199 @@
+import { OpenInlineInserter } from '../../pages';
+import { BlockFlow, EditorContext, PublishedPostContext } from '.';
+
+interface ConfigurationData {
+	labelPrefix: string;
+}
+
+/**
+ * Class representing the flow of using an block in the editor.
+ */
+export class AllFormFieldsFlow implements BlockFlow {
+	private configurationData: ConfigurationData;
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData data with which to configure and validate the block
+	 */
+	constructor( configurationData: ConfigurationData ) {
+		this.configurationData = configurationData;
+	}
+
+	// You add an individual input field...
+	blockSidebarName = 'Text Input Field';
+	// ... but a full Form block is added and marked as selected in the editor!
+	blockEditorSelector = "[aria-label='Block: Form']";
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		// The first block, the "Text Input Field", gets added by the shared block flow code.
+		// We need to label it though still.
+		await this.labelFieldBlock( context, 'Text Input Field' );
+
+		// Next, we need to add an label all the other fields!
+		const blockNames = [
+			'Name Field',
+			'Email Field',
+			'URL Field',
+			'Date Picker',
+			'Phone Number Field',
+			'Multi-line Text Field',
+			'Checkbox',
+			'Multiple Choice (Checkbox)',
+			'Single Choice (Radio)',
+			'Dropdown Field',
+		];
+		for ( const blockName of blockNames ) {
+			await this.addFieldBlockToForm( context, blockName );
+			await this.labelFieldBlock( context, blockName );
+		}
+
+		// Finally we add the Terms Consent block. It's a unique case in that its "label" is really its full text
+		// and looks different in the DOM.
+		await this.addFieldBlockToForm( context, 'Terms Consent' );
+
+		// Now, we just need to add any final configuration pieces!
+		await this.configureSingleChoiceOption( context );
+		await this.configureMultipleChoiceOption( context );
+		await this.configureTermsConsent( context );
+		await this.configureSubmitButton( context );
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		interface ExpectedField {
+			type: 'textbox' | 'checkbox' | 'radio' | 'combobox' | 'button';
+			accessibleName: string;
+		}
+
+		const expectedFields: ExpectedField[] = [
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Text Input Field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Name Field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Email Field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'URL Field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Phone Number Field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Multi-line Text Field' ) },
+			{ type: 'checkbox', accessibleName: this.addLabelPrefix( 'Checkbox' ) },
+			{ type: 'radio', accessibleName: this.addLabelPrefix( 'Single Option' ) },
+			{ type: 'checkbox', accessibleName: this.addLabelPrefix( 'Multiple Option' ) },
+			// Currently broken, sadly! See: https://github.com/Automattic/jetpack/issues/30762
+			// { type: 'combobox', accessibleName: this.addLabelPrefix( 'Dropdown Field' ) },
+			{ type: 'button', accessibleName: this.addLabelPrefix( 'Submit' ) },
+		];
+
+		for ( const expectedField of expectedFields ) {
+			const { type, accessibleName } = expectedField;
+			await context.page.getByRole( type, { name: accessibleName } ).first().waitFor();
+		}
+
+		// The terms consent is kind of weird because it's applied to a hidden checkbox.
+		await context.page
+			.getByRole( 'checkbox', {
+				name: this.addLabelPrefix( 'Terms Consent Message' ),
+				includeHidden: true,
+			} )
+			.first()
+			.waitFor( { state: 'hidden' } );
+	}
+
+	/**
+	 *
+	 * @param label
+	 * @returns
+	 */
+	private addLabelPrefix( label: string ): string {
+		return `${ this.configurationData.labelPrefix } ${ label }`;
+	}
+
+	/**
+	 *
+	 * @param blockName
+	 * @returns
+	 */
+	private makeBlockSelector( blockName: string ): string {
+		return `div[aria-label="Block: ${ blockName }"]`;
+	}
+
+	/**
+	 *
+	 * @param context
+	 * @param blockName
+	 */
+	private async addFieldBlockToForm( context: EditorContext, blockName: string ) {
+		const openInlineInserter: OpenInlineInserter = async ( editorCanvas ) => {
+			await context.editorPage.selectBlockParent();
+			await editorCanvas.getByRole( 'button', { name: 'Add block' } ).click();
+		};
+		await context.editorPage.addBlockInline(
+			blockName,
+			this.makeBlockSelector( blockName ),
+			openInlineInserter
+		);
+	}
+
+	/** */
+	private async labelFieldBlock( context: EditorContext, blockName: string ) {
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		await editorCanvas
+			.locator( this.makeBlockSelector( blockName ) )
+			.getByRole( 'textbox', { name: 'Add label…' } )
+			.fill( this.addLabelPrefix( blockName ) );
+	}
+
+	/**
+	 *
+	 * @param context
+	 */
+	private async configureSingleChoiceOption( context: EditorContext ) {
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		await editorCanvas
+			.locator( this.makeBlockSelector( 'Single Choice (Radio)' ) )
+			.getByRole( 'textbox', { name: 'Add option…' } )
+			.fill( this.addLabelPrefix( 'Single Option' ) );
+	}
+
+	/**
+	 *
+	 * @param context
+	 */
+	private async configureMultipleChoiceOption( context: EditorContext ) {
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		await editorCanvas
+			.locator( this.makeBlockSelector( 'Multiple Choice (Checkbox)' ) )
+			.getByRole( 'textbox', { name: 'Add option…' } )
+			.fill( this.addLabelPrefix( 'Multiple Option' ) );
+	}
+
+	/**
+	 *
+	 * @param context
+	 */
+	private async configureTermsConsent( context: EditorContext ) {
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		await editorCanvas
+			.locator( this.makeBlockSelector( 'Terms Consent' ) )
+			.getByRole( 'textbox', { name: 'Add implicit consent message…' } )
+			.fill( this.addLabelPrefix( 'Terms Consent Message' ) );
+	}
+
+	/**
+	 *
+	 * @param context
+	 */
+	private async configureSubmitButton( context: EditorContext ) {
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		await editorCanvas
+			.locator( this.makeBlockSelector( 'Button' ) )
+			.getByRole( 'textbox', { name: 'Add text…' } )
+			.fill( `${ this.configurationData.labelPrefix } Submit` );
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
@@ -131,7 +131,7 @@ export class AllFormFieldsFlow implements BlockFlow {
 	 */
 	private async addFieldBlockToForm( context: EditorContext, blockName: string ) {
 		const openInlineInserter: OpenInlineInserter = async ( editorCanvas ) => {
-			await context.editorPage.selectBlockParent( 'Form' );
+			await context.editorPage.selectParentBlock( 'Form' );
 			const addBlockLocater = await editorCanvas.getByRole( 'button', { name: 'Add block' } );
 			if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
 				// See: https://github.com/Automattic/jetpack/issues/32695

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/contact-form.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/contact-form.ts
@@ -47,15 +47,6 @@ export class ContactFormFlow implements BlockFlow {
 		} );
 	}
 
-	/** */
-	private async labelFieldBlock( context: EditorContext, blockName: string ) {
-		const parentFormBlock = context.addedBlockLocator;
-		await parentFormBlock
-			.locator( makeSelectorFromBlockName( blockName ) )
-			.getByRole( 'textbox', { name: 'Add label…' } )
-			.fill( this.addLabelPrefix( blockName ) );
-	}
-
 	/**
 	 * This flow uses a prefix for labels to make them unique. This function adds that prefix to a label.
 	 *

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/contact-form.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/contact-form.ts
@@ -1,3 +1,8 @@
+import {
+	labelFormFieldBlock,
+	makeSelectorFromBlockName,
+	validatePublishedFormFields,
+} from './shared';
 import { BlockFlow, EditorContext, PublishedPostContext } from '.';
 
 interface ConfigurationData {
@@ -20,7 +25,7 @@ export class ContactFormFlow implements BlockFlow {
 	}
 
 	blockSidebarName = 'Contact Form';
-	blockEditorSelector = 'div[aria-label="Block: Form"]';
+	blockEditorSelector = makeSelectorFromBlockName( 'Form' );
 
 	/**
 	 * Configure the block in the editor with the configuration data from the constructor
@@ -28,37 +33,37 @@ export class ContactFormFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		// Name and Email are common fields shared amongst most Form patterns.
+		// Name and Email are common fields shared amongst all Form patterns.
 		// So let's make them unique here!
-		await this.labelFieldBlock( context, 'Name Field' );
-		await this.labelFieldBlock( context, 'Email Field' );
+		await labelFormFieldBlock( context.addedBlockLocator, {
+			blockName: 'Name Field',
+			accessibleLabelName: 'Add label…',
+			labelText: this.addLabelPrefix( 'Name Field' ),
+		} );
+		await labelFormFieldBlock( context.addedBlockLocator, {
+			blockName: 'Email Field',
+			accessibleLabelName: 'Add label…',
+			labelText: this.addLabelPrefix( 'Email Field' ),
+		} );
 	}
 
 	/** */
 	private async labelFieldBlock( context: EditorContext, blockName: string ) {
 		const parentFormBlock = context.addedBlockLocator;
 		await parentFormBlock
-			.locator( this.makeBlockSelector( blockName ) )
+			.locator( makeSelectorFromBlockName( blockName ) )
 			.getByRole( 'textbox', { name: 'Add label…' } )
 			.fill( this.addLabelPrefix( blockName ) );
 	}
 
 	/**
+	 * This flow uses a prefix for labels to make them unique. This function adds that prefix to a label.
 	 *
-	 * @param label
-	 * @returns
+	 * @param {string} label
+	 * @returns The label with the prefix added.
 	 */
 	private addLabelPrefix( label: string ): string {
 		return `${ this.configurationData.labelPrefix } ${ label }`;
-	}
-
-	/**
-	 *
-	 * @param blockName
-	 * @returns
-	 */
-	private makeBlockSelector( blockName: string ): string {
-		return `div[aria-label="Block: ${ blockName }"]`;
 	}
 
 	/**
@@ -67,12 +72,7 @@ export class ContactFormFlow implements BlockFlow {
 	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
-		interface ExpectedField {
-			type: 'textbox' | 'checkbox' | 'radio' | 'combobox' | 'button';
-			accessibleName: string;
-		}
-
-		const expectedFields: ExpectedField[] = [
+		await validatePublishedFormFields( context.page, [
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Name Field' ) },
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Email Field' ) },
 			// This is the default label pulled in by the Contact Form pattern.
@@ -80,11 +80,6 @@ export class ContactFormFlow implements BlockFlow {
 			{ type: 'textbox', accessibleName: 'Message' },
 			// Same with the default text on the submit button.
 			{ type: 'button', accessibleName: 'Contact Us' },
-		];
-
-		for ( const expectedField of expectedFields ) {
-			const { type, accessibleName } = expectedField;
-			await context.page.getByRole( type, { name: accessibleName } ).first().waitFor();
-		}
+		] );
 	}
 }

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
@@ -1,15 +1,15 @@
-import { Locator } from 'playwright';
+import {
+	ExpectedFormField,
+	labelFormFieldBlock,
+	makeSelectorFromBlockName,
+	validatePublishedFormFields,
+} from './shared';
 import { BlockFlow, EditorContext, PublishedPostContext } from '.';
-
-interface ExpectedField {
-	type: 'textbox' | 'checkbox' | 'radio' | 'combobox' | 'button';
-	accessibleName: string;
-}
 
 interface ConfigurationData {
 	labelPrefix: string;
 	patternName: string;
-	otherExpectedFields: ExpectedField[];
+	otherExpectedFields: ExpectedFormField[];
 }
 
 /**
@@ -28,7 +28,7 @@ export class FormPatternsFlow implements BlockFlow {
 	}
 
 	blockSidebarName = 'Form';
-	blockEditorSelector = 'div[aria-label="Block: Form"]';
+	blockEditorSelector = makeSelectorFromBlockName( 'Form' );
 
 	/**
 	 * Configure the block in the editor with the configuration data from the constructor
@@ -36,6 +36,46 @@ export class FormPatternsFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
+		await this.addFormPattern( context );
+
+		// Adding the pattern unfortunately wipes out the old parent Form block and replaces it with a new one.
+		// So we have to grab a new parent locator ourselves instead of relying on the old on in the context.
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		const newParentBlockId = await editorCanvas
+			.locator( '[aria-label="Block: Form"].is-selected' )
+			.getAttribute( 'id' );
+		const newParentBlockLocator = editorCanvas.locator( `#${ newParentBlockId }` );
+
+		// Name and Email are common fields shared amongst all Form patterns.
+		// So let's make them unique here!
+		await labelFormFieldBlock( newParentBlockLocator, {
+			blockName: 'Name Field',
+			accessibleLabelName: 'Add label…',
+			labelText: this.addLabelPrefix( 'Name Field' ),
+		} );
+		await labelFormFieldBlock( newParentBlockLocator, {
+			blockName: 'Email Field',
+			accessibleLabelName: 'Add label…',
+			labelText: this.addLabelPrefix( 'Email Field' ),
+		} );
+	}
+
+	/**
+	 * This flow uses a prefix for labels to make them unique. This function adds that prefix to a label.
+	 *
+	 * @param {string} label
+	 * @returns The label with the prefix added.
+	 */
+	private addLabelPrefix( label: string ): string {
+		return `${ this.configurationData.labelPrefix } ${ label }`;
+	}
+
+	/**
+	 * Opens the form pattern modal and adds the form pattern.
+	 *
+	 * @param {EditorContext} context Editor context object.
+	 */
+	private async addFormPattern( context: EditorContext ) {
 		// Okay, this timeout wait is gross, but we really don't have any other options here.
 		// For whatever reason, if you try to open the forms pattern modal too quickly, it will get dismissed.
 		// After a lot of testing, there is no network request or anything reliable in the DOM that we can key off of.
@@ -47,6 +87,7 @@ export class FormPatternsFlow implements BlockFlow {
 		await context.addedBlockLocator
 			.getByRole( 'button', { name: 'Explore Form Patterns' } )
 			.click();
+
 		const editorParent = await context.editorPage.getEditorParent();
 		await editorParent
 			.getByRole( 'dialog', { name: 'Choose a pattern' } )
@@ -55,66 +96,6 @@ export class FormPatternsFlow implements BlockFlow {
 			.getByRole( 'option' )
 			// These patterns can load in quite slowly, messing with animation wait checks, so let's give extra time.
 			.click( { timeout: 20 * 1000 } );
-
-		const editorCanvas = await context.editorPage.getEditorCanvas();
-		// Adding the pattern unfortunately wipes out the old parent Form block and replaces it with a new one.
-		// So we have to grab a new parent locator ourselves instead of relying on the old on in the context.
-		const newParentBlockId = await editorCanvas
-			.locator( '[aria-label="Block: Form"].is-selected' )
-			.getAttribute( 'id' );
-		const newParentBlockLocator = editorCanvas.locator( `#${ newParentBlockId }` );
-
-		// Name and Email are common fields shared amongst most Form patterns.
-		// So let's make them unique here!
-		await this.labelFieldBlock( newParentBlockLocator, 'Name Field' );
-		await this.labelFieldBlock( newParentBlockLocator, 'Email Field' );
-	}
-
-	/** */
-	private async openFormPatterns( context: EditorContext ) {
-		const MAX_TRIES = 3;
-		for ( let i = 0; i < MAX_TRIES; i++ ) {
-			try {
-				await context.addedBlockLocator
-					.getByRole( 'button', { name: 'Explore Form Patterns' } )
-					.click();
-				const editorParent = await context.editorPage.getEditorParent();
-				await editorParent
-					.getByRole( 'dialog', { name: 'Choose a pattern' } )
-					.waitFor( { timeout: 3000 } );
-				return;
-			} catch ( e ) {
-				if ( i === MAX_TRIES - 1 ) {
-					throw e;
-				}
-			}
-		}
-	}
-
-	/** */
-	private async labelFieldBlock( parentFormBlock: Locator, blockName: string ) {
-		await parentFormBlock
-			.locator( this.makeBlockSelector( blockName ) )
-			.getByRole( 'textbox', { name: 'Add label…' } )
-			.fill( this.addLabelPrefix( blockName ) );
-	}
-
-	/**
-	 *
-	 * @param label
-	 * @returns
-	 */
-	private addLabelPrefix( label: string ): string {
-		return `${ this.configurationData.labelPrefix } ${ label }`;
-	}
-
-	/**
-	 *
-	 * @param blockName
-	 * @returns
-	 */
-	private makeBlockSelector( blockName: string ): string {
-		return `div[aria-label="Block: ${ blockName }"]`;
 	}
 
 	/**
@@ -123,15 +104,10 @@ export class FormPatternsFlow implements BlockFlow {
 	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
-		const expectedFields: ExpectedField[] = [
+		await validatePublishedFormFields( context.page, [
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Name Field' ) },
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Email Field' ) },
 			...this.configurationData.otherExpectedFields,
-		];
-
-		for ( const expectedField of expectedFields ) {
-			const { type, accessibleName } = expectedField;
-			await context.page.getByRole( type, { name: accessibleName } ).first().waitFor();
-		}
+		] );
 	}
 }

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
@@ -9,6 +9,9 @@ import { BlockFlow, EditorContext, PublishedPostContext } from '.';
 interface ConfigurationData {
 	labelPrefix: string;
 	patternName: string;
+}
+
+interface ValidationData {
 	otherExpectedFields: ExpectedFormField[];
 }
 
@@ -17,14 +20,17 @@ interface ConfigurationData {
  */
 export class FormPatternsFlow implements BlockFlow {
 	private configurationData: ConfigurationData;
+	private validationData: ValidationData;
 
 	/**
 	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
 	 *
 	 * @param {ConfigurationData} configurationData data with which to configure and validate the block
+	 * @param {ValidationData} validationData data with which to validate the block
 	 */
-	constructor( configurationData: ConfigurationData ) {
+	constructor( configurationData: ConfigurationData, validationData: ValidationData ) {
 		this.configurationData = configurationData;
+		this.validationData = validationData;
 	}
 
 	blockSidebarName = 'Form';
@@ -83,7 +89,7 @@ export class FormPatternsFlow implements BlockFlow {
 		// pass sometimes and then the modal will still get dismissed.
 		// There must be some slow-ish Editor rerender that is dismissing the dialog.
 		// This wait, although "against the rules", has proved to be the most reliable approach so far.
-		await context.page.waitForTimeout( 2000 );
+		await context.page.waitForTimeout( 2 * 1000 );
 		await context.addedBlockLocator
 			.getByRole( 'button', { name: 'Explore Form Patterns' } )
 			.click();
@@ -107,7 +113,7 @@ export class FormPatternsFlow implements BlockFlow {
 		await validatePublishedFormFields( context.page, [
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Name Field' ) },
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Email Field' ) },
-			...this.configurationData.otherExpectedFields,
+			...this.validationData.otherExpectedFields,
 		] );
 	}
 }

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
@@ -1,0 +1,137 @@
+import { Locator } from 'playwright';
+import { BlockFlow, EditorContext, PublishedPostContext } from '.';
+
+interface ExpectedField {
+	type: 'textbox' | 'checkbox' | 'radio' | 'combobox' | 'button';
+	accessibleName: string;
+}
+
+interface ConfigurationData {
+	labelPrefix: string;
+	patternName: string;
+	otherExpectedFields: ExpectedField[];
+}
+
+/**
+ * Class representing the flow of using an block in the editor.
+ */
+export class FormPatternsFlow implements BlockFlow {
+	private configurationData: ConfigurationData;
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData data with which to configure and validate the block
+	 */
+	constructor( configurationData: ConfigurationData ) {
+		this.configurationData = configurationData;
+	}
+
+	blockSidebarName = 'Form';
+	blockEditorSelector = 'div[aria-label="Block: Form"]';
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		// Okay, this timeout wait is gross, but we really don't have any other options here.
+		// For whatever reason, if you try to open the forms pattern modal too quickly, it will get dismissed.
+		// After a lot of testing, there is no network request or anything reliable in the DOM that we can key off of.
+		// And a loop design where you try to launch and see if you were successful is also flaky, because the check will
+		// pass sometimes and then the modal will still get dismissed.
+		// There must be some slow-ish Editor rerender that is dismissing the dialog.
+		// This wait, although "against the rules", has proved to be the most reliable approach so far.
+		await context.page.waitForTimeout( 2000 );
+		await context.addedBlockLocator
+			.getByRole( 'button', { name: 'Explore Form Patterns' } )
+			.click();
+		const editorParent = await context.editorPage.getEditorParent();
+		await editorParent
+			.getByRole( 'dialog', { name: 'Choose a pattern' } )
+			// The a11y is a little bit messed up here -- the right label isn't directly assocaited with the option element.
+			.locator( `[aria-label="${ this.configurationData.patternName }"]` )
+			.getByRole( 'option' )
+			// These patterns can load in quite slowly, messing with animation wait checks, so let's give extra time.
+			.click( { timeout: 20 * 1000 } );
+
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		// Adding the pattern unfortunately wipes out the old parent Form block and replaces it with a new one.
+		// So we have to grab a new parent locator ourselves instead of relying on the old on in the context.
+		const newParentBlockId = await editorCanvas
+			.locator( '[aria-label="Block: Form"].is-selected' )
+			.getAttribute( 'id' );
+		const newParentBlockLocator = editorCanvas.locator( `#${ newParentBlockId }` );
+
+		// Name and Email are common fields shared amongst most Form patterns.
+		// So let's make them unique here!
+		await this.labelFieldBlock( newParentBlockLocator, 'Name Field' );
+		await this.labelFieldBlock( newParentBlockLocator, 'Email Field' );
+	}
+
+	/** */
+	private async openFormPatterns( context: EditorContext ) {
+		const MAX_TRIES = 3;
+		for ( let i = 0; i < MAX_TRIES; i++ ) {
+			try {
+				await context.addedBlockLocator
+					.getByRole( 'button', { name: 'Explore Form Patterns' } )
+					.click();
+				const editorParent = await context.editorPage.getEditorParent();
+				await editorParent
+					.getByRole( 'dialog', { name: 'Choose a pattern' } )
+					.waitFor( { timeout: 3000 } );
+				return;
+			} catch ( e ) {
+				if ( i === MAX_TRIES - 1 ) {
+					throw e;
+				}
+			}
+		}
+	}
+
+	/** */
+	private async labelFieldBlock( parentFormBlock: Locator, blockName: string ) {
+		await parentFormBlock
+			.locator( this.makeBlockSelector( blockName ) )
+			.getByRole( 'textbox', { name: 'Add label…' } )
+			.fill( this.addLabelPrefix( blockName ) );
+	}
+
+	/**
+	 *
+	 * @param label
+	 * @returns
+	 */
+	private addLabelPrefix( label: string ): string {
+		return `${ this.configurationData.labelPrefix } ${ label }`;
+	}
+
+	/**
+	 *
+	 * @param blockName
+	 * @returns
+	 */
+	private makeBlockSelector( blockName: string ): string {
+		return `div[aria-label="Block: ${ blockName }"]`;
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		const expectedFields: ExpectedField[] = [
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Name Field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Email Field' ) },
+			...this.configurationData.otherExpectedFields,
+		];
+
+		for ( const expectedField of expectedFields ) {
+			const { type, accessibleName } = expectedField;
+			await context.page.getByRole( type, { name: accessibleName } ).first().waitFor();
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -21,6 +21,7 @@ export * from './layout-grid';
 export * from './ai-assistant';
 export * from './donations-form';
 export * from './all-form-fields';
+export * from './form-patterns';
 
 /* Types */
 export * from './types';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -20,6 +20,7 @@ export * from './youtube';
 export * from './layout-grid';
 export * from './ai-assistant';
 export * from './donations-form';
+export * from './all-form-fields';
 
 /* Types */
 export * from './types';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/pay-with-paypal.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/pay-with-paypal.ts
@@ -34,7 +34,7 @@ export class PayWithPaypalBlockFlow implements BlockFlow {
 		this.configurationData = configurationData;
 	}
 
-	blockSidebarName = 'Pay with Paypal';
+	blockSidebarName = 'Pay with PayPal';
 	blockEditorSelector = blockParentSelector;
 
 	// @todo the `configure` below should also support a target: SiteType option as it wraps the `EditorPage`

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/shared/block-helpers.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/shared/block-helpers.ts
@@ -1,0 +1,53 @@
+import { Locator, Page } from 'playwright';
+
+/**
+ * Makes a selector for a block based on the block name.
+ * Blocks often follow a predictable pattern using aria-labels, and this centralizes that!
+ *
+ * @param {string} blockName The name of the block, often how it appears in the sidebar.
+ * @returns A selector string to use to make a locator for the block.
+ */
+export function makeSelectorFromBlockName( blockName: string ): string {
+	return `div[aria-label="Block: ${ blockName }"]`;
+}
+
+export interface ExpectedFormField {
+	type: 'textbox' | 'checkbox' | 'radio' | 'combobox' | 'button';
+	accessibleName: string;
+}
+
+/**
+ * A shared validate function for published form blocks.
+ *
+ * @param {Locator | Page} publishedPage A locator/page object for the published page.
+ * @param {ExpectedFormField[]} expectedFormFields An array of fields to validate.
+ */
+export async function validatePublishedFormFields(
+	publishedPage: Locator | Page,
+	expectedFormFields: ExpectedFormField[]
+) {
+	for ( const expectedField of expectedFormFields ) {
+		const { type, accessibleName } = expectedField;
+		await publishedPage.getByRole( type, { name: accessibleName } ).first().waitFor();
+	}
+}
+
+interface FieldLabelDetails {
+	blockName: string;
+	accessibleLabelName: string;
+	labelText: string;
+}
+
+/**
+ * Labels a field block within the form.
+ *
+ * @param {Locator} parentFormBlock Locator for the parent form block.
+ * @param {FieldLabelDetails} details The details for labeling.
+ */
+export async function labelFormFieldBlock( parentFormBlock: Locator, details: FieldLabelDetails ) {
+	const { blockName, accessibleLabelName, labelText } = details;
+	await parentFormBlock
+		.locator( makeSelectorFromBlockName( blockName ) )
+		.getByRole( 'textbox', { name: accessibleLabelName } )
+		.fill( labelText );
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/shared/block-helpers.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/shared/block-helpers.ts
@@ -1,5 +1,16 @@
 import { Locator, Page } from 'playwright';
 
+export interface ExpectedFormField {
+	type: 'textbox' | 'checkbox' | 'radio' | 'combobox' | 'button';
+	accessibleName: string;
+}
+
+interface FieldLabelDetails {
+	blockName: string;
+	accessibleLabelName: string;
+	labelText: string;
+}
+
 /**
  * Makes a selector for a block based on the block name.
  * Blocks often follow a predictable pattern using aria-labels, and this centralizes that!
@@ -9,11 +20,6 @@ import { Locator, Page } from 'playwright';
  */
 export function makeSelectorFromBlockName( blockName: string ): string {
 	return `div[aria-label="Block: ${ blockName }"]`;
-}
-
-export interface ExpectedFormField {
-	type: 'textbox' | 'checkbox' | 'radio' | 'combobox' | 'button';
-	accessibleName: string;
 }
 
 /**
@@ -30,12 +36,6 @@ export async function validatePublishedFormFields(
 		const { type, accessibleName } = expectedField;
 		await publishedPage.getByRole( type, { name: accessibleName } ).first().waitFor();
 	}
-}
-
-interface FieldLabelDetails {
-	blockName: string;
-	accessibleLabelName: string;
-	labelText: string;
 }
 
 /**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/shared/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/shared/index.ts
@@ -1,0 +1,1 @@
+export * from './block-helpers';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Locator, Page } from 'playwright';
 import { EditorPage } from '../../pages';
 
 /**
@@ -21,6 +21,7 @@ export interface EditorContext {
 	// We could also then get the editorLocator off of the EditorPage.
 	// However, they are provided in this context for convenience to simplify the writing of block flows!
 	editorPage: EditorPage;
+	addedBlockLocator: Locator;
 }
 
 /**

--- a/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
@@ -89,4 +89,16 @@ export class EditorBlockToolbarComponent {
 		const locator = editorParent.locator( selectors.button( { ariaLabel: 'Move down' } ) );
 		await locator.click();
 	}
+
+	/**
+	 *
+	 */
+	async clickParentBlockButton(): Promise< void > {
+		const editorParent = await this.editor.parent();
+		const locator = editorParent
+			.locator( parentSelector )
+			.locator( 'button.block-editor-block-parent-selector__button' );
+		await locator.click();
+		await locator.waitFor( { state: 'detached' } );
+	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
@@ -92,20 +92,23 @@ export class EditorBlockToolbarComponent {
 	}
 
 	/**
+	 * Clicks the parent block button on the toolbar. Note, this only applies to desktop, as this button
+	 * is hidden under more options on mobile.
 	 *
+	 * @param {string} expectedParentBlockName The expected name of the parent block.
 	 */
-	async clickParentBlockButton(): Promise< void > {
+	async clickParentBlockButton( expectedParentBlockName: string ): Promise< void > {
 		// On mobile, you select the parent block in a separate options menu item.
 		// That interaction should be driven by the parent method in Editor pages.
 		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
 			const editorParent = await this.editor.parent();
 			const locator = editorParent
 				.locator( parentSelector )
-				.locator( 'button.block-editor-block-parent-selector__button' );
+				.getByRole( 'button', { name: `Select ${ expectedParentBlockName }` } );
 			await locator.click();
 			await locator.waitFor( { state: 'detached' } );
 		} else {
-			throw new Error( 'The separate parent block button is not available on mobile.' );
+			throw new Error( 'The separate parent block toolbar button is not available on mobile.' );
 		}
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright';
+import { envVariables } from '../..';
 import { EditorComponent } from './editor-component';
 
 const parentSelector = '[aria-label="Block tools"]';
@@ -94,11 +95,17 @@ export class EditorBlockToolbarComponent {
 	 *
 	 */
 	async clickParentBlockButton(): Promise< void > {
-		const editorParent = await this.editor.parent();
-		const locator = editorParent
-			.locator( parentSelector )
-			.locator( 'button.block-editor-block-parent-selector__button' );
-		await locator.click();
-		await locator.waitFor( { state: 'detached' } );
+		// On mobile, you select the parent block in a separate options menu item.
+		// That interaction should be driven by the parent method in Editor pages.
+		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
+			const editorParent = await this.editor.parent();
+			const locator = editorParent
+				.locator( parentSelector )
+				.locator( 'button.block-editor-block-parent-selector__button' );
+			await locator.click();
+			await locator.waitFor( { state: 'detached' } );
+		} else {
+			throw new Error( 'The separate parent block button is not available on mobile.' );
+		}
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -6,8 +6,6 @@ const sidebarParentSelector = '.block-editor-inserter__main-area';
 const selectors = {
 	closeBlockInserterButton: 'button[aria-label="Close block inserter"]',
 	blockSearchInput: `${ sidebarParentSelector } input[type="search"]`,
-	blockResultItem: ( name: string ) =>
-		`${ sidebarParentSelector } .block-editor-block-types-list__list-item span:text("${ name }")`,
 	patternResultItem: ( name: string ) => `${ sidebarParentSelector } div[aria-label="${ name }"]`,
 };
 
@@ -45,6 +43,8 @@ export class EditorSidebarBlockInserterComponent {
 		if ( ( await blockInserterPanelLocator.count() ) > 0 ) {
 			await blockInserterPanelLocator.click();
 		}
+
+		await this.page.locator( sidebarParentSelector ).waitFor( { state: 'detached' } );
 	}
 
 	/**
@@ -78,7 +78,10 @@ export class EditorSidebarBlockInserterComponent {
 		if ( type === 'pattern' ) {
 			locator = editorParent.locator( selectors.patternResultItem( name ) ).first();
 		} else {
-			locator = editorParent.locator( selectors.blockResultItem( name ) ).first();
+			locator = editorParent
+				.getByRole( 'tabpanel', { name: 'Blocks' } )
+				.getByRole( 'option', { name, exact: true } )
+				.first();
 		}
 
 		await Promise.all( [ locator.hover(), locator.focus() ] );

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -454,8 +454,17 @@ export class EditorPage {
 	 * Select the parent block of the current block using the block toolbar.
 	 * This will fail and throw if the currently focused block doesn't have a parent.
 	 */
-	async selectBlockParent(): Promise< void > {
-		await this.editorBlockToolbarComponent.clickParentBlockButton();
+	async selectBlockParent( expectedParentBlockName: string ): Promise< void > {
+		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
+			await this.editorBlockToolbarComponent.clickParentBlockButton();
+		} else {
+			await this.editorBlockToolbarComponent.clickOptionsButton();
+			await this.editorPopoverMenuComponent.clickMenuButton(
+				`Select parent block (${ expectedParentBlockName })`
+			);
+			// It stays open on modal! We have to close it again.
+			await this.editorBlockToolbarComponent.clickOptionsButton();
+		}
 	}
 
 	//#endregion

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -450,6 +450,14 @@ export class EditorPage {
 		await this.editorBlockToolbarComponent.clickPrimaryButton( name );
 	}
 
+	/**
+	 * Select the parent block of the current block using the block toolbar.
+	 * This will fail and throw if the currently focused block doesn't have a parent.
+	 */
+	async selectBlockParent(): Promise< void > {
+		await this.editorBlockToolbarComponent.clickParentBlockButton();
+	}
+
 	//#endregion
 
 	//#region Settings Sidebar

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -456,7 +456,7 @@ export class EditorPage {
 	 */
 	async selectBlockParent( expectedParentBlockName: string ): Promise< void > {
 		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
-			await this.editorBlockToolbarComponent.clickParentBlockButton();
+			await this.editorBlockToolbarComponent.clickParentBlockButton( expectedParentBlockName );
 		} else {
 			await this.editorBlockToolbarComponent.clickOptionsButton();
 			await this.editorPopoverMenuComponent.clickMenuButton(

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -454,7 +454,7 @@ export class EditorPage {
 	 * Select the parent block of the current block using the block toolbar.
 	 * This will fail and throw if the currently focused block doesn't have a parent.
 	 */
-	async selectBlockParent( expectedParentBlockName: string ): Promise< void > {
+	async selectParentBlock( expectedParentBlockName: string ): Promise< void > {
 		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
 			await this.editorBlockToolbarComponent.clickParentBlockButton( expectedParentBlockName );
 		} else {

--- a/test/e2e/specs/blocks/blocks__jetpack-forms.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-forms.ts
@@ -17,15 +17,19 @@ const blockFlows: BlockFlow[] = [
 	new ContactFormFlow( {
 		labelPrefix: 'Contact Form',
 	} ),
-	new FormPatternsFlow( {
-		labelPrefix: 'Form Patterns',
-		patternName: 'RSVP Form',
-		otherExpectedFields: [
-			{ type: 'radio', accessibleName: 'Yes' },
-			{ type: 'radio', accessibleName: 'No' },
-			{ type: 'button', accessibleName: 'Send RSVP' },
-		],
-	} ),
+	new FormPatternsFlow(
+		{
+			labelPrefix: 'Form Patterns',
+			patternName: 'RSVP Form',
+		},
+		{
+			otherExpectedFields: [
+				{ type: 'radio', accessibleName: 'Yes' },
+				{ type: 'radio', accessibleName: 'No' },
+				{ type: 'button', accessibleName: 'Send RSVP' },
+			],
+		}
+	),
 ];
 
 createBlockTests( 'Blocks: Jetpack Forms', blockFlows );

--- a/test/e2e/specs/blocks/blocks__jetpack-forms.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-forms.ts
@@ -1,0 +1,14 @@
+/**
+ * @group gutenberg
+ * @group jetpack-wpcom-integration
+ */
+import { AllFormFieldsFlow, BlockFlow } from '@automattic/calypso-e2e';
+import { createBlockTests } from './shared/block-smoke-testing';
+
+const blockFlows: BlockFlow[] = [
+	new AllFormFieldsFlow( {
+		labelPrefix: 'All Fields',
+	} ),
+];
+
+createBlockTests( 'Blocks: Jetpack Forms', blockFlows );

--- a/test/e2e/specs/blocks/blocks__jetpack-forms.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-forms.ts
@@ -2,12 +2,29 @@
  * @group gutenberg
  * @group jetpack-wpcom-integration
  */
-import { AllFormFieldsFlow, BlockFlow } from '@automattic/calypso-e2e';
+import {
+	AllFormFieldsFlow,
+	BlockFlow,
+	ContactFormFlow,
+	FormPatternsFlow,
+} from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
 	new AllFormFieldsFlow( {
 		labelPrefix: 'All Fields',
+	} ),
+	new ContactFormFlow( {
+		labelPrefix: 'Contact Form',
+	} ),
+	new FormPatternsFlow( {
+		labelPrefix: 'Form Patterns',
+		patternName: 'RSVP Form',
+		otherExpectedFields: [
+			{ type: 'radio', accessibleName: 'Yes' },
+			{ type: 'radio', accessibleName: 'No' },
+			{ type: 'button', accessibleName: 'Send RSVP' },
+		],
 	} ),
 ];
 

--- a/test/e2e/specs/blocks/blocks__jetpack-grow.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-grow.ts
@@ -6,7 +6,6 @@ import {
 	BlockFlow,
 	BusinessHoursFlow,
 	WhatsAppButtonFlow,
-	ContactFormFlow,
 	PaidContentBlockFlow,
 	SubscribeFlow,
 	ContactInfoBlockFlow,
@@ -17,7 +16,6 @@ import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
 	new BusinessHoursFlow( { day: 'Sat' } ),
-	new ContactFormFlow( { nameLabel: 'Angry dolphins flip swiftly' } ),
 	new SubscribeFlow(),
 	new ContactInfoBlockFlow( { email: 'foo@example.com', phoneNumber: '(213) 621-0002' } ),
 	new WhatsAppButtonFlow( { phoneNumber: 1234567890, buttonText: 'Porpoises swim happily' } ),

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -51,14 +51,18 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 		describe( 'Add and configure blocks in the editor', function () {
 			for ( const blockFlow of blockFlows ) {
 				it( `${ blockFlow.blockSidebarName }: Add the block from the sidebar`, async function () {
-					await editorPage.addBlockFromSidebar(
+					const blockHandle = await editorPage.addBlockFromSidebar(
 						blockFlow.blockSidebarName,
 						blockFlow.blockEditorSelector,
 						{ noSearch: true }
 					);
+					const id = await blockHandle.getAttribute( 'id' );
+					const editorCanvas = await editorPage.getEditorCanvas();
+					const addedBlockLocator = editorCanvas.locator( `#${ id }` );
 					editorContext = {
 						page,
 						editorPage,
+						addedBlockLocator,
 					};
 				} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This reworks and greatly expands our Forms block smoke testing.

I've arranged three flows that I think together cover the majority of editor-focused Form cases:

1. The "All Fields" flow, where we build a form with literally every possible form field to make sure all are compatible with the editor.
2. The "Contact Form" flow, where we use the "Contact Form" block to test the pre-canned Form options that are presented to users as blocks in the block library.
3. The "Form Patterns" flow, where we launch the patterns modal from the "Form" block and build the form out of a pattern/

To make all of these play together nicely, we rely on label prefixing -- we label potentially conflicting fields with a prefix unique to the flow. This allows easy, a11y-friendly validation of all form field inputs on the published page! 🎉 


## Testing Instructions

- [x] Gutenberg tests pass
- [x] Jetpack Simple Mobile
- [x] Jetpack Simple Desktop
- [x] Jetpack Atomic

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
