### PR TITLE
Launchpad: Added skip button to fullscreen Launchpad - Pt 2

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
@@ -1,6 +1,11 @@
-import { useSelector } from 'calypso/state';
+import { useState } from 'react';
+import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
+import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
+import { useSelector, useDispatch } from 'calypso/state';
+import { requestSite } from 'calypso/state/sites/actions';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import CelebrateLaunchModal from '../../components/celebrate-launch-modal';
 import CustomerHomeLaunchpad from '.';
 import type { AppState } from 'calypso/types';
 
@@ -8,8 +13,42 @@ const LaunchpadPreLaunch = (): JSX.Element => {
 	const siteId = useSelector( getSelectedSiteId ) || '';
 	const site = useSelector( ( state: AppState ) => getSite( state, siteId ) );
 	const checklistSlug = site?.options?.site_intent ?? '';
+	const [ celebrateLaunchModalIsOpen, setCelebrateLaunchModalIsOpen ] = useState( false );
+	const { data: allDomains = [] } = useGetDomainsQuery( site?.ID ?? null, {
+		retry: false,
+	} );
 
-	return <CustomerHomeLaunchpad checklistSlug={ checklistSlug } />;
+	const dispatch = useDispatch();
+	const layout = useHomeLayoutQuery( siteId || null );
+
+	const setCelebrateLaunchModalIsOpenWrapper = ( value: boolean ) => {
+		// Triggered when the site is launched (true) and when the modal is closed (false)
+		setCelebrateLaunchModalIsOpen( value );
+
+		if ( value ) {
+			// Site launched, update site data
+			dispatch( requestSite( siteId ) );
+		} else {
+			// Modal closed, update the launchpad data/checklist
+			layout?.refetch();
+		}
+	};
+
+	return (
+		<>
+			<CustomerHomeLaunchpad
+				checklistSlug={ checklistSlug }
+				extraActions={ { setCelebrateLaunchModalIsOpen: setCelebrateLaunchModalIsOpenWrapper } }
+			/>
+			{ celebrateLaunchModalIsOpen && (
+				<CelebrateLaunchModal
+					setModalIsOpen={ setCelebrateLaunchModalIsOpenWrapper }
+					site={ site }
+					allDomains={ allDomains }
+				/>
+			) }
+		</>
+	);
 };
 
 export default LaunchpadPreLaunch;

--- a/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
@@ -21,11 +21,11 @@ const LaunchpadPreLaunch = (): JSX.Element => {
 	const dispatch = useDispatch();
 	const layout = useHomeLayoutQuery( siteId || null );
 
-	const setCelebrateLaunchModalIsOpenWrapper = ( value: boolean ) => {
+	const setCelebrateLaunchModalIsOpenWrapper = ( isOpen: boolean ) => {
 		// Triggered when the site is launched (true) and when the modal is closed (false)
-		setCelebrateLaunchModalIsOpen( value );
+		setCelebrateLaunchModalIsOpen( isOpen );
 
-		if ( value ) {
+		if ( isOpen ) {
 			// Site launched, update site data
 			dispatch( requestSite( siteId ) );
 		} else {
@@ -34,12 +34,13 @@ const LaunchpadPreLaunch = (): JSX.Element => {
 		}
 	};
 
+	const siteLaunched = () => {
+		setCelebrateLaunchModalIsOpenWrapper( true );
+	};
+
 	return (
 		<>
-			<CustomerHomeLaunchpad
-				checklistSlug={ checklistSlug }
-				extraActions={ { setCelebrateLaunchModalIsOpen: setCelebrateLaunchModalIsOpenWrapper } }
-			/>
+			<CustomerHomeLaunchpad checklistSlug={ checklistSlug } extraActions={ { siteLaunched } } />
 			{ celebrateLaunchModalIsOpen && (
 				<CelebrateLaunchModal
 					setModalIsOpen={ setCelebrateLaunchModalIsOpenWrapper }

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -20,7 +20,7 @@ export const setUpActionsForTasks = ( {
 	uiContext = 'calypso',
 }: LaunchpadTaskActionsProps ): Task[] => {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
-	const { setShareSiteModalIsOpen } = extraActions || {};
+	const { setShareSiteModalIsOpen, setCelebrateLaunchModalIsOpen } = extraActions || {};
 
 	//Record click events for tasks
 	const recordTaskClickTracksEvent = ( task: Task ) => {
@@ -131,7 +131,7 @@ export const setUpActionsForTasks = ( {
 							apiVersion: '1.1',
 							method: 'post',
 						} );
-						window.location.assign( `/home/${ siteSlug }?celebrateLaunch=true` );
+						setCelebrateLaunchModalIsOpen?.( true );
 					};
 					break;
 				default:

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -20,7 +20,7 @@ export const setUpActionsForTasks = ( {
 	uiContext = 'calypso',
 }: LaunchpadTaskActionsProps ): Task[] => {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
-	const { setShareSiteModalIsOpen, setCelebrateLaunchModalIsOpen } = extraActions || {};
+	const { setShareSiteModalIsOpen, siteLaunched } = extraActions || {};
 
 	//Record click events for tasks
 	const recordTaskClickTracksEvent = ( task: Task ) => {
@@ -131,7 +131,7 @@ export const setUpActionsForTasks = ( {
 							apiVersion: '1.1',
 							method: 'post',
 						} );
-						setCelebrateLaunchModalIsOpen?.( true );
+						siteLaunched?.();
 					};
 					break;
 				default:

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -56,7 +56,7 @@ export interface LaunchpadResponse {
 
 export interface PermittedActions {
 	setShareSiteModalIsOpen?: ( isOpen: boolean ) => void;
-	setCelebrateLaunchModalIsOpen?: ( isOpen: boolean ) => void;
+	siteLaunched?: () => void;
 }
 
 export interface LaunchpadTaskActionsProps {

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -56,6 +56,7 @@ export interface LaunchpadResponse {
 
 export interface PermittedActions {
 	setShareSiteModalIsOpen?: ( isOpen: boolean ) => void;
+	setCelebrateLaunchModalIsOpen?: ( isOpen: boolean ) => void;
 }
 
 export interface LaunchpadTaskActionsProps {


### PR DESCRIPTION
Built on top of https://github.com/Automattic/wp-calypso/pull/80661

This PR changes how we open the Site Launched Celebration Modal - from the task instead of reloading the page.

## Testing Instructions

- Access calypso.live
- Create a site with `/start`, use the `write` intent
![image](https://github.com/Automattic/wp-calypso/assets/3801502/78023d72-a145-4d6a-80f6-ee90d2860bb1)

- You will be redirected to fullscreen Launchpad
- Click on the `Skip for now` button
![image](https://github.com/Automattic/wp-calypso/assets/3801502/8fb83d66-a4d0-4301-830c-e04a25c23324)

- You should see the same checklist
![image](https://github.com/Automattic/wp-calypso/assets/3801502/9c26ab33-d568-47ec-9169-a9c767cd33e5)

- Click on the Launch your site task
- Check the celebrate modal is shown without the page reload.
 
![image](https://github.com/Automattic/wp-calypso/assets/3801502/8578b0c1-6c42-4d1d-b486-1315d2f63301)

- You should now see the post-launch checklist

![image](https://github.com/Automattic/wp-calypso/assets/3801502/a780cdf3-abbe-447a-ab8b-e4b3d394d7bb)

- The site data should be updated:
![image](https://github.com/Automattic/wp-calypso/assets/3801502/790e8b83-0a2e-4cce-a0fc-c74ecb5f65cb)

