### PR TITLE
VideoPress Intent e2e test - support temporary flow change

### DIFF
--- a/test/e2e/specs/onboarding/setup__videopress.ts
+++ b/test/e2e/specs/onboarding/setup__videopress.ts
@@ -38,6 +38,12 @@ describe( DataHelper.createSuiteTitle( 'VideoPress Tailored Onboarding' ), () =>
 			await page.goto( DataHelper.getCalypsoURL( '/setup/videopress' ) );
 		} );
 
+		jest.mock( '@automattic/calypso-config', () => ( key ) => {
+			if ( 'videopress-onboarding-user-intent' === key ) {
+				return false;
+			}
+		} );
+
 		it( 'Click Get Started', async function () {
 			await Promise.all( [ page.waitForNavigation(), page.click( 'text=Get started' ) ] );
 		} );

--- a/test/e2e/specs/onboarding/setup__videopress.ts
+++ b/test/e2e/specs/onboarding/setup__videopress.ts
@@ -38,14 +38,20 @@ describe( DataHelper.createSuiteTitle( 'VideoPress Tailored Onboarding' ), () =>
 			await page.goto( DataHelper.getCalypsoURL( '/setup/videopress' ) );
 		} );
 
-		jest.mock( '@automattic/calypso-config', () => ( key ) => {
-			if ( 'videopress-onboarding-user-intent' === key ) {
-				return false;
-			}
-		} );
-
 		it( 'Click Get Started', async function () {
-			await Promise.all( [ page.waitForNavigation(), page.click( 'text=Get started' ) ] );
+			const btnGetStarted = await page.$( 'text=Get started' );
+
+			// if Get Started is present, its the normal flow, otherwise its the User Intent flow
+			// -- if user intent, lets get on track to the normal flow
+			if ( null !== btnGetStarted ) {
+				await Promise.all( [ page.waitForNavigation(), page.click( 'text=Get started' ) ] );
+			} else {
+				await Promise.all( [
+					page.waitForNavigation(),
+					page.click( 'img[alt="Get a video portfolio"]' ),
+					page.click( 'button.intro__button' ),
+				] );
+			}
 		} );
 
 		it( 'Navigate VideoMaker Setup', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/greenhouse/issues/1837

## Proposed Changes

* add a conditional check on content of the `/intro` page to determine which buttons to press to allow the videopress onboarding e2e test to complete the flow successfully

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run the e2e test against current production, it should pass `yarn workspace wp-e2e-tests test -- specs/onboarding/setup__videopress.ts`
   * you will notice it goes through the current flow (single "Get started" button at the start)
* start local dev server `yarn && yarn start`
* run the e2e test against local dev server, it should pass `CALYPSO_BASE_URL=http://calypso.localhost:3000 yarn workspace wp-e2e-tests test -- specs/onboarding/setup__videopress.ts`
   * you should notice it goes through the new user intent flow (grid of 6 images at the start)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?