### PR TITLE
Jetpack E2E: update expectations for the AI Assistant flow.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
@@ -96,9 +96,11 @@ export class AIAssistantFlow implements BlockFlow {
 	 * @param {Locator} block Locator to the block.
 	 */
 	private async waitForQuery( block: Locator ) {
+		// Some users on AT are very slow to process queries, hence the very long
+		// timeout.
 		await block
 			.getByRole( 'button', { name: 'Stop request' } )
-			.waitFor( { state: 'detached', timeout: 15 * 1000 } );
+			.waitFor( { state: 'detached', timeout: 30 * 1000 } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
@@ -17,12 +17,16 @@ interface ConfigurationData {
 	improve?: 'Summarize' | 'Make longer' | 'Make shorter';
 	keywords: string[];
 }
+interface ValidationData {
+	keywords: string[];
+}
 
 /**
  * Represents the flow of using the AI Assistant block.
  */
 export class AIAssistantFlow implements BlockFlow {
 	private configurationData: ConfigurationData;
+	private validationData: ValidationData;
 
 	/**
 	 * Constructs an instance of this block flow with data to be used when
@@ -30,8 +34,9 @@ export class AIAssistantFlow implements BlockFlow {
 	 *
 	 * @param {ConfigurationData} configurationData Configuration data for the block.
 	 */
-	constructor( configurationData: ConfigurationData ) {
+	constructor( configurationData: ConfigurationData, validationData: ValidationData ) {
 		this.configurationData = configurationData;
+		this.validationData = validationData;
 	}
 
 	blockSidebarName = 'AI Assistant (Experimental)';
@@ -110,7 +115,7 @@ export class AIAssistantFlow implements BlockFlow {
 	 * the point of test execution.
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
-		for ( const keyword of this.configurationData.keywords ) {
+		for ( const keyword of this.validationData.keywords ) {
 			await context.page.getByRole( 'main' ).filter( { hasText: keyword } ).waitFor();
 		}
 	}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
@@ -15,7 +15,6 @@ interface ConfigurationData {
 		| 'Passionate'
 		| 'Provocative';
 	improve?: 'Summarize' | 'Make longer' | 'Make shorter';
-	keywords: string[];
 }
 interface ValidationData {
 	keywords: string[];

--- a/test/e2e/specs/blocks/blocks__jetpack-writing.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-writing.ts
@@ -10,7 +10,7 @@ const blockFlows: BlockFlow[] = [
 		query: 'In two short sentences, tell me about Vancouver, Canada.',
 		tone: 'Passionate',
 		improve: 'Make shorter',
-		keywords: [ 'Vancouver, Canada' ],
+		keywords: [ 'Vancouver' ],
 	} ),
 ];
 

--- a/test/e2e/specs/blocks/blocks__jetpack-writing.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-writing.ts
@@ -6,12 +6,14 @@ import { BlockFlow, AIAssistantFlow } from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
-	new AIAssistantFlow( {
-		query: 'In two short sentences, tell me about Vancouver, Canada.',
-		tone: 'Passionate',
-		improve: 'Make shorter',
-		keywords: [ 'Vancouver' ],
-	} ),
+	new AIAssistantFlow(
+		{
+			query: 'In two short sentences, tell me about Vancouver, Canada.',
+			tone: 'Passionate',
+			improve: 'Make shorter',
+		},
+		{ keywords: [ 'Vancouver' ] }
+	),
 ];
 
 createBlockTests( 'Blocks: Jetpack Writing', blockFlows );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80730.

## Proposed Changes

This PR updates the expectations for the AI Assistant block.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
