### PR TITLE
Add Banner jitm for Google domain transfer jitm

### DIFF
--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -53,6 +53,14 @@ function renderTemplate( template, props ) {
 					placeholder={ null }
 				/>
 			);
+		case 'banner':
+			return (
+				<AsyncLoad
+					{ ...props }
+					require="calypso/blocks/jitm/templates/banner"
+					placeholder={ null }
+				/>
+			);
 		default:
 			return (
 				<AsyncLoad

--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -176,10 +176,10 @@ JITM.defaultProps = {
 	isFetching: false,
 };
 
-const mapStateToProps = ( state, { messagePath } ) => {
+const mapStateToProps = ( state, { messagePath, selectedSiteOverride = false } ) => {
 	const currentSite = getSelectedSite( state );
 	return {
-		currentSite,
+		currentSite: selectedSiteOverride || currentSite,
 		jitm: getTopJITM( state, messagePath ),
 		isFetching: isFetchingJITM( state, messagePath ),
 		isJetpack: currentSite && isJetpackSite( state, currentSite.ID ),

--- a/client/blocks/jitm/templates/banner.jsx
+++ b/client/blocks/jitm/templates/banner.jsx
@@ -15,6 +15,7 @@ export default function BannerTemplate( props ) {
 				callToAction={ CTA.message }
 				iconPath={ iconPath }
 				onClick={ onClick }
+				compactButton={ false }
 				disableCircle
 			/>
 		</>

--- a/client/blocks/jitm/templates/banner.jsx
+++ b/client/blocks/jitm/templates/banner.jsx
@@ -1,0 +1,22 @@
+import { Banner } from 'calypso/components/banner';
+
+import './banner.scss';
+
+export default function BannerTemplate( props ) {
+	const { trackImpression, message, CTA, description, iconPath, onClick } = props;
+
+	return (
+		<>
+			{ trackImpression && trackImpression() }
+			<Banner
+				className="banner-jitm"
+				title={ message }
+				description={ description }
+				callToAction={ CTA.message }
+				iconPath={ iconPath }
+				onClick={ onClick }
+				disableCircle
+			/>
+		</>
+	);
+}

--- a/client/blocks/jitm/templates/banner.scss
+++ b/client/blocks/jitm/templates/banner.scss
@@ -1,22 +1,38 @@
-.banner-jitm {
-	&.card.banner {
-		border-left: none;
-		padding: 21px 40px 21px 43px;
-	}
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
-	display: flex;
-	align-items: center;
-	gap: 20px;
-
+.banner-jitm.card.banner {
 	border-radius: 2px;
 	border: 1px solid var(--gray-gray-5);
-
+	display: flex;
+	flex-direction: column;
+	padding: 29px 20px 20px 20px;
 	background:
-		radial-gradient(circle at top, rgba(235, 206, 224, 1), transparent 70%),
-		linear-gradient(20deg, rgba(8, 117, 196, 0.8), transparent 60%),
-		linear-gradient(240deg, rgba(0, 126, 101, 1), transparent 70%);
+		radial-gradient(ellipse at top left, rgba(235, 206, 224, 0.9), transparent 60%),
+		linear-gradient(10deg, rgba(8, 117, 196, 0.6), transparent 60%),
+		linear-gradient(240deg, rgba(0, 126, 101, 0.5), transparent 60%);
+
 	background-repeat: no-repeat;
-	background-size: 66px 100%;
+	background-size: 100% 52px;
+
+	margin-top: 9px;
+	margin-left: 17px;
+	margin-right: 17px;
+
+	@include break-medium {
+		flex-direction: row;
+		gap: 20px;
+		align-items: center;
+		padding: 21px 40px 21px 43px;
+		background-size: 66px 100%;
+		margin-left: 0;
+		margin-right: 0;
+	}
+
+	.banner__icons,
+	.banner__content {
+		justify-content: flex-start;
+	}
 
 	.banner__icons {
 		.banner__icon,
@@ -28,36 +44,51 @@
 		}
 	}
 
-	.banner__info {
-		.banner__title {
-			color: var(--gray-gray-100);
-			font-size: $font-body;
-			line-height: 24px; /* 150% */
-			letter-spacing: -0.32px;
+	.banner__content {
+		margin-top: 11px;
+		@include break-medium {
+			margin-top: 0;
 		}
-		.banner_description {
-			color: var(--gray-gray-70);
-			font-size: $font-body-small;
-			line-height: 20px; /* 142.857% */
-			letter-spacing: -0.15px;
+
+		.banner__info {
+			.banner__title {
+				color: var(--studio-gray-100);
+				font-size: $font-body;
+				line-height: 24px; /* 150% */
+			}
+			.banner__description {
+				color: var(--studio-gray-70);
+				font-size: $font-body-small;
+				line-height: 20px; /* 142.857% */
+
+				margin-top: 12px;
+				@include break-medium {
+					margin-top: 0;
+				}
+			}
 		}
-	}
 
-	.banner__action {
-		button,
-		button:hover,
-		button:focus {
-			display: flex;
-			height: 40px;
-			padding: 10px 24px;
-			justify-content: center;
-			align-items: center;
-			gap: 8px;
+		.banner__action {
+			margin-top: 20px;
+			@include break-medium {
+				margin-top: 0;
+			}
 
-			border-radius: 4px;
-			background: var(--black-white-black, #000);
-			box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-			border-color: var(--black-white-black, #000);
+			button,
+			button:hover,
+			button:focus {
+				display: flex;
+				height: 40px;
+				padding: 10px 24px;
+				justify-content: center;
+				align-items: center;
+				gap: 8px;
+
+				border-radius: 4px;
+				background: var(--black-white-black, #000);
+				box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+				border-color: var(--black-white-black, #000);
+			}
 		}
 	}
 }

--- a/client/blocks/jitm/templates/banner.scss
+++ b/client/blocks/jitm/templates/banner.scss
@@ -1,21 +1,63 @@
 .banner-jitm {
 	&.card.banner {
 		border-left: none;
+		padding: 21px 40px 21px 43px;
 	}
 
+	display: flex;
+	align-items: center;
+	gap: 20px;
+
+	border-radius: 2px;
+	border: 1px solid var(--gray-gray-5);
+
 	background:
-		linear-gradient(170deg, rgba(225, 212, 229, 1), rgba(225, 212, 229, 0) 60%),
-		linear-gradient(5deg, rgba(101, 162, 215, 1), rgba(101, 162, 215, 0) 70%),
-		linear-gradient(220deg, rgba(102, 171, 160, 1), rgba(102, 171, 160, 0) 60%);
+		radial-gradient(circle at top, rgba(235, 206, 224, 1), transparent 70%),
+		linear-gradient(20deg, rgba(8, 117, 196, 0.8), transparent 60%),
+		linear-gradient(240deg, rgba(0, 126, 101, 1), transparent 70%);
 	background-repeat: no-repeat;
-	background-size: 56px 100%;
+	background-size: 66px 100%;
 
 	.banner__icons {
 		.banner__icon,
 		.banner__icon-no-circle {
+			padding: 0;
+			margin: 0;
 			width: 46px;
 			height: 46px;
 		}
+	}
 
+	.banner__info {
+		.banner__title {
+			color: var(--gray-gray-100);
+			font-size: $font-body;
+			line-height: 24px; /* 150% */
+			letter-spacing: -0.32px;
+		}
+		.banner_description {
+			color: var(--gray-gray-70);
+			font-size: $font-body-small;
+			line-height: 20px; /* 142.857% */
+			letter-spacing: -0.15px;
+		}
+	}
+
+	.banner__action {
+		button,
+		button:hover,
+		button:focus {
+			display: flex;
+			height: 40px;
+			padding: 10px 24px;
+			justify-content: center;
+			align-items: center;
+			gap: 8px;
+
+			border-radius: 4px;
+			background: var(--black-white-black, #000);
+			box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+			border-color: var(--black-white-black, #000);
+		}
 	}
 }

--- a/client/blocks/jitm/templates/banner.scss
+++ b/client/blocks/jitm/templates/banner.scss
@@ -1,0 +1,21 @@
+.banner-jitm {
+	&.card.banner {
+		border-left: none;
+	}
+
+	background:
+		linear-gradient(170deg, rgba(225, 212, 229, 1), rgba(225, 212, 229, 0) 60%),
+		linear-gradient(5deg, rgba(101, 162, 215, 1), rgba(101, 162, 215, 0) 70%),
+		linear-gradient(220deg, rgba(102, 171, 160, 1), rgba(102, 171, 160, 0) 60%);
+	background-repeat: no-repeat;
+	background-size: 56px 100%;
+
+	.banner__icons {
+		.banner__icon,
+		.banner__icon-no-circle {
+			width: 46px;
+			height: 46px;
+		}
+
+	}
+}

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { stringify, parse } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import AsyncLoad from 'calypso/components/async-load';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryAllDomains from 'calypso/components/data/query-all-domains';
@@ -411,6 +412,13 @@ class AllDomains extends Component {
 		return (
 			<>
 				<div className="all-domains__filter">{ this.renderDomainTableFilterButton() }</div>
+
+				<AsyncLoad
+					require="calypso/blocks/jitm"
+					template="banner"
+					messagePath="calypso:domains:admin_notices"
+				/>
+
 				<DomainsTable
 					currentRoute={ currentRoute }
 					domains={ domains }

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -411,13 +411,13 @@ class AllDomains extends Component {
 
 		return (
 			<>
-				<div className="all-domains__filter">{ this.renderDomainTableFilterButton() }</div>
-
 				<AsyncLoad
 					require="calypso/blocks/jitm"
 					template="banner"
 					messagePath="calypso:domains:admin_notices"
 				/>
+
+				<div className="all-domains__filter">{ this.renderDomainTableFilterButton() }</div>
 
 				<DomainsTable
 					currentRoute={ currentRoute }

--- a/client/my-sites/domains/domain-management/list/all-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/all-domains.jsx
@@ -33,6 +33,7 @@ import {
 } from 'calypso/state/purchases/selectors';
 import canCurrentUserForSites from 'calypso/state/selectors/can-current-user-for-sites';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import getSites from 'calypso/state/selectors/get-sites';
 import isRequestingAllDomains from 'calypso/state/selectors/is-requesting-all-domains';
 import {
@@ -41,6 +42,7 @@ import {
 	getFlatDomainsList,
 } from 'calypso/state/sites/domains/selectors';
 import { hasAllSitesList } from 'calypso/state/sites/selectors';
+import getSite from 'calypso/state/sites/selectors/get-site';
 import BulkEditContactInfo from './bulk-edit-contact-info';
 import DomainsTable from './domains-table';
 import DomainsTableFilterButton from './domains-table-filter-button';
@@ -65,6 +67,7 @@ class AllDomains extends Component {
 		sites: PropTypes.object.isRequired,
 		requestingSiteDomains: PropTypes.object,
 		isContactEmailEditContext: PropTypes.bool,
+		primarySite: PropTypes.object,
 	};
 
 	state = {
@@ -411,11 +414,14 @@ class AllDomains extends Component {
 
 		return (
 			<>
-				<AsyncLoad
-					require="calypso/blocks/jitm"
-					template="banner"
-					messagePath="calypso:domains:admin_notices"
-				/>
+				{ this.props.primarySite && (
+					<AsyncLoad
+						require="calypso/blocks/jitm"
+						template="banner"
+						messagePath="calypso:domains:admin_notices"
+						selectedSiteOverride={ this.props.primarySite }
+					/>
+				) }
 
 				<div className="all-domains__filter">{ this.renderDomainTableFilterButton() }</div>
 
@@ -784,5 +790,6 @@ export default connect( ( state, { context } ) => {
 		requestingFlatDomains: isRequestingAllDomains( state ),
 		requestingSiteDomains: getAllRequestingSiteDomains( state ),
 		sites,
+		primarySite: getSite( state, getPrimarySiteId( state ) ),
 	};
 } )( localize( AllDomains ) );

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -185,13 +185,11 @@ export class SiteDomains extends Component {
 						[ 'has-no-wpcom-domain' ]: ! wpcomDomain,
 					} ) }
 				>
-					{ ! this.isLoading() && (
-						<AsyncLoad
-							require="calypso/blocks/jitm"
-							template="banner"
-							messagePath="calypso:domains:admin_notices"
-						/>
-					) }
+					<AsyncLoad
+						require="calypso/blocks/jitm"
+						template="banner"
+						messagePath="calypso:domains:admin_notices"
+					/>
 
 					<div className="domain-management-list__filter">
 						{ this.renderDomainTableFilterButton() }

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -10,6 +10,7 @@ import { stringify } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import DomainToPlanNudge from 'calypso/blocks/domain-to-plan-nudge';
+import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import EmptyContent from 'calypso/components/empty-content';
@@ -179,19 +180,6 @@ export class SiteDomains extends Component {
 
 				{ ! this.isLoading() && <GoogleSaleBanner domains={ domains } /> }
 
-				{ wpcomDomain && (
-					<FreeDomainItem
-						key="wpcom-domain-item"
-						isAtomicSite={ isAtomicSite }
-						currentRoute={ currentRoute }
-						domain={ wpcomDomain }
-						disabled={ disabled }
-						isBusy={ settingPrimaryDomain }
-						site={ selectedSite }
-						onMakePrimary={ this.handleUpdatePrimaryDomainWpcom }
-					/>
-				) }
-
 				<div
 					className={ classnames( 'domain-management-list__items', {
 						[ 'has-no-wpcom-domain' ]: ! wpcomDomain,
@@ -200,6 +188,13 @@ export class SiteDomains extends Component {
 					<div className="domain-management-list__filter">
 						{ this.renderDomainTableFilterButton() }
 					</div>
+					{ ! this.isLoading() && (
+						<AsyncLoad
+							require="calypso/blocks/jitm"
+							template="banner"
+							messagePath="calypso:domains:admin_notices"
+						/>
+					) }
 					<DomainsTable
 						currentRoute={ currentRoute }
 						domains={ nonWpcomDomains }
@@ -214,7 +209,20 @@ export class SiteDomains extends Component {
 						sites={ { [ selectedSite.ID ]: selectedSite } }
 						hasLoadedPurchases={ ! isFetchingPurchases }
 					/>
+					{ wpcomDomain && (
+						<FreeDomainItem
+							key="wpcom-domain-item"
+							isAtomicSite={ isAtomicSite }
+							currentRoute={ currentRoute }
+							domain={ wpcomDomain }
+							disabled={ disabled }
+							isBusy={ settingPrimaryDomain }
+							site={ selectedSite }
+							onMakePrimary={ this.handleUpdatePrimaryDomainWpcom }
+						/>
+					) }
 				</div>
+
 				{ ! this.isLoading() && nonWpcomDomains.length === 0 && ! selectedFilter && (
 					<EmptyDomainsListCard
 						selectedSite={ selectedSite }

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -185,9 +185,6 @@ export class SiteDomains extends Component {
 						[ 'has-no-wpcom-domain' ]: ! wpcomDomain,
 					} ) }
 				>
-					<div className="domain-management-list__filter">
-						{ this.renderDomainTableFilterButton() }
-					</div>
 					{ ! this.isLoading() && (
 						<AsyncLoad
 							require="calypso/blocks/jitm"
@@ -195,6 +192,11 @@ export class SiteDomains extends Component {
 							messagePath="calypso:domains:admin_notices"
 						/>
 					) }
+
+					<div className="domain-management-list__filter">
+						{ this.renderDomainTableFilterButton() }
+					</div>
+
 					<DomainsTable
 						currentRoute={ currentRoute }
 						domains={ nonWpcomDomains }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3474

## Proposed Changes

* Adds a new jitm template wrapping the Banner component

Todo:
- [ ] Figure out why jitm's aren't loading on the all domains page

## Testing Instructions

* Sandbox public-api (for the jitm) and wordpress.com (for the domains icon image)
* Apply D119290-code and D119834-code 
* Set the domain owner user attribute on your test user: `update_user_attribute(238083941, 'is_google_domain_owner', true);`
* Jitm should show up on both the site domain pages and all domain pages.

![Screenshot 2023-08-29 at 11-16-03 Domains ‹ Atomic test site 1 — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/107e3d9f-8515-47d3-875e-ff357f32572b)

(typo fixed)
<img src="https://github.com/Automattic/wp-calypso/assets/811776/489244cc-a34a-429a-b5da-ab5218d624e2" width="200">
