### PR TITLE
Subscriptions Management: Refactor SiteSubscriptionPage for portability & decoupling from dependencies

### DIFF
--- a/client/landing/subscriptions/components/site-subscription-page/index.ts
+++ b/client/landing/subscriptions/components/site-subscription-page/index.ts
@@ -1,1 +1,0 @@
-export { default as SiteSubscriptionPage } from './site-subscription-page';

--- a/client/landing/subscriptions/components/site-subscription-page/index.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/index.tsx
@@ -1,0 +1,10 @@
+import { SubscriptionProvider } from './site-subscription-context';
+import SiteSubscription from './site-subscription-page';
+
+export const SiteSubscriptionPage = () => {
+	return (
+		<SubscriptionProvider>
+			<SiteSubscription />
+		</SubscriptionProvider>
+	);
+};

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-context.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-context.tsx
@@ -1,0 +1,48 @@
+import { Reader, SubscriptionManager } from '@automattic/data-stores';
+import { createContext, useContext, ReactNode } from 'react';
+import { useNavigate, useParams } from 'react-router';
+
+interface SubscriptionContextProps {
+	blogId: string;
+	navigate: ( path: string ) => void;
+	data?: Reader.SiteSubscriptionDetails;
+	isLoading: boolean;
+	error?: Reader.ErrorResponse | unknown;
+}
+
+const SubscriptionContext = createContext< SubscriptionContextProps | undefined >( undefined );
+
+export const useSubscription = () => {
+	const context = useContext( SubscriptionContext );
+	if ( ! context ) {
+		throw new Error( 'useSubscription must be used within a SubscriptionProvider' );
+	}
+	return context;
+};
+
+export const SubscriptionProvider: React.FC< { children: ReactNode } > = ( { children } ) => {
+	const navigate = useNavigate();
+	const { blogId = '' } = useParams();
+	const { data, isLoading, error } = SubscriptionManager.useSiteSubscriptionDetailsQuery( blogId );
+
+	let subscriptionData: Reader.SiteSubscriptionDetails | undefined;
+	let subscriptionError: Reader.ErrorResponse | undefined;
+
+	if ( Reader.isSiteSubscriptionDetails( data ) ) {
+		subscriptionData = data;
+	} else if ( Reader.isErrorResponse( data ) ) {
+		subscriptionError = data;
+	}
+
+	const contextValue: SubscriptionContextProps = {
+		blogId,
+		navigate,
+		data: subscriptionData,
+		isLoading,
+		error: error || subscriptionError,
+	};
+
+	return (
+		<SubscriptionContext.Provider value={ contextValue }>{ children }</SubscriptionContext.Provider>
+	);
+};

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-helpers.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-helpers.tsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 export type SiteSubscriptionDetailsProps = {
 	subscriberCount: number;
 	dateSubscribed: Date;
-	siteIcon: string;
+	siteIcon: string | null;
 	name: string;
 	blogId: string;
 	deliveryMethods: Reader.SiteSubscriptionDeliveryMethods;

--- a/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/site-subscription-page.tsx
@@ -1,19 +1,17 @@
 import { Gridicon } from '@automattic/components';
-import { SubscriptionManager, Reader } from '@automattic/data-stores';
+import { Reader } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useNavigate, useParams } from 'react-router-dom';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { Notice, NoticeType } from 'calypso/landing/subscriptions/components/notice';
 import PoweredByWPFooter from 'calypso/layout/powered-by-wp-footer';
-import './styles.scss';
+import { useSubscription } from './site-subscription-context';
 import SiteSubscriptionDetails from './site-subscription-details';
