### PR TITLE
Jetpack E2E: add spec for Jetpack Blaze.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/advertising-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/advertising-page.ts
@@ -38,24 +38,42 @@ export class AdvertisingPage {
 	}
 
 	/**
-	 * Clicks on a button with the accessible name matching the supplied parameter `name`.
+	 * Clicks on a button with the accessible name matching supplied parameter `name`,
+	 * narrowed down by either one of the following parameters.
 	 *
-	 * If the optional parameter `row` is specified, this method will look for a button
+	 * If the parameter `row` is specified, this method will look for a button
 	 * in a specific row. Rows are 0-indexed.
+	 *
+	 * Alternatively, if the parameter `postTitle` is defined, this method will
+	 * click on the button matching the accessible name found in a row with the matching
+	 * post title.
+	 *
+	 * If neither is defined, an error is thrown.
 	 *
 	 * @param {string} name Accessible name of the button.
 	 * @param param1 Keyed object parameter.
 	 * @param {number} [param1.row] Row number to look for the button. 0-indexed.
+	 * @param {string} [param1.postTitle] Post title to locate the button by.
+	 * @throws {Error} If neither `postTitle` or `row` is defined.
 	 */
-	async clickButton( name: string, { row }: { row?: number } = {} ) {
-		if ( row !== undefined ) {
+	async clickButtonByNameOnRow(
+		name: string,
+		{ row, postTitle }: { row?: number; postTitle?: string } = {}
+	) {
+		if ( row !== undefined && row >= 0 ) {
 			await this.page
 				.getByRole( 'row' )
 				.nth( row + 1 ) // The header row is counted as one row.
 				.getByRole( 'button', { name: name } )
 				.click();
+		} else if ( postTitle ) {
+			await this.page
+				.getByRole( 'row' )
+				.filter( { hasText: postTitle } )
+				.getByRole( 'button', { name: name } )
+				.click();
 		} else {
-			await this.page.getByRole( 'button', { name: name } ).click();
+			throw new Error( `Must pass in either row or postTitle.` );
 		}
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/advertising-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/advertising-page.ts
@@ -1,0 +1,61 @@
+import { Page } from 'playwright';
+import { getCalypsoURL } from '../../data-helper';
+import { clickNavTab } from '../../element-helper';
+
+type AdvertisingTab = 'Ready to promote' | 'Campaigns';
+
+/**
+ * Page representing the Tools > Advertising page.
+ */
+export class AdvertisingPage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Navigates directly to the Advertising page for the site.
+	 *
+	 * @param {string} siteSlug Site slug.
+	 */
+	async visit( siteSlug: string ) {
+		await this.page.goto( getCalypsoURL( `advertising/${ siteSlug }` ) );
+	}
+
+	/**
+	 * Click on the tab name matching the given parameter `name`.
+	 *
+	 * @param {AdvertisingTab} name Name of the tab to click on the top of the page.
+	 */
+	async clickTab( name: AdvertisingTab ) {
+		await clickNavTab( this.page, name );
+	}
+
+	/**
+	 * Clicks on a button with the accessible name matching the supplied parameter `name`.
+	 *
+	 * If the optional parameter `row` is specified, this method will look for a button
+	 * in a specific row. Rows are 0-indexed.
+	 *
+	 * @param {string} name Accessible name of the button.
+	 * @param param1 Keyed object parameter.
+	 * @param {number} [param1.row] Row number to look for the button. 0-indexed.
+	 */
+	async clickButton( name: string, { row }: { row?: number } = {} ) {
+		if ( row !== undefined ) {
+			await this.page
+				.getByRole( 'row' )
+				.nth( row + 1 ) // The header row is counted as one row.
+				.getByRole( 'button', { name: name } )
+				.click();
+		} else {
+			await this.page.getByRole( 'button', { name: name } ).click();
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
@@ -1,0 +1,62 @@
+import { Page } from 'playwright';
+import { TestFile } from '../../types';
+
+/**
+ * Page representing the Blaze Campaign page (/advertising/posts).
+ */
+export class BlazeCampaignPage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Clicks on a button with the accessible name matching the supplied parameter `name`.
+	 *
+	 * @param {string} name Accessible name of the button.
+	 */
+	async clickButton( name: string ) {
+		await this.page.getByRole( 'button', { name: name } ).click();
+	}
+
+	/**
+	 * Enters text into any text field, except for the secure payment details fields.
+	 *
+	 * @param {string} name Accessible name of the target text field.
+	 * @param {string} text Text to enter.
+	 */
+	async enterText( name: string, text: string ) {
+		await this.page.getByRole( 'textbox', { name: name } ).fill( text );
+	}
+
+	/**
+	 * Uploads the specified image to the Blaze campaign image.
+	 *
+	 * @param {TestFile} path TestFile object.
+	 */
+	async uploadImage( path: TestFile ) {
+		await this.page
+			.getByLabel( 'Click or drag an image here to upload.' )
+			.setInputFiles( path.fullpath );
+
+		await this.page.getByRole( 'region', { name: 'Appearance' } ).locator( 'img' ).waitFor();
+	}
+
+	/**
+	 * Validates the expected contents are in the preview.
+	 *
+	 * @param param0 Keyed object parameter.
+	 * @param {string} param0.title Expected title.
+	 * @param {string} param0.snippet Expected snippet.
+	 */
+	async validatePreview( { title, snippet }: { title: string; snippet: string } ) {
+		await this.page.locator( '.grid-widget-summary' ).getByText( title ).waitFor();
+		await this.page.locator( '.grid-widget-summary' ).getByText( snippet ).waitFor();
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -31,6 +31,8 @@ export * from './use-a-domain-i-own-page';
 export * from './woocommerce-landing-page';
 export * from './writing-settings-page';
 export * from './wp-admin-media-settings-page';
+export * from './advertising-page';
+export * from './blaze-campaign-page';
 
 export * from './external';
 export * from './me';

--- a/test/e2e/specs/tools/advertising__promote.ts
+++ b/test/e2e/specs/tools/advertising__promote.ts
@@ -1,0 +1,75 @@
+/**
+ * @group calypso-pr
+ * @group jetpack-wpcom-integration
+ */
+
+import {
+	getTestAccountByFeature,
+	envToFeatureKey,
+	envVariables,
+	DataHelper,
+	SidebarComponent,
+	AdvertisingPage,
+	TestAccount,
+	MediaHelper,
+} from '@automattic/calypso-e2e';
+import { BlazeCampaignPage } from '@automattic/calypso-e2e/src/lib/pages/blaze-campaign-page';
+import { Page, Browser } from 'playwright';
+import { TEST_IMAGE_PATH } from '../constants';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Advertising: Promote' ), function () {
+	const pageTitle = DataHelper.getRandomPhrase();
+	const snippet = Array( 5 ).fill( DataHelper.getRandomPhrase() ).toString();
+	let page: Page;
+	let testAccount: TestAccount;
+	let advertisingPage: AdvertisingPage;
+	let blazeCampaignPage: BlazeCampaignPage;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+
+		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+		testAccount = new TestAccount( accountName );
+		await testAccount.authenticate( page );
+
+		advertisingPage = new AdvertisingPage( page );
+	} );
+
+	it( 'Navigate to Tools > Advertising page', async function () {
+		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
+			await advertisingPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+		} else {
+			const sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Tools', 'Advertising' );
+		}
+	} );
+
+	it( 'Click on Promote for the first post', async function () {
+		await advertisingPage.clickButton( 'Promote', { row: 0 } );
+	} );
+
+	it( 'Land in Blaze campaign landing page', async function () {
+		await page.waitForURL( /advertising/ );
+		blazeCampaignPage = new BlazeCampaignPage( page );
+	} );
+
+	it( 'Click on Get started', async function () {
+		await blazeCampaignPage.clickButton( 'Get started' );
+	} );
+
+	it( 'Upload image', async function () {
+		const testFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
+		await blazeCampaignPage.uploadImage( testFile );
+	} );
+
+	it( 'Enter title and snippet', async function () {
+		await blazeCampaignPage.enterText( 'Page title', pageTitle );
+		await blazeCampaignPage.enterText( 'Article Snippet', snippet );
+	} );
+
+	it( 'Validate preview', async function () {
+		await blazeCampaignPage.validatePreview( { title: pageTitle, snippet: snippet } );
+	} );
+} );

--- a/test/e2e/specs/tools/advertising__promote.ts
+++ b/test/e2e/specs/tools/advertising__promote.ts
@@ -25,6 +25,10 @@ declare const browser: Browser;
 /**
  * Walks through the Advertising/Blaze flow until immediately prior to the checkout.
  *
+ * The actual checkout is outside the scope of this spec.
+ *
+ * @see pdWQjU-rL-p2#comment-575.
+ *
  * Keywords: Jetpack, Blaze, Advertising
  */
 skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(

--- a/test/e2e/specs/tools/advertising__promote.ts
+++ b/test/e2e/specs/tools/advertising__promote.ts
@@ -12,64 +12,74 @@ import {
 	AdvertisingPage,
 	TestAccount,
 	MediaHelper,
+	BlazeCampaignPage,
 } from '@automattic/calypso-e2e';
-import { BlazeCampaignPage } from '@automattic/calypso-e2e/src/lib/pages/blaze-campaign-page';
 import { Page, Browser } from 'playwright';
+import { skipDescribeIf } from '../../jest-helpers';
 import { TEST_IMAGE_PATH } from '../constants';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Advertising: Promote' ), function () {
-	const pageTitle = DataHelper.getRandomPhrase();
-	const snippet = Array( 5 ).fill( DataHelper.getRandomPhrase() ).toString();
-	let page: Page;
-	let testAccount: TestAccount;
-	let advertisingPage: AdvertisingPage;
-	let blazeCampaignPage: BlazeCampaignPage;
+/**
+ * Walks through the Advertising/Blaze flow until immediately prior to the checkout.
+ *
+ * Keywords: Jetpack, Blaze, Advertising
+ */
+skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
+	DataHelper.createSuiteTitle( 'Advertising: Promote' ),
+	function () {
+		const pageTitle = DataHelper.getRandomPhrase();
+		const snippet = Array( 5 ).fill( DataHelper.getRandomPhrase() ).toString();
 
-	beforeAll( async () => {
-		page = await browser.newPage();
+		let page: Page;
+		let testAccount: TestAccount;
+		let advertisingPage: AdvertisingPage;
+		let blazeCampaignPage: BlazeCampaignPage;
 
-		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
-		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		beforeAll( async () => {
+			page = await browser.newPage();
 
-		advertisingPage = new AdvertisingPage( page );
-	} );
+			const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+			testAccount = new TestAccount( accountName );
+			await testAccount.authenticate( page );
 
-	it( 'Navigate to Tools > Advertising page', async function () {
-		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
-			await advertisingPage.visit( testAccount.getSiteURL( { protocol: false } ) );
-		} else {
-			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.navigate( 'Tools', 'Advertising' );
-		}
-	} );
+			advertisingPage = new AdvertisingPage( page );
+		} );
 
-	it( 'Click on Promote for the first post', async function () {
-		await advertisingPage.clickButton( 'Promote', { row: 0 } );
-	} );
+		it( 'Navigate to Tools > Advertising page', async function () {
+			if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
+				await advertisingPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+			} else {
+				const sidebarComponent = new SidebarComponent( page );
+				await sidebarComponent.navigate( 'Tools', 'Advertising' );
+			}
+		} );
 
-	it( 'Land in Blaze campaign landing page', async function () {
-		await page.waitForURL( /advertising/ );
-		blazeCampaignPage = new BlazeCampaignPage( page );
-	} );
+		it( 'Click on Promote for the first post', async function () {
+			await advertisingPage.clickButton( 'Promote', { row: 0 } );
+		} );
 
-	it( 'Click on Get started', async function () {
-		await blazeCampaignPage.clickButton( 'Get started' );
-	} );
+		it( 'Land in Blaze campaign landing page', async function () {
+			await page.waitForURL( /advertising/ );
+			blazeCampaignPage = new BlazeCampaignPage( page );
+		} );
 
-	it( 'Upload image', async function () {
-		const testFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
-		await blazeCampaignPage.uploadImage( testFile );
-	} );
+		it( 'Click on Get started', async function () {
+			await blazeCampaignPage.clickButton( 'Get started' );
+		} );
 
-	it( 'Enter title and snippet', async function () {
-		await blazeCampaignPage.enterText( 'Page title', pageTitle );
-		await blazeCampaignPage.enterText( 'Article Snippet', snippet );
-	} );
+		it( 'Upload image', async function () {
+			const testFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
+			await blazeCampaignPage.uploadImage( testFile );
+		} );
 
-	it( 'Validate preview', async function () {
-		await blazeCampaignPage.validatePreview( { title: pageTitle, snippet: snippet } );
-	} );
-} );
+		it( 'Enter title and snippet', async function () {
+			await blazeCampaignPage.enterText( 'Page title', pageTitle );
+			await blazeCampaignPage.enterText( 'Article Snippet', snippet );
+		} );
+
+		it( 'Validate preview', async function () {
+			await blazeCampaignPage.validatePreview( { title: pageTitle, snippet: snippet } );
+		} );
+	}
+);


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80730.

## Proposed Changes

This PR adds a new spec to test the Blaze dashboard and part of the process of Blazing a post.

Key flows:
- Tools > Advertising dashboard loading.
- entering details to Blaze a post.


## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?