### PR TITLE
Domain management: add fuzzy domain search

### DIFF
--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -1,9 +1,8 @@
-import Search from '@automattic/search';
+import Search, { SearchIcon } from '@automattic/search';
 import { translate } from 'i18n-calypso';
 import React, { useEffect } from 'react';
 import './style.scss';
 import SelectDropdown from 'calypso/components/select-dropdown';
-import { SitesSearchIcon } from 'calypso/sites-dashboard/components/sites-search-icon';
 import CampaignsFilter, { CampaignsFilterType } from '../campaigns-filter';
 
 export type SearchOptions = {
@@ -178,7 +177,7 @@ export default function SearchBar( props: Props ) {
 	return (
 		<div className="promote-post-i2__search-bar-wrapper">
 			<Search
-				searchIcon={ <SitesSearchIcon /> }
+				searchIcon={ <SearchIcon /> }
 				className="promote-post-i2__search-bar-search"
 				defaultValue={ searchInput }
 				disableAutocorrect={ true }

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -1,3 +1,4 @@
+import { SearchIcon, type ImperativeHandle as SearchImperativeHandle } from '@automattic/search';
 import { GroupableSiteLaunchStatuses, useSitesListGrouping } from '@automattic/sites';
 import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
@@ -8,9 +9,7 @@ import SelectDropdown from 'calypso/components/select-dropdown';
 import { MEDIA_QUERIES } from '../utils';
 import { SitesDisplayModeSwitcher } from './sites-display-mode-switcher';
 import { SitesSearch } from './sites-search';
-import { SitesSearchIcon } from './sites-search-icon';
 import { SitesSortingDropdown } from './sites-sorting-dropdown';
-import type { ImperativeHandle as SearchImperativeHandle } from '@automattic/search';
 
 export interface SitesDashboardQueryParams {
 	page?: number;
@@ -92,7 +91,6 @@ type SitesContentControlsProps = {
 /**
  * Updates one or more query param used by the sites dashboard, causing a page navigation.
  * Param will be removed if it is empty or matches its default value.
- *
  * @param queryParams Query parameters to assign to the URL.
  */
 export function handleQueryParamChange( queryParams: SitesDashboardQueryParams ) {
@@ -131,7 +129,7 @@ export const SitesContentControls = ( {
 	return (
 		<FilterBar>
 			<SitesSearch
-				searchIcon={ <SitesSearchIcon /> }
+				searchIcon={ <SearchIcon /> }
 				onSearch={ ( term ) => onQueryParamChange( { search: term?.trim(), page: undefined } ) }
 				isReskinned
 				placeholder={ __( 'Search by name or domain…' ) }

--- a/packages/domains-table/src/bulk-actions-toolbar/style.scss
+++ b/packages/domains-table/src/bulk-actions-toolbar/style.scss
@@ -1,5 +1,3 @@
-$domains-table-bulk-actions-toolbar-height: 40px;
-
 .domains-table-bulk-actions-toolbar {
 	display: flex;
 	flex-direction: row;
@@ -11,11 +9,11 @@ $domains-table-bulk-actions-toolbar-height: 40px;
 }
 
 .domains-table-bulk-actions-toolbar__select.select-dropdown {
-	height: $domains-table-bulk-actions-toolbar-height;
+	height: var(--domains-table-toolbar-height);
 	z-index: 1; // Needed for the dropdown to appear overtop of the checkboxes
 
 	.select-dropdown__header {
-		height: $domains-table-bulk-actions-toolbar-height;
+		height: var(--domains-table-toolbar-height);
 		font-weight: 400;
 		color: var(--studio-gray-70);
 	}

--- a/packages/domains-table/src/domains-table-filters/index.tsx
+++ b/packages/domains-table/src/domains-table-filters/index.tsx
@@ -1,0 +1,30 @@
+import SearchControl, { SearchIcon } from '@automattic/search';
+import './style.scss';
+import { useI18n } from '@wordpress/react-i18n';
+
+export interface DomainsTableFilter {
+	query: string;
+}
+
+interface DomainsTableFiltersProps {
+	onSearch( query: string ): void;
+	filter: DomainsTableFilter;
+}
+
+export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersProps ) => {
+	const { __ } = useI18n();
+
+	return (
+		<div className="domains-table-filter">
+			<SearchControl
+				searchIcon={ <SearchIcon /> }
+				className="domains-table-filter__search"
+				onSearch={ ( query ) => onSearch( query.trim() ) }
+				defaultValue={ filter.query }
+				isReskinned
+				placeholder={ __( 'Search by domain…' ) }
+				disableAutocorrect={ true }
+			/>
+		</div>
+	);
+};

--- a/packages/domains-table/src/domains-table-filters/index.tsx
+++ b/packages/domains-table/src/domains-table-filters/index.tsx
@@ -1,6 +1,6 @@
 import SearchControl, { SearchIcon } from '@automattic/search';
-import './style.scss';
 import { useI18n } from '@wordpress/react-i18n';
+import './style.scss';
 
 export interface DomainsTableFilter {
 	query: string;

--- a/packages/domains-table/src/domains-table-filters/style.scss
+++ b/packages/domains-table/src/domains-table-filters/style.scss
@@ -1,0 +1,17 @@
+@import "@automattic/onboarding/styles/mixins";
+@import "@automattic/typography/styles/variables";
+
+.domains-table-filter {
+	@include break-large {
+		width: 50%;
+	}
+
+	&__search {
+		--color-surface: var(--studio-white);
+
+		height: var(--domains-table-toolbar-height) !important;
+		box-sizing: border-box;
+		overflow: hidden;
+		border: 1px solid #c3c4c7;
+	}
+}

--- a/packages/domains-table/src/domains-table/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/index.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { DomainsTable } from '..';
 import { renderWithProvider, testDomain, testPartialDomain } from '../../test-utils';
@@ -72,7 +73,7 @@ test( 'when two domains share the same underlying site, there is only one fetch 
 	expect( fetchSiteDomains ).toHaveBeenCalledWith( 1337 );
 } );
 
-test( 'when shouldDisplayPrimaryDomainLabel is true, the primary domain label is displayed if a domain is marked as primary', async () => {
+test( 'when isAllSitesView is true, the primary domain label is displayed if a domain is marked as primary', async () => {
 	const [ primaryPartial, primaryFull ] = testDomain( {
 		domain: 'example.com',
 		blog_id: 123,
@@ -314,4 +315,24 @@ test( 'bulk actions controls appear when a domain is selected', async () => {
 	fireEvent.click( getDomainCheckbox( 'example1.com' ) );
 
 	expect( screen.queryByRole( 'button', { name: 'Auto-renew settings' } ) ).not.toBeInTheDocument();
+} );
+
+test( 'search for a domain hides other domains from table', async () => {
+	const user = userEvent.setup();
+
+	render(
+		<DomainsTable
+			domains={ [
+				testPartialDomain( { domain: 'dog.com' } ),
+				testPartialDomain( { domain: 'cat.org' } ),
+			] }
+			isAllSitesView
+		/>
+	);
+
+	const searchInput = screen.getByRole( 'searchbox', { name: 'Search' } );
+	await user.type( searchInput, 'dog.com' );
+
+	expect( screen.queryByText( 'dog.com' ) ).toBeInTheDocument();
+	expect( screen.queryByText( 'cat.org' ) ).not.toBeInTheDocument();
 } );

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -6,9 +6,11 @@ import {
 	getSiteDomainsQueryObject,
 	useDomainsBulkActionsMutation,
 } from '@automattic/data-stores';
+import { useFuzzySearch } from '@automattic/search';
 import { useQueries } from '@tanstack/react-query';
 import { useState, useCallback, useLayoutEffect, useMemo } from 'react';
 import { BulkActionsToolbar } from '../bulk-actions-toolbar';
+import { DomainsTableFilters, DomainsTableFilter } from '../domains-table-filters';
 import { DomainsTableColumn, DomainsTableHeader } from '../domains-table-header';
 import { domainsTableColumns } from '../domains-table-header/columns';
 import { getDomainId } from '../get-domain-id';
@@ -45,6 +47,7 @@ export function DomainsTable( {
 	} );
 
 	const [ selectedDomains, setSelectedDomains ] = useState( () => new Set< string >() );
+	const [ filter, setFilter ] = useState< DomainsTableFilter >( () => ( { query: '' } ) );
 
 	const allSiteIds = [ ...new Set( domains?.map( ( { blog_id } ) => blog_id ) || [] ) ];
 	const allSiteDomains = useQueries( {
@@ -113,6 +116,12 @@ export function DomainsTable( {
 			return result;
 		} );
 	}, [ fetchedSiteDomains, domains, sortKey, sortDirection ] );
+
+	const filteredData = useFuzzySearch( {
+		data: sortedDomains ?? [],
+		keys: [ 'domain' ],
+		query: filter.query,
+	} );
 
 	const handleSelectDomain = useCallback(
 		( domain: PartialDomainData ) => {
@@ -184,14 +193,18 @@ export function DomainsTable( {
 
 	return (
 		<div className="domains-table">
-			{ hasSelectedDomains && (
+			{ hasSelectedDomains ? (
 				<BulkActionsToolbar
 					onAutoRenew={ handlAutoRenew }
 					selectedDomainCount={ selectedDomains.size }
 				/>
+			) : (
+				<DomainsTableFilters
+					onSearch={ ( query ) => setFilter( ( filter ) => ( { ...filter, query } ) ) }
+					filter={ filter }
+				/>
 			) }
-			{ /* This spacer will be replaced by searching and filtering controls. In the meantime it stops the table jumping around when selecting domains. */ }
-			{ ! hasSelectedDomains && <div style={ { height: 40 } } /> }
+
 			<table>
 				<DomainsTableHeader
 					columns={ domainsTableColumns }
@@ -202,7 +215,7 @@ export function DomainsTable( {
 					onChangeSortOrder={ onSortChange }
 				/>
 				<tbody>
-					{ sortedDomains?.map( ( domain ) => (
+					{ filteredData.map( ( domain ) => (
 						<DomainsTableRow
 							key={ getDomainId( domain ) }
 							domain={ domain }

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -121,6 +121,9 @@ export function DomainsTable( {
 		data: sortedDomains ?? [],
 		keys: [ 'domain' ],
 		query: filter.query,
+		options: {
+			threshold: 0.3,
+		},
 	} );
 
 	const handleSelectDomain = useCallback(

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -177,6 +177,16 @@ export function DomainsTable( {
 	};
 
 	const changeBulkSelection = () => {
+		if ( filter.query ) {
+			if ( ! hasSelectedDomains ) {
+				setSelectedDomains( new Set( filteredData.map( getDomainId ) ) );
+			} else {
+				setSelectedDomains( new Set() );
+			}
+
+			return;
+		}
+
 		if ( ! hasSelectedDomains || ! areAllDomainsSelected ) {
 			setSelectedDomains( new Set( domains.map( getDomainId ) ) );
 		} else {

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -1,6 +1,8 @@
 @import "@automattic/typography/styles/variables";
 
 .domains-table {
+	--domains-table-toolbar-height: 40px;
+
 	border-collapse: collapse;
 
 	table {

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -1,3 +1,4 @@
 export { default } from './search';
 export type { ImperativeHandle } from './search';
+export { SearchIcon } from './search-icon';
 export { useFuzzySearch } from './use-fuzzy-search';

--- a/packages/search/src/search-icon.tsx
+++ b/packages/search/src/search-icon.tsx
@@ -1,4 +1,4 @@
-export const SitesSearchIcon = () => {
+export const SearchIcon = () => {
 	return (
 		<svg
 			width="20"


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3424.

## Proposed Changes

Adds the search field to domains, and allows selecting the filtered subset.

TODO

- [ ] Tests
- [ ] Match designs (it's incredibly hard to change the font size of the text field and center it. For some reason it's off by a couple of pixels)

### Initial state

![image](https://github.com/Automattic/wp-calypso/assets/26530524/0be90d4e-5cde-4091-a125-09dc8e07849f)

### Filtered

![filtered](https://github.com/Automattic/wp-calypso/assets/26530524/06141de8-98c3-4538-a391-724a2652bc1d)

### Filtered + selected

It shows as a partial selection, because it is. Even though the user is selecting all the domains in the view, it isn't all the available domains, so we should reflect that in the UI.

![selected](https://github.com/Automattic/wp-calypso/assets/26530524/71543aba-c08b-45fd-a77d-efc099551dd4)

## Testing Instructions

Open the new domains management table, try querying for specific domains and check the table getting smaller. Notice that when you select a domain, the input gets replaced by the bulk action selectbox.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?