### PR TITLE
Stats: fix flickering highlight cards on Subscribers page

### DIFF
--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -75,8 +75,9 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 		( state ) => state.memberships?.productList?.items[ siteId as number ]
 	);
 	// Check if the site has any paid subscription products added.
-	const hasAddedPaidSubscriptionProduct = products && products.length > 0;
-	const isPaidSubscriptionProductsLoading = ! products;
+	// Odyssey Stats doesn't support the membership API endpoint yet.
+	const hasAddedPaidSubscriptionProduct = ! isOdysseyStats && products && products.length > 0;
+	const isPaidSubscriptionProductsLoading = ! isOdysseyStats && ! products;
 
 	const highlights = useSubscriberHighlights( siteId, hasAddedPaidSubscriptionProduct );
 

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -72,6 +72,7 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	// Check if the site has any paid subscription products added.
+	// Intentionally not using `getProductsForSiteId` here because we want to show the loading state.
 	const products = useSelector( ( state ) => state.memberships?.productList?.items[ siteId ?? 0 ] );
 
 	// Odyssey Stats doesn't support the membership API endpoint yet.

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -71,11 +71,13 @@ function SubscriberHighlightsHeader() {
 function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
+	// Check if the site has any paid subscription products added.
 	const products = useSelector(
 		( state ) => state.memberships?.productList?.items[ siteId as number ]
 	);
-	// Check if the site has any paid subscription products added.
+
 	// Odyssey Stats doesn't support the membership API endpoint yet.
+	// Products with an `undefined` value rather than an empty array means the API call has not been completed yet.
 	const hasAddedPaidSubscriptionProduct = ! isOdysseyStats && products && products.length > 0;
 	const isPaidSubscriptionProductsLoading = ! isOdysseyStats && ! products;
 

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -3,7 +3,6 @@ import { CountComparisonCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import QueryMembershipProducts from 'calypso/components/data/query-memberships';
 import { useSelector } from 'calypso/state';
-import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
 import useSubscribersTotalsQueries from '../hooks/use-subscribers-totals-query';
 import './style.scss';
 
@@ -72,9 +71,12 @@ function SubscriberHighlightsHeader() {
 function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
-	const products = useSelector( ( state ) => getProductsForSiteId( state, siteId ) );
+	const products = useSelector(
+		( state ) => state.memberships?.productList?.items[ siteId as number ]
+	);
 	// Check if the site has any paid subscription products added.
-	const hasAddedPaidSubscriptionProduct = products.length > 0;
+	const hasAddedPaidSubscriptionProduct = products && products.length > 0;
+	const isPaidSubscriptionProductsLoading = ! products;
 
 	const highlights = useSubscriberHighlights( siteId, hasAddedPaidSubscriptionProduct );
 
@@ -87,8 +89,8 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 						<CountComparisonCard
 							compact={ true }
 							key={ highlight.heading }
-							heading={ highlight.heading }
-							count={ highlight.count }
+							heading={ isPaidSubscriptionProductsLoading ? '-' : highlight.heading }
+							count={ isPaidSubscriptionProductsLoading ? null : highlight.count }
 							showValueTooltip
 							note={ highlight.note }
 						/>

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -72,9 +72,7 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	// Check if the site has any paid subscription products added.
-	const products = useSelector(
-		( state ) => state.memberships?.productList?.items[ siteId as number ]
-	);
+	const products = useSelector( ( state ) => state.memberships?.productList?.items[ siteId ?? 0 ] );
 
 	// Odyssey Stats doesn't support the membership API endpoint yet.
 	// Products with an `undefined` value rather than an empty array means the API call has not been completed yet.


### PR DESCRIPTION
Related to #81011 

## Proposed Changes

- Only show Paid/Free subscribers for Calypso Stats
- Stop using an empty array as the default of `productList`, so that we know whether it's loading or not
- When `productList` is loading, show `-` in labels and numbers of the highlight cards to avoid flickering

## Testing Instructions

* Open Calypso Live Branch
* Open `/stats/subscribers/:siteSlug`
* Ensure it doesn't flicker
* Open a site with paid products set up (for example, paid newsletter)
* Ensure it doesn't flicker
* Ensure it doesn't flicker for Odyssey Stats

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?