### PR TITLE
Domains: Add Apple iCloud Mail to DNS Records page

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -81,6 +81,10 @@ export const dnsTemplates = {
 		PROVIDER: 'g-suite',
 		SERVICE: 'G-Suite',
 	},
+	ICLOUD_MAIL: {
+		PROVIDER: 'apple-icloud-mail',
+		SERVICE: 'icloud-mail',
+	},
 	MICROSOFT_OFFICE365: {
 		PROVIDER: 'microsoft-office365',
 		SERVICE: 'O365',

--- a/client/my-sites/domains/domain-management/email-setup/index.jsx
+++ b/client/my-sites/domains/domain-management/email-setup/index.jsx
@@ -28,12 +28,15 @@ class EmailSetup extends Component {
 				{
 					name: googleServiceName,
 					label: translate(
-						'%(serviceName)s Verification Token - from the TXT record verification',
+						'Paste the verification token provided by %(serviceName)s for the {{strong}}TXT{{/strong}} record:',
 						{
 							args: { serviceName: googleServiceName },
 							comment:
 								'%(serviceName)s will be replaced with the name of the service ' +
 								'that this token applies to, for example G Suite or Office 365',
+							components: {
+								strong: <strong />,
+							},
 						}
 					),
 					placeholder: 'google-site-verification=...',
@@ -42,14 +45,36 @@ class EmailSetup extends Component {
 					dnsTemplateService: dnsTemplates.G_SUITE.SERVICE,
 				},
 				{
+					name: 'iCloud Mail',
+					label: translate(
+						'Paste the verification token provided by %(serviceName)s for the {{strong}}TXT{{/strong}} record:',
+						{
+							args: { serviceName: 'iCloud Mail' },
+							comment:
+								'%(serviceName)s will be replaced with the name of the service ' +
+								'that this token applies to, for example G Suite or Office 365',
+							components: {
+								strong: <strong />,
+							},
+						}
+					),
+					placeholder: 'apple-domain=...',
+					validationPattern: /^apple-domain=[A-Za-z0-9]{16}$/,
+					dnsTemplateProvider: dnsTemplates.ICLOUD_MAIL.PROVIDER,
+					dnsTemplateService: dnsTemplates.ICLOUD_MAIL.SERVICE,
+				},
+				{
 					name: 'Office 365',
 					label: translate(
-						'%(serviceName)s Verification Token - from the TXT record verification',
+						'Paste the verification token provided by %(serviceName)s for the {{strong}}TXT{{/strong}} record:',
 						{
 							args: { serviceName: 'Office 365' },
 							comment:
 								'%(serviceName)s will be replaced with the name of the service ' +
 								'that this token applies to, for example G Suite or Office 365',
+							components: {
+								strong: <strong />,
+							},
 						}
 					),
 					placeholder: 'MS=ms...',
@@ -63,7 +88,18 @@ class EmailSetup extends Component {
 				},
 				{
 					name: 'Zoho Mail',
-					label: translate( 'Zoho Mail CNAME zb code' ),
+					label: translate(
+						'Paste the verification code provided by %(serviceName)s for the {{strong}}CNAME{{/strong}} record:',
+						{
+							args: { serviceName: 'Zoho Mail' },
+							comment:
+								'%(serviceName)s will be replaced with the name of the service ' +
+								'that this token applies to, for example G Suite or Office 365',
+							components: {
+								strong: <strong />,
+							},
+						}
+					),
 					placeholder: 'zb...',
 					validationPattern: /^zb\w{1,100}$/,
 					dnsTemplateProvider: dnsTemplates.ZOHO_MAIL.PROVIDER,

--- a/client/my-sites/domains/domain-management/email-setup/style.scss
+++ b/client/my-sites/domains/domain-management/email-setup/style.scss
@@ -60,7 +60,7 @@
 }
 
 .dns-records.main {
-	* + .email-setup {
+	.email-setup.foldable-card.card {
 		margin-top: 32px;
 	}
 }


### PR DESCRIPTION
Related patch: D120337-code

This pull request adds `Apple iCloud Mail` to the list of email providers in the `Email setup` section of the `DNS Records` page:

![image](https://github.com/Automattic/wp-calypso/assets/594356/fdac8893-2771-479d-8124-c04763268195)

This pull request also refines the text of each provider to better guide the user:

Before | After
------ | -----
![image](https://github.com/Automattic/wp-calypso/assets/594356/f7d7554f-3cbd-42f2-8c5d-efb9c3ce98e4) | ![image](https://github.com/Automattic/wp-calypso/assets/594356/e006ceac-3ae4-44d6-bb42-b9f1a80d58e9)

Finally, it fixes a small issue with the top margin of the `Email setup` section that would otherwise disappear when the latter is collapsed. FYI, here are support pages for each email provider:

* [Google Workspace](https://support.google.com/webmasters/answer/9008080?hl=en#zippy=%2Cdomain-name-provider)
* [iCloud Mail](https://support.apple.com/en-us/102374)
* [Office 365](https://learn.microsoft.com/en-us/microsoft-365/admin/get-help-with-domains/create-dns-records-at-any-dns-hosting-provider?view=o365-worldwide#recommended-verify-with-a-txt-record)
* [Zoho Mail](https://www.zoho.com/mail/help/adminconsole/domain-verification.html#cname-method)

And our own support pages:

1. https://wordpress.com/support/add-email/
2. https://wordpress.com/support/add-email/add-email-through-google-workspace/
3. https://wordpress.com/support/add-email/add-email-through-office-365/
4. https://wordpress.com/support/add-email/add-email-through-zoho-mail/

A few additional notes/follow-up actions about those pages:

- [ ] Create a support page for `Apple iCloud Mail`
- [ ] Remove section about account creation for `Zoho Mail`
- [ ] Update all screenshots to match label changes introduced in this pull request

#### Testing instructions

1. Run `git checkout add/icloud-mail-setup` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/81260#issuecomment-1700652055)
2. Apply this patch: D120337-code, to enable the backend changes needed to support the template
3. Log into a WordPress.com account with a domain
4. Open the [`Domains` page](http://calypso.localhost:3000/domains/manage)
5. Click the name of your domain
6. Expand the `DNS records` section, and click the `Manage` button
7. Expand the `Email setup` section, and click the `iCloud Mail` tab
8. Paste a verification token, and submit that form
9. Assert that the [right DNS records](https://support.apple.com/en-us/102374) were added to your domain