### PR TITLE
add parameter and text to discover page heading

### DIFF
--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -33,10 +33,12 @@ const exported = {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		context.primary = (
 			<>
-				<DocumentHead title={ translate( 'Browse Popular %s Blogs & Read Articles ‹ Reader', {
-					args: [ tabTitle ],
-					comment: '%s is the type of blog being explored e.g. food, art, technology etc.',
-				} ) } />
+				<DocumentHead
+					title={ translate( 'Browse %s Blogs & Read Articles ‹ Reader', {
+						args: [ tabTitle ],
+						comment: '%s is the type of blog being explored e.g. food, art, technology etc.',
+					} ) }
+				/>
 				<AsyncLoad
 					require="calypso/reader/discover/discover-stream"
 					key="discover-page"
@@ -56,7 +58,6 @@ const exported = {
 					showBack={ false }
 					className="is-discover-stream"
 					selectedTab={ selectedTab }
-
 				/>
 			</>
 		);

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -29,7 +29,7 @@ const exported = {
 			context.renderHeaderSection = renderHeaderSection;
 		}
 		const selectedTab = context.query.selectedTab;
-		const tabTitle = titlecase( getSelectedTabTitle( selectedTab ) );
+		const tabTitle = titlecase( getSelectedTabTitle( selectedTab ) || '' );
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		context.primary = (
 			<>

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -10,6 +10,7 @@ import {
 import { recordTrack } from 'calypso/reader/stats';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import renderHeaderSection from '../lib/header-section';
+import { getSelectedTabTitle } from './helper';
 
 const ANALYTICS_PAGE_TITLE = 'Reader';
 
@@ -26,10 +27,16 @@ const exported = {
 		if ( ! isUserLoggedIn( context.store.getState() ) ) {
 			context.renderHeaderSection = renderHeaderSection;
 		}
+		const selectedTab = context.query.selectedTab;
+		const tabTitle = getSelectedTabTitle( selectedTab );
+
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		context.primary = (
 			<>
-				<DocumentHead title={ translate( 'Browse Popular Blogs & Read Articles ‹ Reader' ) } />
+				<DocumentHead title={ translate( 'Browse Popular %s Blogs & Read Articles ‹ Reader', {
+					args: [ tabTitle ],
+					comment: '%s is the type of blog being explored e.g. food, art, technology etc.',
+				} ) } />
 				<AsyncLoad
 					require="calypso/reader/discover/discover-stream"
 					key="discover-page"
@@ -48,6 +55,8 @@ const exported = {
 					useCompactCards={ true }
 					showBack={ false }
 					className="is-discover-stream"
+					selectedTab={ selectedTab }
+
 				/>
 			</>
 		);

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -1,4 +1,5 @@
 import { translate } from 'i18n-calypso';
+import titlecase from 'to-title-case';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import { sectionify } from 'calypso/lib/route';
@@ -28,8 +29,7 @@ const exported = {
 			context.renderHeaderSection = renderHeaderSection;
 		}
 		const selectedTab = context.query.selectedTab;
-		const tabTitle = getSelectedTabTitle( selectedTab );
-
+		const tabTitle = titlecase( getSelectedTabTitle( selectedTab ) );
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		context.primary = (
 			<>

--- a/client/reader/discover/discover-navigation.js
+++ b/client/reader/discover/discover-navigation.js
@@ -2,8 +2,10 @@ import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { throttle } from 'lodash';
+import page from 'page';
 import { useRef } from 'react';
 import SegmentedControl from 'calypso/components/segmented-control';
+import { addQueryArgs } from 'calypso/lib/url';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
 import { DEFAULT_TAB, LATEST_TAB } from './helper';
@@ -15,7 +17,7 @@ const DEFAULT_CLASS = 'discover-stream-navigation';
 const showElement = ( element ) => element && element.classList.remove( 'display-none' );
 const hideElement = ( element ) => element && element.classList.add( 'display-none' );
 
-const DiscoverNavigation = ( { recommendedTags, selectedTab, setSelectedTab, width } ) => {
+const DiscoverNavigation = ( { recommendedTags, selectedTab, width } ) => {
 	const scrollRef = useRef();
 
 	const recordTabClick = () => {
@@ -24,7 +26,9 @@ const DiscoverNavigation = ( { recommendedTags, selectedTab, setSelectedTab, wid
 	};
 
 	const menuTabClick = ( tab ) => {
-		setSelectedTab( tab );
+		page.replace(
+			addQueryArgs( { selectedTab: tab }, window.location.pathname + window.location.search )
+		);
 		recordTabClick();
 	};
 

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -2,7 +2,6 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
-import { useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import withDimensions from 'calypso/lib/with-dimensions';
 import wpcom from 'calypso/lib/wp';
@@ -15,7 +14,12 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getReaderRecommendedSites } from 'calypso/state/reader/recommended-sites/selectors';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
 import DiscoverNavigation from './discover-navigation';
-import { getDiscoverStreamTags, DEFAULT_TAB, buildDiscoverStreamKey } from './helper';
+import {
+	getDiscoverStreamTags,
+	DEFAULT_TAB,
+	getSelectedTabTitle,
+	buildDiscoverStreamKey,
+} from './helper';
 
 const DiscoverStream = ( props ) => {
 	const locale = useLocale();
@@ -24,7 +28,7 @@ const DiscoverStream = ( props ) => {
 	const recommendedSites = useSelector(
 		( state ) => getReaderRecommendedSites( state, 'discover-recommendations' ) || []
 	);
-	const [ selectedTab, setSelectedTab ] = useState( DEFAULT_TAB );
+	const selectedTab = props.selectedTab;
 	const { data: interestTags = [] } = useQuery( {
 		queryKey: [ 'read/interests', locale ],
 		queryFn: () =>
@@ -54,12 +58,16 @@ const DiscoverStream = ( props ) => {
 		isLoggedIn
 	);
 	const streamKey = buildDiscoverStreamKey( selectedTab, recommendedStreamTags );
+	const tabTitle = getSelectedTabTitle( selectedTab );
 
 	const DiscoverHeader = () => (
 		<FormattedHeader
 			brandFont
 			headerText={ translate( 'Discover' ) }
-			subHeaderText={ translate( 'Explore new blogs that inspire, educate, and entertain.' ) }
+			subHeaderText={ translate( 'Explore new %s blogs that inspire, educate, and entertain.', {
+				args: [ tabTitle ],
+				comment: '%s is the type of blog being explored e.g. food, art, technology etc.',
+			} ) }
 			align="left"
 			hasScreenOptions
 			className={ classNames( 'discover-stream-header', {
@@ -98,7 +106,6 @@ const DiscoverStream = ( props ) => {
 			<DiscoverNavigation
 				width={ props.width }
 				selectedTab={ selectedTab }
-				setSelectedTab={ setSelectedTab }
 				recommendedTags={ recommendedTags }
 			/>
 			<Stream { ...streamProps } />

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -64,7 +64,7 @@ const DiscoverStream = ( props ) => {
 		<FormattedHeader
 			brandFont
 			headerText={ translate( 'Discover' ) }
-			subHeaderText={ translate( 'Explore new %s blogs that inspire, educate, and entertain.', {
+			subHeaderText={ translate( 'Explore %s blogs that inspire, educate, and entertain.', {
 				args: [ tabTitle ],
 				comment: '%s is the type of blog being explored e.g. food, art, technology etc.',
 			} ) }

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -23,8 +23,11 @@ export function getDiscoverStreamTags( tags, isLoggedIn ) {
 }
 
 export function getSelectedTabTitle( selectedTab ) {
-	if ( selectedTab === DEFAULT_TAB || selectedTab === LATEST_TAB ) {
-		return '';
+	if ( selectedTab === DEFAULT_TAB ) {
+		return 'popular';
+	}
+	if ( selectedTab === LATEST_TAB ) {
+		return 'new';
 	}
 	return selectedTab;
 }

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -22,6 +22,13 @@ export function getDiscoverStreamTags( tags, isLoggedIn ) {
 	return tags;
 }
 
+export function getSelectedTabTitle( selectedTab ) {
+	if ( selectedTab === DEFAULT_TAB || selectedTab === LATEST_TAB ) {
+		return '';
+	}
+	return selectedTab;
+}
+
 /**
  * Builds a stream key for the discover feed based on the selectedTab and tags for recommended feed.
  *


### PR DESCRIPTION
part of pe7F0s-18c-p2

Adds unique title tag to the discover page heading.

I added a url parameter so that a search engine would be able to recognise the pages as being different.

### Testing instructions

Go to discover page and change tabs, the tabs other than "Recommended" and "Latest" should include the tag name in the page heading