### PR TITLE
Assembler - Accessibility - Add aria-label with pattern title in large preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -75,6 +75,7 @@ const PatternLargePreview = ( {
 		return (
 			<li
 				key={ key }
+				aria-label={ pattern.title }
 				className={ classnames(
 					'pattern-large-preview__pattern',
 					`pattern-large-preview__pattern-${ type }`


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add `aria-label` with pattern title in large preview

|BEFORE|AFTER|
|--|--|
|<img width="666" alt="Screenshot 2566-08-29 at 12 40 23" src="https://github.com/Automattic/wp-calypso/assets/1881481/fa67ffb3-e87a-4c41-8cfd-5211a2c9d6c7">|<img width="796" alt="Screenshot 2566-08-29 at 12 36 46" src="https://github.com/Automattic/wp-calypso/assets/1881481/000f8e76-5e51-4206-accf-6cd77668c0f9">|

So now we have the `aria-label` in both lists, the pattern selector, and the large preview.

|Selector|Large preview|
|--|--|
|<img width="688" alt="Screenshot 2566-08-29 at 12 36 14" src="https://github.com/Automattic/wp-calypso/assets/1881481/6730cc13-5fd6-4d74-858e-f5f57a2dfb13">|<img width="796" alt="Screenshot 2566-08-29 at 12 36 46" src="https://github.com/Automattic/wp-calypso/assets/1881481/bb4cec8e-c133-47a9-949b-820d58fd7518">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }`
* Using the Accessibility inspector tool or Dev tools to verify the `aria-label` contains the pattern title

|Selector|Large preview|
|--|--|
|<img width="586" alt="Screenshot 2566-08-29 at 12 42 35" src="https://github.com/Automattic/wp-calypso/assets/1881481/d39de188-16f0-4e78-b2f5-36768b0b49b2">|<img width="404" alt="Screenshot 2566-08-29 at 12 43 39" src="https://github.com/Automattic/wp-calypso/assets/1881481/8bd484dc-4e20-4c0c-a837-1bb85922b4bb">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
