### PR TITLE
Stats: Align Stats products on My Plan and Plans page

### DIFF
--- a/client/my-sites/plans/jetpack-plans/constants.ts
+++ b/client/my-sites/plans/jetpack-plans/constants.ts
@@ -176,8 +176,8 @@ export const INDIRECT_CHECKOUT_PRODUCT_STATS_PWYW_YEARLY = (): SelectorProduct =
 
 	// The Stats PWYW product in the Plans grid is shown as `Stats` but also referred to `Stats (Personal)`,
 	// which aligns with the naming in packages/calypso-products/src/translations.tsx.
-	displayName: translate( 'Stats' ),
-	shortName: translate( 'Stats' ),
+	displayName: translate( 'Stats (Personal)' ),
+	shortName: translate( 'Stats (Personal)' ),
 	productSlug: PRODUCT_JETPACK_STATS_PWYW_YEARLY,
 	costProductSlug: PRODUCT_JETPACK_STATS_PWYW_YEARLY,
 	term: TERM_ANNUALLY,

--- a/packages/components/src/product-icon/config.ts
+++ b/packages/components/src/product-icon/config.ts
@@ -223,6 +223,7 @@ export const iconToProductSlugMap: Record< keyof typeof paths, readonly Supporte
 	],
 	'jetpack-stats': [
 		'jetpack_stats_monthly',
+		'jetpack_stats_yearly',
 		'jetpack_stats_pwyw_yearly',
 		'jetpack_stats_free_yearly',
 	],

--- a/packages/components/src/product-icon/config.ts
+++ b/packages/components/src/product-icon/config.ts
@@ -108,6 +108,7 @@ export type SupportedSlugs =
 	| 'jetpack_search'
 	| 'jetpack_search_monthly'
 	| 'jetpack_stats_monthly'
+	| 'jetpack_stats_yearly'
 	| 'jetpack_stats_pwyw_yearly'
 	| 'jetpack_stats_free_yearly'
 	| 'jetpack_social'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80258 

## Proposed Changes

* Fix the Stats Yearly icon on the `My Plan` page.
* Align Stats product naming in the `Plans` page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to Upgrades > `My Plan` page: `/plans/my-plan/{site-slug}`.
* Ensure the `Stats Yearly` product icon displays as expected.

|Before|After|
|-|-|
|<img width="1237" alt="截圖 2023-08-29 下午11 41 03" src="https://github.com/Automattic/wp-calypso/assets/6869813/9f10289a-7d65-4655-8604-d7c6bea1d911">|<img width="1233" alt="截圖 2023-08-29 下午11 35 11" src="https://github.com/Automattic/wp-calypso/assets/6869813/f9057681-a6fb-45d2-9227-d1d082add496">|

* Navigate to Upgrades > `Plans` page: `/plans/{site-slug}`.
* Ensure the Stats personal product displays with the name `Stats (Personal)` rather than `Stats`.

|Before|After|
|-|-|
|<img width="1331" alt="截圖 2023-08-29 下午11 41 25" src="https://github.com/Automattic/wp-calypso/assets/6869813/073b4c4d-3a5a-4fde-8d0c-bbec52f8de29">|<img width="1296" alt="截圖 2023-08-29 下午11 36 17" src="https://github.com/Automattic/wp-calypso/assets/6869813/0850224a-c00e-4d47-aa64-04deb530defc">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
