### PR TITLE
Remove `min_themes_in_subject` param from requests to `/theme-filters`

### DIFF
--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -79,7 +79,6 @@ export function fetchThemeFilters( context, next ) {
 
 	wpcom.req
 		.get( '/theme-filters', {
-			min_themes_in_subject: 2,
 			apiVersion: '1.2',
 			locale: context.lang, // Note: undefined will be omitted by the query string builder.
 		} )

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -100,7 +100,6 @@ export function fetchThemeFilters( context, next ) {
 
 	wpcom.req
 		.get( '/theme-filters', {
-			min_themes_in_subject: 2,
 			apiVersion: '1.2',
 			locale: context.lang, // Note: undefined will be omitted by the query string builder.
 		} )

--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -9,20 +9,13 @@ import {
 	THEME_FILTERS_REQUEST_FAILURE,
 } from 'calypso/state/themes/action-types';
 
-const defaultThemeFiltersArguments = {
-	min_themes_in_subject: 2,
-};
-
 const fetchFilters = ( action ) =>
 	http(
 		{
 			method: 'GET',
 			apiVersion: '1.2',
 			path: '/theme-filters',
-			query: {
-				...defaultThemeFiltersArguments,
-				...( action.locale ? { locale: action.locale } : {} ),
-			},
+			query: action.locale ? { locale: action.locale } : {},
 		},
 		action
 	);


### PR DESCRIPTION
Follow-up to D119551-code

## Proposed Changes

As of D119551-code, the `/theme-filters` endpoint no longer uses the `min_themes_in_subject` param (it is just ignored) so this PR removes that param from existing requests to such endpoint.

## Testing Instructions

- Use the Calypso live link below
- Go to Appearance > Themes
- Make sure you see the same categories than in production (you should see 17 categories)