### PR TITLE
Plans: Highlight newsletter import/pricing features

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/plan-features-container.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-features-container.tsx
@@ -17,6 +17,7 @@ const PlanFeaturesContainer: React.FC< {
 	selectedFeature?: string;
 	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >; // indicate when a custom domain is allowed to be used with the Free plan.
 	isTableCell: boolean | undefined;
+	flowName?: string | null;
 } > = ( {
 	plansWithFeatures,
 	paidDomainName,
@@ -26,6 +27,7 @@ const PlanFeaturesContainer: React.FC< {
 	selectedFeature,
 	isCustomDomainAllowedOnFreePlan,
 	isTableCell,
+	flowName,
 } ) => {
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 
@@ -47,6 +49,7 @@ const PlanFeaturesContainer: React.FC< {
 						isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
 						setActiveTooltipId={ setActiveTooltipId }
 						activeTooltipId={ activeTooltipId }
+						flowName={ flowName }
 					/>
 					{ jetpackFeatures.length !== 0 && (
 						<div className="plan-features-2023-grid__jp-logo" key="jp-logo">

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -614,6 +614,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			selectedFeature,
 			wpcomFreeDomainSuggestion,
 			isCustomDomainAllowedOnFreePlan,
+			flowName,
 		} = this.props;
 		const plansWithFeatures = renderedGridPlans.filter(
 			( gridPlan ) =>
@@ -623,6 +624,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 
 		return (
 			<PlanFeaturesContainer
+				flowName={ flowName }
 				plansWithFeatures={ plansWithFeatures }
 				paidDomainName={ paidDomainName }
 				wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Follow up to https://github.com/Automattic/wp-calypso/pull/81245. Merge that PR first.
* Ensures that import and pricing features for Newsletter sites are highlighted on the Plans screen

<img width="1111" alt="plans-after" src="https://github.com/Automattic/wp-calypso/assets/21228350/4cc5e58d-adbe-4c95-9f37-c6d2e3d9709f">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Checkout this branch and start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro
2) Proceed to plans page and confirm the feature list looks like above (note: if you test before https://github.com/Automattic/wp-calypso/pull/81245 is merged, the right features will be highlighted, but will not all be at the top of the list). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
