### PR TITLE
Assembler - Fix patterns using min-height with vh units

### DIFF
--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -21,7 +21,7 @@ const PatternRenderer = ( {
 }: Props ) => {
 	const renderedPatterns = usePatternsRendererContext();
 	const pattern = renderedPatterns[ patternId ];
-	const { isMinHeight100vh, patternHtml } = usePatternMinHeightVh( pattern?.html );
+	const patternHtml = usePatternMinHeightVh( pattern?.html, viewportHeight );
 
 	return (
 		<BlockRendererContainer
@@ -31,7 +31,7 @@ const PatternRenderer = ( {
 			viewportHeight={ viewportHeight }
 			maxHeight={ maxHeight }
 			minHeight={ minHeight }
-			isMinHeight100vh={ isMinHeight100vh }
+			isMinHeight100vh={ pattern?.html?.includes( 'min-height:100vh' ) }
 			minHeightFor100vh={ minHeightFor100vh }
 		>
 			<div

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import usePatternMinHeightVh from '../hooks/use-pattern-min-height-vh';
 import BlockRendererContainer from './block-renderer-container';
 import { usePatternsRendererContext } from './patterns-renderer-context';
-
 interface Props {
 	patternId: string;
 	viewportWidth?: number;
@@ -22,6 +21,7 @@ const PatternRenderer = ( {
 }: Props ) => {
 	const renderedPatterns = usePatternsRendererContext();
 	const pattern = renderedPatterns[ patternId ];
+	const { isMinHeight100vh, patternHtml } = usePatternMinHeightVh( pattern?.html );
 
 	return (
 		<BlockRendererContainer
@@ -31,12 +31,12 @@ const PatternRenderer = ( {
 			viewportHeight={ viewportHeight }
 			maxHeight={ maxHeight }
 			minHeight={ minHeight }
-			isMinHeight100vh={ pattern?.html?.includes( 'min-height:100vh' ) }
+			isMinHeight100vh={ isMinHeight100vh }
 			minHeightFor100vh={ minHeightFor100vh }
 		>
 			<div
 				// eslint-disable-next-line react/no-danger
-				dangerouslySetInnerHTML={ { __html: pattern?.html ?? '' } }
+				dangerouslySetInnerHTML={ { __html: patternHtml ?? '' } }
 			/>
 		</BlockRendererContainer>
 	);

--- a/packages/block-renderer/src/hooks/use-pattern-min-height-vh.ts
+++ b/packages/block-renderer/src/hooks/use-pattern-min-height-vh.ts
@@ -1,21 +1,18 @@
 import { useMemo } from 'react';
 
-const usePatternMinHeightVh = ( html = '' ) => {
+const usePatternMinHeightVh = ( html = '', viewportHeight: number | undefined = 0 ) => {
 	return useMemo( () => {
-		const minHeightVhResults = html.match( /min-height:(\d+)vh;?/ );
-		const minHeightVhDeclaration = minHeightVhResults?.[ 0 ];
-		const minHeightVhValue = minHeightVhResults?.[ 1 ];
-
-		const isMinHeight100vh = minHeightVhValue === '100';
-
-		// Remove min-height declaration except for 100vh
-		const patternHtml =
-			minHeightVhDeclaration && ! isMinHeight100vh
-				? html.replace( minHeightVhDeclaration, '' )
-				: html;
-
-		return { isMinHeight100vh, patternHtml, minHeightVhValue };
-	}, [ html ] );
+		return html.replace( /min-height:\s?(?<value>\d+)vh;?/g, ( match, value ) => {
+			if ( viewportHeight ) {
+				// In the large preview, replace with the percentage of viewport height in pixels.
+				return `min-height:${ ( Number( value ) * viewportHeight ) / 100 }px;`;
+			} else if ( value !== '100' ) {
+				// In the small pattern previews, remove the min-height declaration except for 100vh
+				return '';
+			}
+			return match;
+		} );
+	}, [ html, viewportHeight ] );
 };
 
 export default usePatternMinHeightVh;

--- a/packages/block-renderer/src/hooks/use-pattern-min-height-vh.ts
+++ b/packages/block-renderer/src/hooks/use-pattern-min-height-vh.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+
+const usePatternMinHeightVh = ( html = '' ) => {
+	return useMemo( () => {
+		const minHeightVhResults = html.match( /min-height:(\d+)vh/ );
+		const minHeightVhDeclaration = minHeightVhResults?.[ 0 ];
+		const minHeightVhValue = minHeightVhResults?.[ 1 ];
+
+		const isMinHeight100vh = minHeightVhValue === '100';
+
+		// Remove min-height declaration except for 100vh
+		const patternHtml =
+			minHeightVhDeclaration && ! isMinHeight100vh
+				? html.replace( minHeightVhDeclaration, '' )
+				: html;
+
+		return { isMinHeight100vh, patternHtml, minHeightVhValue };
+	}, [ html ] );
+};
+
+export default usePatternMinHeightVh;

--- a/packages/block-renderer/src/hooks/use-pattern-min-height-vh.ts
+++ b/packages/block-renderer/src/hooks/use-pattern-min-height-vh.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 const usePatternMinHeightVh = ( html = '' ) => {
 	return useMemo( () => {
-		const minHeightVhResults = html.match( /min-height:(\d+)vh/ );
+		const minHeightVhResults = html.match( /min-height:(\d+)vh;?/ );
 		const minHeightVhDeclaration = minHeightVhResults?.[ 0 ];
 		const minHeightVhValue = minHeightVhResults?.[ 1 ];
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Remove pattern `min-height` using `vh` units except for `100vh`
* Calculate `min-height` as a percentage of the large preview height in pixels 


**Note:** The height of this kind of pattern depends on the viewport height. This PR fixes this behavior on the pattern assembler previews because it doesn't work as expected as each pattern is rendered in an iframe.

|Pattern height in editor or site front|Pattern height in assembler preview|
|--|--|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/676685d9-ea81-4cd8-9b19-cf450df57079">|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/075fc7e2-4b15-4396-bc99-1f7b5c7389f6">|

I also tested patterns with `min-height:100vh` and they work well too 🎉

https://github.com/Automattic/wp-calypso/assets/1881481/15fb715f-1ebb-4082-8d9e-8d6254974481





## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }&screen=main&screen_parameter=call-to-action&pattern_ids=12076`
  * That URL pre-selects a pattern with `min-height:75vh`. See https://dotcompatterns.wordpress.com/?p=12076.
* Expect to fully see the cover image used in that pattern
* Expect that the height of that pattern depends on the viewport height in the assembler as in the editor and site front

|BEFORE|AFTER|
|--|--|
|<img width="1440" alt="Screenshot 2566-08-30 at 16 15 37" src="https://github.com/Automattic/wp-calypso/assets/1881481/d58c6747-915a-465b-9494-c9e1fcde4eee">|<img width="1435" alt="Screenshot 2566-08-30 at 16 15 16" src="https://github.com/Automattic/wp-calypso/assets/1881481/724388e7-db7f-46f6-a008-1096788ffd01">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?