### PR TITLE
Jetpack E2E: expand the Marketing: SEO spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -31,6 +31,8 @@ export class MarketingPage {
 		this.page = page;
 	}
 
+	/* Generic methods */
+
 	/**
 	 * Navigates directly to the Marketing page for the site.
 	 *
@@ -49,7 +51,25 @@ export class MarketingPage {
 		await clickNavTab( this.page, name );
 	}
 
+	/**
+	 * Given an accessible name of the button, click on the button.
+	 *
+	 * @param {string} name Accessible name of the button.
+	 */
+	async clickButton( name: string ) {
+		await this.page.getByRole( 'button', { name: name } ).click();
+	}
+
 	/* SEO Preview Methods */
+
+	/**
+	 *
+	 */
+	async saveSettings() {
+		await this.page.getByRole( 'button', { name: 'Save settings' } ).first().click();
+
+		await this.page.waitForResponse( /settings/ );
+	}
 
 	/**
 	 * Enters text into the Website Meta Information field.
@@ -73,15 +93,6 @@ export class MarketingPage {
 	}
 
 	/**
-	 * Given an accessible name of the button, click on the button.
-	 *
-	 * @param {string} name Accessible name of the button.
-	 */
-	async clickButton( name: string ) {
-		await this.page.getByRole( 'button', { name: name } ).click();
-	}
-
-	/**
 	 * Enters the specified text into the input of the specified category, changing the
 	 * page title structure.
 	 *
@@ -102,17 +113,13 @@ export class MarketingPage {
 	/**
 	 * Returns the preview text for the page title structure category.
 	 *
-	 * @param {SEOPageTitleStructureCategories} category Category to return preview text for.
-	 * @returns {Promise<string>} Preview text.
+	 * @param {string} text Text to validate.
 	 */
