### PR TITLE
Clean up x-post styles in reader

### DIFF
--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -259,14 +259,8 @@
 .is-reader-page {
 
 	.reader__card.card.is-x-post {
-		border-bottom: 1px solid var(--color-neutral-10);
 		margin: 0 15px;
-		padding: 20px;
-
-		@include breakpoint-deprecated( ">660px" ) {
-			margin: 0;
-			padding: 20px 52px;
-		}
+		padding: 0 0 20px;
 
 		.reader__post-title-link,
 		.reader__post-title-link:visited {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -260,7 +260,11 @@
 
 	.reader__card.card.is-x-post {
 		margin: 0 15px;
-		padding: 0 0 20px;
+		padding: 16px 0 16px;
+
+		+ .reader-post-card {
+			margin-top: 16px;
+		}
 
 		.reader__post-title-link,
 		.reader__post-title-link:visited {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -874,23 +874,15 @@
 	margin: 6px 0 0 0;
 
 	@include breakpoint-deprecated(">660px") {
-		padding: 12px 0 4px 0;
+		padding: 0;
 	}
 
 	@include breakpoint-deprecated( ">960px" ) {
-		margin: 6px 0 0 15px;
+		margin: 0;
 	}
 
 	.blogging-prompt__menu {
 		display: none;
-	}
-
-	+ article.reader-post-card {
-		border-top: 5px solid var(--color-neutral-0);
-
-		@include breakpoint-deprecated(">660px") {
-			border-top: 1px solid var(--color-neutral-5);
-		}
 	}
 
 	.blogging-prompt__card,


### PR DESCRIPTION
## Description

@shaunandrews brought up that the lines under x-posts in the reader as somewhat unnecessary. I agreed and took the opportunity to clean up some of the padding/margins while I was in there and made some adjustments to the writing prompt card margin/padding as well.

## Before
<img width="633" alt="before" src="https://github.com/Automattic/wp-calypso/assets/5634774/79948ba4-3332-4b77-8e0b-ec539dc8ffb9">
<img width="633" alt="CleanShot 2023-08-29 at 15 46 03@2x" src="https://github.com/Automattic/wp-calypso/assets/5634774/c886e232-467f-4170-85b4-0cbf62703ce1">

## After
<img width="624" alt="after" src="https://github.com/Automattic/wp-calypso/assets/5634774/623916e4-f5c1-4716-83bf-f5e50ecdd236">
<img width="661" alt="CleanShot 2023-08-29 at 15 44 55@2x" src="https://github.com/Automattic/wp-calypso/assets/5634774/90ce8fd9-fa55-43d6-8f6d-bd2660d22ee6">

## Testing

- Click the Calypso Live link below
- Head to `/read/a8c`