### PR TITLE
VideoPress User Intent Onboarding: Remove incentive from the survey phrasing

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
@@ -115,7 +115,9 @@ const VideoPressOnboardingIntentModal: React.FC< VideoPressOnboardingIntentModal
 					<div className="videopress-intro-modal__survey-info">
 						<div className="videopress-intro-modal__survey-title">{ surveyTitle }</div>
 						<div className="videopress-intro-modal__survey-description">
-							{ translate( 'Answer a short survey and you’ll have the chance to win $50.' ) }
+							{ translate(
+								'Send your feedback and help us shape the future of VideoPress by answering this short survey.'
+							) }
 						</div>
 					</div>
 					<div className="videopress-intro-modal__survey-button-wrapper">


### PR DESCRIPTION
## Proposed Changes

This PR removes the incentive from the CTA for the VideoPress user intent survey.

## Testing Instructions

* Apply PR
* Go to /setup/videopress
* Click on a coming soon feature
* ✅ The CTA shouldn't have the incentive mentioned anymore
* ✅ The phrase should still make sense.

![Capture d’écran 2023-09-01 à 09 48 34](https://github.com/Automattic/wp-calypso/assets/1420594/4761e5c7-6ce7-42c3-b8c2-8c02cfa33a8f)

