### PR TITLE
Jetpack Backup: Fix storage add-on recommendation on retention settings page

### DIFF
--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -108,7 +108,10 @@ const BackupRetentionManagement: FunctionComponent< OwnProps > = ( {
 	);
 
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) ) as string;
-	const { upsellSlug, originalPrice, isPriceFetching, currencyCode } = useUpsellInfo( siteId );
+	const { upsellSlug, originalPrice, isPriceFetching, currencyCode } = useUpsellInfo(
+		siteId,
+		retentionSelected
+	);
 
 	const upgradePrice = (
 		<UpsellPrice

--- a/client/components/backup-storage-space/usage-warning/use-upsell-slug.ts
+++ b/client/components/backup-storage-space/usage-warning/use-upsell-slug.ts
@@ -40,7 +40,7 @@ export const isJetpackProductSlugMatch =
 	( { subscriptionStatus, productSlug }: Purchase ) =>
 		subscriptionStatus === 'active' && slugList.includes( productSlug );
 
-export default ( siteId: number ) => {
+export default ( siteId: number, retentionSelected?: number ) => {
 	const TEN_GIGABYTES = useJetpack10GbStorageAmountText();
 	const HUNDRED_GIGABYTES = useJetpack100GbStorageAmountText();
 	const ONE_TERABYTES = useJetpack1TbStorageAmountText();
@@ -63,7 +63,8 @@ export default ( siteId: number ) => {
 		getBackupRetentionDays( state, siteId )
 	);
 	// The retention days that currently applies for this customer.
-	const currentRetentionPeriod = customerRetentionPeriod || planRetentionPeriod || 0;
+	const currentRetentionPeriod =
+		retentionSelected || customerRetentionPeriod || planRetentionPeriod || 0;
 
 	const upsellSlug = useMemo( () => {
 		const ADD_ON_STORAGE_MAP: Record< string, TranslateResult > = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Issue reported: p1693385808753609-slack-CB7AEN79D
Related to #79357

## Proposed Changes

In #79357, we introduced a bug that stopped considering the user's selected retention option on the settings page while suggesting a storage add-on upgrade. The logic was displaying add-on recommendations based on already saved custom retention (or the default retention that comes with the plan if not set) but not considering the currently selected option on the retention settings UI, resulting in incorrect recommendations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- For a test, update the VP attribute `site_used_storage_<site_id>` and `site_last_backup_size_<site_id>` to a value such that they won't fit under the default retention. (e.g. update usage to 0.7GB for a 10GB plan site)
- Verify the issue, by going to Jetpack Cloud -> Retention Settings Page -> Try selecting the retention options one by one, it will display incorrect recommendations when compared with **Space needed** value.
- Use the Jetpack Cloud live link and verify again if the issue is fixed by doing the above step again, it should suggest a storage add-on bigger than **Space needed** of the selected option, up to maximum of **1TB**.

**Before: (It was suggesting a 100GB add-on when selected yearly retention even when _Space needed_ was greater)**

<img width="704" alt="Screenshot 2023-08-30 at 5 38 12 PM" src="https://github.com/Automattic/wp-calypso/assets/13975226/e05b1b64-cea8-472c-98b5-d47e3d3f7d8d">

**After: (Now it suggests the correct upgrade add-on of 1TB since _Space needed_ is greater than 100GB and less than 1TB**

<img width="712" alt="Screenshot 2023-08-30 at 5 38 04 PM" src="https://github.com/Automattic/wp-calypso/assets/13975226/ccda0d94-a7f8-4b1d-83d7-9a5ae9f5e103">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?