### PR TITLE
/read/subscriptions: Go to individual subscription page URL in reader when clicking on a site title

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
@@ -151,11 +151,8 @@ const SiteRow = ( {
 
 	const siteTitleUrl = useMemo( () => {
 		if ( isReaderPortal ) {
-			if (
-				config.isEnabled( 'reader/individual-subscription-page' ) &&
-				Reader.isValidId( blog_id )
-			) {
-				return `/read/subscriptions/site/${ blog_id }`;
+			if ( config.isEnabled( 'reader/individual-subscription-page' ) ) {
+				return `/read/subscriptions/${ subscriptionId }`;
 			}
 
 			return `/read/feeds/${ feed_id }`;
@@ -168,7 +165,7 @@ const SiteRow = ( {
 			}
 			return `/subscriptions/site/${ blog_id }`;
 		}
-	}, [ blog_id, feed_id, isReaderPortal, isSubscriptionsPortal ] );
+	}, [ blog_id, feed_id, isReaderPortal, isSubscriptionsPortal, subscriptionId ] );
 
 	const handleNotifyMeOfNewPostsChange = ( send_posts: boolean ) => {
 		// Update post notification settings

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { isValidId } from '@automattic/data-stores/src/reader';
@@ -150,6 +151,13 @@ const SiteRow = ( {
 
 	const siteTitleUrl = useMemo( () => {
 		if ( isReaderPortal ) {
+			if (
+				config.isEnabled( 'reader/individual-subscription-page' ) &&
+				Reader.isValidId( blog_id )
+			) {
+				return `/read/subscriptions/site/${ blog_id }`;
+			}
+
 			return `/read/feeds/${ feed_id }`;
 		}
 

--- a/config/development.json
+++ b/config/development.json
@@ -164,6 +164,7 @@
 		"reader/full-errors": true,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,
+		"reader/individual-subscription-page": true,
 		"recommend-plugins": true,
 		"redirect-fallback-browsers": false,
 		"rum-tracking/logstash": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #81205

## Proposed Changes

* Introduce a feature flag for opening individual subscription page when clicking on a specific subscription. For now, make the feature flag apply to development env only.
* Open `/read/subscriptions/${subscriptionId}` when the feature flag is on and the related site has a valid blog ID associated

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/read/subscriptions
* Click on a site title of a subscription.
  * The subscription needs to have a valid WPCOM blog ID associated 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
