### PR TITLE
Tweak deletion message for free trials

### DIFF
--- a/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
+++ b/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
@@ -17,9 +17,11 @@ function DeleteSiteWarningDialog( { isVisible, p2HubP2Count, onClose, isTrialSit
 				</Button>
 			);
 		} else if ( isTrialSite ) {
-			<Button primary href={ purchasesRoot }>
-				{ translate( 'Cancel trial', { context: 'button label' } ) }
-			</Button>;
+			buttons.push(
+				<Button primary href={ purchasesRoot }>
+					{ translate( 'Cancel trial', { context: 'button label' } ) }
+				</Button>
+			);
 		} else {
 			buttons.push(
 				<Button primary href={ purchasesRoot }>

--- a/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
+++ b/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
@@ -5,7 +5,7 @@ import { purchasesRoot } from 'calypso/me/purchases/paths';
 
 import './style.scss';
 
-function DeleteSiteWarningDialog( { isVisible, p2HubP2Count, onClose } ) {
+function DeleteSiteWarningDialog( { isVisible, p2HubP2Count, onClose, isTrialSite = false } ) {
 	const translate = useTranslate();
 
 	const getButtons = () => {
@@ -16,6 +16,10 @@ function DeleteSiteWarningDialog( { isVisible, p2HubP2Count, onClose } ) {
 					{ translate( 'Go to your site listing' ) }
 				</Button>
 			);
+		} else if ( isTrialSite ) {
+			<Button primary href={ purchasesRoot }>
+				{ translate( 'Cancel trial', { context: 'button label' } ) }
+			</Button>;
 		} else {
 			buttons.push(
 				<Button primary href={ purchasesRoot }>
@@ -30,6 +34,11 @@ function DeleteSiteWarningDialog( { isVisible, p2HubP2Count, onClose } ) {
 		if ( p2HubP2Count ) {
 			return translate( 'P2 workspace' );
 		}
+
+		if ( isTrialSite ) {
+			return translate( 'Free Trial Active' );
+		}
+
 		return translate( 'Paid Upgrades' );
 	};
 
@@ -46,6 +55,13 @@ function DeleteSiteWarningDialog( { isVisible, p2HubP2Count, onClose } ) {
 				}
 			);
 		}
+
+		if ( isTrialSite ) {
+			return translate(
+				'You have an active or expired free trial on your site. Please cancel this plan prior to deleting your site.'
+			);
+		}
+
 		return translate(
 			'You have active paid upgrades on your site. Please cancel your upgrades prior to deleting your site.'
 		);
@@ -68,6 +84,7 @@ DeleteSiteWarningDialog.propTypes = {
 	isVisible: PropTypes.bool.isRequired,
 	p2HubP2Count: PropTypes.number,
 	onClose: PropTypes.func.isRequired,
+	isTrialSite: PropTypes.bool,
 };
 
 export default DeleteSiteWarningDialog;

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -20,6 +20,7 @@ import { hasLoadedSitePurchasesFromServer } from 'calypso/state/purchases/select
 import hasCancelableSitePurchases from 'calypso/state/selectors/has-cancelable-site-purchases';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { deleteSite } from 'calypso/state/sites/actions';
+import { isTrialSite } from 'calypso/state/sites/plans/selectors';
 import { getSite, getSiteDomain } from 'calypso/state/sites/selectors';
 import { hasSitesAsLandingPage } from 'calypso/state/sites/selectors/has-sites-as-landing-page';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
@@ -37,6 +38,7 @@ class DeleteSite extends Component {
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
 		translate: PropTypes.func.isRequired,
+		isTrialSite: PropTypes.bool,
 	};
 
 	state = {
@@ -317,6 +319,7 @@ class DeleteSite extends Component {
 					<DeleteSiteWarningDialog
 						isVisible={ this.state.showWarningDialog }
 						onClose={ this.closeWarningDialog }
+						isTrialSite={ this.props.isTrialSite }
 					/>
 					<Dialog
 						isVisible={ this.state.showConfirmDialog }
@@ -370,6 +373,7 @@ export default connect(
 			siteExists: !! getSite( state, siteId ),
 			hasCancelablePurchases: hasCancelableSitePurchases( state, siteId ),
 			useSitesAsLandingPage: hasSitesAsLandingPage( state ),
+			isTrialSite: isTrialSite( state, siteId ),
 		};
 	},
 	{


### PR DESCRIPTION
## Proposed Changes

* Changes the deletion message for just free trial sites (active or expired) that has a plan enabled to remove confusing language. See relevant discussion here: p1692857303685489/1692855037.064929-slack-C01A60HCGUA

Before:
![CleanShot 2023-08-25 at 12 46 45](https://github.com/Automattic/wp-calypso/assets/533/4e7e0c78-e562-4c7f-9733-ceb420c1cd7e)

After:
![CleanShot 2023-08-25 at 12 48 28](https://github.com/Automattic/wp-calypso/assets/533/ccc59a0b-e8c6-475e-bff1-fd10142dae7c)


## Testing Instructions

* Test the Settings > General > Site Tools > Delete your site permanently flow with:
* An active migration trial (should display new notice)
* An expired migration trial (should display new notice) 
* An active eCommerce trial (should display new notice)
* An expired eCommerce trial (should display new notice)
* An active atomic site (should display old notice)
* A simple site (should display no notice)

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?