### PR TITLE
Discover stream - fix default tab and feed with no selectedTab on query params

### DIFF
--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -11,7 +11,7 @@ import {
 import { recordTrack } from 'calypso/reader/stats';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import renderHeaderSection from '../lib/header-section';
-import { getSelectedTabTitle } from './helper';
+import { getSelectedTabTitle, DEFAULT_TAB } from './helper';
 
 const ANALYTICS_PAGE_TITLE = 'Reader';
 
@@ -28,7 +28,7 @@ const exported = {
 		if ( ! isUserLoggedIn( context.store.getState() ) ) {
 			context.renderHeaderSection = renderHeaderSection;
 		}
-		const selectedTab = context.query.selectedTab;
+		const selectedTab = context.query.selectedTab || DEFAULT_TAB;
 		const tabTitle = titlecase( getSelectedTabTitle( selectedTab ) || '' );
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		context.primary = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/81179

## Proposed Changes

* Fixes a regression introduced from the PR above. As a result the discover stream loads the wrong feed and has no tab selected by default.
*  Here we supply `DEFAULT_TAB` as a fallback to `query.selectedTab` so that the discover stream selects the "Recommended" tab and loads the recommended feed by default.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the discover reader page. Verify that it loads with the 'recommended' tab selected and stream by default.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
