### PR TITLE
Jetpack E2E: Paywall block.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/donations-form.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/donations-form.ts
@@ -91,7 +91,7 @@ export class DonationsFormFlow implements BlockFlow {
 			.click();
 
 		// Verify the donation popup.
-		// For sitse with plans Premium or lower, the block cannot be used and so the popup modal
+		// For sites with plans Premium or lower, the block cannot be used and so the popup modal
 		// states as such.
 		// For sites where sales are allowed, ther are two variants in how this flow can behave:
 		// 	1. on normal, user-controlled browsers, a Stripe-powered overlay appears.

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/donations-form.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/donations-form.ts
@@ -105,5 +105,8 @@ export class DonationsFormFlow implements BlockFlow {
 				.frameLocator( 'iframe[id=TB_iframeContent]' )
 				.getByRole( 'heading', { name: 'Sales disabled' } ),
 		] );
+
+		// Close the modal and return to the post.
+		await context.page.keyboard.press( 'Escape' );
 	}
 }

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -23,6 +23,7 @@ export * from './donations-form';
 export * from './all-form-fields';
 export * from './form-patterns';
 export * from './ad';
+export * from './paywall';
 
 /* Types */
 export * from './types';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paywall.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paywall.ts
@@ -71,13 +71,12 @@ export class PaywallFlow implements BlockFlow {
 			.waitFor();
 
 		// Unrelated user sees a paywall.
-		const browser = context.page.context().browser();
+		// Verify in a new browser context.
 
-		if ( ! browser ) {
-			throw new Error( `Failed to retrieve browser instance.` );
-		}
+		const publishedPostURL = context.page.url();
+
 		const newPage = await ( await browser.newContext() ).newPage();
-		await newPage.goto( context.page.url(), { waitUntil: 'domcontentloaded' } );
+		await newPage.goto( publishedPostURL, { waitUntil: 'domcontentloaded' } );
 
 		await newPage.getByRole( 'main' ).getByText( this.configurationData.prePaywallText ).waitFor();
 		await newPage

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paywall.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paywall.ts
@@ -37,12 +37,14 @@ export class PaywallFlow implements BlockFlow {
 		// pre and post-paywall text.
 		const prePaywallParagraphHandle = await context.editorPage.addBlockFromSidebar(
 			ParagraphBlock.blockName,
-			ParagraphBlock.blockEditorSelector
+			ParagraphBlock.blockEditorSelector,
+			{ noSearch: true }
 		);
 		await prePaywallParagraphHandle.fill( this.configurationData.prePaywallText );
 		const postPaywallParagraphHandle = await context.editorPage.addBlockFromSidebar(
 			ParagraphBlock.blockName,
-			ParagraphBlock.blockEditorSelector
+			ParagraphBlock.blockEditorSelector,
+			{ noSearch: true }
 		);
 		await postPaywallParagraphHandle.fill( this.configurationData.postPaywallText );
 

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paywall.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paywall.ts
@@ -40,7 +40,6 @@ export class PaywallFlow implements BlockFlow {
 			ParagraphBlock.blockEditorSelector
 		);
 		await prePaywallParagraphHandle.fill( this.configurationData.prePaywallText );
-
 		const postPaywallParagraphHandle = await context.editorPage.addBlockFromSidebar(
 			ParagraphBlock.blockName,
 			ParagraphBlock.blockEditorSelector

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paywall.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paywall.ts
@@ -1,0 +1,60 @@
+import { ParagraphBlock } from '../paragraph-block';
+import { BlockFlow, EditorContext, PublishedPostContext } from '.';
+
+const prePaywallBlockText = 'Content everyone can see';
+const postPaywallBlockText = 'Content only subscribers can see';
+
+const blockParentSelector = 'div[aria-label="Block: Paywall (beta)"]';
+
+/**
+ * Flow for the Paywall block.
+ */
+export class PaywallFlow implements BlockFlow {
+	blockSidebarName = 'Paywall (beta)';
+	blockEditorSelector = blockParentSelector;
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution.
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+
+		// Click on the post title, and hit enter.
+		// This in effect inserts a new Paragraph block immediate below
+		// the title.
+		await editorCanvas
+			.getByRole( 'textbox', {
+				name: 'Add title',
+				exact: true,
+			} )
+			.click();
+
+		// Insert a block that is not behind a paywall.
+		await context.page.keyboard.press( 'Enter' );
+
+		await context.editorPage.enterText( prePaywallBlockText );
+
+		// Click on the Paywall block, and hit enter.
+		await editorCanvas.getByRole( 'document', { name: 'Block: Paywall' } ).click();
+
+		// Insert a block that is behind a paywall and configure text.
+		const postPaywallParagraphHandle = await context.editorPage.addBlockFromSidebar(
+			ParagraphBlock.blockName,
+			ParagraphBlock.blockEditorSelector
+		);
+		await postPaywallParagraphHandle.fill( postPaywallBlockText );
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		// Publisher/owner of the post can see everything.
+		await context.page.getByText( prePaywallBlockText ).waitFor();
+		await context.page.getByText( postPaywallBlockText ).waitFor();
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paywall.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paywall.ts
@@ -45,7 +45,7 @@ export class PaywallFlow implements BlockFlow {
 			ParagraphBlock.blockName,
 			ParagraphBlock.blockEditorSelector
 		);
-		await postPaywallParagraphHandle.fill( this.configurationData.prePaywallText );
+		await postPaywallParagraphHandle.fill( this.configurationData.postPaywallText );
 
 		// Click on the Paywall block, and hit enter.
 		await editorCanvas.getByRole( 'document', { name: 'Block: Paywall' } ).click();
@@ -62,8 +62,14 @@ export class PaywallFlow implements BlockFlow {
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
 		// Publisher/owner of the post can see everything.
-		await context.page.getByText( this.configurationData.prePaywallText ).waitFor();
-		await context.page.getByText( this.configurationData.postPaywallText ).waitFor();
+		await context.page
+			.getByRole( 'main' )
+			.getByText( this.configurationData.prePaywallText )
+			.waitFor();
+		await context.page
+			.getByRole( 'main' )
+			.getByText( this.configurationData.postPaywallText )
+			.waitFor();
 
 		// Unrelated user sees a paywall.
 		const browser = context.page.context().browser();
@@ -72,11 +78,11 @@ export class PaywallFlow implements BlockFlow {
 			throw new Error( `Failed to retrieve browser instance.` );
 		}
 		const newPage = await ( await browser.newContext() ).newPage();
-		await newPage.goto( context.page.url() );
+		await newPage.goto( context.page.url(), { waitUntil: 'domcontentloaded' } );
 
-		await newPage.getByText( this.configurationData.prePaywallText ).waitFor();
-		await newPage.getByText( this.configurationData.postPaywallText ).waitFor();
+		await newPage.getByRole( 'main' ).getByText( this.configurationData.prePaywallText ).waitFor();
 		await newPage
+			.getByRole( 'main' )
 			.getByText( this.configurationData.postPaywallText )
 			.waitFor( { state: 'detached' } );
 	}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from 'playwright';
+import { Browser, Locator, Page } from 'playwright';
 import { EditorPage } from '../../pages';
 
 /**
@@ -28,5 +28,6 @@ export interface EditorContext {
  * An interface representing all the Playwright & DOM context that might be needed when validataing a block in a published post.
  */
 export interface PublishedPostContext {
+	browser: Browser;
 	page: Page;
 }

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -627,7 +627,10 @@ export class EditorPage {
 	 * @param {boolean} visit Whether to then visit the page.
 	 * @returns {URL} Published article's URL.
 	 */
-	async publish( { visit = false }: { visit?: boolean } = {} ): Promise< URL > {
+	async publish( {
+		visit = false,
+		timeout,
+	}: { visit?: boolean; timeout?: number } = {} ): Promise< URL > {
 		const publishButtonText = await this.editorToolbarComponent.getPublishButtonText();
 		const actionsArray = [];
 
@@ -649,12 +652,14 @@ export class EditorPage {
 				this.page.waitForResponse(
 					async ( response ) =>
 						/v2\/(posts|pages)\/[\d]+/.test( response.url() ) &&
-						response.request().method() === 'POST'
+						response.request().method() === 'POST',
+					{ timeout: timeout }
 				),
 				this.page.waitForResponse(
 					async ( response ) =>
 						/.*v2\/sites\/[\d]+\/(posts|pages)\/[\d]+.*/.test( response.url() ) &&
-						response.request().method() === 'PUT'
+						response.request().method() === 'PUT',
+					{ timeout: timeout }
 				),
 			] ),
 			...actionsArray,
@@ -668,7 +673,7 @@ export class EditorPage {
 		}
 
 		if ( visit ) {
-			await this.visitPublishedPost( publishedURL );
+			await this.visitPublishedPost( publishedURL, { timeout: timeout } );
 		}
 
 		return new URL( publishedURL );
@@ -732,7 +737,10 @@ export class EditorPage {
 	 *
 	 * @returns {Promise<void>} No return value.
 	 */
-	private async visitPublishedPost( url: string ): Promise< void > {
+	private async visitPublishedPost(
+		url: string,
+		{ timeout }: { timeout?: number } = {}
+	): Promise< void > {
 		// Some blocks, like "Click To Tweet" or "Logos" cause the post-publish
 		// panel to close immediately and leave the post in the unsaved state for
 		// some reason. Since the post state is unsaved, the warning dialog will be
@@ -744,7 +752,7 @@ export class EditorPage {
 		// this listener can be removed.
 		this.allowLeavingWithoutSaving();
 
-		await this.page.goto( url, { waitUntil: 'domcontentloaded' } );
+		await this.page.goto( url, { waitUntil: 'domcontentloaded', timeout: timeout } );
 
 		await reloadAndRetry( this.page, confirmPostShown );
 
@@ -761,7 +769,7 @@ export class EditorPage {
 		 * @param page
 		 */
 		async function confirmPostShown( page: Page ): Promise< void > {
-			await page.waitForSelector( '.entry-content', { timeout: 15 * 1000 } );
+			await page.getByRole( 'main' ).waitFor( { timeout: timeout } );
 		}
 	}
 

--- a/test/e2e/specs/blocks/blocks__jetpack-earn.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-earn.ts
@@ -10,6 +10,7 @@ import {
 	AdFlow,
 	envVariables,
 	PaywallFlow,
+	envVariables,
 	// PaymentsBlockFlow,
 	// envVariables,
 } from '@automattic/calypso-e2e';
@@ -23,10 +24,6 @@ const blockFlows: BlockFlow[] = [
 	} ),
 	new OpenTableFlow( {
 		restaurant: 'Miku Restaurant - Vancouver',
-	} ),
-	new PaywallFlow( {
-		prePaywallText: 'Pre-paywall text',
-		postPaywallText: 'Post-paywall text',
 	} ),
 	new DonationsFormFlow(
 		{

--- a/test/e2e/specs/blocks/blocks__jetpack-earn.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-earn.ts
@@ -9,6 +9,7 @@ import {
 	DonationsFormFlow,
 	AdFlow,
 	envVariables,
+	PaywallFlow,
 	// PaymentsBlockFlow,
 	// envVariables,
 } from '@automattic/calypso-e2e';
@@ -53,6 +54,20 @@ if (
 	envVariables.ATOMIC_VARIATION !== 'private'
 ) {
 	blockFlows.push( new AdFlow( {} ) );
+}
+
+// Private sites also do not apply to Private sites.
+if ( envVariables.ATOMIC_VARIATION !== 'private' ) {
+	// Splice instead of push because the Donations block should be the last item
+	// because clicking "Pay now" behavior is slightly unpredictable.
+	blockFlows.splice(
+		-1,
+		0,
+		new PaywallFlow( {
+			prePaywallText: 'Pre-paywall text',
+			postPaywallText: 'Post-paywall text',
+		} )
+	);
 }
 
 createBlockTests( 'Blocks: Jetpack Earn', blockFlows );

--- a/test/e2e/specs/blocks/blocks__jetpack-earn.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-earn.ts
@@ -24,6 +24,10 @@ const blockFlows: BlockFlow[] = [
 	new OpenTableFlow( {
 		restaurant: 'Miku Restaurant - Vancouver',
 	} ),
+	new PaywallFlow( {
+		prePaywallText: 'Pre-paywall text',
+		postPaywallText: 'Post-paywall text',
+	} ),
 	new DonationsFormFlow(
 		{
 			frequency: 'Yearly',

--- a/test/e2e/specs/blocks/blocks__jetpack-earn.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-earn.ts
@@ -10,7 +10,6 @@ import {
 	AdFlow,
 	envVariables,
 	PaywallFlow,
-	envVariables,
 	// PaymentsBlockFlow,
 	// envVariables,
 } from '@automattic/calypso-e2e';

--- a/test/e2e/specs/blocks/blocks__jetpack-earn.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-earn.ts
@@ -56,7 +56,7 @@ if (
 	blockFlows.push( new AdFlow( {} ) );
 }
 
-// Private sites also do not apply to Private sites.
+// Paywall also does not apply to Private sites.
 if ( envVariables.ATOMIC_VARIATION !== 'private' ) {
 	// Splice instead of push because the Donations block should be the last item
 	// because clicking "Pay now" behavior is slightly unpredictable.

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -80,7 +80,7 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 
 		describe( 'Publishing the post', function () {
 			it( 'Publish and visit post', async function () {
-				await editorPage.publish( { visit: true } );
+				await editorPage.publish( { visit: true, timeout: 15 * 1000 } );
 				publishedPostContext = {
 					page: page,
 				};

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -82,6 +82,7 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 			it( 'Publish and visit post', async function () {
 				await editorPage.publish( { visit: true, timeout: 15 * 1000 } );
 				publishedPostContext = {
+					browser: browser,
 					page: page,
 				};
 			} );


### PR DESCRIPTION
Related to: https://github.com/Automattic/wp-calypso/issues/80730.

## Proposed Changes

This PR adds testing flow for the Paywall block.

Key flows:
- add block
- insert pre and post-paywall content.
- verify as unrelated user, the functionality of the paywall block.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?