### PR TITLE
Help Center: Record the suggested AI answer in the initial Messaging message

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -38,6 +38,7 @@ import { HelpCenterGPT } from './help-center-gpt';
 import HelpCenterSearchResults from './help-center-search-results';
 import { HelpCenterSitePicker } from './help-center-site-picker';
 import ThirdPartyCookiesNotice from './help-center-third-party-cookies-notice';
+import type { JetpackSearchAIResult } from '../data/use-jetpack-search-ai';
 import type { AnalysisReport } from '../types';
 import type { HelpCenterSelect, SiteDetails, HelpCenterSite } from '@automattic/data-stores';
 import './help-center-contact-form.scss';
@@ -102,6 +103,7 @@ export const HelpCenterContactForm = () => {
 	const [ sitePickerChoice, setSitePickerChoice ] = useState< 'CURRENT_SITE' | 'OTHER_SITE' >(
 		'CURRENT_SITE'
 	);
+	const [ gptResponse, setGptResponse ] = useState< JetpackSearchAIResult >();
 	const { currentSite, subject, message, userDeclaredSiteUrl } = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return {
@@ -301,7 +303,15 @@ export const HelpCenterContactForm = () => {
 						section: sectionName,
 					} );
 
-					openChatWidget( message, supportSite.URL, () => setHasSubmittingError( true ) );
+					let initialChatMessage = message;
+					if ( gptResponse ) {
+						initialChatMessage += '<br /><br />';
+						initialChatMessage += `<strong>Automated AI response from ${ gptResponse.source }</strong>:<br />`;
+						initialChatMessage += gptResponse.response;
+					}
+					openChatWidget( initialChatMessage, supportSite.URL, () =>
+						setHasSubmittingError( true )
+					);
 					break;
 				}
 				break;
@@ -513,7 +523,7 @@ export const HelpCenterContactForm = () => {
 		return (
 			<div className="help-center__articles-page">
 				<BackButton />
-				<HelpCenterGPT />
+				<HelpCenterGPT onResponseReceived={ setGptResponse } />
 				<section className="contact-form-submit">
 					<Button
 						isBusy={ isFetchingGPTResponse }

--- a/packages/help-center/src/components/help-center-gpt.tsx
+++ b/packages/help-center/src/components/help-center-gpt.tsx
@@ -15,6 +15,7 @@ import './help-center-article-content.scss';
 import { useJetpackSearchAIQuery } from '../data/use-jetpack-search-ai';
 import { useTyper } from '../hooks';
 import { HELP_CENTER_STORE } from '../stores';
+import type { JetpackSearchAIResult } from '../data/use-jetpack-search-ai';
 
 const GPTResponsePlaceholder = styled( LoadingPlaceholder )< { width?: string } >`
 	:not( :last-child ) {
@@ -33,11 +34,11 @@ const GPTResponseDisclaimer = styled.div`
 	}
 `;
 
-interface Props {
+interface LoadingPlaceholderProps {
 	loadingMessage: string;
 }
 
-const LoadingPlaceholders: React.FC< Props > = ( { loadingMessage } ) => (
+const LoadingPlaceholders: React.FC< LoadingPlaceholderProps > = ( { loadingMessage } ) => (
 	<>
 		<p className="help-center-gpt-response__loading">{ loadingMessage }</p>
 		<GPTResponsePlaceholder width="80%" />
@@ -46,7 +47,11 @@ const LoadingPlaceholders: React.FC< Props > = ( { loadingMessage } ) => (
 	</>
 );
 
-export function HelpCenterGPT() {
+interface Props {
+	onResponseReceived: ( response: JetpackSearchAIResult ) => void;
+}
+
+export function HelpCenterGPT( { onResponseReceived }: Props ) {
 	const { __ } = useI18n();
 
 	const [ feedbackGiven, setFeedbackGiven ] = useState< boolean >( false );
@@ -86,6 +91,8 @@ export function HelpCenterGPT() {
 				location: 'help-center',
 				answer_source: data?.source,
 			} );
+
+			onResponseReceived( data );
 		}
 	}, [ data ] );
 


### PR DESCRIPTION
As per this request: peCdcN-db-p2.

## Proposed Changes

* If present, append the GPT response (DocsBot/Sitebot) to the initial Messaging message. This will give HEs better context on the user's support experience so far. Hopefully, this will prevent duplicate questions and smoother experience for both sides.

## Testing Instructions

- Make sure you're logged in and active in the Zendesk Sandbox (ending with `1654197491`). Or hack the `is-available` check to return always true.
- Set a breakpoint in `help-center-contact-form.tsx` around line 306 to verify the following cases:
     - If GPT response is present, it should be appended to the initial message.
     - If it's not present, just the user's message should be sent.
- Additionally, check some edge cases like:
     - User tries contacting us, gets an AI response, closes Help Center. Then they re-open it and try submitting a different support request and skip the waiting for AI response => no GPT response should be present and sent to the backend.

You can also check the values we send to the `update-user-fields` endpoint.
