### PR TITLE
Migration trial: Add tracking events on 'Trial expired' page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/controller.jsx
+++ b/client/my-sites/plans/ecommerce-trial/controller.jsx
@@ -10,12 +10,16 @@ import TrialUpgradeConfirmation from './upgrade-confirmation';
 export function trialExpired( context, next ) {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
+	let trialType = undefined;
+
+	if ( wasEcommerceTrialSite( state, selectedSite.ID ) ) {
+		trialType = 'ecommerce';
+	} else if ( wasBusinessTrialSite( state, selectedSite.ID ) ) {
+		trialType = 'business';
+	}
 
 	context.store.dispatch(
-		recordTracksEvent( 'calypso_plan_trial_expired_page', {
-			was_ecommerce_trial_site: wasEcommerceTrialSite( state, selectedSite.ID ),
-			was_business_trial_site: wasBusinessTrialSite( state, selectedSite.ID ),
-		} )
+		recordTracksEvent( 'calypso_plan_trial_expired_page', { trial_type: trialType } )
 	);
 
 	if ( wasEcommerceTrialSite( state, selectedSite.ID ) ) {

--- a/client/my-sites/plans/ecommerce-trial/controller.jsx
+++ b/client/my-sites/plans/ecommerce-trial/controller.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import wasBusinessTrialSite from 'calypso/state/selectors/was-business-trial-site';
 import wasEcommerceTrialSite from 'calypso/state/selectors/was-ecommerce-trial-site';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -9,6 +10,14 @@ import TrialUpgradeConfirmation from './upgrade-confirmation';
 export function trialExpired( context, next ) {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
+
+	context.store.dispatch(
+		recordTracksEvent( 'calypso_plan_trial_expired_page', {
+			site_id: selectedSite.ID,
+			was_ecommerce_trial_site: wasEcommerceTrialSite( state, selectedSite.ID ),
+			was_business_trial_site: wasBusinessTrialSite( state, selectedSite.ID ),
+		} )
+	);
 
 	if ( wasEcommerceTrialSite( state, selectedSite.ID ) ) {
 		context.primary = <ECommerceTrialExpired />;

--- a/client/my-sites/plans/ecommerce-trial/controller.jsx
+++ b/client/my-sites/plans/ecommerce-trial/controller.jsx
@@ -13,7 +13,6 @@ export function trialExpired( context, next ) {
 
 	context.store.dispatch(
 		recordTracksEvent( 'calypso_plan_trial_expired_page', {
-			site_id: selectedSite.ID,
 			was_ecommerce_trial_site: wasEcommerceTrialSite( state, selectedSite.ID ),
 			was_business_trial_site: wasBusinessTrialSite( state, selectedSite.ID ),
 		} )

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
@@ -2,7 +2,8 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo, useState } from 'react';
+import page from 'page';
+import React, { useCallback, useMemo, useState } from 'react';
 import QueryPlans from 'calypso/components/data/query-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Main from 'calypso/components/main';
@@ -54,6 +55,21 @@ const ECommerceTrialExpired = (): JSX.Element => {
 		siteIsAtomic && selectedSite?.URL
 			? `${ selectedSite.URL }/wp-admin/export.php`
 			: `/export/${ siteSlug }`;
+	const settingsDeleteSiteUrl = `/settings/delete-site/${ siteSlug }`;
+
+	const onDeleteClick = useCallback(
+		( e: React.MouseEvent< HTMLButtonElement > ) => {
+			e.preventDefault();
+
+			recordTracksEvent( 'calypso_plan_trial_expired_page_delete_site', {
+				site_id: siteId,
+				site_slug: siteSlug,
+				trial_type: 'ecommerce',
+			} );
+			page.redirect( settingsDeleteSiteUrl );
+		},
+		[ page, recordTracksEvent, settingsDeleteSiteUrl ]
+	);
 
 	return (
 		<>
@@ -101,7 +117,7 @@ const ECommerceTrialExpired = (): JSX.Element => {
 						<Gridicon icon="cloud-download" />
 						<span>{ translate( 'Export your content' ) }</span>
 					</Button>
-					<Button href={ `/settings/delete-site/${ siteSlug }` } scary>
+					<Button href={ settingsDeleteSiteUrl } onClick={ onDeleteClick } scary>
 						<Gridicon icon="trash" />
 						<span>{ translate( 'Delete your site permanently' ) }</span>
 					</Button>

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
@@ -62,7 +62,6 @@ const ECommerceTrialExpired = (): JSX.Element => {
 			e.preventDefault();
 
 			recordTracksEvent( 'calypso_plan_trial_expired_page_delete_site', {
-				site_id: siteId,
 				site_slug: siteSlug,
 				trial_type: 'ecommerce',
 			} );

--- a/client/my-sites/plans/trials/business-trial-expired/index.tsx
+++ b/client/my-sites/plans/trials/business-trial-expired/index.tsx
@@ -49,7 +49,6 @@ const BusinessTrialExpired = (): JSX.Element => {
 			e.preventDefault();
 
 			recordTracksEvent( 'calypso_plan_trial_expired_page_delete_site', {
-				site_id: siteId,
 				site_slug: siteSlug,
 				trial_type: 'business',
 			} );

--- a/client/my-sites/plans/trials/business-trial-expired/index.tsx
+++ b/client/my-sites/plans/trials/business-trial-expired/index.tsx
@@ -51,7 +51,7 @@ const BusinessTrialExpired = (): JSX.Element => {
 			recordTracksEvent( 'calypso_plan_trial_expired_page_delete_site', {
 				site_id: siteId,
 				site_slug: siteSlug,
-				trial_type: 'migration',
+				trial_type: 'business',
 			} );
 			page.redirect( settingsDeleteSiteUrl );
 		},

--- a/client/my-sites/plans/trials/business-trial-expired/index.tsx
+++ b/client/my-sites/plans/trials/business-trial-expired/index.tsx
@@ -2,7 +2,8 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo } from 'react';
+import page from 'page';
+import React, { useCallback, useMemo } from 'react';
 import QueryPlans from 'calypso/components/data/query-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Main from 'calypso/components/main';
@@ -41,6 +42,21 @@ const BusinessTrialExpired = (): JSX.Element => {
 		siteIsAtomic && selectedSite?.URL
 			? `${ selectedSite.URL }/wp-admin/export.php`
 			: `/export/${ siteSlug }`;
+	const settingsDeleteSiteUrl = `/settings/delete-site/${ siteSlug }`;
+
+	const onDeleteClick = useCallback(
+		( e: React.MouseEvent< HTMLButtonElement > ) => {
+			e.preventDefault();
+
+			recordTracksEvent( 'calypso_plan_trial_expired_page_delete_site', {
+				site_id: siteId,
+				site_slug: siteSlug,
+				trial_type: 'migration',
+			} );
+			page.redirect( settingsDeleteSiteUrl );
+		},
+		[ page, recordTracksEvent, settingsDeleteSiteUrl ]
+	);
 
 	return (
 		<>
@@ -82,7 +98,7 @@ const BusinessTrialExpired = (): JSX.Element => {
 						<Gridicon icon="cloud-download" />
 						<span>{ translate( 'Export your content' ) }</span>
 					</Button>
-					<Button href={ `/settings/delete-site/${ siteSlug }` } scary>
+					<Button href={ settingsDeleteSiteUrl } onClick={ onDeleteClick } scary>
 						<Gridicon icon="trash" />
 						<span>{ translate( 'Delete your site permanently' ) }</span>
 					</Button>

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -64,12 +64,16 @@ export function general( context, next ) {
 export function deleteSite( context, next ) {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
+	let trialType = undefined;
+
+	if ( wasEcommerceTrialSite( state, siteId ) ) {
+		trialType = 'ecommerce';
+	} else if ( wasBusinessTrialSite( state, siteId ) ) {
+		trialType = 'business';
+	}
 
 	context.store.dispatch(
-		recordTracksEvent( 'calypso_settings_delete_site_page', {
-			was_ecommerce_trial_site: wasEcommerceTrialSite( state, siteId ),
-			was_business_trial_site: wasBusinessTrialSite( state, siteId ),
-		} )
+		recordTracksEvent( 'calypso_settings_delete_site_page', { trial_type: trialType } )
 	);
 
 	context.primary = <DeleteSite path={ context.path } />;

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -67,7 +67,6 @@ export function deleteSite( context, next ) {
 
 	context.store.dispatch(
 		recordTracksEvent( 'calypso_settings_delete_site_page', {
-			site_id: siteId,
 			was_ecommerce_trial_site: wasEcommerceTrialSite( state, siteId ),
 			was_business_trial_site: wasBusinessTrialSite( state, siteId ),
 		} )

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -1,10 +1,13 @@
 import page from 'page';
 import { billingHistory } from 'calypso/me/purchases/paths';
 import SiteSettingsMain from 'calypso/my-sites/site-settings/main';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import canCurrentUserStartSiteOwnerTransfer from 'calypso/state/selectors/can-current-user-start-site-owner-transfer';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
+import wasBusinessTrialSite from 'calypso/state/selectors/was-business-trial-site';
+import wasEcommerceTrialSite from 'calypso/state/selectors/was-ecommerce-trial-site';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import DeleteSite from './delete-site';
@@ -59,8 +62,18 @@ export function general( context, next ) {
 }
 
 export function deleteSite( context, next ) {
-	context.primary = <DeleteSite path={ context.path } />;
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
 
+	context.store.dispatch(
+		recordTracksEvent( 'calypso_settings_delete_site_page', {
+			site_id: siteId,
+			was_ecommerce_trial_site: wasEcommerceTrialSite( state, siteId ),
+			was_business_trial_site: wasBusinessTrialSite( state, siteId ),
+		} )
+	);
+
+	context.primary = <DeleteSite path={ context.path } />;
 	next();
 }
 


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3595

## Proposed Changes

* Added tracking events
  * `calypso_plan_trial_expired_page`
  * `calypso_settings_delete_site_page`
  * `calypso_plan_trial_expired_page_delete_site`

## Testing Instructions

* Take a site with an expired Trial plan
* You'll be redirected to `/plans/my-plan/trial-expired/{SITE_SLUG}`
* Check if the recording event is triggered
* Click on the "Delete your site permanently" button
* Check if the recording event is triggered
* You'll be redirected to `/settings/delete-site/{SITE_SLUG}`
* Check if the recording event is triggered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?