### PR TITLE
Stats: refactor product test to a hook

### DIFF
--- a/client/my-sites/stats/hooks/use-stats-purchases.ts
+++ b/client/my-sites/stats/hooks/use-stats-purchases.ts
@@ -1,0 +1,52 @@
+import {
+	PRODUCT_JETPACK_STATS_BI_YEARLY,
+	PRODUCT_JETPACK_STATS_FREE,
+	PRODUCT_JETPACK_STATS_MONTHLY,
+	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
+	PRODUCT_JETPACK_STATS_YEARLY,
+} from '@automattic/calypso-products';
+import { useMemo } from 'react';
+import { useSelector } from 'calypso/state';
+import { isFetchingSitePurchases, getSitePurchases } from 'calypso/state/purchases/selectors';
+import type { Purchase } from 'calypso/lib/purchases/types';
+
+const isProductOwned = ( ownedPurchases: Purchase[], searchedProduct: string ) => {
+	if ( ! ownedPurchases.length ) {
+		return false;
+	}
+
+	return ownedPurchases
+		.filter( ( purchase ) => purchase.expiryStatus !== 'expired' )
+		.map( ( purchase ) => purchase.productSlug )
+		.includes( searchedProduct );
+};
+
+export default function useStatsPurchases( siteId: number | null ) {
+	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
+	const isRequestingSitePurchases = useSelector( isFetchingSitePurchases );
+
+	// Determine whether a product is owned.
+	// TODO we need to do plan check as well, because Stats products would be built into other plans.
+	const isFreeOwned = useMemo( () => {
+		return isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_FREE );
+	}, [ sitePurchases ] );
+
+	const isCommercialOwned = useMemo( () => {
+		return (
+			isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_MONTHLY ) ||
+			isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_YEARLY ) ||
+			isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_BI_YEARLY )
+		);
+	}, [ sitePurchases ] );
+
+	const isPWYWOwned = useMemo( () => {
+		return isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_PWYW_YEARLY );
+	}, [ sitePurchases ] );
+
+	return {
+		isRequestingSitePurchases,
+		isFreeOwned,
+		isPWYWOwned,
+		isCommercialOwned,
+	};
+}

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -53,8 +53,10 @@ const StatsPurchasePage = ( {
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
+
 	const { isRequestingSitePurchases, isFreeOwned, isPWYWOwned, isCommercialOwned } =
 		useStatsPurchases( siteId );
+
 	useEffect( () => {
 		if ( ! siteSlug ) {
 			return;

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -3,7 +3,6 @@ import {
 	PRODUCT_JETPACK_STATS_YEARLY,
 	PRODUCT_JETPACK_STATS_MONTHLY,
 	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
-	PRODUCT_JETPACK_STATS_FREE,
 } from '@automattic/calypso-products';
 import { ProductsList } from '@automattic/data-stores';
 import classNames from 'classnames';
@@ -18,10 +17,10 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Main from 'calypso/components/main';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
-import { isFetchingSitePurchases, getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import useStatsPurchases from '../hooks/use-stats-purchases';
 import PageViewTracker from '../stats-page-view-tracker';
 import {
 	StatsPurchaseNoticePage,
@@ -38,18 +37,6 @@ import StatsPurchaseWizard, {
 	TYPE_COMMERCIAL,
 	TYPE_PERSONAL,
 } from './stats-purchase-wizard';
-import type { Purchase } from 'calypso/lib/purchases/types';
-
-const isProductOwned = ( ownedPurchases: Purchase[], searchedProduct: string ) => {
-	if ( ! ownedPurchases.length ) {
-		return false;
-	}
-
-	return ownedPurchases
-		.filter( ( purchase ) => purchase.expiryStatus !== 'expired' )
-		.map( ( purchase ) => purchase.productSlug )
-		.includes( searchedProduct );
-};
 
 const StatsPurchasePage = ( {
 	query,
@@ -66,27 +53,8 @@ const StatsPurchasePage = ( {
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
-
-	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
-	const isRequestingSitePurchases = useSelector( isFetchingSitePurchases );
-
-	// Determine whether a product is owned.
-	// TODO we need to do plan check as well, because Stats products would be built into other plans.
-	const isFreeOwned = useMemo( () => {
-		return isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_FREE );
-	}, [ sitePurchases ] );
-
-	const isCommercialOwned = useMemo( () => {
-		return (
-			isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_MONTHLY ) ||
-			isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_YEARLY )
-		);
-	}, [ sitePurchases ] );
-
-	const isPWYWOwned = useMemo( () => {
-		return isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_PWYW_YEARLY );
-	}, [ sitePurchases ] );
-
+	const { isRequestingSitePurchases, isFreeOwned, isPWYWOwned, isCommercialOwned } =
+		useStatsPurchases( siteId );
 	useEffect( () => {
 		if ( ! siteSlug ) {
 			return;


### PR DESCRIPTION
## Proposed Changes

Extracted product tests to a hook `useStatsPurchases`, which could be used in Traffic page banner visibility.

cc @annacmc

## Testing Instructions

* Ensure purchase page still work as expected
* Please follow instructions at https://github.com/Automattic/wp-calypso/pull/81250

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?