### PR TITLE
VideoPress Onboarding Intent: Add intent modals

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
@@ -19,6 +19,7 @@ import VideoPressOnboardingIntentModalBlog from './videopress-onboarding-intent-
 import VideoPressOnboardingIntentModalChannel from './videopress-onboarding-intent-modal-channel';
 import VideoPressOnboardingIntentModalJetpack from './videopress-onboarding-intent-modal-jetpack';
 import VideoPressOnboardingIntentModalPortfolio from './videopress-onboarding-intent-modal-portfolio';
+import VideoPressOnboardingIntentModalVideoUpload from './videopress-onboarding-intent-modal-video-upload';
 import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 
 import './styles.scss';
@@ -54,6 +55,7 @@ const VideoPressOnboardingIntent: Step = ( { navigation } ) => {
 
 	const onUploadVideoIntentClicked = () => {
 		sendTracksIntent( 'videoupload' );
+		setModal( <VideoPressOnboardingIntentModalVideoUpload onSubmit={ handleSubmit } /> );
 	};
 
 	const onJetpackIntentClicked = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
@@ -15,6 +15,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CloseIcon from '../intro/icons/close-icon';
 import VideoPressOnboardingIntentItem from './intent-item';
+import VideoPressOnboardingIntentModalBlog from './videopress-onboarding-intent-modal-blog';
 import VideoPressOnboardingIntentModalPortfolio from './videopress-onboarding-intent-modal-portfolio';
 import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 
@@ -58,6 +59,7 @@ const VideoPressOnboardingIntent: Step = ( { navigation } ) => {
 
 	const onVideoBlogIntentClicked = () => {
 		sendTracksIntent( 'blog' );
+		setModal( <VideoPressOnboardingIntentModalBlog onSubmit={ handleSubmit } /> );
 	};
 
 	const onOtherIntentClicked = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
@@ -16,6 +16,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CloseIcon from '../intro/icons/close-icon';
 import VideoPressOnboardingIntentItem from './intent-item';
 import VideoPressOnboardingIntentModalBlog from './videopress-onboarding-intent-modal-blog';
+import VideoPressOnboardingIntentModalJetpack from './videopress-onboarding-intent-modal-jetpack';
 import VideoPressOnboardingIntentModalPortfolio from './videopress-onboarding-intent-modal-portfolio';
 import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 
@@ -53,8 +54,9 @@ const VideoPressOnboardingIntent: Step = ( { navigation } ) => {
 		sendTracksIntent( 'videoupload' );
 	};
 
-	const onAddVideoIntentClicked = () => {
+	const onJetpackIntentClicked = () => {
 		sendTracksIntent( 'jetpack' );
+		setModal( <VideoPressOnboardingIntentModalJetpack /> );
 	};
 
 	const onVideoBlogIntentClicked = () => {
@@ -99,7 +101,7 @@ const VideoPressOnboardingIntent: Step = ( { navigation } ) => {
 						'All the advantages and features from VideoPress, on your own WordPress site.'
 					) }
 					image={ JetpackIntentImage }
-					onClick={ onAddVideoIntentClicked }
+					onClick={ onJetpackIntentClicked }
 				/>
 				<VideoPressOnboardingIntentItem
 					title={ __( 'Start a blog with video content' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
@@ -16,6 +16,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CloseIcon from '../intro/icons/close-icon';
 import VideoPressOnboardingIntentItem from './intent-item';
 import VideoPressOnboardingIntentModalBlog from './videopress-onboarding-intent-modal-blog';
+import VideoPressOnboardingIntentModalChannel from './videopress-onboarding-intent-modal-channel';
 import VideoPressOnboardingIntentModalJetpack from './videopress-onboarding-intent-modal-jetpack';
 import VideoPressOnboardingIntentModalPortfolio from './videopress-onboarding-intent-modal-portfolio';
 import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -48,6 +49,7 @@ const VideoPressOnboardingIntent: Step = ( { navigation } ) => {
 
 	const onVideoChannelIntentClicked = () => {
 		sendTracksIntent( 'videochannel' );
+		setModal( <VideoPressOnboardingIntentModalChannel onSubmit={ handleSubmit } /> );
 	};
 
 	const onUploadVideoIntentClicked = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
@@ -20,10 +20,16 @@ import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/ty
 
 import './styles.scss';
 
-const VideoPressOnboardingIntent: Step = () => {
+const VideoPressOnboardingIntent: Step = ( { navigation } ) => {
 	const { __ } = useI18n();
 	const [ intentClickNumber, setIntentClicksNumber ] = useState( 1 );
 	const [ modal, setModal ] = useState< ReactElement | null >( null );
+
+	const { submit } = navigation;
+
+	const handleSubmit = () => {
+		submit?.();
+	};
 
 	const sendTracksIntent = ( intent: string ) => {
 		recordTracksEvent( 'calypso_videopress_onboarding_intent_clicked', {
@@ -35,7 +41,7 @@ const VideoPressOnboardingIntent: Step = () => {
 
 	const onVideoPortfolioIntentClicked = () => {
 		sendTracksIntent( 'portfolio' );
-		setModal( <VideoPressOnboardingIntentModalPortfolio onSubmit={ () => false } /> );
+		setModal( <VideoPressOnboardingIntentModalPortfolio onSubmit={ handleSubmit } /> );
 	};
 
 	const onVideoChannelIntentClicked = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
+import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
-import { useState } from 'react';
+import classNames from 'classnames';
+import { ReactElement, useState } from 'react';
 import BlogIntentImage from 'calypso/assets/images/onboarding/videopress-onboarding-intent/intent-blog.png';
 import ChannelIntentImage from 'calypso/assets/images/onboarding/videopress-onboarding-intent/intent-channel.png';
 import JetpackIntentImage from 'calypso/assets/images/onboarding/videopress-onboarding-intent/intent-jetpack.png';
@@ -11,7 +13,9 @@ import PortfolioIntentImage from 'calypso/assets/images/onboarding/videopress-on
 import SingleVideoIntentImage from 'calypso/assets/images/onboarding/videopress-onboarding-intent/intent-single-video.png';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import CloseIcon from '../intro/icons/close-icon';
 import VideoPressOnboardingIntentItem from './intent-item';
+import VideoPressOnboardingIntentModalPortfolio from './videopress-onboarding-intent-modal-portfolio';
 import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 
 import './styles.scss';
@@ -19,6 +23,7 @@ import './styles.scss';
 const VideoPressOnboardingIntent: Step = () => {
 	const { __ } = useI18n();
 	const [ intentClickNumber, setIntentClicksNumber ] = useState( 1 );
+	const [ modal, setModal ] = useState< ReactElement | null >( null );
 
 	const sendTracksIntent = ( intent: string ) => {
 		recordTracksEvent( 'calypso_videopress_onboarding_intent_clicked', {
@@ -30,6 +35,7 @@ const VideoPressOnboardingIntent: Step = () => {
 
 	const onVideoPortfolioIntentClicked = () => {
 		sendTracksIntent( 'portfolio' );
+		setModal( <VideoPressOnboardingIntentModalPortfolio onSubmit={ () => false } /> );
 	};
 
 	const onVideoChannelIntentClicked = () => {
@@ -52,47 +58,66 @@ const VideoPressOnboardingIntent: Step = () => {
 		sendTracksIntent( 'other' );
 	};
 
+	const modalClasses = classNames( 'intro__more-modal videopress-intro-modal', {
+		show: modal ? true : false,
+	} );
+
 	const stepContent = (
-		<div className="videopress-onboarding-intent__step-content">
-			<VideoPressOnboardingIntentItem
-				title={ __( 'Get a video portfolio' ) }
-				description={ __( 'Share your work with the world.' ) }
-				image={ PortfolioIntentImage }
-				onClick={ onVideoPortfolioIntentClicked }
-			/>
-			<VideoPressOnboardingIntentItem
-				title={ __( 'Create a channel for your videos' ) }
-				description={ __( 'The easiest way to upload videos and create a community around them.' ) }
-				image={ ChannelIntentImage }
-				onClick={ onVideoChannelIntentClicked }
-			/>
-			<VideoPressOnboardingIntentItem
-				title={ __( 'Upload a video' ) }
-				description={ __( 'Just put a video on the internet.' ) }
-				image={ SingleVideoIntentImage }
-				onClick={ onUploadVideoIntentClicked }
-			/>
-			<VideoPressOnboardingIntentItem
-				title={ __( 'Add video to an existing site' ) }
-				description={ __(
-					'All the advantages and features from VideoPress, on your own WordPress site.'
-				) }
-				image={ JetpackIntentImage }
-				onClick={ onAddVideoIntentClicked }
-			/>
-			<VideoPressOnboardingIntentItem
-				title={ __( 'Start a blog with video content' ) }
-				description={ __( 'Use advanced media formats to enhance your storytelling.' ) }
-				image={ BlogIntentImage }
-				onClick={ onVideoBlogIntentClicked }
-			/>
-			<VideoPressOnboardingIntentItem
-				title={ __( 'Other' ) }
-				description={ __( 'What are you looking for? Let us know!' ) }
-				image={ OtherIntentImage }
-				onClick={ onOtherIntentClicked }
-			/>
-		</div>
+		<>
+			<div className="videopress-onboarding-intent__step-content">
+				<VideoPressOnboardingIntentItem
+					title={ __( 'Get a video portfolio' ) }
+					description={ __( 'Share your work with the world.' ) }
+					image={ PortfolioIntentImage }
+					onClick={ onVideoPortfolioIntentClicked }
+				/>
+				<VideoPressOnboardingIntentItem
+					title={ __( 'Create a channel for your videos' ) }
+					description={ __(
+						'The easiest way to upload videos and create a community around them.'
+					) }
+					image={ ChannelIntentImage }
+					onClick={ onVideoChannelIntentClicked }
+				/>
+				<VideoPressOnboardingIntentItem
+					title={ __( 'Upload a video' ) }
+					description={ __( 'Just put a video on the internet.' ) }
+					image={ SingleVideoIntentImage }
+					onClick={ onUploadVideoIntentClicked }
+				/>
+				<VideoPressOnboardingIntentItem
+					title={ __( 'Add video to an existing site' ) }
+					description={ __(
+						'All the advantages and features from VideoPress, on your own WordPress site.'
+					) }
+					image={ JetpackIntentImage }
+					onClick={ onAddVideoIntentClicked }
+				/>
+				<VideoPressOnboardingIntentItem
+					title={ __( 'Start a blog with video content' ) }
+					description={ __( 'Use advanced media formats to enhance your storytelling.' ) }
+					image={ BlogIntentImage }
+					onClick={ onVideoBlogIntentClicked }
+				/>
+				<VideoPressOnboardingIntentItem
+					title={ __( 'Other' ) }
+					description={ __( 'What are you looking for? Let us know!' ) }
+					image={ OtherIntentImage }
+					onClick={ onOtherIntentClicked }
+				/>
+			</div>
+
+			<div className={ modalClasses }>
+				<div className="intro__more-modal-container">
+					<div className="intro__more-modal-header">
+						<Button plain onClick={ () => setModal( null ) }>
+							<CloseIcon />
+						</Button>
+					</div>
+					{ modal && <modal.type { ...modal.props } /> }
+				</div>
+			</div>
+		</>
 	);
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/styles.scss
@@ -224,5 +224,87 @@
 				max-width: 80%;
 			}
 		}
+
+		.videopress-intro-modal__coming-soon {
+			text-transform: uppercase;
+			background-color: #fff;
+			color: #000;
+			border-radius: 30px; /* stylelint-disable-line */
+			font-size: 12px; /* stylelint-disable-line */
+			font-weight: 600;
+			padding: 5px 12px;
+		}
+
+		.videopress-intro-modal__waitlist {
+			display: flex;
+			gap: 8px;
+
+			input {
+				min-width: 300px;
+			}
+
+			.button {
+				white-space: nowrap;
+				width: auto;
+				box-sizing: border-box;
+				max-width: none;
+				min-width: fit-content;
+			}
+		}
+
+		.videopress-intro-modal__waitlist-presentation {
+			display: flex;
+			flex-direction: column;
+			align-content: center;
+			gap: 16px;
+
+			.videopress-intro-modal__waitlist-description {
+				max-width: 460px;
+			}
+
+			.videopress-intro-modal__waitlist-description,
+			.videopress-intro-modal__waitlist-description a,
+			.videopress-intro-modal__waitlist-description button {
+				font-size: 15px; /* stylelint-disable-line */
+				font-weight: 400;
+				text-align: center;
+				color: #a7aaad;
+			}
+
+			.videopress-intro-modal__waitlist-description button,
+			.videopress-intro-modal__waitlist-description a {
+				text-decoration: underline;
+			}
+
+			.videopress-intro-modal__waitlist-description button {
+				background: none;
+				border: none;
+				padding: 0;
+				margin: 0;
+			}
+		}
+
+		.videopress-intro-modal__survey {
+			position: absolute;
+			bottom: 0;
+			left: 0;
+			right: 0;
+			background: linear-gradient(116.82deg, #fffc1b 0%, #ffe61c 0.01%, #ffc700 100%);
+			color: #000;
+			padding: 32px;
+			display: flex;
+			justify-content: space-around;
+
+			button {
+				background: none !important;
+				border: 1px solid #000 !important;
+				border-radius: 4px;
+				font-weight: 500;
+			}
+
+			.videopress-intro-modal__survey-title {
+				font-weight: 600;
+			}
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/styles.scss
@@ -4,6 +4,7 @@
 
 .videopress-onboarding-intent {
 	max-width: 1200px !important;
+	font-family: "SF Pro Display", $sans;
 
 	.videopress-onboarding-intent__step-content {
 		display: grid;
@@ -140,10 +141,15 @@
 		align-items: center;
 		height: 100%;
 		padding: 24px 32px;
+		font-size: 18px; /* stylelint-disable-line */
+		font-weight: 400;
 
 		.intro__title {
 			margin-top: 16px;
 			text-align: center;
+			font-size: 44px; /* stylelint-disable-line */
+			font-weight: 400;
+			font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
 		}
 
 		.intro__description {
@@ -184,11 +190,11 @@
 			flex: 1;
 
 			button.is-primary {
-				width: 100%;
-				max-width: 220px;
+				width: auto;
+				max-width: initial;
 				font-weight: 500;
-				padding-top: 10px;
-				padding-bottom: 10px;
+				padding: 12px 24px;
+				border-radius: 4px;
 			}
 
 			.learn-more {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/styles.scss
@@ -65,11 +65,11 @@
 	}
 
 	.intro__more-modal {
-		position: absolute;
+		position: fixed;
 		left: 0;
 		right: 0;
 		top: 0;
-		bottom: -10px;
+		bottom: 0;
 		padding: 24px;
 		z-index: 100;
 		display: flex;
@@ -77,6 +77,7 @@
 		justify-content: center;
 		align-items: center;
 		pointer-events: none;
+		box-sizing: border-box;
 
 		.intro__more-modal-container {
 			border-radius: 8px; /* stylelint-disable-line */

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/styles.scss
@@ -189,12 +189,16 @@
 			align-items: center;
 			flex: 1;
 
+			a.is-primary,
 			button.is-primary {
 				width: auto;
 				max-width: initial;
 				font-weight: 500;
 				padding: 12px 24px;
 				border-radius: 4px;
+				background-color: #ffe61c;
+				color: #000;
+				border: none;
 			}
 
 			.learn-more {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/styles.scss
@@ -1,61 +1,218 @@
+.videopress.intro .signup-header {
+	z-index: 0;
+}
+
 .videopress-onboarding-intent {
 	max-width: 1200px !important;
-}
 
-.videopress-onboarding-intent__step-content {
-	display: grid;
-	grid-template: "a b c" 1fr;
-	grid-row-gap: 48px;
-	justify-items: center;
-}
-
-@media (max-width: 1060px) {
 	.videopress-onboarding-intent__step-content {
-		grid-template: "a b" 1fr;
+		display: grid;
+		grid-template: "a b c" 1fr;
+		grid-row-gap: 48px;
+		justify-items: center;
 	}
-}
 
-@media (max-width: 760px) {
-	.videopress-onboarding-intent__step-content {
-		grid-template: "a" 1fr;
+	@media (max-width: 1060px) {
+		.videopress-onboarding-intent__step-content {
+			grid-template: "a b" 1fr;
+		}
 	}
-}
 
-.videopress-intent-item__preview {
-	width: 328px;
-	height: 220px;
-	overflow: hidden;
-	border: solid 8px #212121;
-	border-radius: 8px; /* stylelint-disable-line */
-	cursor: pointer;
-	transition: border-color 0.3s ease-in-out;
-
-	&:hover {
-		border-color: #ffe61c;
+	@media (max-width: 760px) {
+		.videopress-onboarding-intent__step-content {
+			grid-template: "a" 1fr;
+		}
 	}
-}
 
-.videopress-intent-item {
-	display: flex;
-	flex-direction: column;
-	gap: 12px;
-	width: 328px;
-}
+	.videopress-intent-item__preview {
+		width: 328px;
+		height: 220px;
+		overflow: hidden;
+		border: solid 8px #212121;
+		border-radius: 8px; /* stylelint-disable-line */
+		cursor: pointer;
+		transition: border-color 0.3s ease-in-out;
 
-.videopress-intent-item__description {
-	display: flex;
-	flex-direction: column;
-	text-align: center;
-	gap: 4px;
+		&:hover {
+			border-color: #ffe61c;
+		}
+	}
 
-	.videopress-intent-item__title {
-		font-size: 17px; /* stylelint-disable-line */
-		font-weight: 600;
+	.videopress-intent-item {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+		width: 328px;
 	}
 
 	.videopress-intent-item__description {
-		font-size: 14px; /* stylelint-disable-line */
-		font-weight: 400;
-		color: #a7aaad;
+		display: flex;
+		flex-direction: column;
+		text-align: center;
+		gap: 4px;
+
+		.videopress-intent-item__title {
+			font-size: 17px; /* stylelint-disable-line */
+			font-weight: 600;
+		}
+
+		.videopress-intent-item__description {
+			font-size: 14px; /* stylelint-disable-line */
+			font-weight: 400;
+			color: #a7aaad;
+		}
+	}
+
+	.intro__more-modal {
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: 0;
+		bottom: -10px;
+		padding: 24px;
+		z-index: 100;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		pointer-events: none;
+
+		.intro__more-modal-container {
+			border-radius: 8px; /* stylelint-disable-line */
+			background-color: #000;
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+			width: 100%;
+			overflow: hidden;
+			will-change: opacity, transform;
+			opacity: 0;
+			transform: scale(0.9);
+			transition: 0.2s ease-in-out;
+			box-shadow: 0 100px 80px rgba(0, 0, 0, 0.08), 0 20px 10px rgba(0, 0, 0, 0.1), 0 6px 6px rgba(0, 0, 0, 0.1);
+			border: 1px solid #fff3;
+		}
+		&.show {
+			pointer-events: all;
+
+			.intro__more-modal-container {
+				opacity: 1;
+				animation-name: intro__more-modal-pop;
+				animation-duration: 0.3s;
+				animation-timing-function: cubic-bezier(0.455, 0.03, 0.515, 0.955);
+				animation-fill-mode: forwards;
+				transform-origin: center center;
+			}
+		}
+
+		.intro__more-modal-header {
+			display: flex;
+			justify-content: right;
+			margin-right: 24px;
+			margin-top: 24px;
+
+			button {
+				cursor: pointer;
+			}
+		}
+
+		@keyframes intro__more-modal-pop {
+			0% {
+				opacity: 0;
+				transform: scale(0.9);
+			}
+
+			50% {
+				opacity: 1;
+				transform: scale(1.01);
+			}
+
+			100% {
+				opacity: 1;
+				transform: scale(1);
+			}
+		}
+	}
+
+	.videopress-intro-modal {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		height: 100%;
+		padding: 24px 32px;
+
+		.intro__title {
+			margin-top: 16px;
+			text-align: center;
+		}
+
+		.intro__description {
+			color: #a7aaad;
+			max-width: 420px;
+			text-align: center;
+		}
+
+		.videopress-intro-modal__list {
+			margin-top: 40px;
+			margin-bottom: 48px;
+			list-style: none;
+
+			li {
+				display: flex;
+				flex-direction: row;
+				align-items: baseline;
+				margin-bottom: 4px;
+
+				a {
+					color: #ffe61c;
+					border-bottom: 1px solid currentColor;
+					font-weight: 500;
+					padding: 1px;
+				}
+
+				.checkmark-icon {
+					margin-right: 16px;
+				}
+			}
+		}
+
+		.videopress-intro-modal__button-column {
+			display: flex;
+			flex-direction: column;
+			width: 100%;
+			align-items: center;
+			flex: 1;
+
+			button.is-primary {
+				width: 100%;
+				max-width: 220px;
+				font-weight: 500;
+				padding-top: 10px;
+				padding-bottom: 10px;
+			}
+
+			.learn-more {
+				margin-top: 16px;
+
+				a {
+					color: #a7aaad;
+					transition: color 0.1s ease-in-out;
+					&:hover {
+						color: #fff;
+					}
+				}
+
+			}
+		}
+
+		.videopress-intro-modal__screenshots {
+			margin-top: 48px;
+			text-align: center;
+			width: 100%;
+
+			img {
+				max-width: 80%;
+			}
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-blog.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-blog.tsx
@@ -1,8 +1,6 @@
-import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import '../intro/videopress-intro-modal-styles.scss';
-import CheckmarkIcon from '../intro/icons/checkmark-icon';
 import { IntroModalContentProps } from '../intro/intro';
+import VideoPressOnboardingIntentModal from './videopress-onboarding-intent-modal';
 
 const VideoPressOnboardingIntentModalBlog: React.FC< IntroModalContentProps > = ( {
 	onSubmit,
@@ -10,72 +8,29 @@ const VideoPressOnboardingIntentModalBlog: React.FC< IntroModalContentProps > = 
 	const translate = useTranslate();
 
 	return (
-		<div className="videopress-intro-modal">
-			<h1 className="intro__title">
-				{ translate( 'The best blogging system with the best video.' ) }
-			</h1>
-			<div className="intro__description">
-				{ translate(
-					'Create a new blog on WordPress.com with unmatched video capabilities out of the box.'
-				) }
-			</div>
-			<ul className="videopress-intro-modal__list">
-				<li>
-					<CheckmarkIcon />
-					<span>
-						{ translate( 'Unbranded, ad-free, customizable {{a}}VideoPress{{/a}} player.', {
-							components: {
-								a: (
-									<a
-										href="https://videopress.com"
-										target="_blank"
-										rel="external noreferrer noopener"
-									/>
-								),
-							},
-						} ) }
-					</span>
-				</li>
-				<li>
-					<CheckmarkIcon />
-					<span>
-						{ translate( 'Upload videos directly to your site using the WordPress editor.' ) }
-					</span>
-				</li>
-				<li>
-					<CheckmarkIcon />
-					<span>{ translate( 'Up to 200GB of storage and your own domain for a year.' ) }</span>
-				</li>
-				<li>
-					<CheckmarkIcon />
-					<span>{ translate( 'The best premium themes at your disposal.' ) }</span>
-				</li>
-			</ul>
-			<div className="videopress-intro-modal__button-column">
-				<Button className="intro__button" primary onClick={ onSubmit }>
-					{ translate( 'Get started with premium' ) }
-				</Button>
-				<div className="learn-more">
-					{ translate( '{{a}}Or learn more about VideoPress.{{/a}}', {
-						components: {
-							a: (
-								<a
-									href="https://videopress.com/"
-									target="_blank"
-									rel="external noreferrer noopener"
-								/>
-							),
-						},
-					} ) }
-				</div>
-			</div>
-			<div className="videopress-intro-modal__screenshots">
-				<img
-					src="https://videopress2.files.wordpress.com/2023/02/videopress-modal-screenshots-2x.png"
-					alt={ translate( 'Mobile device screenshot samples of the Videomaker theme.' ) }
-				/>
-			</div>
-		</div>
+		<VideoPressOnboardingIntentModal
+			title={ translate( 'The best blogging system with the best video.' ) }
+			description={ translate(
+				'Create a new blog on WordPress.com with unmatched video capabilities out of the box.'
+			) }
+			featuresList={ [
+				translate( 'Unbranded, ad-free, customizable {{a}}VideoPress{{/a}} player.', {
+					components: {
+						a: (
+							<a href="https://videopress.com" target="_blank" rel="external noreferrer noopener" />
+						),
+					},
+				} ),
+				translate( 'Upload videos directly to your site using the WordPress editor.' ),
+				translate( 'Up to 200GB of storage and your own domain for a year.' ),
+				translate( 'The best premium themes at your disposal.' ),
+			] }
+			actionButton={ {
+				type: 'button',
+				text: translate( 'Get started with premium' ),
+				onClick: onSubmit,
+			} }
+		/>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-blog.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-blog.tsx
@@ -1,0 +1,82 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import '../intro/videopress-intro-modal-styles.scss';
+import CheckmarkIcon from '../intro/icons/checkmark-icon';
+import { IntroModalContentProps } from '../intro/intro';
+
+const VideoPressOnboardingIntentModalBlog: React.FC< IntroModalContentProps > = ( {
+	onSubmit,
+} ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="videopress-intro-modal">
+			<h1 className="intro__title">
+				{ translate( 'The best blogging system with the best video.' ) }
+			</h1>
+			<div className="intro__description">
+				{ translate(
+					'Create a new blog on WordPress.com with unmatched video capabilities out of the box.'
+				) }
+			</div>
+			<ul className="videopress-intro-modal__list">
+				<li>
+					<CheckmarkIcon />
+					<span>
+						{ translate( 'Unbranded, ad-free, customizable {{a}}VideoPress{{/a}} player.', {
+							components: {
+								a: (
+									<a
+										href="https://videopress.com"
+										target="_blank"
+										rel="external noreferrer noopener"
+									/>
+								),
+							},
+						} ) }
+					</span>
+				</li>
+				<li>
+					<CheckmarkIcon />
+					<span>
+						{ translate( 'Upload videos directly to your site using the WordPress editor.' ) }
+					</span>
+				</li>
+				<li>
+					<CheckmarkIcon />
+					<span>{ translate( 'Up to 200GB of storage and your own domain for a year.' ) }</span>
+				</li>
+				<li>
+					<CheckmarkIcon />
+					<span>{ translate( 'The best premium themes at your disposal.' ) }</span>
+				</li>
+			</ul>
+			<div className="videopress-intro-modal__button-column">
+				<Button className="intro__button" primary onClick={ onSubmit }>
+					{ translate( 'Get started with premium' ) }
+				</Button>
+				<div className="learn-more">
+					{ translate( '{{a}}Or learn more about VideoPress.{{/a}}', {
+						components: {
+							a: (
+								<a
+									href="https://videopress.com/"
+									target="_blank"
+									rel="external noreferrer noopener"
+								/>
+							),
+						},
+					} ) }
+				</div>
+			</div>
+			<div className="videopress-intro-modal__screenshots">
+				<img
+					src="https://videopress2.files.wordpress.com/2023/02/videopress-modal-screenshots-2x.png"
+					alt={ translate( 'Mobile device screenshot samples of the Videomaker theme.' ) }
+				/>
+			</div>
+		</div>
+	);
+};
+
+export default VideoPressOnboardingIntentModalBlog;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-channel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-channel.tsx
@@ -1,0 +1,29 @@
+import { useTranslate } from 'i18n-calypso';
+import { IntroModalContentProps } from '../intro/intro';
+import VideoPressOnboardingIntentModal from './videopress-onboarding-intent-modal';
+
+const VideoPressOnboardingIntentModalChannel: React.FC< IntroModalContentProps > = ( {
+	onSubmit,
+} ) => {
+	const translate = useTranslate();
+
+	return (
+		<VideoPressOnboardingIntentModal
+			title={ translate( 'A home for all your videos.' ) }
+			description={ translate(
+				'VideoPress TV is the easiest way to upload videos and create a community around them.'
+			) }
+			featuresList={ [
+				translate( 'Ready to go! No setup needed.' ),
+				translate( 'The easiest way to upload your videos.' ),
+				translate( 'Earn money through subscriptions.' ),
+				translate( 'Foster and engage with your community.' ),
+			] }
+			onSubmit={ onSubmit }
+			isComingSoon={ true }
+			surveyTitle={ translate( 'Which additional features are you looking for?' ) }
+		/>
+	);
+};
+
+export default VideoPressOnboardingIntentModalChannel;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-jetpack.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-jetpack.tsx
@@ -1,0 +1,81 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import '../intro/videopress-intro-modal-styles.scss';
+import CheckmarkIcon from '../intro/icons/checkmark-icon';
+import { IntroModalContentProps } from '../intro/intro';
+
+const VideoPressOnboardingIntentModalJetpack: React.FC< IntroModalContentProps > = () => {
+	const translate = useTranslate();
+
+	return (
+		<div className="videopress-intro-modal">
+			<h1 className="intro__title">{ translate( 'Add videos to your existing site.' ) }</h1>
+			<div className="intro__description">
+				{ translate(
+					'Already have a self-hosted WordPress site? Enable the finest video with Jetpack VideoPress.'
+				) }
+			</div>
+			<ul className="videopress-intro-modal__list">
+				<li>
+					<CheckmarkIcon />
+					<span>{ translate( 'High-quality, lightning-fast video hosting.' ) }</span>
+				</li>
+				<li>
+					<CheckmarkIcon />
+					<span>{ translate( 'Drag and drop videos directly into WordPress.' ) }</span>
+				</li>
+				<li>
+					<CheckmarkIcon />
+					<span>
+						{ translate( 'Unbranded, ad-free, customizable {{a}}VideoPress{{/a}} player.', {
+							components: {
+								a: (
+									<a
+										href="https://videopress.com"
+										target="_blank"
+										rel="external noreferrer noopener"
+									/>
+								),
+							},
+						} ) }
+					</span>
+				</li>
+				<li>
+					<CheckmarkIcon />
+					<span>{ translate( '1TB of storage and unlimited users.' ) }</span>
+				</li>
+			</ul>
+			<div className="videopress-intro-modal__button-column">
+				<Button
+					type="link"
+					href="https://jetpack.com/videopress/"
+					className="intro__button"
+					primary
+				>
+					{ translate( 'Discover Jetpack VideoPress' ) }
+				</Button>
+				<div className="learn-more">
+					{ translate( '{{a}}Or learn more about VideoPress.{{/a}}', {
+						components: {
+							a: (
+								<a
+									href="https://videopress.com/"
+									target="_blank"
+									rel="external noreferrer noopener"
+								/>
+							),
+						},
+					} ) }
+				</div>
+			</div>
+			<div className="videopress-intro-modal__screenshots">
+				<img
+					src="https://videopress2.files.wordpress.com/2023/02/videopress-modal-screenshots-2x.png"
+					alt={ translate( 'Mobile device screenshot samples of the Videomaker theme.' ) }
+				/>
+			</div>
+		</div>
+	);
+};
+
+export default VideoPressOnboardingIntentModalJetpack;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-jetpack.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-jetpack.tsx
@@ -1,80 +1,34 @@
-import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import '../intro/videopress-intro-modal-styles.scss';
-import CheckmarkIcon from '../intro/icons/checkmark-icon';
 import { IntroModalContentProps } from '../intro/intro';
+import VideoPressOnboardingIntentModal from './videopress-onboarding-intent-modal';
 
 const VideoPressOnboardingIntentModalJetpack: React.FC< IntroModalContentProps > = () => {
 	const translate = useTranslate();
 
 	return (
-		<div className="videopress-intro-modal">
-			<h1 className="intro__title">{ translate( 'Add videos to your existing site.' ) }</h1>
-			<div className="intro__description">
-				{ translate(
-					'Already have a self-hosted WordPress site? Enable the finest video with Jetpack VideoPress.'
-				) }
-			</div>
-			<ul className="videopress-intro-modal__list">
-				<li>
-					<CheckmarkIcon />
-					<span>{ translate( 'High-quality, lightning-fast video hosting.' ) }</span>
-				</li>
-				<li>
-					<CheckmarkIcon />
-					<span>{ translate( 'Drag and drop videos directly into WordPress.' ) }</span>
-				</li>
-				<li>
-					<CheckmarkIcon />
-					<span>
-						{ translate( 'Unbranded, ad-free, customizable {{a}}VideoPress{{/a}} player.', {
-							components: {
-								a: (
-									<a
-										href="https://videopress.com"
-										target="_blank"
-										rel="external noreferrer noopener"
-									/>
-								),
-							},
-						} ) }
-					</span>
-				</li>
-				<li>
-					<CheckmarkIcon />
-					<span>{ translate( '1TB of storage and unlimited users.' ) }</span>
-				</li>
-			</ul>
-			<div className="videopress-intro-modal__button-column">
-				<Button
-					type="link"
-					href="https://jetpack.com/videopress/"
-					className="intro__button"
-					primary
-				>
-					{ translate( 'Discover Jetpack VideoPress' ) }
-				</Button>
-				<div className="learn-more">
-					{ translate( '{{a}}Or learn more about VideoPress.{{/a}}', {
-						components: {
-							a: (
-								<a
-									href="https://videopress.com/"
-									target="_blank"
-									rel="external noreferrer noopener"
-								/>
-							),
-						},
-					} ) }
-				</div>
-			</div>
-			<div className="videopress-intro-modal__screenshots">
-				<img
-					src="https://videopress2.files.wordpress.com/2023/02/videopress-modal-screenshots-2x.png"
-					alt={ translate( 'Mobile device screenshot samples of the Videomaker theme.' ) }
-				/>
-			</div>
-		</div>
+		<VideoPressOnboardingIntentModal
+			title={ translate( 'Add videos to your existing site.' ) }
+			description={ translate(
+				'Already have a self-hosted WordPress site? Enable the finest video with Jetpack VideoPress.'
+			) }
+			featuresList={ [
+				translate( 'High-quality, lightning-fast video hosting.' ),
+				translate( 'Drag and drop videos directly into WordPress.' ),
+				translate( 'Unbranded, ad-free, customizable {{a}}VideoPress{{/a}} player.', {
+					components: {
+						a: (
+							<a href="https://videopress.com" target="_blank" rel="external noreferrer noopener" />
+						),
+					},
+				} ),
+				translate( '1TB of storage and unlimited users.' ),
+			] }
+			actionButton={ {
+				type: 'link',
+				text: translate( 'Discover Jetpack VideoPress' ),
+				href: 'https://jetpack.com/videopress/',
+			} }
+		/>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-portfolio.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-portfolio.tsx
@@ -1,15 +1,13 @@
-import { Button } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
-import '../intro/videopress-intro-modal-styles.scss';
 import { PlansSelect } from 'calypso/../packages/data-stores/src';
 import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
 import { PLANS_STORE } from 'calypso/landing/stepper/stores';
-import CheckmarkIcon from '../intro/icons/checkmark-icon';
 import { IntroModalContentProps } from '../intro/intro';
+import VideoPressOnboardingIntentModal from './videopress-onboarding-intent-modal';
 
 const VideoPressOnboardingIntentModalPortfolio: React.FC< IntroModalContentProps > = ( {
 	onSubmit,
@@ -47,82 +45,39 @@ const VideoPressOnboardingIntentModalPortfolio: React.FC< IntroModalContentProps
 	}
 
 	return (
-		<div className="videopress-intro-modal">
-			<h1 className="intro__title">{ translate( 'Your video portfolio, with no hassle.' ) }</h1>
-			<div className="intro__description">
-				{ translate(
-					'Create a WordPress.com site with everything you need to share your videos with the world.'
-				) }
-			</div>
-			<ul className="videopress-intro-modal__list">
-				<li>
-					<CheckmarkIcon />
-					<span>
-						{ translate( '{{a}}Videomaker{{/a}}, a premium theme optimized to display videos.', {
-							components: {
-								a: (
-									<a
-										href="https://videomakerdemo.wordpress.com/"
-										target="_blank"
-										rel="external noreferrer noopener"
-									/>
-								),
-							},
-						} ) }
-					</span>
-				</li>
-				<li>
-					<CheckmarkIcon />
-					<span>
-						{ translate( 'Unbranded, ad-free, customizable {{a}}VideoPress{{/a}} player.', {
-							components: {
-								a: (
-									<a
-										href="https://videopress.com"
-										target="_blank"
-										rel="external noreferrer noopener"
-									/>
-								),
-							},
-						} ) }
-					</span>
-				</li>
-				<li>
-					<CheckmarkIcon />
-					<span>
-						{ translate( 'Upload videos directly to your site using the WordPress editor.' ) }
-					</span>
-				</li>
-				<li>
-					<CheckmarkIcon />
-					<span>{ translate( 'Up to 200GB of storage and your own domain for a year.' ) }</span>
-				</li>
-			</ul>
-			<div className="videopress-intro-modal__button-column">
-				<Button className="intro__button" primary onClick={ onSubmit }>
-					{ getStartedText }
-				</Button>
-				<div className="learn-more">
-					{ translate( '{{a}}Or learn more about VideoPress.{{/a}}', {
-						components: {
-							a: (
-								<a
-									href="https://videopress.com/"
-									target="_blank"
-									rel="external noreferrer noopener"
-								/>
-							),
-						},
-					} ) }
-				</div>
-			</div>
-			<div className="videopress-intro-modal__screenshots">
-				<img
-					src="https://videopress2.files.wordpress.com/2023/02/videopress-modal-screenshots-2x.png"
-					alt={ translate( 'Mobile device screenshot samples of the Videomaker theme.' ) }
-				/>
-			</div>
-		</div>
+		<VideoPressOnboardingIntentModal
+			title={ translate( 'Your video portfolio, with no hassle.' ) }
+			description={ translate(
+				'Create a WordPress.com site with everything you need to share your videos with the world.'
+			) }
+			featuresList={ [
+				translate( '{{a}}Videomaker{{/a}}, a premium theme optimized to display videos.', {
+					components: {
+						a: (
+							<a
+								href="https://videomakerdemo.wordpress.com/"
+								target="_blank"
+								rel="external noreferrer noopener"
+							/>
+						),
+					},
+				} ),
+				translate( 'Unbranded, ad-free, customizable {{a}}VideoPress{{/a}} player.', {
+					components: {
+						a: (
+							<a href="https://videopress.com" target="_blank" rel="external noreferrer noopener" />
+						),
+					},
+				} ),
+				translate( 'Upload videos directly to your site using the WordPress editor.' ),
+				translate( 'Up to 200GB of storage and your own domain for a year.' ),
+			] }
+			actionButton={ {
+				type: 'button',
+				text: getStartedText,
+				onClick: onSubmit,
+			} }
+		/>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-portfolio.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-portfolio.tsx
@@ -1,0 +1,92 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import '../intro/videopress-intro-modal-styles.scss';
+import CheckmarkIcon from '../intro/icons/checkmark-icon';
+import { IntroModalContentProps } from '../intro/intro';
+
+const VideoPressOnboardingIntentModalPortfolio: React.FC< IntroModalContentProps > = ( {
+	onSubmit,
+} ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="videopress-intro-modal">
+			<h1 className="intro__title">{ translate( 'Your video site, with no hassle.' ) }</h1>
+			<div className="intro__description">
+				{ translate(
+					'Create a WordPress.com site with everything you need to share your videos with the world.'
+				) }
+			</div>
+			<ul className="videopress-intro-modal__list">
+				<li>
+					<CheckmarkIcon />
+					<span>
+						{ translate( '{{a}}Videomaker{{/a}}, a premium theme optimized to display videos.', {
+							components: {
+								a: (
+									<a
+										href="https://videomakerdemo.wordpress.com/"
+										target="_blank"
+										rel="external noreferrer noopener"
+									/>
+								),
+							},
+						} ) }
+					</span>
+				</li>
+				<li>
+					<CheckmarkIcon />
+					<span>
+						{ translate( 'Unbranded, ad-free, customizable {{a}}VideoPress{{/a}} player.', {
+							components: {
+								a: (
+									<a
+										href="https://videopress.com"
+										target="_blank"
+										rel="external noreferrer noopener"
+									/>
+								),
+							},
+						} ) }
+					</span>
+				</li>
+				<li>
+					<CheckmarkIcon />
+					<span>
+						{ translate( 'Upload videos directly to your site using the WordPress editor.' ) }
+					</span>
+				</li>
+				<li>
+					<CheckmarkIcon />
+					<span>{ translate( 'Up to 200GB of storage and your own domain for a year.' ) }</span>
+				</li>
+			</ul>
+			<div className="videopress-intro-modal__button-column">
+				<Button className="intro__button" primary onClick={ onSubmit }>
+					{ translate( 'Get started' ) }
+				</Button>
+				<div className="learn-more">
+					{ translate( '{{a}}Or learn more about VideoPress.{{/a}}', {
+						components: {
+							a: (
+								<a
+									href="https://videopress.com/"
+									target="_blank"
+									rel="external noreferrer noopener"
+								/>
+							),
+						},
+					} ) }
+				</div>
+			</div>
+			<div className="videopress-intro-modal__screenshots">
+				<img
+					src="https://videopress2.files.wordpress.com/2023/02/videopress-modal-screenshots-2x.png"
+					alt={ translate( 'Mobile device screenshot samples of the Videomaker theme.' ) }
+				/>
+			</div>
+		</div>
+	);
+};
+
+export default VideoPressOnboardingIntentModalPortfolio;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-video-upload.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-video-upload.tsx
@@ -1,0 +1,32 @@
+import { useTranslate } from 'i18n-calypso';
+import { IntroModalContentProps } from '../intro/intro';
+import VideoPressOnboardingIntentModal from './videopress-onboarding-intent-modal';
+
+const VideoPressOnboardingIntentModalVideoUpload: React.FC< IntroModalContentProps > = ( {
+	onSubmit,
+} ) => {
+	const translate = useTranslate();
+
+	return (
+		<VideoPressOnboardingIntentModal
+			title={ translate( 'The fastest way to share a video.' ) }
+			description={ translate( 'All the power of VideoPress, simplified.' ) }
+			featuresList={ [
+				translate( 'Upload a video file and obtain a share link. That’s it.' ),
+				translate( 'Embed your video anywhere.' ),
+				translate( 'Unbranded, ad-free, customizable {{a}}VideoPress{{/a}} player.', {
+					components: {
+						a: (
+							<a href="https://videopress.com" target="_blank" rel="external noreferrer noopener" />
+						),
+					},
+				} ),
+			] }
+			onSubmit={ onSubmit }
+			isComingSoon={ true }
+			surveyTitle={ translate( 'Are you interested in specific features?' ) }
+		/>
+	);
+};
+
+export default VideoPressOnboardingIntentModalVideoUpload;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
@@ -1,0 +1,76 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import '../intro/videopress-intro-modal-styles.scss';
+import CheckmarkIcon from '../intro/icons/checkmark-icon';
+import { IntroModalContentProps } from '../intro/intro';
+
+export interface VideoPressOnboardingIntentModalContentProps extends IntroModalContentProps {
+	title: string;
+	description: string;
+	featuresList?: string[] | React.ReactNode[];
+	actionButton: {
+		type: 'link' | 'button';
+		text: string | JSX.Element;
+		href?: string;
+		onClick?: () => void;
+	};
+}
+
+const VideoPressOnboardingIntentModal: React.FC< VideoPressOnboardingIntentModalContentProps > = ( {
+	title,
+	description,
+	featuresList,
+	actionButton,
+} ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="videopress-intro-modal">
+			<h1 className="intro__title">{ title }</h1>
+			<div className="intro__description">{ description }</div>
+			{ featuresList && (
+				<ul className="videopress-intro-modal__list">
+					{ featuresList?.map( ( feature ) => (
+						<li>
+							<CheckmarkIcon />
+							<span>{ feature }</span>
+						</li>
+					) ) }
+				</ul>
+			) }
+			<div className="videopress-intro-modal__button-column">
+				<Button
+					type={ actionButton.type }
+					href={ actionButton.href ?? '' }
+					className="intro__button"
+					primary
+					onClick={ actionButton.onClick }
+				>
+					{ actionButton.text }
+				</Button>
+				<div className="learn-more">
+					{ translate( '{{a}}Or learn more about VideoPress.{{/a}}', {
+						components: {
+							a: (
+								<a
+									href="https://videopress.com/"
+									target="_blank"
+									rel="external noreferrer noopener"
+								/>
+							),
+						},
+					} ) }
+				</div>
+			</div>
+			<div className="videopress-intro-modal__screenshots">
+				<img
+					src="https://videopress2.files.wordpress.com/2023/02/videopress-modal-screenshots-2x.png"
+					alt={ translate( 'Mobile device screenshot samples of the Videomaker theme.' ) }
+				/>
+			</div>
+		</div>
+	);
+};
+
+export default VideoPressOnboardingIntentModal;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import '../intro/videopress-intro-modal-styles.scss';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 import CheckmarkIcon from '../intro/icons/checkmark-icon';
 import { IntroModalContentProps } from '../intro/intro';
 
@@ -9,12 +10,14 @@ export interface VideoPressOnboardingIntentModalContentProps extends IntroModalC
 	title: string;
 	description: string;
 	featuresList?: string[] | React.ReactNode[];
-	actionButton: {
+	actionButton?: {
 		type: 'link' | 'button';
 		text: string | JSX.Element;
 		href?: string;
 		onClick?: () => void;
 	};
+	isComingSoon?: boolean;
+	surveyTitle?: string;
 }
 
 const VideoPressOnboardingIntentModal: React.FC< VideoPressOnboardingIntentModalContentProps > = ( {
@@ -22,11 +25,17 @@ const VideoPressOnboardingIntentModal: React.FC< VideoPressOnboardingIntentModal
 	description,
 	featuresList,
 	actionButton,
+	isComingSoon,
+	surveyTitle,
+	onSubmit,
 } ) => {
 	const translate = useTranslate();
 
 	return (
 		<div className="videopress-intro-modal">
+			{ isComingSoon && (
+				<div className="videopress-intro-modal__coming-soon">{ translate( 'Coming soon!' ) }</div>
+			) }
 			<h1 className="intro__title">{ title }</h1>
 			<div className="intro__description">{ description }</div>
 			{ featuresList && (
@@ -40,28 +49,59 @@ const VideoPressOnboardingIntentModal: React.FC< VideoPressOnboardingIntentModal
 				</ul>
 			) }
 			<div className="videopress-intro-modal__button-column">
-				<Button
-					type={ actionButton.type }
-					href={ actionButton.href ?? '' }
-					className="intro__button"
-					primary
-					onClick={ actionButton.onClick }
-				>
-					{ actionButton.text }
-				</Button>
-				<div className="learn-more">
-					{ translate( '{{a}}Or learn more about VideoPress.{{/a}}', {
-						components: {
-							a: (
-								<a
-									href="https://videopress.com/"
-									target="_blank"
-									rel="external noreferrer noopener"
-								/>
-							),
-						},
-					} ) }
-				</div>
+				{ actionButton && (
+					<>
+						<Button
+							type={ actionButton.type }
+							href={ actionButton.href ?? '' }
+							className="intro__button"
+							primary
+							onClick={ actionButton.onClick }
+						>
+							{ actionButton.text }
+						</Button>
+						<div className="learn-more">
+							{ translate( '{{a}}Or learn more about VideoPress.{{/a}}', {
+								components: {
+									a: (
+										<a
+											href="https://videopress.com/"
+											target="_blank"
+											rel="external noreferrer noopener"
+										/>
+									),
+								},
+							} ) }
+						</div>
+					</>
+				) }
+				{ isComingSoon && (
+					<div className="videopress-intro-modal__waitlist-presentation">
+						<div className="videopress-intro-modal__waitlist">
+							<FormTextInput placeholder={ translate( 'Enter your email' ) } />
+							<Button className="intro__button" primary>
+								{ translate( 'Join the waitlist' ) }
+							</Button>
+						</div>
+						<div className="videopress-intro-modal__waitlist-description">
+							{ translate(
+								'In the meantime, you can {{a}}create a blog with video{{/a}}, a {{b}}video portfolio{{/b}}, or {{c}}add videos to your existing site{{/c}}.',
+								{
+									components: {
+										a: <Button onClick={ () => onSubmit?.() && false } />,
+										b: <Button onClick={ () => onSubmit?.() && false } />,
+										c: (
+											<a
+												href="https://jetpack.com/videopress/"
+												rel="external noreferrer noopener"
+											/>
+										),
+									},
+								}
+							) }
+						</div>
+					</div>
+				) }
 			</div>
 			<div className="videopress-intro-modal__screenshots">
 				<img
@@ -69,6 +109,19 @@ const VideoPressOnboardingIntentModal: React.FC< VideoPressOnboardingIntentModal
 					alt={ translate( 'Mobile device screenshot samples of the Videomaker theme.' ) }
 				/>
 			</div>
+			{ surveyTitle && (
+				<div className="videopress-intro-modal__survey">
+					<div className="videopress-intro-modal__survey-info">
+						<div className="videopress-intro-modal__survey-title">{ surveyTitle }</div>
+						<div className="videopress-intro-modal__survey-description">
+							{ translate( 'Answer a short survey and you’ll have the chance to win $50.' ) }
+						</div>
+					</div>
+					<Button className="intro__button button-survey" primary>
+						{ translate( 'Answer the survey ->' ) }
+					</Button>
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
@@ -31,8 +31,8 @@ const VideoPressOnboardingIntentModal: React.FC< VideoPressOnboardingIntentModal
 			<div className="intro__description">{ description }</div>
 			{ featuresList && (
 				<ul className="videopress-intro-modal__list">
-					{ featuresList?.map( ( feature ) => (
-						<li>
+					{ featuresList?.map( ( feature, index ) => (
+						<li key={ index }>
 							<CheckmarkIcon />
 							<span>{ feature }</span>
 						</li>


### PR DESCRIPTION
## Proposed Changes

This PR adds modals to the VideoPress onboarding intent and the following modal content:
* Video Portfolio
* Jetpack
* Blog

## Testing Instructions

* Apply PR
* Go to /setup/videopress
* Click on "Get a video portfolio"
* ✅ A modal should appear
* ✅ The content should match the selection
* Close the modal
* Click on "Add video to existing site"
* ✅ A modal should appear
* ✅ The content should match the selection
* Close the modal
* Click on "Start a blog with video content"
* ✅ A modal should appear
* ✅ The content should match the selection
* Click on "Create a channel"
* ✅ A modal should appear
* ✅ The content should match the selection
* ✅ The content should be in "coming soon" mode 
* Click on "Upload a video"
* ✅ A modal should appear
* ✅ The content should match the selection
* ✅ The content should be in "coming soon" mode