### PR TITLE
Agency Dashboard: Replace "add new site" button in sidebar with new split button from Sites Overview

### DIFF
--- a/client/components/jetpack/add-new-site-button/index.tsx
+++ b/client/components/jetpack/add-new-site-button/index.tsx
@@ -1,0 +1,57 @@
+import { WordPressLogo } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import SplitButton from 'calypso/components/split-button';
+import type { MutableRefObject } from 'react';
+
+type Props = {
+	showMainButtonLabel?: boolean;
+	className?: string;
+	popoverContext?: MutableRefObject< HTMLElement | null >;
+	onToggleMenu?: ( isOpen: boolean ) => void;
+	onClickAddNewSite?: () => void;
+	onClickWpcomMenuItem?: () => void;
+	onClickJetpackMenuItem?: () => void;
+};
+
+const AddNewSiteButton = ( {
+	showMainButtonLabel = true,
+	className,
+	popoverContext,
+	onToggleMenu,
+	onClickAddNewSite,
+	onClickWpcomMenuItem,
+	onClickJetpackMenuItem,
+}: Props ): JSX.Element => {
+	const translate = useTranslate();
+
+	return (
+		<SplitButton
+			primary
+			whiteSeparator
+			popoverContext={ popoverContext }
+			className={ className }
+			label={ showMainButtonLabel ? translate( 'Add new site' ) : undefined }
+			toggleIcon={ showMainButtonLabel ? undefined : 'plus' }
+			onToggle={ onToggleMenu }
+			onClick={ onClickAddNewSite }
+			href="/partner-portal/create-site"
+		>
+			<PopoverMenuItem onClick={ onClickWpcomMenuItem } href="/partner-portal/create-site">
+				<WordPressLogo className="gridicon" size={ 18 } />
+				<span>{ translate( 'Create a new WordPress.com site' ) }</span>
+			</PopoverMenuItem>
+
+			<PopoverMenuItem
+				onClick={ onClickJetpackMenuItem }
+				href="https://wordpress.com/jetpack/connect"
+			>
+				<JetpackLogo className="gridicon" size={ 18 } />
+				<span>{ translate( 'Connect a site to Jetpack' ) }</span>
+			</PopoverMenuItem>
+		</SplitButton>
+	);
+};
+
+export default AddNewSiteButton;

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -26,6 +26,7 @@ import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 import { withSitesSortingPreference } from 'calypso/state/sites/hooks/with-sites-sorting';
 import { getSite, hasAllSitesList } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import JetpackAgencyAddSite from '../jetpack/add-new-site-button';
 import SiteSelectorAddSite from './add-site';
 import SitesList from './sites-list';
 import { getUserSiteCountForPlatform, getUserVisibleSiteCountForPlatform } from './utils';
@@ -39,6 +40,7 @@ const debug = debugFactory( 'calypso:site-selector' );
 export class SiteSelector extends Component {
 	static propTypes = {
 		isPlaceholder: PropTypes.bool,
+		isJetpackAgencyDashboard: PropTypes.bool,
 		sites: PropTypes.array,
 		siteBasePath: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		wpcomSiteBasePath: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
@@ -480,7 +482,28 @@ export class SiteSelector extends Component {
 								{ this.props.translate( 'Manage sites' ) }
 							</Button>
 						) }
-						{ this.props.showAddNewSite && <SiteSelectorAddSite /> }
+						{ this.props.showAddNewSite &&
+							( this.props.isJetpackAgencyDashboard ? (
+								<JetpackAgencyAddSite
+									onClickAddNewSite={ () =>
+										this.props.recordTracksEvent(
+											'calypso_jetpack_agency_dashboard_sidebar_add_new_site_click'
+										)
+									}
+									onClickWpcomMenuItem={ () =>
+										this.props.recordTracksEvent(
+											'calypso_jetpack_agency_dashboard_sidebar_create_wpcom_site_click'
+										)
+									}
+									onClickJetpackMenuItem={ () =>
+										this.props.recordTracksEvent(
+											'calypso_jetpack_agency_dashboard_sidebar_connect_jetpack_site_click'
+										)
+									}
+								/>
+							) : (
+								<SiteSelectorAddSite />
+							) ) }
 					</div>
 				) }
 			</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
