### PR TITLE
Separate jetpack and wordpress 2 year plan upsell and clear up design

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/jetpack-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/jetpack-checkout-sidebar-plan-upsell/index.tsx
@@ -1,10 +1,11 @@
-import { isPlan, isJetpackPlan } from '@automattic/calypso-products';
+import { isJetpackProduct, isJetpackPlan } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
 import debugFactory from 'debug';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
@@ -12,35 +13,72 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useGetProductVariants } from '../../hooks/product-variants';
-import {
-	getItemVariantCompareToPrice,
-	getItemVariantDiscountPercentage,
-} from '../item-variation-picker/util';
+import { getItemVariantDiscountPercentage } from '../item-variation-picker/util';
+import type { FC } from 'react';
 
 import './style.scss';
 
 const debug = debugFactory( 'calypso:checkout-sidebar-plan-upsell' );
 
-export function CheckoutSidebarPlanUpsell() {
+interface UpsellLineProps {
+	label: string;
+	value?: string;
+	boldLabel?: boolean;
+	boldValue?: boolean;
+	isTitle?: boolean;
+}
+
+const UpsellLine: FC< UpsellLineProps > = ( {
+	label,
+	value,
+	boldLabel = false,
+	boldValue = false,
+	isTitle = false,
+} ) => {
+	const labelMarkup = boldLabel ? <strong>{ label }</strong> : label;
+	const valueMarkup = boldValue ? <strong>{ value }</strong> : value;
+	return (
+		<>
+			<div
+				className={ classNames(
+					'checkout-sidebar-plan-upsell__plan-grid-cell',
+					isTitle ? 'section-title' : ''
+				) }
+			>
+				{ labelMarkup }
+			</div>
+			<div
+				className={ classNames(
+					'checkout-sidebar-plan-upsell__plan-grid-cell',
+					isTitle ? 'section-title' : ''
+				) }
+			>
+				{ valueMarkup }
+			</div>
+		</>
+	);
+};
+
+const JetpackCheckoutSidebarPlanUpsell: FC = () => {
 	const { formStatus } = useFormStatus();
-	const reduxDispatch = useDispatch();
 	const isFormLoading = FormStatus.READY !== formStatus;
+	const reduxDispatch = useDispatch();
 	const { __ } = useI18n();
 	const cartKey = useCartKey();
 	const { responseCart, replaceProductInCart } = useShoppingCart( cartKey );
 	const plan = responseCart.products.find(
-		( product ) => isPlan( product ) && ! isJetpackPlan( product )
+		( product ) => isJetpackProduct( product ) || isJetpackPlan( product )
 	);
+
 	const variants = useGetProductVariants( plan );
 
 	if ( ! plan ) {
-		debug( 'no plan found in cart' );
+		debug( 'no jetpack plan found in cart' );
 		return null;
 	}
 
-	const biennialVariant = variants?.find( ( product ) => product.termIntervalInMonths === 24 );
-	const triennialVariant = variants?.find( ( product ) => product.termIntervalInMonths === 36 );
 	const currentVariant = variants?.find( ( product ) => product.productId === plan.product_id );
+	const biennialVariant = variants?.find( ( product ) => product.termIntervalInMonths === 24 );
 
 	if ( ! biennialVariant ) {
 		debug( 'plan in cart has no biennial variant; variants are', variants );
@@ -57,12 +95,6 @@ export function CheckoutSidebarPlanUpsell() {
 		return null;
 	}
 
-	// If the current plan is a triennial plan, we don't want to show an upsell.
-	if ( triennialVariant?.productId === plan.product_id ) {
-		debug( 'plan is triennial. hide upsell.' );
-		return null;
-	}
-
 	const onUpgradeClick = () => {
 		if ( isFormLoading ) {
 			return;
@@ -73,7 +105,7 @@ export function CheckoutSidebarPlanUpsell() {
 		};
 		debug( 'switching from', plan.product_slug, 'to', newPlan.product_slug );
 		reduxDispatch(
-			recordTracksEvent( 'calypso_checkout_sidebar_upsell_click', {
+			recordTracksEvent( 'calypso_jetpack_checkout_sidebar_upsell_click', {
 				upsell_type: 'biennial-plan',
 				switching_from: plan.product_slug,
 				switching_to: newPlan.product_slug,
@@ -82,10 +114,6 @@ export function CheckoutSidebarPlanUpsell() {
 		replaceProductInCart( plan.uuid, newPlan );
 	};
 
-	const compareToPriceForVariantTerm = getItemVariantCompareToPrice(
-		biennialVariant,
-		currentVariant
-	);
 	const percentSavings = getItemVariantDiscountPercentage( biennialVariant, currentVariant );
 	if ( percentSavings === 0 ) {
 		debug( 'percent savings is too low', percentSavings );
@@ -97,6 +125,10 @@ export function CheckoutSidebarPlanUpsell() {
 		biennialVariant.introductoryTerm === 'year' &&
 		currentVariant.introductoryInterval === 1 &&
 		currentVariant.introductoryTerm === 'year';
+	const currencyConfig = {
+		stripZeros: true,
+		isSmallestUnit: true,
+	};
 
 	const cardTitle = createInterpolateElement(
 		sprintf(
@@ -108,48 +140,56 @@ export function CheckoutSidebarPlanUpsell() {
 	);
 
 	return (
-		<PromoCard title={ cardTitle } className="checkout-sidebar-plan-upsell">
+		<PromoCard title={ cardTitle } className="checkout-sidebar-plan-upsell jetpack">
 			<div className="checkout-sidebar-plan-upsell__plan-grid">
-				{ isComparisonWithIntroOffer && (
-					<>
-						<div className="checkout-sidebar-plan-upsell__plan-grid-cell"></div>
-						<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-							<strong>{ __( 'Two-year cost' ) }</strong>
-						</div>
-					</>
-				) }
-				<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-					{ currentVariant.variantLabel }
-				</div>
-				<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-					{ formatCurrency(
-						currentVariant.priceInteger +
-							( isComparisonWithIntroOffer ? currentVariant.priceBeforeDiscounts : 0 ),
+				<UpsellLine label={ __( 'Yearly plan' ) } boldLabel isTitle />
+
+				<UpsellLine
+					label={ __( 'Year 1' ) }
+					value={ formatCurrency(
+						isComparisonWithIntroOffer
+							? currentVariant.priceInteger
+							: currentVariant.priceBeforeDiscounts,
 						currentVariant.currency,
-						{
-							stripZeros: true,
-							isSmallestUnit: true,
-						}
+						currencyConfig
 					) }
-				</div>
-				<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-					{ biennialVariant.variantLabel }
-				</div>
-				<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-					{ compareToPriceForVariantTerm && (
-						<del className="checkout-sidebar-plan-upsell__do-not-pay">
-							{ formatCurrency( compareToPriceForVariantTerm, currentVariant.currency, {
-								stripZeros: true,
-								isSmallestUnit: true,
-							} ) }
-						</del>
+				/>
+
+				<UpsellLine
+					label={ __( 'Year 2' ) }
+					value={ formatCurrency(
+						currentVariant.priceBeforeDiscounts,
+						currentVariant.currency,
+						currencyConfig
 					) }
-					{ formatCurrency( biennialVariant.priceInteger, biennialVariant.currency, {
-						stripZeros: true,
-						isSmallestUnit: true,
-					} ) }
-				</div>
+				/>
+
+				<UpsellLine
+					label={ __( 'Total' ) }
+					value={ formatCurrency(
+						currentVariant.priceBeforeDiscounts +
+							( isComparisonWithIntroOffer
+								? currentVariant.priceInteger
+								: currentVariant.priceBeforeDiscounts ),
+						currentVariant.currency,
+						currencyConfig
+					) }
+					boldValue
+				/>
+
+				<UpsellLine label={ __( '2-year plan' ) } boldLabel isTitle />
+
+				<UpsellLine
+					label={ __( 'Years 1 and 2' ) }
+					value={ formatCurrency(
+						biennialVariant.priceInteger,
+						biennialVariant.currency,
+						currencyConfig
+					) }
+					boldValue
+				/>
 			</div>
+
 			<PromoCardCTA
 				cta={ {
 					disabled: isFormLoading,
@@ -160,4 +200,6 @@ export function CheckoutSidebarPlanUpsell() {
 			/>
 		</PromoCard>
 	);
-}
+};
+
+export default JetpackCheckoutSidebarPlanUpsell;

--- a/client/my-sites/checkout/composite-checkout/components/jetpack-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/jetpack-checkout-sidebar-plan-upsell/index.tsx
@@ -177,7 +177,7 @@ const JetpackCheckoutSidebarPlanUpsell: FC = () => {
 					boldValue
 				/>
 
-				<UpsellLine label={ __( '2-year plan' ) } boldLabel isTitle />
+				<UpsellLine label={ __( 'Two-year plan' ) } boldLabel isTitle />
 
 				<UpsellLine
 					label={ __( 'Years 1 and 2' ) }

--- a/client/my-sites/checkout/composite-checkout/components/jetpack-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/jetpack-checkout-sidebar-plan-upsell/index.tsx
@@ -2,7 +2,7 @@ import { isJetpackProduct, isJetpackPlan } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import { createElement, createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
@@ -136,7 +136,7 @@ const JetpackCheckoutSidebarPlanUpsell: FC = () => {
 			__( '<strong>Save %(percentSavings)d%%</strong> by paying for two years' ),
 			{ percentSavings }
 		),
-		{ strong: createElement( 'strong' ) }
+		{ strong: <strong /> }
 	);
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/components/jetpack-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/jetpack-checkout-sidebar-plan-upsell/index.tsx
@@ -180,7 +180,7 @@ const JetpackCheckoutSidebarPlanUpsell: FC = () => {
 				<UpsellLine label={ __( 'Two-year plan' ) } boldLabel isTitle />
 
 				<UpsellLine
-					label={ __( 'Years 1 and 2' ) }
+					label={ __( 'Two-year total' ) }
 					value={ formatCurrency(
 						biennialVariant.priceInteger,
 						biennialVariant.currency,

--- a/client/my-sites/checkout/composite-checkout/components/jetpack-checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/composite-checkout/components/jetpack-checkout-sidebar-plan-upsell/style.scss
@@ -1,0 +1,23 @@
+.checkout-sidebar-plan-upsell.jetpack {
+	.action-panel__title,
+	strong,
+	div {
+		color: var(--studio-gray-80);
+	}
+
+	.checkout-sidebar-plan-upsell__plan-grid {
+		grid-template-columns: 1fr 1fr;
+
+		> div {
+			border-top: none;
+		}
+	}
+
+	.checkout-sidebar-plan-upsell__plan-grid-cell.section-title {
+		border-bottom: 1px solid #ccc;
+
+		:not(:first-child) {
+			padding-top: 0.75rem;
+		}
+	}
+}

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -71,6 +71,7 @@ import { CheckoutSidebarPlanUpsell } from './checkout-sidebar-plan-upsell';
 import { CheckoutSlowProcessingNotice } from './checkout-slow-processing-notice';
 import { EmptyCart, shouldShowEmptyCartPage } from './empty-cart';
 import { GoogleDomainsCopy } from './google-transfers-copy';
+import JetpackCheckoutSidebarPlanUpsell from './jetpack-checkout-sidebar-plan-upsell';
 import PaymentMethodStepContent from './payment-method-step';
 import SecondaryCartPromotions from './secondary-cart-promotions';
 import ThirdPartyDevsAccount from './third-party-plugins-developer-account';
@@ -415,7 +416,10 @@ export default function WPCheckout( {
 									nextDomainIsFree={ responseCart?.next_domain_is_free }
 								/>
 								{ ! isWcMobile && ! isDIFMInCart && ! hasMonthlyProduct && (
-									<CheckoutSidebarPlanUpsell />
+									<>
+										<CheckoutSidebarPlanUpsell />
+										<JetpackCheckoutSidebarPlanUpsell />
+									</>
 								) }
 								<SecondaryCartPromotions
 									responseCart={ responseCart }


### PR DESCRIPTION
## Proposed Changes

* Creates a separate component for jetpack sidebar upsell
* Updates jetpack upsell to try and make 2 year plans make more sense

## Testing Instructions

1. Use the calypso live link or your local environment to checkout this branch
2. Go to `/checkout/jetpack/jetpack_complete` to try out a plan with an intro discount. Make sure the upsell is clear and makes sense
![image](https://github.com/Automattic/wp-calypso/assets/65001528/f6c1e69e-1159-4ac6-8a06-766525fb1b71)
3. Go to `/checkout/jetpack/jetpack_ai_yearly` to try out a plan without an intro discount. Make sure it still makes sense
![image](https://github.com/Automattic/wp-calypso/assets/65001528/f48a52a0-19cd-4afb-96c8-3e3538802e2b)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)