### PR TITLE
Hosting Metrics: Update uPlot from 1.6.24 to 1.6.25

### DIFF
--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -155,7 +155,7 @@
 		color: var(--studio-gray-100);
 
 		// Disable rendering first u-marker, which is for "Date" and is empty.
-		> .u-series:first-child {
+		> tbody > .u-series:first-child {
 			display: none;
 		}
 
@@ -164,7 +164,7 @@
 		}
 
 		// Use increased specificity to override original uPlot styles.
-		> tr.u-series > th {
+		> tbody > tr.u-series > th {
 			cursor: initial;
 			pointer-events: none;
 

--- a/client/package.json
+++ b/client/package.json
@@ -196,7 +196,7 @@
 		"tracekit": "^0.4.5",
 		"twemoji": "^12.1.4",
 		"ua-parser-js": "^0.7.22",
-		"uplot": "^1.6.24",
+		"uplot": "^1.6.25",
 		"uplot-react": "^1.1.4",
 		"use-debounce": "^3.1.0",
 		"util": "^0.12.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11282,7 +11282,7 @@ __metadata:
     tracekit: ^0.4.5
     twemoji: ^12.1.4
     ua-parser-js: ^0.7.22
-    uplot: ^1.6.24
+    uplot: ^1.6.25
     uplot-react: ^1.1.4
     use-debounce: ^3.1.0
     util: ^0.12.3
@@ -30010,10 +30010,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uplot@npm:^1.6.24":
-  version: 1.6.24
-  resolution: "uplot@npm:1.6.24"
-  checksum: 90282fd1ef29440c20b2f73a038a8e5c421adafd1e896ea298739d3a8e687bfd94bbf48d8ed5b98f8dbad2c67d46a1be74f17c4c8bcf171360f216abd5d13f48
+"uplot@npm:^1.6.25":
+  version: 1.6.25
+  resolution: "uplot@npm:1.6.25"
+  checksum: a5dddfdae92d90a817ae63fe3ac70f2ef38622410e2c5b8bf6d480becf0b1528916a0e5906b1b3b2b238bb2852ebdc455e26026a0ba48801b830f0fa4267bfd7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3497

## Proposed Changes

Upgrades uPlot from v1.6.24 to v1.6.25. https://github.com/leeoniya/uPlot/releases/tag/1.6.25

### Local

<img width="1246" alt="CleanShot 2023-08-28 at 15 08 22@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/8cbf496c-1e0c-41c5-a712-74492e835ca6">

### Staging

<img width="1240" alt="CleanShot 2023-08-28 at 15 08 04@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/e2df9d5c-4616-41db-af2a-ceecd7215eb2">

## Testing Instructions

1. Check out this PR.
2. Compare http://calypso.localhost:3000/site-monitoring/ to https://wordpress.com/site-monitoring/
3. Verify all of the uPlot charts load as expected.