### PR TITLE
E2E: update expectations of Site Assembler flow.

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
@@ -30,7 +30,7 @@ export class SiteAssemblerFlow {
 	 *
 	 * @param {LayoutType} type Type of the layout component.
 	 */
-	async selectLayoutComponentType( type: LayoutType ): Promise< void > {
+	async clickLayoutComponentType( type: LayoutType ): Promise< void > {
 		await this.page.getByRole( 'button', { name: type } ).click();
 	}
 
@@ -68,6 +68,18 @@ export class SiteAssemblerFlow {
 			.getByRole( 'listitem' )
 			.last()
 			.waitFor( { timeout: 15 * 1000 } );
+	}
+
+	/**
+	 * Given an accessible name of the color style, waits for and clicks on the style.
+	 *
+	 * @param {string} name Accessible name of the color style to pick.
+	 */
+	async pickStyle( name: string ) {
+		const anchor = this.page.getByRole( 'listbox', { name: 'Color palette variations' } );
+		await anchor.waitFor();
+
+		await anchor.getByRole( 'option', { name: name } ).click();
 	}
 
 	/**

--- a/test/e2e/specs/onboarding/ftme__site-assembler.ts
+++ b/test/e2e/specs/onboarding/ftme__site-assembler.ts
@@ -90,24 +90,32 @@ describe( 'Site Assembler', () => {
 		} );
 
 		it( 'Select "Header"', async function () {
-			await siteAssemblerFlow.selectLayoutComponentType( 'Header' );
+			// The pane is now open by default.
+			// @see https://github.com/Automattic/wp-calypso/pull/80924
 			await siteAssemblerFlow.selectLayoutComponent( 'Simple Header' );
 
 			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 1 );
 		} );
 
 		it( 'Select "Sections"', async function () {
-			await siteAssemblerFlow.selectLayoutComponentType( 'Sections' );
+			await siteAssemblerFlow.clickLayoutComponentType( 'Sections' );
 			await siteAssemblerFlow.selectLayoutComponent( 'Heading with two images and descriptions' );
 
 			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 2 );
 		} );
 
 		it( 'Select "Footer"', async function () {
-			await siteAssemblerFlow.selectLayoutComponentType( 'Footer' );
+			await siteAssemblerFlow.clickLayoutComponentType( 'Footer' );
 			await siteAssemblerFlow.selectLayoutComponent( 'Simple centered footer' );
 
 			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 3 );
+		} );
+
+		it( 'Pick default style', async function () {
+			// The visible button text is "Pick your style" but the accessible name is
+			// as below. Introduced in https://github.com/Automattic/wp-calypso/pull/80924.
+			await siteAssemblerFlow.clickButton( 'Add your first pattern to get started.' );
+			await siteAssemblerFlow.pickStyle( 'Color: Free style' );
 		} );
 
 		it( 'Click "Save and continue" and land on the Site Editor', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/80924.

## Proposed Changes

This PR updates expectations and actions for the Site Assembler flow in light of changes in https://github.com/Automattic/wp-calypso/pull/80924.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
