### PR TITLE
Subscription Management: Improve sign-up & login flow for external users.

### DIFF
--- a/client/landing/subscriptions/components/subscription-manager-page/subscription-manager-page.tsx
+++ b/client/landing/subscriptions/components/subscription-manager-page/subscription-manager-page.tsx
@@ -1,5 +1,7 @@
 import { SubscriptionManager } from '@automattic/data-stores';
+import { useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
 import { UniversalNavbarHeader } from '@automattic/wpcom-template-parts';
+import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -13,8 +15,21 @@ import {
 import './styles.scss';
 
 const SubscriptionManagementPage = () => {
+	const locale = useLocale();
+	const localizeUrl = useLocalizeUrl();
 	const translate = useTranslate();
 	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
+	const emailAddress = SubscriptionManager.useSubscriberEmailAddress();
+
+	const startUrl = addQueryArgs(
+		localizeUrl( '//wordpress.com/start/account/user', locale, isLoggedIn ),
+		{
+			redirect_to: '/read',
+			ref: 'reader-lp',
+			...( emailAddress ? { email_address: emailAddress } : {} ),
+		}
+	);
+
 	return (
 		<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Subscriptions }>
 			<UniversalNavbarHeader
@@ -23,6 +38,7 @@ const SubscriptionManagementPage = () => {
 				} ) }
 				variant="minimal"
 				isLoggedIn={ isLoggedIn }
+				startUrl={ startUrl }
 			/>
 			<Main className="subscription-manager__container">
 				<FormattedHeader

--- a/client/landing/subscriptions/components/subscription-manager-page/subscription-manager-page.tsx
+++ b/client/landing/subscriptions/components/subscription-manager-page/subscription-manager-page.tsx
@@ -30,6 +30,13 @@ const SubscriptionManagementPage = () => {
 		}
 	);
 
+	const loginUrl = addQueryArgs(
+		localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn, true ),
+		{
+			...( emailAddress ? { email_address: emailAddress } : {} ),
+		}
+	);
+
 	return (
 		<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Subscriptions }>
 			<UniversalNavbarHeader
@@ -39,6 +46,7 @@ const SubscriptionManagementPage = () => {
 				variant="minimal"
 				isLoggedIn={ isLoggedIn }
 				startUrl={ startUrl }
+				loginUrl={ loginUrl }
 			/>
 			<Main className="subscription-manager__container">
 				<FormattedHeader

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -510,6 +510,7 @@ export class UserStep extends Component {
 			<>
 				<SignupForm
 					{ ...omit( this.props, [ 'translate' ] ) }
+					email={ this.props.queryObject?.email_address || '' }
 					redirectToAfterLoginUrl={ getRedirectToAfterLoginUrl( this.props ) }
 					disabled={ this.userCreationStarted() }
 					submitting={ this.userCreationStarted() }

--- a/packages/wpcom-template-parts/src/types.ts
+++ b/packages/wpcom-template-parts/src/types.ts
@@ -7,6 +7,8 @@ export interface HeaderProps {
 	sectionName?: string;
 	logoColor?: string;
 	variant?: 'default' | 'minimal';
+	startUrl?: string;
+	loginUrl?: string;
 }
 
 export interface FooterProps {

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -14,6 +14,8 @@ const UniversalNavbarHeader = ( {
 	sectionName,
 	logoColor,
 	variant = 'default',
+	startUrl,
+	loginUrl,
 }: HeaderProps ) => {
 	const locale = useLocale();
 	const localizeUrl = useLocalizeUrl();
@@ -21,18 +23,20 @@ const UniversalNavbarHeader = ( {
 	const [ isMobileMenuOpen, setMobileMenuOpen ] = useState( false );
 	const isEnglishLocale = useIsEnglishLocale();
 
-	const startUrl = addQueryArgs(
-		// url
-		sectionName === 'plugins'
-			? localizeUrl( '//wordpress.com/start/business', locale, isLoggedIn )
-			: localizeUrl( '//wordpress.com/start', locale, isLoggedIn ),
-		// query
-		sectionName
-			? {
-					ref: sectionName + '-lp',
-			  }
-			: {}
-	);
+	if ( ! startUrl ) {
+		startUrl = addQueryArgs(
+			// url
+			sectionName === 'plugins'
+				? localizeUrl( '//wordpress.com/start/business', locale, isLoggedIn )
+				: localizeUrl( '//wordpress.com/start', locale, isLoggedIn ),
+			// query
+			sectionName
+				? {
+						ref: sectionName + '-lp',
+				  }
+				: {}
+		);
+	}
 
 	return (
 		<div className={ className }>
@@ -323,7 +327,10 @@ const UniversalNavbarHeader = ( {
 											className="x-nav-item x-nav-item__wide"
 											titleValue=""
 											content={ __( 'Log In', __i18n_text_domain__ ) }
-											urlValue={ localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn, true ) }
+											urlValue={
+												loginUrl ||
+												localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn, true )
+											}
 											type="nav"
 										/>
 									) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

**Functional changes:**
- Get Started button should go to Reader sign-up flow with email address prefilled.
- Login button should go to the login page with email address prefilled.
- Prefill signup form with email from the `email_address` url param if exists.
- Add `startUrl` & `loginUrl` props to `UniversalHeaderNavigation`.

## Testing Instructions

* Go to `/subscriptions` as an external user (use subkey cookie injection).
* Click on the "Get Started" button.
  * It will go to `wordpress.com` hostname but update the url on the address bar to point to `calypso.localhost:3000`.
  * You should see your email prefilled.
  * You should be in the Reader signup flow where:
    * You will not be asked to create a site.
    * You will land in Reader after signing up.
* Click on the "Login" button.
  * You should see your email prefilled.

![image](https://github.com/Automattic/wp-calypso/assets/1287077/c8acdd29-e8b4-454b-84dd-adc686696e2a)

![image](https://github.com/Automattic/wp-calypso/assets/1287077/225ed5f0-5ca4-4bbd-8514-04197623690e)

![image](https://github.com/Automattic/wp-calypso/assets/1287077/35e06fc0-ba10-4cd0-8e9b-34e250f469f8)

  
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?