### PR TITLE
Line clamp inline comments in collapsed mode.

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -421,6 +421,18 @@ class PostCommentList extends Component {
 				? translate( 'View more' )
 				: translate( 'View more comments' );
 
+		let viewFewerText = translate( 'View fewer comments' );
+		if ( this.state.isExpanded ) {
+			const { displayedCommentsCount: collapsedDisplayedCommentsCount } =
+				this.getDisplayedCollapsedInlineComments( commentsTreeToShow );
+
+			// If collapsing will not reduce the number of comments shown (only line-clamp them
+			// visually), display 'View less' instead of 'View fewer comments'.
+			if ( displayedCommentsCount === collapsedDisplayedCommentsCount ) {
+				viewFewerText = translate( 'View less' );
+			}
+		}
+
 		return (
 			<>
 				<ol className="comments__list is-root">
@@ -428,7 +440,7 @@ class PostCommentList extends Component {
 				</ol>
 				{ ( shouldShowViewMoreToggle || this.state.showExpandWhenOnlyComments ) && (
 					<button className="comments__toggle-expand" onClick={ this.toggleExpanded }>
-						{ this.state.isExpanded ? translate( 'View fewer comments' ) : viewMoreText }
+						{ this.state.isExpanded ? viewFewerText : viewMoreText }
 					</button>
 				) }
 				{ shouldShowLinkToFullPost && (

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -196,10 +196,12 @@ class PostCommentList extends Component {
 		// false or new comments have been posted. We avoid the setState loops by not running this
 		// check when the state it would set is already present.
 		if (
-			// The view has been collapsed, or the amount of comments have changed.
+			// The view is not expanded and has just been collapsed or the amount of comments have changed.
 			// Note more safety conditions are contained generally in checkForClampedComments.
-			prevState.isExpanded || // Current state isExpanded checked in function below.
-			Object.keys( prevProps.commentsTree ).length !== Object.keys( this.props.commentsTree ).length
+			! this.state.isExpanded &&
+			( prevState.isExpanded ||
+				Object.keys( prevProps.commentsTree ).length !==
+					Object.keys( this.props.commentsTree ).length )
 		) {
 			this.checkForClampedComments();
 		}
@@ -232,19 +234,24 @@ class PostCommentList extends Component {
 		) {
 			return;
 		}
+
 		// Query selector ALL since we might be showing the readers reply as well.
 		const commentContentEles = this.listRef.current.querySelectorAll(
 			'.comments__comment-content'
 		);
 		let isClampedComment = false;
+
 		// Check if either the comment or reply that might be shown are line clamped.
 		commentContentEles.forEach( ( comment ) => {
 			if ( comment.scrollHeight > comment.clientHeight ) {
 				isClampedComment = true;
 			}
 		} );
+
 		// There is no need to set false, as it already is false if this is running.
-		isClampedComment && this.setState( { showExpandWhenOnlyComments: true } );
+		if ( isClampedComment ) {
+			this.setState( { showExpandWhenOnlyComments: true } );
+		}
 	};
 
 	commentIsOnDOM = ( commentId ) => !! window.document.getElementById( `comment-${ commentId }` );

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -196,14 +196,10 @@ class PostCommentList extends Component {
 		// false or new comments have been posted. We avoid the setState loops by not running this
 		// check when the state it would set is already present.
 		if (
-			this.props.expandableView &&
-			! this.state.isExpanded &&
 			// The view has been collapsed, or the amount of comments have changed.
-			( prevState.isExpanded ||
-				Object.keys( prevProps.commentsTree ).length !==
-					Object.keys( this.props.commentsTree ).length ) &&
-			// showExpandWhenOnlyComments is not already true.
-			! this.state.showExpandWhenOnlyComments
+			// Note more safety conditions are contained generally in checkForClampedComments.
+			prevState.isExpanded ||
+			Object.keys( prevProps.commentsTree ).length !== Object.keys( this.props.commentsTree ).length
 		) {
 			this.checkForClampedComments();
 		}
@@ -223,17 +219,16 @@ class PostCommentList extends Component {
 		}
 	}
 
-	// Determines if CSS rules are line-clamping displayed comments in inline-collapsed mode
-	// (expandableView and ! isExpanded) so that a 'view more' link to expand can be displayed when
-	// necessary.
 	checkForClampedComments = () => {
-		// Return early if showExpandWhenOnlyComments is already set true in state to make this safe for
-		// componentDidUpdate. Return early if we have no listRef to query, or the list is expanded
-		// and not line clamping in the first place.
 		if (
+			// This check isnt necessary if we arent in expandableView or are expanded.
+			! this.props.expandableView ||
+			this.state.isExpanded ||
+			// Bail early if there is no listRef to query.
 			! this.listRef.current ||
-			this.state.showExpandWhenOnlyComments ||
-			this.state.isExpanded
+			// Bail early if this state is already flagged, avoids setState loops in methods like
+			// componentDidUpdate.
+			this.state.showExpandWhenOnlyComments
 		) {
 			return;
 		}

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -103,7 +103,7 @@ class PostCommentList extends Component {
 		amountOfCommentsToTake: this.props.initialSize,
 		commentText: '',
 		isExpanded: false,
-		hasClampedComments: false,
+		showExpandWhenOnlyComments: false,
 	};
 
 	shouldFetchInitialComment = () => {
@@ -202,8 +202,8 @@ class PostCommentList extends Component {
 			( prevState.isExpanded ||
 				Object.keys( prevProps.commentsTree ).length !==
 					Object.keys( this.props.commentsTree ).length ) &&
-			// hasClampedComments is not already true.
-			! this.state.hasClampedComments
+			// showExpandWhenOnlyComments is not already true.
+			! this.state.showExpandWhenOnlyComments
 		) {
 			this.checkForClampedComments();
 		}
@@ -227,10 +227,14 @@ class PostCommentList extends Component {
 	// (expandableView and ! isExpanded) so that a 'view more' link to expand can be displayed when
 	// necessary.
 	checkForClampedComments = () => {
-		// Return early if hasClampedComments is already set true in state to make this safe for
+		// Return early if showExpandWhenOnlyComments is already set true in state to make this safe for
 		// componentDidUpdate. Return early if we have no listRef to query, or the list is expanded
 		// and not line clamping in the first place.
-		if ( ! this.listRef.current || this.state.hasClampedComments || this.state.isExpanded ) {
+		if (
+			! this.listRef.current ||
+			this.state.showExpandWhenOnlyComments ||
+			this.state.isExpanded
+		) {
 			return;
 		}
 		// Query selector ALL since we might be showing the readers reply as well.
@@ -245,7 +249,7 @@ class PostCommentList extends Component {
 			}
 		} );
 		// There is no need to set false, as it already is false if this is running.
-		isClampedComment && this.setState( { hasClampedComments: true } );
+		isClampedComment && this.setState( { showExpandWhenOnlyComments: true } );
 	};
 
 	commentIsOnDOM = ( commentId ) => !! window.document.getElementById( `comment-${ commentId }` );
@@ -371,7 +375,7 @@ class PostCommentList extends Component {
 				this.maybeScrollToListTop();
 			}
 
-			this.setState( { isExpanded: ! this.state.isExpanded, hasClampedComments: false } );
+			this.setState( { isExpanded: ! this.state.isExpanded } );
 		}
 	};
 
@@ -411,7 +415,7 @@ class PostCommentList extends Component {
 			displayedCommentsCount < actualCommentsCount;
 
 		const viewMoreText =
-			! shouldShowViewMoreToggle && this.state.hasClampedComments
+			! shouldShowViewMoreToggle && this.state.showExpandWhenOnlyComments
 				? translate( 'View more' )
 				: translate( 'View more comments' );
 
@@ -420,7 +424,7 @@ class PostCommentList extends Component {
 				<ol className="comments__list is-root">
 					{ commentIds.map( ( commentId ) => this.renderComment( commentId, commentsTreeToShow ) ) }
 				</ol>
-				{ ( shouldShowViewMoreToggle || this.state.hasClampedComments ) && (
+				{ ( shouldShowViewMoreToggle || this.state.showExpandWhenOnlyComments ) && (
 					<button className="comments__toggle-expand" onClick={ this.toggleExpanded }>
 						{ this.state.isExpanded ? translate( 'View fewer comments' ) : viewMoreText }
 					</button>

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -198,7 +198,7 @@ class PostCommentList extends Component {
 		if (
 			// The view has been collapsed, or the amount of comments have changed.
 			// Note more safety conditions are contained generally in checkForClampedComments.
-			prevState.isExpanded ||
+			prevState.isExpanded || // Current state isExpanded checked in function below.
 			Object.keys( prevProps.commentsTree ).length !== Object.keys( this.props.commentsTree ).length
 		) {
 			this.checkForClampedComments();

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -56,6 +56,15 @@
 	.comments__form .form-fieldset {
 		margin: 0;
 	}
+
+	&.is-inline.is-collapsed {
+		.comments__comment-content {
+			display: -webkit-box;
+			overflow: hidden;
+			-webkit-box-orient: vertical;
+			-webkit-line-clamp: 1;
+		}
+	}
 }
 
 .comments__info-bar {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Line clamps collapsed inline comments to 1 line:

![line-clamp-good](https://github.com/Automattic/wp-calypso/assets/28742426/539e7d18-55c0-4f7b-b436-d5990689f66a)

Translations: Use of new "View more" and "View less" shown here:
![view-less](https://github.com/Automattic/wp-calypso/assets/28742426/92ec5a41-917f-4ff9-bbc5-cbc9e22a9c78)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
