### PR TITLE
Google banners: Add target=_blank to banner link

### DIFF
--- a/client/my-sites/domains/domain-management/list/google-domain-owner-banner.tsx
+++ b/client/my-sites/domains/domain-management/list/google-domain-owner-banner.tsx
@@ -27,6 +27,7 @@ const GoogleDomainOwnerBanner = () => {
 				tracksClickName="calypso_google_domain_owner_click"
 				tracksImpressionName="calypso_google_domain_owner_impression"
 				compactButton={ false }
+				target="_blank"
 			/>
 		)
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/81222

## Proposed Changes

* The Google domains banner CTA is not properly opening the CTA link. It loads the URL in the address bar, but the page does not update. Adding target="_blank" is a work around to force the new page to load.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The issues has only been reproduced in production. So we ensure this PR does not cause regressions, push, and see if the link in production is working.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?