### PR TITLE
Domains: Add BIND file import to DNS management page

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
@@ -25,56 +25,9 @@ function DnsImportBindFileButton( { domain, isMobile }: DnsImportBindFileButtonP
 		'is-icon-button': isMobile,
 	} );
 
-	const processRecords = ( records ) => {
-		return records.map( ( record ) => {
-			const processedRecord = {
-				name: record.host,
-				type: record.type,
-			};
-
-			switch ( record.type ) {
-				case 'A':
-					return {
-						...processedRecord,
-						data: record.ip,
-					};
-				case 'AAAA':
-					return {
-						...processedRecord,
-						data: record.ipv6,
-					};
-				case 'CNAME':
-				case 'NS':
-					return {
-						...processedRecord,
-						data: record.target,
-					};
-				case 'MX':
-					return {
-						...processedRecord,
-						data: record.target,
-						aux: record.pri,
-					};
-				case 'TXT':
-					return {
-						...processedRecord,
-						data: record.txt,
-					};
-				case 'SRV':
-					return {
-						...processedRecord,
-						...record,
-					};
-				default:
-					return null;
-			}
-		} );
-	};
-
 	const importDnsRecords = async () => {
 		try {
-			const recordsToAdd = processRecords( recordsToImport );
-			await dispatch( updateDns( domain, recordsToAdd, [] ) );
+			await dispatch( updateDns( domain, recordsToImport, [] ) );
 			dispatch( successNotice( __( 'BIND file imported succesfully!' ) ) );
 		} catch ( error: unknown ) {
 			if ( error instanceof Error ) {

--- a/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
@@ -70,16 +70,13 @@ function DnsImportBindFileButton( { domain, isMobile }: DnsImportBindFileButtonP
 		} );
 
 		try {
-			const recordsToImport = await wpcom.req.post(
-				{
-					path: `/domains/dns/import/bind/${ domain }`,
-					apiNamespace: 'wpcom/v2',
-				},
-				formData
-			);
-			console.log( { recordsToImport } );
+			const recordsToImport = await wpcom.req.post( {
+				path: `/domains/dns/import/bind/${ domain }`,
+				apiNamespace: 'wpcom/v2',
+				formData,
+			} );
 
-			setRecordsToImport( [] );
+			setRecordsToImport( recordsToImport );
 			showImportBindFileDialog();
 		} catch ( error: unknown ) {
 			if ( error instanceof Error ) {
@@ -88,9 +85,6 @@ function DnsImportBindFileButton( { domain, isMobile }: DnsImportBindFileButtonP
 		} finally {
 			setSubmitting( false );
 		}
-
-		// TODO: Remove this when the new endpoint is ready
-		// showImportBindFileDialog();
 	};
 
 	return (

--- a/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
@@ -21,7 +21,7 @@ function DnsImportBindFileButton( { domain, isMobile }: DnsImportBindFileButtonP
 	const [ submitting, setSubmitting ] = useState( false );
 	const [ recordsToImport, setRecordsToImport ] = useState< string[] | null >( null );
 
-	const className = classNames( 'dns__breadcrumb-button add-record', {
+	const className = classNames( 'dns__breadcrumb-button import-bind-file', {
 		'is-icon-button': isMobile,
 	} );
 
@@ -32,7 +32,6 @@ function DnsImportBindFileButton( { domain, isMobile }: DnsImportBindFileButtonP
 		} catch ( error: unknown ) {
 			if ( error instanceof Error ) {
 				dispatch( errorNotice( error.message ) );
-				return;
 			}
 		} finally {
 			setSubmitting( false );

--- a/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
@@ -1,0 +1,114 @@
+import { Button } from '@automattic/components';
+import { Icon, cloudUpload } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
+import { useCallback, useState } from 'react';
+import FilePicker from 'calypso/components/file-picker';
+import wpcom from 'calypso/lib/wp';
+import { useDispatch } from 'calypso/state';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import ImportBindFileConfirmationDialog from './import-bind-file-confirmation-dialog';
+import { DnsImportBindFileButtonProps } from './types';
+
+function DnsImportBindFileButton( { domain, isMobile }: DnsImportBindFileButtonProps ) {
+	const { __ } = useI18n();
+	const dispatch = useDispatch();
+	const [
+		importBindFileConfirmationDialogIsVisible,
+		setImportBindFileConfirmationDialogIsVisible,
+	] = useState( false );
+	const [ submitting, setSubmitting ] = useState( false );
+	const [ recordsToImport, setRecordsToImport ] = useState< string[] | null >( null );
+
+	const className = classNames( 'dns__breadcrumb-button add-record', {
+		'is-icon-button': isMobile,
+	} );
+
+	const importDnsRecords = async () => {
+		console.log( 'importing DNS records' );
+		try {
+			await wpcom.req.post(
+				{
+					path: `/domains/${ domain }/dns`,
+					apiVersion: '1.1',
+				},
+				{ recordsToImport }
+			);
+			dispatch( successNotice( __( 'DNS records imported succesfully!' ) ) );
+		} catch ( error: unknown ) {
+			if ( error instanceof Error ) {
+				dispatch( errorNotice( error.message ) );
+				return;
+			}
+		} finally {
+			setSubmitting( false );
+		}
+	};
+
+	const closeImportBindFileDialog = ( result: boolean ) => {
+		setImportBindFileConfirmationDialogIsVisible( false );
+		setRecordsToImport( [] );
+		if ( result ) {
+			importDnsRecords();
+		}
+	};
+
+	const showImportBindFileDialog = useCallback(
+		() => setImportBindFileConfirmationDialogIsVisible( true ),
+		[]
+	);
+
+	const onFileSelected = async ( files: FileList ) => {
+		if ( ! files || files.length === 0 ) {
+			return;
+		}
+
+		setSubmitting( true );
+		const formData: [ string, File, string ][] = [];
+		[ ...files ].forEach( ( file: File ) => {
+			formData.push( [ 'files[]', file, file.name ] );
+		} );
+
+		try {
+			const recordsToImport = await wpcom.req.post(
+				{
+					path: `/domains/dns/import/bind/${ domain }`,
+					apiNamespace: 'wpcom/v2',
+				},
+				formData
+			);
+			console.log( { recordsToImport } );
+
+			setRecordsToImport( [] );
+			showImportBindFileDialog();
+		} catch ( error: unknown ) {
+			if ( error instanceof Error ) {
+				dispatch( errorNotice( error.message ) );
+			}
+		} finally {
+			setSubmitting( false );
+		}
+
+		// TODO: Remove this when the new endpoint is ready
+		// showImportBindFileDialog();
+	};
+
+	return (
+		<>
+			<ImportBindFileConfirmationDialog
+				visible={ importBindFileConfirmationDialogIsVisible }
+				onClose={ closeImportBindFileDialog }
+				recordsToImport={ recordsToImport }
+			/>
+
+			<FilePicker onPick={ onFileSelected }>
+				<Button borderless={ isMobile } disabled={ submitting } className={ className }>
+					<Icon icon={ cloudUpload } viewBox="4 4 16 16" size={ 16 } />
+					{ ! isMobile && __( 'Import BIND file' ) }
+				</Button>
+			</FilePicker>
+		</>
+	);
+}
+
+export default DnsImportBindFileButton;

--- a/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
@@ -56,10 +56,8 @@ function DnsImportBindFileButton( { domain, isMobile }: DnsImportBindFileButtonP
 		}
 
 		setSubmitting( true );
-		const formData: [ string, File, string ][] = [];
-		[ ...files ].forEach( ( file: File ) => {
-			formData.push( [ 'files[]', file, file.name ] );
-		} );
+
+		const formData = [ [ 'files[]', files[ 0 ], files[ 0 ].name ] ];
 
 		try {
 			const recordsToImport = await wpcom.req.post( {

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -28,6 +28,7 @@ import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import DnsAddNewRecordButton from './dns-add-new-record-button';
 import DnsDetails from './dns-details';
+import DnsImportBindFileButton from './dns-import-bind-file-button';
 import DnsMenuOptionsButton from './dns-menu-options-button';
 import './style.scss';
 
@@ -97,12 +98,23 @@ class DnsRecords extends Component {
 				site={ selectedSite?.slug }
 				domain={ selectedDomainName }
 			/>,
+			<DnsImportBindFileButton
+				key="import-bind-file-button"
+				site={ selectedSite?.slug }
+				domain={ selectedDomainName }
+			/>,
 			optionsButton,
 		];
 
 		const mobileButtons = [
 			<DnsAddNewRecordButton
 				key="mobile-add-new-record-button"
+				site={ selectedSite?.slug }
+				domain={ selectedDomainName }
+				isMobile={ true }
+			/>,
+			<DnsImportBindFileButton
+				key="import-bind-file-button"
 				site={ selectedSite?.slug }
 				domain={ selectedDomainName }
 				isMobile={ true }

--- a/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
@@ -36,18 +36,15 @@ function ImportBindFileConfirmationDialog( { onClose, visible, recordsToImport }
 		const recordAsString = `${ record.host } ${ record.class } ${ record.type }`;
 		switch ( record.type ) {
 			case 'A':
-				return `${ recordAsString } ${ record.ip }`;
 			case 'AAAA':
-				return `${ recordAsString } ${ record.ipv6 }`;
 			case 'CNAME':
 			case 'NS':
-				return `${ recordAsString } ${ record.target }`;
-			case 'MX':
-				return `${ recordAsString } ${ record.pri } ${ record.target }`;
 			case 'TXT':
-				return `${ recordAsString } ${ record.txt }`;
+				return `${ recordAsString } ${ record.data }`;
+			case 'MX':
+				return `${ recordAsString } ${ record.aux } ${ record.data }`;
 			case 'SRV':
-				return `${ record.service }.${ record.protocol }.${ recordAsString } ${ record.aux } ${ record.weight } ${ record.port } ${ record.target }`;
+				return `${ record.service }.${ record.protocol }.${ recordAsString } ${ record.aux } ${ record.weight } ${ record.port } ${ record.data }`;
 		}
 	};
 
@@ -72,7 +69,7 @@ function ImportBindFileConfirmationDialog( { onClose, visible, recordsToImport }
 					<pre className="import-records-dialog__records">{ renderImportedRecords() }</pre>
 				</>
 			) : (
-				<p>{ __( "We couldn't find valid DNS records in the selected file." ) }</p>
+				<p>{ __( "We couldn't find valid DNS records in the selected BIND file." ) }</p>
 			) }
 		</Dialog>
 	);

--- a/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
@@ -32,16 +32,29 @@ function ImportBindFileConfirmationDialog( { onClose, visible, recordsToImport }
 		},
 	];
 
-	const renderImportedRecords = () => {
-		if ( ! recordsToImport ) {
-			return '';
+	const renderRecordAsString = ( record ) => {
+		const recordAsString = `${ record.host } ${ record.class } ${ record.type }`;
+		switch ( record.type ) {
+			case 'A':
+				return `${ recordAsString } ${ record.ip }`;
+			case 'AAAA':
+				return `${ recordAsString } ${ record.ipv6 }`;
+			case 'CNAME':
+			case 'NS':
+				return `${ recordAsString } ${ record.target }`;
+			case 'MX':
+				return `${ recordAsString } ${ record.pri } ${ record.target }`;
+			case 'TXT':
+				return `${ recordAsString } ${ record.txt }`;
+			case 'SRV':
+				return `${ record.service }.${ record.protocol }.${ recordAsString } ${ record.aux } ${ record.weight } ${ record.port } ${ record.target }`;
 		}
+	};
 
+	const renderImportedRecords = () => {
 		let records = '';
-		console.log( 'recordsToImport' );
-		console.log( recordsToImport );
-		( recordsToImport || [] ).forEach( ( record ) => {
-			records += `${ record }\n`;
+		recordsToImport.forEach( ( record ) => {
+			records += renderRecordAsString( record ) + '\n';
 		} );
 		return records;
 	};
@@ -49,17 +62,17 @@ function ImportBindFileConfirmationDialog( { onClose, visible, recordsToImport }
 	return (
 		<Dialog
 			isVisible={ visible }
-			buttons={ recordsToImport ? buttons : okButton }
+			buttons={ recordsToImport && recordsToImport.length > 0 ? buttons : okButton }
 			onClose={ onCancel }
 		>
 			<h1>{ __( 'Import DNS records' ) }</h1>
-			{ recordsToImport ? (
+			{ recordsToImport && recordsToImport.length > 0 ? (
 				<>
 					<p>{ __( 'The following DNS records will be added to your domain:' ) }</p>
-					<code className="import-records-dialog__records">{ renderImportedRecords() }</code>
+					<pre className="import-records-dialog__records">{ renderImportedRecords() }</pre>
 				</>
 			) : (
-				<p>{ __( 'We could not find valid DNS records in the file you chose' ) }</p>
+				<p>{ __( "We couldn't find valid DNS records in the selected file." ) }</p>
 			) }
 		</Dialog>
 	);

--- a/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
@@ -12,7 +12,7 @@ function ImportBindFileConfirmationDialog( { onClose, visible, recordsToImport }
 		onClose( false );
 	};
 
-	const buttons = [
+	const importButtons = [
 		{
 			action: 'cancel',
 			label: __( 'Cancel' ),
@@ -34,6 +34,7 @@ function ImportBindFileConfirmationDialog( { onClose, visible, recordsToImport }
 
 	const renderRecordAsString = ( record ) => {
 		const recordAsString = `${ record.host } ${ record.class } ${ record.type }`;
+
 		switch ( record.type ) {
 			case 'A':
 			case 'AAAA':
@@ -45,28 +46,28 @@ function ImportBindFileConfirmationDialog( { onClose, visible, recordsToImport }
 				return `${ recordAsString } ${ record.aux } ${ record.data }`;
 			case 'SRV':
 				return `${ record.service }.${ record.protocol }.${ recordAsString } ${ record.aux } ${ record.weight } ${ record.port } ${ record.data }`;
+			default:
+				return recordAsString;
 		}
 	};
 
 	const renderImportedRecords = () => {
-		let records = '';
-		recordsToImport.forEach( ( record ) => {
-			records += renderRecordAsString( record ) + '\n';
-		} );
-		return records;
+		return recordsToImport.reduce( ( output, record ) => {
+			return output + renderRecordAsString( record ) + '\n';
+		}, '' );
 	};
 
 	return (
 		<Dialog
 			isVisible={ visible }
-			buttons={ recordsToImport && recordsToImport.length > 0 ? buttons : okButton }
+			buttons={ recordsToImport && recordsToImport.length > 0 ? importButtons : okButton }
 			onClose={ onCancel }
 		>
 			<h1>{ __( 'Import DNS records' ) }</h1>
 			{ recordsToImport && recordsToImport.length > 0 ? (
 				<>
 					<p>{ __( 'The following DNS records will be added to your domain:' ) }</p>
-					<pre className="import-records-dialog__records">{ renderImportedRecords() }</pre>
+					<pre>{ renderImportedRecords() }</pre>
 				</>
 			) : (
 				<p>{ __( "We couldn't find valid DNS records in the selected BIND file." ) }</p>

--- a/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
@@ -1,0 +1,68 @@
+import { Dialog } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+
+function ImportBindFileConfirmationDialog( { onClose, visible, recordsToImport } ) {
+	const { __ } = useI18n();
+
+	const onImportRecords = () => {
+		onClose( true );
+	};
+
+	const onCancel = () => {
+		onClose( false );
+	};
+
+	const buttons = [
+		{
+			action: 'cancel',
+			label: __( 'Cancel' ),
+		},
+		{
+			action: 'import',
+			label: __( 'Import records' ),
+			isPrimary: true,
+			onClick: onImportRecords,
+		},
+	];
+
+	const okButton = [
+		{
+			action: 'cancel',
+			label: __( 'Ok' ),
+		},
+	];
+
+	const renderImportedRecords = () => {
+		if ( ! recordsToImport ) {
+			return '';
+		}
+
+		let records = '';
+		console.log( 'recordsToImport' );
+		console.log( recordsToImport );
+		( recordsToImport || [] ).forEach( ( record ) => {
+			records += `${ record }\n`;
+		} );
+		return records;
+	};
+
+	return (
+		<Dialog
+			isVisible={ visible }
+			buttons={ recordsToImport ? buttons : okButton }
+			onClose={ onCancel }
+		>
+			<h1>{ __( 'Import DNS records' ) }</h1>
+			{ recordsToImport ? (
+				<>
+					<p>{ __( 'The following DNS records will be added to your domain:' ) }</p>
+					<code className="import-records-dialog__records">{ renderImportedRecords() }</code>
+				</>
+			) : (
+				<p>{ __( 'We could not find valid DNS records in the file you chose' ) }</p>
+			) }
+		</Dialog>
+	);
+}
+
+export default ImportBindFileConfirmationDialog;

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -225,18 +225,21 @@ body.dns__body-white {
 	}
 }
 
-a.dns__breadcrumb-button {
+a.dns__breadcrumb-button,
+button.dns__breadcrumb-button {
 	display: flex;
 	align-items: center;
 
-	&.add-record {
+	&.add-record,
+	&.import-bind-file {
 		@include break-mobile {
 			svg {
 				margin-right: 8px;
 			}
 		}
 	}
-	&.add-record.is-icon-button {
+	&.add-record.is-icon-button,
+	&.import-bind-file.is-icon-button {
 		width: 40px;
 		display: flex;
 		justify-content: center;

--- a/client/my-sites/domains/domain-management/dns/types.ts
+++ b/client/my-sites/domains/domain-management/dns/types.ts
@@ -57,3 +57,8 @@ export type DndAddNewRecordButtonProps = {
 	domain: string;
 	isMobile?: boolean;
 };
+
+export type DnsImportBindFileButtonProps = {
+	domain: string;
+	isMobile?: boolean;
+};


### PR DESCRIPTION
## Proposed Changes

This PR adds a button to import DNS records from a BIND file in the DNS management page of a domain. When a file is selected, a dialog box with the DNS records that will be imported is shown so the user can confirm if the records look correct.

Depends on D120338-code, which defines the endpoint that's called to process the BIND file.

### Screenshots

> ![Annotation-Annotation on 2023-09-15 at 19-00-07 png](https://github.com/Automattic/wp-calypso/assets/5324818/bbc4b52d-b042-4436-9aa3-0ae5f9e84b61)

> <img width="891" alt="Screenshot 2023-09-15 at 18 56 17" src="https://github.com/Automattic/wp-calypso/assets/5324818/856550a2-baa4-4755-bf62-accc29250e5c">

## Testing Instructions

- Apply D120338-code to your backend
- Open the live Calypso link or build this branch locally
- Go to a domain's DNS management page
- Click on the "Import BIND file" button
- Select a BIND file and ensure the processed DNS records are correct
- Import these records and ensure they were added correctly to your domain

Note: The base domain of your BIND file must match the domain you're importing records to, otherwise the current domain will be appended to all imported records. For example, suppose you're importing records to `foo.com`, but the selected BIND file contains a record like this:

```
bar.com. 3600 IN A 1.2.3.4
```

Then the imported record would be processed as `bar.com.foo.com`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
