### PR TITLE
Assembler - Show pattern name tooltip only on hover, not on focus

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.scss
@@ -7,5 +7,14 @@
 		max-width: 100%;
 		margin: 0 auto;
 	}
+
+	// Force Tooltip from @wordpress/components to show on hover only, not on focus
+	.components-popover {
+		visibility: hidden;
+	}
+
+	&:hover .components-popover {
+		visibility: visible;
+	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75478
Closes #75994


## Proposed Changes

* Show pattern tooltip with name only on hover, not on focus

**Note:** This change doesn't affect the accessibility because each pattern has `aria-label`.


https://github.com/Automattic/wp-calypso/assets/1881481/637e40ca-b94c-456b-8fdc-3fb103aa2b0e



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }`
* Verify the tooltip doesn't appear initially when the first header gets the focus
* Verify the tooltip still appears on hover


### Initial load

|BEFORE|AFTER|
|--|--|
|<img width="697" alt="Screenshot 2566-08-30 at 13 35 25" src="https://github.com/Automattic/wp-calypso/assets/1881481/9c68719f-a6bb-48ce-8ae9-907049b9daff">|<img width="695" alt="Screenshot 2566-08-30 at 13 34 57" src="https://github.com/Automattic/wp-calypso/assets/1881481/ba54a094-7f0e-4a46-893b-76de321e9de9">|

### Focus 

|BEFORE|AFTER|
|--|--|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/3b830cb6-45ab-4ca0-b069-ba9a842823a8">|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/e71a154d-5e14-44f8-b632-0e76785c9137">|

### Hover 

|BEFORE|AFTER - No changes|
|--|--|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/5830b262-d13c-480c-baa0-ff70eda86351">|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/5830b262-d13c-480c-baa0-ff70eda86351">|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?