### PR TITLE
Assembler - Show "Pick your style" button tooltip only when is disabled

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -48,6 +48,11 @@ const ScreenMain = ( {
 	const selectedCategory = params.categorySlug as string;
 	const shouldOpenCategoryList =
 		!! selectedCategory && selectedCategory !== 'header' && selectedCategory !== 'footer';
+	const isButtonDisabled = ! hasSections && ! hasHeader && ! hasFooter;
+	const buttonText =
+		isEnglishLocale || i18n.hasTranslation( 'Pick your style' )
+			? translate( 'Pick your style' )
+			: translate( 'Save and continue' );
 
 	const handleClick = () => {
 		goTo( NAVIGATOR_PATHS.STYLES_COLORS );
@@ -131,15 +136,14 @@ const ScreenMain = ( {
 			<div className="screen-container__footer">
 				<Button
 					className="pattern-assembler__button"
-					disabled={ ! hasSections && ! hasHeader && ! hasFooter }
+					disabled={ isButtonDisabled }
+					showTooltip={ isButtonDisabled }
 					onClick={ handleClick }
-					label="Add your first pattern to get started."
-					variant="primary"
-					text={
-						isEnglishLocale || i18n.hasTranslation( 'Pick your style' )
-							? translate( 'Pick your style' )
-							: translate( 'Save and continue' )
+					label={
+						isButtonDisabled ? translate( 'Add your first pattern to get started.' ) : buttonText
 					}
+					variant="primary"
+					text={ buttonText }
 					__experimentalIsFocusable
 				/>
 			</div>

--- a/test/e2e/specs/onboarding/ftme__site-assembler.ts
+++ b/test/e2e/specs/onboarding/ftme__site-assembler.ts
@@ -112,9 +112,7 @@ describe( 'Site Assembler', () => {
 		} );
 
 		it( 'Pick default style', async function () {
-			// The visible button text is "Pick your style" but the accessible name is
-			// as below. Introduced in https://github.com/Automattic/wp-calypso/pull/80924.
-			await siteAssemblerFlow.clickButton( 'Add your first pattern to get started.' );
+			await siteAssemblerFlow.clickButton( 'Pick your style' );
 			await siteAssemblerFlow.pickStyle( 'Color: Free style' );
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/81064 https://github.com/Automattic/wp-calypso/pull/80917

## Proposed Changes

* Show "Pick your style" button tooltip only when is disabled
* Update the accessible label when the button is enabled
* Update the test selector to use the right accessible name

|BEFORE|AFTER|
|--|--|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/a9fe6527-216f-4c97-964d-96eb0e732696">|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/cf740384-8016-4a99-a9b7-fda24df69e6d">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }`
* Hover the button `Pick your style`
* Expect to see the tooltip `Add your first pattern to get started.`
* Choose any pattern
* Hover the button `Pick your style`
* Expect to see no tooltip


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
