### PR TITLE
100 Year: Hide link to plans in top navigation, and redirect requests to the plans page to my-plan

### DIFF
--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -17,7 +17,7 @@ function showJetpackPlans( context ) {
 function is100YearPlanUser( context ) {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
-	return selectedSite.plan.product_slug === PLAN_100_YEARS;
+	return selectedSite?.plan?.product_slug === PLAN_100_YEARS;
 }
 
 export function plans( context, next ) {

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -1,3 +1,4 @@
+import { PLAN_100_YEARS } from '@automattic/calypso-products';
 import page from 'page';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
 import { productSelect } from 'calypso/my-sites/plans/jetpack-plans/controller';
@@ -13,7 +14,17 @@ function showJetpackPlans( context ) {
 	return ! isWpcom;
 }
 
+function is100YearPlanUser( context ) {
+	const state = context.store.getState();
+	const selectedSite = getSelectedSite( state );
+	return selectedSite.plan.product_slug === PLAN_100_YEARS;
+}
+
 export function plans( context, next ) {
+	// Redirecting users for the 100-Year plan to the my-plan page.
+	if ( is100YearPlanUser( context ) ) {
+		return page.redirect( `/plans/my-plan/${ context.params.site }` );
+	}
 	if ( showJetpackPlans( context ) ) {
 		if ( context.params.intervalType ) {
 			return page.redirect( `/plans/${ context.params.site }` );

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -41,7 +41,7 @@ class PlansNavigation extends Component {
 
 	isSiteOn100YearPlan() {
 		const { site } = this.props;
-		return site && site.plan && site.plan.product_slug === PLAN_100_YEARS;
+		return site?.plan?.product_slug === PLAN_100_YEARS;
 	}
 
 	render() {

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -1,3 +1,4 @@
+import { PLAN_100_YEARS } from '@automattic/calypso-products';
 import { isMobile } from '@automattic/viewport';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -38,6 +39,11 @@ class PlansNavigation extends Component {
 		}
 	}
 
+	isSiteOn100YearPlan() {
+		const { site } = this.props;
+		return site && site.plan && site.plan.product_slug === PLAN_100_YEARS;
+	}
+
 	render() {
 		const { site, shouldShowNavigation, translate, isTrial } = this.props;
 		const path = sectionify( this.props.path );
@@ -57,17 +63,19 @@ class PlansNavigation extends Component {
 							>
 								{ myPlanItemTitle }
 							</NavItem>
-							<NavItem
-								path={ `/plans/${ site.slug }` }
-								selected={
-									path === '/plans' ||
-									path === '/plans/monthly' ||
-									path === '/plans/yearly' ||
-									path === '/plans/2yearly'
-								}
-							>
-								{ translate( 'Plans' ) }
-							</NavItem>
+							{ ! this.isSiteOn100YearPlan() && (
+								<NavItem
+									path={ `/plans/${ site.slug }` }
+									selected={
+										path === '/plans' ||
+										path === '/plans/monthly' ||
+										path === '/plans/yearly' ||
+										path === '/plans/2yearly'
+									}
+								>
+									{ translate( 'Plans' ) }
+								</NavItem>
+							) }
 						</NavTabs>
 					</SectionNav>
 				</div>

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -2748,7 +2748,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 			].includes( plan ),
 		getProductId: () => 1061,
 		getStoreSlug: () => PLAN_100_YEARS,
-		getPathSlug: () => '100-year-plan',
+		getPathSlug: () => 'wp_bundle_hundred_year',
 	},
 
 	[ PLAN_ECOMMERCE_MONTHLY ]: {

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -2748,7 +2748,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 			].includes( plan ),
 		getProductId: () => 1061,
 		getStoreSlug: () => PLAN_100_YEARS,
-		getPathSlug: () => 'wp_bundle_hundred_year',
+		getPathSlug: () => '100-year-plan',
 	},
 
 	[ PLAN_ECOMMERCE_MONTHLY ]: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/martech#2126

## Proposed Changes

* Redirects users on 100-year to my-plan
* Hides the link to plans from the top-level navigation on plans sub-routes, as it redirects anyways.
* This is done because the plans page offers these users nothing right now.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a site with the 100 year plan, and click on "plans" under upgrades
* You should be redirected to my-plan
* The button to go the to plans page is also hidden
* No regression for other plans, e.g. Business, Premium, etc.


![Screenshot 2023-08-25 at 15 14 28](https://github.com/Automattic/wp-calypso/assets/52675688/3926a6ed-d1e4-44bc-b054-3f00d00e717a)
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
