### PR TITLE
Jetpack Pro Dashboard: add atomic site actions to the dashboard site actions

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/get-action-event-name.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/get-action-event-name.ts
@@ -26,6 +26,18 @@ const actionEventNames: ActionEventNames = {
 		large_screen: 'calypso_jetpack_agency_dashboard_site_settings_large_screen',
 		small_screen: 'calypso_jetpack_agency_dashboard_site_settings_small_screen',
 	},
+	setup_site: {
+		large_screen: 'calypso_jetpack_agency_dashboard_setup_site_large_screen',
+		small_screen: 'calypso_jetpack_agency_dashboard_setup_site_small_screen',
+	},
+	change_domain: {
+		large_screen: 'calypso_jetpack_agency_dashboard_change_domain_large_screen',
+		small_screen: 'calypso_jetpack_agency_dashboard_change_domain_small_screen',
+	},
+	hosting_configuration: {
+		large_screen: 'calypso_jetpack_agency_dashboard_hosting_configuration_large_screen',
+		small_screen: 'calypso_jetpack_agency_dashboard_hosting_configuration_small_screen',
+	},
 };
 
 // Returns event name based on the action type

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon, Button } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -38,6 +39,7 @@ export default function SiteActions( { isLargeScreen = false, site, siteError }:
 	const siteUrlWithScheme = site?.value?.url_with_scheme;
 	const siteId = site?.value?.blog_id;
 	const siteHasBackup = site?.value?.has_backup;
+	const isAtomicSite = site?.value?.is_atomic;
 
 	const handleClickMenuItem = ( actionType: AllowedActionTypes ) => {
 		const eventName = getActionEventName( actionType, isLargeScreen );
@@ -46,7 +48,31 @@ export default function SiteActions( { isLargeScreen = false, site, siteError }:
 
 	const siteSlug = urlToSlug( siteUrl );
 
+	const isWPCOMAtomicSiteCreationEnabled =
+		isEnabled( 'jetpack/pro-dashboard-wpcom-atomic-hosting' ) && isAtomicSite;
+
 	const siteActions = [
+		{
+			name: translate( 'Setup site' ),
+			href: `https://wordpress.com/home/${ siteSlug }`,
+			onClick: () => handleClickMenuItem( 'setup_site' ),
+			isExternalLink: true,
+			isEnabled: isWPCOMAtomicSiteCreationEnabled,
+		},
+		{
+			name: translate( 'Change domain' ),
+			href: `https://wordpress.com/domains/manage/${ siteSlug }`,
+			onClick: () => handleClickMenuItem( 'change_domain' ),
+			isExternalLink: true,
+			isEnabled: isWPCOMAtomicSiteCreationEnabled,
+		},
+		{
+			name: translate( 'Hosting configuration' ),
+			href: `https://wordpress.com/hosting-config/${ siteSlug }`,
+			onClick: () => handleClickMenuItem( 'hosting_configuration' ),
+			isExternalLink: true,
+			isEnabled: isWPCOMAtomicSiteCreationEnabled,
+		},
 		{
 			name: translate( 'Issue new license' ),
 			href: `/partner-portal/issue-license/?site_id=${ siteId }&source=dashboard`,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -44,6 +44,53 @@ export default function SiteActions( { isLargeScreen = false, site, siteError }:
 		dispatch( recordTracksEvent( eventName ) );
 	};
 
+	const siteSlug = urlToSlug( siteUrl );
+
+	const siteActions = [
+		{
+			name: translate( 'Issue new license' ),
+			href: `/partner-portal/issue-license/?site_id=${ siteId }&source=dashboard`,
+			onClick: () => handleClickMenuItem( 'issue_license' ),
+			isExternalLink: false,
+			isEnabled: ! siteError,
+		},
+		{
+			name: translate( 'View activity' ),
+			href: `/activity-log/${ siteSlug }`,
+			onClick: () => handleClickMenuItem( 'view_activity' ),
+			isExternalLink: false,
+			isEnabled: ! siteError,
+		},
+		{
+			name: translate( 'Copy this site' ),
+			href: `/backup/${ siteSlug }/clone`,
+			onClick: () => handleClickMenuItem( 'clone_site' ),
+			isExternalLink: false,
+			isEnabled: siteHasBackup,
+		},
+		{
+			name: translate( 'Site settings' ),
+			href: `/settings/${ siteSlug }`,
+			onClick: () => handleClickMenuItem( 'site_settings' ),
+			isExternalLink: false,
+			isEnabled: siteHasBackup,
+		},
+		{
+			name: translate( 'View site' ),
+			href: siteUrlWithScheme,
+			onClick: () => handleClickMenuItem( 'view_site' ),
+			isExternalLink: true,
+			isEnabled: true,
+		},
+		{
+			name: translate( 'Visit WP Admin' ),
+			href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack#/dashboard`,
+			onClick: () => handleClickMenuItem( 'visit_wp_admin' ),
+			isExternalLink: true,
+			isEnabled: true,
+		},
+	];
+
 	return (
 		<>
 			<Button
@@ -65,58 +112,20 @@ export default function SiteActions( { isLargeScreen = false, site, siteError }:
 				onClose={ closeDropdown }
 				position="bottom left"
 			>
-				{ ! siteError && (
-					<>
-						<PopoverMenuItem
-							onClick={ () => handleClickMenuItem( 'issue_license' ) }
-							href={ `/partner-portal/issue-license/?site_id=${ siteId }&source=dashboard` }
-							className="site-actions__menu-item"
-						>
-							{ translate( 'Issue new license' ) }
-						</PopoverMenuItem>
-						<PopoverMenuItem
-							onClick={ () => handleClickMenuItem( 'view_activity' ) }
-							href={ `/activity-log/${ urlToSlug( siteUrl ) }` }
-							className="site-actions__menu-item"
-						>
-							{ translate( 'View activity' ) }
-						</PopoverMenuItem>
-					</>
+				{ siteActions.map(
+					( action ) =>
+						action.isEnabled && (
+							<PopoverMenuItem
+								key={ action.name }
+								isExternalLink={ action.isExternalLink }
+								onClick={ action.onClick }
+								href={ action.href }
+								className="site-actions__menu-item"
+							>
+								{ action.name }
+							</PopoverMenuItem>
+						)
 				) }
-				{ siteHasBackup && (
-					<>
-						<PopoverMenuItem
-							onClick={ () => handleClickMenuItem( 'clone_site' ) }
-							href={ `/backup/${ urlToSlug( siteUrl ) }/clone` }
-							className="site-actions__menu-item"
-						>
-							{ translate( 'Copy this site' ) }
-						</PopoverMenuItem>
-						<PopoverMenuItem
-							onClick={ () => handleClickMenuItem( 'site_settings' ) }
-							href={ `/settings/${ urlToSlug( siteUrl ) }` }
-							className="site-actions__menu-item"
-						>
-							{ translate( 'Site settings' ) }
-						</PopoverMenuItem>
-					</>
-				) }
-				<PopoverMenuItem
-					isExternalLink
-					onClick={ () => handleClickMenuItem( 'view_site' ) }
-					href={ siteUrlWithScheme }
-					className="site-actions__menu-item"
-				>
-					{ translate( 'View site' ) }
-				</PopoverMenuItem>
-				<PopoverMenuItem
-					isExternalLink
-					onClick={ () => handleClickMenuItem( 'visit_wp_admin' ) }
-					href={ `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack#/dashboard` }
-					className="site-actions__menu-item"
-				>
-					{ translate( 'Visit WP Admin' ) }
-				</PopoverMenuItem>
 			</PopoverMenu>
 		</>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -1,15 +1,10 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon, Button } from '@automattic/components';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import { urlToSlug } from 'calypso/lib/url/http-utils';
-import { useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import getActionEventName from './get-action-event-name';
-import type { SiteNode, AllowedActionTypes } from '../types';
+import useSiteActions from './use-site-actions';
+import type { SiteNode } from '../types';
 
 import './style.scss';
 
@@ -20,9 +15,6 @@ interface Props {
 }
 
 export default function SiteActions( { isLargeScreen = false, site, siteError }: Props ) {
-	const translate = useTranslate();
-	const dispatch = useDispatch();
-
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
@@ -35,87 +27,7 @@ export default function SiteActions( { isLargeScreen = false, site, siteError }:
 		setIsOpen( false );
 	};
 
-	const siteUrl = site?.value?.url;
-	const siteUrlWithScheme = site?.value?.url_with_scheme;
-	const siteId = site?.value?.blog_id;
-	const siteHasBackup = site?.value?.has_backup;
-	const isAtomicSite = site?.value?.is_atomic;
-
-	const handleClickMenuItem = ( actionType: AllowedActionTypes ) => {
-		const eventName = getActionEventName( actionType, isLargeScreen );
-		dispatch( recordTracksEvent( eventName ) );
-	};
-
-	const siteSlug = urlToSlug( siteUrl );
-
-	const isWPCOMAtomicSiteCreationEnabled =
-		isEnabled( 'jetpack/pro-dashboard-wpcom-atomic-hosting' ) && isAtomicSite;
-
-	const siteActions = [
-		{
-			name: translate( 'Setup site' ),
-			href: `https://wordpress.com/home/${ siteSlug }`,
-			onClick: () => handleClickMenuItem( 'setup_site' ),
-			isExternalLink: true,
-			isEnabled: isWPCOMAtomicSiteCreationEnabled,
-		},
-		{
-			name: translate( 'Change domain' ),
-			href: `https://wordpress.com/domains/manage/${ siteSlug }`,
-			onClick: () => handleClickMenuItem( 'change_domain' ),
-			isExternalLink: true,
-			isEnabled: isWPCOMAtomicSiteCreationEnabled,
-		},
-		{
-			name: translate( 'Hosting configuration' ),
-			href: `https://wordpress.com/hosting-config/${ siteSlug }`,
-			onClick: () => handleClickMenuItem( 'hosting_configuration' ),
-			isExternalLink: true,
-			isEnabled: isWPCOMAtomicSiteCreationEnabled,
-		},
-		{
-			name: translate( 'Issue new license' ),
-			href: `/partner-portal/issue-license/?site_id=${ siteId }&source=dashboard`,
-			onClick: () => handleClickMenuItem( 'issue_license' ),
-			isExternalLink: false,
-			isEnabled: ! siteError,
-		},
-		{
-			name: translate( 'View activity' ),
-			href: `/activity-log/${ siteSlug }`,
-			onClick: () => handleClickMenuItem( 'view_activity' ),
-			isExternalLink: false,
-			isEnabled: ! siteError,
-		},
-		{
-			name: translate( 'Copy this site' ),
-			href: `/backup/${ siteSlug }/clone`,
-			onClick: () => handleClickMenuItem( 'clone_site' ),
-			isExternalLink: false,
-			isEnabled: siteHasBackup,
-		},
-		{
-			name: translate( 'Site settings' ),
-			href: `/settings/${ siteSlug }`,
-			onClick: () => handleClickMenuItem( 'site_settings' ),
-			isExternalLink: false,
-			isEnabled: siteHasBackup,
-		},
-		{
-			name: translate( 'View site' ),
-			href: siteUrlWithScheme,
-			onClick: () => handleClickMenuItem( 'view_site' ),
-			isExternalLink: true,
-			isEnabled: true,
-		},
-		{
-			name: translate( 'Visit WP Admin' ),
-			href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack#/dashboard`,
-			onClick: () => handleClickMenuItem( 'visit_wp_admin' ),
-			isExternalLink: true,
-			isEnabled: true,
-		},
-	];
+	const siteActions = useSiteActions( site, isLargeScreen, siteError );
 
 	return (
 		<>
@@ -138,20 +50,19 @@ export default function SiteActions( { isLargeScreen = false, site, siteError }:
 				onClose={ closeDropdown }
 				position="bottom left"
 			>
-				{ siteActions.map(
-					( action ) =>
-						action.isEnabled && (
-							<PopoverMenuItem
-								key={ action.name }
-								isExternalLink={ action.isExternalLink }
-								onClick={ action.onClick }
-								href={ action.href }
-								className="site-actions__menu-item"
-							>
-								{ action.name }
-							</PopoverMenuItem>
-						)
-				) }
+				{ siteActions
+					.filter( ( action ) => action.isEnabled )
+					.map( ( action ) => (
+						<PopoverMenuItem
+							key={ action.name }
+							isExternalLink={ action.isExternalLink }
+							onClick={ action.onClick }
+							href={ action.href }
+							className="site-actions__menu-item"
+						>
+							{ action.name }
+						</PopoverMenuItem>
+					) ) }
 			</PopoverMenu>
 		</>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -16,85 +17,87 @@ export default function useSiteActions(
 
 	const siteValue = site?.value;
 
-	if ( ! siteValue ) {
-		return [];
-	}
+	return useMemo( () => {
+		if ( ! siteValue ) {
+			return [];
+		}
 
-	const { url, url_with_scheme, blog_id, has_backup, is_atomic } = siteValue;
+		const { url, url_with_scheme, blog_id, has_backup, is_atomic } = siteValue;
 
-	const siteSlug = urlToSlug( url );
+		const siteSlug = urlToSlug( url );
 
-	const handleClickMenuItem = ( actionType: AllowedActionTypes ) => {
-		const eventName = getActionEventName( actionType, isLargeScreen );
-		dispatch( recordTracksEvent( eventName ) );
-	};
+		const handleClickMenuItem = ( actionType: AllowedActionTypes ) => {
+			const eventName = getActionEventName( actionType, isLargeScreen );
+			dispatch( recordTracksEvent( eventName ) );
+		};
 
-	const isWPCOMAtomicSiteCreationEnabled =
-		isEnabled( 'jetpack/pro-dashboard-wpcom-atomic-hosting' ) && is_atomic;
+		const isWPCOMAtomicSiteCreationEnabled =
+			isEnabled( 'jetpack/pro-dashboard-wpcom-atomic-hosting' ) && is_atomic;
 
-	return [
-		{
-			name: translate( 'Setup site' ),
-			href: `https://wordpress.com/home/${ siteSlug }`,
-			onClick: () => handleClickMenuItem( 'setup_site' ),
-			isExternalLink: true,
-			isEnabled: isWPCOMAtomicSiteCreationEnabled,
-		},
-		{
-			name: translate( 'Change domain' ),
-			href: `https://wordpress.com/domains/manage/${ siteSlug }`,
-			onClick: () => handleClickMenuItem( 'change_domain' ),
-			isExternalLink: true,
-			isEnabled: isWPCOMAtomicSiteCreationEnabled,
-		},
-		{
-			name: translate( 'Hosting configuration' ),
-			href: `https://wordpress.com/hosting-config/${ siteSlug }`,
-			onClick: () => handleClickMenuItem( 'hosting_configuration' ),
-			isExternalLink: true,
-			isEnabled: isWPCOMAtomicSiteCreationEnabled,
-		},
-		{
-			name: translate( 'Issue new license' ),
-			href: `/partner-portal/issue-license/?site_id=${ blog_id }&source=dashboard`,
-			onClick: () => handleClickMenuItem( 'issue_license' ),
-			isExternalLink: false,
-			isEnabled: ! siteError,
-		},
-		{
-			name: translate( 'View activity' ),
-			href: `/activity-log/${ siteSlug }`,
-			onClick: () => handleClickMenuItem( 'view_activity' ),
-			isExternalLink: false,
-			isEnabled: ! siteError,
-		},
-		{
-			name: translate( 'Copy this site' ),
-			href: `/backup/${ siteSlug }/clone`,
-			onClick: () => handleClickMenuItem( 'clone_site' ),
-			isExternalLink: false,
-			isEnabled: has_backup,
-		},
-		{
-			name: translate( 'Site settings' ),
-			href: `/settings/${ siteSlug }`,
-			onClick: () => handleClickMenuItem( 'site_settings' ),
-			isExternalLink: false,
-			isEnabled: has_backup,
-		},
-		{
-			name: translate( 'View site' ),
-			href: url_with_scheme,
-			onClick: () => handleClickMenuItem( 'view_site' ),
-			isExternalLink: true,
-			isEnabled: true,
-		},
-		{
-			name: translate( 'Visit WP Admin' ),
-			href: `${ url_with_scheme }/wp-admin/admin.php?page=jetpack#/dashboard`,
-			onClick: () => handleClickMenuItem( 'visit_wp_admin' ),
-			isExternalLink: true,
-			isEnabled: true,
-		},
-	];
+		return [
+			{
+				name: translate( 'Setup site' ),
+				href: `https://wordpress.com/home/${ siteSlug }`,
+				onClick: () => handleClickMenuItem( 'setup_site' ),
+				isExternalLink: true,
+				isEnabled: isWPCOMAtomicSiteCreationEnabled,
+			},
+			{
+				name: translate( 'Change domain' ),
+				href: `https://wordpress.com/domains/manage/${ siteSlug }`,
+				onClick: () => handleClickMenuItem( 'change_domain' ),
+				isExternalLink: true,
+				isEnabled: isWPCOMAtomicSiteCreationEnabled,
+			},
+			{
+				name: translate( 'Hosting configuration' ),
+				href: `https://wordpress.com/hosting-config/${ siteSlug }`,
+				onClick: () => handleClickMenuItem( 'hosting_configuration' ),
+				isExternalLink: true,
+				isEnabled: isWPCOMAtomicSiteCreationEnabled,
+			},
+			{
+				name: translate( 'Issue new license' ),
+				href: `/partner-portal/issue-license/?site_id=${ blog_id }&source=dashboard`,
+				onClick: () => handleClickMenuItem( 'issue_license' ),
+				isExternalLink: false,
+				isEnabled: ! siteError,
+			},
+			{
+				name: translate( 'View activity' ),
+				href: `/activity-log/${ siteSlug }`,
+				onClick: () => handleClickMenuItem( 'view_activity' ),
+				isExternalLink: false,
+				isEnabled: ! siteError,
+			},
+			{
+				name: translate( 'Copy this site' ),
+				href: `/backup/${ siteSlug }/clone`,
+				onClick: () => handleClickMenuItem( 'clone_site' ),
+				isExternalLink: false,
+				isEnabled: has_backup,
+			},
+			{
+				name: translate( 'Site settings' ),
+				href: `/settings/${ siteSlug }`,
+				onClick: () => handleClickMenuItem( 'site_settings' ),
+				isExternalLink: false,
+				isEnabled: has_backup,
+			},
+			{
+				name: translate( 'View site' ),
+				href: url_with_scheme,
+				onClick: () => handleClickMenuItem( 'view_site' ),
+				isExternalLink: true,
+				isEnabled: true,
+			},
+			{
+				name: translate( 'Visit WP Admin' ),
+				href: `${ url_with_scheme }/wp-admin/admin.php?page=jetpack#/dashboard`,
+				onClick: () => handleClickMenuItem( 'visit_wp_admin' ),
+				isExternalLink: true,
+				isEnabled: true,
+			},
+		];
+	}, [ dispatch, isLargeScreen, siteError, siteValue, translate ] );
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
@@ -1,0 +1,100 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useTranslate } from 'i18n-calypso';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getActionEventName from './get-action-event-name';
+import type { SiteNode, AllowedActionTypes } from '../types';
+
+export default function useSiteActions(
+	site: SiteNode,
+	isLargeScreen: boolean,
+	siteError?: boolean
+) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const siteValue = site?.value;
+
+	if ( ! siteValue ) {
+		return [];
+	}
+
+	const { url, url_with_scheme, blog_id, has_backup, is_atomic } = siteValue;
+
+	const siteSlug = urlToSlug( url );
+
+	const handleClickMenuItem = ( actionType: AllowedActionTypes ) => {
+		const eventName = getActionEventName( actionType, isLargeScreen );
+		dispatch( recordTracksEvent( eventName ) );
+	};
+
+	const isWPCOMAtomicSiteCreationEnabled =
+		isEnabled( 'jetpack/pro-dashboard-wpcom-atomic-hosting' ) && is_atomic;
+
+	return [
+		{
+			name: translate( 'Setup site' ),
+			href: `https://wordpress.com/home/${ siteSlug }`,
+			onClick: () => handleClickMenuItem( 'setup_site' ),
+			isExternalLink: true,
+			isEnabled: isWPCOMAtomicSiteCreationEnabled,
+		},
+		{
+			name: translate( 'Change domain' ),
+			href: `https://wordpress.com/domains/manage/${ siteSlug }`,
+			onClick: () => handleClickMenuItem( 'change_domain' ),
+			isExternalLink: true,
+			isEnabled: isWPCOMAtomicSiteCreationEnabled,
+		},
+		{
+			name: translate( 'Hosting configuration' ),
+			href: `https://wordpress.com/hosting-config/${ siteSlug }`,
+			onClick: () => handleClickMenuItem( 'hosting_configuration' ),
+			isExternalLink: true,
+			isEnabled: isWPCOMAtomicSiteCreationEnabled,
+		},
+		{
+			name: translate( 'Issue new license' ),
+			href: `/partner-portal/issue-license/?site_id=${ blog_id }&source=dashboard`,
+			onClick: () => handleClickMenuItem( 'issue_license' ),
+			isExternalLink: false,
+			isEnabled: ! siteError,
+		},
+		{
+			name: translate( 'View activity' ),
+			href: `/activity-log/${ siteSlug }`,
+			onClick: () => handleClickMenuItem( 'view_activity' ),
+			isExternalLink: false,
+			isEnabled: ! siteError,
+		},
+		{
+			name: translate( 'Copy this site' ),
+			href: `/backup/${ siteSlug }/clone`,
+			onClick: () => handleClickMenuItem( 'clone_site' ),
+			isExternalLink: false,
+			isEnabled: has_backup,
+		},
+		{
+			name: translate( 'Site settings' ),
+			href: `/settings/${ siteSlug }`,
+			onClick: () => handleClickMenuItem( 'site_settings' ),
+			isExternalLink: false,
+			isEnabled: has_backup,
+		},
+		{
+			name: translate( 'View site' ),
+			href: url_with_scheme,
+			onClick: () => handleClickMenuItem( 'view_site' ),
+			isExternalLink: true,
+			isEnabled: true,
+		},
+		{
+			name: translate( 'Visit WP Admin' ),
+			href: `${ url_with_scheme }/wp-admin/admin.php?page=jetpack#/dashboard`,
+			onClick: () => handleClickMenuItem( 'visit_wp_admin' ),
+			isExternalLink: true,
+			isEnabled: true,
+		},
+	];
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -97,7 +97,7 @@ export interface Site {
 	php_version_num: number;
 	is_connected: boolean;
 	has_paid_agency_monitor: boolean;
-	is_atomic?: boolean;
+	is_atomic: boolean;
 }
 export interface SiteNode {
 	value: Site;
@@ -191,7 +191,10 @@ export type AllowedActionTypes =
 	| 'view_site'
 	| 'visit_wp_admin'
 	| 'clone_site'
-	| 'site_settings';
+	| 'site_settings'
+	| 'setup_site'
+	| 'change_domain'
+	| 'hosting_configuration';
 
 export type ActionEventNames = {
 	[ key in AllowedActionTypes ]: { small_screen: string; large_screen: string };


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-avalon/issues/45

## Proposed Changes

This PR implements adding atomic site actions(`Setup site`, `Change domain` & `Hosting configuration`) to the dashboard site actions.

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/atomic-site-dashboard-site-actions` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that the previously added actions(`Issue new license`, `View activity`, `Copy this site`, `Site settings`, `View site` & `Visit WP Admin`) appear as expected and that the code changes make sense.
4. Since our current /sites endpoint does not include WPCOM atomic sites, we must modify the code to test and verify these changes.

<img width="339" alt="Screenshot 2023-08-31 at 3 32 12 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/09a74d10-10fa-4380-a2d8-4d70bbad071a">


Go to /jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx#L42 and change the line to 

```
const isAtomicSite = true;
```

5. Verify that the atomic site actions(Setup site`, `Change domain` & `Hosting configuration`) are shown, and clicking on them redirects you to the correct links, and all open in a new tab. Also. verify that the event names are tracked when these menu items are clicked. 

<img width="313" alt="Screenshot 2023-08-31 at 3 32 56 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/103789ed-c9fa-42b5-9631-2e5f0ebd7123">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?