@@ -13,6 +13,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import 'calypso/components/jetpack/sidebar/style.scss';
 import type { FunctionComponent } from 'react';
+import './style.scss';
 
 interface Props {
 	path: string;
@@ -32,7 +33,8 @@ const DashboardSidebar: FunctionComponent< Props > = ( { path } ) => {
 
 	const isPluginsPage = path.includes( '/plugins' );
 	const isPluginManagementEnabled = config.isEnabled( 'jetpack/plugin-management' );
-	const isWPCOMAtomicSiteCreationEnabled = config.isEnabled(
+
+	const isAtomicSiteCreationEnabled = config.isEnabled(
 		'jetpack/pro-dashboard-wpcom-atomic-hosting'
 	);
 
@@ -41,9 +43,11 @@ const DashboardSidebar: FunctionComponent< Props > = ( { path } ) => {
 			<SiteSelector
 				showAddNewSite
 				showAllSites
+				isJetpackAgencyDashboard={ isAtomicSiteCreationEnabled }
+				className="sidebar__site-selector"
 				allSitesPath={ path }
 				siteBasePath="/backup"
-				wpcomSiteBasePath={ isWPCOMAtomicSiteCreationEnabled && 'https://wordpress.com/home' }
+				wpcomSiteBasePath={ isAtomicSiteCreationEnabled && 'https://wordpress.com/home' }
 			/>
 			<Sidebar className="sidebar__jetpack-cloud">
 				<SidebarRegion>

--- a/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
@@ -11,8 +11,9 @@ import SidebarRegion from 'calypso/layout/sidebar/region';
 import CurrentSite from 'calypso/my-sites/current-site';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import 'calypso/components/jetpack/sidebar/style.scss';
 import type { FunctionComponent } from 'react';
+
+import 'calypso/components/jetpack/sidebar/style.scss';
 import './style.scss';
 
 interface Props {

--- a/client/jetpack-cloud/sections/agency-dashboard/sidebar/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sidebar/style.scss
@@ -1,0 +1,20 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.sidebar__site-selector .site-selector__actions {
+	// Leave room for the chat support button + horizontal padding
+	// on mobile screens
+	max-width: calc(100% - 80px - 32px);
+
+	@include breakpoint-deprecated( ">660px" ) {
+		max-width: initial;
+	}
+}
+
+.sidebar__site-selector .site-selector__actions .split-button {
+	display: flex;
+
+	.split-button__main {
+		flex-grow: 1;
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sidebar/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sidebar/style.scss
@@ -17,4 +17,9 @@
 	.split-button__main {
 		flex-grow: 1;
 	}
+
+	.split-button__toggle {
+		border-top-left-radius: 0;
+		border-bottom-left-radius: 0;
+	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -1,12 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Button, WordPressLogo } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
-import JetpackLogo from 'calypso/components/jetpack-logo';
-import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import SplitButton from 'calypso/components/split-button';
+import AddNewSiteButton from 'calypso/components/jetpack/add-new-site-button';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import WPCOMHostingPopover from './wpcom-hosting-popover';
@@ -20,7 +18,7 @@ export default function SiteTopHeaderButtons() {
 		'jetpack/pro-dashboard-wpcom-atomic-hosting'
 	);
 
-	const buttonRef = useRef< any | null >( null );
+	const buttonRef = useRef< HTMLElement | null >( null );
 	const [ toggleIsOpen, setToggleIsOpen ] = useState( false );
 
 	return (
@@ -43,49 +41,32 @@ export default function SiteTopHeaderButtons() {
 
 			{ isWPCOMAtomicSiteCreationEnabled ? (
 				<span>
-					<SplitButton
-						primary
-						whiteSeparator
-						label={ isMobile ? undefined : translate( 'Add new site' ) }
-						onClick={ () =>
+					<AddNewSiteButton
+						showMainButtonLabel={ ! isMobile }
+						popoverContext={ buttonRef }
+						onToggleMenu={ ( isOpen: boolean ) => setToggleIsOpen( isOpen ) }
+						onClickAddNewSite={ () =>
 							dispatch(
 								recordTracksEvent(
-									'calypso_jetpack_agency_dashboard_create_wpcom_atomic_site_button_click'
+									'calypso_jetpack_agency_dashboard_sites_overview_add_new_site_click'
 								)
 							)
 						}
-						href="/partner-portal/create-site"
-						toggleIcon={ isMobile ? 'plus' : undefined }
-						onToggle={ ( isOpen: boolean ) => setToggleIsOpen( isOpen ) }
-						popoverContext={ buttonRef }
-					>
-						<PopoverMenuItem
-							onClick={ () => {
+						onClickWpcomMenuItem={ () =>
+							dispatch(
 								recordTracksEvent(
-									'calypso_jetpack_agency_dashboard_create_wpcom_atomic_site_menu_item_click'
-								);
-							} }
-							href="/partner-portal/create-site"
-						>
-							<WordPressLogo className="gridicon" size={ 18 } />
-							<span>{ translate( 'Create a new WordPress.com site' ) }</span>
-						</PopoverMenuItem>
-
-						<PopoverMenuItem
-							onClick={ () =>
-								dispatch(
-									recordTracksEvent(
-										'calypso_jetpack_agency_dashboard_connect_jetpack_site_menu_item_click'
-									)
+									'calypso_jetpack_agency_dashboard_sites_overview_create_wpcom_site_click'
 								)
-							}
-							href="https://wordpress.com/jetpack/connect"
-							isExternalLink
-						>
-							<JetpackLogo className="gridicon" size={ 18 } />
-							<span>{ translate( 'Connect a site to Jetpack' ) }</span>
-						</PopoverMenuItem>
-					</SplitButton>
+							)
+						}
+						onClickJetpackMenuItem={ () =>
+							dispatch(
+								recordTracksEvent(
+									'calypso_jetpack_agency_dashboard_sites_overview_connect_jetpack_site_click'
+								)
+							)
+						}
+					/>
 					<WPCOMHostingPopover
 						context={ buttonRef.current }
 						// Show the popover only when the split button is closed

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -66,6 +66,10 @@
 	}
 }
 
+.sites-overview__add-new-site {
+	white-space: nowrap;
+}
+
 .sites-overview__content {
 	// We need these negative margin values because we want to make the container full-width,
 	// but our element is inside a limited-width parent.


### PR DESCRIPTION
This pull request replaces the existing "Add new site" button in the navigation sidebar with a new split button that allows customers to choose between a new WordPress.com site or a new Jetpack site. For more information, 

Depends on #81067.
Resolves https://github.com/Automattic/jetpack-avalon/issues/21.

## Proposed Changes

* Extract the new split button from #81067 into its own component in `client/components/jetpack`.
* Add a boolean prop to `client/components/sidebar` called `isJetpackAgencyDashboard`, to toggle the new split button interface on (true) and off (false).
* Add styling so that the split button will play nicely with the pre-sales chat bubble and will not wrap on small screens.

## Testing Instructions

### Testing the sidebar

* In your Jetpack Cloud testing environment, visit `/dashboard`.
* Confirm that the *Add new site* button is visible in the sidebar when you click *Switch site* to bring up the site selector.
* Confirm that clicking the *Add new site* button should redirect to `/partner-portal/create-site`.
* Confirm that clicking the drop-down icon displays a sub-menu with two buttons: *Add new WordPress.com site* and *Connect a site to Jetpack*.
* Confirm that clicking *Add new WordPress.com site* redirects to `/partner-portal/create-site`.
* Confirm that clicking *Connect a site to Jetpack* redirects to `https://wordpress.com/jetpack/connect`.
* Finally, repeat the above instructions on a small/mobile viewport.
  * Confirm that the entire split button is visible and does not overlap the pre-sales chat button.

### Testing Sites Overview

* Confirm that the button appears and behaves as it does in #81067.
* Confirm that the two button segments do not separate or wrap as the screen size gets narrower.

### Reference screenshots

<img height="300" src="https://github.com/Automattic/wp-calypso/assets/670067/1e810fa1-d3f7-4895-a680-220fefee38e1">
<img height="300" src="https://github.com/Automattic/wp-calypso/assets/670067/418bc012-5356-40c2-a5b4-a28634856f8e">
<img height="300" src="https://github.com/Automattic/wp-calypso/assets/670067/d401a21b-e2ee-4122-a90e-b8cb972ae2d0">