+import './styles.scss';
 
 const SiteSubscriptionPage = () => {
 	const translate = useTranslate();
-	const navigate = useNavigate();
-	const { blogId = '' } = useParams();
-	const { data, isLoading, error } = SubscriptionManager.useSiteSubscriptionDetailsQuery( blogId );
+	const { blogId, data, isLoading, error, navigate } = useSubscription();
 
 	if ( isLoading ) {
 		return <WordPressLogo size={ 72 } className="wpcom-site__logo" />;

--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -1,6 +1,5 @@
 import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
 import wpcomRequest from 'wpcom-proxy-request';
-import { ErrorResponse } from '../types';
 import isValidId from './validators';
 
 type callApiParams = {
@@ -120,14 +119,7 @@ const getSubscriptionMutationParams = (
 	};
 };
 
-const isErrorResponse = (
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	response: any
-): response is ErrorResponse => {
-	// This is good enough for us to know that the response is an error response
-	return response && ( response.errors || response.error_data );
-};
-
-export { callApi, applyCallbackToPages, getSubkey, getSubscriptionMutationParams, isErrorResponse };
+export { callApi, applyCallbackToPages, getSubkey, getSubscriptionMutationParams };
 export { default as buildQueryKey } from './query-key';
+export { isErrorResponse, isSiteSubscriptionDetails } from './type-guards';
 export { default as isValidId } from './validators';

--- a/packages/data-stores/src/reader/helpers/type-guards.ts
+++ b/packages/data-stores/src/reader/helpers/type-guards.ts
@@ -1,0 +1,33 @@
+import {
+	ErrorResponse,
+	SiteSubscriptionDetails,
+	SiteSubscriptionDetailsErrorResponse,
+} from '../types';
+
+export const isErrorResponse = ( response: unknown ): response is ErrorResponse => {
+	return (
+		typeof response === 'object' &&
+		response !== null &&
+		( 'errors' in response || 'error_data' in response )
+	);
+};
+
+export const isSiteSubscriptionDetails = ( obj: unknown ): obj is SiteSubscriptionDetails => {
+	if ( ! obj || typeof obj !== 'object' ) {
+		return false;
+	}
+
+	const siteSubscriptionDetails = obj as SiteSubscriptionDetails;
+	return (
+		typeof siteSubscriptionDetails?.ID === 'number' &&
+		typeof siteSubscriptionDetails?.blog_ID === 'number' &&
+		typeof siteSubscriptionDetails?.name === 'string' &&
+		typeof siteSubscriptionDetails?.URL === 'string'
+	);
+};
+
+export const isSiteSubscriptionDetailsErrorResponse = (
+	obj: unknown
+): obj is SiteSubscriptionDetailsErrorResponse => {
+	return isErrorResponse( obj );
+};

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -59,7 +59,7 @@ export {
 	SiteSubscriptionsFilterBy,
 	SiteSubscriptionsSortBy,
 } from './constants';
-export { isErrorResponse, isValidId } from './helpers';
+export { isErrorResponse, isSiteSubscriptionDetails, isValidId } from './helpers';
 export { UnsubscribedFeedsSearchProvider, useUnsubscribedFeedsSearch } from './contexts';
 export { useReadFeedSearchQuery, useReadFeedSiteQuery, useReadFeedQuery } from './queries';
 

--- a/packages/data-stores/src/reader/queries/use-site-subscription-details-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscription-details-query.ts
@@ -1,14 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
-import { callApi } from '../helpers';
-import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
+import { buildQueryKey, callApi } from '../helpers';
+import { useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { SiteSubscriptionDetailsResponse } from '../types';
 
 const useSiteSubscriptionDetailsQuery = ( siteId: string ) => {
-	const { isLoggedIn } = useIsLoggedIn();
+	const { id, isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
-	const cacheKey = useCacheKey( [ 'read', 'site-subscription-details', siteId ] );
 	return useQuery( {
-		queryKey: cacheKey,
+		queryKey: buildQueryKey( [ 'read', 'site-subscription-details', siteId ], isLoggedIn, id ),
 		queryFn: async () => {
 			const subscriptionDetails = await callApi< SiteSubscriptionDetailsResponse >( {
 				path: '/read/sites/' + siteId + '/subscription-details',

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -137,11 +137,11 @@ export type PendingPostSubscriptionsResult = {
 };
 
 export type SiteSubscriptionDetails = {
-	ID: string;
-	blog_ID: string;
+	ID: number;
+	blog_ID: number;
 	name: string;
 	URL: string;
-	site_icon: string;
+	site_icon: string | null;
 	date_subscribed: Date;
 	subscriber_count: number;
 	delivery_methods: SiteSubscriptionDeliveryMethods;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #81266 

## Proposed Changes

Create a context for `SiteSubscriptionPage` to encapsulate the use of navigation and params which depend on "react-router-dom". This is in preparation for re-using the component in Calypso, which does not use the dependency.

Note that this PR will be followed up with moving the component into `client/blocks` and renaming it to `ReaderSiteSubscription` (to match the naming convention of other reader blocks).

For more background see the description of: #81266

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/subscriptions/sites
* Click on any subscription's site title. The individual subscription page should open up with no regressions.
* Repeat the test for multiple subscription sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?