### PR TITLE
Checkout: experiment to test plan feature list copy

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -18,6 +18,10 @@ import {
 	isAkismetProduct,
 	planHasFeature,
 	WPCOM_FEATURES_ATOMIC,
+	isPersonal,
+	isPremium,
+	isBusiness,
+	isEcommerce,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import {
@@ -38,6 +42,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
+import { useExperiment } from 'calypso/lib/explat';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
@@ -53,6 +58,10 @@ import type { TranslateResult } from 'i18n-calypso';
 
 // This will make converting to TS less noisy. The order of components can be reorganized later
 /* eslint-disable @typescript-eslint/no-use-before-define */
+
+function isPlanEligibleForCheckoutFeatureListExperiment( plan: ResponseCartProduct ) {
+	return isPersonal( plan ) || isPremium( plan ) || isBusiness( plan ) || isEcommerce( plan );
+}
 
 export default function WPCheckoutOrderSummary( {
 	siteId,
@@ -83,6 +92,10 @@ export default function WPCheckoutOrderSummary( {
 	const plan = responseCart.products.find( ( product ) => isPlan( product ) );
 	const hasMonthlyPlanInCart = Boolean( plan && isMonthly( plan?.product_slug ) );
 
+	const [ isLoadingExperimentAssignment ] = useExperiment( 'calypso_checkout_feature_list_copy', {
+		isEligible: plan && isPlanEligibleForCheckoutFeatureListExperiment( plan ),
+	} );
+
 	return (
 		<CheckoutSummaryCard
 			className={ isCartUpdating ? 'is-loading' : '' }
@@ -94,7 +107,7 @@ export default function WPCheckoutOrderSummary( {
 						? translate( 'WordPress.com Gift Subscription' )
 						: translate( 'Included with your purchase' ) }
 				</CheckoutSummaryFeaturesTitle>
-				{ isCartUpdating ? (
+				{ isCartUpdating || isLoadingExperimentAssignment ? (
 					<LoadingCheckoutSummaryFeaturesList />
 				) : (
 					<CheckoutSummaryFeaturesWrapper siteId={ siteId } nextDomainIsFree={ nextDomainIsFree } />
@@ -607,12 +620,19 @@ function CheckoutSummaryPlanFeatures( props: {
 	const hasRenewalInCart = responseCart.products.some(
 		( product ) => product.extra.purchaseType === 'renewal'
 	);
+
+	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_feature_list_copy', {
+		isEligible: planInCart && isPlanEligibleForCheckoutFeatureListExperiment( planInCart ),
+	} );
+	const showPricingGridFeatures = 'treatment' === experimentAssignment?.variationName;
+
 	const planFeatures = getPlanFeatures(
 		planInCart,
 		translate,
 		hasDomainsInCart,
 		hasRenewalInCart,
-		nextDomainIsFree
+		nextDomainIsFree,
+		showPricingGridFeatures
 	);
 
 	return (

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -92,9 +92,12 @@ export default function WPCheckoutOrderSummary( {
 	const plan = responseCart.products.find( ( product ) => isPlan( product ) );
 	const hasMonthlyPlanInCart = Boolean( plan && isMonthly( plan?.product_slug ) );
 
-	const [ isLoadingExperimentAssignment ] = useExperiment( 'calypso_checkout_feature_list_copy', {
-		isEligible: plan && isPlanEligibleForCheckoutFeatureListExperiment( plan ),
-	} );
+	const [ isLoadingExperimentAssignment ] = useExperiment(
+		'calypso_checkout_feature_list_copy_v2',
+		{
+			isEligible: plan && isPlanEligibleForCheckoutFeatureListExperiment( plan ),
+		}
+	);
 
 	return (
 		<CheckoutSummaryCard
@@ -621,7 +624,7 @@ function CheckoutSummaryPlanFeatures( props: {
 		( product ) => product.extra.purchaseType === 'renewal'
 	);
 
-	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_feature_list_copy', {
+	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_feature_list_copy_v2', {
 		isEligible: planInCart && isPlanEligibleForCheckoutFeatureListExperiment( planInCart ),
 	} );
 	const showPricingGridFeatures = 'treatment' === experimentAssignment?.variationName;

--- a/client/my-sites/checkout/src/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/src/lib/get-plan-features.ts
@@ -9,9 +9,13 @@ import {
 	isWpComPremiumPlan,
 	isStarterPlan,
 	is100YearPlan,
+	FEATURE_FREE_DOMAIN,
+	Feature,
+	applyTestFiltersToPlansList,
 } from '@automattic/calypso-products';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
+import { FEATURES_LIST } from 'calypso/lib/plans/features-list';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 export default function getPlanFeatures(
@@ -19,7 +23,8 @@ export default function getPlanFeatures(
 	translate: ReturnType< typeof useTranslate >,
 	hasDomainsInCart: boolean,
 	hasRenewalInCart: boolean,
-	nextDomainIsFree: boolean
+	nextDomainIsFree: boolean,
+	showPricingGridFeatures?: boolean
 ): string[] {
 	const showFreeDomainFeature = ! hasDomainsInCart && ! hasRenewalInCart && nextDomainIsFree;
 	const productSlug = plan?.product_slug;
@@ -29,6 +34,27 @@ export default function getPlanFeatures(
 	}
 
 	const isMonthlyPlan = isMonthly( productSlug );
+
+	if ( showPricingGridFeatures ) {
+		const planObject = applyTestFiltersToPlansList( productSlug, undefined );
+
+		if ( ! planObject ) {
+			return [];
+		}
+
+		const featureList: Feature[] = planObject?.getCheckoutFeatures?.() || [];
+		const annualPlanOnlyFeatures = planObject?.getAnnualPlansOnlyFeatures?.() || [];
+
+		return (
+			featureList
+				// Exclude annual plan only features if the current plan is a monthly plan
+				?.filter( ( feature ) => ! isMonthlyPlan || ! annualPlanOnlyFeatures.includes( feature ) )
+				// Show the free domain feature if `showFreeDomainFeature` is true
+				?.filter( ( feature ) => feature !== FEATURE_FREE_DOMAIN || showFreeDomainFeature )
+				?.map( ( feature ) => String( FEATURES_LIST[ feature ].getTitle() ) )
+		);
+	}
+
 	const emailSupport = String( translate( 'Customer support via email' ) );
 	const liveChatSupport = String( translate( 'Live chat support' ) );
 	const freeOneYearDomain = showFreeDomainFeature

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -891,6 +891,13 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_PREMIUM_CONTENT_JP,
 		FEATURE_PAID_SUBSCRIBERS_JP,
 	],
+	getCheckoutFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_SUPPORT_EMAIL,
+		FEATURE_AD_FREE_EXPERIENCE,
+		FEATURE_FAST_DNS,
+		FEATURE_PAID_SUBSCRIBERS_JP,
+	],
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: () => [ FEATURE_AUDIO_UPLOADS ],
 	getInferiorFeatures: () => [],
@@ -1044,6 +1051,17 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 		[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
 			? FEATURE_PAYMENT_TRANSACTION_FEES_0_ALL
 			: FEATURE_PAYMENT_TRANSACTION_FEES_0,
+	],
+	getCheckoutFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_LIVE_CHAT_SUPPORT,
+		FEATURE_PLUGINS_THEMES,
+		FEATURE_ACCEPT_PAYMENTS,
+		FEATURE_SHIPPING_CARRIERS,
+		FEATURE_UNLIMITED_PRODUCTS_SERVICES,
+		FEATURE_LOYALTY_PROG,
+		FEATURE_INVENTORY,
+		FEATURE_CUSTOM_MARKETING_AUTOMATION,
 	],
 	get2023PricingGridSignupJetpackFeatures: () => [],
 	get2023PricingGridSignupStorageOptions: ( showLegacyStorageFeature, isCurrentPlan ) => {
@@ -1436,6 +1454,16 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_STYLE_CUSTOMIZATION,
 		FEATURE_PAYMENT_TRANSACTION_FEES_4,
 	],
+	getCheckoutFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_LIVE_CHAT_SUPPORT,
+		FEATURE_PREMIUM_THEMES_V2,
+		FEATURE_WORDADS,
+		FEATURE_STYLE_CUSTOMIZATION,
+		FEATURE_VIDEOPRESS_JP,
+		FEATURE_UNLTD_SOCIAL_MEDIA_JP,
+		FEATURE_SITE_ACTIVITY_LOG_JP,
+	],
 	get2023PricingGridSignupJetpackFeatures: () => [
 		FEATURE_VIDEOPRESS_JP,
 		FEATURE_UNLTD_SOCIAL_MEDIA_JP,
@@ -1619,6 +1647,19 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
 			? [ FEATURE_PAYMENT_TRANSACTION_FEES_0_WOO, FEATURE_PAYMENT_TRANSACTION_FEES_2_REGULAR ]
 			: [ FEATURE_PAYMENT_TRANSACTION_FEES_2 ] ),
+	],
+	getCheckoutFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_PLUGINS_THEMES,
+		FEATURE_BANDWIDTH,
+		FEATURE_CDN,
+		FEATURE_ADVANCED_SEO_TOOLS,
+		FEATURE_LIVE_CHAT_SUPPORT,
+		FEATURE_DEV_TOOLS,
+		FEATURE_REALTIME_BACKUPS_JP,
+		FEATURE_SITE_ACTIVITY_LOG_JP,
+		FEATURE_SECURITY_DDOS,
+		FEATURE_SITE_STAGING_SITES,
 	],
 	get2023PricingGridSignupJetpackFeatures: () => [
 		FEATURE_REALTIME_BACKUPS_JP,

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -303,6 +303,11 @@ export type Plan = BillingTerm & {
 	getBlogOnboardingSignupFeatures?: () => Feature[];
 	getBlogOnboardingHighlightedFeatures?: () => Feature[];
 	getBlogOnboardingSignupJetpackFeatures?: () => Feature[];
+
+	/**
+	 * Features that are shown on the right sidebar of the checkout page.
+	 */
+	getCheckoutFeatures?: () => Feature[];
 };
 
 export type WithSnakeCaseSlug = { product_slug: string };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/growth-foundations#184
Related to https://github.com/Automattic/growth-foundations/issues/153

## Proposed Changes

* This PR adds experiment code to test the feature list copy on the checkout page for WPCOM plans. The new copy will be picked up from the existing feature list shown on the plans grid.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to the treatment variation for 21402-explat-experiment
* Go to `/plans/<site slug>` for a site on the free plan.
* Click on upgrade for each of the plans and confirm that the checkout page shows an updated feature list that matches the screenshots below.

Here are the screenshots:

**Personal monthly**


![Image](https://github.com/Automattic/growth-foundations/assets/5436027/3b8177f2-5511-4b2d-a312-e6300ac1a96e)

**Personal annual**


![Image](https://github.com/Automattic/growth-foundations/assets/5436027/190adee0-8c48-4f30-beb7-def52ab73bac)

**Premium monthly**


![Image](https://github.com/Automattic/growth-foundations/assets/5436027/3041fed5-ad26-41ce-9c83-ef54b1ab9c52)


**Premium annual**


![Image](https://github.com/Automattic/growth-foundations/assets/5436027/97109b9b-45cc-46fa-9c9b-1734fe2de685)


**Business monthly**


![Image](https://github.com/Automattic/growth-foundations/assets/5436027/864f7bef-e911-40fa-bcb2-47af20313f1e)


**Business annual**

<img width="1200" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/8e3a3017-eb26-49fc-9ee0-7e24eec2b629">


**Commerce monthly**



![Image](https://github.com/Automattic/growth-foundations/assets/5436027/5e04b2a7-b6d0-4279-a1a9-3fb16a7c8a49)




**Commerce annual**


![Image](https://github.com/Automattic/growth-foundations/assets/5436027/93d2c014-3973-40c3-aa86-479d44489978)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?