### PR TITLE
Login: Social login button remains disabled if Google SDK fails to init

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -101,7 +101,7 @@ class GoogleSocialButton extends Component {
 	}
 
 	async loadGoogleIdentityServicesAPI() {
-		if ( ! window.google?.accounts?.oauth2 ) {
+		if ( ! window?.google?.accounts?.oauth2 ) {
 			try {
 				await loadScript( 'https://accounts.google.com/gsi/client' );
 			} catch {
@@ -110,7 +110,7 @@ class GoogleSocialButton extends Component {
 			}
 		}
 
-		return window.google.accounts.oauth2;
+		return window?.google?.accounts?.oauth2 ?? null;
 	}
 
 	async handleAuthorizationCode( { auth_code, redirect_uri } ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes error raised by p1693237148930679-slack-C04U5A26MJB

## Proposed Changes

* `loadGoogleIdentityServicesAPI()` will returns a falsey value when the Google SDK fails to set up the globals correctly.

It's unclear why this might happen, but we have seen it happen in production. The code is already designed to handle this case. When `loadGoogleIdentityServicesAPI()` returns falsey the social login button stays disabled and the user must use a different login/signup method.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The usual way of testing—blocking Google scripts—won't work here. In this situation there was no exception thrown by `loadScript()` so Google's SDK had no issue loading. In this case I believe we just need to visually confirm that this code change is safe.

And also run through the happy login path.