### PR TITLE
Comments / Publicize: remove mentions of non-available Twitter

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -347,10 +347,10 @@ export const getTask = (
 				title: translate( 'Enable post sharing' ),
 				description: isBlogger
 					? translate(
-							'Enable post sharing to automatically share your new blog posts to Twitter, Facebook, or LinkedIn to ensure your audience will never miss an update.'
+							'Enable post sharing to automatically share your new blog posts to Facebook, LinkedIn, Instagram, Tumblr, or Mastodon to ensure your audience will never miss an update.'
 					  )
 					: translate(
-							'Enable post sharing to automatically share your new posts to Twitter, Facebook, or LinkedIn to ensure your audience will never miss an update.'
+							'Enable post sharing to automatically share your new posts to Facebook, LinkedIn, Instagram, Tumblr, or Mastodon to ensure your audience will never miss an update.'
 					  ),
 				actionText: translate( 'Enable sharing' ),
 				actionUrl: `/marketing/connections/${ siteSlug }`,

--- a/client/my-sites/site-settings/comment-display-settings/index.jsx
+++ b/client/my-sites/site-settings/comment-display-settings/index.jsx
@@ -34,9 +34,7 @@ class CommentDisplaySettings extends Component {
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
 					moduleSlug="comments"
-					label={ translate(
-						'Let visitors use a WordPress.com, Twitter, Facebook, or Google account to comment.'
-					) }
+					label={ translate( 'Let visitors use a WordPress.com or Facebook account to comment.' ) }
 					disabled={ !! submittingForm }
 				/>
 				<div className="comment-display-settings__module-setting is-indented">


### PR DESCRIPTION
Fixes #80972

## Proposed Changes

Folks can no longer publicize to Twitter, or log in via Twitter to comment on a site. Let's remove the brand from the different settings.

<img width="829" alt="image" src="https://github.com/Automattic/wp-calypso/assets/426388/ec809908-956c-46ca-9578-51eb353dbb33">


## Testing Instructions

1. Go to Settings > Discussions on an atomic or simple site.
2. You should no longer see Twitter in the mention of comment options.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
