### PR TITLE
Design Picker: Prevent layout changes in sidebar

### DIFF
--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -270,7 +270,8 @@ $design-preview-sidebar-width: 311px;
 	width: 100%;
 	padding: 16px 20px 8px;
 	box-sizing: border-box;
-	overflow: auto;
+	overflow-x: auto;
+	overflow-y: hidden;
 
 	> p {
 		color: var(--studio-gray-100);
@@ -313,10 +314,18 @@ $design-preview-sidebar-width: 311px;
 	}
 
 	@include break-large {
-		padding: 8px 16px 0;
-		margin: 0 -16px;
-		box-sizing: content-box;
+		padding: 0;
+		margin: 8px 0 0;
 		animation: none;
+		// Increase width to ensure the scrollbar doesn't "push" the content to the left.
+		width: calc(100% + 16px);
+		overflow-x: hidden;
+		overflow-y: scroll;
+
+		@supports ( scrollbar-gutter: stable ) {
+			overflow-y: auto;
+			scrollbar-gutter: stable;
+		}
 
 		> p {
 			display: block;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/80632

## Proposed Changes

Updates the CSS styles of the Design Picker sidebar to prevent the layout width from changing since this was causing a vibration effect when the content started to overflow.

The fix relies on `scrollbar-gutter` (props to @arthur791004 for the idea!) which is unsupported on Safari, so we fallback to `overflow: scroll` when the browser does not support it.

### Chrome

#### Before

https://github.com/Automattic/wp-calypso/assets/1233880/46077294-e504-4341-aad7-1162cb6eee16

#### After

https://github.com/Automattic/wp-calypso/assets/1233880/e7551e55-b399-4bdc-a434-e7061399c431

### Safari

#### Before

https://github.com/Automattic/wp-calypso/assets/1233880/6d008520-063e-4b9d-902f-ba837d71e4c2

#### After

https://github.com/Automattic/wp-calypso/assets/1233880/411a3222-efc2-4317-a0e6-fa5ace49f72f

## Testing Instructions

- Open the Appearance macOS settings and change "Show scroll bars" to "Always":
<img width="250" alt="Screenshot 2023-08-28 at 13 55 48" src="https://github.com/Automattic/wp-calypso/assets/1233880/dcc03c25-8a51-4c8b-a50d-c2441dff69ec">

- Open the Calypso live link below in Chrome.
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>&theme=twentytwentythree`.
- Resize the browser so all style variations are visible.
- Make sure the scroll bar is not visible.
- Slightly reduce the browser height so the style variations start to overflow.
- Make sure the width of the style variations container does not change.
- Make sure the scroll bar is visible now.
- Make sure the vibration effect noted above is gone.
- Switch to Safari.
- Resize the browser so all style variations are visible.
- Make sure the scroll bar is visible.
- Slightly reduce the browser height so the style variations start to overflow.
- Make sure the width of the style variations container does not change.
- Make sure the scroll bar is still visible.
- Make sure the vibration effect noted above is gone.
