### PR TITLE
Jetpack Pro Dashboard: Implement a popover to showcase the WPCOM hosting feature

### DIFF
--- a/client/components/split-button/index.jsx
+++ b/client/components/split-button/index.jsx
@@ -87,6 +87,7 @@ class SplitButton extends PureComponent {
 			popoverClassName,
 			whiteSeparator,
 			toggleIcon = 'chevron-down',
+			popoverContext,
 		} = this.props;
 		const { isMenuVisible } = this.state;
 		const toggleClasses = classNames( 'split-button__toggle', {
@@ -101,6 +102,8 @@ class SplitButton extends PureComponent {
 
 		const isEmptyOnClick = this.props.onClick === noop;
 		const onClick = isEmptyOnClick ? undefined : this.handleMainClick;
+
+		const popoverContextRef = popoverContext ?? this.popoverContext;
 
 		return (
 			<span className={ classes }>
@@ -122,7 +125,7 @@ class SplitButton extends PureComponent {
 					compact={ compact }
 					primary={ primary }
 					scary={ scary }
-					ref={ this.popoverContext }
+					ref={ popoverContextRef }
 					onClick={ this.handleMenuClick }
 					title={ toggleTitle || translate( 'Toggle menu' ) }
 					disabled={ disabled || disableMenu }
@@ -134,7 +137,7 @@ class SplitButton extends PureComponent {
 					isVisible={ isMenuVisible }
 					onClose={ this.hideMenu }
 					position={ position }
-					context={ this.popoverContext.current }
+					context={ popoverContextRef.current }
 					className={ popoverClasses }
 				>
 					{ children }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -1,5 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { Button, Count, WordPressLogo } from '@automattic/components';
+import { Button, Count } from '@automattic/components';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { getQueryArg, removeQueryArgs, addQueryArgs } from '@wordpress/url';
@@ -9,13 +8,10 @@ import page from 'page';
 import { useContext, useEffect, useState, useMemo, createRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryProductsList from 'calypso/components/data/query-products-list';
-import JetpackLogo from 'calypso/components/jetpack-logo';
-import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
-import SplitButton from 'calypso/components/split-button';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import useFetchMonitorVerfiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -38,6 +34,7 @@ import SiteContent from './site-content';
 import useDashboardShowLargeScreen from './site-content/hooks/use-dashboard-show-large-screen';
 import SiteContentHeader from './site-content-header';
 import SiteSearchFilterContainer from './site-search-filter-container/SiteSearchFilterContainer';
+import SiteTopHeaderButtons from './site-top-header-buttons';
 import type { Site } from '../sites-overview/types';
 
 import './style.scss';
@@ -199,94 +196,6 @@ export default function SitesOverview() {
 		} );
 	}, [ selectedLicensesSiteId, selectedLicenses ] );
 
-	const AddSiteIssueLicenseButtons = () => {
-		const dispatch = useDispatch();
-		const translate = useTranslate();
-
-		const isWPCOMAtomicSiteCreationEnabled = isEnabled(
-			'jetpack/pro-dashboard-wpcom-atomic-hosting'
-		);
-
-		return (
-			<div
-				className={ classNames( 'sites-overview__add-site-issue-license-buttons', {
-					'is-with-split-button': isWPCOMAtomicSiteCreationEnabled,
-				} ) }
-			>
-				<Button
-					className="sites-overview__issue-license-button"
-					href="/partner-portal/issue-license"
-					onClick={ () =>
-						dispatch(
-							recordTracksEvent( 'calypso_jetpack_agency_dashboard_issue_license_button_click' )
-						)
-					}
-				>
-					{ translate( 'Issue License', { context: 'button label' } ) }
-				</Button>
-
-				{ ! isWPCOMAtomicSiteCreationEnabled && (
-					<Button
-						className="sites-overview__issue-license-button"
-						primary
-						href="https://wordpress.com/jetpack/connect"
-						onClick={ () =>
-							dispatch(
-								recordTracksEvent( 'calypso_jetpack_agency_dashboard_add_site_button_click' )
-							)
-						}
-					>
-						{ translate( 'Add New Site', { context: 'button label' } ) }
-					</Button>
-				) }
-
-				{ isWPCOMAtomicSiteCreationEnabled && (
-					<SplitButton
-						primary
-						whiteSeparator
-						label={ isMobile ? undefined : translate( 'Add new site' ) }
-						onClick={ () =>
-							dispatch(
-								recordTracksEvent(
-									'calypso_jetpack_agency_dashboard_create_wpcom_atomic_site_button_click'
-								)
-							)
-						}
-						href="/partner-portal/create-site"
-						toggleIcon={ isMobile ? 'plus' : undefined }
-					>
-						<PopoverMenuItem
-							onClick={ () => {
-								recordTracksEvent(
-									'calypso_jetpack_agency_dashboard_create_wpcom_atomic_site_button_click'
-								);
-							} }
-							href="/partner-portal/create-site"
-						>
-							<WordPressLogo className="gridicon" size={ 18 } />
-							<span>{ translate( 'Create a new WordPress.com site' ) }</span>
-						</PopoverMenuItem>
-
-						<PopoverMenuItem
-							onClick={ () =>
-								dispatch(
-									recordTracksEvent(
-										'calypso_jetpack_agency_dashboard_connect_jetpack_site_button_click'
-									)
-								)
-							}
-							href="https://wordpress.com/jetpack/connect"
-							isExternalLink
-						>
-							<JetpackLogo className="gridicon" size={ 18 } />
-							<span>{ translate( 'Connect a site to Jetpack' ) }</span>
-						</PopoverMenuItem>
-					</SplitButton>
-				) }
-			</div>
-		);
-	};
-
 	const renderIssueLicenseButton = () => {
 		return (
 			<div className="sites-overview__licenses-buttons">
@@ -344,7 +253,7 @@ export default function SitesOverview() {
 								( selectedLicensesCount > 0 ? (
 									renderIssueLicenseButton()
 								) : (
-									<AddSiteIssueLicenseButtons />
+									<SiteTopHeaderButtons />
 								) )
 							}
 							pageTitle={ pageTitle }
@@ -354,7 +263,7 @@ export default function SitesOverview() {
 
 						{
 							// Render the add site and issue license buttons on mobile as a different component.
-							! isLargeScreen && <AddSiteIssueLicenseButtons />
+							! isLargeScreen && <SiteTopHeaderButtons />
 						}
 						<SectionNav
 							applyUpdatedStyles

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -1,0 +1,99 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { Button, WordPressLogo } from '@automattic/components';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import SplitButton from 'calypso/components/split-button';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+export default function SiteTopHeaderButtons() {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const isMobile = useMobileBreakpoint();
+
+	const isWPCOMAtomicSiteCreationEnabled = isEnabled(
+		'jetpack/pro-dashboard-wpcom-atomic-hosting'
+	);
+
+	return (
+		<div
+			className={ classNames( 'sites-overview__add-site-issue-license-buttons', {
+				'is-with-split-button': isWPCOMAtomicSiteCreationEnabled,
+			} ) }
+		>
+			<Button
+				className="sites-overview__issue-license-button"
+				href="/partner-portal/issue-license"
+				onClick={ () =>
+					dispatch(
+						recordTracksEvent( 'calypso_jetpack_agency_dashboard_issue_license_button_click' )
+					)
+				}
+			>
+				{ translate( 'Issue License', { context: 'button label' } ) }
+			</Button>
+
+			{ ! isWPCOMAtomicSiteCreationEnabled && (
+				<Button
+					className="sites-overview__issue-license-button"
+					primary
+					href="https://wordpress.com/jetpack/connect"
+					onClick={ () =>
+						dispatch(
+							recordTracksEvent( 'calypso_jetpack_agency_dashboard_add_site_button_click' )
+						)
+					}
+				>
+					{ translate( 'Add New Site', { context: 'button label' } ) }
+				</Button>
+			) }
+
+			{ isWPCOMAtomicSiteCreationEnabled && (
+				<SplitButton
+					primary
+					whiteSeparator
+					label={ isMobile ? undefined : translate( 'Add new site' ) }
+					onClick={ () =>
+						dispatch(
+							recordTracksEvent(
+								'calypso_jetpack_agency_dashboard_create_wpcom_atomic_site_button_click'
+							)
+						)
+					}
+					href="/partner-portal/create-site"
+					toggleIcon={ isMobile ? 'plus' : undefined }
+				>
+					<PopoverMenuItem
+						onClick={ () => {
+							recordTracksEvent(
+								'calypso_jetpack_agency_dashboard_create_wpcom_atomic_site_button_click'
+							);
+						} }
+						href="/partner-portal/create-site"
+					>
+						<WordPressLogo className="gridicon" size={ 18 } />
+						<span>{ translate( 'Create a new WordPress.com site' ) }</span>
+					</PopoverMenuItem>
+
+					<PopoverMenuItem
+						onClick={ () =>
+							dispatch(
+								recordTracksEvent(
+									'calypso_jetpack_agency_dashboard_connect_jetpack_site_button_click'
+								)
+							)
+						}
+						href="https://wordpress.com/jetpack/connect"
+						isExternalLink
+					>
+						<JetpackLogo className="gridicon" size={ 18 } />
+						<span>{ translate( 'Connect a site to Jetpack' ) }</span>
+					</PopoverMenuItem>
+				</SplitButton>
+			) }
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -3,11 +3,13 @@ import { Button, WordPressLogo } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useRef, useState } from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import WPCOMHostingPopover from './wpcom-hosting-popover';
 
 export default function SiteTopHeaderButtons() {
 	const dispatch = useDispatch();
@@ -17,6 +19,10 @@ export default function SiteTopHeaderButtons() {
 	const isWPCOMAtomicSiteCreationEnabled = isEnabled(
 		'jetpack/pro-dashboard-wpcom-atomic-hosting'
 	);
+
+	const buttonRef = useRef< any | null >( null );
+	const [ showPopover, setShowPopover ] = useState( false );
+	const [ toggleIsOpen, setToggleIsOpen ] = useState( false );
 
 	return (
 		<div
@@ -37,51 +43,65 @@ export default function SiteTopHeaderButtons() {
 			</Button>
 
 			{ isWPCOMAtomicSiteCreationEnabled ? (
-				<SplitButton
-					primary
-					whiteSeparator
-					label={ isMobile ? undefined : translate( 'Add new site' ) }
-					onClick={ () =>
-						dispatch(
-							recordTracksEvent(
-								'calypso_jetpack_agency_dashboard_create_wpcom_atomic_site_button_click'
-							)
-						)
-					}
-					href="/partner-portal/create-site"
-					toggleIcon={ isMobile ? 'plus' : undefined }
+				<span
+					ref={ buttonRef }
+					onMouseEnter={ () => setShowPopover( true ) }
+					onMouseLeave={ () => setShowPopover( false ) }
+					role="button"
+					tabIndex={ 0 }
 				>
-					<PopoverMenuItem
-						onClick={ () => {
-							recordTracksEvent(
-								'calypso_jetpack_agency_dashboard_create_wpcom_atomic_site_button_click'
-							);
-						} }
-						href="/partner-portal/create-site"
-					>
-						<WordPressLogo className="gridicon" size={ 18 } />
-						<span>{ translate( 'Create a new WordPress.com site' ) }</span>
-					</PopoverMenuItem>
-
-					<PopoverMenuItem
+					<SplitButton
+						primary
+						whiteSeparator
+						label={ isMobile ? undefined : translate( 'Add new site' ) }
 						onClick={ () =>
 							dispatch(
 								recordTracksEvent(
-									'calypso_jetpack_agency_dashboard_connect_jetpack_site_button_click'
+									'calypso_jetpack_agency_dashboard_create_wpcom_atomic_site_button_click'
 								)
 							)
 						}
-						href="https://wordpress.com/jetpack/connect"
-						isExternalLink
+						href="/partner-portal/create-site"
+						toggleIcon={ isMobile ? 'plus' : undefined }
+						onToggle={ ( isOpen: boolean ) => setToggleIsOpen( isOpen ) }
 					>
-						<JetpackLogo className="gridicon" size={ 18 } />
-						<span>{ translate( 'Connect a site to Jetpack' ) }</span>
-					</PopoverMenuItem>
-				</SplitButton>
+						<PopoverMenuItem
+							onClick={ () => {
+								recordTracksEvent(
+									'calypso_jetpack_agency_dashboard_create_wpcom_atomic_site_button_click'
+								);
+							} }
+							href="/partner-portal/create-site"
+						>
+							<WordPressLogo className="gridicon" size={ 18 } />
+							<span>{ translate( 'Create a new WordPress.com site' ) }</span>
+						</PopoverMenuItem>
+
+						<PopoverMenuItem
+							onClick={ () =>
+								dispatch(
+									recordTracksEvent(
+										'calypso_jetpack_agency_dashboard_connect_jetpack_site_button_click'
+									)
+								)
+							}
+							href="https://wordpress.com/jetpack/connect"
+							isExternalLink
+						>
+							<JetpackLogo className="gridicon" size={ 18 } />
+							<span>{ translate( 'Connect a site to Jetpack' ) }</span>
+						</PopoverMenuItem>
+					</SplitButton>
+					<WPCOMHostingPopover
+						context={ buttonRef.current }
+						// Show the popover only when the split button is closed
+						isVisible={ ! toggleIsOpen && showPopover }
+						position="bottom"
+					/>
+				</span>
 			) : (
 				<Button
 					className="sites-overview__issue-license-button"
-					primary
 					href="https://wordpress.com/jetpack/connect"
 					onClick={ () =>
 						dispatch(

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -62,7 +62,7 @@ export default function SiteTopHeaderButtons() {
 						<PopoverMenuItem
 							onClick={ () => {
 								recordTracksEvent(
-									'calypso_jetpack_agency_dashboard_create_wpcom_atomic_site_button_click'
+									'calypso_jetpack_agency_dashboard_create_wpcom_atomic_site_menu_item_click'
 								);
 							} }
 							href="/partner-portal/create-site"
@@ -75,7 +75,7 @@ export default function SiteTopHeaderButtons() {
 							onClick={ () =>
 								dispatch(
 									recordTracksEvent(
-										'calypso_jetpack_agency_dashboard_connect_jetpack_site_button_click'
+										'calypso_jetpack_agency_dashboard_connect_jetpack_site_menu_item_click'
 									)
 								)
 							}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -94,6 +94,7 @@ export default function SiteTopHeaderButtons() {
 				</span>
 			) : (
 				<Button
+					primary
 					className="sites-overview__issue-license-button"
 					href="https://wordpress.com/jetpack/connect"
 					onClick={ () =>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -36,22 +36,7 @@ export default function SiteTopHeaderButtons() {
 				{ translate( 'Issue License', { context: 'button label' } ) }
 			</Button>
 
-			{ ! isWPCOMAtomicSiteCreationEnabled && (
-				<Button
-					className="sites-overview__issue-license-button"
-					primary
-					href="https://wordpress.com/jetpack/connect"
-					onClick={ () =>
-						dispatch(
-							recordTracksEvent( 'calypso_jetpack_agency_dashboard_add_site_button_click' )
-						)
-					}
-				>
-					{ translate( 'Add New Site', { context: 'button label' } ) }
-				</Button>
-			) }
-
-			{ isWPCOMAtomicSiteCreationEnabled && (
+			{ isWPCOMAtomicSiteCreationEnabled ? (
 				<SplitButton
 					primary
 					whiteSeparator
@@ -93,6 +78,19 @@ export default function SiteTopHeaderButtons() {
 						<span>{ translate( 'Connect a site to Jetpack' ) }</span>
 					</PopoverMenuItem>
 				</SplitButton>
+			) : (
+				<Button
+					className="sites-overview__issue-license-button"
+					primary
+					href="https://wordpress.com/jetpack/connect"
+					onClick={ () =>
+						dispatch(
+							recordTracksEvent( 'calypso_jetpack_agency_dashboard_add_site_button_click' )
+						)
+					}
+				>
+					{ translate( 'Add New Site', { context: 'button label' } ) }
+				</Button>
 			) }
 		</div>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -96,7 +96,6 @@ export default function SiteTopHeaderButtons() {
 						context={ buttonRef.current }
 						// Show the popover only when the split button is closed
 						isVisible={ ! toggleIsOpen && showPopover }
-						position="bottom"
 					/>
 				</span>
 			) : (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -21,7 +21,6 @@ export default function SiteTopHeaderButtons() {
 	);
 
 	const buttonRef = useRef< any | null >( null );
-	const [ showPopover, setShowPopover ] = useState( false );
 	const [ toggleIsOpen, setToggleIsOpen ] = useState( false );
 
 	return (
@@ -43,13 +42,7 @@ export default function SiteTopHeaderButtons() {
 			</Button>
 
 			{ isWPCOMAtomicSiteCreationEnabled ? (
-				<span
-					ref={ buttonRef }
-					onMouseEnter={ () => setShowPopover( true ) }
-					onMouseLeave={ () => setShowPopover( false ) }
-					role="button"
-					tabIndex={ 0 }
-				>
+				<span>
 					<SplitButton
 						primary
 						whiteSeparator
@@ -64,6 +57,7 @@ export default function SiteTopHeaderButtons() {
 						href="/partner-portal/create-site"
 						toggleIcon={ isMobile ? 'plus' : undefined }
 						onToggle={ ( isOpen: boolean ) => setToggleIsOpen( isOpen ) }
+						popoverContext={ buttonRef }
 					>
 						<PopoverMenuItem
 							onClick={ () => {
@@ -95,7 +89,7 @@ export default function SiteTopHeaderButtons() {
 					<WPCOMHostingPopover
 						context={ buttonRef.current }
 						// Show the popover only when the split button is closed
-						isVisible={ ! toggleIsOpen && showPopover }
+						isVisible={ ! toggleIsOpen }
 					/>
 				</span>
 			) : (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/style.scss
@@ -1,0 +1,33 @@
+@import "@wordpress/base-styles/mixins";
+
+.wpcom-hosting-popover {
+	z-index: 100000;
+	border-radius: 4px;
+
+	.popover__inner {
+		display: flex;
+		gap: 16px;
+		padding: 16px;
+		flex-direction: column;
+		align-items: flex-start;
+	}
+}
+
+.wpcom-hosting-popover__heading {
+	font-size: rem(14px);
+	line-height: 1.5;
+}
+
+.wpcom-hosting-popover__description {
+	color: var(--studio-gray-80);
+	font-size: rem(12px);
+	line-height: 1.5;
+	max-width: 200px;
+	text-align: left;
+	margin-block-end: 0;
+}
+
+.wpcom-hosting-popover__button {
+	padding: 4px 8px;
+	font-size: rem(12px);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/style.scss
@@ -22,7 +22,7 @@
 	color: var(--studio-gray-80);
 	font-size: rem(12px);
 	line-height: 1.5;
-	max-width: 200px;
+	max-width: 220px;
 	text-align: left;
 	margin-block-end: 0;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/style.scss
@@ -31,3 +31,7 @@
 	padding: 4px 8px;
 	font-size: rem(12px);
 }
+
+.wpcom-hosting-popover__icon {
+	margin-inline-start: 4px;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/wpcom-hosting-popover.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/wpcom-hosting-popover.tsx
@@ -1,0 +1,79 @@
+import { Popover, Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import {
+	JETPACK_DASHBOARD_WPCOM_HOSTING_FEATURE_TOOLTIP_PREFERENCE as tooltipPreference,
+	getJetpackDashboardPreference as getPreference,
+} from 'calypso/state/jetpack-agency-dashboard/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { PreferenceType } from '../../sites-overview/types';
+
+import './style.scss';
+
+type Props = {
+	context: HTMLElement | null;
+	isVisible: boolean;
+	position?: string;
+};
+
+export default function WPCOMHostingPopover( { context, isVisible, position }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const preference = useSelector( ( state ) => getPreference( state, tooltipPreference ) );
+
+	const isDismissed = preference?.dismiss;
+
+	const savePreferenceType = useCallback(
+		( type: PreferenceType ) => {
+			dispatch( savePreference( tooltipPreference, { ...preference, [ type ]: true } ) );
+		},
+		[ dispatch, preference ]
+	);
+
+	const handleClick = () => {
+		savePreferenceType( 'dismiss' );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_agency_dashboard_wpcom_hosting_feature_popover_accept' )
+		);
+	};
+
+	const handleOnShow = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_agency_dashboard_wpcom_hosting_feature_popover_view' )
+		);
+	};
+
+	// Don't show the popover if the user has dismissed it
+	if ( isDismissed ) {
+		return null;
+	}
+
+	return (
+		<Popover
+			className="wpcom-hosting-popover"
+			context={ context }
+			isVisible={ isVisible }
+			position={ position }
+			showDelay={ 300 }
+			onShow={ handleOnShow }
+			relativePosition={ {
+				left: 10,
+			} }
+		>
+			<h2 className="wpcom-hosting-popover__heading">{ translate( 'New Feature!' ) }</h2>
+
+			<p className="wpcom-hosting-popover__description">
+				{ translate(
+					'You can now create a WordPress.com site directly from Jetpack Manage. Give it a try!'
+				) }
+			</p>
+
+			<Button className="wpcom-hosting-popover__button" onClick={ handleClick }>
+				{ translate( 'Got it' ) }
+			</Button>
+		</Popover>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/wpcom-hosting-popover.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/wpcom-hosting-popover.tsx
@@ -15,10 +15,9 @@ import './style.scss';
 type Props = {
 	context: HTMLElement | null;
 	isVisible: boolean;
-	position?: string;
 };
 
-export default function WPCOMHostingPopover( { context, isVisible, position }: Props ) {
+export default function WPCOMHostingPopover( { context, isVisible }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -56,12 +55,9 @@ export default function WPCOMHostingPopover( { context, isVisible, position }: P
 			className="wpcom-hosting-popover"
 			context={ context }
 			isVisible={ isVisible }
-			position={ position }
+			position="bottom"
 			showDelay={ 300 }
 			onShow={ handleOnShow }
-			relativePosition={ {
-				left: 10,
-			} }
 		>
 			<h2 className="wpcom-hosting-popover__heading">{ translate( 'New Feature!' ) }</h2>
 
@@ -69,6 +65,7 @@ export default function WPCOMHostingPopover( { context, isVisible, position }: P
 				{ translate(
 					'You can now create a WordPress.com site directly from Jetpack Manage. Give it a try!'
 				) }
+				<span className="wpcom-hosting-popover__icon">&#128640;</span>
 			</p>
 
 			<Button className="wpcom-hosting-popover__button" onClick={ handleClick }>

--- a/client/state/jetpack-agency-dashboard/selectors.ts
+++ b/client/state/jetpack-agency-dashboard/selectors.ts
@@ -25,6 +25,9 @@ export const JETPACK_DASHBOARD_CHECKOUT_REDIRECT_MODAL_DISMISSED =
 export const JETPACK_DASHBOARD_DOWNTIME_MONITORING_UPGRADE_TOOLTIP_PREFERENCE =
 	'jetpack-dashboard-agency-program-downtime-monitoring-upgrade-tooltip-preference';
 
+export const JETPACK_DASHBOARD_WPCOM_HOSTING_FEATURE_TOOLTIP_PREFERENCE =
+	'jetpack-dashboard-agency-program-wpcom-hosting-feature-tooltip-preference';
+
 /**
  * Returns preference associated with the key provided.
  */


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-avalon/issues/48

## Proposed Changes

This PR implements a popover to showcase the WPCOM hosting feature on the Jetpack Pro Dashboard.

Also includes the following changes:

- Move the piece of code that deals with the rendering the buttons to a new component
- Minor code refactor

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud live link.
2. Verify that the popover appears.

<img width="412" alt="Screenshot 2023-09-04 at 3 48 32 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/07fd127d-e919-49f7-a625-ecd6575f965b">


3. Click on the down arrow and verify that the popover is not shown and the dropdown items are shown.

<img width="405" alt="Screenshot 2023-09-01 at 2 13 06 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3e6b3511-8fe5-43e0-a22b-d9628b5dddea">

4. Click the `Got it` button and verify that it is not shown again by refreshing the page
5. Verify that the buttons work as expected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?