### PR TITLE
Localize the links to support documents on https://wordpress.com/subscribers

### DIFF
--- a/client/my-sites/subscribers/components/empty-list-view/empty-list-view.tsx
+++ b/client/my-sites/subscribers/components/empty-list-view/empty-list-view.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Card, CardBody, Icon } from '@wordpress/components';
 import { chartBar, chevronRight, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -40,17 +41,21 @@ const EmptyListView = () => {
 			<EmptyListCTALink
 				icon={ chartBar }
 				text={ translate( 'Turn your visitors into subscribers' ) }
-				url="https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/"
+				url={ localizeUrl(
+					'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/'
+				) }
 			/>
 			<EmptyListCTALink
 				icon={ people }
 				text={ translate( 'Import existing subscribers' ) }
-				url="https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/"
+				url={ localizeUrl(
+					'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/'
+				) }
 			/>
 			<EmptyListCTALink
 				icon={ trendingUp }
 				text={ translate( 'Grow your audience' ) }
-				url="https://wordpress.com/support/category/grow-your-audience/"
+				url={ localizeUrl( 'https://wordpress.com/support/category/grow-your-audience/' ) }
 			/>
 		</div>
 	);

--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Card, CardBody, Icon } from '@wordpress/components';
 import { chartBar, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -48,7 +49,9 @@ const GrowYourAudience = () => {
 						'Using a subscriber block is the first step to growing your audience.'
 					) }
 					title={ translate( 'Every visitor is a potential subscriber' ) }
-					url="https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/"
+					url={ localizeUrl(
+						'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/'
+					) }
 				/>
 
 				<GrowYourAudienceCard
@@ -57,7 +60,7 @@ const GrowYourAudience = () => {
 						'Create fresh content, publish regularly, and understand your audience with site stats.'
 					) }
 					title={ translate( 'Keep your readers engaged' ) }
-					url="https://wordpress.com/go/content-blogging/how-to-start-a-successful-blog-that-earns-links-traffic-and-revenue/#creating-a-blog-content-strategy"
+					url="https://wordpress.com/go/content-blogging/how-to-start-a-successful-blog-that-earns-links-traffic-and-revenue/#creating-a-blog-content-strategy" // eslint-disable-line wpcalypso/i18n-unlocalized-url
 				/>
 
 				<GrowYourAudienceCard


### PR DESCRIPTION
Related to 673-gh-Automattic/i18n-issues

## Proposed Changes

* Wrap the links to support documents on https://wordpress.com/subscribers in localizeUrl calls so that they'd point to the correct version for each language.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch your profile to a Mag-16 locale.
* On calypso.live or a local instance open /subscribers.
* Select a site with no subscribers and confirm that the three links to support documents/categories are fully localized.
* Repeat with a site which has subscribers and confirm that there is a link to a localized support document, a link to an English /go article and a link to /earn.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?