### PR TITLE
Stepper Design Carousel: Ensure selectedDesign is not null before accessing its sub properties

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
@@ -98,7 +98,7 @@ const DesignCarousel: Step = function DesignCarousel( { navigation, flow } ) {
 
 	function pickDesign( _selectedDesign: Design ) {
 		setSelectedDesign( _selectedDesign );
-		submit?.( { theme: _selectedDesign.slug, theme_type: _selectedDesign.design_type } );
+		submit?.( { theme: _selectedDesign?.slug, theme_type: _selectedDesign?.design_type } );
 	}
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fix an error that popped up in Sentry that occurs when `_selectedDesign` is undefined. Add optional chaining to ensure `_selectedDesign` is defined before trying to access its sub-properties.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visual inspection should be fine, but ensure the Stepper design carousel for the ecommerce flow still works:

* Go to `/setup/ecommerce`
* Ensure you can still select a design at the `/setup/ecommerce/designCarousel` step
* Ensure the relevant Tracks event still fires with the `theme` and `theme_type`:

<img width="1391" alt="Screenshot 2023-08-28 at 12 27 15 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/1672a7b7-8906-482c-9789-6d4a28eef730">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
