### PR TITLE
Design Picker: Update theme screenshot distance from the description on mobile screens

### DIFF
--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -41,10 +41,11 @@ $design-preview-sidebar-width: 311px;
 		border: 10px solid var(--color-print);
 		border-radius: 40px; /* stylelint-disable-line scales/radii */
 		margin-bottom: 70px;
-		margin-top: 60px;
+		margin-top: 0;
 
 		@include break-large {
 			margin-bottom: 0;
+			margin-top: 60px;
 		}
 
 		.design-preview__screenshot {


### PR DESCRIPTION


## Proposed Changes

Design Picker: Update theme screenshot distance from the description on mobile screens

## Testing Instructions
* Apply the diff D118900-code to your sandbox and direct requests to the sandbox
* Go to the Design Picker page with a Marketplace theme selected `/setup/update-design/designSetup?siteSlug=:site&theme=:theme_slug`. Theme slugs such as `makoney`, `macchiato` and `olsen-fse` can be used.
* Check the mobile version of the screen
* The distance from the description should be smaller than the prod version

| Before  | After |
| ------------- | ------------- |
|<img width="661" alt="CleanShot 2023-08-25 at 19 42 03@2x" src="https://github.com/Automattic/wp-calypso/assets/5039531/f18086a2-3792-490f-ad77-baf783e3cbd7">|
<img width="711" alt="CleanShot 2023-08-25 at 19 38 12@2x" src="https://github.com/Automattic/wp-calypso/assets/5039531/4e0af113-4204-4432-bb2a-780382b54034">|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
