### PR TITLE
Paid Stats: Pre-fill the purchase wizard based on the Personal site type

### DIFF
--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -26,6 +26,7 @@ import StatsPurchaseWizard, {
 	SCREEN_PURCHASE,
 	SCREEN_TYPE_SELECTION,
 	TYPE_COMMERCIAL,
+	TYPE_PERSONAL,
 } from './stats-purchase-wizard';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
@@ -109,6 +110,10 @@ const StatsPurchasePage = ( {
 		if ( isTypeDetectionEnabled ) {
 			if ( options.isCommercial && ! isCommercialOwned ) {
 				return [ SCREEN_PURCHASE, TYPE_COMMERCIAL ];
+			}
+			// If the site is detected as personal
+			else if ( options.isCommercial === false && ! isCommercialOwned ) {
+				return [ SCREEN_PURCHASE, TYPE_PERSONAL ];
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80848

## Proposed Changes

* Apply proper props for the purchase wizard to direct the user to a private site depending on the flag added in #80846

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the purchase page behaviour has not changed when no feature flag is applied
* Verify that the purchase page behaviour has changed for a personal page with stats/type-detection feature flag, and that it bypasses the option to choose personal or commercial and instead goes straight to personal. 
* Currently it's hard to test the flow because the detection has not yet been finalised - verify that for commercial pages the flow doesn't change or you are redirected straight to the commercial plan purchase screen

* You can force some variables in the code to test it, by passing variables from the controller and/or the stats purchase page. 
		
		To change the is_commercial value to false, modify In the controller, line 644:

			// const isCommercial = getSiteOption( context.store.getState(), givenSiteId, 'is_commercial' ); 
			const isCommercial = false

	To force the `stats/type-detection` you can use the feature flag, or if that config is not currently working then In the 				stats purchase page, line 52:

  			// const isTypeDetectionEnabled = config.isEnabled( 'stats/type-detection' );
 			 const isTypeDetectionEnabled = true;


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
