### PR TITLE
Assembler: Categories should only show 6-8 patterns by default

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
@@ -34,6 +34,7 @@ export const PATTERN_ASSEMBLER_EVENTS = {
 	 * Pattern Panels
 	 */
 	PATTERN_SELECT_CLICK: 'calypso_signup_pattern_assembler_pattern_select_click',
+	PATTERN_SHOW_MORE_CLICK: 'calypso_signup_pattern_assembler_pattern_show_more_click',
 
 	/**
 	 * Pattern Actions

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-patterns-map-by-category.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-patterns-map-by-category.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { PATTERN_CATEGORIES } from '../constants';
+import { isPriorityPattern } from '../utils';
 import type { Pattern, Category } from '../types';
 
 const usePatternsMapByCategory = ( patterns: Pattern[], categories: Category[] ) => {
@@ -15,7 +16,11 @@ const usePatternsMapByCategory = ( patterns: Pattern[], categories: Category[] )
 				if ( ! categoriesMap[ category ] ) {
 					categoriesMap[ category ] = [];
 				}
-				categoriesMap[ category ].push( pattern );
+				if ( isPriorityPattern( pattern ) ) {
+					categoriesMap[ category ].unshift( pattern );
+				} else {
+					categoriesMap[ category ].push( pattern );
+				}
 			} );
 		} );
 		return categoriesMap;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-patterns-map-by-category.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-patterns-map-by-category.ts
@@ -7,7 +7,7 @@ const usePatternsMapByCategory = ( patterns: Pattern[], categories: Category[] )
 	return useMemo( () => {
 		const categoriesMap: Record< string, Pattern[] > = {};
 
-		patterns.forEach( ( pattern ) => {
+		patterns.reverse().forEach( ( pattern ) => {
 			Object.keys( pattern.categories ).forEach( ( category ) => {
 				if ( ! PATTERN_CATEGORIES.includes( category ) ) {
 					// Only show allowed categories

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -554,6 +554,7 @@ const PatternAssembler = ( {
 						selectedFooter={ footer }
 						patternsMapByCategory={ patternsMapByCategory }
 						onSelect={ onSelect }
+						recordTracksEvent={ recordTracksEvent }
 					/>
 				</NavigatorScreen>
 				<NavigatorScreen path={ NAVIGATOR_PATHS.STYLES_COLORS }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
@@ -38,3 +38,12 @@
 	letter-spacing: -0.15px;
 	text-wrap: pretty;
 }
+
+.pattern-list-panel__show-more {
+	text-align: center;
+	padding-top: 10px;
+
+	svg {
+		margin-inline-start: 10px;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
@@ -2,7 +2,7 @@ import { Button } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
-import PATTERN_ASSEMBLER_EVENTS from './events';
+import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import PatternSelector from './pattern-selector';
 import type { Pattern, Category } from './types';
 import './pattern-list-panel.scss';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
@@ -2,6 +2,7 @@ import { Button } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
+import PATTERN_ASSEMBLER_EVENTS from './events';
 import PatternSelector from './pattern-selector';
 import type { Pattern, Category } from './types';
 import './pattern-list-panel.scss';
@@ -15,6 +16,7 @@ type PatternListPanelProps = {
 	selectedPatterns?: Pattern[];
 	label?: string;
 	description?: string;
+	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 };
 
 const PatternListPanel = ( {
@@ -26,6 +28,7 @@ const PatternListPanel = ( {
 	label,
 	description,
 	onSelect,
+	recordTracksEvent,
 }: PatternListPanelProps ) => {
 	const translate = useTranslate();
 	const [ isShowMorePatterns, setIsShowMorePatterns ] = useState( false );
@@ -56,7 +59,7 @@ const PatternListPanel = ( {
 				<div className="pattern-list-panel__show-more">
 					<Button
 						onClick={ () => {
-							// recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_DELETE_CLICK, eventProps );
+							recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_SHOW_MORE_CLICK );
 							setIsShowMorePatterns( true );
 						} }
 						icon={ chevronDown }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import PatternSelector from './pattern-selector';
+import { isPriorityPattern } from './utils';
 import type { Pattern, Category } from './types';
 import './pattern-list-panel.scss';
 
@@ -38,6 +39,10 @@ const PatternListPanel = ( {
 		[ categories, selectedCategory ]
 	);
 
+	const hasNonPriorityPatterns = categoryPatterns?.find(
+		( pattern ) => ! isPriorityPattern( pattern )
+	);
+
 	if ( ! category ) {
 		return null;
 	}
@@ -55,7 +60,7 @@ const PatternListPanel = ( {
 				selectedPatterns={ selectedPatterns }
 				isShowMorePatterns={ isShowMorePatterns }
 			/>
-			{ ! isShowMorePatterns && (
+			{ ! isShowMorePatterns && hasNonPriorityPatterns && (
 				<div className="pattern-list-panel__show-more">
 					<Button
 						onClick={ () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
@@ -1,4 +1,7 @@
-import { useMemo } from 'react';
+import { Button } from '@wordpress/components';
+import { chevronDown } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo, useState } from 'react';
 import PatternSelector from './pattern-selector';
 import type { Pattern, Category } from './types';
 import './pattern-list-panel.scss';
@@ -24,8 +27,9 @@ const PatternListPanel = ( {
 	description,
 	onSelect,
 }: PatternListPanelProps ) => {
+	const translate = useTranslate();
+	const [ isShowMorePatterns, setIsShowMorePatterns ] = useState( false );
 	const categoryPatterns = selectedCategory ? patternsMapByCategory[ selectedCategory ] : [];
-
 	const category = useMemo(
 		() => selectedCategory && categories.find( ( { name } ) => name === selectedCategory ),
 		[ categories, selectedCategory ]
@@ -46,7 +50,22 @@ const PatternListPanel = ( {
 				onSelect={ onSelect }
 				selectedPattern={ selectedPattern }
 				selectedPatterns={ selectedPatterns }
+				isShowMorePatterns={ isShowMorePatterns }
 			/>
+			{ ! isShowMorePatterns && (
+				<div className="pattern-list-panel__show-more">
+					<Button
+						onClick={ () => {
+							// recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_DELETE_CLICK, eventProps );
+							setIsShowMorePatterns( true );
+						} }
+						icon={ chevronDown }
+						iconSize={ 23 }
+						iconPosition="right"
+						text={ translate( 'Show more patterns' ) }
+					/>
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -3,7 +3,7 @@ import { Tooltip, __unstableCompositeItem as CompositeItem } from '@wordpress/co
 import classnames from 'classnames';
 import { useEffect, useCallback, useRef } from 'react';
 import { useInView } from 'react-intersection-observer';
-import { encodePatternId } from './utils';
+import { encodePatternId, isPriorityPattern } from './utils';
 import type { Pattern } from './types';
 import './pattern-list-renderer.scss';
 
@@ -25,6 +25,7 @@ interface PatternListRendererProps {
 	activeClassName: string;
 	composite?: Record< string, unknown >;
 	onSelect: ( selectedPattern: Pattern | null ) => void;
+	isShowMorePatterns?: boolean;
 }
 
 const PLACEHOLDER_HEIGHT = 100;
@@ -97,9 +98,13 @@ const PatternListRenderer = ( {
 	activeClassName,
 	composite,
 	onSelect,
+	isShowMorePatterns,
 }: PatternListRendererProps ) => {
 	const filterPriorityPatterns = ( pattern: Pattern ) => {
-		if ( ! pattern.tags.assembler_priority ) {
+		if ( isShowMorePatterns ) {
+			return pattern;
+		}
+		if ( isPriorityPattern( pattern ) ) {
 			return pattern;
 		}
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -98,9 +98,15 @@ const PatternListRenderer = ( {
 	composite,
 	onSelect,
 }: PatternListRendererProps ) => {
+	const filterPriorityPatterns = ( pattern: Pattern ) => {
+		if ( ! pattern.tags.assembler_priority ) {
+			return pattern;
+		}
+	};
+
 	return (
 		<>
-			{ patterns?.map( ( pattern, index ) => (
+			{ patterns?.filter( filterPriorityPatterns ).map( ( pattern, index ) => (
 				<PatternListItem
 					key={ `${ index }-${ pattern.ID }` }
 					pattern={ pattern }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -100,14 +100,8 @@ const PatternListRenderer = ( {
 	onSelect,
 	isShowMorePatterns,
 }: PatternListRendererProps ) => {
-	const filterPriorityPatterns = ( pattern: Pattern ) => {
-		if ( isShowMorePatterns ) {
-			return pattern;
-		}
-		if ( isPriorityPattern( pattern ) ) {
-			return pattern;
-		}
-	};
+	const filterPriorityPatterns = ( pattern: Pattern ) =>
+		isShowMorePatterns || isPriorityPattern( pattern );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -12,6 +12,7 @@ type PatternSelectorProps = {
 	onSelect: ( selectedPattern: Pattern | null ) => void;
 	selectedPattern: Pattern | null;
 	selectedPatterns?: Pattern[];
+	isShowMorePatterns?: boolean;
 };
 
 const PatternSelector = ( {
@@ -19,6 +20,7 @@ const PatternSelector = ( {
 	onSelect,
 	selectedPattern,
 	selectedPatterns,
+	isShowMorePatterns,
 }: PatternSelectorProps ) => {
 	const translate = useTranslate();
 	const shownPatterns = useAsyncList( patterns );
@@ -41,6 +43,7 @@ const PatternSelector = ( {
 						activeClassName="pattern-selector__block-list--selected-pattern"
 						composite={ composite }
 						onSelect={ onSelect }
+						isShowMorePatterns={ isShowMorePatterns }
 					/>
 				</Composite>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pattern-list-panel.tsx
@@ -14,6 +14,7 @@ interface Props {
 		selectedPattern: Pattern | null,
 		selectedCategory: string | null
 	) => void;
+	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 }
 
 const ScreenPatternListPanel = ( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pattern-list-panel.tsx
@@ -60,6 +60,7 @@ const ScreenPatternListPanel = ( {
 
 	return (
 		<PatternListPanel
+			key={ selectedCategory }
 			{ ...props }
 			{ ...currentPanel }
 			selectedCategory={ selectedCategory }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -248,6 +248,7 @@ $font-family: "SF Pro Text", $sans;
 
 			&:last-child {
 				margin-bottom: 0;
+				padding-bottom: 0;
 			}
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -8,6 +8,7 @@ export type Pattern = {
 	key?: string;
 	pattern_meta?: Record< string, boolean | undefined >;
 	html?: string;
+	tags: Record< string, Tag >;
 };
 
 export type PatternType = 'header' | 'footer' | 'section';
@@ -34,3 +35,9 @@ export type PanelObject = {
 };
 
 export type ScreenName = 'main' | 'styles' | 'confirmation' | 'activation' | 'upsell';
+
+export type Tag = {
+	slug: string;
+	title: string;
+	description: string;
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -8,7 +8,7 @@ export type Pattern = {
 	key?: string;
 	pattern_meta?: Record< string, boolean | undefined >;
 	html?: string;
-	tags: Record< string, Tag >;
+	tags: Record< string, Tag | undefined >;
 };
 
 export type PatternType = 'header' | 'footer' | 'section';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -27,3 +27,6 @@ export const injectCategoryToPattern = (
 
 	return pattern;
 };
+
+export const isPriorityPattern = ( { tags: { assembler_priority } }: Pattern ) =>
+	!! assembler_priority;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80726

## Proposed Changes

* Show only patterns with the tag `Assembler_priority` and the button `Show more patterns`
* Show the rest of the patterns right after the priority patterns when users click `Show more patterns`
* Show the button `Show more patterns` again the next time the category is selected
* Reverse patterns so we can control the order by changing the publish date. The most recently saved go on top of the list.
* Emit the Tracks event `calypso_signup_pattern_assembler_pattern_show_more_click`

|BEFORE|AFTER - Initally|AFTER - Click show more|
|--|--|--|
|<img width="697" alt="Screenshot 2566-08-28 at 13 49 49" src="https://github.com/Automattic/wp-calypso/assets/1881481/36190a12-7fbf-487d-ab78-6683de171a8b">|<img width="698" alt="Screenshot 2566-08-28 at 13 50 05" src="https://github.com/Automattic/wp-calypso/assets/1881481/82e8b342-8fc8-45c4-92d5-20c44a400edd">|<img width="697" alt="Screenshot 2566-08-28 at 13 49 49" src="https://github.com/Automattic/wp-calypso/assets/1881481/36190a12-7fbf-487d-ab78-6683de171a8b">|


https://github.com/Automattic/wp-calypso/assets/1881481/1dc62721-d5d3-446b-af5c-e3dee9b4e91b

**Note:** Originally this feature was designed to show and hide the patterns without priority but this PR proposes a simpler version without the button `Show less patterns`. This makes the implementation much easier while still achieving the goal. I asked for the designer's feedback about it in #80726


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }`
* Verify the `Header` section shows only 6 headers and then the button `Show more patterns`
* Verify that when you click `Show more patterns` the rest of the patterns are shown right after and the button disappears
* Verify that when you toggle the category or open another and then back to the same, the button `Show more patterns` appears again 
* Verify the event `calypso_signup_pattern_assembler_pattern_show_more_click` is emitted when you click the button Show more patterns`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?