### PR TITLE
Revert "VideoPress Intent e2e test - support temporary flow change (#…

### DIFF
--- a/test/e2e/specs/onboarding/setup__videopress.ts
+++ b/test/e2e/specs/onboarding/setup__videopress.ts
@@ -39,19 +39,7 @@ describe( DataHelper.createSuiteTitle( 'VideoPress Tailored Onboarding' ), () =>
 		} );
 
 		it( 'Click Get Started', async function () {
-			const btnGetStarted = await page.$( 'text=Get started' );
-
-			// if Get Started is present, its the normal flow, otherwise its the User Intent flow
-			// -- if user intent, lets get on track to the normal flow
-			if ( null !== btnGetStarted ) {
-				await Promise.all( [ page.waitForNavigation(), page.click( 'text=Get started' ) ] );
-			} else {
-				await Promise.all( [
-					page.waitForNavigation(),
-					page.click( 'img[alt="Get a video portfolio"]' ),
-					page.click( 'button.intro__button' ),
-				] );
-			}
+			await Promise.all( [ page.waitForNavigation(), page.click( 'text=Get started' ) ] );
 		} );
 
 		it( 'Navigate VideoMaker Setup', async function () {


### PR DESCRIPTION
…81151)"

This reverts commit f77b542d5ffdad612bc20cc3bcbcad22e01b3b9c.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
