### PR TITLE
Disable Live Preview on Atomic sites

### DIFF
--- a/client/state/themes/selectors/get-is-live-preview-supported.ts
+++ b/client/state/themes/selectors/get-is-live-preview-supported.ts
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed';
 import { AppState } from 'calypso/types';
@@ -87,6 +88,14 @@ const isNotCompatibleThemes = ( themeId: string ) => {
  */
 export const getIsLivePreviewSupported = ( state: AppState, themeId: string, siteId: number ) => {
 	if ( ! config.isEnabled( 'themes/block-theme-previews' ) ) {
+		return false;
+	}
+
+	/**
+	 * This is temporary condition to disable Block Theme Previews on Atomic sites.
+	 * FIXME: Remove this condition once we addressed https://github.com/WordPress/gutenberg/issues/53284.
+	 */
+	if ( isSiteWpcomAtomic( state, siteId ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Disable Live Preview on Atomic sites until we resolve https://github.com/WordPress/gutenberg/issues/53284. c.f. pbxlJb-3Uv-p2#comment-2939

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create/Use an Atomic site
* Go to the Theme showcase page 
* Click three-dots menu on the Theme Card
* Verify the Live Preview option is not present and "Demo site" option is present instead

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?