### PR TITLE
Move the Information Icon in Traffic Settings 

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -21,6 +21,7 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import MetaTitleEditor from 'calypso/components/seo/meta-title-editor';
 import { toApi as seoTitleToApi } from 'calypso/components/seo/meta-title-editor/mappings';
+import SupportInfo from 'calypso/components/support-info';
 import WebPreview from 'calypso/components/web-preview';
 import { protectForm } from 'calypso/lib/protect-form';
 import { getFirstConflictingPlugin } from 'calypso/lib/seo';
@@ -348,6 +349,16 @@ export class SiteSettingsFormSEO extends Component {
 											'social media sites, and browser tabs.'
 									) }
 								</p>
+								{ siteIsJetpack && (
+									<SupportInfo
+										text={ translate(
+											'To help improve your search page ranking, you can customize how the content titles' +
+												' appear for your site. You can reorder items such as ‘Site Name’ and ‘Tagline’,' +
+												' and also add custom separators between the items.'
+										) }
+										link=" https://wordpress.com/support/seo-tools/#page-title-structure"
+									/>
+								) }
 							</Card>
 							<Card>
 								<MetaTitleEditor

--- a/client/my-sites/site-settings/seo-settings/help.jsx
+++ b/client/my-sites/site-settings/seo-settings/help.jsx
@@ -3,7 +3,6 @@ import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { connect } from 'react-redux';
-import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import getJetpackModules from 'calypso/state/selectors/get-jetpack-modules';
@@ -42,16 +41,6 @@ export const SeoSettingsHelpCard = ( {
 						) }
 					</p>
 
-					{ siteIsJetpack && (
-						<SupportInfo
-							text={ translate(
-								'To help improve your search page ranking, you can customize how the content titles' +
-									' appear for your site. You can reorder items such as ‘Site Name’ and ‘Tagline’,' +
-									' and also add custom separators between the items.'
-							) }
-							link="https://jetpack.com/support/seo-tools/"
-						/>
-					) }
 					{ siteIsJetpack && (
 						<JetpackModuleToggle
 							siteId={ siteId }


### PR DESCRIPTION
## Before

![image](https://github.com/Automattic/wp-calypso/assets/52076348/1829917d-0f85-479c-94a9-4360306083b6)


## After

![image](https://github.com/Automattic/wp-calypso/assets/52076348/e08c11a3-c25b-45bf-b0e5-5ef14983fc34)


Also changed the `Learn More` link  from https://jetpack.com/support/seo-tools/  to https://wordpress.com/support/seo-tools/#page-title-structure 

## Testing

Use the live link.

On a Business or Commerce plan site:
1. Navigate to Tools → Marketing
2. Select the Traffic tab
3. "i" icon should appear in `Page Title Structure` with the updated link

Fixes https://github.com/Automattic/wp-calypso/issues/80592