### PR TITLE
Earn: Fix missing numberFormat method

### DIFF
--- a/client/my-sites/earn/ads/payments.jsx
+++ b/client/my-sites/earn/ads/payments.jsx
@@ -1,6 +1,6 @@
 import { Badge, Card } from '@automattic/components';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import { numberFormat, useTranslate } from 'i18n-calypso';
 import QueryWordadsPayments from 'calypso/components/data/query-wordads-payments';
 import QueryWordadsSettings from 'calypso/components/data/query-wordads-settings';
 import Notice from 'calypso/components/notice';
@@ -10,7 +10,7 @@ import { getWordadsSettings } from 'calypso/state/selectors/get-wordads-settings
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getWordAdsPayments } from 'calypso/state/wordads/payments/selectors';
 
-const WordAdsPayments = ( { numberFormat } ) => {
+const WordAdsPayments = () => {
 	const translate = useTranslate();
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const payments = useSelector( ( state ) => getWordAdsPayments( state, siteId ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR fixes an issue introduced in https://github.com/Automattic/wp-calypso/pull/81034. When refactoring that component, I didn't realize one method, numberFormat, was being provided by the localize higher order component. I thought it was being provided to the component when invoked. This PR imports that method directly from i18n. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Checkout this branch and go to `http://calypso.localhost:3000/earn/YOURDOMAIN`
2) Test Ads pages to confirm they look and behave the same as before: 
   - If you haven't yet, find the Ads card and enable Ads. 
   - Click around on the ads dashboard and confirm everything loads as expect. 
   - Trying to Ads Dashboard > Settings and saving settings to confirm that works. 
3) Bonus: I don't have a personal site with ad revenue to check earning stats. I tested this by using the Switch to User functionality. I went to an active WordPress.com site with ads and confirmed totals still show. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
