### PR TITLE
Jetpack Partner Portal: implement UI for creating a site page.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -1,0 +1,132 @@
+import { Button, JetpackLogo, WooLogo, CloudLogo } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useRef, useState } from 'react';
+import Tooltip from 'calypso/components/tooltip';
+
+import './style.scss';
+
+// FIXME: These should be imported from a shared file when available
+const JETPACK_HOSTING_WPCOM_BUSINESS = 'JETPACK_HOSTING_WPCOM_BUSINESS';
+const JETPACK_HOSTING_WPCOM_ECOMMERCE = 'JETPACK_HOSTING_WPCOM_ECOMMERCE';
+
+interface PlanInfo {
+	title: string;
+	description: string;
+	price: string;
+	interval: string;
+	wpcomFeatures: string[];
+	jetpackFeatures: string[];
+	storage: string;
+	logo: JSX.Element | null;
+}
+
+export default function CardContent( { planSlug }: { planSlug: string } ) {
+	const translate = useTranslate();
+	const tooltipRef = useRef< HTMLDivElement | null >( null );
+	const [ showPopover, setShowPopover ] = useState( false );
+
+	const getLogo = ( planSlug: string ) => {
+		switch ( planSlug ) {
+			case JETPACK_HOSTING_WPCOM_BUSINESS:
+				return <CloudLogo />;
+			case JETPACK_HOSTING_WPCOM_ECOMMERCE:
+				return <WooLogo />;
+			default:
+				return null;
+		}
+	};
+
+	const getPlanInfo = ( planSlug: string ): PlanInfo => {
+		// FIXME: This is a placeholder until we have the real data
+		return {
+			title: 'Plan Title',
+			description: 'Plan description goes here',
+			price: '$25',
+			interval: 'month',
+			wpcomFeatures: [ 'Feature 1', 'Feature 2', 'Feature 3', 'Feature 4', 'Feature 5' ],
+			jetpackFeatures:
+				planSlug === JETPACK_HOSTING_WPCOM_BUSINESS
+					? [ 'Feature 1', 'Feature 2', 'Feature 3', 'Feature 4' ]
+					: [],
+			storage: '50GB',
+			logo: getLogo( planSlug ),
+		};
+	};
+
+	const plan = getPlanInfo( planSlug );
+
+	if ( ! plan ) {
+		return null;
+	}
+
+	return (
+		<>
+			<div className="wpcom-atomic-hosting__card-content">
+				{ plan.logo }
+				<div className="wpcom-atomic-hosting__card-title">{ plan.title }</div>
+				<div className="wpcom-atomic-hosting__card-description">{ plan.description }</div>
+				<div className="wpcom-atomic-hosting__card-price">{ plan.price }</div>
+				<div className="wpcom-atomic-hosting__card-interval">
+					{ plan.interval === 'day' && translate( '/USD per license per day' ) }
+					{ plan.interval === 'month' && translate( '/USD per license per month' ) }
+				</div>
+				<Button className="wpcom-atomic-hosting__card-button" primary>
+					{ translate( 'Get %(title)s', {
+						args: {
+							title: plan.title,
+						},
+						comment: '%(title) is the plan title. Example: Get Business or Get Commerce',
+					} ) }
+				</Button>
+				<div className="wpcom-atomic-hosting__card-features">
+					<div className="wpcom-atomic-hosting__card-features-heading">
+						{ translate( 'Everything in %(previousProductName)s, plus:', {
+							args: { previousProductName: 'Product Name' }, // FIXME: This should be the plan name
+						} ) }
+					</div>
+					{ plan.wpcomFeatures.length > 0 &&
+						plan.wpcomFeatures.map( ( feature ) => (
+							<div
+								key={ feature.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase() }
+								className="wpcom-atomic-hosting__card-feature"
+							>
+								{ feature }
+							</div>
+						) ) }
+				</div>
+				{ plan.jetpackFeatures.length > 0 && (
+					<div className="wpcom-atomic-hosting__card-features">
+						<span
+							className="wpcom-atomic-hosting__card-features-heading"
+							onMouseEnter={ () => setShowPopover( true ) }
+							onMouseLeave={ () => setShowPopover( false ) }
+							onMouseDown={ () => setShowPopover( false ) }
+							role="button"
+							tabIndex={ 0 }
+							ref={ tooltipRef }
+						>
+							<JetpackLogo size={ 16 } />
+						</span>
+						<Tooltip context={ tooltipRef.current } isVisible={ showPopover } position="right">
+							{ translate(
+								'Security, performance and growth tools made by the WordPress experts.'
+							) }
+						</Tooltip>
+						{ plan.jetpackFeatures.map( ( feature ) => (
+							<div
+								key={ feature.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase() }
+								className="wpcom-atomic-hosting__card-feature"
+							>
+								{ feature }
+							</div>
+						) ) }
+					</div>
+				) }
+			</div>
+			<div>
+				<div className="wpcom-atomic-hosting__card-heading">{ translate( 'STORAGE' ) }</div>
+				<div className="wpcom-atomic-hosting__card-storage-amount">{ plan.storage }</div>
+			</div>
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/index.tsx
@@ -1,16 +1,34 @@
+import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import CardHeading from 'calypso/components/card-heading';
 import Layout from '../../layout';
 import LayoutHeader from '../../layout/header';
+import CardContent from './card-content';
+
+import './style.scss';
 
 export default function WPCOMAtomicHosting() {
 	const translate = useTranslate();
 	const title = translate( 'Create a new WordPress.com site' );
+
+	const plansToBeDisplayed = [
+		'JETPACK_HOSTING_WPCOM_BUSINESS',
+		'JETPACK_HOSTING_WPCOM_ECOMMERCE',
+	]; // Get the plans from the API
+
 	return (
 		<Layout title={ title } wide>
 			<LayoutHeader>
 				<CardHeading size={ 36 }>{ title }</CardHeading>
 			</LayoutHeader>
+
+			<div className="wpcom-atomic-hosting__card-container">
+				{ plansToBeDisplayed.map( ( plan ) => (
+					<Card key={ plan } className="wpcom-atomic-hosting__card" compact>
+						<CardContent planSlug={ plan } />
+					</Card>
+				) ) }
+			</div>
 		</Layout>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/style.scss
@@ -32,7 +32,7 @@
 .wpcom-atomic-hosting__card-price {
 	font-family: Recoleta, serif;
 	color: var(--studio-gray-100);
-	margin-block-start: 64px;
+	margin-block-start: 32px;
 	font-size: 2.75rem;
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/style.scss
@@ -1,0 +1,87 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "@automattic/onboarding/styles/mixins";
+
+.wpcom-atomic-hosting__card-container {
+	display: flex;
+	flex-wrap: wrap;
+	margin-block-start: 24px;
+}
+
+.wpcom-atomic-hosting__card {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+
+	@include break-xlarge {
+		width: 50%;
+	}
+}
+
+.wpcom-atomic-hosting__card-title {
+	font-family: Recoleta, serif;
+	color: var(--studio-gray-100);
+	font-size: 2rem;
+}
+
+.wpcom-atomic-hosting__card-description {
+	color: var(--studio-gray-80);
+	font-size: 0.75rem;
+}
+
+.wpcom-atomic-hosting__card-price {
+	font-family: Recoleta, serif;
+	color: var(--studio-gray-100);
+	margin-block-start: 64px;
+	font-size: 2.75rem;
+}
+
+.wpcom-atomic-hosting__card-interval {
+	position: relative;
+	inset-block-start: -0.5rem;
+	color: var(--studio-gray-50);
+	font-size: 0.75rem;
+}
+
+.wpcom-atomic-hosting__card-features {
+	margin-block-start: 36px;
+}
+
+.wpcom-atomic-hosting__card-features-heading {
+	margin-block: 6px 12px;
+	color: #7f54b3;
+	font-size: 0.75rem;
+	font-weight: 600;
+}
+
+.wpcom-atomic-hosting__card-feature {
+	margin-block: 8px;
+	color: var(--studio-gray-80);
+	font-size: 0.75rem;
+}
+
+.wpcom-atomic-hosting__card-button {
+	margin-block-start: 16px;
+	width: 100%;
+}
+
+.wpcom-atomic-hosting__card-content {
+	flex: 1;
+}
+
+.wpcom-atomic-hosting__card-heading {
+	margin-block-start: 36px;
+	color: var(--studio-gray-100);
+	font-size: 0.75rem;
+	font-weight: 500;
+}
+
+.wpcom-atomic-hosting__card-storage-amount {
+	margin-block-start: 4px;
+	color: var(--studio-gray-90);
+	font-size: 0.75rem;
+	background-color: #f2f2f2;
+	padding: 4px 6px;
+	border-radius: 2px;
+	width: fit-content;
+}


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-avalon/issues/42

## Proposed Changes

This PR implements UI for creating a site page.

## Testing Instructions

- Open the Jetpack Cloud live link
- Append the URL with `/partner-portal/create-site` and verify the below screen is shown.

<img width="1387" alt="Screenshot 2023-08-29 at 8 18 30 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2d175b3c-8316-4c51-990f-64d100569de3">

- Verify this screen looks good on other devices

Mobile

![mobile (33)](https://github.com/Automattic/wp-calypso/assets/10586875/cfc023d7-a187-424e-b215-dd7cec5cdcc6)

-----

Tablet

![mobile (34)](https://github.com/Automattic/wp-calypso/assets/10586875/f60e9d16-495f-42e1-8d4e-2292348be81d)

-----

Large screen

![mobile (35)](https://github.com/Automattic/wp-calypso/assets/10586875/e2deef89-0dc5-4ccb-a7e8-2ac781f4ab97)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
