### PR TITLE
Jetpack E2E: fix mobile/desktop viewport logic in Paid Contents block flow.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
@@ -32,21 +32,24 @@ export class PaidContentBlockFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		const editorParent = await context.editorPage.getEditorParent();
 		const editorCanvas = await context.editorPage.getEditorCanvas();
 		const block = editorCanvas.getByRole( 'document', { name: 'Block: Paid Content' } );
 
 		// The Guest View will load by default. Wait for this view to fully render.
 		await block.getByRole( 'document', { name: 'Block: Guest View' } ).waitFor();
 
+		// Using the Block Toolbar, change to the Subscriber view.
+		// The exact steps differ between the viewports.
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			// Mobile viewport hides the Subscriber/Guest view
-			// into a pseudo-dropdown.
-			await editorParent.getByRole( 'button', { name: 'Change view' } ).click();
+			// Mobile viewport hides the Subscriber/Guest buttons into a dropdown.
+			await context.editorPage.clickBlockToolbarButton( { name: 'Change view' } );
+			await context.editorPage.selectFromToolbarPopover( 'Subscriber View' );
+		} else {
+			// Block toolbar for the desktop viewport shows both as a top-level button.
+			await context.editorPage.clickBlockToolbarButton( { name: 'Subscriber View' } );
 		}
 
-		// Using the Block Toolbar, change to the Subscriber view.
-		await context.editorPage.clickBlockToolbarButton( { name: 'Subscriber View' } );
+		// Verify the Subscriber version of the block is now loaded.
 		await block.getByRole( 'document', { name: 'Block: Subscriber View' } ).waitFor();
 
 		// Fill the title and text for subscribers.


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80730, https://github.com/Automattic/wp-calypso/pull/81024.

## Proposed Changes

This PR fixes the mobile/desktop viewport logic relating to interactions with the block toolbar.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
