### PR TITLE
Hosting metrics: Add bottom space for big screens

### DIFF
--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -41,6 +41,12 @@ $section-max-width: 1224px;
 	}
 }
 
+@media (min-width: 1401px) {
+	.layout__primary .main.site-monitoring {
+		padding-bottom: 88px;
+	}
+}
+
 .site-monitoring {
 	position: relative;
 

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -21,6 +21,10 @@ $section-max-width: 1224px;
 		padding: 0;
 		padding-block-start: 79px;
 
+		@media (min-width: 1401px) {
+			padding-bottom: 88px;
+		}
+
 		@media ( min-width: 782px ) {
 			padding-inline-start: calc(var(--sidebar-width-max) + 1px);
 		}
@@ -38,12 +42,6 @@ $section-max-width: 1224px;
 			margin-left: 16px;
 			margin-right: 16px;
 		}
-	}
-}
-
-@media (min-width: 1401px) {
-	.layout__primary .main.site-monitoring {
-		padding-bottom: 88px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Closes https://github.com/Automattic/wp-calypso/issues/81265

## Proposed Changes

- On https://github.com/Automattic/wp-calypso/pull/80964/files#diff-003eae379fd7a53f3e951838f92a572692c92e435e6985f03253384ca3dd1bc8R20-R21 we removed the padding from `layout_content`. The problem is that  the padding bottom for `.layout_primary .main` is also removed for large screens on https://github.com/Automattic/wp-calypso/blob/8dd4a4acc2dfe76b83038457effaf2b16efe597c/client/layout/style.scss#L124-L132 

* Add space on big screens for Hosting metrics page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- On an atomic site, navigate to `/site-monitoring/${siteSlug}`
- Resize the screen width to be bigger than 1440px
- Scroll to the bottom of the page
- Observe there is a space


## Screenshots

| **Before** | **After** |
|---|---|
|<img width="1921" alt="before-chart-bottom" src="https://github.com/Automattic/wp-calypso/assets/779993/a68ada75-d138-4cc0-b840-d4d92dc86387"> | <img width="1923" alt="after-chart-bottom" src="https://github.com/Automattic/wp-calypso/assets/779993/5a3645ed-7283-41ae-b8a8-5a6ca9ff7785"> |
| <img width="1920" alt="before-php-bottom" src="https://github.com/Automattic/wp-calypso/assets/779993/97bf8d14-b49a-49b1-9dee-06d8ef4dc86b"> | <img width="1917" alt="after-http-bottom" src="https://github.com/Automattic/wp-calypso/assets/779993/2f9e8258-af6c-4449-ae76-0611e5beb45a"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?