### PR TITLE
2FA security key: update copies to indicate browser/phone support

### DIFF
--- a/client/blocks/login/two-factor-authentication/security-key-form.jsx
+++ b/client/blocks/login/two-factor-authentication/security-key-form.jsx
@@ -64,7 +64,7 @@ class SecurityKeyForm extends Component {
 							</p>
 							<p>
 								{ translate(
-									'Insert your hardware security key, or follow the instructions in your browser or phone to use your finger print or facial recognition.'
+									'Insert your hardware security key, or follow the instructions in your browser or phone to log in.'
 								) }
 							</p>
 						</div>

--- a/client/blocks/login/two-factor-authentication/security-key-form.jsx
+++ b/client/blocks/login/two-factor-authentication/security-key-form.jsx
@@ -20,6 +20,11 @@ class SecurityKeyForm extends Component {
 		switchTwoFactorAuthType: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 		showOrDivider: PropTypes.bool,
+		isWoo: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		isWoo: false,
 	};
 
 	state = {
@@ -38,7 +43,7 @@ class SecurityKeyForm extends Component {
 	};
 
 	render() {
-		const { translate, switchTwoFactorAuthType } = this.props;
+		const { translate, isWoo, switchTwoFactorAuthType } = this.props;
 
 		return (
 			<form

--- a/client/blocks/login/two-factor-authentication/security-key-form.jsx
+++ b/client/blocks/login/two-factor-authentication/security-key-form.jsx
@@ -20,11 +20,6 @@ class SecurityKeyForm extends Component {
 		switchTwoFactorAuthType: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 		showOrDivider: PropTypes.bool,
-		isWoo: PropTypes.bool,
-	};
-
-	static defaultProps = {
-		isWoo: false,
 	};
 
 	state = {
@@ -43,7 +38,7 @@ class SecurityKeyForm extends Component {
 	};
 
 	render() {
-		const { translate, isWoo, switchTwoFactorAuthType } = this.props;
+		const { translate, switchTwoFactorAuthType } = this.props;
 
 		return (
 			<form
@@ -63,13 +58,9 @@ class SecurityKeyForm extends Component {
 								} ) }
 							</p>
 							<p>
-								{ isWoo
-									? translate(
-											'Insert your security key into your USB port, then tap the button or gold disc.'
-									  )
-									: translate(
-											'Insert your security key into your USB port. Then tap the button or gold disc.'
-									  ) }
+								{ translate(
+									'Insert your hardware security key, or follow the instructions in your browser or phone to use your finger print or facial recognition.'
+								) }
 							</p>
 						</div>
 					) }
@@ -79,7 +70,11 @@ class SecurityKeyForm extends Component {
 							<p className="security-key-form__add-wait-for-key-heading">
 								{ translate( 'Waiting for security key' ) }
 							</p>
-							<p>{ translate( 'Connect and touch your security key to log in.' ) }</p>
+							<p>
+								{ translate(
+									'Connect and touch your security key to log in, or follow the directions in your browser or pop-up.'
+								) }
+							</p>
 						</div>
 					) }
 					<FormButton

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -57,7 +57,7 @@ class SecurityKeyForm extends Component {
 							</p>
 							<p>
 								{ translate(
-									'Insert your hardware security key, or follow the instructions in your browser or phone to use your finger print or facial recognition.'
+									'Insert your hardware security key, or follow the instructions in your browser or phone to log in.'
 								) }
 							</p>
 						</div>

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -57,7 +57,7 @@ class SecurityKeyForm extends Component {
 							</p>
 							<p>
 								{ translate(
-									'Insert your security key into your USB port. Then tap the button or gold disc.'
+									'Insert your hardware security key, or follow the instructions in your browser or phone to use your finger print or facial recognition.'
 								) }
 							</p>
 						</div>
@@ -67,7 +67,11 @@ class SecurityKeyForm extends Component {
 							<p className="security-key-form__add-wait-for-key-heading">
 								{ translate( 'Waiting for security key' ) }
 							</p>
-							<p>{ translate( 'Connect and touch your security key to log in.' ) }</p>
+							<p>
+								{ translate(
+									'Connect and touch your security key to log in, or follow the directions in your browser or pop-up.'
+								) }
+							</p>
 						</div>
 					) }
 					{ this.state.showError && (

--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -1,5 +1,4 @@
 import { Button, Card, Gridicon } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { Component } from 'react';

--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -1,4 +1,5 @@
 import { Button, Card, Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { Component } from 'react';
@@ -114,17 +115,15 @@ class Security2faKey extends Component {
 					<Card>
 						{ isBrowserSupported && (
 							<p>
-								<>
-									{ this.props.translate(
-										'Security keys offer a more robust form of two-step authentication. Your security key may be a physical device, or you can use passkey support built into your browser.'
-									) }{ ' ' }
-									<InlineSupportLink
-										showIcon={ false }
-										supportContext="two-step-authentication-security-key"
-									>
-										{ translate( 'Learn more' ) }
-									</InlineSupportLink>
-								</>
+								{ this.props.translate(
+									'Security keys offer a more robust form of two-step authentication. Your security key may be a physical device, or you can use passkey support built into your browser.'
+								) }{ ' ' }
+								<InlineSupportLink
+									showIcon={ false }
+									supportContext="two-step-authentication-security-key"
+								>
+									{ translate( 'Learn more' ) }
+								</InlineSupportLink>
 							</p>
 						) }
 						{ ! isBrowserSupported && (

--- a/client/me/security-2fa-key/name.jsx
+++ b/client/me/security-2fa-key/name.jsx
@@ -36,7 +36,9 @@ class Security2faKeyAddName extends Component {
 			<form className="security-2fa-key__add-key-name-form" onSubmit={ this.submitName }>
 				<FormFieldset>
 					<FormLabel htmlFor="security-2fa-key__key-name">
-						{ this.props.translate( 'Give the security key a name' ) }
+						{ this.props.translate(
+							'Give the security key a name. Make it up! It can be anything.'
+						) }
 					</FormLabel>
 					<FormTextInput
 						autoComplete="off"
@@ -44,7 +46,7 @@ class Security2faKeyAddName extends Component {
 						id="security-2fa-key__key_name"
 						name="security_key_name"
 						ref={ ( input ) => ( this.keyNameInput = input ) }
-						placeholder={ this.props.translate( 'ex: My FIDO Key' ) }
+						placeholder={ this.props.translate( 'My Android phone' ) }
 						onChange={ this.handleChange }
 						value={ this.state.keyName }
 					/>

--- a/client/me/security-2fa-key/wait-for-key.jsx
+++ b/client/me/security-2fa-key/wait-for-key.jsx
@@ -10,7 +10,11 @@ export default function WaitForKey() {
 			<p className="security-2fa-key__add-wait-for-key-heading">
 				{ translate( 'Waiting for security key' ) }
 			</p>
-			<p>{ translate( 'Connect and touch your security key to register it.' ) }</p>
+			<p>
+				{ translate(
+					'Connect and touch your security key to register it, or follow the directions in your browser or pop-up.'
+				) }
+			</p>
 		</div>
 	);
 }


### PR DESCRIPTION
We reviewed copy for "security key" management & login flows at WP.com, and did some improvements. 

Goals were:

- Make copy clearer to anyone who doesn't know what this is.
- Less assuming that the key is a hardware key; now the key can be browser or phone, too!
- Make it more human, while keeping the geeky technical terms.

Context: pb6Nl-gR1-p2/#comment-103712
Figma: bRVzMcQJiArckAucjmycTf-fi-0-1

## Testing Instructions

Using Chrome browser:

* Open the "calypso live" link below or run this branch in your computer.
* Go to `/me` (avatar icon from header bar)
* Go to 2FA
* See "Security key" section
* Set up key. Delete key. 
* See the emails you receive. (Needs sandboxed patch, WIP)
* Set key up again, then logout
* Now log-in, see new copy

# Screens

### Empty keys list (starting point)

**TODO:** update [support doc](https://wordpress.com/support/security/two-step-authentication/#security-key-authentication), probably need to create a new more focused doc just for the key.  Open an [issue with docs guild](https://github.com/Automattic/en.support-docs-content/issues/).

#### Before

<img width="1078" alt="Screenshot 2023-08-25 at 15 06 48" src="https://github.com/Automattic/wp-calypso/assets/87168/e8bfe598-b6a8-48a5-bee9-0a03c9fab6a5">

#### After

<img width="1084" alt="Screenshot 2023-08-25 at 15 06 42" src="https://github.com/Automattic/wp-calypso/assets/87168/23aa55b1-addd-43f6-9f91-77169b0f5a15">

<img width="1411" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/0eba5a47-7511-4fae-a316-c7799cf1bc24">

## Adding key — name

#### Before

<img width="1064" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/7c50adca-6913-4aab-8f4f-6acb32cf6263">

#### After

<img width="1072" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/0f1e3c38-1e0e-4302-9ba2-c648acf093e4">

## Adding key — authentication

#### Before

<img width="1145" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/95f44881-0763-4a88-8d02-20c64995ae91">

#### After

<img width="1502" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/4acb434e-5127-45a7-bdd7-fc137a122bdc">

## Confirmation email

#### Before

<img width="1012" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/299f698a-da94-4f01-9cbf-5c2f568e799f">

#### After

WIP

- Add: "...or access your account to remove the key. Be sure to reset your password!"
- Instead of a button, just normal link to access your account?
- Remove "Great posts from"
- Update template to modern one

## Deleting they key email

#### Before

<img width="1019" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/6b42f503-1963-4a00-8a40-923da582534e">

#### After

WIP

- Instead of a button, just normal link to access your account.
- If this was you, ignore this message.
- Remove "Great posts from"
- Update template to modern one


## Login

#### Before

<img width="937" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/64957f69-c205-4076-aa67-0ad364b44bce">

#### After

<img width="955" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/fa4ef60e-5164-43b4-b898-939980667a04">

## Login in progress

#### Before

<img width="1283" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/dad38870-b375-4592-b742-9dca0cf2a849">

#### After

<img width="1428" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/4da65a56-c2a4-4ded-8251-7cdaf009911a">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
