### PR TITLE
Sign up flow: Support params screen and screen_parameter

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -121,6 +121,8 @@ function getChecklistThemeDestination( {
 	headerPatternId,
 	footerPatternId,
 	sectionPatternIds,
+	screen,
+	screenParameter,
 } ) {
 	if ( isSiteAssemblerFlow( flowName ) ) {
 		// Check whether to go to the assembler. If not, go to the site editor directly
@@ -133,6 +135,8 @@ function getChecklistThemeDestination( {
 					header_pattern_id: headerPatternId,
 					footer_pattern_id: footerPatternId,
 					pattern_ids: sectionPatternIds,
+					screen,
+					screen_parameter: screenParameter,
 				},
 				`/setup/with-theme-assembler`
 			);

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -304,6 +304,8 @@ export default {
 		const headerPatternId = query && query.header_pattern_id;
 		const footerPatternId = query && query.footer_pattern_id;
 		const sectionPatternIds = query && query.pattern_ids;
+		const screen = query && query.screen;
+		const screenParameter = query && query.screen_parameter;
 		// Set plugin parameter in signup dependency store so we can retrieve it in getWithPluginDestination().
 		const pluginParameter = query && query.plugin;
 		const pluginBillingPeriod = query && query.billing_period;
@@ -316,6 +318,8 @@ export default {
 			...( headerPatternId && { headerPatternId } ),
 			...( footerPatternId && { footerPatternId } ),
 			...( sectionPatternIds && { sectionPatternIds } ),
+			...( screen && { screen } ),
+			...( screenParameter && { screenParameter } ),
 			...( pluginParameter && { pluginParameter } ),
 			...( pluginBillingPeriod && { pluginBillingPeriod } ),
 		};


### PR DESCRIPTION
## Proposed Changes

This PR adds support to the URL parameters `screen` and `screen_parameter` introduced in https://github.com/Automattic/wp-calypso/pull/81069. These parameters are used to override the initial navigation state of the Assembler.

![Screenshot 2023-08-30 at 10 50 17 AM](https://github.com/Automattic/wp-calypso/assets/797888/4991b9ea-ca2d-43d6-b080-c8515adde79b)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/start/with-theme-assembler?ref=calypshowcase&screen=main&screen_parameter=posts&header_pattern_id=5588`.
* Follow the steps to create a new site.
* When landing in the Assembler, ensure that the initial selected navigation item is Section > Blog Posts, as shown in the screenshot above.
* Note that a header pattern has also been pre-selected. This is out-of-scope for this PR but it'd be good to test that it's working as intended as well 🙂

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?