### PR TITLE
Assembler: Hide the back button in front of the title on the Confirmation screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -556,7 +556,7 @@ const PatternAssembler = ( {
 				</NavigatorScreen>
 
 				<NavigatorScreen path={ NAVIGATOR_PATHS.CONFIRMATION } className="screen-confirmation">
-					<ScreenConfirmation onConfirm={ onConfirm } recordTracksEvent={ recordTracksEvent } />
+					<ScreenConfirmation onConfirm={ onConfirm } />
 				</NavigatorScreen>
 			</div>
 			<div className="pattern-assembler__sidebar-panel">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -608,6 +608,7 @@ const PatternAssembler = ( {
 		<StepContainer
 			className="pattern-assembler__sidebar-revamp"
 			stepName="pattern-assembler"
+			stepSectionName={ currentScreen.name }
 			backLabelText={
 				isSiteAssemblerFlow( flow ) && navigator.location.path?.startsWith( NAVIGATOR_PATHS.MAIN )
 					? translate( 'Back to themes' )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
@@ -7,16 +7,14 @@ import {
 } from '@wordpress/components';
 import { Icon, image, verse, layout } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import NavigatorTitle from './navigator-title';
 import './screen-confirmation.scss';
 
 interface Props {
 	onConfirm: () => void;
-	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 }
 
-const ScreenConfirmation = ( { onConfirm, recordTracksEvent }: Props ) => {
+const ScreenConfirmation = ( { onConfirm }: Props ) => {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 
@@ -55,12 +53,7 @@ const ScreenConfirmation = ( { onConfirm, recordTracksEvent }: Props ) => {
 						? translate( 'Time to add some content and bring your site to life!' )
 						: translate( 'Bring your site to life with some content.' )
 				}
-				onBack={ () => {
-					recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_BACK_CLICK, {
-						screen_from: 'confirmation',
-						screen_to: 'styles',
-					} );
-				} }
+				hideBack
 			/>
 			<div className="screen-container__body">
 				<VStack spacing="4" className="screen-confirmation__list">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Hide the back button in front of the title on the Confirmation screen

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/9f813ce8-342b-43f9-ba25-022b09d8fa65) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/825971d0-5008-4c96-a54e-25ff28b0d5db) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Continue to the Design Picker
* Select the `Design your own` button
* Continue to the Confirmation screen
* Ensure the back button in front of the title is gone
* Click the back button next to the WP logo
* Ensure the `calypso_signup_pattern_assembler_screen_back_click` is fired with the correct `screen_from` and `screen_to`
* Ensure the `calypso_signup_previous_step_button_click` is not fired

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
