### PR TITLE
BackupBrowser: Add `id` and `totalItems` params to FileBrowserItem

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/test/util.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/test/util.ts
@@ -2,7 +2,12 @@
  * @jest-environment jsdom
  */
 
-import { BackupLsResponse, BackupPathInfoResponse, FileBrowserItem, FileBrowserItemInfo } from '../types';
+import {
+	BackupLsResponse,
+	BackupPathInfoResponse,
+	FileBrowserItem,
+	FileBrowserItemInfo,
+} from '../types';
 import {
 	convertBytes,
 	encodeToBase64,

--- a/client/my-sites/backup/backup-contents-page/file-browser/types.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/types.ts
@@ -27,6 +27,7 @@ export interface FileBrowserItem {
 	extensionVersion?: string;
 	manifestPath?: string;
 	extensionType?: string;
+	totalItems?: number;
 }
 
 export interface BackupLsResponse {
@@ -46,6 +47,7 @@ export interface BackupLsResponseContents {
 		label?: string;
 		row_count?: number;
 		extension_version?: string;
+		total_items?: number;
 	};
 }
 

--- a/client/my-sites/backup/backup-contents-page/file-browser/types.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/types.ts
@@ -16,6 +16,7 @@ export type FileType =
 	| 'other';
 
 export interface FileBrowserItem {
+	id?: string;
 	name: string;
 	type: FileType;
 	hasChildren: boolean;
@@ -36,6 +37,7 @@ export interface BackupLsResponse {
 
 export interface BackupLsResponseContents {
 	[ key: string ]: {
+		id?: string;
 		type: ApiFileType;
 		has_children: boolean;
 		period?: string;

--- a/client/my-sites/backup/backup-contents-page/file-browser/util.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/util.ts
@@ -91,6 +91,7 @@ export const parseBackupContentsData = ( payload: BackupLsResponse ): FileBrowse
 			...( item.type === 'table' && { rowCount: item.row_count } ),
 			...( item.extension_version && { extensionVersion: item.extension_version } ),
 			...( item.manifest_path && { manifestPath: item.manifest_path } ),
+			...( item.id && { id: item.id } ),
 		};
 	} );
 

--- a/client/my-sites/backup/backup-contents-page/file-browser/util.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/util.ts
@@ -92,6 +92,7 @@ export const parseBackupContentsData = ( payload: BackupLsResponse ): FileBrowse
 			...( item.extension_version && { extensionVersion: item.extension_version } ),
 			...( item.manifest_path && { manifestPath: item.manifest_path } ),
 			...( item.id && { id: item.id } ),
+			...( item.total_items && { totalItems: item.total_items } ),
 		};
 	} );
 


### PR DESCRIPTION
## Proposed Change
* Add `id` and `total_items` params to `FileBrowserItem` that is returned by `backup/ls` API.
* Add some unit tests for `parseBackupContentsData`

## Testing Instructions
The change is pretty straightforward, so you could ensure unit tests are still passing:
```
yarn run test-client client/my-sites/backup/backup-contents-page/file-browser/test
```

You could also start a Jetpack Cloud live branch and validate the backup browser is still working as usual.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?