### PR TITLE
VideoPress User Intent Onboarding: replace last space with non-breaking

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/intent-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/intent-item.tsx
@@ -8,6 +8,9 @@ interface Props {
 const VideoPressOnboardingIntentItem = ( props: Props ) => {
 	const { title, image, description, onClick } = props;
 
+	// Replace last space between words in description with nbsp
+	const descriptionWithNbsp = description.replace( /\s(?=[^\s]*$)/, '\u00a0' );
+
 	return (
 		<div className="videopress-intent-item">
 			<button className="videopress-intent-item__preview" onClick={ onClick }>
@@ -15,7 +18,7 @@ const VideoPressOnboardingIntentItem = ( props: Props ) => {
 			</button>
 			<div className="videopress-intent-item__description">
 				<span className="videopress-intent-item__title">{ title }</span>
-				<span className="videopress-intent-item__description">{ description }</span>
+				<span className="videopress-intent-item__description">{ descriptionWithNbsp }</span>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Proposed Changes

This PR replaces the last space in the user intent items description with a non-breaking space.

## Testing Instructions

* Don't apply PR yet
* `yarn start`
* Go to /setup/videopress
* Notice "your storytelling" under "start a blog with video content", "storytelling" is on a separate line
* Apply PR
* Reload the page
* ✅ "your storytelling" should now be on the second line
