### PR TITLE
Subscriptions: Hide subscribe modal link on atomic

### DIFF
--- a/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/SubscribeModalSetting.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 export const SUBSCRIBE_MODAL_OPTION = 'sm_enabled';
 
@@ -31,6 +32,7 @@ export const SubscribeModalSetting = ( {
 }: SubscribeModalSettingProps ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
+	const isAtomicSite = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 
 	// Construct a link to edit the modal
 	const { data: activeThemeData } = useActiveThemeQuery( siteId, true );
@@ -65,7 +67,7 @@ export const SubscribeModalSetting = ( {
 					: translate(
 							'Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll.'
 					  ) }
-				{ isModalEditTranslated && subscribeModalEditorUrl && (
+				{ isModalEditTranslated && subscribeModalEditorUrl && ! isAtomicSite && (
 					<>
 						{ ' ' }
 						<ExternalLink href={ subscribeModalEditorUrl }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR hides the link to edit the Subscribe Modal that appears on the Settings > Newsletter page when on an Atomic site. There is an issue with how the subscribe modal template part gets loaded in the site editor on Atomic.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Test Atomic. Go to `http://calypso.localhost:3000/settings/newsletter/YOURATOMICDOMAIN` and confirm the link for `Preview and edit the popup` does not show. 

2) Test Simple. Go to `http://calypso.localhost:3000/settings/newsletter/SIMPLESITEDOMAIN` and confirm the link for `Preview and edit the popup` still shows.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
