### PR TITLE
Stepper: Fix improper import in stepper for Sensei ErrorIcon

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/sensei-step-error/components.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/sensei-step-error/components.tsx
@@ -1,5 +1,22 @@
-import { ErrorIcon as UnstyledErrorIcon } from '@automattic/composite-checkout/src/components/shared-icons';
 import styled from '@emotion/styled';
+
+function UnstyledErrorIcon( { className }: { className?: string } ) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			aria-hidden="true"
+			className={ className }
+		>
+			<path
+				fill="#FFFFFF"
+				d="M11 15h2v2h-2v-2zm0-8h2v6h-2V7zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+			/>
+		</svg>
+	);
+}
 
 export const Container = styled.div`
 	display: flex;


### PR DESCRIPTION
## Proposed Changes

The `sensei-step-error` components in the stepper reach into the private implementation details of the `@automattic/composite-checkout` package to use a component that's not part of the package API. That is fragile and will probably break in the future. This bug was added in https://github.com/Automattic/wp-calypso/pull/71406

In this PR we refactor that component to duplicate the component that was imported instead.

## Testing Instructions

None should be needed.