### PR TITLE
Reader comments - fix tab order (second attempt)

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -436,7 +436,10 @@ class PostCommentList extends Component {
 		return (
 			<>
 				<ol className="comments__list is-root">
-					{ commentIds.map( ( commentId ) => this.renderComment( commentId, commentsTreeToShow ) ) }
+					{ commentIds
+						// Reverse comment list so that newest comments are rendered first.
+						?.reverse()
+						.map( ( commentId ) => this.renderComment( commentId, commentsTreeToShow ) ) }
 				</ol>
 				{ ( shouldShowViewMoreToggle || this.state.showExpandWhenOnlyComments ) && (
 					<Button

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -49,11 +49,6 @@
 		}
 	}
 
-	.comments__list.is-root {
-		display: flex;
-		flex-direction: column-reverse;
-	}
-
 	.comments__form .form-fieldset {
 		margin: 0;
 	}


### PR DESCRIPTION
…curate for a11y navigation

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #  https://github.com/Automattic/wp-calypso/pull/81230 

## Proposed Changes

* We previously shipped a similar change in https://github.com/Automattic/wp-calypso/pull/81230 that we had to revert. While all modern browsers support `toReverse` there are older versions that do not, and IE does not, so we got some errors in production with `toReverse` not being available.
* Here we use `reverse` instead of `toReverse` as in the previous attempt. [`reverse` is supported on many more](https://caniuse.com/?search=array%20reverse) browsers [than `toReverse` is](https://caniuse.com/?search=array%20toReverse). The main difference is it sorts the referenced array instead of making a new copy, but for us this is the only place the array is consumed anyways so it doesn't make a difference and is arguably better anyways.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* smoke test comments in the reader
* verify tab order moves down the list between top level comments.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
