### PR TITLE
Pro Dashboard: Update Dashboard table to include 'Host' column.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-default-site-columns.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-default-site-columns.tsx
@@ -16,6 +16,9 @@ const useDefaultSiteColumns = (): SiteColumns => {
 	const translate = useTranslate();
 	const isBoostEnabled = isEnabled( 'jetpack/pro-dashboard-jetpack-boost' );
 	const isPaidMonitorEnabled = isEnabled( 'jetpack/pro-dashboard-monitor-paid-tier' );
+	const isWPCOMAtomicSiteCreationEnabled = isEnabled(
+		'jetpack/pro-dashboard-wpcom-atomic-hosting'
+	);
 
 	return useMemo( () => {
 		const boostColumn: SiteColumn[] = isBoostEnabled
@@ -33,7 +36,13 @@ const useDefaultSiteColumns = (): SiteColumns => {
 		return [
 			{
 				key: 'site',
-				title: translate( 'Site' ),
+				title: isWPCOMAtomicSiteCreationEnabled
+					? translate( '{{div}}Host{{/div}} Site', {
+							components: {
+								div: <div className="fixed-host-column" />,
+							},
+					  } )
+					: translate( 'Site' ),
 				isSortable: true,
 			},
 			{
@@ -69,7 +78,7 @@ const useDefaultSiteColumns = (): SiteColumns => {
 				className: 'width-fit-content',
 			},
 		];
-	}, [ isBoostEnabled, isPaidMonitorEnabled, translate ] );
+	}, [ isBoostEnabled, isPaidMonitorEnabled, isWPCOMAtomicSiteCreationEnabled, translate ] );
 };
 
 export default useDefaultSiteColumns;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-default-site-columns.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-default-site-columns.tsx
