### PR TITLE
[ETK][GB 16.5.0] Workaround for disappearing toolbar settings button in (some) mobile viewport sizes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/force-show-settings-button-icon-mobile.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/force-show-settings-button-icon-mobile.js
@@ -1,0 +1,1 @@
+import './force-show-settings-button-icon-mobile.scss';

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/force-show-settings-button-icon-mobile.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/force-show-settings-button-icon-mobile.scss
@@ -1,0 +1,9 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+
+.interface-pinned-items button[aria-label="Settings"] {
+	@media ( max-width: $break-medium ) {
+		display: block;
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -269,7 +269,6 @@ function enqueue_override_preview_button_url() {
 
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_override_preview_button_url' );
 
-
 /**
  * Force-show the settings button icon in the post editor to fix a bug introduced in
  * Gutenberg 16.5 where the icon disappears in some mobile viewport sizes.
@@ -278,8 +277,7 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_override_pr
  * Gutenberg issue: https://github.com/WordPress/gutenberg/issues/53899#
  *
  * This is meant to be a temporary workaround until a proper fix is implemented in core.
- *
-*/
+ */
 function enqueue_force_show_settings_button_icon_mobile_style() {
 	$style_file = is_rtl()
 		? 'force-show-settings-button-icon-mobile.rtl.css'

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -268,3 +268,27 @@ function enqueue_override_preview_button_url() {
 }
 
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_override_preview_button_url' );
+
+
+/**
+ * Force-show the settings button icon in the post editor to fix a bug introduced in
+ * Gutenberg 16.5 where the icon disappears in some mobile viewport sizes.
+ *
+ * Related discussion: https://a8c.slack.com/archives/CBTN58FTJ/p1692639188443899
+ * Gutenberg issue: https://github.com/WordPress/gutenberg/issues/53899#
+ *
+ * This is meant to be a temporary workaround until a proper fix is implemented in core.
+ *
+*/
+function enqueue_force_show_settings_button_icon_mobile_style() {
+	$style_file = is_rtl()
+		? 'force-show-settings-button-icon-mobile.rtl.css'
+		: 'force-show-settings-button-icon-mobile.css';
+	wp_enqueue_style(
+		'a8c-force-show-settings-button-icon-mobile',
+		plugins_url( 'dist/' . $style_file, __FILE__ ),
+		array(),
+		filemtime( plugin_dir_path( __FILE__ ) . 'dist/' . $style_file )
+	);
+}
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_force_show_settings_button_icon_mobile_style' );

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -16,7 +16,7 @@
 	"scripts": {
 		"build": "NODE_ENV=production yarn dev",
 		"build:block-inserter-modifications": "calypso-build --env source='block-inserter-modifications/contextual-tips'",
-		"build:common": " calypso-build --env source='common','common/data-stores','common/hide-plugin-buttons-mobile','common/disable-heic-images','common/override-preview-button-url'",
+		"build:common": " calypso-build --env source='common','common/data-stores','common/hide-plugin-buttons-mobile','common/disable-heic-images','common/override-preview-button-url','common/force-show-settings-button-icon-mobile'",
 		"build:error-reporting": "calypso-build --env source='error-reporting'",
 		"build:event-countdown-block": "calypso-build --env source='event-countdown-block'",
 		"build:global-styles": "calypso-build --env source='global-styles'",


### PR DESCRIPTION
## Proposed Changes

Make sure the settings button in the toolbar in the post editor is always visible.

The problem was introduced in this PR: https://github.com/WordPress/gutenberg/pull/53412

I'm not acquainted with the rationale/specifics behind those changes, instead, I'm going to focus here on the UX issue this caused in WPCOM: the settings button can't be seen in some mobile viewport sizes and there's no alternative (that I could find) to bring it anywhere else in the UI -- this means if the user has the bad luck of reaching that specific size where the button doesn't appear, then they won't be able to bring up the settings panel at all:

https://github.com/Automattic/wp-calypso/assets/81248/f847128f-b13a-4ebf-bcf0-6dd3acdeb253

There's an ongoing discussion on Slack here: p1692639188443899-slack , and @draganescu created an issue for it in the GB core repo: https://github.com/WordPress/gutenberg/issues/53899. There's also a WIP PR by him: https://github.com/WordPress/gutenberg/pull/53908, but unfortunately, my tests were unsuccessful. Because of that, I decided to work on this temporary workaround.

## Testing Instructions

1) Make sure GB 16.5.0 is active in your simple or AT site.
2) Create a new post and then turn the responsive view on. Resize it until you're able to reproduce the issue (see video above)
3) From this branch, go to `apps/editing-toolkit` and run `yarn dev --sync` to sync the custom ETK build to your sandbox. For the AT site, you'll need to turn it into a dev site and then sync using rsync like so `wp-calypso/apps/editing-toolkit/editing-toolkit-plugin $ yarn && yarn build && rsync -azP -vvv . --exclude .git --exclude node_modules --delete <yourtestatsite>.wordpress.com@sftp.wp.com:/home/<site-id>/htdocs/wp-content/plugins/full-site-editing`
4) Refresh the new post page - resize again and you should always see the settings button now.

**Here are some screencasts of the happy paths with GB 16.5 in the post editor:**

- AT before fix: https://github.com/Automattic/wp-calypso/assets/81248/56041f1d-6510-46be-ad27-00b3d8a7eb3b 	
- AT After fix: https://github.com/Automattic/wp-calypso/assets/81248/029dc282-33da-4389-b1d0-6930d6f2d649 	
- Simple before fix: https://github.com/Automattic/wp-calypso/assets/81248/cedcb6f8-f3d1-43a6-b450-73322fe27540 	
- Simple after fix: https://github.com/Automattic/wp-calypso/assets/81248/e1e2b190-3349-47ce-a5f6-200bd1b22ca6

It does make the settings button sticky in the site editor -- before this change, in the site editor, the settings button would disappear in some mobile viewports, but now, due to this change, it will always be visible. I think it's a benign change and considering this is a temporary workaround, it's okay to leave it like this until a fix in core is implemented cc @draganescu[

⚠️ **One thing I noticed is that in the site editor, the "settings" item/button is also shown in the ellipsis dropdown menu under "plugins".** This is not the case in the post editor and what made this fix more important as there's no other way to access the button if it's hidden there. So probably better implementation for this fix would take care of this, too, though it's out of the scope of this quick workaround (and would probably/ideally need to be done in GB, not here):

| Post editor | Site editor |
|-------------|--------------|
| ![2023-08-24_19-05](https://github.com/Automattic/wp-calypso/assets/81248/d838f428-5f9e-4a63-855f-e0d5c213d666) | ![2023-08-24_19-04](https://github.com/Automattic/wp-calypso/assets/81248/1202363b-f5ad-4609-8c92-72687dc86dbb) |



