### PR TITLE
Remove white behind action bar icons in reader

### DIFF
--- a/client/blocks/follow-button/style.scss
+++ b/client/blocks/follow-button/style.scss
@@ -3,6 +3,7 @@ $follow-button-gray-disabled: var(--color-neutral-10);
 .follow-button,
 button.follow-button {
 	align-items: center;
+	background: unset;
 	border: 0;
 	display: flex;
 	padding: 0;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -20,6 +20,10 @@
 .reader-full-post__content {
 	margin: 0 auto;
 
+	.comment-button__icon path {
+		fill: unset;
+	}
+
 	@include breakpoint-deprecated( ">1280px" ) {
 		width: 720px;
 		padding-left: 260px;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -20,8 +20,9 @@
 .reader-full-post__content {
 	margin: 0 auto;
 
-	.comment-button__icon path {
-		fill: unset;
+	.comment-button__icon path,
+	.conversation-follow-button path {
+		fill: var(--color-neutral-0);
 	}
 
 	@include breakpoint-deprecated( ">1280px" ) {


### PR DESCRIPTION
## Description 

Earlier today @shaunandrews pointed out that on a few screens, our action bar icons had an unexpected white background. This PR aims to remove the white behind the follow and comment icons.

## Before
<img width="918" alt="before" src="https://github.com/Automattic/wp-calypso/assets/5634774/0b2472f5-ccf5-4c8b-aae2-d7534905094e">

## After
<img width="367" alt="after" src="https://github.com/Automattic/wp-calypso/assets/5634774/40566279-203c-430c-a76e-984e3ca77b9c">

## Testing

- Click Calypso live link
- Head to a full page post (like [this one](http://calypso.localhost:3000/read/feeds/102784056/posts/4876104836))
- Scroll down to the action bar below the post