### PR TITLE
Domain Forwarding: Prepare Calypso to work with new API definitions

### DIFF
--- a/client/data/domains/forwarding/use-delete-domain-forwarding-mutation.ts
+++ b/client/data/domains/forwarding/use-delete-domain-forwarding-mutation.ts
@@ -13,7 +13,10 @@ export default function useDeleteDomainForwardingMutation(
 ) {
 	const queryClient = useQueryClient();
 	const mutation = useMutation( {
-		mutationFn: () => wp.req.post( `/sites/all/domain/${ domainName }/redirects/delete` ),
+		mutationFn: ( domain_redirect_id: number ) =>
+			wp.req.post( `/sites/all/domain/${ domainName }/redirects/delete`, {
+				domain_redirect_id,
+			} ),
 		...queryOptions,
 		onSuccess() {
 			queryClient.removeQueries( domainForwardingQueryKey( domainName ) );
@@ -23,7 +26,10 @@ export default function useDeleteDomainForwardingMutation(
 
 	const { mutate } = mutation;
 
-	const deleteDomainForwarding = useCallback( () => mutate(), [ mutate ] );
+	const deleteDomainForwarding = useCallback(
+		( domain_redirect_id: number ) => mutate( domain_redirect_id ),
+		[ mutate ]
+	);
 
 	return { deleteDomainForwarding, ...mutation };
 }

--- a/client/data/domains/forwarding/use-domain-forwarding-query.ts
+++ b/client/data/domains/forwarding/use-domain-forwarding-query.ts
@@ -3,6 +3,7 @@ import wp from 'calypso/lib/wp';
 import { domainForwardingQueryKey } from './domain-forwarding-query-key';
 
 type DomainForwardingResponse = {
+	domain_redirect_id: number;
 	domain: string;
 	target_host: string;
 	target_path: string;
@@ -21,6 +22,7 @@ export default function useDomainForwardingQuery( domainName: string ) {
 		select: ( forwarding: DomainForwardingResponse ) => {
 			if ( forwarding?.domain ) {
 				return {
+					domain_redirect_id: forwarding.domain_redirect_id,
 					domain: forwarding.domain,
 					targetHost: forwarding.target_host,
 					targetPath: forwarding.target_path,

--- a/client/data/domains/forwarding/use-update-domain-forwarding-mutation.ts
+++ b/client/data/domains/forwarding/use-update-domain-forwarding-mutation.ts
@@ -5,6 +5,8 @@ import wp from 'calypso/lib/wp';
 import { domainForwardingQueryKey } from './domain-forwarding-query-key';
 
 export type DomainForwardingUpdate = {
+	domain_redirect_id: number;
+	subdomain: string;
 	targetHost: string;
 	targetPath: string;
 	forwardPaths: boolean;
@@ -25,7 +27,9 @@ export default function useUpdateDomainForwardingMutation(
 	const mutation = useMutation( {
 		mutationFn: ( forwarding: DomainForwardingUpdate ) =>
 			wp.req.post( `/sites/all/domain/${ domainName }/redirects`, {
+				domain_redirect_id: forwarding.domain_redirect_id,
 				domain: domainName,
+				subdomain: forwarding.subdomain,
 				target_host: forwarding.targetHost,
 				target_path: forwarding.targetPath,
 				forward_paths: forwarding.forwardPaths,

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -157,7 +157,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 		if ( isLoading || ! forwarding ) {
 			return;
 		}
-		deleteDomainForwarding();
+		deleteDomainForwarding( forwarding?.domain_redirect_id );
 	};
 
 	const handleChangeProtocol = ( event: React.ChangeEvent< HTMLSelectElement > ) => {
@@ -188,6 +188,8 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 		}
 
 		updateDomainForwarding( {
+			domain_redirect_id: forwarding?.domain_redirect_id || 0,
+			subdomain: '', // we'll soon support subdomains
 			targetHost,
 			targetPath,
 			isSecure,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 3512-gh-Automattic/dotcom-forge
This is a follow-up of https://github.com/Automattic/wp-calypso/pull/81047. We're looking for prepare our frontend for the upcoming backend API changes: D119825-code

## Proposed Changes

* We're supporting the new subdomain backend API definition without changing anything for the user

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure Domain Forwarding still works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?