### PR TITLE
Assembler: CTA copy update

### DIFF
--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -27,9 +27,9 @@ export function usePatternAssemblerCtaData(): PatternAssemblerCtaData {
 		title: translate( 'Design your own' ),
 		subtitle: shouldGoToAssemblerStep ? (
 			<ul>
-				<li>{ translate( ' Select some patterns for your homepage.' ) }</li>
-				<li>{ translate( ' Style it up with custom colors and font pairings.' ) }</li>
-				<li>{ translate( ' Bring your site to life with some content.' ) }</li>
+				<li>{ translate( 'Select patterns to create your homepage layout.' ) }</li>
+				<li>{ translate( 'Style it up with custom colors and font pairings.' ) }</li>
+				<li>{ translate( 'Bring your site to life with your own content.' ) }</li>
 			</ul>
 		) : (
 			translate( 'Jump right into the editor to design your homepage from scratch.' )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80684

## Proposed Changes

As suggested in https://github.com/Automattic/wp-calypso/issues/80684#issuecomment-1685041187, we are updating the CTA copy to be more precise.

| Before | After |
| --- | --- |
| ![Screenshot 2023-08-25 at 5 06 30 PM](https://github.com/Automattic/wp-calypso/assets/797888/f9a6bf18-eb29-45ee-9d76-f7c214454517) | ![Screenshot 2023-08-25 at 5 06 11 PM](https://github.com/Automattic/wp-calypso/assets/797888/267d6c3f-d241-420a-a194-219bceccce23) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Ensure that the copy is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
