### PR TITLE
Jetpack E2E: new flow for the `Ad` block.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ad.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ad.ts
@@ -1,0 +1,54 @@
+import { BlockFlow, EditorContext, PublishedPostContext } from '.';
+
+type AdBlockFormat = 'Rectangle' | 'Leaderboard' | 'Mobile Leaderboard' | 'Wide Skyscraper';
+
+interface ConfigurationData {
+	format?: AdBlockFormat;
+}
+
+const blockParentSelector = 'div[aria-label="Block: Ad"]';
+
+/**
+ * Represents the flow of using an Ad block.
+ */
+export class AdFlow implements BlockFlow {
+	private configurationData: ConfigurationData;
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData data with which to configure and validate the block.
+	 */
+	constructor( configurationData: ConfigurationData ) {
+		this.configurationData = configurationData;
+	}
+
+	blockSidebarName = 'Ad';
+	blockEditorSelector = blockParentSelector;
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		// Nothing to configure on this block aside from the ad block size.
+		// Note, block smoke E2E tests do not call this codepath due to a mismatch in the
+		// accessible role of the menu items.
+		// @see: https://github.com/Automattic/jetpack/issues/32703
+		if ( this.configurationData.format ) {
+			await context.editorPage.clickBlockToolbarButton( { name: 'Pick an ad format' } );
+			await context.editorPage.selectFromToolbarPopover( this.configurationData.format );
+		}
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		// There should be a span with the text 'Advertisements' in place of the block.
+		await context.page.locator( '.wpa-about' ).filter( { hasText: 'Advertisements' } ).waitFor();
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -22,6 +22,7 @@ export * from './ai-assistant';
 export * from './donations-form';
 export * from './all-form-fields';
 export * from './form-patterns';
+export * from './ad';
 
 /* Types */
 export * from './types';

--- a/test/e2e/specs/blocks/blocks__jetpack-earn.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-earn.ts
@@ -15,25 +15,25 @@ import {
 import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
-	// new PayWithPaypalBlockFlow( {
-	// 	name: 'Test Paypal Block',
-	// 	price: 900,
-	// 	email: 'test@wordpress.com',
-	// } ),
-	// new OpenTableFlow( {
-	// 	restaurant: 'Miku Restaurant - Vancouver',
-	// } ),
-	// new DonationsFormFlow(
-	// 	{
-	// 		frequency: 'Yearly',
-	// 		currency: 'CAD',
-	// 	},
-	// 	{
-	// 		frequency: 'Yearly',
-	// 		customAmount: 50,
-	// 		predefinedAmount: 5,
-	// 	}
-	// ),
+	new PayWithPaypalBlockFlow( {
+		name: 'Test Paypal Block',
+		price: 900,
+		email: 'test@wordpress.com',
+	} ),
+	new OpenTableFlow( {
+		restaurant: 'Miku Restaurant - Vancouver',
+	} ),
+	new DonationsFormFlow(
+		{
+			frequency: 'Yearly',
+			currency: 'CAD',
+		},
+		{
+			frequency: 'Yearly',
+			customAmount: 50,
+			predefinedAmount: 5,
+		}
+	),
 ];
 
 // We're just skipping the Payments Button test for now due to this bug:
@@ -44,7 +44,9 @@ const blockFlows: BlockFlow[] = [
 // 	blockFlows.push( new PaymentsBlockFlow( { buttonText: 'Donate to Me' } ) );
 // }
 
-//
+// The Ad block is only available on more premium plans that imply AT.
+// Furthermore, private sites are not eligible to monetize due to the site
+// being, well, private.
 if (
 	envVariables.JETPACK_TARGET === 'wpcom-deployment' &&
 	envVariables.TEST_ON_ATOMIC === true &&

--- a/test/e2e/specs/blocks/blocks__jetpack-earn.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-earn.ts
@@ -47,6 +47,7 @@ const blockFlows: BlockFlow[] = [
 //
 if (
 	envVariables.JETPACK_TARGET === 'wpcom-deployment' &&
+	envVariables.TEST_ON_ATOMIC === true &&
 	envVariables.ATOMIC_VARIATION !== 'private'
 ) {
 	blockFlows.push( new AdFlow( {} ) );

--- a/test/e2e/specs/blocks/blocks__jetpack-earn.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-earn.ts
@@ -7,31 +7,33 @@ import {
 	PayWithPaypalBlockFlow,
 	OpenTableFlow,
 	DonationsFormFlow,
+	AdFlow,
+	envVariables,
 	// PaymentsBlockFlow,
 	// envVariables,
 } from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
-	new PayWithPaypalBlockFlow( {
-		name: 'Test Paypal Block',
-		price: 900,
-		email: 'test@wordpress.com',
-	} ),
-	new OpenTableFlow( {
-		restaurant: 'Miku Restaurant - Vancouver',
-	} ),
-	new DonationsFormFlow(
-		{
-			frequency: 'Yearly',
-			currency: 'CAD',
-		},
-		{
-			frequency: 'Yearly',
-			customAmount: 50,
-			predefinedAmount: 5,
-		}
-	),
+	// new PayWithPaypalBlockFlow( {
+	// 	name: 'Test Paypal Block',
+	// 	price: 900,
+	// 	email: 'test@wordpress.com',
+	// } ),
+	// new OpenTableFlow( {
+	// 	restaurant: 'Miku Restaurant - Vancouver',
+	// } ),
+	// new DonationsFormFlow(
+	// 	{
+	// 		frequency: 'Yearly',
+	// 		currency: 'CAD',
+	// 	},
+	// 	{
+	// 		frequency: 'Yearly',
+	// 		customAmount: 50,
+	// 		predefinedAmount: 5,
+	// 	}
+	// ),
 ];
 
 // We're just skipping the Payments Button test for now due to this bug:
@@ -41,5 +43,13 @@ const blockFlows: BlockFlow[] = [
 // if ( ! envVariables.TEST_ON_ATOMIC ) {
 // 	blockFlows.push( new PaymentsBlockFlow( { buttonText: 'Donate to Me' } ) );
 // }
+
+//
+if (
+	envVariables.JETPACK_TARGET === 'wpcom-deployment' &&
+	envVariables.ATOMIC_VARIATION !== 'private'
+) {
+	blockFlows.push( new AdFlow( {} ) );
+}
 
 createBlockTests( 'Blocks: Jetpack Earn', blockFlows );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80730.

Prerequisite branch: https://github.com/Automattic/wp-calypso/pull/81044.

## Proposed Changes

This PR adds a new block smoke testing flow for the Ad block.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

![image](https://github.com/Automattic/wp-calypso/assets/6549265/ea010fe0-236f-47c7-80a7-9071c717fce1)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
