### PR TITLE
Handle skipped launchpad screen in update-design flow and launchpad step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -91,6 +91,11 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		}
 	}, [ siteSlug, site ] );
 
+	if ( launchpadScreenOption === 'skipped' ) {
+		window.location.assign( `/home/${ siteSlug }` );
+		return;
+	}
+
 	return (
 		<>
 			<DocumentHead title={ almostReadyToLaunchText } />

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -1,3 +1,4 @@
+import { useLaunchpad } from '@automattic/data-stores';
 import { isAssemblerDesign } from '@automattic/design-picker';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
@@ -42,6 +43,8 @@ const updateDesign: Flow = {
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
 			[]
 		);
+		const { data: { launchpad_screen: launchpadScreenOption } = {} } = useLaunchpad( siteSlug );
+
 		const exitFlow = ( to: string ) => {
 			setPendingAction( () => {
 				return new Promise( () => {
@@ -67,6 +70,10 @@ const updateDesign: Flow = {
 						} );
 
 						return exitFlow( `/site-editor/${ siteSlug }?${ params }` );
+					}
+
+					if ( launchpadScreenOption === 'skipped' ) {
+						return window.location.assign( `/home/${ siteSlug }` );
 					}
 
 					return window.location.assign(

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -31,9 +31,11 @@ interface ChecklistStatuses {
 	domain_upsell_deferred?: boolean;
 }
 
+type LaunchpadScreen = 'full' | 'off' | 'skipped' | 'minimized';
+
 interface LaunchpadResponse {
 	site_intent?: string | null;
-	launchpad_screen?: string | boolean | null | undefined;
+	launchpad_screen?: LaunchpadScreen | boolean | null | undefined;
 	checklist?: Task[] | null;
 	checklist_statuses?: ChecklistStatuses;
 	is_enabled: boolean;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* https://github.com/Automattic/wp-calypso/pull/80661
* https://github.com/Automattic/wp-calypso/pull/81305
* https://github.com/Automattic/jetpack/pull/32796

## Proposed Changes

* This change updates the `update-design` Stepper flow and the `launchpad` step to redirect to Customer Home when we detect that the `launchpad_screen` option for a site has been set to `'skipped'`.
  - The new `'skipped'` value is being set by the changes from https://github.com/Automattic/wp-calypso/pull/80661
  - The combined testing for https://github.com/Automattic/wp-calypso/pull/80661 and https://github.com/Automattic/jetpack/pull/32796 uncovered that after we've skipped the launchpad, we can still enter the `design-update` flow, and there may be other situations in which a user may end up on the launchpad step.
* I also updated the `LaunchpadResponse` type to include the possible string values we expect.

## Testing Instructions

* Start by following the testing instructions for https://github.com/Automattic/wp-calypso/pull/80661, as we need a test site with the `write` intent that has correctly skipped the launchpad, but hasn't been launched yet.
* Once you have a site as above, run this branch locally or via Calypso.live
* Navigate to `/setup/update-design/designSetup?siteSlug=:siteSlug`
* Select a new design for your site, and click on "Continue" when shown the style variations and preview for that theme
* Verify that you are redirected to Customer Home
* Now navigate to `/setup/free/launchpad?siteSlug=:siteSlug`
* Verify that you are redirected to Customer Home

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?