### PR TITLE
ToS on the checkout page for the 100 year plan

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -43,6 +43,7 @@ import {
 	TITAN_MAIL_YEARLY_SLUG,
 	isAkismetProduct,
 	isWpcomEnterpriseGridPlan,
+	is100Year,
 } from '@automattic/calypso-products';
 import { isWpComProductRenewal as isRenewal } from '@automattic/wpcom-checkout';
 import { getTld } from 'calypso/lib/domains';
@@ -120,6 +121,10 @@ export function hasProPlan( cart: ObjectWithProducts ): boolean {
 
 export function hasBusinessPlan( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isBusiness );
+}
+
+export function has100YearPlan( cart: ObjectWithProducts ): boolean {
+	return getAllCartItems( cart ).some( is100Year );
 }
 
 export function hasStarterPlan( cart: ObjectWithProducts ): boolean {

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { isAkismetProduct } from '@automattic/calypso-products';
+import { is100Year, isAkismetProduct } from '@automattic/calypso-products';
 import { useStripe } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
 import { Card, Gridicon } from '@automattic/components';
@@ -86,6 +86,7 @@ export default function PaymentMethodSelector( {
 	const currentlyAssignedPaymentMethodId = getPaymentMethodIdFromPayment( purchase?.payment );
 
 	const isAkismetPurchase = purchase ? isAkismetProduct( purchase ) : false;
+	const is100YearPlanPurchase = purchase ? is100Year( purchase ) : false;
 
 	const showRedirectMessage = useCallback( () => {
 		reduxDispatch( infoNotice( translate( 'Redirecting to payment partner…' ) ) );
@@ -193,7 +194,10 @@ export default function PaymentMethodSelector( {
 				<div className="payment-method-selector__terms">
 					<Gridicon icon="info-outline" size={ 18 } />
 					<p>
-						<TosText isAkismetPurchase={ isAkismetPurchase } />
+						<TosText
+							isAkismetPurchase={ isAkismetPurchase }
+							is100YearPlanPurchase={ is100YearPlanPurchase }
+						/>
 					</p>
 				</div>
 

--- a/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/tos-text.tsx
@@ -4,10 +4,30 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 
 interface TosTextProps {
 	isAkismetPurchase: boolean;
+	is100YearPlanPurchase: boolean;
 }
 
-export default function TosText( { isAkismetPurchase }: TosTextProps ) {
+export default function TosText( { isAkismetPurchase, is100YearPlanPurchase }: TosTextProps ) {
 	const translate = useTranslate();
+
+	if ( is100YearPlanPurchase ) {
+		return (
+			<>
+				{ translate( 'You agree to our {{tosLink}}Terms of Service{{/tosLink}}.', {
+					components: {
+						tosLink: (
+							<a
+								href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+				} ) }
+			</>
+		);
+	}
+
 	return (
 		<>
 			{ translate(

--- a/client/my-sites/checkout/src/components/bundled-domain-notice.jsx
+++ b/client/my-sites/checkout/src/components/bundled-domain-notice.jsx
@@ -7,6 +7,7 @@ import {
 	hasJetpackPlan,
 	isNextDomainFree,
 	hasP2PlusPlan,
+	has100YearPlan,
 } from 'calypso/lib/cart-values/cart-items';
 import { REGISTER_DOMAIN } from 'calypso/lib/url/support';
 import CheckoutTermsItem from 'calypso/my-sites/checkout/src/components/checkout-terms-item';
@@ -60,7 +61,8 @@ export default function BundledDomainNotice( { cart } ) {
 		! hasPlan( cart ) ||
 		hasJetpackPlan( cart ) ||
 		hasMonthlyPlan( cart ) ||
-		hasP2PlusPlan( cart )
+		hasP2PlusPlan( cart ) ||
+		has100YearPlan( cart )
 	) {
 		return null;
 	}

--- a/client/my-sites/checkout/src/components/checkout-terms.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms.tsx
@@ -2,7 +2,7 @@ import { isDomainTransfer } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
-import { hasRenewableSubscription } from 'calypso/lib/cart-values/cart-items';
+import { has100YearPlan, hasRenewableSubscription } from 'calypso/lib/cart-values/cart-items';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { useSelector } from 'calypso/state';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -16,7 +16,9 @@ import DomainRegistrationHsts from './domain-registration-hsts';
 import { EbanxTermsOfService } from './ebanx-terms-of-service';
 import { InternationalFeeNotice } from './international-fee-notice';
 import JetpackSocialAdvancedPricingDisclaimer from './jetpack-social-advanced-pricing-disclaimer';
+import { PlanTerms100Year } from './plan-terms-100-year';
 import RefundPolicies from './refund-policies';
+import { RefundTerms100Year } from './refund-terms-100-year';
 import { TermsOfService } from './terms-of-service';
 import ThirdPartyPluginsTermsOfService from './third-party-plugins-terms-of-service';
 import TitanTermsOfService from './titan-terms-of-service';
@@ -53,6 +55,7 @@ export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
 			<TermsOfService
 				hasRenewableSubscription={ hasRenewableSubscription( cart ) || hasDomainTransfer }
 				isGiftPurchase={ Boolean( isGiftPurchase ) }
+				is100YearPlanPurchase={ has100YearPlan( cart ) }
 			/>
 			{ ! isGiftPurchase && <DomainRegistrationAgreement cart={ cart } /> }
 			{ ! isGiftPurchase && <DomainRegistrationHsts cart={ cart } /> }
@@ -61,6 +64,8 @@ export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
 			{ ! isGiftPurchase && <BundledDomainNotice cart={ cart } /> }
 			{ ! isGiftPurchase && <TitanTermsOfService cart={ cart } /> }
 			{ ! isGiftPurchase && <ThirdPartyPluginsTermsOfService cart={ cart } /> }
+			{ ! isGiftPurchase && <PlanTerms100Year cart={ cart } /> }
+			{ ! isGiftPurchase && <RefundTerms100Year cart={ cart } /> }
 			<EbanxTermsOfService />
 			{ shouldShowInternationalFeeNotice && <InternationalFeeNotice /> }
 			{ ! isGiftPurchase && <AdditionalTermsOfServiceInCart /> }

--- a/client/my-sites/checkout/src/components/plan-terms-100-year.tsx
+++ b/client/my-sites/checkout/src/components/plan-terms-100-year.tsx
@@ -1,0 +1,36 @@
+import { PLAN_100_YEARS, getPlan } from '@automattic/calypso-products';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import { has100YearPlan } from 'calypso/lib/cart-values/cart-items';
+import CheckoutTermsItem from './checkout-terms-item';
+import type { ResponseCart } from '@automattic/shopping-cart';
+
+export function PlanTerms100Year( { cart }: { cart: ResponseCart } ) {
+	const translate = useTranslate();
+
+	if ( ! has100YearPlan( cart ) ) {
+		return null;
+	}
+
+	return (
+		<CheckoutTermsItem>
+			{ translate(
+				'You acknowledge that you have read and understand the details about the %(planName)s listed {{supportLink}}here{{/supportLink}}, including feature changes that could occur during the life of your plan.',
+				{
+					components: {
+						supportLink: (
+							<a
+								href={ localizeUrl( 'https://wordpress.com/support/plan-features/100-year-plan/' ) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+					args: {
+						planName: getPlan( PLAN_100_YEARS )?.getTitle() || '',
+					},
+				}
+			) }
+		</CheckoutTermsItem>
+	);
+}

--- a/client/my-sites/checkout/src/components/refund-terms-100-year.tsx
+++ b/client/my-sites/checkout/src/components/refund-terms-100-year.tsx
@@ -1,0 +1,42 @@
+import { formatCurrency } from '@automattic/format-currency';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import { has100YearPlan } from 'calypso/lib/cart-values/cart-items';
+import CheckoutTermsItem from './checkout-terms-item';
+import type { ResponseCart } from '@automattic/shopping-cart';
+
+export function RefundTerms100Year( { cart }: { cart: ResponseCart } ) {
+	const translate = useTranslate();
+
+	if ( ! has100YearPlan( cart ) ) {
+		return null;
+	}
+
+	return (
+		<CheckoutTermsItem>
+			{ translate(
+				'You will be charged %(cost)s and understand that {{supportLink}}refunds{{/supportLink}} are limited to %(refundPeriodDays)d days after purchase.',
+				{
+					components: {
+						supportLink: (
+							<a
+								href={ localizeUrl(
+									'https://wordpress.com/support/manage-purchases/#refund-policy'
+								) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+					args: {
+						cost: formatCurrency( cart.total_cost_integer, cart.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+						refundPeriodDays: 120,
+					},
+				}
+			) }
+		</CheckoutTermsItem>
+	);
+}

--- a/client/my-sites/checkout/src/components/terms-of-service.tsx
+++ b/client/my-sites/checkout/src/components/terms-of-service.tsx
@@ -8,9 +8,11 @@ import CheckoutTermsItem from 'calypso/my-sites/checkout/src/components/checkout
 export const TermsOfService = ( {
 	hasRenewableSubscription,
 	isGiftPurchase,
+	is100YearPlanPurchase,
 }: {
 	hasRenewableSubscription: boolean;
 	isGiftPurchase: boolean;
+	is100YearPlanPurchase: boolean;
 } ) => {
 	const translate = useTranslate();
 	const recordTermsAndConditionsClick = () => {
@@ -36,7 +38,12 @@ export const TermsOfService = ( {
 
 		// Don't show the extended ToS notice for one-time purchases or gifts
 		if ( ! isGiftPurchase && hasRenewableSubscription ) {
-			message = <TosText isAkismetPurchase={ isAkismetCheckout() } />;
+			message = (
+				<TosText
+					isAkismetPurchase={ isAkismetCheckout() }
+					is100YearPlanPurchase={ is100YearPlanPurchase }
+				/>
+			);
 		}
 
 		return message;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#2140

## Proposed Changes

* This PR updates the ToS and checkout terms for the 100-year plan. More details in the parent issue: Automattic/martech#2140

![image](https://github.com/Automattic/wp-calypso/assets/5436027/9cd1e195-2154-4add-8412-b5e86748fcdc)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/checkout/<site slug>/wp_com_hundred_year_bundle_centennially`
* Scroll down and confirm that the terms match the screenshot and also match the ones in the parent issue.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?