### PR TITLE
Use Button component for inline comments expand/collapse links.

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -439,15 +439,25 @@ class PostCommentList extends Component {
 					{ commentIds.map( ( commentId ) => this.renderComment( commentId, commentsTreeToShow ) ) }
 				</ol>
 				{ ( shouldShowViewMoreToggle || this.state.showExpandWhenOnlyComments ) && (
-					<button className="comments__toggle-expand" onClick={ this.toggleExpanded }>
+					<Button
+						compact
+						borderless
+						className="comments__toggle-expand"
+						onClick={ this.toggleExpanded }
+					>
 						{ this.state.isExpanded ? viewFewerText : viewMoreText }
-					</button>
+					</Button>
 				) }
 				{ shouldShowLinkToFullPost && (
-					<button className="comments__open-post" onClick={ this.onOpenPostPageAtComments }>
+					<Button
+						compact
+						borderless
+						className="comments__open-post"
+						onClick={ this.onOpenPostPageAtComments }
+					>
 						{ shouldShowViewMoreToggle && '• ' }
 						{ translate( 'View more comments on the full post' ) }
-					</button>
+					</Button>
 				) }
 			</>
 		);

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -8,8 +8,9 @@
 
 	.comments__toggle-expand,
 	.comments__open-post {
-		cursor: pointer;
-		margin-top: 16px;
+		margin-top: 9px;
+		margin-bottom: -7px;
+
 		&:hover {
 			color: var(--color-link);
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Updates inline comments to use our Button component, which gives them better features such as a11y focus. This also allows them to pick up more cohesive button styles, in our limited case of borderless and compact button I think this is limited to font weight/size and padding.

Before (with an without a11y focus):

<img width="694" alt="Screenshot 2023-08-30 at 12 39 22 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/0890a038-adf2-4433-a1b3-8b7796722d4d">

After:

(with a11y focus)
<img width="695" alt="Screenshot 2023-08-30 at 12 39 53 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/63c99697-bd72-4383-a40d-b871dd08db03">

(without)
<img width="674" alt="Screenshot 2023-08-30 at 12 41 50 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/2a65f336-4fd7-41f8-bbd5-52928154331a">

Note a slight change in the visual text weight due to picking up more cohesive button styles. I think it makes sense to keep these.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