-	async getPreviewTextForPageStructureCategory(
-		category: SEOPageTitleStructureCategories
-	): Promise< string > {
-		return await this.page
-			.locator( selectors.pageTitleStructureInput )
-			.filter( { has: this.page.getByText( category ) } )
+	async validatePreviewTextForPageStructureCategory( text: string ) {
+		await this.page
 			.locator( '.title-format-editor__preview' )
-			.innerText();
+			.filter( { hasText: text } )
+			.waitFor();
 	}
 
 	/* Social Connectisons */

--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -8,14 +8,12 @@ type MarketingPageTab =
 	| 'Connections'
 	| 'Sharing Buttons'
 	| 'Business Tools';
+type SEOPageTitleStructureCategories = 'Front Page' | 'Posts' | 'Pages' | 'Tags' | 'Archives';
+type SEOExternalServices = 'Google search' | 'Facebook' | 'Twitter';
 type SocialConnection = 'Facebook' | 'LinkedIn' | 'Tumblr' | 'Mastodon' | 'Instagram Business';
 
 const selectors = {
-	// Traffic tab
-	websiteMetaTextArea: '#advanced_seo_front_page_description',
-	seoPreviewButton: '.seo-settings__preview-button',
-	seoPreviewPane: '.web-preview.is-seo',
-	seoPreviewPaneCloseButton: '.web-preview__close',
+	pageTitleStructureInput: '.title-format-editor',
 };
 
 /**
@@ -56,32 +54,65 @@ export class MarketingPage {
 	/**
 	 * Enters text into the Website Meta Information field.
 	 *
-	 * @param {string} [text] String to be used as the description of the web site in SEO.
-	 * @returns {Promise<void>} No return value.
+	 * @param {string} text String to be used as the description of the web site in SEO.
 	 */
-	async enterWebsiteMetaInformation( text = 'test text' ): Promise< void > {
-		await this.page.fill( selectors.websiteMetaTextArea, text );
+	async enterExternalPreviewText( text: string ) {
+		await this.page.getByRole( 'textbox', { name: 'Front Page Meta Description' } ).fill( text );
 	}
 
 	/**
-	 * Open the preview of SEO changes.
+	 * Validates the external preview for the specified service contains the text.
 	 *
-	 * @returns {Promise<void>} No return value.
+	 * @param {SEOExternalServices} service External service.
+	 * @param {string} text Text to validate.
 	 */
-	async openSEOPreview(): Promise< void > {
-		const locator = this.page.locator( selectors.seoPreviewButton );
-		await locator.click();
-		await this.page.waitForSelector( selectors.seoPreviewPane );
+	async validateExternalPreview( service: SEOExternalServices, text: string ) {
+		await this.page.locator( '.vertical-menu__social-item' ).filter( { hasText: service } ).click();
+
+		await this.page.locator( '.seo-preview-pane__preview' ).getByText( text ).waitFor();
 	}
 
 	/**
-	 * Close the preview of SEO changes.
+	 * Given an accessible name of the button, click on the button.
 	 *
-	 * @returns {Promise<void>} No return value.
+	 * @param {string} name Accessible name of the button.
 	 */
-	async closeSEOPreview(): Promise< void > {
-		await this.page.click( selectors.seoPreviewPaneCloseButton );
-		await this.page.waitForSelector( selectors.seoPreviewButton );
+	async clickButton( name: string ) {
+		await this.page.getByRole( 'button', { name: name } ).click();
+	}
+
+	/**
+	 * Enters the specified text into the input of the specified category, changing the
+	 * page title structure.
+	 *
+	 * @param {SEOPageTitleStructureCategories} category Category to modify.
+	 * @param {string} text Text to enter.
+	 */
+	async enterPageTitleStructure( category: SEOPageTitleStructureCategories, text: string ) {
+		const target = this.page
+			.locator( selectors.pageTitleStructureInput )
+			.filter( { has: this.page.getByText( category ) } )
+			.getByRole( 'textbox' );
+
+		await target.scrollIntoViewIfNeeded();
+
+		await target.fill( text );
+	}
+
+	/**
+	 * Returns the preview text for the page title structure category.
+	 *
+	 * @param {SEOPageTitleStructureCategories} category Category to return preview text for.
+	 * @returns {Promise<string>} Preview text.
+	 */
+	async getPreviewTextForPageStructureCategory(
+		category: SEOPageTitleStructureCategories
+	): Promise< string > {
+		return await this.page
+			.locator( selectors.pageTitleStructureInput )
+			.filter( { has: this.page.getByText( category ) } )
+			.locator( '.title-format-editor__preview' )
+			.innerText();
 	}
 
 	/* Social Connectisons */

--- a/test/e2e/specs/tools/marketing__seo.ts
+++ b/test/e2e/specs/tools/marketing__seo.ts
@@ -1,20 +1,52 @@
 /**
  * @group calypso-pr
+ * @group jetpack-wpcom-integration
  */
 
-import { DataHelper, SidebarComponent, MarketingPage, TestAccount } from '@automattic/calypso-e2e';
+import {
+	getTestAccountByFeature,
+	envToFeatureKey,
+	envVariables,
+	DataHelper,
+	SidebarComponent,
+	MarketingPage,
+	TestAccount,
+} from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
+/**
+ * Quick test to verify various SEO text fields and previews render.
+ *
+ * This is a feature exclusive to Business plans and higher.
+ *
+ * Keywords: Jetpack, SEO, Traffic, Marketing.
+ */
 describe( DataHelper.createSuiteTitle( 'Marketing: SEO Preview' ), function () {
-	let marketingPage: MarketingPage;
+	const externalPreviewText = 'Test front page meta description';
+
 	let page: Page;
+	let testAccount: TestAccount;
+	let marketingPage: MarketingPage;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
 
-		const testAccount = new TestAccount( 'atomicUser' );
+		// Simple sites do not have the ability to change SEO parameters.
+		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+			{
+				gutenberg: 'stable',
+				siteType: 'simple',
+				accountName: 'atomicUser',
+			},
+			{
+				gutenberg: 'edge',
+				siteType: 'simple',
+				accountName: 'atomicUser',
+			},
+		] );
+		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
 	} );
 
@@ -28,12 +60,27 @@ describe( DataHelper.createSuiteTitle( 'Marketing: SEO Preview' ), function () {
 		await marketingPage.clickTab( 'Traffic' );
 	} );
 
-	it( 'Enter SEO meta description', async function () {
-		await marketingPage.enterWebsiteMetaInformation();
+	it( 'Enter and verify SEO page title front page structure', async function () {
+		const frontPageText = 'test front page title text';
+		await marketingPage.enterPageTitleStructure( 'Front Page', frontPageText );
+
+		const previewText = await marketingPage.getPreviewTextForPageStructureCategory( 'Front Page' );
+		expect( previewText ).toContain( frontPageText );
 	} );
 
-	it( 'Open and close SEO preview', async function () {
-		await marketingPage.openSEOPreview();
-		await marketingPage.closeSEOPreview();
+	it( 'Enter SEO external preview description', async function () {
+		await marketingPage.enterExternalPreviewText( externalPreviewText );
+	} );
+
+	it( 'Open SEO preview', async function () {
+		await marketingPage.clickButton( 'Show Previews' );
+	} );
+
+	it( 'Verify preview for Facebook', async function () {
+		await marketingPage.validateExternalPreview( 'Facebook', externalPreviewText );
+	} );
+
+	it( 'Close SEO preview', async function () {
+		await marketingPage.clickButton( 'Close preview' );
 	} );
 } );

--- a/test/e2e/specs/tools/marketing__seo.ts
+++ b/test/e2e/specs/tools/marketing__seo.ts
@@ -48,15 +48,20 @@ describe( DataHelper.createSuiteTitle( 'Marketing: SEO Preview' ), function () {
 		] );
 		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
+
+		marketingPage = new MarketingPage( page );
 	} );
 
 	it( 'Navigate to Tools > Marketing page', async function () {
-		const sidebarComponent = new SidebarComponent( page );
-		await sidebarComponent.navigate( 'Tools', 'Marketing' );
+		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
+			await marketingPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+		} else {
+			const sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Tools', 'Marketing' );
+		}
 	} );
 
 	it( 'Click on Traffic tab', async function () {
-		marketingPage = new MarketingPage( page );
 		await marketingPage.clickTab( 'Traffic' );
 	} );
 

--- a/test/e2e/specs/tools/marketing__seo.ts
+++ b/test/e2e/specs/tools/marketing__seo.ts
@@ -11,6 +11,7 @@ import {
 	SidebarComponent,
 	MarketingPage,
 	TestAccount,
+	NoticeComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
@@ -24,7 +25,7 @@ declare const browser: Browser;
  * Keywords: Jetpack, SEO, Traffic, Marketing.
  */
 describe( DataHelper.createSuiteTitle( 'Marketing: SEO Preview' ), function () {
-	const externalPreviewText = 'Test front page meta description';
+	const externalPreviewText = DataHelper.getRandomPhrase();
 
 	let page: Page;
 	let testAccount: TestAccount;
@@ -66,11 +67,10 @@ describe( DataHelper.createSuiteTitle( 'Marketing: SEO Preview' ), function () {
 	} );
 
 	it( 'Enter and verify SEO page title front page structure', async function () {
-		const frontPageText = 'test front page title text';
+		const frontPageText = DataHelper.getRandomPhrase();
 		await marketingPage.enterPageTitleStructure( 'Front Page', frontPageText );
 
-		const previewText = await marketingPage.getPreviewTextForPageStructureCategory( 'Front Page' );
-		expect( previewText ).toContain( frontPageText );
+		await marketingPage.validatePreviewTextForPageStructureCategory( frontPageText );
 	} );
 
 	it( 'Enter SEO external preview description', async function () {
@@ -87,5 +87,12 @@ describe( DataHelper.createSuiteTitle( 'Marketing: SEO Preview' ), function () {
 
 	it( 'Close SEO preview', async function () {
 		await marketingPage.clickButton( 'Close preview' );
+	} );
+
+	it( 'Save changes', async function () {
+		await marketingPage.saveSettings();
+
+		const noticeComponent = new NoticeComponent( page );
+		await noticeComponent.noticeShown( 'Settings saved successfully!' );
 	} );
 } );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80730.

## Proposed Changes

This PR expands the existing SEO spec to something more substantial.

Key flows:
- change one of the page structure.
- check how the SEO external preview looks like for Facebook.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?