### PR TITLE
Migration trial: Extend tracking event properties

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -12,6 +12,7 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { EVERY_TEN_SECONDS, Interval } from 'calypso/lib/interval';
 import { SectionMigrate } from 'calypso/my-sites/migrate/section-migrate';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+import { isMigrationTrialSite } from 'calypso/sites-dashboard/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -107,32 +108,46 @@ export class ImportEverything extends SectionMigrate {
 	};
 
 	recordMigrationStatusChange = ( prevState: State ) => {
+		const trackEventProps = {
+			sourceSiteId: this.props.sourceSiteId,
+			sourceSiteUrl: this.props.sourceUrlAnalyzedData?.url,
+			targetSiteId: this.props.targetSiteId,
+			targetSiteSlug: this.props.targetSiteSlug,
+			isTrial: isMigrationTrialSite( this.props.targetSite ),
+		};
+
 		if (
 			prevState.migrationStatus !== MigrationStatus.BACKING_UP &&
 			this.state.migrationStatus === MigrationStatus.BACKING_UP
 		) {
-			this.props.recordTracksEvent( 'calypso_site_importer_import_progress_backing_up' );
+			this.props.recordTracksEvent(
+				'calypso_site_importer_import_progress_backing_up',
+				trackEventProps
+			);
 		}
 
 		if (
 			prevState.migrationStatus !== MigrationStatus.RESTORING &&
 			this.state.migrationStatus === MigrationStatus.RESTORING
 		) {
-			this.props.recordTracksEvent( 'calypso_site_importer_import_progress_restoring' );
+			this.props.recordTracksEvent(
+				'calypso_site_importer_import_progress_restoring',
+				trackEventProps
+			);
 		}
 
 		if (
 			prevState.migrationStatus !== MigrationStatus.ERROR &&
 			this.state.migrationStatus === MigrationStatus.ERROR
 		) {
-			this.props.recordTracksEvent( 'calypso_site_importer_import_failure' );
+			this.props.recordTracksEvent( 'calypso_site_importer_import_failure', trackEventProps );
 		}
 
 		if (
 			prevState.migrationStatus !== MigrationStatus.DONE &&
 			this.state.migrationStatus === MigrationStatus.DONE
 		) {
-			this.props.recordTracksEvent( 'calypso_site_importer_import_success' );
+			this.props.recordTracksEvent( 'calypso_site_importer_import_success', trackEventProps );
 		}
 	};
 

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -190,6 +190,7 @@ export class ImportEverything extends SectionMigrate {
 					isTargetSitePlanCompatible={ isTargetSitePlanCompatible }
 					targetSite={ targetSite }
 					isMigrateFromWp={ isMigrateFromWp }
+					isTrial={ isMigrationTrialSite( this.props.targetSite ) }
 					onContentOnlyClick={ onContentOnlySelection }
 					onFreeTrialClick={ () => {
 						stepNavigator?.navigate( `migrationTrial${ window.location.search }` );

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -109,11 +109,11 @@ export class ImportEverything extends SectionMigrate {
 
 	recordMigrationStatusChange = ( prevState: State ) => {
 		const trackEventProps = {
-			sourceSiteId: this.props.sourceSiteId,
-			sourceSiteUrl: this.props.sourceUrlAnalyzedData?.url,
-			targetSiteId: this.props.targetSiteId,
-			targetSiteSlug: this.props.targetSiteSlug,
-			isTrial: isMigrationTrialSite( this.props.targetSite ),
+			source_site_id: this.props.sourceSiteId,
+			source_site_url: this.props.sourceUrlAnalyzedData?.url,
+			target_site_id: this.props.targetSiteId,
+			target_site_slug: this.props.targetSiteSlug,
+			is_trial: isMigrationTrialSite( this.props.targetSite ),
 		};
 
 		if (

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -205,6 +205,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 								targetSite={ targetSite }
 								startImport={ startImport }
 								selectedHost={ selectedHost }
+								migrationTrackingProps={ migrationTrackingProps }
 								onChangeProtocol={ changeCredentialsProtocol }
 							/>
 						</div>

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -96,12 +96,12 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	);
 
 	const migrationTrackingProps = {
-		sourceSiteId: sourceSiteId,
-		sourceSiteUrl: sourceSiteUrl,
-		targetSiteId: targetSite.ID,
-		targetSiteSlug: targetSite.slug,
-		isMigrateFromWp,
-		isTrial,
+		source_site_id: sourceSiteId,
+		source_site_url: sourceSiteUrl,
+		target_site_id: targetSite.ID,
+		target_site_slug: targetSite.slug,
+		is_migrate_from_wp: isMigrateFromWp,
+		is_trial: isTrial,
 	};
 
 	const [ queryTargetSitePlanStatus, setQueryTargetSitePlanStatus ] = useState<

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -90,6 +90,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	);
 
 	const migrationTrackingProps = {
+		source_site_id: sourceSiteId,
 		source_site_url: sourceSiteUrl,
 		target_site_id: targetSite.ID,
 		target_site_slug: targetSite.slug,
@@ -153,8 +154,12 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	// This should be better handled by using a state after the refactor
 	useEffect( () => {
 		if ( ! showUpdatePluginInfo && isTargetSitePlanCompatible ) {
+			const _migrationTrackingProps: { [ key: string ]: unknown } = { ...migrationTrackingProps };
+			// There is a case where source_site_id is 0|undefined, so we need to delete it
+			delete _migrationTrackingProps?.source_site_id;
+
 			dispatch(
-				recordTracksEvent( 'calypso_site_migration_ready_screen', migrationTrackingProps )
+				recordTracksEvent( 'calypso_site_migration_ready_screen', _migrationTrackingProps )
 			);
 		}
 	}, [ showUpdatePluginInfo, isTargetSitePlanCompatible ] );

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -90,7 +90,6 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	);
 
 	const migrationTrackingProps = {
-		source_site_id: sourceSiteId,
 		source_site_url: sourceSiteUrl,
 		target_site_id: targetSite.ID,
 		target_site_slug: targetSite.slug,

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -150,6 +150,16 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		fetchMigrationEnabledStatus();
 	};
 
+	// We want to record the tracks event, so we use the same condition as the one in the render function
+	// This should be better handled by using a state after the refactor
+	useEffect( () => {
+		if ( ! showUpdatePluginInfo && isTargetSitePlanCompatible ) {
+			dispatch(
+				recordTracksEvent( 'calypso_site_migration_ready_screen', migrationTrackingProps )
+			);
+		}
+	}, [ showUpdatePluginInfo, isTargetSitePlanCompatible ] );
+
 	// Initiate the migration if initImportRun is set
 	useEffect( () => {
 		initImportRun && startImport( { type: 'without-credentials', ...migrationTrackingProps } );
@@ -228,8 +238,6 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 			return <LoadingEllipsis />;
 		}
 
-		dispatch( recordTracksEvent( 'calypso_site_migration_ready_screen', migrationTrackingProps ) );
-
 		return (
 			<>
 				{ showConfirmModal && (
@@ -273,13 +281,13 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	}
 
 	function renderUpdatePluginInfo() {
-		dispatch(
-			recordTracksEvent( 'calypso_site_migration_install_jetpack_screen', migrationTrackingProps )
-		);
-
 		return (
 			<>
-				<UpdatePluginInfo isMigrateFromWp={ isMigrateFromWp } sourceSiteUrl={ sourceSiteUrl } />
+				<UpdatePluginInfo
+					isMigrateFromWp={ isMigrateFromWp }
+					sourceSiteUrl={ sourceSiteUrl }
+					migrationTrackingProps={ migrationTrackingProps }
+				/>
 				<Interval onTick={ fetchMigrationEnabledStatus } period={ EVERY_FIVE_SECONDS } />
 			</>
 		);

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -35,6 +35,7 @@ interface PreMigrationProps {
 	initImportRun?: boolean;
 	isTargetSitePlanCompatible: boolean;
 	isMigrateFromWp: boolean;
+	isTrial?: boolean;
 	onContentOnlyClick: () => void;
 	onFreeTrialClick: () => void;
 }
@@ -48,6 +49,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		targetSite,
 		isTargetSitePlanCompatible,
 		isMigrateFromWp,
+		isTrial,
 		onContentOnlyClick,
 		onFreeTrialClick,
 	} = props;
@@ -92,6 +94,15 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		fetchMigrationEnabledOnMount,
 		onfetchCallback
 	);
+
+	const migrationTrackingProps = {
+		sourceSiteId: sourceSiteId,
+		sourceSiteUrl: sourceSiteUrl,
+		targetSiteId: targetSite.ID,
+		targetSiteSlug: targetSite.slug,
+		isMigrateFromWp,
+		isTrial,
+	};
 
 	const [ queryTargetSitePlanStatus, setQueryTargetSitePlanStatus ] = useState<
 		'init' | 'fetching' | 'fetched'
@@ -140,7 +151,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 
 	// Initiate the migration if initImportRun is set
 	useEffect( () => {
-		initImportRun && startImport( { type: 'without-credentials' } );
+		initImportRun && startImport( { type: 'without-credentials', ...migrationTrackingProps } );
 	}, [] );
 
 	useEffect( () => {
@@ -156,7 +167,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 			return;
 		}
 		if ( sourceSite ) {
-			startImport();
+			startImport( migrationTrackingProps );
 		}
 	}, [ continueImport, sourceSite, startImport, showUpdatePluginInfo ] );
 
@@ -225,7 +236,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 						onConfirm={ () => {
 							// reset migration confirmation to initial state
 							setMigrationConfirmed( false );
-							startImport( { type: 'without-credentials' } );
+							startImport( { type: 'without-credentials', ...migrationTrackingProps } );
 						} }
 					/>
 				) }
@@ -244,7 +255,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 								type="button"
 								onClick={ () => {
 									migrationConfirmed
-										? startImport( { type: 'without-credentials' } )
+										? startImport( { type: 'without-credentials', ...migrationTrackingProps } )
 										: setShowConfirmModal( true );
 								} }
 							>

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -286,10 +286,6 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	}
 
 	function renderUpgradePlan() {
-		dispatch(
-			recordTracksEvent( 'calypso_site_migration_upgrade_plan_screen', migrationTrackingProps )
-		);
-
 		return (
 			<>
 				{ queryTargetSitePlanStatus === 'fetching' && <QuerySites siteId={ targetSite.ID } /> }
@@ -303,6 +299,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 					isBusy={
 						isFetchingMigrationData || isAddingTrial || queryTargetSitePlanStatus === 'fetched'
 					}
+					migrationTrackingProps={ migrationTrackingProps }
 				/>
 			</>
 		);

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form.tsx
@@ -25,11 +25,12 @@ interface Props {
 	targetSite: SiteDetails;
 	startImport: ( props?: StartImportTrackingProps ) => void;
 	selectedHost: string;
+	migrationTrackingProps: StartImportTrackingProps;
 	onChangeProtocol: ( protocol: CredentialsProtocol ) => void;
 }
 
 export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( props ) => {
-	const { sourceSite, targetSite, startImport } = props;
+	const { sourceSite, targetSite, migrationTrackingProps, startImport } = props;
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { hostname } = new URL( sourceSite.URL );
@@ -146,7 +147,7 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 	useEffect( () => {
 		switch ( formSubmissionStatus ) {
 			case 'success':
-				startImportCallback( { type: 'with-credentials' } );
+				startImportCallback( { type: 'with-credentials', ...migrationTrackingProps } );
 				break;
 		}
 	}, [ formSubmissionStatus, startImportCallback ] );
@@ -217,10 +218,13 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 							if ( ! migrationConfirmed ) {
 								setShowConfirmModal( true );
 								setConfirmCallback( () =>
-									startImportCallback.bind( null, { type: 'skip-credentials' } )
+									startImportCallback.bind( null, {
+										type: 'skip-credentials',
+										...migrationTrackingProps,
+									} )
 								);
 							} else {
-								startImportCallback( { type: 'skip-credentials' } );
+								startImportCallback( { type: 'skip-credentials', ...migrationTrackingProps } );
 							}
 						} }
 					>

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/types.ts
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/types.ts
@@ -1,5 +1,6 @@
 export interface StartImportTrackingProps {
-	type: string;
+	type?: string;
+	[ key: string ]: unknown;
 }
 
 export type CredentialsStatus = 'unsubmitted' | 'pending' | 'success' | 'failed';

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/update-plugins.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/update-plugins.tsx
@@ -12,15 +12,17 @@ import { URL } from 'calypso/types';
 interface Props {
 	isMigrateFromWp: boolean;
 	sourceSiteUrl: URL;
+	migrationTrackingProps?: Record< string, unknown >;
 }
 
 export const UpdatePluginInfo: React.FunctionComponent< Props > = ( props: Props ) => {
 	const translate = useTranslate();
-	const { isMigrateFromWp, sourceSiteUrl } = props;
+	const { isMigrateFromWp, sourceSiteUrl, migrationTrackingProps } = props;
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_site_importer_show_update_info', {
 			plugins_info: isMigrateFromWp ? 'wpcom_migration_plugin' : 'jetpack',
+			...migrationTrackingProps,
 		} );
 	}, [] );
 

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
@@ -5,9 +5,11 @@ import { SiteDetails } from '@automattic/data-stores';
 import { Title, SubTitle, NextButton } from '@automattic/onboarding';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { convertToFriendlyWebsiteName } from 'calypso/blocks/import/util';
 import useCheckEligibilityMigrationTrialPlan from 'calypso/data/plans/use-check-eligibility-migration-trial-plan';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ConfirmUpgradePlan from './../confirm-upgrade-plan';
 import type { URL } from 'calypso/types';
 
