### PR TITLE
Launchpad: Remove conditional check for newlsetter task

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -105,10 +105,6 @@ export function getEnhancedTasks(
 
 	const shouldDisplayWarning = displayGlobalStylesWarning || isVideoPressFlowWithUnsupportedPlan;
 
-	const isStripeConnected = Boolean(
-		tasks?.find( ( task ) => task.id === 'set_up_payments' )?.completed
-	);
-
 	const completeMigrateContentTask = async () => {
 		if ( siteSlug ) {
 			await updateLaunchpadSettings( siteSlug, {
@@ -532,7 +528,6 @@ export function getEnhancedTasks(
 					break;
 				case 'newsletter_plan_created':
 					taskData = {
-						disabled: ! isStripeConnected,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							completePaidNewsletterTask();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR removes a conditional check to enable/disable the Launchpad task for setting up a paid newsletter plan. This check was added in https://github.com/Automattic/wp-calypso/pull/80338. Subsequent changes have made it such that plans can now be added before Stripe connection. Based on that and [discussion](124-gh-Automattic/gold), we're just enabling this task immediately for users. 

It is worth noting that even though you can add a plan, if you navigate away from Launchpad before connecting Stripe, you cannot see/access/edit any paid plans you create until you connect Stripe. You will still see this page on Earn > Payments until you connect Stripe: 

<img width="1075" alt="stripe" src="https://github.com/Automattic/wp-calypso/assets/21228350/52449d09-7572-47d3-b4db-96392a3e393e">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Check out this branch and start a new newsletter site at http://calypso.localhost:3000/setup/newsletter/intro. Select the paid option.
2) Proceed to Launchpad and confirm that the `Create paid newsletter`task is enabled immediately even if Stripe is not connected. 
3) Confirm you can add a plan. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?