### PR TITLE
VideoPress User Intent Onboarding: "create a blog" redirects to the wpcom flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
@@ -65,7 +65,7 @@ const VideoPressOnboardingIntent: Step = ( { navigation } ) => {
 
 	const onVideoBlogIntentClicked = () => {
 		sendTracksIntent( 'blog' );
-		setModal( <VideoPressOnboardingIntentModalBlog onSubmit={ handleSubmit } /> );
+		setModal( <VideoPressOnboardingIntentModalBlog /> );
 	};
 
 	const onOtherIntentClicked = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-blog.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-blog.tsx
@@ -2,9 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import { IntroModalContentProps } from '../intro/intro';
 import VideoPressOnboardingIntentModal from './videopress-onboarding-intent-modal';
 
-const VideoPressOnboardingIntentModalBlog: React.FC< IntroModalContentProps > = ( {
-	onSubmit,
-} ) => {
+const VideoPressOnboardingIntentModalBlog: React.FC< IntroModalContentProps > = () => {
 	const translate = useTranslate();
 
 	return (
@@ -26,9 +24,9 @@ const VideoPressOnboardingIntentModalBlog: React.FC< IntroModalContentProps > = 
 				translate( 'The best premium themes at your disposal.' ),
 			] }
 			actionButton={ {
-				type: 'button',
+				type: 'link',
 				text: translate( 'Get started with premium' ),
-				onClick: onSubmit,
+				href: 'https://wordpress.com/start/premium/?ref=videopress',
 			} }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
@@ -86,11 +86,16 @@ const VideoPressOnboardingIntentModal: React.FC< VideoPressOnboardingIntentModal
 						</div>
 						<div className="videopress-intro-modal__waitlist-description">
 							{ translate(
-								'In the meantime, you can {{a}}create a blog with video{{/a}}, a {{b}}video portfolio{{/b}}, or {{c}}add videos to your existing site{{/c}}.',
+								'In the meantime, you can {{a}}create a video portfolio{{/a}}, {{b}}a blog with video{{/b}}, or {{c}}add videos to your existing site{{/c}}.',
 								{
 									components: {
 										a: <Button onClick={ () => onSubmit?.() && false } />,
-										b: <Button onClick={ () => onSubmit?.() && false } />,
+										b: (
+											<a
+												href="https://wordpress.com/start/premium/?ref=videopress"
+												rel="external noreferrer noopener"
+											/>
+										),
 										c: (
 											<a
 												href="https://jetpack.com/videopress/"


### PR DESCRIPTION
Related to Automattic/greenhouse#1838

## Proposed Changes

This PR redirects users to https://wordpress.com/start/premium/?ref=videopress when using the "create a blog" option on the VideoPress user intent onboarding.

## Testing Instructions

* Apply PR
* Go to /setup/videopress
* Select the "Start a blog with video content" option and click on the action button
* ✅ You should be redirected to https://wordpress.com/start/premium/?ref=videopress
* Go back to the onboarding and select a coming soon feature
* Click on "create a blog with video" in the "in the meantime" paragraph
* ✅ You should be redirected to https://wordpress.com/start/premium/?ref=videopress
