### PR TITLE
Plans: Change order of newsletter features

### DIFF
--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -603,13 +603,13 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 	get2023PlanComparisonConditionalFeatures: () => [ FEATURE_SHARES_SOCIAL_MEDIA_JP ],
 	getNewsletterSignupFeatures: () => [
 		FEATURE_NEWSLETTER_IMPORT_SUBSCRIBERS_FREE,
+		FEATURE_PAYMENT_TRANSACTION_FEES_10,
 		FEATURE_PREMIUM_CONTENT_JP,
 		FEATURE_NEWSLETTERS_RSS,
 		FEATURE_UNLIMITED_EMAILS,
 		FEATURE_STATS_JP,
 		FEATURE_BANDWIDTH,
 		FEATURE_LTD_SOCIAL_MEDIA_JP,
-		FEATURE_PAYMENT_TRANSACTION_FEES_10,
 	],
 	getLinkInBioSignupFeatures: () => [
 		FEATURE_BEAUTIFUL_THEMES,
@@ -841,9 +841,9 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	getNewsletterSignupFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_UNLIMITED_SUBSCRIBERS,
+		FEATURE_PAYMENT_TRANSACTION_FEES_8,
 		FEATURE_SUPPORT_EMAIL,
 		FEATURE_AD_FREE_EXPERIENCE,
-		FEATURE_PAYMENT_TRANSACTION_FEES_8,
 	],
 	getNewsletterHighlightedFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,
@@ -1345,13 +1345,12 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 			'Take your Newsletter further, faster. Get everything included in Personal, plus premium design themes, baked-in video uploads, ad monetization, deep visitor insights from Google Analytics, and live chat support.'
 		),
 	getNewsletterSignupFeatures: () => [
-		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_PAYMENT_TRANSACTION_FEES_4,
 		FEATURE_LIVE_CHAT_SUPPORT,
 		FEATURE_STYLE_CUSTOMIZATION,
 		FEATURE_PREMIUM_THEMES_V2,
 		FEATURE_UNLTD_SOCIAL_MEDIA_JP,
 		FEATURE_VIDEOPRESS_JP,
-		FEATURE_PAYMENT_TRANSACTION_FEES_4,
 	],
 	getNewsletterHighlightedFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Based on feedback, this PR moves import and pricing features to the top on the Plans selection page for newsletters (specifically features named 'Import up to 100 subscribers', 'Import unlimited subscribers', and all the tasks with 'transaction fee for payments'.

While doing this, I removed the 'Free Domain for One Year' feature from the last column, since it is already in the second column, and the third column says 'Everything in Personal, Plus'...

A [follow up PR](https://github.com/Automattic/wp-calypso/pull/81247) will also highlight these same features. See screenshot in that PR for final appearance of the plans table.

**Before**
<img width="1088" alt="newsletter-plans-before" src="https://github.com/Automattic/wp-calypso/assets/21228350/0351a57b-e162-4b49-97c0-b4bb6027abee">

**After**
<img width="1056" alt="newsletter-plans-after" src="https://github.com/Automattic/wp-calypso/assets/21228350/d611de3b-34b2-4a00-9cce-ce452655e874">

## Testing Instructions

1) Checkout this branch and start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro
2) Proceed to plans page and confirm that order is updated as above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
