### PR TITLE
/themes: Update copy for the website design service banner

### DIFF
--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -32,7 +32,7 @@ class UpworkBanner extends PureComponent {
 				className="upwork-banner__troubleshooting"
 				showIcon
 				onClick={ () => window.open( builtByWpUrl, '_blank' ) }
-				callToAction={ translate( 'Find your expert' ) }
+				callToAction={ translate( 'Let’s get started' ) }
 				dismissPreferenceName="upwork-dismissible-banner"
 				tracksClickName="calypso_upwork_banner_start_now_button_click"
 				tracksClickProperties={ { location, plan } }
@@ -40,9 +40,9 @@ class UpworkBanner extends PureComponent {
 				tracksDismissName="calypso_upwork_banner_dismiss_icon_click"
 				tracksDismissProperties={ { location, plan } }
 				href="#"
-				title={ translate( 'Let our WordPress.com experts build your site!' ) }
+				title={ translate( 'Let us launch your dream site' ) }
 				description={ translate(
-					'You want the website of your dreams. Our experts can create it for you.'
+					'Our professional website-building service can create the site of your dreams, no matter the scope of your project.'
 				) }
 			/>
 		);

--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -40,9 +40,9 @@ class UpworkBanner extends PureComponent {
 				tracksDismissName="calypso_upwork_banner_dismiss_icon_click"
 				tracksDismissProperties={ { location, plan } }
 				href="#"
-				title={ translate( 'Let us launch your dream site' ) }
+				title={ translate( 'Let us build your dream website!' ) }
 				description={ translate(
-					'Our professional website-building service can create the site of your dreams, no matter the scope of your project.'
+					'We can help you reach your launch day faster, no matter the scope of your project.'
 				) }
 			/>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes 1992-gh-martech

## Proposed Changes

Update the copy for the website design service banner (in logged-in pages) to the one mentioned in pau2Xa-51k#comment-13714:

> **Let us build your dream website!**
We can help you reach your launch day faster, no matter the scope of your project.

#### BEFORE
<img width="1573" alt="Screenshot 2023-08-30 at 10 26 10 AM" src="https://github.com/Automattic/wp-calypso/assets/1269602/a55168d3-59dd-4bf1-bc1d-31e18eababaa">


#### AFTER

<img width="1432" alt="Screenshot 2023-08-30 at 10 51 15 AM" src="https://github.com/Automattic/wp-calypso/assets/1269602/9e16b1aa-20c2-4904-9c77-200453cf34de">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in and visit /themes.
* Verify that the banner copy is updated.
* In non-EN, the copy will be untranslated (should be fine since this will be merged only after translations are complete).

