### PR TITLE
Domain Management i1: Remove wpcom subdomains from bulk update selection

### DIFF
--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -127,15 +127,17 @@ export function DomainsTableRow( {
 	return (
 		<tr key={ domain.domain } ref={ ref }>
 			<td>
-				<CheckboxControl
-					__nextHasNoMarginBottom
-					checked={ isSelected }
-					onChange={ () => onSelect( domain ) }
-					/* translators: Label for a checkbox control that selects a domain name.*/
-					aria-label={ sprintf( __( 'Tick box for %(domain)s', __i18n_text_domain__ ), {
-						domain: domain.domain,
-					} ) }
-				/>
+				{ ! domain.wpcom_domain && (
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						checked={ isSelected }
+						onChange={ () => onSelect( domain ) }
+						/* translators: Label for a checkbox control that selects a domain name.*/
+						aria-label={ sprintf( __( 'Tick box for %(domain)s', __i18n_text_domain__ ), {
+							domain: domain.domain,
+						} ) }
+					/>
+				) }
 			</td>
 			<td>
 				{ shouldDisplayPrimaryDomainLabel && <PrimaryDomainLabel /> }

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -171,7 +171,8 @@ export function DomainsTable( {
 	};
 
 	const hasSelectedDomains = selectedDomains.size > 0;
-	const areAllDomainsSelected = domains.length === selectedDomains.size;
+	const areAllDomainsSelected =
+		domains.filter( ( domain ) => ! domain.wpcom_domain ).length === selectedDomains.size;
 
 	const getBulkSelectionStatus = () => {
 		if ( hasSelectedDomains && areAllDomainsSelected ) {
@@ -188,7 +189,9 @@ export function DomainsTable( {
 	const changeBulkSelection = () => {
 		if ( filter.query ) {
 			if ( ! hasSelectedDomains ) {
-				setSelectedDomains( new Set( filteredData.map( getDomainId ) ) );
+				setSelectedDomains(
+					new Set( filteredData.filter( ( domain ) => ! domain.wpcom_domain ).map( getDomainId ) )
+				);
 			} else {
 				setSelectedDomains( new Set() );
 			}
@@ -197,7 +200,10 @@ export function DomainsTable( {
 		}
 
 		if ( ! hasSelectedDomains || ! areAllDomainsSelected ) {
-			setSelectedDomains( new Set( domains.map( getDomainId ) ) );
+			// filter out wpcom domains from bulk selection
+			setSelectedDomains(
+				new Set( domains.filter( ( domain ) => ! domain.wpcom_domain ).map( getDomainId ) )
+			);
 		} else {
 			setSelectedDomains( new Set() );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/3563

## Proposed Changes

This PR removes `*wordpress.com` and `*wpcomstaging ` subdomains from being part of bulk selection.
WPCOM domains are only shown in site-specific domains table

* Do not show selection checkbox for wpcom subdomains
* Remove those domains from bulk selection 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to` /domains/manage/siteSlug?flags=domains/management`
* Verify selection checkbox is not shown for wpcom subdomains 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?