### PR TITLE
Design Picker: Add the is_externally_managed prop to the metrics

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -113,6 +113,7 @@ export function getDesignEventProps( {
 		theme_style: design.recipe?.stylesheet + variationSlugSuffix,
 		design_type: design.design_type,
 		is_premium: design.is_premium,
+		is_externally_managed: design?.is_externally_managed,
 		has_style_variations: ( design.style_variations || [] ).length > 0,
 		is_style_variation: is_style_variation,
 		...( colorVariation && {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -422,6 +422,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	function handleCheckout() {
 		recordTracksEvent( 'calypso_signup_design_upgrade_modal_checkout_button_click', {
 			theme: selectedDesign?.slug,
+			is_externally_managed: selectedDesign?.is_externally_managed,
 		} );
 
 		const themeHasWooCommerce = selectedDesign?.software_sets?.find(

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -108,6 +108,7 @@ export default function DesignPickerStep( props ) {
 		theme: design?.stylesheet ?? `pub/${ design?.theme }`,
 		template: design?.template,
 		is_premium: design?.is_premium,
+		is_externally_managed: design?.is_externally_managed,
 		flow: flowName,
 		intent: dependencies.intent,
 	} );

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -125,6 +125,7 @@ const useTrackDesignView = ( {
 					is_premium_available: isPremiumThemeAvailable,
 					slug: design.slug,
 					is_virtual: design.is_virtual,
+					is_externally_managed: design.is_externally_managed,
 				} );
 
 				if ( category ) {


### PR DESCRIPTION
Resolves https://github.com/Automattic/dotcom-forge/issues/3586

## Proposed Changes

Add the is_externally_managed prop to the metrics on the Design picker.

## Testing Instructions

* On your browse console, enable the logging with: `localStorage.setItem( 'debug', 'calypso:analytics*' );`
* Apply the diff D118900-code to your sandbox and direct requests to the sandbox
* Go to the Design Picker page with a Marketplace theme selected `/setup/update-design/designSetup?siteSlug=:site&theme=:theme_slug`. Theme slugs such as `makoney` and `olsen-fse` can be used.
* Click on `Unlock Theme`
* You should see the modal for the checkout
* Proceed clicking on the CTA
* There should be a number of logs related to this flow on the console, check if all applicable have the `is_externally_managed` prop

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
