### PR TITLE
Don't show checkbox is not selectable

### DIFF
--- a/packages/domains-table/src/domains-table-header/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table-header/__tests__/index.tsx
@@ -37,11 +37,13 @@ test( 'domain columns are rendered in the header', () => {
 			onChangeSortOrder={ jest.fn() }
 			bulkSelectionStatus="no-domains"
 			onBulkSelectionChange={ noop }
+			canSelectAnyDomains
 		/>
 	);
 
 	expect( screen.queryByText( 'Domain' ) ).toBeInTheDocument();
 	expect( screen.queryByText( 'Status' ) ).toBeInTheDocument();
+	expect( screen.queryByTestId( 'domains-select-all-checkbox' ) ).toBeInTheDocument();
 } );
 
 test( 'renders custom header component', () => {
@@ -105,4 +107,20 @@ test( 'columns that are not sortable do not renders a chevron', () => {
 
 	const chevronIcon = statusHeader.parentElement?.querySelector( 'svg' );
 	expect( chevronIcon ).not.toBeInTheDocument();
+} );
+
+test( 'no checkbox is rendered if no domains are selectable', () => {
+	render(
+		<DomainsTableHeader
+			columns={ domainsTableColumns }
+			activeSortKey="domain"
+			activeSortDirection="asc"
+			onChangeSortOrder={ jest.fn() }
+			bulkSelectionStatus="no-domains"
+			onBulkSelectionChange={ noop }
+			canSelectAnyDomains={ false }
+		/>
+	);
+
+	expect( screen.queryByTestId( 'domain-select-all-checkbox' ) ).not.toBeInTheDocument();
 } );

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -66,6 +66,7 @@ export const DomainsTableHeader = ( {
 	headerClasses,
 	hideOwnerColumn = false,
 	domainsRequiringAttention,
+	canSelectAnyDomains,
 }: DomainsTableHeaderProps ) => {
 	const { __ } = useI18n();
 	const listHeaderClasses = classNames( 'domains-table-header', headerClasses );
@@ -89,13 +90,18 @@ export const DomainsTableHeader = ( {
 		<thead className={ listHeaderClasses }>
 			<tr>
 				<th className="domains-table__bulk-action-container">
-					<CheckboxControl
-						__nextHasNoMarginBottom
-						onChange={ onBulkSelectionChange }
-						indeterminate={ bulkSelectionStatus === 'some-domains' }
-						checked={ bulkSelectionStatus === 'all-domains' }
-						aria-label={ __( 'Select all tick boxes for domains in table', __i18n_text_domain__ ) }
-					/>
+					{ canSelectAnyDomains && (
+						<CheckboxControl
+							__nextHasNoMarginBottom
+							onChange={ onBulkSelectionChange }
+							indeterminate={ bulkSelectionStatus === 'some-domains' }
+							checked={ bulkSelectionStatus === 'all-domains' }
+							aria-label={ __(
+								'Select all tick boxes for domains in table',
+								__i18n_text_domain__
+							) }
+						/>
+					) }
 				</th>
 
 				{ columns.map( ( column ) => {

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -54,6 +54,7 @@ type DomainsTableHeaderProps = {
 	headerClasses?: string;
 	hideOwnerColumn?: boolean;
 	domainsRequiringAttention?: number;
+	canSelectAnyDomains?: boolean;
 };
 
 export const DomainsTableHeader = ( {
@@ -66,7 +67,7 @@ export const DomainsTableHeader = ( {
 	headerClasses,
 	hideOwnerColumn = false,
 	domainsRequiringAttention,
-	canSelectAnyDomains,
+	canSelectAnyDomains = true,
 }: DomainsTableHeaderProps ) => {
 	const { __ } = useI18n();
 	const listHeaderClasses = classNames( 'domains-table-header', headerClasses );
@@ -92,6 +93,7 @@ export const DomainsTableHeader = ( {
 				<th className="domains-table__bulk-action-container">
 					{ canSelectAnyDomains && (
 						<CheckboxControl
+							data-testid="domains-select-all-checkbox"
 							__nextHasNoMarginBottom
 							onChange={ onBulkSelectionChange }
 							indeterminate={ bulkSelectionStatus === 'some-domains' }

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -172,8 +172,9 @@ export function DomainsTable( {
 	};
 
 	const hasSelectedDomains = selectedDomains.size > 0;
-	const areAllDomainsSelected =
-		domains.filter( ( domain ) => ! domain.wpcom_domain ).length === selectedDomains.size;
+	const selectableDomains = domains.filter( ( domain ) => ! domain.wpcom_domain );
+	const canSelectAnyDomains = selectableDomains.length > 0;
+	const areAllDomainsSelected = selectableDomains.length === selectedDomains.size;
 
 	const getBulkSelectionStatus = () => {
 		if ( hasSelectedDomains && areAllDomainsSelected ) {
@@ -245,6 +246,7 @@ export function DomainsTable( {
 					onChangeSortOrder={ onSortChange }
 					hideOwnerColumn={ hideOwnerColumn }
 					domainsRequiringAttention={ domainsRequiringAttention }
+					canSelectAnyDomains={ canSelectAnyDomains }
 				/>
 				<tbody>
 					{ filteredData.map( ( domain ) => (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/81249

## Proposed Changes

* Don't show checkbox if no rows are selectable. This commit was supposed to have been added to https://github.com/Automattic/wp-calypso/pull/81249 but I forgot to hit "push". 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See https://github.com/Automattic/wp-calypso/pull/81249

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?