### PR TITLE
Hosting Metrics: Fix page header alignment

### DIFF
--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -25,6 +25,12 @@ $section-max-width: 1224px;
 			padding-inline-start: calc(var(--sidebar-width-max) + 1px);
 		}
 	}
+	.site-monitoring__formatted-header.formatted-header.modernized-header.is-left-align {
+		padding: 0 max(calc(50% - #{math.div( $section-max-width, 2 )}), 32px);
+		padding-bottom: 24px;
+		margin-left: 0;
+		margin-right: 0;
+	}
 	& .site-logs-container {
 		padding: 0 max(calc(50% - #{math.div( $section-max-width, 2 )}), 32px);
 		@media screen and ( max-width: 782px ) {
@@ -61,16 +67,6 @@ $section-max-width: 1224px;
 	margin-left: 16px;
 	margin-right: 16px;
 	max-width: 1224px;
-}
-
-.site-monitoring__formatted-header.formatted-header.modernized-header.is-left-align {
-	padding-bottom: 24px;
-	margin-left: 32px;
-	margin-right: 32px;
-	@media screen and ( max-width: 782px ) {
-		margin-left: 16px;
-		margin-right: 16px;
-	}
 }
 
 .site-monitoring-metrics-tab {


### PR DESCRIPTION
From https://github.com/Automattic/wp-calypso/pull/80959#issuecomment-1698796819
See https://github.com/Automattic/dotcom-forge/issues/3392

## Proposed Changes

Fixes the page header alignment.

### Before

<img width="521" alt="CleanShot 2023-08-30 at 14 57 39@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/05b07794-5da9-4bc7-a5e6-2ac0a035aa94">

<img width="1243" alt="CleanShot 2023-08-30 at 14 58 19@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/b2f770c3-8de2-412b-9ffa-2afe2882398b">

<img width="1740" alt="CleanShot 2023-08-30 at 15 00 09@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/55b2a788-fb78-40a2-ae43-c20082eccad1">

### After

<img width="521" alt="CleanShot 2023-08-30 at 14 57 54@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/a0a9cf09-bb36-431f-9d5f-e8679e8e01a6">

<img width="1220" alt="CleanShot 2023-08-30 at 14 58 06@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/ac49f12b-8992-4585-9e72-f3a005e6d99b">

<img width="1744" alt="CleanShot 2023-08-30 at 15 00 24@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/d7666fdb-fa7c-4e50-8fbb-c46977a14114">

## Testing Instructions

1. Test the margins on desktop and mobile.