### PR TITLE
Update the Jetpack cancellation flow

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -401,9 +401,9 @@ const CancelJetpackForm: React.FC< Props > = ( {
 					<FormattedHeader
 						headerText={ translate( 'Confirm removal' ) }
 						subHeaderText={
-							/* Translators: %(percentDiscount)d%% should be a percentage like 15% or 20% */
+							/* Translators: productName is the name of a Jetpack product. */
 							translate(
-								'We’re sorry to see you go. Click Remove subscription to confirm and remove %(productName)s from your account.',
+								'We’re sorry to see you go. Click "Remove subscription" to confirm and remove %(productName)s from your account.',
 								{
 									args: {
 										productName,
@@ -414,7 +414,6 @@ const CancelJetpackForm: React.FC< Props > = ( {
 						align="center"
 						isSecondary={ true }
 					/>
-					<p></p>
 				</>
 			);
 		}

--- a/client/components/marketing-survey/cancel-jetpack-form/steps.ts
+++ b/client/components/marketing-survey/cancel-jetpack-form/steps.ts
@@ -2,3 +2,4 @@ export const FEATURES_LOST_STEP = 'features_lost';
 export const CANCELLATION_REASON_STEP = 'cancellation_reason';
 export const CANCELLATION_OFFER_STEP = 'cancellation_offer';
 export const OFFER_ACCEPTED_STEP = 'offer_accepted';
+export const CANCEL_CONFIRM_STEP = 'cancel_confirm';


### PR DESCRIPTION
## Proposed Changes

This diff updates the product cancellation flow for Jetpack with two changes
- For products that are expired, the flow will now only show a removal confirmation step
- Clean up some edge case handling that was causing some issues with the cancellations survey showing on both cancellation and removal in some cases

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You will need a test purchase that is expired and a test purchase made with credits
* Either spin up your local Calypso and apply this diff, OR test with the Calypso live link
* Navigate to /me/purchases
* For the purchase that is expired, confirm that clicking the "Remove" button from the purchase overview page shows only a confirmation screen with options to remove or keep the subscription. Clicking on "Remove subscription" should remove the subscription from your account:
![Screenshot 2023-08-25 at 11 19 27 AM](https://github.com/Automattic/wp-calypso/assets/18016357/c69bcdc0-4ca5-49ca-97e5-79fe49c96296)
* For the purchase made with credits, go to cancel the product first. Confirm while cancelling the subscription, you see the survey step as the first step in the flow:
![Screenshot 2023-08-25 at 11 20 40 AM](https://github.com/Automattic/wp-calypso/assets/18016357/55914855-60e6-47b9-8a0f-9ab7ac2186aa)
* If you did not cancel the credits purchase in the previous step, go ahead and cancel it.
* Now, remove the credits purchase. Confirm that. the first step in the flow shows the benefits that you will lose when the purchase is removed:
![Screenshot 2023-08-25 at 11 20 26 AM](https://github.com/Automattic/wp-calypso/assets/18016357/aa68b1c2-b1e6-4314-884a-6a7518686d98)
* Confirm that you do NOT see the survey again when removing the product

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
