### PR TITLE
Checkout: Display noticeable error message when credit card fields incomplete

### DIFF
--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -53,9 +53,8 @@ export default function CreditCardPayButton( {
 	const [ displayError, setDisplayError ] = useState( '' );
 	const reduxDispatch = useDispatch();
 	useEffect( () => {
-		document.body.scrollTop = document.documentElement.scrollTop = 0;
-
 		if ( displayError ) {
+			document.body.scrollTop = document.documentElement.scrollTop = 0;
 			reduxDispatch( errorNotice( displayError ) );
 		}
 	}, [ displayError ] );
@@ -69,65 +68,63 @@ export default function CreditCardPayButton( {
 	}
 
 	return (
-		<>
-			<Button
-				disabled={ disabled }
-				onClick={ () => {
-					if ( isCreditCardFormValid( store, paymentPartner, __, setDisplayError ) ) {
-						if ( paymentPartner === 'stripe' ) {
-							debug( 'submitting stripe payment' );
-							onClick( {
-								stripe,
-								name: cardholderName?.value,
-								stripeConfiguration,
-								cardNumberElement,
-								paymentPartner,
-								countryCode: fields?.countryCode?.value ?? '',
-								postalCode: fields?.postalCode?.value ?? '',
-								state: fields?.state?.value,
-								city: fields?.city?.value,
-								organization: fields?.organization?.value,
-								address: fields?.address1?.value,
-								useForAllSubscriptions,
-								eventSource: 'checkout',
-							} );
-							return;
-						}
-						if ( paymentPartner === 'ebanx' ) {
-							debug( 'submitting ebanx payment' );
-							onClick( {
-								name: cardholderName?.value || '',
-								countryCode: fields?.countryCode?.value || '',
-								number: fields?.number?.value?.replace( /\s+/g, '' ) || '',
-								cvv: fields?.cvv?.value || '',
-								'expiration-date': fields[ 'expiration-date' ]?.value || '',
-								state: fields?.state?.value || '',
-								city: fields?.city?.value || '',
-								postalCode: fields[ 'postal-code' ]?.value || '',
-								address: fields[ 'address-1' ]?.value || '',
-								streetNumber: fields[ 'street-number' ]?.value || '',
-								phoneNumber: fields[ 'phone-number' ]?.value || '',
-								document: fields?.document?.value || '', // Taxpayer Identification Number
-								paymentPartner,
-							} );
-							return;
-						}
-						throw new Error(
-							'Unrecognized payment partner in submit handler: "' + paymentPartner + '"'
-						);
+		<Button
+			disabled={ disabled }
+			onClick={ () => {
+				if ( isCreditCardFormValid( store, paymentPartner, __, setDisplayError ) ) {
+					if ( paymentPartner === 'stripe' ) {
+						debug( 'submitting stripe payment' );
+						onClick( {
+							stripe,
+							name: cardholderName?.value,
+							stripeConfiguration,
+							cardNumberElement,
+							paymentPartner,
+							countryCode: fields?.countryCode?.value ?? '',
+							postalCode: fields?.postalCode?.value ?? '',
+							state: fields?.state?.value,
+							city: fields?.city?.value,
+							organization: fields?.organization?.value,
+							address: fields?.address1?.value,
+							useForAllSubscriptions,
+							eventSource: 'checkout',
+						} );
+						return;
 					}
-				} }
-				buttonType="primary"
-				isBusy={ FormStatus.SUBMITTING === formStatus }
-				fullWidth
-			>
-				<ButtonContents
-					formStatus={ formStatus }
-					total={ total }
-					activeButtonText={ activeButtonText }
-				/>
-			</Button>
-		</>
+					if ( paymentPartner === 'ebanx' ) {
+						debug( 'submitting ebanx payment' );
+						onClick( {
+							name: cardholderName?.value || '',
+							countryCode: fields?.countryCode?.value || '',
+							number: fields?.number?.value?.replace( /\s+/g, '' ) || '',
+							cvv: fields?.cvv?.value || '',
+							'expiration-date': fields[ 'expiration-date' ]?.value || '',
+							state: fields?.state?.value || '',
+							city: fields?.city?.value || '',
+							postalCode: fields[ 'postal-code' ]?.value || '',
+							address: fields[ 'address-1' ]?.value || '',
+							streetNumber: fields[ 'street-number' ]?.value || '',
+							phoneNumber: fields[ 'phone-number' ]?.value || '',
+							document: fields?.document?.value || '', // Taxpayer Identification Number
+							paymentPartner,
+						} );
+						return;
+					}
+					throw new Error(
+						'Unrecognized payment partner in submit handler: "' + paymentPartner + '"'
+					);
+				}
+			} }
+			buttonType="primary"
+			isBusy={ FormStatus.SUBMITTING === formStatus }
+			fullWidth
+		>
+			<ButtonContents
+				formStatus={ formStatus }
+				total={ total }
+				activeButtonText={ activeButtonText }
+			/>
+		</Button>
 	);
 }
 

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -190,6 +190,12 @@ function isCreditCardFormValid(
 ) {
 	debug( 'validating credit card fields for partner', paymentPartner );
 
+	function setFieldsError() {
+		setDisplayFieldsError(
+			__( 'Something seems to be missing — please fill out all the required fields.' )
+		);
+	}
+
 	switch ( paymentPartner ) {
 		case 'stripe': {
 			const fields = selectors.getFields( store.getState() );
@@ -198,9 +204,7 @@ function isCreditCardFormValid(
 				// Touch the field so it displays a validation error
 				store.dispatch( actions.setFieldValue( 'cardholderName', '' ) );
 				store.dispatch( actions.setFieldError( 'cardholderName', __( 'This field is required' ) ) );
-				setDisplayFieldsError(
-					__( 'Something seems to be missing — please fill out all the required fields.' )
-				);
+				setFieldsError();
 			}
 			const errors = selectors.getCardDataErrors( store.getState() );
 			const incompleteFieldKeys = selectors.getIncompleteFieldKeys( store.getState() );
@@ -211,9 +215,7 @@ function isCreditCardFormValid(
 				incompleteFieldKeys.map( ( key ) =>
 					store.dispatch( actions.setCardDataError( key, __( 'This field is required' ) ) )
 				);
-				setDisplayFieldsError(
-					__( 'Something seems to be missing — please fill out all the required fields.' )
-				);
+				setFieldsError();
 			}
 			if ( areThereErrors || ! cardholderName?.value.length || incompleteFieldKeys.length > 0 ) {
 				debug( 'card info is not valid', { errors, incompleteFieldKeys, cardholderName } );

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -75,63 +75,65 @@ export default function CreditCardPayButton( {
 	}
 
 	return (
-		<Button
-			disabled={ disabled }
-			onClick={ () => {
-				if ( isCreditCardFormValid( store, paymentPartner, __, setDisplayError ) ) {
-					if ( paymentPartner === 'stripe' ) {
-						debug( 'submitting stripe payment' );
-						onClick( {
-							stripe,
-							name: cardholderName?.value,
-							stripeConfiguration,
-							cardNumberElement,
-							paymentPartner,
-							countryCode: fields?.countryCode?.value ?? '',
-							postalCode: fields?.postalCode?.value ?? '',
-							state: fields?.state?.value,
-							city: fields?.city?.value,
-							organization: fields?.organization?.value,
-							address: fields?.address1?.value,
-							useForAllSubscriptions,
-							eventSource: 'checkout',
-						} );
-						return;
+		<>
+			<Button
+				disabled={ disabled }
+				onClick={ () => {
+					if ( isCreditCardFormValid( store, paymentPartner, __, setDisplayError ) ) {
+						if ( paymentPartner === 'stripe' ) {
+							debug( 'submitting stripe payment' );
+							onClick( {
+								stripe,
+								name: cardholderName?.value,
+								stripeConfiguration,
+								cardNumberElement,
+								paymentPartner,
+								countryCode: fields?.countryCode?.value ?? '',
+								postalCode: fields?.postalCode?.value ?? '',
+								state: fields?.state?.value,
+								city: fields?.city?.value,
+								organization: fields?.organization?.value,
+								address: fields?.address1?.value,
+								useForAllSubscriptions,
+								eventSource: 'checkout',
+							} );
+							return;
+						}
+						if ( paymentPartner === 'ebanx' ) {
+							debug( 'submitting ebanx payment' );
+							onClick( {
+								name: cardholderName?.value || '',
+								countryCode: fields?.countryCode?.value || '',
+								number: fields?.number?.value?.replace( /\s+/g, '' ) || '',
+								cvv: fields?.cvv?.value || '',
+								'expiration-date': fields[ 'expiration-date' ]?.value || '',
+								state: fields?.state?.value || '',
+								city: fields?.city?.value || '',
+								postalCode: fields[ 'postal-code' ]?.value || '',
+								address: fields[ 'address-1' ]?.value || '',
+								streetNumber: fields[ 'street-number' ]?.value || '',
+								phoneNumber: fields[ 'phone-number' ]?.value || '',
+								document: fields?.document?.value || '', // Taxpayer Identification Number
+								paymentPartner,
+							} );
+							return;
+						}
+						throw new Error(
+							'Unrecognized payment partner in submit handler: "' + paymentPartner + '"'
+						);
 					}
-					if ( paymentPartner === 'ebanx' ) {
-						debug( 'submitting ebanx payment' );
-						onClick( {
-							name: cardholderName?.value || '',
-							countryCode: fields?.countryCode?.value || '',
-							number: fields?.number?.value?.replace( /\s+/g, '' ) || '',
-							cvv: fields?.cvv?.value || '',
-							'expiration-date': fields[ 'expiration-date' ]?.value || '',
-							state: fields?.state?.value || '',
-							city: fields?.city?.value || '',
-							postalCode: fields[ 'postal-code' ]?.value || '',
-							address: fields[ 'address-1' ]?.value || '',
-							streetNumber: fields[ 'street-number' ]?.value || '',
-							phoneNumber: fields[ 'phone-number' ]?.value || '',
-							document: fields?.document?.value || '', // Taxpayer Identification Number
-							paymentPartner,
-						} );
-						return;
-					}
-					throw new Error(
-						'Unrecognized payment partner in submit handler: "' + paymentPartner + '"'
-					);
-				}
-			} }
-			buttonType="primary"
-			isBusy={ FormStatus.SUBMITTING === formStatus }
-			fullWidth
-		>
-			<ButtonContents
-				formStatus={ formStatus }
-				total={ total }
-				activeButtonText={ activeButtonText }
-			/>
-		</Button>
+				} }
+				buttonType="primary"
+				isBusy={ FormStatus.SUBMITTING === formStatus }
+				fullWidth
+			>
+				<ButtonContents
+					formStatus={ formStatus }
+					total={ total }
+					activeButtonText={ activeButtonText }
+				/>
+			</Button>
+		</>
 	);
 }
 

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -8,6 +8,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
 import MaterialIcon from 'calypso/components/material-icon';
+import Notice from 'calypso/components/notice';
 import { validatePaymentDetails } from 'calypso/lib/checkout/validation';
 import { actions, selectors } from './store';
 import type { WpcomCreditCardSelectors } from './store';
@@ -17,13 +18,15 @@ import type { ReactNode } from 'react';
 
 const debug = debugFactory( 'calypso:credit-card' );
 
-function showError( error: string ) {
+const showError = ( error: string ) => {
+	document.body.scrollTop = document.documentElement.scrollTop = 0;
+
 	return (
-		<div className="error">
-			<p>{ error }</p>
-		</div>
+		<Notice status="is-error" icon="mention">
+			{ error }
+		</Notice>
 	);
-}
+};
 
 export default function CreditCardPayButton( {
 	disabled,
@@ -201,6 +204,7 @@ function isCreditCardFormValid(
 				// Touch the field so it displays a validation error
 				store.dispatch( actions.setFieldValue( 'cardholderName', '' ) );
 				store.dispatch( actions.setFieldError( 'cardholderName', __( 'This field is required' ) ) );
+				setDisplayError( 'Please fill out all required fields' );
 			}
 			const errors = selectors.getCardDataErrors( store.getState() );
 			const incompleteFieldKeys = selectors.getIncompleteFieldKeys( store.getState() );
@@ -211,8 +215,7 @@ function isCreditCardFormValid(
 				incompleteFieldKeys.map( ( key ) =>
 					store.dispatch( actions.setCardDataError( key, __( 'This field is required' ) ) )
 				);
-				document.body.scrollTop = document.documentElement.scrollTop = 0;
-				setDisplayError( __( 'Please fill out all required fields' ) );
+				setDisplayError( 'Please fill out all required fields' );
 			}
 			if ( areThereErrors || ! cardholderName?.value.length || incompleteFieldKeys.length > 0 ) {
 				debug( 'card info is not valid', { errors, incompleteFieldKeys, cardholderName } );

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -198,6 +198,7 @@ function isCreditCardFormValid(
 			}
 			if ( areThereErrors || ! cardholderName?.value.length || incompleteFieldKeys.length > 0 ) {
 				debug( 'card info is not valid', { errors, incompleteFieldKeys, cardholderName } );
+
 				return false;
 			}
 			return true;

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -7,9 +7,10 @@ import { useState, useEffect } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
+import { useDispatch } from 'react-redux';
 import MaterialIcon from 'calypso/components/material-icon';
-import Notice from 'calypso/components/notice';
 import { validatePaymentDetails } from 'calypso/lib/checkout/validation';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { actions, selectors } from './store';
 import type { WpcomCreditCardSelectors } from './store';
 import type { CardFieldState, CardStoreType } from './types';
@@ -17,16 +18,6 @@ import type { ProcessPayment, LineItem } from '@automattic/composite-checkout';
 import type { ReactNode } from 'react';
 
 const debug = debugFactory( 'calypso:credit-card' );
-
-const showError = ( error: string ) => {
-	document.body.scrollTop = document.documentElement.scrollTop = 0;
-
-	return (
-		<Notice status="is-error" icon="mention">
-			{ error }
-		</Notice>
-	);
-};
 
 export default function CreditCardPayButton( {
 	disabled,
@@ -60,11 +51,14 @@ export default function CreditCardPayButton( {
 	const cardNumberElement = elements?.getElement( CardNumberElement ) ?? undefined;
 
 	const [ displayError, setDisplayError ] = useState( '' );
-
+	const reduxDispatch = useDispatch();
 	useEffect( () => {
-		showError( displayError );
-	}, [ displayError ] );
+		document.body.scrollTop = document.documentElement.scrollTop = 0;
 
+		if ( displayError ) {
+			reduxDispatch( errorNotice( displayError ) );
+		}
+	}, [ displayError ] );
 	// This must be typed as optional because it's injected by cloning the
 	// element in CheckoutSubmitButton, but the uncloned element does not have
 	// this prop yet.

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -50,14 +50,15 @@ export default function CreditCardPayButton( {
 	const elements = useElements();
 	const cardNumberElement = elements?.getElement( CardNumberElement ) ?? undefined;
 
-	const [ displayError, setDisplayError ] = useState( '' );
+	const [ displayFieldsError, setDisplayFieldsError ] = useState( '' );
 	const reduxDispatch = useDispatch();
 	useEffect( () => {
-		if ( displayError ) {
+		if ( displayFieldsError ) {
 			document.body.scrollTop = document.documentElement.scrollTop = 0;
-			reduxDispatch( errorNotice( displayError ) );
+			reduxDispatch( errorNotice( displayFieldsError ) );
+			setDisplayFieldsError( '' );
 		}
-	}, [ displayError ] );
+	}, [ displayFieldsError ] );
 	// This must be typed as optional because it's injected by cloning the
 	// element in CheckoutSubmitButton, but the uncloned element does not have
 	// this prop yet.
@@ -71,7 +72,7 @@ export default function CreditCardPayButton( {
 		<Button
 			disabled={ disabled }
 			onClick={ () => {
-				if ( isCreditCardFormValid( store, paymentPartner, __, setDisplayError ) ) {
+				if ( isCreditCardFormValid( store, paymentPartner, __, setDisplayFieldsError ) ) {
 					if ( paymentPartner === 'stripe' ) {
 						debug( 'submitting stripe payment' );
 						onClick( {
@@ -185,7 +186,7 @@ function isCreditCardFormValid(
 	store: CardStoreType,
 	paymentPartner: string,
 	__: ( value: string ) => string,
-	setDisplayError: ( value: string ) => void
+	setDisplayFieldsError: ( value: string ) => void
 ) {
 	debug( 'validating credit card fields for partner', paymentPartner );
 
@@ -197,7 +198,9 @@ function isCreditCardFormValid(
 				// Touch the field so it displays a validation error
 				store.dispatch( actions.setFieldValue( 'cardholderName', '' ) );
 				store.dispatch( actions.setFieldError( 'cardholderName', __( 'This field is required' ) ) );
-				setDisplayError( 'Please fill out all required fields' );
+				setDisplayFieldsError(
+					__( 'Something seems to be missing — please fill out all the required fields.' )
+				);
 			}
 			const errors = selectors.getCardDataErrors( store.getState() );
 			const incompleteFieldKeys = selectors.getIncompleteFieldKeys( store.getState() );
@@ -208,7 +211,9 @@ function isCreditCardFormValid(
 				incompleteFieldKeys.map( ( key ) =>
 					store.dispatch( actions.setCardDataError( key, __( 'This field is required' ) ) )
 				);
-				setDisplayError( 'Please fill out all required fields' );
+				setDisplayFieldsError(
+					__( 'Something seems to be missing — please fill out all the required fields.' )
+				);
 			}
 			if ( areThereErrors || ! cardholderName?.value.length || incompleteFieldKeys.length > 0 ) {
 				debug( 'card info is not valid', { errors, incompleteFieldKeys, cardholderName } );

--- a/client/my-sites/checkout/src/payment-methods/credit-card/store.ts
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/store.ts
@@ -53,10 +53,6 @@ export const selectors = {
 			( key ) => ! state.cardDataComplete[ key as CardElementType ]
 		) as CardElementType[];
 	},
-	getFirstIncompleteFieldKey( state: CardStoreState ): CardElementType | null {
-		const incompleteFieldKeys = selectors.getIncompleteFieldKeys( state );
-		return incompleteFieldKeys[ 0 ] || null;
-	},
 	getFields( state: CardStoreState ) {
 		return state.fields;
 	},

--- a/client/my-sites/checkout/src/payment-methods/credit-card/store.ts
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/store.ts
@@ -53,6 +53,10 @@ export const selectors = {
 			( key ) => ! state.cardDataComplete[ key as CardElementType ]
 		) as CardElementType[];
 	},
+	getFirstIncompleteFieldKey( state: CardStoreState ): CardElementType | null {
+		const incompleteFieldKeys = selectors.getIncompleteFieldKeys( state );
+		return incompleteFieldKeys[ 0 ] || null;
+	},
 	getFields( state: CardStoreState ) {
 		return state.fields;
 	},

--- a/client/my-sites/checkout/src/test/credit-card.tsx
+++ b/client/my-sites/checkout/src/test/credit-card.tsx
@@ -172,7 +172,5 @@ describe( 'Credit card payment method', () => {
 		await waitFor( () => {
 			expect( screen.getByText( /Something seems to be missing/i ) );
 		} );
-		// For debugging
-		screen.debug();
 	} );
 } );

--- a/client/my-sites/checkout/src/test/credit-card.tsx
+++ b/client/my-sites/checkout/src/test/credit-card.tsx
@@ -21,6 +21,7 @@ import {
 	createCreditCardMethod,
 } from 'calypso/my-sites/checkout/src/payment-methods/credit-card';
 import { actions } from 'calypso/my-sites/checkout/src/payment-methods/credit-card/store';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { createTestReduxStore, fetchStripeConfiguration, stripeConfiguration } from './util';
 import type { CardStoreType } from 'calypso/my-sites/checkout/src/payment-methods/credit-card/types';
 
@@ -67,7 +68,18 @@ function ResetCreditCardStoreFields() {
 	} );
 }
 
+jest.mock( 'calypso/state/notices/actions' );
+
 describe( 'Credit card payment method', () => {
+	beforeEach( () => {
+		( errorNotice as jest.Mock ).mockImplementation( ( value ) => {
+			return {
+				type: 'errorNotice',
+				value,
+			};
+		} );
+	} );
+
 	it( 'renders a credit card option', async () => {
 		const store = createCreditCardPaymentMethodStore( {} );
 		const paymentMethod = getPaymentMethod( store );
@@ -169,8 +181,8 @@ describe( 'Credit card payment method', () => {
 		await user.click( await screen.findByText( activePayButtonText ) );
 
 		// Verify the error message overlay appears
-		await waitFor( () => {
-			expect( screen.getByText( /Something seems to be missing/i ) );
-		} );
+		expect( errorNotice ).toHaveBeenCalledWith(
+			expect.stringMatching( /Something seems to be missing/ )
+		);
 	} );
 } );

--- a/client/my-sites/checkout/src/test/util/index.ts
+++ b/client/my-sites/checkout/src/test/util/index.ts
@@ -10,6 +10,7 @@ import nock from 'nock';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import domainManagementReducer from 'calypso/state/domains/management/reducer';
+import noticesReducer from 'calypso/state/notices/reducer';
 import type { PricedAPIPlan, StorePlanSlug } from '@automattic/data-stores';
 import type {
 	CartKey,
@@ -1559,6 +1560,7 @@ export function createTestReduxStore() {
 	const rootReducer = ( state, action ) => {
 		return {
 			...state,
+			notices: noticesReducer( state, action ),
 			plans: {
 				items: getPlansItemsState(),
 			},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Summary:

When the "Credit or debit card" payment method is selected, if the user ignores the credit card data fields and clicks the submit button, no dramatic error is displayed (and the button is not disabled). Instead, small "This field is required" errors are shown underneath each required field. However, these errors may not be easily visible if the user has scrolled down far enough especially if there is a lot of TOS.

Related to https://github.com/Automattic/wp-calypso/issues/79371

## Proposed Changes

1. When such a situation occurs, perform a scroll up to the top of the window
2. Display a more explicit error message until the credit cards fields are field in as expected like this: 

### Desktop:

![Y7ylv4.png](https://github.com/Automattic/wp-calypso/assets/552016/b358d9ee-7fda-4b33-bbdc-dd98c2c1b37d)

### Mobile:

![2qtiKT.png](https://github.com/Automattic/wp-calypso/assets/552016/b5fd6118-948c-4eb2-bc13-eb53a42eea3b)


## Testing Instructions

1. Apply this patch and switch to sandbox mode
2. Add a plan to cart and arrive at the checkout page.
4. Under the `Pick a payment method` section, select `Credit or debit card`
5. Proceed to fill out but leave out one of the credit card fields: Cardholder name, Card number, Expiry date and security code.
6. Click the blue `Pay` button below
7. The Page should scroll up and you should see a error notice `Something seems to be missing — please fill out all the required fields.`
8. You could empty out another field and test again to see the same flow until all four of the credit card fields are filled.
9. Check dev console for any console errors.
                                                                                                                    

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?