### PR TITLE
Emails: Update forwarding UI to be aware of limit; Update limit to 100

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan/index.jsx
+++ b/client/my-sites/email/email-management/home/email-plan/index.jsx
@@ -263,7 +263,7 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 			);
 		}
 
-		const emailForwardsLimit = 100;
+		const emailForwardsLimit = 25;
 		const isAtEmailForwardsLimit = mailboxes.length >= emailForwardsLimit;
 
 		return (

--- a/client/my-sites/email/email-management/home/email-plan/index.jsx
+++ b/client/my-sites/email/email-management/home/email-plan/index.jsx
@@ -195,8 +195,12 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 			? getManagePurchaseUrlFor( selectedSite.slug, purchase.id )
 			: '';
 
+		if ( ! hasSubscription || ! purchase ) {
+			return null;
+		}
+
 		return (
-			<VerticalNavItem path={ managePurchaseUrl } disabled={ ! hasSubscription || ! purchase }>
+			<VerticalNavItem path={ managePurchaseUrl }>
 				{ translate( 'View billing and payment settings' ) }
 			</VerticalNavItem>
 		);
@@ -242,7 +246,7 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 		);
 	}
 
-	function renderAddNewMailboxesOrRenewNavItem() {
+	function renderAddNewMailboxesOrRenewNavItem( mailboxes ) {
 		if ( hasTitanMailWithUs( domain ) || hasGSuiteWithUs( domain ) ) {
 			if ( purchase && isExpired( purchase ) ) {
 				return (
@@ -259,9 +263,16 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 			);
 		}
 
+		const emailForwardsLimit = 100;
+		const isAtEmailForwardsLimit = mailboxes.length >= emailForwardsLimit;
+
 		return (
-			<VerticalNavItem { ...getAddMailboxProps() }>
-				{ translate( 'Add new email forwards' ) }
+			<VerticalNavItem { ...getAddMailboxProps() } disabled={ isAtEmailForwardsLimit }>
+				{ isAtEmailForwardsLimit
+					? translate( 'Using %1$s of %1$s email forwards', {
+							args: [ emailForwardsLimit ],
+					  } )
+					: translate( 'Add new email forwards' ) }
 			</VerticalNavItem>
 		);
 	}
@@ -300,7 +311,7 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 			/>
 			<div className="email-plan__actions">
 				<VerticalNav>
-					{ renderAddNewMailboxesOrRenewNavItem() }
+					{ renderAddNewMailboxesOrRenewNavItem( getMailboxes( emailAccounts ) ) }
 					<UpgradeNavItem
 						currentRoute={ currentRoute }
 						domain={ domain }


### PR DESCRIPTION
See p58i-fgS-p2 

## Proposed Changes

- Hide payment information nav link if no subscription to link user to.
- Make UI aware of limit.
- Update limit to 25 email forwards.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout patch
* Visit domain that does not have professional
* Add email forwards
* Ensure that you an add more than 5
* Ensure that from 26 on, that the button is inactive

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?