### PR TITLE
hide owner column if all domains belong to the same current user

### DIFF
--- a/packages/domains-table/src/domains-table/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/index.tsx
@@ -317,33 +317,6 @@ test( 'bulk actions controls appear when a domain is selected', async () => {
 	expect( screen.queryByRole( 'button', { name: 'Auto-renew settings' } ) ).not.toBeInTheDocument();
 } );
 
-test( 'Owner column is rendered when domains has owner', async () => {
-	const [ primaryPartial, primaryFull ] = testDomain( {
-		domain: 'primary-domain.blog',
-		blog_id: 123,
-		primary_domain: true,
-		owner: 'owner',
-	} );
-
-	const fetchSiteDomains = jest.fn().mockImplementation( () =>
-		Promise.resolve( {
-			domains: [ primaryFull ],
-		} )
-	);
-
-	render(
-		<DomainsTable
-			domains={ [ primaryPartial ] }
-			isAllSitesView
-			fetchSiteDomains={ fetchSiteDomains }
-		/>
-	);
-
-	await waitFor( () => {
-		expect( screen.queryByText( 'Owner' ) ).toBeInTheDocument();
-	} );
-} );
-
 test( 'Owner column is rendered when domains has owner that is not the currently logged in user', async () => {
 	const [ primaryPartial, primaryFull ] = testDomain( {
 		domain: 'primary-domain.blog',
@@ -388,6 +361,40 @@ test( 'Owner column is not rendered when domains do not have an owner', async ()
 	render(
 		<DomainsTable
 			domains={ [ primaryPartial ] }
+			isAllSitesView
+			fetchSiteDomains={ fetchSiteDomains }
+		/>
+	);
+
+	await waitFor( () => {
+		expect( screen.queryByText( 'Owner' ) ).not.toBeInTheDocument();
+	} );
+} );
+
+test( 'Owner column is not rendered when all domains have the same owner', async () => {
+	const [ primaryPartial, primaryFull ] = testDomain( {
+		domain: 'primary-domain.blog',
+		blog_id: 123,
+		primary_domain: true,
+		owner: 'owner',
+	} );
+
+	const [ notPrimaryPartial, notPrimaryFull ] = testDomain( {
+		domain: 'primary-domain.blog',
+		blog_id: 124,
+		primary_domain: true,
+		owner: 'owner',
+	} );
+
+	const fetchSiteDomains = jest.fn().mockImplementation( () =>
+		Promise.resolve( {
+			domains: [ primaryFull, notPrimaryFull ],
+		} )
+	);
+
+	render(
+		<DomainsTable
+			domains={ [ primaryPartial, notPrimaryPartial ] }
 			isAllSitesView
 			fetchSiteDomains={ fetchSiteDomains }
 		/>

--- a/packages/domains-table/src/utils.ts
+++ b/packages/domains-table/src/utils.ts
@@ -62,7 +62,7 @@ export const getSiteSortFunctions = () => {
 };
 
 export const shouldHideOwnerColumn = ( domains: DomainData[] ) => {
-	return ! domains.some( ( domain ) => domain.owner );
+	return ! domains.some( ( domain ) => domain.owner && ! domain.current_user_is_owner );
 };
 export const countDomainsRequiringAttention = (
 	domainStatutes: ResolveDomainStatusReturn[] | undefined


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR is a quick fix to https://github.com/Automattic/wp-calypso/pull/81234 based on this p9Jlb4-8BQ-p2#comment-8877 to hide owners column if all the domains belong to the current user

## Proposed Changes

* Hide column if all domains belong to the current user

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/domains/manage?flags=domains/management`
* Verify owners column doesn't show when all the domain is owned by the same user.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?