### PR TITLE
Add forms AI e2e block smoke test

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
@@ -2,7 +2,7 @@ import { makeSelectorFromBlockName, validatePublishedFormFields } from './shared
 import { BlockFlow, EditorContext, PublishedPostContext } from '.';
 
 interface ConfigurationData {
-	aiPrompt: string;
+	prompt: string;
 }
 
 interface ValidationData {
@@ -46,10 +46,10 @@ export class FormAiFlow implements BlockFlow {
 			name: 'Send request',
 		} );
 
-		await aiInputReadyLocator.fill( this.configurationData.aiPrompt );
+		await aiInputReadyLocator.fill( this.configurationData.prompt );
 		await sendButtonLocator.click();
 		await aiInputBusyLocator.waitFor();
-		await aiInputReadyLocator.waitFor();
+		await aiInputReadyLocator.waitFor( { timeout: 30 * 1000 } );
 
 		// Grab a first sample input label and submit button text to use for validation.
 		this.validationData = {

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
@@ -1,0 +1,109 @@
+import { makeSelectorFromBlockName, validatePublishedFormFields } from './shared';
+import { BlockFlow, EditorContext, PublishedPostContext } from '.';
+
+interface ConfigurationData {
+	aiPrompt: string;
+}
+
+interface ValidationData {
+	sampleInputLabel: string;
+	submitButtonText: string;
+}
+
+/**
+ * Class representing the flow of using an block in the editor.
+ */
+export class FormAiFlow implements BlockFlow {
+	private configurationData: ConfigurationData;
+	private validationData: ValidationData | undefined;
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData data with which to configure and validate the block
+	 */
+	constructor( configurationData: ConfigurationData ) {
+		this.configurationData = configurationData;
+	}
+
+	blockSidebarName = 'Form';
+	blockEditorSelector = makeSelectorFromBlockName( 'Form' );
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		const aiInputReadyLocator = context.addedBlockLocator.getByRole( 'textbox', {
+			name: 'Ask Jetpack AI to create your form',
+		} );
+		const aiInputBusyLocator = context.addedBlockLocator.getByRole( 'textbox', {
+			name: 'Creating your form. Please wait a few moments.',
+			disabled: true,
+		} );
+		const sendButtonLocator = context.addedBlockLocator.getByRole( 'button', {
+			name: 'Send request',
+		} );
+
+		await aiInputReadyLocator.fill( this.configurationData.aiPrompt );
+		await sendButtonLocator.click();
+		await aiInputBusyLocator.waitFor();
+		await aiInputReadyLocator.waitFor();
+
+		// Grab a first sample input label and submit button text to use for validation.
+		this.validationData = {
+			sampleInputLabel: await this.getFirstTextFieldLabel( context ),
+			submitButtonText: await this.getSubmitButtonText( context ),
+		};
+	}
+
+	/**
+	 * Gets the label text for the first text-input field in the form in the editor.
+	 *
+	 * @param {EditorContext} context The editor context object.
+	 * @returns {Promise<string>} The label text of the first text-input field.
+	 */
+	private async getFirstTextFieldLabel( context: EditorContext ): Promise< string > {
+		return await context.addedBlockLocator
+			.getByRole( 'document', {
+				// The form will always have one of these input fields, and they are easy
+				// to validate later in the editor with accessible checks!
+				name: /^Block: (Text Input|Name|Email|Multi-line Text) Field$/,
+			} )
+			.locator( 'label' )
+			.first()
+			.innerText();
+	}
+
+	/**
+	 * Gets the innerText on the submit button on the form in the editor.
+	 *
+	 * @param {EditorContext} context The editor context object.
+	 * @returns {Promise<string>} The innerText of the submit button.
+	 */
+	private async getSubmitButtonText( context: EditorContext ): Promise< string > {
+		return await context.addedBlockLocator
+			.getByRole( 'document', {
+				name: 'Block: Button',
+			} )
+			.first()
+			.innerText();
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		if ( ! this.validationData ) {
+			throw new Error( 'Unable to find fields in the editor from the AI form.' );
+		}
+
+		await validatePublishedFormFields( context.page, [
+			{ type: 'textbox', accessibleName: this.validationData.sampleInputLabel },
+			{ type: 'button', accessibleName: this.validationData.submitButtonText },
+		] );
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -24,6 +24,7 @@ export * from './all-form-fields';
 export * from './form-patterns';
 export * from './ad';
 export * from './paywall';
+export * from './form-ai';
 
 /* Types */
 export * from './types';

--- a/test/e2e/specs/blocks/blocks__jetpack-forms.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-forms.ts
@@ -32,10 +32,10 @@ const blockFlows: BlockFlow[] = [
 		}
 	),
 	new FormAiFlow( {
-		aiPrompt:
+		prompt:
 			// The prefix part of the prompt isn't necessary for the test to be stable and have value
 			// but it doesn't hurt and will make debugging easier!
-			'Please create a registration form for a conference. Please prefix all field labels and the submit button with "AI".',
+			'Please create a small and simple registration form for a conference. Please prefix all field labels and the submit button with "AI".',
 	} ),
 ];
 

--- a/test/e2e/specs/blocks/blocks__jetpack-forms.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-forms.ts
@@ -6,6 +6,7 @@ import {
 	AllFormFieldsFlow,
 	BlockFlow,
 	ContactFormFlow,
+	FormAiFlow,
 	FormPatternsFlow,
 } from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared/block-smoke-testing';
@@ -30,6 +31,12 @@ const blockFlows: BlockFlow[] = [
 			],
 		}
 	),
+	new FormAiFlow( {
+		aiPrompt:
+			// The prefix part of the prompt isn't necessary for the test to be stable and have value
+			// but it doesn't hurt and will make debugging easier!
+			'Please create a registration form for a conference. Please prefix all field labels and the submit button with "AI".',
+	} ),
 ];
 
 createBlockTests( 'Blocks: Jetpack Forms', blockFlows );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This expands our form-focused block smoke testing to include an AI flow/case!

## Testing Instructions

- [x] Jetpack Simple Desktop
- [x] Jetpack Simple Mobile
- [x] Jetpack Atomic

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
