### PR TITLE
Newsletter Categories: Fix error when marking as newsletter category

### DIFF
--- a/client/data/newsletter-categories/use-mark-as-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-mark-as-newsletter-category-mutation.tsx
@@ -37,14 +37,18 @@ const useMarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 
 			queryClient.setQueryData( cacheKey, ( oldData?: NewsletterCategories ) => {
 				const newNewsletterCategory = categories?.find(
-					( category ) => category.id === categoryId
-				) as NewsletterCategory;
+					( category ) => category?.id === categoryId
+				);
+
+				if ( ! newNewsletterCategory ) {
+					return oldData;
+				}
 
 				const updatedData = {
 					...oldData,
 					newsletterCategories: [
 						...( oldData?.newsletterCategories ? oldData.newsletterCategories : [] ),
-						newNewsletterCategory,
+						newNewsletterCategory as NewsletterCategory,
 					],
 				};
 

--- a/client/data/newsletter-categories/use-unmark-as-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-unmark-as-newsletter-category-mutation.tsx
@@ -40,7 +40,7 @@ const useUnmarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 					...oldData,
 					newsletterCategories:
 						oldData?.newsletterCategories.filter(
-							( category: NewsletterCategory ) => category.id !== categoryId
+							( category: NewsletterCategory ) => category?.id !== categoryId
 						) || [],
 				};
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80583

## Proposed Changes

* The cached value from the categories query may be outdated in some scenarios (such as adding categories through the Add New Category button). This was making the mutation break during the optimistic update.
* This PR adds some safety checks to ensure we won't set the cache with undefined values

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/settings/newsletter/{site-slug}
* Enable Newsletter Categories
* Select/unselect categories and save changes multiple times
* Refresh the page to see if the data is saved
* You shouldn't get any error message

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?