### PR TITLE
Paid Stats: Apply commercial site detection to Notice Banners

### DIFF
--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -56,14 +56,17 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 			const showUpgradeNoticeForJetpackNotAtomic =
 				config.isEnabled( 'stats/paid-stats' ) && isSiteJetpackNotAtomic;
 
-			return !! (
-				( showUpgradeNoticeOnOdyssey ||
-					showUpgradeNoticeForJetpackNotAtomic ||
-					showUpgradeNoticeForWpcomSites ) &&
-				// Show the notice if the site has not purchased the paid stats product.
-				! hasPaidStats &&
-				// Show the notice only if the site is commercial.
-				isCommercial
+			return (
+				config.isEnabled( 'stats/type-detection' ) &&
+				!! (
+					( showUpgradeNoticeOnOdyssey ||
+						showUpgradeNoticeForJetpackNotAtomic ||
+						showUpgradeNoticeForWpcomSites ) &&
+					// Show the notice if the site has not purchased the paid stats product.
+					! hasPaidStats &&
+					// Show the notice only if the site is commercial.
+					isCommercial
+				)
 			);
 		},
 		disabled: false,
@@ -102,7 +105,8 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 				// Show the notice if the site has not purchased the paid stats product.
 				! hasPaidStats &&
 				// Show the notice if the site is not commercial.
-				! isCommercial
+				config.isEnabled( 'stats/type-detection' ) &&
+				( ! isCommercial || ! config.isEnabled( 'stats/type-detection' ) )
 			);
 		},
 		disabled: false,

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -30,8 +30,8 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 		disabled: false,
 	},
 	{
-		component: DoYouLoveJetpackStatsNotice,
-		noticeId: 'do_you_love_jetpack_stats',
+		component: CommercialSiteUpgradeNotice,
+		noticeId: 'commercial_site_upgrade',
 		isVisibleFunc: ( {
 			isOdysseyStats,
 			isWpcom,
@@ -40,6 +40,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 			isOwnedByTeam51,
 			hasPaidStats,
 			isSiteJetpackNotAtomic,
+			isCommercial,
 		}: StatsNoticeProps ) => {
 			// Gate notices for WPCOM sites behind a flag.
 			const showUpgradeNoticeForWpcomSites =
@@ -60,16 +61,51 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 					showUpgradeNoticeForJetpackNotAtomic ||
 					showUpgradeNoticeForWpcomSites ) &&
 				// Show the notice if the site has not purchased the paid stats product.
-				! hasPaidStats
+				! hasPaidStats &&
+				// Show the notice only if the site is commercial.
+				isCommercial
 			);
 		},
 		disabled: false,
 	},
 	{
-		component: CommercialSiteUpgradeNotice,
-		noticeId: 'commercial_site_upgrade',
-		isVisibleFunc: () => false, // prevent accidental display of notice for now
-		disabled: true, // prevent accidental display of notice for now
+		component: DoYouLoveJetpackStatsNotice,
+		noticeId: 'do_you_love_jetpack_stats',
+		isVisibleFunc: ( {
+			isOdysseyStats,
+			isWpcom,
+			isVip,
+			isP2,
+			isOwnedByTeam51,
+			hasPaidStats,
+			isSiteJetpackNotAtomic,
+			isCommercial,
+		}: StatsNoticeProps ) => {
+			// Gate notices for WPCOM sites behind a flag.
+			const showUpgradeNoticeForWpcomSites =
+				config.isEnabled( 'stats/paid-wpcom-stats' ) &&
+				isWpcom &&
+				! isVip &&
+				! isP2 &&
+				! isOwnedByTeam51;
+
+			// Show the notice if the site is Jetpack or it is Odyssey Stats.
+			const showUpgradeNoticeOnOdyssey = config.isEnabled( 'stats/paid-stats' ) && isOdysseyStats;
+
+			const showUpgradeNoticeForJetpackNotAtomic =
+				config.isEnabled( 'stats/paid-stats' ) && isSiteJetpackNotAtomic;
+
+			return !! (
+				( showUpgradeNoticeOnOdyssey ||
+					showUpgradeNoticeForJetpackNotAtomic ||
+					showUpgradeNoticeForWpcomSites ) &&
+				// Show the notice if the site has not purchased the paid stats product.
+				! hasPaidStats &&
+				// Show the notice if the site is not commercial.
+				! isCommercial
+			);
+		},
+		disabled: false,
 	},
 ];
 

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -105,8 +105,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 				// Show the notice if the site has not purchased the paid stats product.
 				! hasPaidStats &&
 				// Show the notice if the site is not commercial.
-				config.isEnabled( 'stats/type-detection' ) &&
-				( ! isCommercial || ! config.isEnabled( 'stats/type-detection' ) )
+				( ! config.isEnabled( 'stats/type-detection' ) || ! isCommercial )
 			);
 		},
 		disabled: false,

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -56,20 +56,17 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 			const showUpgradeNoticeForJetpackNotAtomic =
 				config.isEnabled( 'stats/paid-stats' ) && isSiteJetpackNotAtomic;
 
