### PR TITLE
Cleaning up reader styles on mobile

### DIFF
--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -64,6 +64,10 @@
 			overflow: hidden;
 			-webkit-box-orient: vertical;
 			-webkit-line-clamp: 1;
+
+			p {
+				display: inline;
+			}
 		}
 	}
 }

--- a/client/blocks/comments/post-comment.scss
+++ b/client/blocks/comments/post-comment.scss
@@ -31,6 +31,11 @@
 	.comments__form {
 		margin-top: 10px;
 	}
+
+	&:not(.depth-0) .comments__comment-actions .comments__comment-actions-reply-label,
+	&:not(.depth-0) .comments__comment-actions .reader-share__reblog-label {
+		display: none;
+	}
 }
 
 // A list of comments
@@ -75,6 +80,10 @@
 	color: var(--color-text);
 	height: 21px;
 	margin-right: 7px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 100%;
 }
 
 a.comments__comment-username {

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -8,6 +8,10 @@
 	justify-content: flex-end;
 	list-style-type: none;
 	margin: 10px 0 0;
+
+	@include breakpoint-deprecated( "<660px" ) {
+		justify-content: space-evenly;
+	}
 }
 
 .reader-post-actions:not(.has-views) .reader-post-actions__item {
@@ -27,10 +31,16 @@
 			display: flex;
 			gap: 4px;
 		}
+		@include breakpoint-deprecated( "<660px" ) {
+			display: none;
+		}
 	}
 
 	&.reader-post-actions__views {
 		flex: 1;
+		@include breakpoint-deprecated( "<660px" ) {
+			display: none;
+		}
 	}
 
 	&:last-child {


### PR DESCRIPTION
## Description

@ebinnion reported a few responsive issues with the WP.com reader. Below I've highlighted before and after screenshots for 3 issues that we've fixed in this PR.

## Action bar overflow and layout issues on mobile

### Before
<img width="371" alt="action-before" src="https://github.com/Automattic/wp-calypso/assets/5634774/53474f89-4907-4462-8321-fadb7a918f12">

### After
<img width="380" alt="action-after" src="https://github.com/Automattic/wp-calypso/assets/5634774/999049fc-b937-4cbf-898f-efd59e8d1f57">

## Threaded comments overflow issues

### Before
<img width="396" alt="threaded-before" src="https://github.com/Automattic/wp-calypso/assets/5634774/3a9ef70b-a060-40ee-a608-2a2fcfde4d2c">

### After
<img width="368" alt="threaded-after" src="https://github.com/Automattic/wp-calypso/assets/5634774/53731986-4514-4694-a66a-23aefaa91a24">

## Overflow content issues on Safari

### Before
<img width="538" alt="lineclamp-before" src="https://github.com/Automattic/wp-calypso/assets/5634774/c4853a64-029b-4ad9-afd0-2543ad24d2f8">

### After
<img width="499" alt="lineclamp-after" src="https://github.com/Automattic/wp-calypso/assets/5634774/eb148bfb-23a3-4221-b0bb-d84a8f697498">

## Testing

- Click Calypso live link
- Head to the reader in Safari responsive view
- Double check that everything listed above has been fixed