### PR TITLE
BackupBrowser: Add ID to the Redux include/exclude lists

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -84,9 +84,9 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 					addChildNodes(
 						siteId,
 						path,
-						backupFiles
-							.filter( shouldAddChildNode )
-							.map( ( childItem: FileBrowserItem ) => childItem.name )
+						backupFiles.filter( shouldAddChildNode ).map( ( childItem: FileBrowserItem ) => {
+							return { id: childItem.id ?? '', path: childItem.name };
+						} )
 					)
 				);
 			}

--- a/client/state/rewind/browser/actions.ts
+++ b/client/state/rewind/browser/actions.ts
@@ -3,12 +3,13 @@ import {
 	JETPACK_BACKUP_BROWSER_ADD_CHILDREN,
 	JETPACK_BACKUP_BROWSER_SET_CHECK_STATE,
 } from 'calypso/state/action-types';
+import { BackupBrowserCheckListInfo } from 'calypso/state/rewind/browser/types';
 
 type BrowserAddChildrenActionType = Action< typeof JETPACK_BACKUP_BROWSER_ADD_CHILDREN > & {
 	siteId: number;
 	payload: {
 		parentPath: string[] | string;
-		childrenPaths: string[];
+		childrenPaths: BackupBrowserCheckListInfo[];
 	};
 };
 
@@ -23,7 +24,7 @@ type BrowserSetCheckStateActionType = Action< typeof JETPACK_BACKUP_BROWSER_SET_
 export const addChildNodes = (
 	siteId: number,
 	parentPath: string[] | string,
-	childrenPaths: string[]
+	childrenPaths: BackupBrowserCheckListInfo[]
 ): BrowserAddChildrenActionType => ( {
 	type: JETPACK_BACKUP_BROWSER_ADD_CHILDREN,
 	siteId,

--- a/client/state/rewind/browser/reducer.ts
+++ b/client/state/rewind/browser/reducer.ts
@@ -192,7 +192,8 @@ export default ( state = initialState, { type, payload }: AnyAction ) => {
 			// They'll inherit the parent's state with default childrenLoading/Loaded/children values
 			for ( const childPath of childrenPaths ) {
 				parentNode.children.push( {
-					path: childPath,
+					id: childPath.id,
+					path: childPath.path,
 					ancestors: [ ...parentNode.ancestors, parentNode.path ],
 					checkState: parentNode.checkState === 'checked' ? 'checked' : 'unchecked',
 					childrenLoaded: false,

--- a/client/state/rewind/browser/types.ts
+++ b/client/state/rewind/browser/types.ts
@@ -1,4 +1,5 @@
 export type BackupBrowserItem = {
+	id: string;
 	path: string;
 	ancestors: string[];
 	checkState: 'checked' | 'unchecked' | 'mixed';
@@ -6,8 +7,13 @@ export type BackupBrowserItem = {
 	children: BackupBrowserItem[];
 };
 
+export type BackupBrowserCheckListInfo = {
+	id: string;
+	path: string;
+};
+
 export type BackupBrowserItemCheckList = {
 	totalItems: number;
-	includeList: string[];
-	excludeList: string[];
+	includeList: BackupBrowserCheckListInfo[];
+	excludeList: BackupBrowserCheckListInfo[];
 };

--- a/client/state/rewind/selectors/get-backup-browser-check-list.ts
+++ b/client/state/rewind/selectors/get-backup-browser-check-list.ts
@@ -2,7 +2,7 @@ import { BackupBrowserItem, BackupBrowserItemCheckList } from 'calypso/state/rew
 import type { AppState } from 'calypso/types';
 
 const getNodeFullPath = ( node: BackupBrowserItem ): string => {
-	let fullPath = node.ancestors.join( '/' ) + node.path;
+	let fullPath = node.ancestors.join( '/' ) + '/' + node.path;
 	if ( node.ancestors[ 0 ] === '/' ) {
 		fullPath = fullPath.slice( 1 );
 	}

--- a/client/state/rewind/selectors/get-backup-browser-check-list.ts
+++ b/client/state/rewind/selectors/get-backup-browser-check-list.ts
@@ -1,6 +1,14 @@
 import { BackupBrowserItem, BackupBrowserItemCheckList } from 'calypso/state/rewind/browser/types';
 import type { AppState } from 'calypso/types';
 
+const getNodeFullPath = ( node: BackupBrowserItem ): string => {
+	let fullPath = node.ancestors.join( '/' ) + node.path;
+	if ( node.ancestors[ 0 ] === '/' ) {
+		fullPath = fullPath.slice( 1 );
+	}
+	return fullPath;
+};
+
 // Recursive function to iterate through tree and add items to the list
 const addChildrenToList = (
 	currentNode: BackupBrowserItem,
@@ -13,7 +21,10 @@ const addChildrenToList = (
 
 	// If we're in a directory and we're checked, we just add the directory path and return to include all children
 	if ( currentNode.checkState === 'checked' ) {
-		currentList.includeList.push( currentNode.path );
+		currentList.includeList.push( {
+			id: currentNode.id,
+			path: getNodeFullPath( currentNode ),
+		} );
 		currentList.totalItems++;
 		return currentList;
 	}
@@ -28,7 +39,10 @@ const addChildrenToList = (
 	// If all children are selected we add the directory itself to the list and return
 	// This shouldn't hit, because the currentNode should be checked
 	if ( totalChildren === selectedChildren ) {
-		currentList.includeList.push( currentNode.path );
+		currentList.includeList.push( {
+			id: currentNode.id,
+			path: getNodeFullPath( currentNode ),
+		} );
 		currentList.totalItems++;
 		return currentList;
 	}
@@ -43,14 +57,20 @@ const addChildrenToList = (
 		} );
 
 	if ( useExclusion ) {
-		currentList.includeList.push( currentNode.path );
+		currentList.includeList.push( {
+			id: currentNode.id,
+			path: getNodeFullPath( currentNode ),
+		} );
 
 		// Lets sum only the selected children
 		currentList.totalItems = currentList.totalItems + selectedChildren;
 
 		currentNode.children.forEach( ( node: BackupBrowserItem ) => {
 			if ( node.checkState === 'unchecked' ) {
-				currentList.excludeList.push( node.path );
+				currentList.excludeList.push( {
+					id: node.id,
+					path: getNodeFullPath( node ),
+				} );
 			}
 		} );
 		return currentList;
@@ -60,7 +80,7 @@ const addChildrenToList = (
 	// For each mixed child, call addChildrenToList
 	currentNode.children.forEach( ( node: BackupBrowserItem ) => {
 		if ( 'checked' === node.checkState ) {
-			currentList.includeList.push( node.path );
+			currentList.includeList.push( { id: node.id, path: getNodeFullPath( node ) } );
 			currentList.totalItems++;
 		}
 		if ( 'mixed' === node.checkState ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This changes our includeList and excludeList for the checkbox states into arrays of `BackupBrowserCheckListInfo` ( id/path objects ).
* We need the ids for the base64 encoded values we'll use for the restores and downloads
* We retain the path (building out the full path from ancestors) for use in the Restore Confirmation screen UI

## Testing Instructions

* Load up a Live branch and add ?flags=jetpack/backup-granular to the url after visiting the Backup Browser.
* Enable selection and select some items
* Click the `Download` button in the Backup Browser header
* Open your browser's developer tools and check the console, it will log out include / exclude lists.  You can expand those to see the id and paths represented for the files you selected.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?