### PR TITLE
Flaky E2E: some more tweaks to the Site Assembler spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
@@ -84,7 +84,7 @@ export class SiteAssemblerFlow {
 		await this.page
 			.locator( '.device-switcher__viewport' )
 			.getByRole( 'listitem', { name: name } )
-			.waitFor( { state: 'visible', timeout: 25 * 1000 } );
+			.waitFor( { state: 'attached', timeout: 15 * 1000 } );
 	}
 
 	/**

--- a/test/e2e/specs/onboarding/ftme__site-assembler.ts
+++ b/test/e2e/specs/onboarding/ftme__site-assembler.ts
@@ -114,13 +114,14 @@ describe( 'Site Assembler', () => {
 		it( 'Pick default style', async function () {
 			await siteAssemblerFlow.clickButton( 'Pick your style' );
 			await siteAssemblerFlow.pickStyle( 'Color: Free style' );
+			await siteAssemblerFlow.clickButton( 'Save and continue' );
 		} );
 
 		it( 'Click "Save and continue" and land on the Site Editor', async function () {
-			await Promise.all( [
-				page.waitForURL( /processing/ ),
-				siteAssemblerFlow.clickButton( 'Save and continue' ),
-			] );
+			const urlPromise = page.waitForURL( /processing/ );
+			await siteAssemblerFlow.clickButton( 'Start adding content' );
+			await urlPromise;
+
 			await page.waitForURL( /site-editor/, {
 				timeout: 30 * 1000,
 			} );

--- a/test/e2e/specs/onboarding/ftme__site-assembler.ts
+++ b/test/e2e/specs/onboarding/ftme__site-assembler.ts
@@ -70,7 +70,7 @@ describe( 'Site Assembler', () => {
 		} );
 
 		it( 'Select "Start designing" and land on the Site Assembler', async function () {
-			await startSiteFlow.clickButton( 'Get started' );
+			await startSiteFlow.clickButton( 'Design your own' );
 			await page.waitForURL(
 				DataHelper.getCalypsoURL(
 					`/setup/site-setup/patternAssembler?siteSlug=${ selectedFreeDomain }&siteId=${ newSiteDetails.blog_details.blogid }`
@@ -92,21 +92,21 @@ describe( 'Site Assembler', () => {
 		it( 'Select "Header"', async function () {
 			// The pane is now open by default.
 			// @see https://github.com/Automattic/wp-calypso/pull/80924
-			await siteAssemblerFlow.selectLayoutComponent( 'Simple Header' );
+			await siteAssemblerFlow.selectLayoutComponent( { index: 0 } );
 
 			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 1 );
 		} );
 
 		it( 'Select "Sections"', async function () {
 			await siteAssemblerFlow.clickLayoutComponentType( 'Sections' );
-			await siteAssemblerFlow.selectLayoutComponent( 'Heading with two images and descriptions' );
+			await siteAssemblerFlow.selectLayoutComponent( { index: 0 } );
 
 			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 2 );
 		} );
 
 		it( 'Select "Footer"', async function () {
 			await siteAssemblerFlow.clickLayoutComponentType( 'Footer' );
-			await siteAssemblerFlow.selectLayoutComponent( 'Simple centered footer' );
+			await siteAssemblerFlow.selectLayoutComponent( { index: 0 } );
 
 			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 3 );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/81156.

## Proposed Changes

This PR updates the `selectLayoutComponent` method to support both index and name-based selections. This is so that site asssembler components being removed or added do not affect the spec.

Additionally, after inserting a new component, the wait method is new and is based on counter.



## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
