### PR TITLE
Migration trial: update subtitle copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/trial-plan.tsx
@@ -106,7 +106,9 @@ const TrialPlan = function ( props: Props ) {
 				<SubTitle>
 					{ sprintf(
 						/* translators: the planName could be "Pro" or "Business" */
-						__( 'Try the %(planName)s plan free for 7 days and migrate your site for free' ),
+						__(
+							'Give the %(planName)s plan a try with the 7-day free trial, and migrate your site without costs'
+						),
 						{ planName: plan?.getTitle() }
 					) }
 				</SubTitle>


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3566

## Proposed Changes

* Updated copy

## Testing Instructions

* Go to `/setup/import-focused/migrationTrial?siteSlug={SIMPLE_SITE_SLUG}&from={SELF_HOSTED_SITE_URL}&option=everything`
* Check if there is updated subtitle copy

<img width="790" alt="Screenshot 2023-08-25 at 15 37 30" src="https://github.com/Automattic/wp-calypso/assets/1241413/79c03ee0-aed2-4f9a-a454-7f7373c37ce7">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
