### PR TITLE
VP User Intent: Add the survey link, re-style button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/styles.scss
@@ -296,11 +296,23 @@
 			display: flex;
 			justify-content: space-around;
 
-			button {
+			.videopress-intro-modal__survey-button-wrapper {
+				display: flex;
+				align-items: center;
 				background: none !important;
 				border: 1px solid #000 !important;
 				border-radius: 4px;
+				font-size: 14px; /* stylelint-disable-line */
 				font-weight: 500;
+				padding: 4px 8px;
+
+				a {
+					display: inline-flex;
+					align-items: center;
+					gap: 4px;
+					color: #000;
+					white-space: nowrap;
+				}
 			}
 
 			.videopress-intro-modal__survey-title {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { Icon, arrowRight } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import '../intro/videopress-intro-modal-styles.scss';
@@ -117,9 +118,17 @@ const VideoPressOnboardingIntentModal: React.FC< VideoPressOnboardingIntentModal
 							{ translate( 'Answer a short survey and you’ll have the chance to win $50.' ) }
 						</div>
 					</div>
-					<Button className="intro__button button-survey" primary>
-						{ translate( 'Answer the survey ->' ) }
-					</Button>
+					<div className="videopress-intro-modal__survey-button-wrapper">
+						<Button
+							className="intro__button button-survey"
+							href="https://automattic.survey.fm/videopress-onboarding-user-intent-survey"
+							target="_blank"
+							plain
+						>
+							{ translate( 'Answer the survey' ) }
+							<Icon icon={ arrowRight } />
+						</Button>
+					</div>
 				</div>
 			) }
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/greenhouse/issues/1833

## Proposed Changes

* add link to placeholder survey that opens in a new tab
* adjust styling after button changed to an `a` internally due to adding `href`

<img width="979" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4081020/4408da83-d7fb-489e-9169-52ae9d1bdc7a">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn && yarn start`
* `/setup/videopress`
* select the "Create a channel" item
* the survey button should match designs https://www.figma.com/file/VWoFEOpEaOyeLspB9GoRvm/%F0%9F%9A%80-VideoPress-Ongoing-Projects?type=design&node-id=3075-13052&mode=design&t=TlW7NNYWGGUUK4o1-4
* the survey button should open the placeholder survey in a new tab (right click copy should also work)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