-			return (
-				config.isEnabled( 'stats/type-detection' ) &&
-				!! (
-					( showUpgradeNoticeOnOdyssey ||
-						showUpgradeNoticeForJetpackNotAtomic ||
-						showUpgradeNoticeForWpcomSites ) &&
-					// Show the notice if the site has not purchased the paid stats product.
-					! hasPaidStats &&
-					// Show the notice only if the site is commercial.
-					isCommercial
-				)
+			return !! (
+				( showUpgradeNoticeOnOdyssey ||
+					showUpgradeNoticeForJetpackNotAtomic ||
+					showUpgradeNoticeForWpcomSites ) &&
+				// Show the notice if the site has not purchased the paid stats product.
+				! hasPaidStats &&
+				// Show the notice only if the site is commercial.
+				isCommercial
 			);
 		},
-		disabled: false,
+		disabled: ! config.isEnabled( 'stats/type-detection' ),
 	},
 	{
 		component: DoYouLoveJetpackStatsNotice,

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -113,7 +113,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 			{ ALL_STATS_NOTICES.map(
 				( notice ) =>
 					calculatedNoticesVisibility[ notice.noticeId ] && (
-						<notice.component { ...noticeOptions } />
+						<notice.component key={ notice.noticeId } { ...noticeOptions } />
 					)
 			) }
 		</>

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -47,6 +47,9 @@ const ensureOnlyOneNoticeVisible = (
 const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: StatsNoticesProps ) => {
 	const dispatch = useDispatch();
 
+	// find out if a site is commerical or not
+	const isCommercial = useSelector( ( state ) => getSiteOption( state, siteId, 'is_commercial' ) );
+
 	// Clear loaded flag when switching sites on Calypso.
 	const [ currentSiteId, setCurrentSiteId ] = useState( siteId );
 	useEffect( () => {
@@ -84,6 +87,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		hasFreeStats,
 		isSiteJetpackNotAtomic,
 		statsPurchaseSuccess,
+		isCommercial,
 	};
 
 	const { isLoading, isError, data: serverNoticesVisibility } = useNoticesVisibilityQuery( siteId );

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -48,10 +48,9 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 	const dispatch = useDispatch();
 
 	// find out if a site is commerical or not. handle potential null value as a false
-	const isCommercialRaw = useSelector( ( state ) =>
+	const isCommercial = !! useSelector( ( state ) =>
 		getSiteOption( state, siteId, 'is_commercial' )
 	);
-	const isCommercial = isCommercialRaw === null ? false : Boolean( isCommercialRaw );
 
 	// Clear loaded flag when switching sites on Calypso.
 	const [ currentSiteId, setCurrentSiteId ] = useState( siteId );

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -48,8 +48,8 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 	const dispatch = useDispatch();
 
 	// find out if a site is commerical or not. handle potential null value as a false
-	const isCommercial = !! useSelector( ( state ) =>
-		getSiteOption( state, siteId, 'is_commercial' )
+	const isCommercial = useSelector(
+		( state ) => !! getSiteOption( state, siteId, 'is_commercial' )
 	);
 
 	// Clear loaded flag when switching sites on Calypso.

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -47,8 +47,11 @@ const ensureOnlyOneNoticeVisible = (
 const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: StatsNoticesProps ) => {
 	const dispatch = useDispatch();
 
-	// find out if a site is commerical or not
-	const isCommercial = useSelector( ( state ) => getSiteOption( state, siteId, 'is_commercial' ) );
+	// find out if a site is commerical or not. handle potential null value as a false
+	const isCommercialRaw = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'is_commercial' )
+	);
+	const isCommercial = isCommercialRaw === null ? false : Boolean( isCommercialRaw );
 
 	// Clear loaded flag when switching sites on Calypso.
 	const [ currentSiteId, setCurrentSiteId ] = useState( siteId );

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -16,6 +16,7 @@ export interface StatsNoticeProps {
 	hasFreeStats?: boolean;
 	isSiteJetpackNotAtomic?: boolean;
 	statsPurchaseSuccess?: string;
+	isCommercial?: boolean;
 }
 
 export interface NoticeBodyProps {
@@ -31,4 +32,5 @@ export interface StatsNoticesProps {
 	siteId: number | null;
 	isOdysseyStats: boolean;
 	statsPurchaseSuccess?: string;
+	isCommercial?: boolean;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81058

## Proposed Changes

* This PR applies commercial site detection to control the display logic for the commercial sites upgrade banner

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  You can force the `isCommercial` value to true In `/my-sites/stats/stats-notices/index.tsx` lines `50-53` by replacing the following:
```
// find out if a site is commerical or not. handle potential null value as a false
const isCommercial = !! useSelector( ( state ) =>
getSiteOption( state, siteId, 'is_commercial' )
);
```
with:
```
const isCommercial = true;
```
* visit the URL `/stats/day/{site_URL}?flag=stats/type-detection`
* confirm you are seeing the commercial sites upgrade notice:
![image](https://github.com/Automattic/wp-calypso/assets/30754158/8c18d297-7559-4580-a7f9-84c4378232b6)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?