### PR TITLE
Add loading state to commerce "Start your store" button so the link doesn't 404

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -110,13 +110,13 @@ class AtomicStoreThankYouCard extends Component {
 
 		return (
 			<div className="checkout-thank-you__atomic-store-action-buttons">
-				<a
+				<Button
 					disabled={ ! isSiteAtomic }
 					className={ classNames( 'button', 'thank-you-card__button' ) }
-					href={ siteWooCommerceWizardUrl }
+					onClick={ () => ( window.location.href = siteWooCommerceWizardUrl ) }
 				>
-					{ isSiteAtomic ? translate( 'Create your store!' ) : translate( 'Please wait' ) }
-				</a>
+					{ isSiteAtomic ? translate( 'Create your store!' ) : 'Loading site' }
+				</Button>
 			</div>
 		);
 	};

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -115,7 +115,7 @@ class AtomicStoreThankYouCard extends Component {
 					className={ classNames( 'button', 'thank-you-card__button' ) }
 					onClick={ () => ( window.location.href = siteWooCommerceWizardUrl ) }
 				>
-					{ isSiteAtomic ? translate( 'Create your store!' ) : 'Loading site' }
+					{ isSiteAtomic ? translate( 'Create your store!' ) : translate( 'Loading site' ) }
 				</Button>
 			</div>
 		);

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -14,6 +14,7 @@ import {
 	isCurrentUserEmailVerified,
 } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteWooCommerceWizardUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -85,7 +86,7 @@ class AtomicStoreThankYouCard extends Component {
 	};
 
 	renderAction = () => {
-		const { isEmailVerified, translate, siteWooCommerceWizardUrl } = this.props;
+		const { isEmailVerified, translate, siteWooCommerceWizardUrl, isSiteAtomic } = this.props;
 		const { resendStatus } = this.state;
 
 		if ( isWcMobileApp() ) {
@@ -110,10 +111,11 @@ class AtomicStoreThankYouCard extends Component {
 		return (
 			<div className="checkout-thank-you__atomic-store-action-buttons">
 				<a
+					disabled={ ! isSiteAtomic }
 					className={ classNames( 'button', 'thank-you-card__button' ) }
 					href={ siteWooCommerceWizardUrl }
 				>
-					{ translate( 'Create your store!' ) }
+					{ isSiteAtomic ? translate( 'Create your store!' ) : translate( 'Please wait' ) }
 				</a>
 			</div>
 		);
@@ -175,6 +177,7 @@ export default connect(
 		const emailAddress = getCurrentUserEmail( state );
 		const isEmailVerified = isCurrentUserEmailVerified( state );
 		const siteWooCommerceWizardUrl = getSiteWooCommerceWizardUrl( state, siteId );
+		const isSiteAtomic = isAtomicSite( state, siteId );
 
 		return {
 			siteId,
@@ -183,6 +186,7 @@ export default connect(
 			isEmailVerified,
 			planClass,
 			siteWooCommerceWizardUrl,
+			isSiteAtomic,
 		};
 	},
 	{ errorNotice, fetchCurrentUser, removeNotice }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74345 and bottle pickup Automattic/martech#2135

## Proposed Changes

* Checking whether the site is atomic, and conditionally rendering text in button
* WIP. Will add a proper disable and loading indicator to the button. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new Commerce site (e.g. via start/ecommerce/), pay and go thorugh the atomic transfer flow. Once that finishes, you'll end up on the thank you page.
    * You will see the button being disabled briefly (maybe 3-5 seconds). Clicking on it won't do anything.
    *  Afterwards, it will change and you should be able to click it to go to wp-admin. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
