### PR TITLE
Reader: Update linear gradient on excerpt only posts

### DIFF
--- a/client/components/post-excerpt/style.scss
+++ b/client/components/post-excerpt/style.scss
@@ -33,7 +33,7 @@
 			right: 0;
 			width: 50%;
 			height: 24px;
-			background: linear-gradient(to right, rgba(255, 255, 255, 0), var(--color-neutral-0) 50%);
+			background: linear-gradient(to right, rgba(var(--color-neutral-0-rgb), 0), var(--color-neutral-0) 50%);
 
 			@include breakpoint-deprecated( "<480px" ) {
 				height: 22px;

--- a/client/components/post-excerpt/style.scss
+++ b/client/components/post-excerpt/style.scss
@@ -33,7 +33,7 @@
 			right: 0;
 			width: 50%;
 			height: 24px;
-			background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 50%);
+			background: linear-gradient(to right, rgba(255, 255, 255, 0), var(--color-neutral-0) 50%);
 
 			@include breakpoint-deprecated( "<480px" ) {
 				height: 22px;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/81032

### Test instructions 

For an atomic site, set the *Settings/Reading/"For each post in the feed, include:"* setting to *Excerpt*.

Create a post with an excerpt and view it in the reader full post view.

e.g. https://wordpress.com/read/blogs/197699678/posts/68

The white shadow should be removed and the fade out should be smooth