@@ -19,9 +21,11 @@ interface Props {
 	onFreeTrialClick: () => void;
 	onContentOnlyClick: () => void;
 	isBusy: boolean;
+	migrationTrackingProps?: Record< string, unknown >;
 }
 
 export const PreMigrationUpgradePlan: React.FunctionComponent< Props > = ( props: Props ) => {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const plan = getPlan( PLAN_BUSINESS );
 	const {
@@ -32,6 +36,7 @@ export const PreMigrationUpgradePlan: React.FunctionComponent< Props > = ( props
 		onFreeTrialClick,
 		onContentOnlyClick,
 		isBusy,
+		migrationTrackingProps,
 	} = props;
 	const { data: migrationTrialEligibility } = useCheckEligibilityMigrationTrialPlan(
 		targetSite.ID
@@ -39,6 +44,12 @@ export const PreMigrationUpgradePlan: React.FunctionComponent< Props > = ( props
 	const isEligibleForTrialPlan = migrationTrialEligibility?.eligible;
 	const [ popoverVisible, setPopoverVisible ] = useState( false );
 	const trialBtnRef: React.RefObject< HTMLButtonElement > = useRef( null );
+
+	useEffect( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_site_migration_upgrade_plan_screen', migrationTrackingProps )
+		);
+	}, [] );
 
 	return (
 		<div

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-trial/style.scss
@@ -31,6 +31,7 @@
 	p {
 		color: var(--studio-gray-100);
 		margin-bottom: 2.5rem;
+		text-align: start;
 
 		a {
 			color: inherit;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/81169
Closes https://github.com/Automattic/wp-calypso/issues/80965

## Proposed Changes

* Unified paragraph alignment between the "Upgrade your plan" and "Try before you buy" screens
* Extended tacking event object with more details such as:
```
	const migrationTrackingProps = {
		source_site_id: sourceSiteId,
		source_site_url: sourceSiteUrl,
		target_site_id: targetSite.ID,
		target_site_slug: targetSite.slug,
		is_migrate_from_wp,
		is_trial,
	};
```

* Added tracking events:
  * `calypso_site_migration_ready_screen`
  * `calypso_site_migration_install_jetpack_screen`
  * `calypso_site_migration_upgrade_plan_screen`

## Testing Instructions

* Start migration process from any flow we support right now
* For example `/setup/import-focused/?siteSlug={SITE_SLUG}`


<img width="767" alt="Screenshot 2023-08-29 at 16 03 09" src="https://github.com/Automattic/wp-calypso/assets/1241413/375ab1b8-a615-4bc0-b34f-765640d9d54c">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?