### PR TITLE
Fix srv dns records rendering

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-record-data.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-record-data.jsx
@@ -85,7 +85,9 @@ class DnsRecordData extends Component {
 		const domain = this.props.selectedDomainName;
 
 		if ( 'SRV' === type ) {
-			return `${ service }.${ protocol }.${ name }`;
+			return `${ service }.${ protocol }.${
+				name.replace( /\.$/, '' ) === domain ? name : name + '.' + domain + '.'
+			}`;
 		}
 
 		if ( name.replace( /\.$/, '' ) === domain ) {

--- a/client/my-sites/domains/domain-management/dns/dns-record-data.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-record-data.jsx
@@ -84,12 +84,12 @@ class DnsRecordData extends Component {
 		const { name, service, protocol, type } = this.props.dnsRecord;
 		const domain = this.props.selectedDomainName;
 
-		if ( name.replace( /\.$/, '' ) === domain ) {
-			return '@';
+		if ( 'SRV' === type ) {
+			return `${ service }.${ protocol }.${ name }`;
 		}
 
-		if ( 'SRV' === type ) {
-			return `_${ service }._${ protocol }.${ name }`;
+		if ( name.replace( /\.$/, '' ) === domain ) {
+			return '@';
 		}
 
 		return name;

--- a/client/my-sites/domains/domain-management/settings/dns/dns-record-item.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/dns-record-item.tsx
@@ -49,12 +49,12 @@ const DnsRecordItem = ( { dnsRecord, selectedDomainName }: DnsRecordItemProps ) 
 	const getName = () => {
 		const { name, service, protocol, type } = dnsRecord;
 
-		if ( name.replace( /\.$/, '' ) === selectedDomainName ) {
-			return '@';
-		}
-
 		if ( 'SRV' === type ) {
 			return `_${ service }._${ protocol }.${ name }`;
+		}
+
+		if ( name.replace( /\.$/, '' ) === selectedDomainName ) {
+			return '@';
 		}
 
 		return name;

--- a/client/my-sites/domains/domain-management/settings/dns/dns-record-item.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/dns-record-item.tsx
@@ -50,7 +50,11 @@ const DnsRecordItem = ( { dnsRecord, selectedDomainName }: DnsRecordItemProps ) 
 		const { name, service, protocol, type } = dnsRecord;
 
 		if ( 'SRV' === type ) {
-			return `_${ service }._${ protocol }.${ name }`;
+			return `${ service }.${ protocol }.${
+				name.replace( /\.$/, '' ) === selectedDomainName
+					? name
+					: name + '.' + selectedDomainName + '.'
+			}`;
 		}
 
 		if ( name.replace( /\.$/, '' ) === selectedDomainName ) {


### PR DESCRIPTION
## Proposed Changes

This PR fixes a couple of bug on SRV dns records rendering:
- if subdomain field wasn't filled, the name field always showed @, hiding the service and the protocol
- if subdomain field was filled, the name field showed the service and the protocol with 2 underscores, hiding the full domain

![fix-before](https://github.com/Automattic/wp-calypso/assets/2797601/1b225d54-03a0-403f-8ddf-4f83d8be104e)

![fix-after](https://github.com/Automattic/wp-calypso/assets/2797601/a4a9e234-a245-4c18-91e5-5d76cdfd2107)


## Testing Instructions

Apply the patch and add a couple of SRV records for a custom domain you own, and verify that they are rendered correctly:

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