@@ -37,11 +37,11 @@ const useDefaultSiteColumns = (): SiteColumns => {
 			{
 				key: 'site',
 				title: isWPCOMAtomicSiteCreationEnabled
-					? translate( '{{div}}Host{{/div}} Site', {
+					? ( translate( '{{div}}Host{{/div}} Site', {
 							components: {
 								div: <div className="fixed-host-column" />,
 							},
-					  } )
+					  } ) as string )
 					: translate( 'Site' ),
 				isSortable: true,
 			},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/style.scss
@@ -25,7 +25,7 @@
 	margin-inline-end: 16px;
 	font-size: 0.75rem;
 	font-weight: bold;
-	margin-inline-start: 38px;
+	margin-inline-start: 20px;
 	position: relative;
 
 	span {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -12,7 +12,7 @@
 	}
 
 	.sites-overview__row-text {
-		margin-inline-start: 55px;
+		margin-inline-start: 32px;
 		width: calc(100% - 55px);
 		font-size: 0.875rem !important;
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -58,7 +58,7 @@ export default function SiteStatusContent( {
 		'jetpack/pro-dashboard-wpcom-atomic-hosting'
 	);
 
-	const isWPCOMAtomicSite = rows.site.value.is_wpcom_atomic;
+	const isWPCOMAtomicSite = rows.site.value.is_atomic;
 
 	const siteId = rows.site.value.blog_id;
 	const siteUrl = rows.site.value.url;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -1,4 +1,5 @@
-import { Button, Gridicon, ShortenedNumber } from '@automattic/components';
+import { isEnabled } from '@automattic/calypso-config';
+import { Button, Gridicon, ShortenedNumber, WordPressLogo } from '@automattic/components';
 import { Icon, arrowUp, arrowDown } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
@@ -52,6 +53,12 @@ export default function SiteStatusContent( {
 	let { tooltip } = metadataRest;
 
 	const { isBulkManagementActive } = useContext( SitesOverviewContext );
+
+	const isWPCOMAtomicSiteCreationEnabled = isEnabled(
+		'jetpack/pro-dashboard-wpcom-atomic-hosting'
+	);
+
+	const isWPCOMAtomicSite = rows.site.value.is_wpcom_atomic;
 
 	const siteId = rows.site.value.blog_id;
 	const siteUrl = rows.site.value.url;
@@ -147,6 +154,15 @@ export default function SiteStatusContent( {
 			);
 		}
 
+		const WPCOMHostedSiteBadgeColumn = isWPCOMAtomicSiteCreationEnabled && (
+			<div className="fixed-host-column">
+				<WordPressLogo
+					className={ classNames( 'wordpress-logo', { 'is-visible': isWPCOMAtomicSite } ) }
+					size={ 18 }
+				/>
+			</div>
+		);
+
 		return (
 			<>
 				{ isBulkManagementActive ? (
@@ -169,13 +185,17 @@ export default function SiteStatusContent( {
 						compact
 						href={ `/activity-log/${ urlToSlug( siteUrl ) }` }
 					>
+						{ WPCOMHostedSiteBadgeColumn }
 						{ siteUrl }
 						<SiteBackupStaging siteId={ siteId } />
 					</Button>
 				) : (
-					<span className="sites-overview__row-text">
-						{ siteUrl } <SiteBackupStaging siteId={ siteId } />
-					</span>
+					<>
+						<span className="sites-overview__row-text">
+							{ WPCOMHostedSiteBadgeColumn }
+							{ siteUrl } <SiteBackupStaging siteId={ siteId } />
+						</span>
+					</>
 				) }
 				<span className="sites-overview__overlay"></span>
 				{ errorContent }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
@@ -89,7 +89,7 @@
 }
 
 .site-table-site-title {
-	margin-inline-start: 32px;
+	margin-inline-start: 8px;
 }
 
 .site-table__tr-loading {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -241,6 +241,29 @@
 		font-size: 1rem !important;
 	}
 }
+
+.fixed-host-column {
+	display: none;
+	margin-inline-end: 10px;
+	width: 40px;
+	text-align: center;
+
+	.wordpress-logo {
+		display: inline-block;
+		fill: var(--studio-blue-50);
+		visibility: hidden;
+		margin: auto 0;
+
+		&.is-visible {
+			visibility: visible;
+		}
+	}
+
+	@include break-wide {
+		display: inline-block;
+	}
+}
+
 .sites-overview__overlay {
 	display: block;
 	position: absolute;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -97,6 +97,7 @@ export interface Site {
 	php_version_num: number;
 	is_connected: boolean;
 	has_paid_agency_monitor: boolean;
+	is_wpcom_atomic?: boolean;
 }
 export interface SiteNode {
 	value: Site;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -97,7 +97,7 @@ export interface Site {
 	php_version_num: number;
 	is_connected: boolean;
 	has_paid_agency_monitor: boolean;
-	is_wpcom_atomic?: boolean;
+	is_atomic?: boolean;
 }
 export interface SiteNode {
 	value: Site;


### PR DESCRIPTION
This PR adds a **Host** column in the Dashboard table.

<img width="864" alt="Screen Shot 2023-08-30 at 4 21 09 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/0a70f30e-b25c-4b47-a176-fa5374df8820">

Related to https://github.com/orgs/Automattic/projects/756/views/5

## Proposed Changes

* Update the Agency Dashboard table to include a 'Host' column displaying a WP icon for sites hosted on WordPress.com.

_**NOTE: the changes made here will also affect minor UI spacing in production with the Site column.**_

## Testing Instructions

Since our current Site endpoint does not include WPCOM atomic sites, we must modify the code to test and verify the **Host** column. This will require us to run a local Jetpack cloud server.

* Checkout the branch with the following command: `git checkout add/dashboard-table-host-column`
* Then run Jetpack cloud using the following command: `yarn start-jetpack-cloud`
* Change the following [line](https://github.com/Automattic/wp-calypso/commit/c9fe7f568e160f02084294eed72a7ef6c3a123d5#diff-ee3d7d66a384a9270ff88de22fb80c7e96642290a126b6a19e9b13486f449a99R61) to
   ```
	const isWPCOMAtomicSite = ! rows.site.value.is_wpcom_atomic;
   ```
    _This will force non-WPCOM atomic sites to be treated as one._

* Goto `http://jetpack.cloud.localhost:3000/dashboard`
* Confirm that the **Host** column is visible next to the **Site** column. The Wordpress logo should also be visible next to the site name.
* Also test that the site table is rendering properly when the feature is disabled by using the following link: http://jetpack.cloud.localhost:3000/dashboard?flags=-jetpack/pro-dashboard-wpcom-atomic-hosting

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
