### PR TITLE
Update reader page titles

### DIFF
--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -1,4 +1,6 @@
+import { translate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
+import DocumentHead from 'calypso/components/data/document-head';
 import { sectionify } from 'calypso/lib/route';
 import {
 	trackPageLoad,
@@ -26,25 +28,28 @@ const exported = {
 		}
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		context.primary = (
-			<AsyncLoad
-				require="calypso/reader/discover/discover-stream"
-				key="discover-page"
-				streamKey={ streamKey }
-				title="Discover"
-				trackScrollPage={ trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					ANALYTICS_PAGE_TITLE,
-					mcKey
-				) }
-				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-				suppressSiteNameLink={ true }
-				isDiscoverStream={ true }
-				useCompactCards={ true }
-				showBack={ false }
-				className="is-discover-stream"
-			/>
+			<>
+				<DocumentHead title={ translate( 'Browse Popular Blogs & Read Articles ‹ Reader' ) } />
+				<AsyncLoad
+					require="calypso/reader/discover/discover-stream"
+					key="discover-page"
+					streamKey={ streamKey }
+					title="Discover"
+					trackScrollPage={ trackScrollPage.bind(
+						null,
+						basePath,
+						fullAnalyticsPageTitle,
+						ANALYTICS_PAGE_TITLE,
+						mcKey
+					) }
+					onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+					suppressSiteNameLink={ true }
+					isDiscoverStream={ true }
+					useCompactCards={ true }
+					showBack={ false }
+					className="is-discover-stream"
+				/>
+			</>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 		next();

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -40,7 +40,7 @@ export const tagListing = ( context, next ) => {
 	context.primary = (
 		<>
 			<DocumentHead
-				title={ translate( 'Articles About %s ‹ Reader', {
+				title={ translate( 'Articles & Posts About %s ‹ Reader', {
 					args: [ tagTitle ],
 					comment: 'page title for reader tag pages. %s is the name of the tag e.g. "art"',
 				} ) }


### PR DESCRIPTION
Part of pe7F0s-18c-p2

Update page titles on discover page and tags pages.

### Testing instructions

title on discover page: `Browse Popular Blogs & Read Articles ‹ Reader — WordPress.com`
title on category pages: `Articles & Posts About <TAG> ‹ Reader — WordPress.com`

