### PR TITLE
Design Picker Preview: Fix the back button is missing

### DIFF
--- a/packages/onboarding/src/navigator/hooks/index.tsx
+++ b/packages/onboarding/src/navigator/hooks/index.tsx
@@ -1,1 +1,2 @@
 export { default as useNavigatorListener } from './use-navigator-listener';
+export type { OnNavigatorPathChange } from './use-navigator-listener';

--- a/packages/onboarding/src/navigator/hooks/use-navigator-listener.tsx
+++ b/packages/onboarding/src/navigator/hooks/use-navigator-listener.tsx
@@ -1,10 +1,17 @@
 import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
-const useNavigatorListener = ( onNavigatorPathChange?: ( path?: string ) => void ) => {
+export type OnNavigatorPathChange = ( path?: string ) => void;
+
+const useNavigatorListener = ( onNavigatorPathChange?: OnNavigatorPathChange ) => {
 	const { location } = useNavigator();
+	const previousPathRef = useRef( '' );
+
 	useEffect( () => {
-		onNavigatorPathChange?.( location.path );
+		if ( location.path && location.path !== previousPathRef.current ) {
+			onNavigatorPathChange?.( location.path );
+			previousPathRef.current = location.path;
+		}
 	}, [ location.path, onNavigatorPathChange ] );
 };
 

--- a/packages/onboarding/src/navigator/index.ts
+++ b/packages/onboarding/src/navigator/index.ts
@@ -2,5 +2,6 @@ export * from './hooks';
 export { NavigatorButtonAsItem, NavigatorItem } from './navigator-buttons';
 export { default as NavigatorHeader } from './navigator-header';
 export { default as NavigatorItemGroup } from './navigator-item-group';
+export { default as NavigatorListener } from './navigator-listener';
 export { default as NavigatorScreen } from './navigator-screen';
 export * from './navigator-screens';

--- a/packages/onboarding/src/navigator/navigator-listener/index.tsx
+++ b/packages/onboarding/src/navigator/navigator-listener/index.tsx
@@ -1,0 +1,12 @@
+import { useNavigatorListener, OnNavigatorPathChange } from '../hooks';
+
+interface Props {
+	onNavigatorPathChange?: OnNavigatorPathChange;
+}
+
+const NavigatorListener = ( { onNavigatorPathChange }: Props ) => {
+	useNavigatorListener( onNavigatorPathChange );
+	return null;
+};
+
+export default NavigatorListener;

--- a/packages/onboarding/src/navigator/navigator-screens/navigator-screens.tsx
+++ b/packages/onboarding/src/navigator/navigator-screens/navigator-screens.tsx
@@ -2,7 +2,7 @@ import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalNavigatorScreen as NavigatorScreen,
 } from '@wordpress/components';
-import { useNavigatorListener } from '../hooks';
+import NavigatorListener from '../navigator-listener';
 import { useNavigatorScreens } from './hooks';
 import type { NavigatorScreenObject } from './types';
 import './navigator-screens.scss';
@@ -22,8 +22,6 @@ const NavigatorScreens = ( {
 }: Props ) => {
 	const navigatorScreens = useNavigatorScreens( screens );
 
-	useNavigatorListener( onNavigatorPathChange );
-
 	// We don't need navigator if there is only one screen
 	if ( screens.length === 1 ) {
 		return children;
@@ -33,6 +31,9 @@ const NavigatorScreens = ( {
 		<NavigatorProvider initialPath={ initialPath }>
 			<NavigatorScreen path={ initialPath }>{ children }</NavigatorScreen>
 			{ navigatorScreens }
+			{ onNavigatorPathChange && (
+				<NavigatorListener onNavigatorPathChange={ onNavigatorPathChange } />
+			) }
 		</NavigatorProvider>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1693303672280329-slack-C048CUFRGFQ

## Proposed Changes

* The back button is missing as the initial path is not `/`. The reason is the `useNavigatorListener` is not under the `NavigatorProvider` after https://github.com/Automattic/wp-calypso/pull/81069... Hence, added the `NavigatorListener` component back so we're able to detect the change of the path.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Continue to Design Picker
* Select the following designs
  * design with the style variations
  * design without the style variations
  * virtual designs
* Ensure each preview has the back button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
