### PR TITLE
VideoPress user intent: e2e test better support for User Intent flow with better wait for the start button

### DIFF
--- a/test/e2e/specs/onboarding/setup__videopress.ts
+++ b/test/e2e/specs/onboarding/setup__videopress.ts
@@ -39,7 +39,22 @@ describe( DataHelper.createSuiteTitle( 'VideoPress Tailored Onboarding' ), () =>
 		} );
 
 		it( 'Click Get Started', async function () {
-			await Promise.all( [ page.waitForNavigation(), page.click( 'text=Get started' ) ] );
+			let isButtonPresent = false;
+
+			try {
+				await page.waitForSelector( 'text=Get started' );
+				isButtonPresent = true;
+			} catch ( ex ) {}
+
+			// if Get Started is present, its the normal flow, otherwise its the User Intent flow
+			// -- if user intent, lets choose the item that sends us to the normal flow
+			if ( isButtonPresent ) {
+				await Promise.all( [ page.waitForNavigation(), page.click( 'text=Get started' ) ] );
+			} else {
+				await page.waitForSelector( 'img[alt="Get a video portfolio"]' );
+				await page.click( 'img[alt="Get a video portfolio"]' );
+				await page.click( 'button.intro__button' );
+			}
 		} );
 
 		it( 'Navigate VideoMaker Setup', async function () {

--- a/test/e2e/specs/onboarding/setup__videopress.ts
+++ b/test/e2e/specs/onboarding/setup__videopress.ts
@@ -51,7 +51,6 @@ describe( DataHelper.createSuiteTitle( 'VideoPress Tailored Onboarding' ), () =>
 			if ( 'get-started-button' === foundButtonKey ) {
 				await Promise.all( [ page.waitForNavigation(), page.click( 'text=Get started' ) ] );
 			} else {
-				await page.waitForSelector( 'img[alt="Get a video portfolio"]' );
 				await page.click( 'img[alt="Get a video portfolio"]' );
 				await page.click( 'button.intro__button' );
 			}

--- a/test/e2e/specs/onboarding/setup__videopress.ts
+++ b/test/e2e/specs/onboarding/setup__videopress.ts
@@ -39,16 +39,16 @@ describe( DataHelper.createSuiteTitle( 'VideoPress Tailored Onboarding' ), () =>
 		} );
 
 		it( 'Click Get Started', async function () {
-			let isButtonPresent = false;
-
-			try {
-				await page.waitForSelector( 'text=Get started' );
-				isButtonPresent = true;
-			} catch ( ex ) {}
+			// Return a button "key" for the button that is found on page.
+			// Only 1 should be present.
+			const foundButtonKey = await Promise.any( [
+				page.waitForSelector( 'text=Get started' ).then( () => 'get-started-button' ),
+				page.waitForSelector( 'img[alt="Get a video portfolio"]' ).then( () => 'portfolio-button' ),
+			] );
 
 			// if Get Started is present, its the normal flow, otherwise its the User Intent flow
 			// -- if user intent, lets choose the item that sends us to the normal flow
-			if ( isButtonPresent ) {
+			if ( 'get-started-button' === foundButtonKey ) {
 				await Promise.all( [ page.waitForNavigation(), page.click( 'text=Get started' ) ] );
 			} else {
 				await page.waitForSelector( 'img[alt="Get a video portfolio"]' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* re-instate the test changes from https://github.com/Automattic/wp-calypso/pull/81151 with better wait support for the button that needs to be pressed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run the e2e test against current production, it should pass `yarn workspace wp-e2e-tests test -- specs/onboarding/setup__videopress.ts`
   * you will notice it goes through the current flow (single "Get started" button at the start)
* start local dev server `yarn && yarn start`
* run the e2e test against local dev server, it should pass `CALYPSO_BASE_URL=http://calypso.localhost:3000 yarn workspace wp-e2e-tests test -- specs/onboarding/setup__videopress.ts`
   * you should notice it goes through the new user intent flow (grid of 6 images at the start)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?