### PR TITLE
GS on Personal A/B: Stop upselling Personal to `treatment` users

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -434,8 +434,7 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 		$site_slug = wp_parse_url( $home_url, PHP_URL_HOST );
 	}
 
-	$plan        = wpcom_site_has_global_styles_in_personal_plan() ? 'personal-bundle' : 'value_bundle';
-	$upgrade_url = "https://wordpress.com/plans/$site_slug?plan=$plan&feature=style-customization";
+	$upgrade_url = "https://wordpress.com/plans/$site_slug?plan=value_bundle&feature=style-customization";
 
 	if ( wpcom_is_previewing_global_styles() ) {
 		$preview_location = add_query_arg( 'hide-global-styles', '' );
@@ -472,26 +471,14 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 				</div>
 				<div class="launch-bar-global-styles-message">
 					<?php
-					// @TODO Remove after global styles on personal plans A/B test is complete.
-					if ( wpcom_site_has_global_styles_in_personal_plan() ) {
-						$message = sprintf(
+					$message = sprintf(
 						/* translators: %s - documentation URL. */
-							__(
-								'Your site includes <a href="%s" target="_blank">customized styles</a> that are only visible to visitors after upgrading to the Personal plan or higher.',
-								'full-site-editing'
-							),
-							'https://wordpress.com/support/using-styles/'
-						);
-					} else {
-						$message = sprintf(
-						/* translators: %s - documentation URL. */
-							__(
-								'Your site includes <a href="%s" target="_blank">customized styles</a> that are only visible to visitors after upgrading to the Premium plan or higher.',
-								'full-site-editing'
-							),
-							'https://wordpress.com/support/using-styles/'
-						);
-					}
+						__(
+							'Your site includes <a href="%s" target="_blank">customized styles</a> that are only visible to visitors after upgrading to the Premium plan or higher.',
+							'full-site-editing'
+						),
+						'https://wordpress.com/support/using-styles/'
+					);
 					echo sprintf(
 						wp_kses(
 							$message,

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -161,8 +161,6 @@ function wpcom_global_styles_enqueue_block_editor_assets() {
 		true
 	);
 	wp_set_script_translations( 'wpcom-global-styles-editor', 'full-site-editing' );
-	$is_global_styles_in_personal_plan = wpcom_site_has_global_styles_in_personal_plan();
-	$plan                              = $is_global_styles_in_personal_plan ? 'personal-bundle' : 'value_bundle';
 
 	$reset_global_styles_support_url = 'https://wordpress.com/support/using-styles/#reset-all-styles';
 	if ( class_exists( 'WPCom_Languages' ) ) {
@@ -173,9 +171,8 @@ function wpcom_global_styles_enqueue_block_editor_assets() {
 		'wpcomGlobalStyles',
 		array(
 			'assetsUrl'                   => plugins_url( 'dist/', __FILE__ ),
-			'upgradeUrl'                  => "$calypso_domain/plans/$site_slug?plan=$plan&feature=style-customization",
+			'upgradeUrl'                  => "$calypso_domain/plans/$site_slug?plan=value_bundle&feature=style-customization",
 			'wpcomBlogId'                 => wpcom_global_styles_get_wpcom_current_blog_id(),
-			'globalStylesInPersonalPlan'  => $is_global_styles_in_personal_plan,
 			'resetGlobalStylesSupportUrl' => $reset_global_styles_support_url,
 		)
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -11,8 +11,6 @@ import { useCanvas } from './use-canvas';
 
 import './modal.scss';
 
-const GLOBAL_STYLES_TREATMENT_GROUP = '1';
-
 const GlobalStylesModal = () => {
 	const isSiteEditor = useSelect( ( select ) => !! select( 'core/edit-site' ), [] );
 	const { viewCanvasPath } = useCanvas();
@@ -63,18 +61,10 @@ const GlobalStylesModal = () => {
 		return null;
 	}
 
-	let description;
-	if ( wpcomGlobalStyles?.globalStylesInPersonalPlan === GLOBAL_STYLES_TREATMENT_GROUP ) {
-		description = __(
-			"Change all of your site's fonts, colors and more. Available on the Personal plan.",
-			'full-site-editing'
-		);
-	} else {
-		description = __(
-			"Change all of your site's fonts, colors and more. Available on the Premium plan.",
-			'full-site-editing'
-		);
-	}
+	const description = __(
+		"Change all of your site's fonts, colors and more. Available on the Premium plan.",
+		'full-site-editing'
+	);
 
 	return (
 		<Modal

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
@@ -15,8 +15,6 @@ import { useGlobalStylesConfig } from './use-global-styles-config';
 import { usePreview } from './use-preview';
 import './notice.scss';
 
-const GLOBAL_STYLES_TREATMENT_GROUP = '1';
-
 const trackEvent = ( eventName, isSiteEditor = true ) =>
 	recordTracksEvent( eventName, {
 		context: isSiteEditor ? 'site-editor' : 'post-editor',
@@ -36,18 +34,10 @@ function GlobalStylesWarningNotice() {
 		return null;
 	}
 
-	let upgradeTranslation;
-	if ( wpcomGlobalStyles?.globalStylesInPersonalPlan === GLOBAL_STYLES_TREATMENT_GROUP ) {
-		upgradeTranslation = __(
-			'Your site includes customized styles that are only visible to visitors after <a>upgrading to the Personal plan or higher</a>.',
-			'full-site-editing'
-		);
-	} else {
-		upgradeTranslation = __(
-			'Your site includes customized styles that are only visible to visitors after <a>upgrading to the Premium plan or higher</a>.',
-			'full-site-editing'
-		);
-	}
+	const upgradeTranslation = __(
+		'Your site includes customized styles that are only visible to visitors after <a>upgrading to the Premium plan or higher</a>.',
+		'full-site-editing'
+	);
 
 	return (
 		<Notice status="warning" isDismissible={ false } className="wpcom-global-styles-notice">
@@ -171,29 +161,16 @@ function GlobalStylesEditNotice() {
 				: 'wpcom-global-styles-action-has-icon wpcom-global-styles-action-is-external wpcom-global-styles-action-is-support',
 		} );
 
-		if ( wpcomGlobalStyles?.globalStylesInPersonalPlan === GLOBAL_STYLES_TREATMENT_GROUP ) {
-			createWarningNotice(
-				__(
-					'Your site includes customized styles that are only visible to visitors after upgrading to the Personal plan or higher.',
-					'full-site-editing'
-				),
-				{
-					id: NOTICE_ID,
-					actions: actions,
-				}
-			);
-		} else {
-			createWarningNotice(
-				__(
-					'Your site includes customized styles that are only visible to visitors after upgrading to the Premium plan or higher.',
-					'full-site-editing'
-				),
-				{
-					id: NOTICE_ID,
-					actions: actions,
-				}
-			);
-		}
+		createWarningNotice(
+			__(
+				'Your site includes customized styles that are only visible to visitors after upgrading to the Premium plan or higher.',
+				'full-site-editing'
+			),
+			{
+				id: NOTICE_ID,
+				actions: actions,
+			}
+		);
 
 		trackEvent( 'calypso_global_styles_gating_notice_show', isSiteEditor );
 	}, [

--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -6,7 +6,6 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
-import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 
 import './style.scss';
 
@@ -30,7 +29,6 @@ export default function PremiumGlobalStylesUpgradeModal( {
 }: PremiumGlobalStylesUpgradeModalProps ) {
 	const translate = useTranslate();
 	const premiumPlanProduct = useSelector( ( state ) => getProductBySlug( state, PLAN_PREMIUM ) );
-	const { globalStylesInPersonalPlan } = useSiteGlobalStylesStatus();
 	const isLoading = ! premiumPlanProduct;
 	const features = [
 		<strong>{ translate( 'Free domain for one year' ) }</strong>,
@@ -40,23 +38,12 @@ export default function PremiumGlobalStylesUpgradeModal( {
 		translate( 'Ad-free experience' ),
 		translate( 'Earn with WordAds' ),
 	];
-	const personalFeatures = [
-		<strong>{ translate( 'Free domain for one year' ) }</strong>,
-		<strong>{ translate( 'Style customization' ) }</strong>,
-		translate( 'Support via email' ),
-		translate( 'Ad-free experience' ),
-	];
-	const displayFeatures = globalStylesInPersonalPlan ? personalFeatures : features;
 
 	const featureList = (
 		<div className="upgrade-modal__included">
-			<h2>
-				{ globalStylesInPersonalPlan
-					? translate( 'Included with your Personal plan' )
-					: translate( 'Included with your Premium plan' ) }
-			</h2>
+			<h2>{ translate( 'Included with your Premium plan' ) }</h2>
 			<ul>
-				{ displayFeatures.map( ( feature, i ) => (
+				{ features.map( ( feature, i ) => (
 					<li key={ i } className="upgrade-modal__included-item">
 						<Gridicon icon="checkmark" size={ 16 } />
 						{ feature }
@@ -85,17 +72,11 @@ export default function PremiumGlobalStylesUpgradeModal( {
 							{ description ?? (
 								<>
 									<p>
-										{ globalStylesInPersonalPlan
-											? translate(
-													'You’ve selected a custom style that will only be visible to visitors after upgrading to the Personal plan or higher.',
-													'You’ve selected custom styles that will only be visible to visitors after upgrading to the Personal plan or higher.',
-													{ count: numOfSelectedGlobalStyles }
-											  )
-											: translate(
-													'You’ve selected a custom style that will only be visible to visitors after upgrading to the Premium plan or higher.',
-													'You’ve selected custom styles that will only be visible to visitors after upgrading to the Premium plan or higher.',
-													{ count: numOfSelectedGlobalStyles }
-											  ) }
+										{ translate(
+											'You’ve selected a custom style that will only be visible to visitors after upgrading to the Premium plan or higher.',
+											'You’ve selected custom styles that will only be visible to visitors after upgrading to the Premium plan or higher.',
+											{ count: numOfSelectedGlobalStyles }
+										) }
 									</p>
 									<p>
 										{ translate(

--- a/client/components/theme-type-badge/test/index.jsx
+++ b/client/components/theme-type-badge/test/index.jsx
@@ -7,12 +7,6 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import ThemeTypeBadge from '../';
 
-jest.mock( 'calypso/state/sites/hooks/use-site-global-styles-status', () => ( {
-	useSiteGlobalStylesStatus: () => ( {
-		globalStylesInPersonalPlan: false,
-	} ),
-} ) );
-
 describe( 'ThemeTypeBadge', () => {
 	function renderWithState( content, { hasPremiumPlan = false, hasPurchasedTheme = false } = {} ) {
 		const initialState = {

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -10,7 +10,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useSelector } from 'calypso/state';
-import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import {
 	canUseTheme,
 	getThemeType,
@@ -72,7 +71,6 @@ const ThemeTypeBadgeTooltip = ( {
 	const isIncludedCurrentPlan = useSelector(
 		( state ) => siteId && canUseTheme( state, siteId, themeId )
 	);
-	const { globalStylesInPersonalPlan } = useSiteGlobalStylesStatus( siteId );
 	const isPurchased = useSelector( ( state ) => {
 		if ( ! siteId ) {
 			return false;
@@ -126,15 +124,9 @@ const ThemeTypeBadgeTooltip = ( {
 
 	let message;
 	if ( isLockedStyleVariation ) {
-		if ( globalStylesInPersonalPlan ) {
-			message = translate(
-				'Unlock this style, and tons of other features, by upgrading to a Personal plan.'
-			);
-		} else {
-			message = translate(
-				'Unlock this style, and tons of other features, by upgrading to a Premium plan.'
-			);
-		}
+		message = translate(
+			'Unlock this style, and tons of other features, by upgrading to a Premium plan.'
+		);
 	} else if ( type === PREMIUM_THEME ) {
 		if ( isPurchased ) {
 			message = translate( 'You have purchased this theme.' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -103,9 +103,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 	const siteTitle = site?.name;
 	const siteDescription = site?.description;
-	const { shouldLimitGlobalStyles, globalStylesInPersonalPlan } = useSiteGlobalStylesStatus(
-		site?.ID
-	);
+	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
 	const isDesignFirstFlow = queryParams.get( 'flowToReturnTo' ) === 'design-first';
 	const [ shouldHideActionButtons, setShouldHideActionButtons ] = useState( false );
 
@@ -510,7 +508,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				siteSlug: siteSlug || urlToSlug( site?.URL || '' ) || '',
 				// When the user is done with checkout, send them back to the current url
 				destination: window.location.href.replace( window.location.origin, '' ),
-				plan: globalStylesInPersonalPlan ? 'personal' : 'premium',
+				plan: 'premium',
 			} );
 
 			setShowPremiumGlobalStylesModal( false );
@@ -769,7 +767,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					actionButtons={ actionButtons }
 					recordDeviceClick={ recordDeviceClick }
 					limitGlobalStyles={ shouldLimitGlobalStyles }
-					globalStylesInPersonalPlan={ globalStylesInPersonalPlan }
 					siteId={ site.ID }
 					stylesheet={ selectedDesign.recipe?.stylesheet }
 					screenshot={ fullLengthScreenshot }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,4 +1,4 @@
-import { PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
+import { PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Badge, Gridicon, CircularProgressBar } from '@automattic/components';
 import { OnboardSelect, useLaunchpad } from '@automattic/data-stores';
 import { Launchpad } from '@automattic/launchpad';
@@ -69,8 +69,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 	const [ showPlansModal, setShowPlansModal ] = useState( false );
 	const queryClient = useQueryClient();
 
-	const { globalStylesInUse, shouldLimitGlobalStyles, globalStylesInPersonalPlan } =
-		useSiteGlobalStylesStatus( site?.ID );
+	const { globalStylesInUse, shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
 
 	const {
 		data: { checklist_statuses: checklistStatuses, checklist: launchpadChecklist },
@@ -105,7 +104,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 			site,
 			submit,
 			globalStylesInUse && shouldLimitGlobalStyles,
-			globalStylesInPersonalPlan ? PLAN_PERSONAL : PLAN_PREMIUM,
+			PLAN_PREMIUM,
 			setShowPlansModal,
 			queryClient,
 			goToStep,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
@@ -28,9 +28,7 @@ const useGlobalStylesUpgradeModal = ( {
 	const site = useSite();
 	const siteSlug = useSiteSlugParam();
 	const siteUrl = siteSlug || urlToSlug( site?.URL || '' ) || '';
-	const { shouldLimitGlobalStyles, globalStylesInPersonalPlan } = useSiteGlobalStylesStatus(
-		site?.ID
-	);
+	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
 	const { goToCheckout } = useCheckout();
 	const numOfSelectedGlobalStyles = [ hasSelectedColorVariation, hasSelectedFontVariation ].filter(
 		Boolean
@@ -57,7 +55,7 @@ const useGlobalStylesUpgradeModal = ( {
 			stepName,
 			siteSlug: siteUrl,
 			destination: redirectUrl,
-			plan: globalStylesInPersonalPlan ? 'personal' : 'premium',
+			plan: 'premium',
 		} );
 
 		setIsOpen( false );

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -317,7 +317,6 @@ type PlanComparisonGridProps = {
 	planActionOverrides?: PlanActionOverrides;
 	selectedPlan?: string;
 	selectedFeature?: string;
-	isGlobalStylesOnPersonal?: boolean;
 	showLegacyStorageFeature?: boolean;
 };
 

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -126,8 +126,6 @@ interface Props {
 		[ key: string ]: boolean;
 	};
 	showLegacyStorageFeature?: boolean;
-	// for AB Test experiment:
-	isGlobalStylesOnPersonal?: boolean;
 }
 
 const usePlanTypesWithIntent = ( {
@@ -224,7 +222,6 @@ const useGridPlans = ( {
 	hideEnterprisePlan,
 	isInSignup,
 	usePlanUpgradeabilityCheck,
-	isGlobalStylesOnPersonal,
 }: Props ): Omit< GridPlan, 'features' >[] => {
 	const availablePlanSlugs = usePlansFromTypes( {
 		planTypes: usePlanTypesWithIntent( {
@@ -268,13 +265,13 @@ const useGridPlans = ( {
 
 		let tagline = '';
 		if ( 'plans-newsletter' === intent ) {
-			tagline = planConstantObj.getNewsletterTagLine?.( isGlobalStylesOnPersonal ) ?? '';
+			tagline = planConstantObj.getNewsletterTagLine?.() ?? '';
 		} else if ( 'plans-link-in-bio' === intent ) {
-			tagline = planConstantObj.getLinkInBioTagLine?.( isGlobalStylesOnPersonal ) ?? '';
+			tagline = planConstantObj.getLinkInBioTagLine?.() ?? '';
 		} else if ( 'plans-blog-onboarding' === intent ) {
-			tagline = planConstantObj.getBlogOnboardingTagLine?.( isGlobalStylesOnPersonal ) ?? '';
+			tagline = planConstantObj.getBlogOnboardingTagLine?.() ?? '';
 		} else {
-			tagline = planConstantObj.getPlanTagline?.( isGlobalStylesOnPersonal ) ?? '';
+			tagline = planConstantObj.getPlanTagline?.() ?? '';
 		}
 
 		const productNameShort =

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
@@ -12,14 +12,12 @@ export type UsePlanFeaturesForGridPlans = ( {
 	// allFeaturesList temporary until feature definitions are ported to calypso-products package
 	allFeaturesList,
 	intent,
-	isGlobalStylesOnPersonal,
 	showLegacyStorageFeature,
 	selectedFeature,
 }: {
 	planSlugs: PlanSlug[];
 	allFeaturesList: FeatureList;
 	intent?: PlansIntent;
-	isGlobalStylesOnPersonal?: boolean;
 	selectedFeature?: string | null;
 	showLegacyStorageFeature?: boolean;
 } ) => { [ planSlug: string ]: PlanFeaturesForGridPlan };
@@ -33,7 +31,6 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 	planSlugs,
 	allFeaturesList,
 	intent,
-	isGlobalStylesOnPersonal,
 	selectedFeature,
 	showLegacyStorageFeature,
 } ) => {
@@ -47,17 +44,17 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 		if ( 'plans-newsletter' === intent ) {
 			wpcomFeatures = getPlanFeaturesObject(
 				allFeaturesList,
-				planConstantObj?.getNewsletterSignupFeatures?.( isGlobalStylesOnPersonal ) ?? []
+				planConstantObj?.getNewsletterSignupFeatures?.() ?? []
 			);
 		} else if ( 'plans-link-in-bio' === intent ) {
 			wpcomFeatures = getPlanFeaturesObject(
 				allFeaturesList,
-				planConstantObj?.getLinkInBioSignupFeatures?.( isGlobalStylesOnPersonal ) ?? []
+				planConstantObj?.getLinkInBioSignupFeatures?.() ?? []
 			);
 		} else if ( 'plans-blog-onboarding' === intent ) {
 			wpcomFeatures = getPlanFeaturesObject(
 				allFeaturesList,
-				planConstantObj?.getBlogOnboardingSignupFeatures?.( isGlobalStylesOnPersonal ) ?? []
+				planConstantObj?.getBlogOnboardingSignupFeatures?.() ?? []
 			);
 
 			jetpackFeatures = getPlanFeaturesObject(
@@ -67,7 +64,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 		} else {
 			wpcomFeatures = getPlanFeaturesObject(
 				allFeaturesList,
-				planConstantObj?.get2023PricingGridSignupWpcomFeatures?.( isGlobalStylesOnPersonal ) ?? []
+				planConstantObj?.get2023PricingGridSignupWpcomFeatures?.() ?? []
 			);
 
 			jetpackFeatures = getPlanFeaturesObject(

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-restructured-plan-features-for-comparison-grid.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-restructured-plan-features-for-comparison-grid.ts
@@ -18,14 +18,12 @@ export type UseRestructuredPlanFeaturesForComparisonGrid = ( {
 	planSlugs,
 	allFeaturesList,
 	intent,
-	isGlobalStylesOnPersonal,
 	showLegacyStorageFeature,
 	selectedFeature,
 }: {
 	planSlugs: PlanSlug[];
 	allFeaturesList: FeatureList;
 	intent?: PlansIntent;
-	isGlobalStylesOnPersonal?: boolean;
 	selectedFeature?: string | null;
 	showLegacyStorageFeature?: boolean;
 } ) => { [ planSlug: string ]: PlanFeaturesForGridPlan };
@@ -35,14 +33,12 @@ const useRestructuredPlanFeaturesForComparisonGrid: UseRestructuredPlanFeaturesF
 		planSlugs,
 		allFeaturesList,
 		intent,
-		isGlobalStylesOnPersonal,
 		selectedFeature,
 		showLegacyStorageFeature,
 	}: {
 		planSlugs: PlanSlug[];
 		allFeaturesList: FeatureList;
 		intent?: PlansIntent;
-		isGlobalStylesOnPersonal?: boolean;
 		selectedFeature?: string | null;
 		showLegacyStorageFeature?: boolean;
 	} ) => {
@@ -50,7 +46,6 @@ const useRestructuredPlanFeaturesForComparisonGrid: UseRestructuredPlanFeaturesF
 			planSlugs,
 			allFeaturesList,
 			intent,
-			isGlobalStylesOnPersonal,
 			selectedFeature,
 			showLegacyStorageFeature,
 		} );
@@ -71,9 +66,7 @@ const useRestructuredPlanFeaturesForComparisonGrid: UseRestructuredPlanFeaturesF
 					  )
 					: getPlanFeaturesObject(
 							allFeaturesList,
-							planConstantObj
-								.get2023PricingGridSignupWpcomFeatures?.( isGlobalStylesOnPersonal )
-								.slice()
+							planConstantObj.get2023PricingGridSignupWpcomFeatures?.().slice()
 					  );
 
 				const jetpackFeatures = planConstantObj.get2023PlanComparisonJetpackFeatureOverride
@@ -151,7 +144,7 @@ const useRestructuredPlanFeaturesForComparisonGrid: UseRestructuredPlanFeaturesF
 				previousPlan = planSlug;
 			}
 			return planFeatureMap;
-		}, [ allFeaturesList, isGlobalStylesOnPersonal, planFeaturesForGridPlans, planSlugs ] );
+		}, [ allFeaturesList, planFeaturesForGridPlans, planSlugs ] );
 
 		return restructuredFeatures;
 	};

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -88,7 +88,6 @@ export interface PlanFeatures2023GridProps {
 	selectedFeature?: string;
 	intent?: PlansIntent;
 	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >; // indicate when a custom domain is allowed to be used with the Free plan.
-	isGlobalStylesOnPersonal?: boolean;
 	showLegacyStorageFeature?: boolean;
 	showUpgradeableStorage: boolean; // feature flag used to show the storage add-on dropdown
 	stickyRowOffset: number;
@@ -697,7 +696,6 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			selectedPlan,
 			selectedFeature,
 			intent,
-			isGlobalStylesOnPersonal,
 			gridPlansForFeaturesGrid,
 			gridPlansForComparisonGrid,
 			showLegacyStorageFeature,
@@ -775,7 +773,6 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 								siteId={ siteId }
 								selectedPlan={ selectedPlan }
 								selectedFeature={ selectedFeature }
-								isGlobalStylesOnPersonal={ isGlobalStylesOnPersonal }
 								showLegacyStorageFeature={ showLegacyStorageFeature }
 							/>
 							<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -39,7 +39,6 @@ import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan';
-import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSitePlanSlug, getSiteSlug } from 'calypso/state/sites/selectors';
 import { FreePlanFreeDomainDialog } from './components/free-plan-free-domain-dialog';
@@ -237,7 +236,6 @@ const PlansFeaturesMain = ( {
 		flowName,
 		!! paidDomainName
 	);
-	const { globalStylesInPersonalPlan } = useSiteGlobalStylesStatus( siteId );
 	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
 	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
@@ -331,14 +329,12 @@ const PlansFeaturesMain = ( {
 		hideEnterprisePlan,
 		usePlanUpgradeabilityCheck,
 		showLegacyStorageFeature,
-		isGlobalStylesOnPersonal: globalStylesInPersonalPlan,
 	} );
 
 	const planFeaturesForFeaturesGrid = usePlanFeaturesForGridPlans( {
 		planSlugs: gridPlans.map( ( gridPlan ) => gridPlan.planSlug ),
 		allFeaturesList: FEATURES_LIST,
 		intent,
-		isGlobalStylesOnPersonal: globalStylesInPersonalPlan,
 		selectedFeature,
 		showLegacyStorageFeature,
 	} );
@@ -347,7 +343,6 @@ const PlansFeaturesMain = ( {
 		planSlugs: gridPlans.map( ( gridPlan ) => gridPlan.planSlug ),
 		allFeaturesList: FEATURES_LIST,
 		intent,
-		isGlobalStylesOnPersonal: globalStylesInPersonalPlan,
 		selectedFeature,
 		showLegacyStorageFeature,
 	} );
@@ -667,7 +662,6 @@ const PlansFeaturesMain = ( {
 							currentSitePlanSlug={ sitePlanSlug }
 							planActionOverrides={ planActionOverrides }
 							intent={ intent }
-							isGlobalStylesOnPersonal={ globalStylesInPersonalPlan }
 							showLegacyStorageFeature={ showLegacyStorageFeature }
 							showUpgradeableStorage={ showUpgradeableStorage }
 							stickyRowOffset={ masterbarHeight }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -6,10 +6,7 @@ import {
 	WPCOM_FEATURES_SITE_PREVIEW_LINKS,
 	FEATURE_STYLE_CUSTOMIZATION,
 } from '@automattic/calypso-products';
-import {
-	PLAN_PERSONAL,
-	WPCOM_FEATURES_SUBSCRIPTION_GIFTING,
-} from '@automattic/calypso-products/src';
+import { WPCOM_FEATURES_SUBSCRIPTION_GIFTING } from '@automattic/calypso-products/src';
 import { Card, CompactCard, Button, Gridicon } from '@automattic/components';
 import { guessTimezone, localizeUrl } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
@@ -921,10 +918,8 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	advancedCustomizationNotice() {
-		const { translate, selectedSite, siteSlug, globalStylesOnPersonalExperiment } = this.props;
-		const upgradeUrl = `/plans/${ siteSlug }?plan=${
-			globalStylesOnPersonalExperiment ? PLAN_PERSONAL : PLAN_PREMIUM
-		}&feature=${ FEATURE_STYLE_CUSTOMIZATION }`;
+		const { translate, selectedSite, siteSlug } = this.props;
+		const upgradeUrl = `/plans/${ siteSlug }?plan=${ PLAN_PREMIUM }&feature=${ FEATURE_STYLE_CUSTOMIZATION }`;
 
 		return (
 			<>
@@ -932,13 +927,9 @@ export class SiteSettingsFormGeneral extends Component {
 					<div className="site-settings__advanced-customization-notice-cta">
 						<Gridicon icon="info-outline" />
 						<span>
-							{ globalStylesOnPersonalExperiment
-								? translate(
-										'Your site contains customized styles that will only be visible once you upgrade to a Personal plan.'
-								  )
-								: translate(
-										'Your site contains customized styles that will only be visible once you upgrade to a Premium plan.'
-								  ) }
+							{ translate(
+								'Your site contains customized styles that will only be visible once you upgrade to a Premium plan.'
+							) }
 						</span>
 					</div>
 					<div className="site-settings__advanced-customization-notice-buttons">
@@ -1034,14 +1025,14 @@ const getFormSettings = ( settings ) => {
 };
 
 const SiteSettingsFormGeneralWithGlobalStylesNotice = ( props ) => {
-	const { globalStylesInUse, shouldLimitGlobalStyles, globalStylesInPersonalPlan } =
-		useSiteGlobalStylesStatus( props.site?.ID );
+	const { globalStylesInUse, shouldLimitGlobalStyles } = useSiteGlobalStylesStatus(
+		props.site?.ID
+	);
 
 	return (
 		<SiteSettingsFormGeneral
 			{ ...props }
 			shouldShowPremiumStylesNotice={ globalStylesInUse && shouldLimitGlobalStyles }
-			globalStylesOnPersonalExperiment={ globalStylesInPersonalPlan }
 		/>
 	);
 };

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1069,14 +1069,11 @@ class ThemeSheet extends Component {
 			this.getPremiumGlobalStylesEventProps()
 		);
 
-		const { globalStylesInPersonalPlan } = this.props;
-		const plan = globalStylesInPersonalPlan ? 'personal' : 'premium';
-
 		const params = new URLSearchParams();
 		params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );
 
 		this.setState( { showUnlockStyleUpgradeModal: false } );
-		page( `/checkout/${ this.props.siteSlug || '' }/${ plan }?${ params.toString() }` );
+		page( `/checkout/${ this.props.siteSlug || '' }/premium?${ params.toString() }` );
 	};
 
 	onPremiumGlobalStylesUpgradeModalTryStyle = () => {
@@ -1397,16 +1394,9 @@ class ThemeSheet extends Component {
 const withSiteGlobalStylesStatus = createHigherOrderComponent(
 	( Wrapped ) => ( props ) => {
 		const { siteId } = props;
-		const { shouldLimitGlobalStyles, globalStylesInPersonalPlan } =
-			useSiteGlobalStylesStatus( siteId );
+		const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteId );
 
-		return (
-			<Wrapped
-				{ ...props }
-				shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
-				globalStylesInPersonalPlan={ globalStylesInPersonalPlan }
-			/>
-		);
+		return <Wrapped { ...props } shouldLimitGlobalStyles={ shouldLimitGlobalStyles } />;
 	},
 	'withSiteGlobalStylesStatus'
 );

--- a/client/my-sites/theme/theme-style-variations/index.tsx
+++ b/client/my-sites/theme/theme-style-variations/index.tsx
@@ -1,5 +1,4 @@
 import AsyncLoad from 'calypso/components/async-load';
-import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import type { StyleVariation } from '@automattic/design-picker/src/types';
 import type { TranslateResult } from 'i18n-calypso';
 import './style.scss';
@@ -19,8 +18,6 @@ const ThemeStyleVariations = ( {
 	splitDefaultVariation,
 	onClick,
 }: ThemeStyleVariationsProps ) => {
-	const { globalStylesInPersonalPlan } = useSiteGlobalStylesStatus();
-
 	return (
 		<div className="theme__sheet-style-variations">
 			{ !! description && <p>{ description }</p> }
@@ -35,7 +32,6 @@ const ThemeStyleVariations = ( {
 					displayFreeLabel={ splitDefaultVariation }
 					showOnlyHoverViewDefaultVariation={ false }
 					onSelect={ onClick }
-					globalStylesInPersonalPlan={ globalStylesInPersonalPlan }
 				/>
 			</div>
 		</div>

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -150,14 +150,11 @@ class ThemePreview extends Component {
 			this.getPremiumGlobalStylesEventProps()
 		);
 
-		const { globalStylesInPersonalPlan } = this.props;
-		const plan = globalStylesInPersonalPlan ? 'personal' : 'premium';
-
 		const params = new URLSearchParams();
 		params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );
 
 		this.setState( { showUnlockStyleUpgradeModal: false } );
-		page( `/checkout/${ this.props.siteSlug || '' }/${ plan }?${ params.toString() }` );
+		page( `/checkout/${ this.props.siteSlug || '' }/premium?${ params.toString() }` );
 	};
 
 	onPremiumGlobalStylesUpgradeModalTryStyle = () => {
@@ -270,16 +267,9 @@ class ThemePreview extends Component {
 const withSiteGlobalStylesStatus = createHigherOrderComponent(
 	( Wrapped ) => ( props ) => {
 		const { siteId } = props;
-		const { shouldLimitGlobalStyles, globalStylesInPersonalPlan } =
-			useSiteGlobalStylesStatus( siteId );
+		const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteId );
 
-		return (
-			<Wrapped
-				{ ...props }
-				shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
-				globalStylesInPersonalPlan={ globalStylesInPersonalPlan }
-			/>
-		);
+		return <Wrapped { ...props } shouldLimitGlobalStyles={ shouldLimitGlobalStyles } />;
 	},
 	'withSiteGlobalStylesStatus'
 );

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -3,78 +3,25 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import type { ExperimentAssignment } from '@automattic/explat-client';
-
-/*
- * We cannot import `loadExperimentAssignment` directly from 'calypso/lib/explat'
- * because it runs a side effect that produces an error on SSR contexts.
- */
-let loadExperimentAssignment = ( experimentName: string ): Promise< ExperimentAssignment > =>
-	Promise.resolve( { experimentName, variationName: null, retrievedTimestamp: 0, ttl: 0 } );
-if ( typeof window !== 'undefined' ) {
-	import( 'calypso/lib/explat' )
-		.then( ( module ) => {
-			loadExperimentAssignment = module.loadExperimentAssignment;
-		} )
-		// eslint-disable-next-line @typescript-eslint/no-empty-function
-		.catch( () => {} );
-}
 
 export type GlobalStylesStatus = {
 	shouldLimitGlobalStyles: boolean;
 	globalStylesInUse: boolean;
-	globalStylesInPersonalPlan: boolean;
 };
-
-function shouldRunGlobalStylesOnPersonalExperiment( siteId: number | null ): boolean {
-	// Do not run it on SSR contexts.
-	if ( typeof window === 'undefined' ) {
-		return false;
-	}
-
-	// Always run it if a site has been selected.
-	if ( siteId !== null ) {
-		return true;
-	}
-
-	// Do not run it on the logged-out theme showcase.
-	if ( window.location.pathname.startsWith( '/theme' ) ) {
-		return false;
-	}
-
-	// Run it by default. Ideally, we should not run it if the user is logged out, but
-	// we cannot rely on the `isUserLoggedIn` selector for users who just signed up
-	// (see pbxNRc-2HR-p2#comment-4607). So, we assume that this hook is not used in
-	// any logged-out context apart from the theme showcase.
-	return true;
-}
 
 // While we are loading the Global Styles Info we can't assume that we should limit global styles, or we would be
 // showing notices for paid sites until we fetch the data from the server.
 const DEFAULT_GLOBAL_STYLES_INFO: GlobalStylesStatus = {
 	shouldLimitGlobalStyles: false,
 	globalStylesInUse: false,
-	globalStylesInPersonalPlan: false,
 };
 
 const getGlobalStylesInfoForSite = ( siteId: number | null ): Promise< GlobalStylesStatus > => {
-	if ( ! shouldRunGlobalStylesOnPersonalExperiment( siteId ) ) {
+	if ( siteId === null ) {
 		return Promise.resolve( {
 			shouldLimitGlobalStyles: true,
 			globalStylesInUse: false,
-			globalStylesInPersonalPlan: false,
 		} );
-	}
-
-	if ( siteId === null ) {
-		return loadExperimentAssignment( 'calypso_global_styles_personal_v2' ).then(
-			( experimentAssignment ) =>
-				Promise.resolve( {
-					shouldLimitGlobalStyles: true,
-					globalStylesInUse: false,
-					globalStylesInPersonalPlan: experimentAssignment.variationName === 'treatment',
-				} )
-		);
 	}
 
 	return wpcom.req

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -759,30 +759,17 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	getBlogAudience: () => i18n.translate( 'Best for personal use' ),
 	getPortfolioAudience: () => i18n.translate( 'Best for personal use' ),
 	getStoreAudience: () => i18n.translate( 'Best for personal use' ),
-	getPlanTagline: ( isGlobalStylesOnPersonal = false ) =>
-		isGlobalStylesOnPersonal
-			? i18n.translate( 'Add a custom domain name, go ad-free, and unlock powerful design tools.' )
-			: i18n.translate( 'Create your home on the web with a custom domain name.' ),
-	getNewsletterTagLine: ( isGlobalStylesOnPersonal = false ) =>
-		isGlobalStylesOnPersonal
-			? i18n.translate( 'Add a custom domain name, go ad-free, and unlock powerful design tools.' )
-			: i18n.translate( 'Monetize your writing, go ad-free, and expand your media content.' ),
-	getLinkInBioTagLine: ( isGlobalStylesOnPersonal = false ) =>
-		isGlobalStylesOnPersonal
-			? i18n.translate(
-					'Make a great first impression with a custom domain name and powerful design tools.'
-			  )
-			: i18n.translate(
-					'Take Link In Bio to the next level with gated content, paid subscribers, and an ad-free site.'
-			  ),
-	getBlogOnboardingTagLine: ( isGlobalStylesOnPersonal = false ) =>
-		isGlobalStylesOnPersonal
-			? i18n.translate(
-					'Take the next step with a custom domain name, ad-free site, and powerful design tools.'
-			  )
-			: i18n.translate(
-					'Take the next step with gated content, paid subscribers, and an ad-free site.'
-			  ),
+	getPlanTagline: () => i18n.translate( 'Create your home on the web with a custom domain name.' ),
+	getNewsletterTagLine: () =>
+		i18n.translate( 'Monetize your writing, go ad-free, and expand your media content.' ),
+	getLinkInBioTagLine: () =>
+		i18n.translate(
+			'Take Link In Bio to the next level with gated content, paid subscribers, and an ad-free site.'
+		),
+	getBlogOnboardingTagLine: () =>
+		i18n.translate(
+			'Take the next step with gated content, paid subscribers, and an ad-free site.'
+		),
 	getDescription: () =>
 		i18n.translate(
 			'{{strong}}Best for personal use:{{/strong}} Boost your' +
@@ -831,12 +818,11 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_COLLECT_PAYMENTS_V2,
 		FEATURE_EMAIL_SUPPORT_SIGNUP,
 	],
-	get2023PricingGridSignupWpcomFeatures: ( isGlobalStylesOnPersonal = false ) => [
+	get2023PricingGridSignupWpcomFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_AD_FREE_EXPERIENCE,
 		FEATURE_FAST_DNS,
 		FEATURE_SUPPORT_EMAIL,
-		...( isGlobalStylesOnPersonal ? [ FEATURE_STYLE_CUSTOMIZATION ] : [] ),
 		FEATURE_PAYMENT_TRANSACTION_FEES_8,
 	],
 	get2023PricingGridSignupStorageOptions: () => {
@@ -852,10 +838,9 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		i18n.translate(
 			'Jumpstart your Newsletter with a custom domain, ad-free experience, and the ability to sell subscriptions, take payments, and collect donations from day one. Backed with email support to help get everything just right.'
 		),
-	getNewsletterSignupFeatures: ( isGlobalStylesOnPersonal = false ) => [
+	getNewsletterSignupFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_UNLIMITED_SUBSCRIBERS,
-		...( isGlobalStylesOnPersonal ? [ FEATURE_STYLE_CUSTOMIZATION ] : [] ),
 		FEATURE_SUPPORT_EMAIL,
 		FEATURE_AD_FREE_EXPERIENCE,
 		FEATURE_PAYMENT_TRANSACTION_FEES_8,
@@ -869,18 +854,16 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		i18n.translate(
 			'Stand out and unlock earnings with an ad-free site, custom domain, and the ability to sell subscriptions, take payments, and collect donations. Backed with email support to help get your site just right.'
 		),
-	getLinkInBioSignupFeatures: ( isGlobalStylesOnPersonal = false ) => [
+	getLinkInBioSignupFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,
-		...( isGlobalStylesOnPersonal ? [ FEATURE_STYLE_CUSTOMIZATION ] : [] ),
 		FEATURE_AD_FREE_EXPERIENCE,
 		FEATURE_SUPPORT_EMAIL,
 		FEATURE_COLLECT_PAYMENTS_LINK_IN_BIO,
 		FEATURE_PAID_SUBSCRIBERS_JP,
 	],
 	getLinkInBioHighlightedFeatures: () => [ FEATURE_CUSTOM_DOMAIN ],
-	getBlogOnboardingSignupFeatures: ( isGlobalStylesOnPersonal = false ) => [
+	getBlogOnboardingSignupFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,
-		...( isGlobalStylesOnPersonal ? [ FEATURE_STYLE_CUSTOMIZATION ] : [] ),
 		FEATURE_AD_FREE_EXPERIENCE,
 		FEATURE_FAST_DNS,
 		FEATURE_SUPPORT_EMAIL,
@@ -1303,32 +1286,15 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 	getBlogAudience: () => i18n.translate( 'Best for freelancers' ),
 	getPortfolioAudience: () => i18n.translate( 'Best for freelancers' ),
 	getStoreAudience: () => i18n.translate( 'Best for freelancers' ),
-	getPlanTagline: ( isGlobalStylesOnPersonal = false ) =>
-		isGlobalStylesOnPersonal
-			? i18n.translate( 'Make it even more unique with premium themes and layouts.' )
-			: i18n.translate( 'Build a unique website with powerful design tools.' ),
-	getNewsletterTagLine: ( isGlobalStylesOnPersonal = false ) =>
-		isGlobalStylesOnPersonal
-			? i18n.translate( 'Set your Newsletter apart with premium themes and layouts.' )
-			: i18n.translate(
-					'Make it even more memorable with premium designs and style customization.'
-			  ),
-	getLinkInBioTagLine: ( isGlobalStylesOnPersonal = false ) =>
-		isGlobalStylesOnPersonal
-			? i18n.translate(
-					'Take personalization to the next level with a range of premium themes and layouts.'
-			  )
-			: i18n.translate(
-					'Make a great first impression with premium designs and style customization.'
-			  ),
-	getBlogOnboardingTagLine: ( isGlobalStylesOnPersonal = false ) =>
-		isGlobalStylesOnPersonal
-			? i18n.translate(
-					'Get more out of your blog with 4K video, extra storage, and premium designs.'
-			  )
-			: i18n.translate(
-					'Make it even more memorable with premium designs, 4K video, and style customization.'
-			  ),
+	getPlanTagline: () => i18n.translate( 'Build a unique website with powerful design tools.' ),
+	getNewsletterTagLine: () =>
+		i18n.translate( 'Make it even more memorable with premium designs and style customization.' ),
+	getLinkInBioTagLine: () =>
+		i18n.translate( 'Make a great first impression with premium designs and style customization.' ),
+	getBlogOnboardingTagLine: () =>
+		i18n.translate(
+			'Make it even more memorable with premium designs, 4K video, and style customization.'
+		),
 	getDescription: () =>
 		i18n.translate(
 			'{{strong}}Best for freelancers:{{/strong}} Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
@@ -1378,10 +1344,10 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		i18n.translate(
 			'Take your Newsletter further, faster. Get everything included in Personal, plus premium design themes, baked-in video uploads, ad monetization, deep visitor insights from Google Analytics, and live chat support.'
 		),
-	getNewsletterSignupFeatures: ( isGlobalStylesOnPersonal = false ) => [
+	getNewsletterSignupFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_LIVE_CHAT_SUPPORT,
-		...( isGlobalStylesOnPersonal ? [] : [ FEATURE_STYLE_CUSTOMIZATION ] ),
+		FEATURE_STYLE_CUSTOMIZATION,
 		FEATURE_PREMIUM_THEMES_V2,
 		FEATURE_UNLTD_SOCIAL_MEDIA_JP,
 		FEATURE_VIDEOPRESS_JP,
@@ -1399,20 +1365,20 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		i18n.translate(
 			'Take your site further, faster. Get everything included in Personal, plus premium design themes, baked-in video uploads, ad monetization, deep visitor insights from Google Analytics, and live chat support.'
 		),
-	getLinkInBioSignupFeatures: ( isGlobalStylesOnPersonal = false ) => [
+	getLinkInBioSignupFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_LIVE_CHAT_SUPPORT,
 		FEATURE_PREMIUM_THEMES_V2,
-		...( isGlobalStylesOnPersonal ? [] : [ FEATURE_STYLE_CUSTOMIZATION ] ),
+		FEATURE_STYLE_CUSTOMIZATION,
 		FEATURE_VIDEOPRESS_JP,
 		FEATURE_UNLTD_SOCIAL_MEDIA_JP,
 		FEATURE_WORDADS,
 	],
 	getLinkInBioHighlightedFeatures: () => [ FEATURE_CUSTOM_DOMAIN ],
-	getBlogOnboardingSignupFeatures: ( isGlobalStylesOnPersonal = false ) => [
+	getBlogOnboardingSignupFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_PREMIUM_THEMES_V2,
-		...( isGlobalStylesOnPersonal ? [] : [ FEATURE_STYLE_CUSTOMIZATION ] ),
+		FEATURE_STYLE_CUSTOMIZATION,
 		FEATURE_LIVE_CHAT_SUPPORT,
 		FEATURE_WORDADS,
 		FEATURE_PAYMENT_TRANSACTION_FEES_4,
@@ -1447,12 +1413,12 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 			isEnabled( 'themes/premium' ) ? FEATURE_PREMIUM_THEMES : null,
 			FEATURE_GOOGLE_ANALYTICS,
 		].filter( isValueTruthy ),
-	get2023PricingGridSignupWpcomFeatures: ( isGlobalStylesOnPersonal = false ) => [
+	get2023PricingGridSignupWpcomFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_LIVE_CHAT_SUPPORT,
 		FEATURE_PREMIUM_THEMES_V2,
 		FEATURE_WORDADS,
-		...( isGlobalStylesOnPersonal ? [] : [ FEATURE_STYLE_CUSTOMIZATION ] ),
+		FEATURE_STYLE_CUSTOMIZATION,
 		FEATURE_PAYMENT_TRANSACTION_FEES_4,
 	],
 	get2023PricingGridSignupJetpackFeatures: () => [

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -64,10 +64,10 @@ export interface WPComPlan extends Plan {
 	getBlogAudience?: () => TranslateResult;
 	getPortfolioAudience?: () => TranslateResult;
 	getStoreAudience?: () => TranslateResult;
-	getPlanTagline?: ( isGlobalStylesOnPersonal?: boolean ) => string;
-	getNewsletterTagLine?: ( isGlobalStylesOnPersonal?: boolean ) => string;
-	getLinkInBioTagLine?: ( isGlobalStylesOnPersonal?: boolean ) => string;
-	getBlogOnboardingTagLine?: ( isGlobalStylesOnPersonal?: boolean ) => string;
+	getPlanTagline?: () => string;
+	getNewsletterTagLine?: () => string;
+	getLinkInBioTagLine?: () => string;
+	getBlogOnboardingTagLine?: () => string;
 	getSubTitle?: () => TranslateResult;
 	getPlanCompareFeatures?: (
 		experiment?: string,
@@ -234,7 +234,7 @@ export type Plan = BillingTerm & {
 	 * this feature list will be ignored in the plans comparison table only.
 	 * Context - pdgrnI-26j
 	 */
-	get2023PricingGridSignupWpcomFeatures?: ( isGlobalStylesOnPersonal?: boolean ) => Feature[];
+	get2023PricingGridSignupWpcomFeatures?: () => Feature[];
 
 	/**
 	 * This function returns the features that are to be overridden and shown in the plans comparison table.
@@ -298,9 +298,9 @@ export type Plan = BillingTerm & {
 	 * a feature for 20GB of storage space would be inferior to it.
 	 */
 	getInferiorFeatures?: () => Feature[];
-	getNewsletterSignupFeatures?: ( isGlobalStylesOnPersonal?: boolean ) => Feature[];
-	getLinkInBioSignupFeatures?: ( isGlobalStylesOnPersonal?: boolean ) => Feature[];
-	getBlogOnboardingSignupFeatures?: ( isGlobalStylesOnPersonal?: boolean ) => Feature[];
+	getNewsletterSignupFeatures?: () => Feature[];
+	getLinkInBioSignupFeatures?: () => Feature[];
+	getBlogOnboardingSignupFeatures?: () => Feature[];
 	getBlogOnboardingHighlightedFeatures?: () => Feature[];
 	getBlogOnboardingSignupJetpackFeatures?: () => Feature[];
 };

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -36,7 +36,6 @@ interface DesignPreviewProps {
 	onSelectFontVariation: ( variation: GlobalStylesObject | null ) => void;
 	onGlobalStylesChange: ( globalStyles?: GlobalStylesObject | null ) => void;
 	limitGlobalStyles: boolean;
-	globalStylesInPersonalPlan: boolean;
 	onNavigatorPathChange?: ( path?: string ) => void;
 	onScreenSelect?: ( screenSlug: string ) => void;
 	onScreenBack?: ( screenSlug: string ) => void;
@@ -71,7 +70,6 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 	onGlobalStylesChange,
 	selectedDesignTitle,
 	limitGlobalStyles,
-	globalStylesInPersonalPlan,
 	onScreenSelect,
 	onScreenBack,
 	onScreenSubmit,
@@ -93,7 +91,6 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 		isVirtual,
 		isExternallyManaged,
 		limitGlobalStyles,
-		globalStylesInPersonalPlan,
 		variations,
 		splitDefaultVariation,
 		selectedVariation,

--- a/packages/design-preview/src/components/style-variation.tsx
+++ b/packages/design-preview/src/components/style-variation.tsx
@@ -10,7 +10,6 @@ interface StyleVariationPreviewsProps {
 	onClick: ( variation: StyleVariation ) => void;
 	description?: TranslateResult;
 	showOnlyHoverViewDefaultVariation?: boolean;
-	globalStylesInPersonalPlan: boolean;
 }
 
 const StyleVariationPreviews: React.FC< StyleVariationPreviewsProps > = ( {
@@ -19,7 +18,6 @@ const StyleVariationPreviews: React.FC< StyleVariationPreviewsProps > = ( {
 	onClick,
 	description,
 	showOnlyHoverViewDefaultVariation,
-	globalStylesInPersonalPlan,
 } ) => {
 	return (
 		<GlobalStylesVariations
@@ -30,7 +28,6 @@ const StyleVariationPreviews: React.FC< StyleVariationPreviewsProps > = ( {
 			onSelect={ ( globalStyleVariation: GlobalStylesObject ) =>
 				onClick( globalStyleVariation as StyleVariation )
 			}
-			globalStylesInPersonalPlan={ globalStylesInPersonalPlan }
 		/>
 	);
 };

--- a/packages/design-preview/src/hooks/use-screens.tsx
+++ b/packages/design-preview/src/hooks/use-screens.tsx
@@ -19,7 +19,6 @@ interface Props {
 	isVirtual?: boolean;
 	isExternallyManaged?: boolean;
 	limitGlobalStyles?: boolean;
-	globalStylesInPersonalPlan: boolean;
 	variations?: StyleVariation[];
 	splitDefaultVariation: boolean;
 	selectedVariation?: StyleVariation;
@@ -39,7 +38,6 @@ const useScreens = ( {
 	isVirtual,
 	isExternallyManaged,
 	limitGlobalStyles,
-	globalStylesInPersonalPlan,
 	variations,
 	splitDefaultVariation,
 	selectedVariation,
@@ -77,7 +75,6 @@ const useScreens = ( {
 										onSelect={ ( globalStyleVariation: GlobalStylesObject ) =>
 											onSelectVariation( globalStyleVariation as StyleVariation )
 										}
-										globalStylesInPersonalPlan={ globalStylesInPersonalPlan }
 									/>
 								</div>
 							</div>

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -30,7 +30,6 @@ interface GlobalStylesVariationsProps {
 	splitDefaultVariation?: boolean;
 	displayFreeLabel?: boolean;
 	onSelect: ( globalStylesVariation: GlobalStylesObject ) => void;
-	globalStylesInPersonalPlan: boolean;
 }
 
 const isDefaultGlobalStyleVariationSlug = ( globalStylesVariation: GlobalStylesObject ) =>
@@ -107,16 +106,11 @@ const GlobalStylesVariations = ( {
 	onSelect,
 	splitDefaultVariation = true,
 	displayFreeLabel = true,
-	globalStylesInPersonalPlan,
 }: GlobalStylesVariationsProps ) => {
 	const isRegisteredCoreBlocks = useRegisterCoreBlocks();
-	const premiumStylesDescription = globalStylesInPersonalPlan
-		? translate(
-				'Unlock custom styles and tons of other features with the Personal plan, or try them out now for free.'
-		  )
-		: translate(
-				'Unlock custom styles and tons of other features with the Premium plan, or try them out now for free.'
-		  );
+	const premiumStylesDescription = translate(
+		'Unlock custom styles and tons of other features with the Premium plan, or try them out now for free.'
+	);
 
 	const baseGlobalStyles = useMemo(
 		() =>


### PR DESCRIPTION
Part of https://github.com/Automattic/dotcom-forge/issues/3062

## Proposed Changes

After finishing the GS on Personal experiment, we decided to stick with `control` (keep Global Styles in the Premium plan, see paYJgx-3PM-p2#comment-4032), so this PR removes the `treatment` upsell experience and always upsells the Premium plan.

Participants who were assigned to `treatment` will continue getting Global Styles on the Personal plan, but the UI will always upsell the Premium plan.

Section | Before | After
--- | --- | ---
Plans grid | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/d9f1ece0-9697-4913-966d-a04c6d3ac2df) | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/8b8992cd-bd91-4c8d-a829-32bb058c4326)
Design picker | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/03133c24-b7e0-4b26-adc5-c0e9a3e97882) | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/b50fa35f-af5f-4bc7-90b7-7dbc654401c4)
Design preview | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/0328cf4c-6ca7-4a81-9f40-4dbf4a3c9e2d) | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/8299899c-286d-4057-b82c-5015227e5751)
Site editor | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/e341151f-df89-4378-8175-385b6fb9d04f) | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/7ba95558-364c-4172-ac17-8340e8cd177b)
Site editor | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/38a8c2bf-81c9-40b5-b68d-ce134716c153) | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/8e19bce8-332e-4224-a66b-45f3f908aafb)
Frontend | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/978f4d66-5e46-47bc-82a9-feda2bc134f8) | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/52b2c5db-74fc-4560-9fd6-bb2168c181c4)
Site assembler | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/28196180-d256-47ea-a051-c7e79c26b5f8) | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/4ba9a849-4f13-4caa-a2c3-7c17f3888993)
Privacy settings | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/4a41737e-2e80-4a6d-9e22-6a26d18f285c) | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/86fb7a0b-6b6a-4aea-b047-66f3a49c3c09)
Theme showcase | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/3909db32-f1fe-45cc-ad18-2255807d385e) | ![image](https://github.com/Automattic/wp-calypso/assets/1233880/bff65011-be84-4884-b335-e9b3b1401a22)

## Testing Instructions

- Assign yourself to the `treatment` variant of the experiment (pbxNRc-2HR-p2)
- Apply these changes to your sandbox
- Sandbox a site with Limited Global Styles
- Use the Calypso live link below
- Check that we're now upselling the Premium plan in all the sections listed above
