### PR TITLE
Stats: Add new commercial site upgrade notice

### DIFF
--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -5,8 +5,8 @@ const DEFAULT_SERVER_NOTICES_VISIBILITY = {
 	opt_in_new_stats: false,
 	traffic_page_highlights_module_settings: false,
 	traffic_page_settings: false,
-	commercial_site_upgrade: false,
 	do_you_love_jetpack_stats: false,
+	commercial_site_upgrade: false,
 };
 const DEFAULT_CLIENT_NOTICES_VISIBILITY = {
 	client_paid_plan_purchase_success: true,
@@ -26,8 +26,8 @@ const CONFLICT_NOTICE_ID_GROUPS: Record< string, Array< NoticeIdType > > = {
 	dashboard_notices: [
 		'client_paid_plan_purchase_success',
 		'client_free_plan_purchase_success',
-		'commercial_site_upgrade',
 		'do_you_love_jetpack_stats',
+		'commercial_site_upgrade',
 	],
 };
 

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -5,6 +5,7 @@ const DEFAULT_SERVER_NOTICES_VISIBILITY = {
 	opt_in_new_stats: false,
 	traffic_page_highlights_module_settings: false,
 	traffic_page_settings: false,
+	commercial_site_upgrade: false,
 	do_you_love_jetpack_stats: false,
 };
 const DEFAULT_CLIENT_NOTICES_VISIBILITY = {
@@ -25,6 +26,7 @@ const CONFLICT_NOTICE_ID_GROUPS: Record< string, Array< NoticeIdType > > = {
 	dashboard_notices: [
 		'client_paid_plan_purchase_success',
 		'client_free_plan_purchase_success',
+		'commercial_site_upgrade',
 		'do_you_love_jetpack_stats',
 	],
 };

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -68,38 +68,8 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 	{
 		component: CommercialSiteUpgradeNotice,
 		noticeId: 'commercial_site_upgrade',
-		isVisibleFunc: ( {
-			isOdysseyStats,
-			isWpcom,
-			isVip,
-			isP2,
-			isOwnedByTeam51,
-			hasPaidStats,
-			isSiteJetpackNotAtomic,
-		}: StatsNoticeProps ) => {
-			// Gate notices for WPCOM sites behind a flag.
-			const showUpgradeNoticeForWpcomSites =
-				config.isEnabled( 'stats/paid-wpcom-stats' ) &&
-				isWpcom &&
-				! isVip &&
-				! isP2 &&
-				! isOwnedByTeam51;
-
-			// Show the notice if the site is Jetpack or it is Odyssey Stats.
-			const showUpgradeNoticeOnOdyssey = config.isEnabled( 'stats/paid-stats' ) && isOdysseyStats;
-
-			const showUpgradeNoticeForJetpackNotAtomic =
-				config.isEnabled( 'stats/paid-stats' ) && isSiteJetpackNotAtomic;
-
-			return !! (
-				( showUpgradeNoticeOnOdyssey ||
-					showUpgradeNoticeForJetpackNotAtomic ||
-					showUpgradeNoticeForWpcomSites ) &&
-				// Show the notice if the site has not purchased the paid stats product.
-				! hasPaidStats
-			);
-		},
-		disabled: false,
+		isVisibleFunc: () => false, // prevent accidental display of notice for now
+		disabled: true, // prevent accidental display of notice for now
 	},
 ];
 

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { NoticeIdType } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import CommercialSiteUpgradeNotice from './commercial-site-upgrade-notice';
 import DoYouLoveJetpackStatsNotice from './do-you-love-jetpack-stats-notice';
 import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-success-notice';
 import PaidPlanPurchaseSuccessJetpackStatsNotice from './paid-plan-purchase-success-notice';
@@ -31,6 +32,42 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 	{
 		component: DoYouLoveJetpackStatsNotice,
 		noticeId: 'do_you_love_jetpack_stats',
+		isVisibleFunc: ( {
+			isOdysseyStats,
+			isWpcom,
+			isVip,
+			isP2,
+			isOwnedByTeam51,
+			hasPaidStats,
+			isSiteJetpackNotAtomic,
+		}: StatsNoticeProps ) => {
+			// Gate notices for WPCOM sites behind a flag.
+			const showUpgradeNoticeForWpcomSites =
+				config.isEnabled( 'stats/paid-wpcom-stats' ) &&
+				isWpcom &&
+				! isVip &&
+				! isP2 &&
+				! isOwnedByTeam51;
+
+			// Show the notice if the site is Jetpack or it is Odyssey Stats.
+			const showUpgradeNoticeOnOdyssey = config.isEnabled( 'stats/paid-stats' ) && isOdysseyStats;
+
+			const showUpgradeNoticeForJetpackNotAtomic =
+				config.isEnabled( 'stats/paid-stats' ) && isSiteJetpackNotAtomic;
+
+			return !! (
+				( showUpgradeNoticeOnOdyssey ||
+					showUpgradeNoticeForJetpackNotAtomic ||
+					showUpgradeNoticeForWpcomSites ) &&
+				// Show the notice if the site has not purchased the paid stats product.
+				! hasPaidStats
+			);
+		},
+		disabled: false,
+	},
+	{
+		component: CommercialSiteUpgradeNotice,
+		noticeId: 'commercial_site_upgrade',
 		isVisibleFunc: ( {
 			isOdysseyStats,
 			isWpcom,

--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -63,7 +63,7 @@ const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticePro
 	return (
 		<div
 			className={ `inner-notice-container has-odyssey-stats-bg-color ${
-				! isOdysseyStats && 'inner-notice-container--calypso'
+				! isOdysseyStats && 'inner-notice-container--calypso' && 'is-dark'
 			}` }
 		>
 			<NoticeBanner

--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -8,7 +8,7 @@ import { StatsNoticeProps } from './types';
 
 const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) => {
 	const from = isOdysseyStats ? 'jetpack' : 'calypso';
-	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/paid-stats&from=${ from }-stats-upgrade-notice`;
+	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/paid-stats&from=${ from }-stats-commercial-site-upgrade-notice`;
 	if ( ! isOdysseyStats ) {
 		return purchasePath;
 	}

--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -63,7 +63,7 @@ const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticePro
 	return (
 		<div
 			className={ `inner-notice-container has-odyssey-stats-bg-color ${
-				! isOdysseyStats && 'inner-notice-container--calypso' && 'is-dark'
+				! isOdysseyStats && 'inner-notice-container--calypso'
 			}` }
 		>
 			<NoticeBanner

--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -1,0 +1,104 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import NoticeBanner from '@automattic/components/src/notice-banner';
+import { Icon, external } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
+import { StatsNoticeProps } from './types';
+
+const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) => {
+	const from = isOdysseyStats ? 'jetpack' : 'calypso';
+	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/paid-stats&from=${ from }-stats-upgrade-notice`;
+	if ( ! isOdysseyStats ) {
+		return purchasePath;
+	}
+	// We use absolute path here as it runs in Odyssey as well.
+	return `https://wordpress.com${ purchasePath }`;
+};
+
+const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps ) => {
+	const translate = useTranslate();
+	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
+	const { mutateAsync: postponeNoticeAsync } = useNoticeVisibilityMutation(
+		siteId,
+		'commercial_site_upgrade',
+		'postponed',
+		30 * 24 * 3600
+	);
+
+	const dismissNotice = () => {
+		isOdysseyStats
+			? recordTracksEvent( 'jetpack_odyssey_stats_commercial_site_upgrade_notice_dismissed' )
+			: recordTracksEvent( 'calypso_stats_commercial_site_upgrade_notice_dismissed' );
+
+		setNoticeDismissed( true );
+		postponeNoticeAsync();
+	};
+
+	const gotoJetpackStatsProduct = () => {
+		isOdysseyStats
+			? recordTracksEvent(
+					'jetpack_odyssey_stats_commercial_site_upgrade_notice_support_button_clicked'
+			  )
+			: recordTracksEvent( 'calypso_stats_commercial_site_upgrade_notice_support_button_clicked' );
+		// Allow some time for the event to be recorded before redirecting.
+		setTimeout(
+			() => ( window.location.href = getStatsPurchaseURL( siteId, isOdysseyStats ) ),
+			250
+		);
+	};
+
+	useEffect( () => {
+		if ( ! noticeDismissed ) {
+			isOdysseyStats
+				? recordTracksEvent( 'jetpack_odyssey_stats_commercial_site_upgrade_notice_viewed' )
+				: recordTracksEvent( 'calypso_stats_commercial_site_upgrade_notice_viewed' );
+		}
+	}, [ noticeDismissed, isOdysseyStats ] );
+
+	if ( noticeDismissed ) {
+		return null;
+	}
+
+	return (
+		<div
+			className={ `inner-notice-container has-odyssey-stats-bg-color ${
+				! isOdysseyStats && 'inner-notice-container--calypso'
+			}` }
+		>
+			<NoticeBanner
+				level="info"
+				title={ translate( 'Upgrade to a commercial license' ) }
+				onClose={ dismissNotice }
+			>
+				{ translate(
+					"{{p}}After analyzing your website, it appears to fall under the category of a commercial site. Upgrade to keep using Jetpack Stats and get early access to new upcoming advanced features.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{commercialUpgradeLink}}{{commercialUpgradeLinkText}}I don't have a commercial site{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}",
+					{
+						components: {
+							p: <p />,
+							jetpackStatsProductLink: (
+								<button
+									type="button"
+									className="notice-banner__action-button"
+									onClick={ gotoJetpackStatsProduct }
+								/>
+							),
+							commercialUpgradeLink: (
+								<a
+									className="notice-banner__action-link"
+									href="https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing"
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+							commercialUpgradeLinkText: <span />,
+							externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
+						},
+					}
+				) }
+			</NoticeBanner>
+		</div>
+	);
+};
+
+export default CommercialSiteUpgradeNotice;

--- a/client/my-sites/stats/stats-notices/style.scss
+++ b/client/my-sites/stats/stats-notices/style.scss
@@ -22,10 +22,18 @@
 			border-color: var(--color-accent);
 			color: var(--color-text-inverted);
 			border-radius: 2px;
+
+			&.is-dark {
+				background-color: var(--studio-black);
+			}
 		}
 
 		.notice-banner.is-info {
 			border-left-color: var(--color-accent);
+
+			&.is-dark {
+				border-left-color: var(--studio-black);
+			}
 		}
 
 		.notice-banner__action-link > span {

--- a/client/my-sites/stats/stats-notices/style.scss
+++ b/client/my-sites/stats/stats-notices/style.scss
@@ -22,20 +22,12 @@
 			border-color: var(--color-accent);
 			color: var(--color-text-inverted);
 			border-radius: 2px;
-
-			&.is-dark {
-				background-color: var(--studio-black);
-			}
 		}
 
 		.notice-banner {
 
 			&.is-info {
 				border-left-color: var(--color-accent);
-			}
-
-			&.is-dark {
-				border-left-color: var(--studio-black);
 			}
 		}
 

--- a/client/my-sites/stats/stats-notices/style.scss
+++ b/client/my-sites/stats/stats-notices/style.scss
@@ -31,7 +31,7 @@
 		.notice-banner {
 
 			&.is-info {
-			border-left-color: var(--color-accent);
+				border-left-color: var(--color-accent);
 			}
 
 			&.is-dark {

--- a/client/my-sites/stats/stats-notices/style.scss
+++ b/client/my-sites/stats/stats-notices/style.scss
@@ -28,8 +28,11 @@
 			}
 		}
 
-		.notice-banner.is-info {
+		.notice-banner {
+
+			&.is-info {
 			border-left-color: var(--color-accent);
+			}
 
 			&.is-dark {
 				border-left-color: var(--studio-black);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81058

## Proposed Changes

* Adds a new commercial site upgrade notice
* This PR does not handle the display logic
* This PR does not handle the direction the links follow
* This is just the creation of the notice component, as well as the copy/wording and dark/black styling

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can force this notice to override the display logic and display itself by modifying the stats notices index file at `/my-sites/stats/stats-notices/index.tsx`

	replace the following on line `108`
		
		
		{ ALL_STATS_NOTICES.map(
						( notice ) =>
							calculatedNoticesVisibility[ notice.noticeId ] && (
								<notice.component { ...noticeOptions } />
							)
					) }
		

	with:
		
		
		<CommercialSiteUpgradeNotice { ...noticeOptions } />
		
		
	and adding the import `client/my-sites/stats/stats-notices/index.tsx` 

* navigate to `/stats/day/{site_URL}` and check that you are seeing the black coloured notice with the "Upgrade to a commercial license" text. Check that it matches the design copy shared below.

| Design provided image  |  |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/30754158/92a499d5-5a61-48d0-ab8c-25f7b9c687ac)  | ![image](https://github.com/Automattic/wp-calypso/assets/30754158/ed6201dd-df54-4e6b-b597-af063a8bc9e0)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
