### PR TITLE
Jetpack Connection: protect connection owner from removal

### DIFF
--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -322,16 +322,17 @@ class DeleteUser extends Component {
 
 		// A user should not be able to remove the Atomic or non-Jetpack site owner.
 		if ( ( ! isJetpack && user.ID === siteOwner ) || user.linked_user_ID === siteOwner ) {
-			const supportLink = isAtomic ? (
-				<InlineSupportLink
-					supportPostId={ 102743 }
-					supportLink={ localizeUrl(
-						'https://wordpress.com/support/transferring-a-site-to-another-wordpress-com-account/'
-					) }
-				/>
-			) : (
-				<InlineSupportLink supportLink="https://jetpack.com/redirect?source=jetpack-transfer-connection" />
-			);
+			const supportLink =
+				! isJetpack || isAtomic ? (
+					<InlineSupportLink
+						supportPostId={ 102743 }
+						supportLink={ localizeUrl(
+							'https://wordpress.com/support/transferring-a-site-to-another-wordpress-com-account/'
+						) }
+					/>
+				) : (
+					<InlineSupportLink supportLink="https://jetpack.com/redirect?source=jetpack-transfer-connection" />
+				);
 
 			return (
 				<Card className="delete-user__single-site">

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -321,10 +321,18 @@ class DeleteUser extends Component {
 		}
 
 		// A user should not be able to remove the Atomic or non-Jetpack site owner.
-		if (
-			( ! isJetpack && user.ID === siteOwner ) ||
-			( isAtomic && user.linked_user_ID === siteOwner )
-		) {
+		if ( ( ! isJetpack && user.ID === siteOwner ) || user.linked_user_ID === siteOwner ) {
+			const supportLink = isAtomic ? (
+				<InlineSupportLink
+					supportPostId={ 102743 }
+					supportLink={ localizeUrl(
+						'https://wordpress.com/support/transferring-a-site-to-another-wordpress-com-account/'
+					) }
+				/>
+			) : (
+				<InlineSupportLink supportLink="https://jetpack.com/redirect?source=jetpack-transfer-connection" />
+			);
+
 			return (
 				<Card className="delete-user__single-site">
 					<FormSectionHeading>{ this.getDeleteText() }</FormSectionHeading>
@@ -332,16 +340,7 @@ class DeleteUser extends Component {
 						{ translate(
 							'You cannot delete the site owner. Please transfer ownership of this site to a different account before deleting this user. {{supportLink}}Learn more.{{/supportLink}}',
 							{
-								components: {
-									supportLink: (
-										<InlineSupportLink
-											supportPostId={ 102743 }
-											supportLink={ localizeUrl(
-												'https://wordpress.com/support/transferring-a-site-to-another-wordpress-com-account/'
-											) }
-										/>
-									),
-								},
+								components: { supportLink },
 							}
 						) }
 					</p>


### PR DESCRIPTION
## Proposed Changes
We already do not allow removal of Jetpack connection owners on simple and WoA sites.
This PR will extend the approach to self-hosted Jetpack sites.

- Hide the "Delete the user" component if the user to delete is a connection owner
- Display the "You cannot delete the site owner" information block with the link to [Jetpack support page](https://jetpack.com/support/transfer-your-jetpack-connection-or-plan-to-another-user/) informing users how to transfer connection to another user

## Testing Instructions

You'll need two WPCOM users added to three sites ("Users -> Add a team member"):
- simple WPCOM site
- WoA site
- standalone Jetpack site

Please keep an eye on the URL's, as you might occasionally get switched to live WP.com 

### The "You cannot delete" block
<img width="738" alt="Screen Shot 2023-08-25 at 08 41 40" src="https://github.com/Automattic/wp-calypso/assets/1341249/014b3d71-5055-4d2a-aaf7-123ec8ddb1a4">

### Simple WPCOM site
1. Load the site via Calypso Live (link below) as a secondary user (not site owner) and open the "Users" section.
2. Choose the site owner and confirm that you see the "Cannot delete" block.
3. Click "Learn more" and the "Transfer a Site to Another WordPress.com Account" widget should pop up.
4. Visit the "Users" page as the site owner WPCOM user, you should see the "Remove username" link. Delete them, confirm they get deleted.

### WoA site
Repeat same steps as a "Simple WPCOM site", everything should look and work the same.
The only difference is that you'll be asked what to do with the content of secondary user upon its removal, you can choose any option.

### Standalone Jetpack site
Repeat the same steps as above, should work and look like a WoA site.
The only difference is the "Learn more" link, which should lead to the Jetpack support page: https://jetpack.com/support/transfer-your-jetpack-connection-or-plan-to-another-user/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
