### PR TITLE
Pro Dashboard: Add Create new site split button in the dashboard.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -1,4 +1,5 @@
-import { Button, Count } from '@automattic/components';
+import { isEnabled } from '@automattic/calypso-config';
+import { Button, Count, WordPressLogo } from '@automattic/components';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { getQueryArg, removeQueryArgs, addQueryArgs } from '@wordpress/url';
@@ -8,10 +9,13 @@ import page from 'page';
 import { useContext, useEffect, useState, useMemo, createRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
+import SplitButton from 'calypso/components/split-button';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import useFetchMonitorVerfiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -199,6 +203,10 @@ export default function SitesOverview() {
 		const dispatch = useDispatch();
 		const translate = useTranslate();
 
+		const isWPCOMAtomicSiteCreationEnabled = isEnabled(
+			'jetpack/pro-dashboard-wpcom-atomic-hosting'
+		);
+
 		return (
 			<div className="sites-overview__add-site-issue-license-buttons">
 				<Button
@@ -212,17 +220,63 @@ export default function SitesOverview() {
 				>
 					{ translate( 'Issue License', { context: 'button label' } ) }
 				</Button>
-				<Button
-					primary
-					href="https://wordpress.com/jetpack/connect"
-					onClick={ () =>
-						dispatch(
-							recordTracksEvent( 'calypso_jetpack_agency_dashboard_add_site_button_click' )
-						)
-					}
-				>
-					{ translate( 'Add New Site', { context: 'button label' } ) }
-				</Button>
+
+				{ ! isWPCOMAtomicSiteCreationEnabled && (
+					<Button
+						primary
+						href="https://wordpress.com/jetpack/connect"
+						onClick={ () =>
+							dispatch(
+								recordTracksEvent( 'calypso_jetpack_agency_dashboard_add_site_button_click' )
+							)
+						}
+					>
+						{ translate( 'Add New Site', { context: 'button label' } ) }
+					</Button>
+				) }
+
+				{ isWPCOMAtomicSiteCreationEnabled && (
+					<SplitButton
+						primary
+						whiteSeparator
+						label={ isMobile ? undefined : translate( 'Add new site' ) }
+						onClick={ () =>
+							dispatch(
+								recordTracksEvent(
+									'calypso_jetpack_agency_dashboard_create_wpcom_atomic_site_button_click'
+								)
+							)
+						}
+						href="/partner-portal/create-site"
+						toggleIcon={ isMobile ? 'plus' : undefined }
+					>
+						<PopoverMenuItem
+							onClick={ () => {
+								recordTracksEvent(
+									'calypso_jetpack_agency_dashboard_create_wpcom_atomic_site_button_click'
+								);
+							} }
+							href="/partner-portal/create-site"
+						>
+							<WordPressLogo className="gridicon" size={ 18 } />
+							<span>{ translate( 'Create a new WordPress.com site' ) }</span>
+						</PopoverMenuItem>
+
+						<PopoverMenuItem
+							onClick={ () =>
+								dispatch(
+									recordTracksEvent(
+										'calypso_jetpack_agency_dashboard_connect_jetpack_site_button_click'
+									)
+								)
+							}
+							href="https://wordpress.com/jetpack/connect"
+						>
+							<JetpackLogo className="gridicon" size={ 18 } />
+							<span>{ translate( 'Connect a site to jetpack' ) }</span>
+						</PopoverMenuItem>
+					</SplitButton>
+				) }
 			</div>
 		);
 	};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -276,6 +276,7 @@ export default function SitesOverview() {
 								)
 							}
 							href="https://wordpress.com/jetpack/connect"
+							isExternalLink
 						>
 							<JetpackLogo className="gridicon" size={ 18 } />
 							<span>{ translate( 'Connect a site to Jetpack' ) }</span>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -278,7 +278,7 @@ export default function SitesOverview() {
 							href="https://wordpress.com/jetpack/connect"
 						>
 							<JetpackLogo className="gridicon" size={ 18 } />
-							<span>{ translate( 'Connect a site to jetpack' ) }</span>
+							<span>{ translate( 'Connect a site to Jetpack' ) }</span>
 						</PopoverMenuItem>
 					</SplitButton>
 				) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -208,7 +208,11 @@ export default function SitesOverview() {
 		);
 
 		return (
-			<div className="sites-overview__add-site-issue-license-buttons">
+			<div
+				className={ classNames( 'sites-overview__add-site-issue-license-buttons', {
+					'is-with-split-button': isWPCOMAtomicSiteCreationEnabled,
+				} ) }
+			>
 				<Button
 					className="sites-overview__issue-license-button"
 					href="/partner-portal/issue-license"
@@ -223,6 +227,7 @@ export default function SitesOverview() {
 
 				{ ! isWPCOMAtomicSiteCreationEnabled && (
 					<Button
+						className="sites-overview__issue-license-button"
 						primary
 						href="https://wordpress.com/jetpack/connect"
 						onClick={ () =>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -35,43 +35,37 @@
 		border-bottom: 1px solid var(--color-primary-5);
 	}
 }
+
 .sites-overview__add-site-issue-license-buttons {
 	// We need these negative margin values because we want to make the container full-width,
 	// but our element is inside a limited-width parent.
-	margin: 0 -32px 8px;
+	margin: 0 -48px 8px;
 	padding: 8px 48px;
 
-	button,
-	a {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+
+	> a,
+	> button {
 		font-size: 1rem;
-		display: block;
-		width: 100%;
 		box-sizing: border-box;
+		max-height: 40px;
 	}
 
-	.sites-overview__issue-license-button {
-		margin-right: 0;
-		margin-bottom: 8px;
-	}
-	@include break-large {
-		margin: unset;
-		padding: unset;
-		flex: none;
-		margin-left: auto;
-		display: inline-block;
-		max-height: 40px;
-		button,
-		a {
-			display: inline-block;
-			width: auto;
-		}
+	&.is-with-split-button {
+		flex-direction: row;
 
 		.sites-overview__issue-license-button {
-			margin-right: 8px;
-			margin-bottom: 8px;
+			flex-grow: 1;
 		}
 	}
+
+	@include break-large {
+		flex-direction: row;
+	}
 }
+
 .sites-overview__content {
 	// We need these negative margin values because we want to make the container full-width,
 	// but our element is inside a limited-width parent.
@@ -89,7 +83,7 @@
 
 	@include breakpoint-deprecated( ">660px" ) {
 		display: flex;
-		align-items: center;
+		justify-content: space-between;
 	}
 
 	&.is-sticky {

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -393,13 +393,24 @@ body.is-section-jetpack-cloud-pricing.is-group-jetpack-cloud .mini-cart {
 
 // Override Split button styles for Jetpack Cloud
 .split-button {
+
 	.button {
+		font-size: 1rem;
 		height: 40px;
 
 		&:focus {
 			border-color: var(--studio-jetpack-green-70);
 			border-width: 1px;
 			box-shadow: none;
+		}
+	}
+
+	.button.split-button__toggle {
+		border-radius: 4px;
+
+		@include breakpoint-deprecated( ">480px" ) {
+			border-top-left-radius: 0;
+			border-bottom-left-radius: 0;
 		}
 	}
 

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -390,3 +390,22 @@ body.is-section-jetpack-cloud-pricing.is-group-jetpack-cloud .mini-cart {
 		}
 	}
 }
+
+// Override Split button styles for Jetpack Cloud
+.split-button {
+	.button {
+		height: 40px;
+
+		&:focus {
+			border-color: var(--studio-jetpack-green-70);
+			border-width: 1px;
+			box-shadow: none;
+		}
+	}
+
+	.gridicon {
+		width: 20px;
+		height: 20px;
+		fill: var(--studio-white);
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-avalon/issues/22
Is depended on by https://github.com/Automattic/jetpack-avalon/issues/21.

## Proposed Changes

Add 'Add Site' split button to handle both WPCOM site creation and Jetpack site connection flow. 

<img width="353" alt="Screen Shot 2023-08-29 at 2 18 53 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/99c40696-7004-484b-9ccf-51052d49e108">
<img width="395" alt="Screen Shot 2023-08-29 at 2 19 13 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/42206473-7b12-4951-9c23-1fa014ca13df">


## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack cloud live link and go to `/dashboard`
* Confirm that the **Add new site** button is visible.
* Confirm that clicking the **Add new site** button should redirect to `/partner-portal/create-site`
* Confirm that by clicking the dropdown icon show up a submenu that includes **Add new WordPress.com site** and **Connect a site to Jetpack**
* Confirm that by clicking **Add new WordPress.com site** will redirect to `partner-portal/create-site`
* Confirm that by clicking **Connect a site to Jetpack** will redirect to `https://wordpress.com/jetpack/connect`
* Finally, test the new split button on mobile view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
