### PR TITLE
Newsletter Categories: Add tests for Newsletter Categories components

### DIFF
--- a/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
+++ b/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
@@ -33,6 +33,7 @@ const NewsletterCategoriesSettings = ( {
 			/>
 
 			<div
+				aria-hidden={ ! toggleValue }
 				className={ classNames( 'newsletter-categories-settings__term-tree-selector', {
 					hidden: ! toggleValue,
 				} ) }

--- a/client/my-sites/site-settings/newsletter-categories-settings/test/newsletter-categories-settings.test.tsx
+++ b/client/my-sites/site-settings/newsletter-categories-settings/test/newsletter-categories-settings.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, fireEvent } from '@testing-library/react';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import { useSelector } from 'calypso/state';
+import { NewsletterCategoriesSettings } from '..';
+import { NEWSLETTER_CATEGORIES_ENABLED_OPTION } from '../newsletter-categories-toggle';
+import useNewsletterCategoriesSettings from '../use-newsletter-categories-settings';
+
+jest.mock( 'i18n-calypso' );
+jest.mock( 'calypso/state' );
+jest.mock( '../use-newsletter-categories-settings' );
+jest.mock( 'calypso/blocks/term-tree-selector', () => () => 'MockTermTreeSelector' );
+
+const mockSiteId = 123;
+
+describe( 'NewsletterCategoriesSettings', () => {
+	beforeEach( () => {
+		( useTranslate as jest.Mock ).mockReturnValue( ( text: string ) => text );
+		( useSelector as jest.Mock ).mockReturnValue( mockSiteId );
+		( useNewsletterCategoriesSettings as jest.Mock ).mockReturnValue( {
+			isSaving: false,
+			newsletterCategoryIds: [ 1, 2, 3 ],
+			handleCategoryToggle: jest.fn(),
+			handleSave: jest.fn(),
+		} );
+	} );
+
+	it( 'renders the toggle correctly', () => {
+		const { getByText } = render(
+			<NewsletterCategoriesSettings handleAutosavingToggle={ jest.fn() } />
+		);
+
+		expect( getByText( 'Enable newsletter categories' ) ).toBeInTheDocument();
+	} );
+
+	it( 'displays the term tree selector when toggleValue is true', () => {
+		const { getByText } = render(
+			<NewsletterCategoriesSettings toggleValue={ true } handleAutosavingToggle={ jest.fn() } />
+		);
+
+		expect( getByText( 'MockTermTreeSelector' ) ).toBeInTheDocument();
+		expect( getByText( 'MockTermTreeSelector' ) ).toHaveAttribute( 'aria-hidden', 'false' );
+		expect( getByText( 'Save settings' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the term tree selector when toggleValue is false', () => {
+		const { queryByText } = render(
+			<NewsletterCategoriesSettings toggleValue={ false } handleAutosavingToggle={ jest.fn() } />
+		);
+
+		expect( queryByText( 'MockTermTreeSelector' ) ).toHaveAttribute( 'aria-hidden', 'true' );
+	} );
+
+	it( 'calls handleAutosavingToggle correctly when toggled off', () => {
+		const mockHandleChange = jest.fn();
+		const mockHandleToggle = jest.fn().mockImplementation( () => mockHandleChange );
+		const { getByLabelText } = render(
+			<NewsletterCategoriesSettings
+				toggleValue={ true }
+				handleAutosavingToggle={ mockHandleToggle }
+			/>
+		);
+
+		fireEvent.click( getByLabelText( 'Enable newsletter categories' ) );
+
+		expect( mockHandleToggle ).toHaveBeenCalledWith( NEWSLETTER_CATEGORIES_ENABLED_OPTION );
+		expect( mockHandleChange ).toHaveBeenCalledWith( false );
+	} );
+
+	it( 'calls handleAutosavingToggle correctly when toggled on', () => {
+		const mockHandleChange = jest.fn();
+		const mockHandleToggle = jest.fn().mockImplementation( () => mockHandleChange );
+		const { getByLabelText } = render(
+			<NewsletterCategoriesSettings
+				toggleValue={ false }
+				handleAutosavingToggle={ mockHandleToggle }
+			/>
+		);
+
+		fireEvent.click( getByLabelText( 'Enable newsletter categories' ) );
+
+		expect( mockHandleToggle ).toHaveBeenCalledWith( NEWSLETTER_CATEGORIES_ENABLED_OPTION );
+		expect( mockHandleChange ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'calls handleSave when the save button is clicked', () => {
+		const handleNewsletterCategoriesSettings = useNewsletterCategoriesSettings( mockSiteId );
+
+		const { getByText } = render(
+			<NewsletterCategoriesSettings handleAutosavingToggle={ jest.fn() } />
+		);
+
+		fireEvent.click( getByText( 'Save settings' ) );
+
+		expect( handleNewsletterCategoriesSettings.handleSave ).toHaveBeenCalled();
+	} );
+} );

--- a/client/my-sites/site-settings/newsletter-categories-settings/test/newsletter-categories-toggle.test.tsx
+++ b/client/my-sites/site-settings/newsletter-categories-settings/test/newsletter-categories-toggle.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, fireEvent } from '@testing-library/react';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import NewsletterCategoriesToggle, {
+	NEWSLETTER_CATEGORIES_ENABLED_OPTION,
+} from '../newsletter-categories-toggle';
+
+jest.mock( 'i18n-calypso' );
+
+describe( 'NewsletterCategoriesToggle', () => {
+	beforeEach( () => {
+		( useTranslate as jest.Mock ).mockReturnValue( ( text: string ) => text );
+	} );
+
+	it( 'renders toggle control correctly with given value', () => {
+		const mockHandleToggle = jest.fn();
+		const { getByText } = render(
+			<NewsletterCategoriesToggle value={ true } handleAutosavingToggle={ mockHandleToggle } />
+		);
+
+		expect( getByText( 'Enable newsletter categories' ) ).toBeInTheDocument();
+	} );
+
+	it( 'calls handleAutosavingToggle correctly when toggled off', () => {
+		const mockHandleChange = jest.fn();
+		const mockHandleToggle = jest.fn().mockImplementation( () => mockHandleChange );
+		const { getByLabelText } = render(
+			<NewsletterCategoriesToggle value={ true } handleAutosavingToggle={ mockHandleToggle } />
+		);
+
+		fireEvent.click( getByLabelText( 'Enable newsletter categories' ) );
+
+		expect( mockHandleToggle ).toHaveBeenCalledWith( NEWSLETTER_CATEGORIES_ENABLED_OPTION );
+		expect( mockHandleChange ).toHaveBeenCalledWith( false );
+	} );
+
+	it( 'calls handleAutosavingToggle correctly when toggled on', () => {
+		const mockHandleChange = jest.fn();
+		const mockHandleToggle = jest.fn().mockImplementation( () => mockHandleChange );
+		const { getByLabelText } = render(
+			<NewsletterCategoriesToggle value={ false } handleAutosavingToggle={ mockHandleToggle } />
+		);
+
+		fireEvent.click( getByLabelText( 'Enable newsletter categories' ) );
+
+		expect( mockHandleToggle ).toHaveBeenCalledWith( NEWSLETTER_CATEGORIES_ENABLED_OPTION );
+		expect( mockHandleChange ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'disables toggle control when disabled prop is true', () => {
+		const mockHandleToggle = jest.fn().mockImplementation( () => () => undefined );
+		const { getByLabelText } = render(
+			<NewsletterCategoriesToggle
+				value={ true }
+				disabled={ true }
+				handleAutosavingToggle={ mockHandleToggle }
+			/>
+		);
+
+		const button = getByLabelText( 'Enable newsletter categories' );
+
+		expect( button ).toBeDisabled();
+	} );
+} );

--- a/client/my-sites/site-settings/newsletter-categories-settings/test/use-newsletter-categories-settings.test.tsx
+++ b/client/my-sites/site-settings/newsletter-categories-settings/test/use-newsletter-categories-settings.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
+import {
+	useMarkAsNewsletterCategoryMutation,
+	useNewsletterCategoriesQuery,
+	useUnmarkAsNewsletterCategoryMutation,
+} from 'calypso/data/newsletter-categories';
+import useNewsletterCategoriesSettings, {
+	convertToNewsletterCategory,
+} from '../use-newsletter-categories-settings';
+
+jest.mock( 'react-redux' );
+jest.mock( 'i18n-calypso' );
+jest.mock( 'calypso/data/newsletter-categories' );
+
+const mockSiteId = 123;
+
+const mockCategory1 = {
+	ID: 1,
+	description: 'Description 1',
+	feed_url: 'feed_url',
+	name: 'Category 1',
+	parent: 0,
+	post_count: 0,
+	slug: 'category-1',
+};
+
+const mockCategory2 = {
+	ID: 2,
+	description: 'Description 2',
+	feed_url: 'feed_url',
+	name: 'Category 2',
+	parent: 0,
+	post_count: 0,
+	slug: 'category-2',
+};
+
+const mockNewsletterCategory1 = convertToNewsletterCategory( mockCategory1 );
+
+describe( 'useNewsletterCategoriesSettings', () => {
+	beforeEach( () => {
+		( useDispatch as jest.Mock ).mockReturnValue( jest.fn() );
+		( useTranslate as jest.Mock ).mockReturnValue( ( text: string ) => text );
+		( useNewsletterCategoriesQuery as jest.Mock ).mockReturnValue( {
+			data: { newsletterCategories: [] },
+			isLoading: true,
+		} );
+		( useMarkAsNewsletterCategoryMutation as jest.Mock ).mockReturnValue( {
+			mutateAsync: jest.fn().mockResolvedValue( null ),
+			isLoading: false,
+		} );
+		( useUnmarkAsNewsletterCategoryMutation as jest.Mock ).mockReturnValue( {
+			mutateAsync: jest.fn().mockResolvedValue( null ),
+			isLoading: false,
+		} );
+	} );
+
+	it( 'returns isLoading correctly', () => {
+		const { result } = renderHook( () => useNewsletterCategoriesSettings( mockSiteId ) );
+
+		expect( result.current.isLoading ).toBe( true );
+	} );
+
+	it( 'handles category toggle correctly', () => {
+		const { result } = renderHook( () => useNewsletterCategoriesSettings( mockSiteId ) );
+
+		act( () => {
+			result.current.handleCategoryToggle( mockCategory1 );
+		} );
+
+		expect( result.current.newsletterCategories ).toEqual( [
+			expect.objectContaining( { id: mockCategory1.ID } ),
+		] );
+	} );
+
+	it( 'handles save correctly for marking and unmarking categories', async () => {
+		( useNewsletterCategoriesQuery as jest.Mock ).mockReturnValue( {
+			data: { newsletterCategories: [ mockNewsletterCategory1 ] },
+			isLoading: false,
+		} );
+
+		const { result } = renderHook( () => useNewsletterCategoriesSettings( mockSiteId ) );
+
+		// Toggle off category 1.
+		act( () => {
+			result.current.handleCategoryToggle( mockCategory1 );
+		} );
+
+		// Toggle on category 2.
+		act( () => {
+			result.current.handleCategoryToggle( mockCategory2 );
+		} );
+
+		await act( async () => {
+			result.current.handleSave();
+		} );
+
+		const markMutation = useMarkAsNewsletterCategoryMutation( mockSiteId );
+		const unmarkMutation = useUnmarkAsNewsletterCategoryMutation( mockSiteId );
+
+		expect( unmarkMutation.mutateAsync ).toHaveBeenCalledWith( 1 );
+		expect( markMutation.mutateAsync ).toHaveBeenCalledWith( 2 );
+	} );
+} );

--- a/client/my-sites/site-settings/newsletter-categories-settings/use-newsletter-categories-settings.ts
+++ b/client/my-sites/site-settings/newsletter-categories-settings/use-newsletter-categories-settings.ts
@@ -19,7 +19,7 @@ type Category = {
 	slug: string;
 };
 
-const convertToNewsletterCategory = ( category: Category ): NewsletterCategory => ( {
+export const convertToNewsletterCategory = ( category: Category ): NewsletterCategory => ( {
 	id: category.ID,
 	name: category.name,
 	slug: category.slug,


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80728
Related to https://github.com/Automattic/wp-calypso/issues/80578

## Proposed Changes

* Add tests for `NewsletterCategoriesSettings`, `NewsletterCategoriesToggle`, and `useNewsletterCategoriesSettings`

## Testing Instructions

* Apply this PR to your local env
* Run `yarn test-client client/my-sites/site-settings/newsletter-categories-settings/test`
* Verify if all the tests passed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
