### PR TITLE
Revert "Pricing page: Improve appearance when US locale is displayed …

### DIFF
--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -231,9 +231,10 @@ function FlatPriceDisplay( {
 	className?: string;
 	isSmallestUnit?: boolean;
 } ) {
-	const { symbol, symbolPosition } = getCurrencyObject( smallerPrice, currencyCode );
-	const currencySymbol = symbol.replace( /^US/, '' );
-
+	const { symbol: currencySymbol, symbolPosition } = getCurrencyObject(
+		smallerPrice,
+		currencyCode
+	);
 	const translate = useTranslate();
 
 	if ( ! higherPrice ) {
@@ -304,23 +305,15 @@ function MultiPriceDisplay( {
 		smallerPrice,
 		currencyCode
 	);
-
-	// Sometimes the US currency symbol is displayed as `US$` instead of just `$`
-	// See: packages/format-currency/README.md (## geolocateCurrencySymbol()) for further details.
-	const hasUslocaleInSymbol = /^US\$$/.test( currencySymbol );
-
 	const translate = useTranslate();
 
 	return createElement(
 		tagName,
 		{ className },
 		<>
-			{ symbolPosition === 'before' && (
-				<CurrencySymbolDisplay
-					currencySymbol={ currencySymbol }
-					hasUslocaleInSymbol={ hasUslocaleInSymbol }
-				/>
-			) }
+			{ symbolPosition === 'before' ? (
+				<sup className="plan-price__currency-symbol">{ currencySymbol }</sup>
+			) : null }
 
 			{ ! higherPrice && (
 				<HtmlPriceDisplay
@@ -353,12 +346,9 @@ function MultiPriceDisplay( {
 					comment: 'The price range for a particular product',
 				} ) }
 
-			{ symbolPosition === 'after' && (
-				<CurrencySymbolDisplay
-					currencySymbol={ currencySymbol }
-					hasUslocaleInSymbol={ hasUslocaleInSymbol }
-				/>
-			) }
+			{ symbolPosition === 'after' ? (
+				<sup className="plan-price__currency-symbol">{ currencySymbol }</sup>
+			) : null }
 
 			{ taxText && (
 				<sup className="plan-price__tax-amount">
@@ -382,23 +372,6 @@ function MultiPriceDisplay( {
 				</Badge>
 			) }
 		</>
-	);
-}
-
-function CurrencySymbolDisplay( {
-	currencySymbol,
-	hasUslocaleInSymbol,
-}: {
-	currencySymbol: string;
-	hasUslocaleInSymbol: boolean;
-} ) {
-	return hasUslocaleInSymbol ? (
-		<>
-			<sup className="plan-price__symbol-locale">US</sup>
-			<sup className="plan-price__currency-symbol">$</sup>
-		</>
-	) : (
-		<sup className="plan-price__currency-symbol">{ currencySymbol }</sup>
 	);
 }
 

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -73,8 +73,3 @@
 	line-height: 1rem;
 	margin-left: 5px;
 }
-
-.plan-price__symbol-locale {
-	font-size: 0.65rem; /* stylelint-disable-line scales/font-sizes */
-	letter-spacing: -0.08em;
-}

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -4,13 +4,6 @@
 .item-price .display-price {
 	display: block;
 
-	.display-price__prices {
-		flex: 0 1 auto;
-	}
-	.display-price__details {
-		flex: 1;
-	}
-
 	.plan-price__currency-symbol,
 	.plan-price__integer,
 	.plan-price__fraction {
@@ -50,8 +43,7 @@
 	&__expiration-date {
 		color: var(--studio-gray-50);
 		font-size: 0.75rem;
-		//Mimic line-height: 24px, but with padding instead, so that the text can wrap to a new line correctly.
-		padding: 0.301rem 0 0.3rem;
+		line-height: 24px;
 	}
 
 	@include break-mobile {
@@ -62,13 +54,7 @@
 }
 
 .item-price .display-price:not(.is-placeholder) {
-	@include break-mobile {
-		max-height: 24px;
-	}
-
-	.plan-price {
-		font-weight: 700;
-	}
+	max-height: 24px;
 
 	.plan-price.is-original {
 		color: var(--studio-gray-50);
@@ -91,6 +77,7 @@
 
 	.plan-price.is-discounted {
 		color: var(--studio-gray-100);
+		font-weight: 700;
 	}
 
 	.plan-price.is-discounted .plan-price__fraction {

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
@@ -42,14 +42,12 @@
 		@media screen and (min-width: 320px) {
 			display: flex;
 			min-height: 24px;
-			align-items: center;
 		}
 	}
 
 	.featured-item-card .item-price .display-price .display-price__billing-time-frame {
 		@media screen and (min-width: 320px) {
 			margin-top: 0;
-			padding-left: 3px;
 		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* Reverts currency update to fix US currency on Jetpack Cloud

This was breaking currencies elsewhere
Slack: p1693394820471939-slack-CFFF01Q4V

## Testing Instructions

N/A: Revert

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?