### PR TITLE
Google banners: Move localizeUrl return value into a const

### DIFF
--- a/client/my-sites/domains/domain-management/list/google-domain-owner-banner.tsx
+++ b/client/my-sites/domains/domain-management/list/google-domain-owner-banner.tsx
@@ -9,6 +9,7 @@ const GoogleDomainOwnerBanner = () => {
 	const translate = useTranslate();
 	const localizeUrl = useLocalizeUrl();
 	const currentUser = useSelector( getCurrentUser );
+	const targetUrl = localizeUrl( 'https://wordpress.com/transfer-google-domains/' );
 
 	return (
 		currentUser?.is_google_domain_owner && (
@@ -22,7 +23,7 @@ const GoogleDomainOwnerBanner = () => {
 				disableCircle
 				event="learn-more"
 				iconPath={ globe }
-				href={ localizeUrl( 'https://wordpress.com/transfer-google-domains/' ) }
+				href={ targetUrl }
 				tracksClickName="calypso_google_domain_owner_click"
 				tracksImpressionName="calypso_google_domain_owner_impression"
 				compactButton={ false }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80255

## Proposed Changes

* The Google domains target banner CTA was not working for some reason ~due to localizeUrl being called directly in the banner component.~ This PR moves the return value of localizeUrl to a const then passes the const to the banner component.

Post deploy update: This PR did not fix the issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure your `is_google_domain_owner` attribute is set and visit /manage/domain and /manage/domains/$site
* View the banner and make sure you can click the "Learn more" link.
* Double check that tracks impression and click events work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?