### PR TITLE
Jetpack Partner Portal: implement WPCOM atomic hosting notification banner

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -248,7 +248,7 @@ export class Banner extends Component {
 							) ) }
 						</ul>
 					) }
-					{ extraContent && <>{ extraContent }</> }
+					{ extraContent }
 				</div>
 				{ ( callToAction || price ) && (
 					<div className="banner__action">

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -76,6 +76,7 @@ export class Banner extends Component {
 		isSiteWPForTeams: PropTypes.bool,
 		displayAsLink: PropTypes.bool,
 		showLinkIcon: PropTypes.bool,
+		extraContent: PropTypes.node,
 	};
 
 	static defaultProps = {
@@ -207,6 +208,7 @@ export class Banner extends Component {
 			target,
 			tracksImpressionName,
 			tracksImpressionProperties,
+			extraContent,
 		} = this.props;
 
 		const prices = Array.isArray( price ) ? price : [ price ];
@@ -246,6 +248,7 @@ export class Banner extends Component {
 							) ) }
 						</ul>
 					) }
+					{ extraContent && <>{ extraContent }</> }
 				</div>
 				{ ( callToAction || price ) && (
 					<div className="banner__action">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/lib/constants.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/lib/constants.ts
@@ -8,3 +8,5 @@ export const DASHBOARD_PRODUCT_SLUGS_BY_TYPE: Record< string, string > = {
 	scan: 'jetpack-scan',
 	monitor: 'jetpack-monitor',
 };
+
+export const WPCOM_HOSTING = 'wpcom-hosting';

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
@@ -4,7 +4,9 @@ import Notice from 'calypso/components/notice';
 import { useDispatch, useSelector } from 'calypso/state';
 import { setPurchasedLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { getPurchasedLicense } from 'calypso/state/jetpack-agency-dashboard/selectors';
+import { WPCOM_HOSTING } from '../lib/constants';
 import { ProductInfo } from '../types';
+import WPCOMAtomicHostingNotification from './wpcom-atomic-hosting-notification';
 
 import './style.scss';
 
@@ -25,7 +27,12 @@ export default function SiteAddLicenseNotification() {
 		return null;
 	}
 
-	const { selectedSite, selectedProducts } = licensesAdded;
+	const { selectedSite, selectedProducts, type } = licensesAdded;
+
+	if ( type === WPCOM_HOSTING ) {
+		return <WPCOMAtomicHostingNotification licensesAdded={ licensesAdded } />;
+	}
+
 	const assignedLicenses = selectedProducts.filter( ( product ) => product.status === 'fulfilled' );
 	const rejectedLicenses = selectedProducts.filter( ( product ) => product.status === 'rejected' );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/style.scss
@@ -1,8 +1,48 @@
+@import "@wordpress/base-styles/mixins";
+
 .site-add-license-notification__license-banner {
 	div.banner__icon {
 		display: flex;
 	}
 	.banner__info .banner__title {
 		font-weight: normal;
+	}
+}
+
+.site-add-license-notification__license-banner-wp {
+	.banner {
+		border-width: 1px 1px 1px 4px;
+		border-style: solid;
+		border-color: var(--studio-green-40);
+		border-radius: 4px 2px 2px 4px;
+
+		.banner__description {
+			max-width: 90%;
+		}
+	}
+
+	.site-add-license-notification__license-banner-wp-buttons {
+		margin-block-start: 20px;
+		display: flex;
+		gap: 16px;
+		flex-wrap: wrap;
+
+		.button {
+
+			.gridicon {
+				margin-inline-start: 8px;
+				width: auto;
+				height: auto;
+				color: var(--studio-white);
+			}
+
+			&.is-borderless {
+				text-decoration: underline;
+
+				.gridicon {
+					color: var(--color-neutral-80);
+				}
+			}
+		}
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/wpcom-atomic-hosting-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/wpcom-atomic-hosting-notification.tsx
@@ -2,6 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import checkIcon from 'calypso/assets/images/jetpack/jetpack-green-checkmark.svg';
 import Banner from 'calypso/components/banner';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setPurchasedLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
@@ -29,10 +30,12 @@ export default function WPCOMAtomicHostingNotification( {
 		dispatch( setPurchasedLicense() );
 	};
 
+	const siteSlug = urlToSlug( selectedSite );
+
 	const extraContent = (
 		<div className="site-add-license-notification__license-banner-wp-buttons">
 			<Button
-				href={ `https://wordpress.com/home/${ selectedSite }` }
+				href={ `https://wordpress.com/home/${ siteSlug }` }
 				primary
 				target="_blank"
 				onClick={ () =>
@@ -48,7 +51,7 @@ export default function WPCOMAtomicHostingNotification( {
 			<Button
 				borderless
 				target="_blank"
-				href={ `https://wordpress.com/domains/manage/${ selectedSite }` }
+				href={ `https://wordpress.com/domains/manage/${ siteSlug }` }
 				onClick={ () => handleOnClick( 'calypso_jetpack_agency_dashboard_change_domain_click' ) }
 			>
 				{ translate( 'Change domain' ) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/wpcom-atomic-hosting-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/wpcom-atomic-hosting-notification.tsx
@@ -1,0 +1,88 @@
+import { Button, Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import checkIcon from 'calypso/assets/images/jetpack/jetpack-green-checkmark.svg';
+import Banner from 'calypso/components/banner';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { setPurchasedLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
+import type { PurchasedProductsInfo } from '../types';
+
+export default function WPCOMAtomicHostingNotification( {
+	licensesAdded,
+}: {
+	licensesAdded: PurchasedProductsInfo;
+} ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const { selectedSite, selectedProducts } = licensesAdded;
+
+	const licenseItem = selectedProducts[ 0 ].name;
+
+	const handleOnClick = ( eventName: string ) => {
+		dispatch(
+			recordTracksEvent( eventName, {
+				site: selectedSite,
+				licenseItem,
+			} )
+		);
+		dispatch( setPurchasedLicense() );
+	};
+
+	const extraContent = (
+		<div className="site-add-license-notification__license-banner-wp-buttons">
+			<Button
+				href={ `https://wordpress.com/home/${ selectedSite }` }
+				primary
+				target="_blank"
+				onClick={ () =>
+					handleOnClick( 'calypso_jetpack_agency_dashboard_setup_site_in_wp_admin_click' )
+				}
+			>
+				{ translate( 'Setup site in wp-admin' ) }
+				<span>
+					<Gridicon icon="external" size={ 18 } />
+				</span>
+			</Button>
+
+			<Button
+				borderless
+				target="_blank"
+				href={ `https://wordpress.com/domains/manage/${ selectedSite }` }
+				onClick={ () => handleOnClick( 'calypso_jetpack_agency_dashboard_change_domain_click' ) }
+			>
+				{ translate( 'Change domain' ) }
+				<span>
+					<Gridicon icon="external" size={ 24 } />
+				</span>
+			</Button>
+		</div>
+	);
+
+	return (
+		<div className="site-add-license-notification__license-banner-wp">
+			<Banner
+				dismissWithoutSavingPreference
+				title={ translate(
+					"Congratulations! You've successfully purchased the %(licenseItem)s License.",
+					{
+						args: {
+							licenseItem,
+						},
+						comment: '%(licenseItem)s is the license name, such as "WordPress Business".',
+					}
+				) }
+				description={ translate(
+					"Start by setting up or freely switch your temporary domain to your preferred one. It's time to create your masterpiece!"
+				) }
+				disableCircle
+				horizontal
+				iconPath={ checkIcon }
+				onDismiss={ () =>
+					handleOnClick( 'calypso_jetpack_agency_dashboard_wpcom_hosting-notification_dismiss' )
+				}
+				extraContent={ extraContent }
+			/>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -245,6 +245,7 @@ export type ProductInfo = { name: string; key: string; status: 'rejected' | 'ful
 export type PurchasedProductsInfo = {
 	selectedSite: string;
 	selectedProducts: Array< ProductInfo >;
+	type?: string;
 };
 
 export interface APIError {


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-avalon/issues/43

## Proposed Changes

This PR implements the WPCOM atomic hosting notification banner.

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/implement-wpcom-atomic-hosting-notification-banner` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Open `/jetpack-cloud/sections/partner-portal/hooks/use-assign-licenses-to-site.ts#L97` and add `type: 'WPCOM_HOSTING',` so it looks like

```
return {
	selectedSite: selectedSite?.domain || '',
	selectedProducts: apiRequests,
	type: 'wpcom-hosting',
};
```

4. Click on the `...` on any site > Click `Issue new license` > Select and issue a license > Verify that you are redirected to the dashboard and below notification is shown. Note: This will be shown only when we assign a WPCOM atomic hosting plan which has not yet been added.
5. Verify that both the buttons work as expected and the banner is dismissed when the button is clicked, or the close button is clicked.
6. Verify that appropriate track event calls are being made when these buttons are clicked.
7. Verify this banner looks good and all the different devices.

![mobile (38)](https://github.com/Automattic/wp-calypso/assets/10586875/51f29a6c-bd76-41c2-8e8d-61b91abcb0d8)

----

Mobile

![mobile (36)](https://github.com/Automattic/wp-calypso/assets/10586875/a687ffc0-77d5-4505-8743-b1ae32883cca)

----
Tablet

![mobile (37)](https://github.com/Automattic/wp-calypso/assets/10586875/828bf477-b0ef-4cbb-8f83-c116077fe19f)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?