### PR TITLE
Jetpack Manage: code refactor & UI test cases for downtime monitoring changes(hooks)

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/index.tsx
@@ -1,0 +1,3 @@
+export { default as useRequestVerificationCode } from './use-request-verification-code';
+export { default as useResendVerificationCode } from './use-resend-verification-code';
+export { default as useValidateVerificationCode } from './use-validate-verification-code';

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/test/use-request-verification-code.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/test/use-request-verification-code.tsx
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import React from 'react';
+import { useRequestVerificationCode } from '..';
+import type { RequestVerificationCodeParams } from '../../../sites-overview/types';
+
+describe( 'useRequestVerificationCode', () => {
+	const queryClient = new QueryClient();
+	const wrapper = ( { children } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+
+	const emailParams = {
+		type: 'email',
+		value: 'testemail@test.com',
+		site_ids: [],
+	} as RequestVerificationCodeParams;
+
+	const phoneParams = {
+		type: 'sms',
+		value: '+93774405234',
+		site_ids: [],
+		number: '774405234',
+		country_code: 'AF',
+		country_numeric_code: '+93',
+	} as RequestVerificationCodeParams;
+
+	it( 'should return initial values for email contact', async () => {
+		const data = { verification_sent: true, email_address: emailParams.value };
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/jetpack-agency/contacts' )
+			.reply( 200, data );
+
+		const { result } = renderHook( () => useRequestVerificationCode(), { wrapper } );
+
+		expect( result.current.isSuccess ).toBe( false );
+
+		act( () => {
+			result.current.mutate( emailParams );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.isSuccess ).toBe( true );
+			expect( result.current.data ).toEqual( data );
+		} );
+	} );
+
+	it( 'should return initial values for SMS contact', async () => {
+		const data = { verification_sent: true, phone_number: phoneParams.value };
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/jetpack-agency/contacts' )
+			.reply( 200, data );
+
+		const { result } = renderHook( () => useRequestVerificationCode(), { wrapper } );
+
+		expect( result.current.isSuccess ).toBe( false );
+
+		act( () => {
+			result.current.mutate( phoneParams );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.isSuccess ).toBe( true );
+			expect( result.current.data ).toEqual( data );
+		} );
+	} );
+
+	it( 'should set isVerified to true when an error with existing_verified_email_contact code occurs', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/jetpack-agency/contacts' )
+			.reply( 400, { code: 'existing_verified_email_contact' } );
+
+		const { result } = renderHook( () => useRequestVerificationCode(), { wrapper } );
+
+		act( () => {
+			result.current.mutate( emailParams );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.isVerified ).toBe( true );
+		} );
+	} );
+
+	it( 'should set isVerified to true when an error with existing_verified_sms_contact code occurs', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/jetpack-agency/contacts' )
+			.reply( 400, { code: 'existing_verified_sms_contact' } );
+
+		const { result } = renderHook( () => useRequestVerificationCode(), { wrapper } );
+
+		act( () => {
+			result.current.mutate( phoneParams );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.isVerified ).toBe( true );
+		} );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/test/use-resend-verification-code.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/test/use-resend-verification-code.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import React from 'react';
+import { useResendVerificationCode } from '..';
+import type { ResendVerificationCodeParams } from '../../../sites-overview/types';
+
+describe( 'useResendVerificationCode', () => {
+	const queryClient = new QueryClient();
+	const wrapper = ( { children } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+
+	const emailParams = {
+		type: 'email',
+		value: 'testemail@test.com',
+	} as ResendVerificationCodeParams;
+
+	const phoneParams = {
+		type: 'sms',
+		value: '+93774405234',
+	} as ResendVerificationCodeParams;
+
+	it( 'should return initial values for email contact', async () => {
+		const data = { verification_sent: true, email_address: emailParams.value };
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( '/wpcom/v2/jetpack-agency/contacts/resend-verification' )
+			.reply( 200, data );
+
+		const { result } = renderHook( () => useResendVerificationCode(), { wrapper } );
+
+		expect( result.current.isSuccess ).toBe( false );
+
+		act( () => {
+			result.current.mutate( emailParams );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.isSuccess ).toBe( true );
+			expect( result.current.data ).toEqual( data );
+		} );
+	} );
+
+	it( 'should return initial values for SMS contact', async () => {
+		const data = { verification_sent: true, phone_number: phoneParams.value };
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( '/wpcom/v2/jetpack-agency/contacts/resend-verification' )
+			.reply( 200, data );
+
+		const { result } = renderHook( () => useResendVerificationCode(), { wrapper } );
+
+		expect( result.current.isSuccess ).toBe( false );
+
+		act( () => {
+			result.current.mutate( phoneParams );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.isSuccess ).toBe( true );
+			expect( result.current.data ).toEqual( data );
+		} );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/test/use-validate-verification-code.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/test/use-validate-verification-code.tsx
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import React from 'react';
+import { useValidateVerificationCode } from '..';
+import type { ValidateVerificationCodeParams } from '../../../sites-overview/types';
+
+describe( 'useValidateVerificationCode', () => {
+	const queryClient = new QueryClient();
+	const wrapper = ( { children } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+
+	const emailParams = {
+		type: 'email',
+		value: 'testemail@test.com',
+		verification_code: 123456,
+	} as ValidateVerificationCodeParams;
+
+	const phoneParams = {
+		type: 'sms',
+		value: '+93774405234',
+	} as ValidateVerificationCodeParams;
+
+	it( 'should return initial values for email contact', async () => {
+		const data = { verified: true, email_address: emailParams.value };
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( '/wpcom/v2/jetpack-agency/contacts/verify' )
+			.reply( 200, data );
+
+		const { result } = renderHook( () => useValidateVerificationCode(), { wrapper } );
+
+		expect( result.current.isSuccess ).toBe( false );
+
+		act( () => {
+			result.current.mutate( emailParams );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.isSuccess ).toBe( true );
+			expect( result.current.data ).toEqual( data );
+		} );
+	} );
+
+	it( 'should return initial values for SMS contact', async () => {
+		const data = { verified: true, phone_number: phoneParams.value };
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( '/wpcom/v2/jetpack-agency/contacts/verify' )
+			.reply( 200, data );
+
+		const { result } = renderHook( () => useValidateVerificationCode(), { wrapper } );
+
+		expect( result.current.isSuccess ).toBe( false );
+
+		act( () => {
+			result.current.mutate( phoneParams );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.isSuccess ).toBe( true );
+			expect( result.current.data ).toEqual( data );
+		} );
+	} );
+
+	it( 'should set isVerified to true when an error with jetpack_agency_contact_is_verified code occurs', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/jetpack-agency/contacts/verify' )
+			.reply( 400, { code: 'jetpack_agency_contact_is_verified' } );
+
+		const { result } = renderHook( () => useValidateVerificationCode(), { wrapper } );
+
+		act( () => {
+			result.current.mutate( emailParams );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.isVerified ).toBe( true );
+		} );
+	} );
+
+	it( 'should show default error message when there is an error', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/jetpack-agency/contacts/verify' )
+			.reply( 400 );
+
+		const { result } = renderHook( () => useValidateVerificationCode(), { wrapper } );
+
+		act( () => {
+			result.current.mutate( emailParams );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.isError ).toBe( true );
+			expect( result.current.errorMessage ).toBe( 'Something went wrong.' );
+		} );
+	} );
+
+	it( 'should show correct error message when the error code is jetpack_agency_contact_invalid_verification_code', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/jetpack-agency/contacts/verify' )
+			.reply( 400, { code: 'jetpack_agency_contact_invalid_verification_code' } );
+
+		const { result } = renderHook( () => useValidateVerificationCode(), { wrapper } );
+
+		act( () => {
+			result.current.mutate( emailParams );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.isError ).toBe( true );
+			expect( result.current.errorMessage ).toBe( 'Invalid Code' );
+		} );
+	} );
+
+	it( 'should show correct error message when the error code is jetpack_agency_contact_expired_verification_code', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/jetpack-agency/contacts/verify' )
+			.reply( 400, { code: 'jetpack_agency_contact_expired_verification_code' } );
+
+		const { result } = renderHook( () => useValidateVerificationCode(), { wrapper } );
+
+		act( () => {
+			result.current.mutate( phoneParams );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.isError ).toBe( true );
+			expect( result.current.errorMessage ).toBe( 'Code Expired' );
+		} );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-request-verification-code.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-request-verification-code.ts
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import useRequestContactVerificationCode from 'calypso/state/jetpack-agency-dashboard/hooks/use-request-contact-verification-code';
+import type { RequestVerificationCodeParams } from '../../sites-overview/types';
+
+export default function useRequestVerificationCode(): {
+	mutate: ( params: RequestVerificationCodeParams ) => void;
+	isError: boolean;
+	isLoading: boolean;
+	isSuccess: boolean;
+	isVerified: boolean;
+} {
+	const [ isAlreadyVerifed, setIsAlreadyVerifed ] = useState( false );
+
+	const data = useRequestContactVerificationCode( {
+		retry: false,
+		onError: async ( error ) => {
+			// Add the contact to the list of contacts if already verified
+			if (
+				error?.code &&
+				[ 'existing_verified_email_contact', 'existing_verified_sms_contact' ].includes(
+					error.code
+				)
+			) {
+				setIsAlreadyVerifed( true );
+			}
+		},
+	} );
+	return { ...data, isVerified: isAlreadyVerifed };
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-request-verification-code.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-request-verification-code.ts
@@ -8,6 +8,7 @@ export default function useRequestVerificationCode(): {
 	isLoading: boolean;
 	isSuccess: boolean;
 	isVerified: boolean;
+	data: any;
 } {
 	const [ isAlreadyVerifed, setIsAlreadyVerifed ] = useState( false );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-resend-verification-code.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-resend-verification-code.ts
@@ -6,6 +6,7 @@ export default function useResendVerificationCode(): {
 	isLoading: boolean;
 	isSuccess: boolean;
 	isError: boolean;
+	data: any;
 } {
 	return useResendVerificationCodeMutation( {
 		retry: () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-resend-verification-code.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-resend-verification-code.ts
@@ -1,0 +1,15 @@
+import useResendVerificationCodeMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-resend-contact-verification-code';
+import type { ResendVerificationCodeParams } from '../../sites-overview/types';
+
+export default function useResendVerificationCode(): {
+	mutate: ( params: ResendVerificationCodeParams ) => void;
+	isLoading: boolean;
+	isSuccess: boolean;
+	isError: boolean;
+} {
+	return useResendVerificationCodeMutation( {
+		retry: () => {
+			return false;
+		},
+	} );
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-validate-verification-code.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-validate-verification-code.ts
@@ -1,47 +1,10 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import useRequestContactVerificationCode from 'calypso/state/jetpack-agency-dashboard/hooks/use-request-contact-verification-code';
-import useResendVerificationCodeMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-resend-contact-verification-code';
 import useValidateVerificationCodeMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-validate-contact-verification-code';
-import {
-	RequestVerificationCodeParams,
-	ValidateVerificationCodeParams,
-	ResendVerificationCodeParams,
-} from '../sites-overview/types';
+import type { ValidateVerificationCodeParams } from '../../sites-overview/types';
 
-export function useRequestVerificationCode(): {
-	mutate: ( params: RequestVerificationCodeParams ) => void;
-	isError: boolean;
-	isLoading: boolean;
-	isSuccess: boolean;
-	isVerified: boolean;
-} {
-	const [ isAlreadyVerifed, setIsAlreadyVerifed ] = useState( false );
-
-	const data = useRequestContactVerificationCode( {
-		retry: false,
-		onError: async ( error ) => {
-			// Add the contact to the list of contacts if already verified
-			if (
-				error?.code &&
-				[ 'existing_verified_email_contact', 'existing_verified_sms_contact' ].includes(
-					error.code
-				)
-			) {
-				setIsAlreadyVerifed( true );
-			}
-		},
-	} );
-	return { ...data, isVerified: isAlreadyVerifed };
-}
-
-const verificationErrorMessages: { [ key: string ]: string } = {
-	jetpack_agency_contact_invalid_verification_code: translate( 'Invalid Code' ),
-	jetpack_agency_contact_expired_verification_code: translate( 'Code Expired' ),
-};
-
-export function useValidateVerificationCode(): {
+export default function useValidateVerificationCode(): {
 	mutate: ( params: ValidateVerificationCodeParams ) => void;
 	isLoading: boolean;
 	isSuccess: boolean;
@@ -50,6 +13,12 @@ export function useValidateVerificationCode(): {
 	isVerified: boolean;
 } {
 	const queryClient = useQueryClient();
+	const translate = useTranslate();
+
+	const verificationErrorMessages: { [ key: string ]: string } = {
+		jetpack_agency_contact_invalid_verification_code: translate( 'Invalid Code' ),
+		jetpack_agency_contact_expired_verification_code: translate( 'Code Expired' ),
+	};
 
 	const [ isAlreadyVerifed, setIsAlreadyVerifed ] = useState( false );
 
@@ -126,17 +95,4 @@ export function useValidateVerificationCode(): {
 		}
 	}
 	return { ...data, errorMessage, isVerified: data.isSuccess || isAlreadyVerifed };
-}
-
-export function useResendVerificationCode(): {
-	mutate: ( params: ResendVerificationCodeParams ) => void;
-	isLoading: boolean;
-	isSuccess: boolean;
-	isError: boolean;
-} {
-	return useResendVerificationCodeMutation( {
-		retry: () => {
-			return false;
-		},
-	} );
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-validate-verification-code.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-validate-verification-code.ts
@@ -11,6 +11,7 @@ export default function useValidateVerificationCode(): {
 	isError: boolean;
 	errorMessage?: string;
 	isVerified: boolean;
+	data: any;
 } {
 	const queryClient = useQueryClient();
 	const translate = useTranslate();
@@ -53,7 +54,7 @@ export default function useValidateVerificationCode(): {
 				...( type === 'email' && {
 					// Replace if it exists, otherwise add it
 					emails: [
-						...oldContacts.emails.filter(
+						...( oldContacts.emails || [] ).filter(
 							( email: { email_address: string } ) => email.email_address !== params.value
 						),
 						newEmailItem,
@@ -62,7 +63,7 @@ export default function useValidateVerificationCode(): {
 				...( type === 'sms' && {
 					// Replace if it exists, otherwise add it
 					sms_numbers: [
-						...oldContacts.sms_numbers.filter(
+						...( oldContacts.sms_numbers || [] ).filter(
 							( sms: { sms_number: string } ) => sms.sms_number !== params.value
 						),
 						newSMSItem,


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-genesis/issues/21


## Proposed Changes

- Refactored all the hooks files into different files by creating a new hooks folder in /downtime-monitoring | **[Commit](https://github.com/Automattic/wp-calypso/pull/81055/commits/14f28ca5b7f3b97ad83e1d40cf5f68bd8dc5231b)**
- Write tests for the following hooks: **[useRequestVerificationCode](https://github.com/Automattic/wp-calypso/pull/81055/commits/5b56a589a1a28a9d0a6a21d7647fe42bdecf935d)** , **[useResendVerificationCode](https://github.com/Automattic/wp-calypso/pull/81055/commits/bbcc4695e453bcec9ea0db2277ddfa2d647354ba)**  & **[useValidateVerificationCode](https://github.com/Automattic/wp-calypso/pull/81055/commits/7f39ee0626d1f782b31472849658dd701e128b13)** 


## Testing Instructions

- Run `git checkout add/test-cases-for-downtime-monitoring-changes-6 && git pull`
- Run `yarn run test-client client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/` to run the tests.
- Verify the tests are passing and code changes make sense
- Visit the Dashboard -> Open the monitor settings -> Verify adding a contact(email & SMS) works as expected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?