### PR TITLE
Storage Add Ons: Implement dropdown UI functionality

### DIFF
--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -6,8 +6,6 @@ import {
 	FEATURE_3GB_STORAGE,
 	FEATURE_1GB_STORAGE,
 	FEATURE_50GB_STORAGE,
-	FEATURE_50GB_STORAGE_ADD_ON,
-	FEATURE_100GB_STORAGE_ADD_ON,
 	FEATURE_6GB_STORAGE,
 	FEATURE_ACCEPT_PAYMENTS,
 	FEATURE_ACTIVITY_LOG,
@@ -301,7 +299,6 @@ import {
 	isBusinessPlan,
 	isFreePlan,
 	FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
-	PRODUCT_1GB_SPACE,
 } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
 import i18n from 'i18n-calypso';
@@ -1781,24 +1778,6 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate( 'Credit card fees are applied in addition to commission fees for payments.' ),
 		getAlternativeTitle: () => '2%',
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
-	},
-	[ FEATURE_50GB_STORAGE_ADD_ON ]: {
-		getSlug: () => FEATURE_50GB_STORAGE_ADD_ON,
-		getUnitProductSlug: () => PRODUCT_1GB_SPACE,
-		getQuantity: () => 50,
-		getTitle: () => i18n.translate( '50 GB' ),
-		getCompareTitle: () => i18n.translate( '50 GB' ),
-		getDescription: () =>
-			i18n.translate( 'Storage space for adding images and documents to your website.' ),
-	},
-	[ FEATURE_100GB_STORAGE_ADD_ON ]: {
-		getSlug: () => FEATURE_100GB_STORAGE_ADD_ON,
-		getUnitProductSlug: () => PRODUCT_1GB_SPACE,
-		getQuantity: () => 100,
-		getTitle: () => i18n.translate( '100 GB' ),
-		getCompareTitle: () => i18n.translate( '100 GB' ),
-		getDescription: () =>
-			i18n.translate( 'Storage space for adding images and documents to your website.' ),
 	},
 	[ FEATURE_UNLIMITED_TRAFFIC ]: {
 		getSlug: () => FEATURE_UNLIMITED_TRAFFIC,

--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -11,8 +11,8 @@ import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { getStatsPurchaseURL } from 'calypso/my-sites/stats/stats-purchase/stats-purchase-notice';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import type { AddOnMeta } from '../hooks/use-add-ons';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import type { AddOnMeta } from '@automattic/data-stores';
 
 type ActionPrimary = {
 	text: string;

--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -11,7 +11,7 @@ import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { getStatsPurchaseURL } from 'calypso/my-sites/stats/stats-purchase/stats-purchase-notice';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { AddOnMeta } from '@automattic/data-stores';
 
 type ActionPrimary = {

--- a/client/my-sites/add-ons/components/add-ons-grid.tsx
+++ b/client/my-sites/add-ons/components/add-ons-grid.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import AddOnCard from './add-ons-card';
 import type { Props as CardProps } from './add-ons-card';
-import type { AddOnMeta } from '../hooks/use-add-ons';
+import type { AddOnMeta } from '@automattic/data-stores';
 
 interface Props extends Omit< CardProps, 'addOnMeta' > {
 	addOns: ( AddOnMeta | null )[];

--- a/client/my-sites/add-ons/hooks/use-add-on-display-cost.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-display-cost.ts
@@ -1,11 +1,11 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
-import useAddOnCost from './use-add-on-prices';
+import useAddOnPrices from './use-add-on-prices';
 
 const useAddOnDisplayCost = ( productSlug: string, quantity?: number ) => {
 	const translate = useTranslate();
-	const prices = useAddOnCost( productSlug, quantity );
+	const prices = useAddOnPrices( productSlug, quantity );
 	const formattedCost = prices?.formattedMonthlyPrice || '';
 
 	return useSelector( ( state ) => {

--- a/client/my-sites/add-ons/hooks/use-add-on-display-cost.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-display-cost.ts
@@ -1,38 +1,17 @@
-import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
-import { getProductCurrencyCode, getProductBySlug } from 'calypso/state/products-list/selectors';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import useAddOnCost from './use-add-on-prices';
 
 const useAddOnDisplayCost = ( productSlug: string, quantity?: number ) => {
 	const translate = useTranslate();
+	const prices = useAddOnCost( productSlug, quantity );
+	const formattedCost = prices?.formattedMonthlyPrice || '';
 
 	return useSelector( ( state ) => {
 		const product = getProductBySlug( state, productSlug );
-		let cost = product?.cost_smallest_unit;
-		const currencyCode = getProductCurrencyCode( state, productSlug );
-
-		if ( ! ( cost && currencyCode ) ) {
-			return null;
-		}
-
-		// Finds the applicable tiered price for the quantity.
-		const priceTier =
-			quantity &&
-			product?.price_tier_list.find( ( tier ) => {
-				if ( quantity >= tier.minimum_units && quantity <= ( tier.maximum_units ?? 0 ) ) {
-					return tier;
-				}
-			} );
-
-		if ( priceTier ) {
-			cost = priceTier?.maximum_price;
-		}
 
 		if ( product?.product_term === 'month' ) {
-			const formattedCost = formatCurrency( cost, currencyCode, {
-				stripZeros: true,
-				isSmallestUnit: true,
-			} );
 			return translate( '%(formattedCost)s/month, billed monthly', {
 				/* Translators: $formattedCost: monthly price formatted with currency */
 				args: {
@@ -41,15 +20,10 @@ const useAddOnDisplayCost = ( productSlug: string, quantity?: number ) => {
 			} );
 		}
 
-		const monthlyCost = formatCurrency( cost / 12, currencyCode, {
-			stripZeros: true,
-			isSmallestUnit: true,
-		} );
-
 		return translate( '%(monthlyCost)s/month, billed yearly', {
 			/* Translators: $montlyCost: monthly price formatted with currency */
 			args: {
-				monthlyCost,
+				monthlyCost: formattedCost,
 			},
 		} );
 	} );

--- a/client/my-sites/add-ons/hooks/use-add-on-feature-slugs.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-feature-slugs.ts
@@ -5,13 +5,16 @@ import {
 	WPCOM_FEATURES_PREMIUM_THEMES,
 	WPCOM_FEATURES_CUSTOM_DESIGN,
 	WPCOM_FEATURES_NO_ADVERTS,
+	FEATURE_50GB_STORAGE_ADD_ON,
+	FEATURE_100GB_STORAGE_ADD_ON,
+	PRODUCT_1GB_SPACE,
 } from '@automattic/calypso-products';
 
 /**
  * Returns any relevant feature slugs for a given add-on.
  * Add-ons are currently uniquely identified by their product slugs.
  */
-const useAddOnFeatureSlugs = ( addOnProductSlug: string ) => {
+const useAddOnFeatureSlugs = ( addOnProductSlug: string, quantity?: number ) => {
 	switch ( addOnProductSlug ) {
 		case PRODUCT_WPCOM_UNLIMITED_THEMES:
 			return [ WPCOM_FEATURES_PREMIUM_THEMES ];
@@ -19,6 +22,12 @@ const useAddOnFeatureSlugs = ( addOnProductSlug: string ) => {
 			return [ WPCOM_FEATURES_CUSTOM_DESIGN ];
 		case PRODUCT_NO_ADS:
 			return [ WPCOM_FEATURES_NO_ADVERTS ];
+		case PRODUCT_1GB_SPACE:
+			if ( quantity === 50 ) {
+				return [ FEATURE_50GB_STORAGE_ADD_ON ];
+			} else if ( quantity === 100 ) {
+				return [ FEATURE_100GB_STORAGE_ADD_ON ];
+			}
 		default:
 			return null;
 	}

--- a/client/my-sites/add-ons/hooks/use-add-on-prices.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-prices.ts
@@ -36,11 +36,11 @@ const useAddOnPrices = ( productSlug: string, quantity?: number ) => {
 		return {
 			monthlyPrice,
 			yearlyPrice,
-			formattedMonthlyPrice: formatCurrency( monthlyPrice, currencyCode, {
+			formattedMonthlyPrice: formatCurrency( Math.round( monthlyPrice ), currencyCode, {
 				stripZeros: true,
 				isSmallestUnit: true,
 			} ),
-			formattedYearlyPrice: formatCurrency( yearlyPrice, currencyCode, {
+			formattedYearlyPrice: formatCurrency( Math.round( yearlyPrice ), currencyCode, {
 				stripZeros: true,
 				isSmallestUnit: true,
 			} ),

--- a/client/my-sites/add-ons/hooks/use-add-on-prices.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-prices.ts
@@ -8,7 +8,7 @@ const useAddOnPrices = ( productSlug: string, quantity?: number ) => {
 		let cost = product?.cost_smallest_unit;
 		const currencyCode = getProductCurrencyCode( state, productSlug );
 
-		if ( ! ( cost && currencyCode ) ) {
+		if ( ! cost || ! currencyCode ) {
 			return null;
 		}
 

--- a/client/my-sites/add-ons/hooks/use-add-on-prices.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-prices.ts
@@ -36,11 +36,11 @@ const useAddOnPrices = ( productSlug: string, quantity?: number ) => {
 		return {
 			monthlyPrice,
 			yearlyPrice,
-			formattedMonthlyPrice: formatCurrency( Math.round( monthlyPrice ), currencyCode, {
+			formattedMonthlyPrice: formatCurrency( monthlyPrice, currencyCode, {
 				stripZeros: true,
 				isSmallestUnit: true,
 			} ),
-			formattedYearlyPrice: formatCurrency( Math.round( yearlyPrice ), currencyCode, {
+			formattedYearlyPrice: formatCurrency( yearlyPrice, currencyCode, {
 				stripZeros: true,
 				isSmallestUnit: true,
 			} ),

--- a/client/my-sites/add-ons/hooks/use-add-on-prices.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-prices.ts
@@ -1,0 +1,51 @@
+import formatCurrency from '@automattic/format-currency';
+import { useSelector } from 'calypso/state';
+import { getProductCurrencyCode, getProductBySlug } from 'calypso/state/products-list/selectors';
+
+const useAddOnPrices = ( productSlug: string, quantity?: number ) => {
+	return useSelector( ( state ) => {
+		const product = getProductBySlug( state, productSlug );
+		let cost = product?.cost_smallest_unit;
+		const currencyCode = getProductCurrencyCode( state, productSlug );
+
+		if ( ! ( cost && currencyCode ) ) {
+			return null;
+		}
+
+		// Finds the applicable tiered price for the quantity.
+		const priceTier =
+			quantity &&
+			product?.price_tier_list.find( ( tier ) => {
+				if ( quantity >= tier.minimum_units && quantity <= ( tier.maximum_units ?? 0 ) ) {
+					return tier;
+				}
+			} );
+
+		if ( priceTier ) {
+			cost = priceTier?.maximum_price;
+		}
+
+		let monthlyPrice = cost / 12;
+		let yearlyPrice = cost;
+
+		if ( product?.product_term === 'month' ) {
+			monthlyPrice = cost;
+			yearlyPrice = cost * 12;
+		}
+
+		return {
+			monthlyPrice,
+			yearlyPrice,
+			formattedMonthlyPrice: formatCurrency( monthlyPrice, currencyCode, {
+				stripZeros: true,
+				isSmallestUnit: true,
+			} ),
+			formattedYearlyPrice: formatCurrency( yearlyPrice, currencyCode, {
+				stripZeros: true,
+				isSmallestUnit: true,
+			} ),
+		};
+	} );
+};
+
+export default useAddOnPrices;

--- a/client/my-sites/add-ons/hooks/use-add-on-purchase-status.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-purchase-status.ts
@@ -3,7 +3,7 @@ import { useSelector } from 'calypso/state';
 import { getSitePurchases } from 'calypso/state/purchases/selectors/get-site-purchases';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { AddOnMeta } from './use-add-ons';
+import type { AddOnMeta } from '@automattic/data-stores';
 
 /**
  * Returns whether add-on product has been purchased or included in site plan.

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -31,6 +31,7 @@ import unlimitedThemesIcon from '../icons/unlimited-themes';
 import isStorageAddonEnabled from '../is-storage-addon-enabled';
 import useAddOnDisplayCost from './use-add-on-display-cost';
 import useAddOnFeatureSlugs from './use-add-on-feature-slugs';
+import useAddOnPrices from './use-add-on-prices';
 
 export interface AddOnMeta {
 	productSlug: string;
@@ -38,11 +39,17 @@ export interface AddOnMeta {
 	icon: JSX.Element;
 	featured?: boolean; // irrelevant to "featureSlugs"
 	name: string | null;
-	quantity?: number;
+	quantity?: number; // used for determining checkout costs for quantity based products
 	description: string | null;
 	displayCost: TranslateResult | null;
 	purchased?: boolean;
 	isLoading?: boolean;
+	prices?: {
+		monthlyPrice: number;
+		yearlyPrice: number;
+		formattedMonthlyPrice: string;
+		formattedYearlyPrice: string;
+	} | null;
 }
 
 // some memoization. executes far too many times
@@ -79,10 +86,12 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 		},
 		{
 			productSlug: PRODUCT_1GB_SPACE,
+			featureSlugs: useAddOnFeatureSlugs( PRODUCT_1GB_SPACE, 50 ),
 			icon: spaceUpgradeIcon,
 			quantity: 50,
 			name: translate( '50 GB Storage' ),
 			displayCost: useAddOnDisplayCost( PRODUCT_1GB_SPACE, 50 ),
+			prices: useAddOnPrices( PRODUCT_1GB_SPACE, 50 ),
 			description: translate(
 				'Make more space for high-quality photos, videos, and other media. '
 			),
@@ -91,10 +100,12 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 		},
 		{
 			productSlug: PRODUCT_1GB_SPACE,
+			featureSlugs: useAddOnFeatureSlugs( PRODUCT_1GB_SPACE, 100 ),
 			icon: spaceUpgradeIcon,
 			quantity: 100,
 			name: translate( '100 GB Storage' ),
 			displayCost: useAddOnDisplayCost( PRODUCT_1GB_SPACE, 100 ),
+			prices: useAddOnPrices( PRODUCT_1GB_SPACE, 100 ),
 			description: translate(
 				'Take your site to the next level. Store all your media in one place without worrying about running out of space.'
 			),

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -9,7 +9,7 @@ import {
 	PRODUCT_1GB_SPACE,
 	WPCOM_FEATURES_AI_ASSISTANT,
 } from '@automattic/calypso-products';
-import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import useMediaStorageQuery from 'calypso/data/media-storage/use-media-storage-query';
 import { filterTransactions } from 'calypso/me/purchases/billing-history/filter-transactions';
 import { useSelector } from 'calypso/state';
@@ -32,25 +32,7 @@ import isStorageAddonEnabled from '../is-storage-addon-enabled';
 import useAddOnDisplayCost from './use-add-on-display-cost';
 import useAddOnFeatureSlugs from './use-add-on-feature-slugs';
 import useAddOnPrices from './use-add-on-prices';
-
-export interface AddOnMeta {
-	productSlug: string;
-	featureSlugs?: string[] | null;
-	icon: JSX.Element;
-	featured?: boolean; // irrelevant to "featureSlugs"
-	name: string | null;
-	quantity?: number; // used for determining checkout costs for quantity based products
-	description: string | null;
-	displayCost: TranslateResult | null;
-	purchased?: boolean;
-	isLoading?: boolean;
-	prices?: {
-		monthlyPrice: number;
-		yearlyPrice: number;
-		formattedMonthlyPrice: string;
-		formattedYearlyPrice: string;
-	} | null;
-}
+import type { AddOnMeta } from '@automattic/data-stores';
 
 // some memoization. executes far too many times
 const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {

--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -36,6 +36,7 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 		planSlugs: [ yearlyVariantPlanSlug ],
 		withoutProRatedCredits: true,
 		storageAddOns: storageAddOnsForPlan,
+		currencyCode,
 	} )?.[ yearlyVariantPlanSlug ];
 
 	if ( isMonthlyPlan && originalPrice?.monthly && yearlyVariantPricing && ! introOffer ) {

--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -36,7 +36,6 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 		planSlugs: [ yearlyVariantPlanSlug ],
 		withoutProRatedCredits: true,
 		storageAddOns: storageAddOnsForPlan,
-		currencyCode,
 	} )?.[ yearlyVariantPlanSlug ];
 
 	if ( isMonthlyPlan && originalPrice?.monthly && yearlyVariantPricing && ! introOffer ) {

--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -20,6 +20,7 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 	const {
 		isMonthlyPlan,
 		pricing: { currencyCode, originalPrice, discountedPrice, billingPeriod, introOffer },
+		storageAddOnsForPlan,
 	} = gridPlansIndex[ planSlug ];
 
 	if ( isWpComFreePlan( planSlug ) || isWpcomEnterpriseGridPlan( planSlug ) ) {
@@ -34,6 +35,7 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 	const yearlyVariantPricing = helpers?.usePricingMetaForGridPlans( {
 		planSlugs: [ yearlyVariantPlanSlug ],
 		withoutProRatedCredits: true,
+		storageAddOns: storageAddOnsForPlan,
 	} )?.[ yearlyVariantPlanSlug ];
 
 	if ( isMonthlyPlan && originalPrice?.monthly && yearlyVariantPricing && ! introOffer ) {

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -33,6 +33,7 @@ import PlanFeatures2023GridBillingTimeframe from './billing-timeframe';
 import PlanFeatures2023GridHeaderPrice from './header-price';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import PopularBadge from './popular-badge';
+import StorageAddOnDropdown from './storage-add-on-dropdown';
 import type {
 	GridPlan,
 	TransformedFeatureObject,
@@ -318,6 +319,7 @@ type PlanComparisonGridProps = {
 	selectedPlan?: string;
 	selectedFeature?: string;
 	showLegacyStorageFeature?: boolean;
+	showUpgradeableStorage?: boolean;
 };
 
 type PlanComparisonGridHeaderProps = {
@@ -533,6 +535,7 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	flowName?: string | null;
 	intervalType?: string;
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
+	showUpgradeableStorage: boolean | undefined;
 	activeTooltipId: string;
 } > = ( {
 	feature,
@@ -541,6 +544,7 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	isStorageFeature,
 	intervalType,
 	activeTooltipId,
+	showUpgradeableStorage,
 	setActiveTooltipId,
 } ) => {
 	const { gridPlansIndex } = usePlansGridContext();
@@ -571,7 +575,11 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 				( feature ) => feature.getSlug() === featureSlug
 		  )
 		: false;
-	const storageOption = gridPlan.features.storageOptions.find( ( option ) => ! option.isAddOn );
+	const storageOptions = gridPlan.features.storageOptions;
+	const defaultStorageOption = storageOptions.find( ( option ) => ! option.isAddOn );
+	const canUpgradeStorageForPlan =
+		storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage;
+
 	const cellClasses = classNames(
 		'plan-comparison-grid__feature-group-row-cell',
 		'plan-comparison-grid__plan',
@@ -595,9 +603,16 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 			{ isStorageFeature ? (
 				<>
 					<span className="plan-comparison-grid__plan-title">{ translate( 'Storage' ) }</span>
-					<StorageButton className="plan-features-2023-grid__storage-button" key={ planSlug }>
-						{ getStorageStringFromFeature( storageOption?.slug || '' ) }
-					</StorageButton>
+					{ canUpgradeStorageForPlan ? (
+						<StorageAddOnDropdown
+							planSlug={ planSlug }
+							storageOptions={ gridPlan.features.storageOptions }
+						/>
+					) : (
+						<StorageButton className="plan-features-2023-grid__storage-button" key={ planSlug }>
+							{ getStorageStringFromFeature( defaultStorageOption?.slug || '' ) }
+						</StorageButton>
+					) }
 				</>
 			) : (
 				<>
@@ -669,6 +684,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	isHighlighted: boolean;
 	intervalType?: string;
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
+	showUpgradeableStorage: boolean | undefined;
 	activeTooltipId: string;
 } > = ( {
 	feature,
@@ -682,6 +698,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	intervalType,
 	activeTooltipId,
 	setActiveTooltipId,
+	showUpgradeableStorage,
 } ) => {
 	const translate = useTranslate();
 	const rowClasses = classNames( 'plan-comparison-grid__feature-group-row', {
@@ -746,6 +763,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 					intervalType={ intervalType }
 					activeTooltipId={ activeTooltipId }
 					setActiveTooltipId={ setActiveTooltipId }
+					showUpgradeableStorage={ showUpgradeableStorage }
 				/>
 			) ) }
 		</Row>
@@ -767,6 +785,7 @@ export const PlanComparisonGrid = ( {
 	planActionOverrides,
 	selectedPlan,
 	selectedFeature,
+	showUpgradeableStorage,
 }: PlanComparisonGridProps ) => {
 	const translate = useTranslate();
 	const { gridPlans, allFeaturesList } = usePlansGridContext();
@@ -985,6 +1004,7 @@ export const PlanComparisonGrid = ( {
 									intervalType={ intervalType }
 									activeTooltipId={ activeTooltipId }
 									setActiveTooltipId={ setActiveTooltipId }
+									showUpgradeableStorage={ showUpgradeableStorage }
 								/>
 							) ) }
 							{ featureGroup.slug === FEATURE_GROUP_ESSENTIAL_FEATURES ? (
@@ -1000,6 +1020,7 @@ export const PlanComparisonGrid = ( {
 									intervalType={ intervalType }
 									activeTooltipId={ activeTooltipId }
 									setActiveTooltipId={ setActiveTooltipId }
+									showUpgradeableStorage={ showUpgradeableStorage }
 								/>
 							) : null }
 						</div>

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -25,6 +25,7 @@ import PlanTypeSelector from 'calypso/my-sites/plans-features-main/components/pl
 import { usePlansGridContext } from '../grid-context';
 import useHighlightAdjacencyMatrix from '../hooks/npm-ready/use-highlight-adjacency-matrix';
 import useIsLargeCurrency from '../hooks/npm-ready/use-is-large-currency';
+import { isStorageUpgradeableForPlan } from '../lib/is-storage-upgradeable-for-plan';
 import { sortPlans } from '../lib/sort-plan-properties';
 import { plansBreakSmall } from '../media-queries';
 import { getStorageStringFromFeature, usePricingBreakpoint } from '../util';
@@ -531,6 +532,7 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	allJetpackFeatures: Set< string >;
 	visibleGridPlans: GridPlan[];
 	planSlug: PlanSlug;
+	isInSignup?: boolean;
 	isStorageFeature: boolean;
 	flowName?: string | null;
 	intervalType?: string;
@@ -541,6 +543,7 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	feature,
 	visibleGridPlans,
 	planSlug,
+	isInSignup,
 	isStorageFeature,
 	intervalType,
 	activeTooltipId,
@@ -577,8 +580,12 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 		: false;
 	const storageOptions = gridPlan.features.storageOptions;
 	const defaultStorageOption = storageOptions.find( ( option ) => ! option.isAddOn );
-	const canUpgradeStorageForPlan =
-		storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage;
+	const canUpgradeStorageForPlan = isStorageUpgradeableForPlan(
+		storageOptions,
+		intervalType,
+		showUpgradeableStorage,
+		isInSignup
+	);
 
 	const cellClasses = classNames(
 		'plan-comparison-grid__feature-group-row-cell',
@@ -679,6 +686,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	allJetpackFeatures: Set< string >;
 	visibleGridPlans: GridPlan[];
 	planFeatureFootnotes: PlanFeatureFootnotes;
+	isInSignup?: boolean;
 	isStorageFeature: boolean;
 	flowName?: string | null;
 	isHighlighted: boolean;
@@ -692,6 +700,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	allJetpackFeatures,
 	visibleGridPlans,
 	planFeatureFootnotes,
+	isInSignup,
 	isStorageFeature,
 	flowName,
 	isHighlighted,
@@ -758,6 +767,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 					allJetpackFeatures={ allJetpackFeatures }
 					visibleGridPlans={ visibleGridPlans }
 					planSlug={ planSlug }
+					isInSignup={ isInSignup }
 					isStorageFeature={ isStorageFeature }
 					flowName={ flowName }
 					intervalType={ intervalType }
@@ -998,6 +1008,7 @@ export const PlanComparisonGrid = ( {
 									allJetpackFeatures={ allJetpackFeatures }
 									visibleGridPlans={ visibleGridPlans }
 									planFeatureFootnotes={ planFeatureFootnotes }
+									isInSignup={ isInSignup }
 									isStorageFeature={ false }
 									flowName={ flowName }
 									isHighlighted={ feature.getSlug() === selectedFeature }
@@ -1014,6 +1025,7 @@ export const PlanComparisonGrid = ( {
 									allJetpackFeatures={ allJetpackFeatures }
 									visibleGridPlans={ visibleGridPlans }
 									planFeatureFootnotes={ planFeatureFootnotes }
+									isInSignup={ isInSignup }
 									isStorageFeature={ true }
 									flowName={ flowName }
 									isHighlighted={ false }

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -305,9 +305,9 @@ const FeatureFootnote = styled.span`
 `;
 
 type PlanComparisonGridProps = {
-	intervalType?: string;
+	intervalType: string;
 	planTypeSelectorProps: PlanTypeSelectorProps;
-	isInSignup?: boolean;
+	isInSignup: boolean;
 	isLaunchPage?: boolean | null;
 	flowName?: string | null;
 	currentSitePlanSlug?: string | null;
@@ -320,13 +320,13 @@ type PlanComparisonGridProps = {
 	selectedPlan?: string;
 	selectedFeature?: string;
 	showLegacyStorageFeature?: boolean;
-	showUpgradeableStorage?: boolean;
+	showUpgradeableStorage: boolean;
 };
 
 type PlanComparisonGridHeaderProps = {
 	displayedGridPlans: GridPlan[];
 	visibleGridPlans: GridPlan[];
-	isInSignup?: boolean;
+	isInSignup: boolean;
 	isLaunchPage?: boolean | null;
 	isFooter?: boolean;
 	flowName?: string | null;
@@ -532,12 +532,12 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	allJetpackFeatures: Set< string >;
 	visibleGridPlans: GridPlan[];
 	planSlug: PlanSlug;
-	isInSignup?: boolean;
+	isInSignup: boolean;
 	isStorageFeature: boolean;
 	flowName?: string | null;
-	intervalType?: string;
+	intervalType: string;
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
-	showUpgradeableStorage: boolean | undefined;
+	showUpgradeableStorage: boolean;
 	activeTooltipId: string;
 } > = ( {
 	feature,
@@ -581,13 +581,13 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 		: false;
 	const storageOptions = gridPlan.features.storageOptions;
 	const defaultStorageOption = storageOptions.find( ( option ) => ! option.isAddOn );
-	const canUpgradeStorageForPlan = isStorageUpgradeableForPlan(
-		storageOptions,
+	const canUpgradeStorageForPlan = isStorageUpgradeableForPlan( {
+		flowName: flowName ?? '',
 		intervalType,
-		showUpgradeableStorage,
 		isInSignup,
-		flowName
-	);
+		showUpgradeableStorage,
+		storageOptions,
+	} );
 
 	const cellClasses = classNames(
 		'plan-comparison-grid__feature-group-row-cell',
@@ -688,13 +688,13 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	allJetpackFeatures: Set< string >;
 	visibleGridPlans: GridPlan[];
 	planFeatureFootnotes: PlanFeatureFootnotes;
-	isInSignup?: boolean;
+	isInSignup: boolean;
 	isStorageFeature: boolean;
 	flowName?: string | null;
 	isHighlighted: boolean;
-	intervalType?: string;
+	intervalType: string;
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
-	showUpgradeableStorage: boolean | undefined;
+	showUpgradeableStorage: boolean;
 	activeTooltipId: string;
 } > = ( {
 	feature,

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -545,6 +545,7 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	planSlug,
 	isInSignup,
 	isStorageFeature,
+	flowName,
 	intervalType,
 	activeTooltipId,
 	showUpgradeableStorage,
@@ -584,7 +585,8 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 		storageOptions,
 		intervalType,
 		showUpgradeableStorage,
-		isInSignup
+		isInSignup,
+		flowName
 	);
 
 	const cellClasses = classNames(

--- a/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
@@ -10,13 +10,13 @@ type StorageAddOnDropdownProps = {
 	label?: string;
 	planSlug: PlanSlug;
 	storageOptions: StorageOption[];
-	showCost?: boolean;
+	showPrice?: boolean;
 };
 
 type StorageAddOnOptionProps = {
 	title: string;
-	cost: string | undefined;
-	showCost: boolean;
+	price: string | undefined;
+	showPrice: boolean;
 };
 
 const getStorageOptionPrice = (
@@ -28,15 +28,15 @@ const getStorageOptionPrice = (
 	} )?.prices?.formattedMonthlyPrice;
 };
 
-const StorageAddOnOption = ( { title, cost, showCost }: StorageAddOnOptionProps ) => {
+const StorageAddOnOption = ( { title, price, showPrice }: StorageAddOnOptionProps ) => {
 	const translate = useTranslate();
 	return (
 		<>
-			{ cost && showCost ? (
+			{ price && showPrice ? (
 				<div>
 					<span className="storage-add-on-dropdown-option__title">{ title }</span>
-					<span className="storage-add-on-dropdown-option__cost">
-						{ ` + ${ cost }/${ translate( 'month' ) }` }
+					<span className="storage-add-on-dropdown-option__price">
+						{ ` + ${ price }/${ translate( 'month' ) }` }
 					</span>
 				</div>
 			) : (
@@ -50,7 +50,7 @@ export const StorageAddOnDropdown = ( {
 	label = '',
 	planSlug,
 	storageOptions,
-	showCost = false,
+	showPrice = false,
 }: StorageAddOnDropdownProps ) => {
 	const { gridPlansIndex } = usePlansGridContext();
 	const { storageAddOnsForPlan } = gridPlansIndex[ planSlug ];
@@ -65,10 +65,10 @@ export const StorageAddOnDropdown = ( {
 	// TODO: Consider transforming storageOptions outside of this component
 	const selectControlOptions = storageOptions.map( ( storageOption ) => {
 		const title = getStorageStringFromFeature( storageOption.slug ) || '';
-		const cost = getStorageOptionPrice( storageAddOnsForPlan, storageOption.slug );
+		const price = getStorageOptionPrice( storageAddOnsForPlan, storageOption.slug );
 		return {
 			key: storageOption?.slug,
-			name: <StorageAddOnOption title={ title } cost={ cost } showCost={ showCost } />,
+			name: <StorageAddOnOption title={ title } price={ price } showPrice={ showPrice } />,
 		};
 	} );
 
@@ -81,8 +81,8 @@ export const StorageAddOnDropdown = ( {
 		name: (
 			<StorageAddOnOption
 				title={ selectedOptionTitle }
-				cost={ selectedOptionPrice }
-				showCost={ showCost }
+				price={ selectedOptionPrice }
+				showPrice={ showPrice }
 			/>
 		),
 	};

--- a/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
@@ -1,7 +1,7 @@
 import { AddOnMeta, WpcomPlansUI } from '@automattic/data-stores';
 import { CustomSelectControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../grid-context';
 import { getStorageStringFromFeature } from '../util';
 import type { PlanSlug, StorageOption, WPComStorageAddOnSlug } from '@automattic/calypso-products';
@@ -63,16 +63,14 @@ export const StorageAddOnDropdown = ( {
 	);
 
 	// TODO: Consider transforming storageOptions outside of this component
-	const selectControlOptions = storageOptions.reduce( ( acc, storageOption ) => {
+	const selectControlOptions = storageOptions.map( ( storageOption ) => {
 		const title = getStorageStringFromFeature( storageOption.slug ) || '';
 		const cost = getStorageOptionPrice( storageAddOnsForPlan, storageOption.slug );
-		acc.push( {
+		return {
 			key: storageOption?.slug,
 			name: <StorageAddOnOption title={ title } cost={ cost } showCost={ showCost } />,
-		} );
-
-		return acc;
-	}, [] as { key: string; name: TranslateResult }[] );
+		};
+	} );
 
 	const defaultStorageOption = storageOptions.find( ( storageOption ) => ! storageOption?.isAddOn );
 	const selectedOptionKey = selectedStorageOptionForPlan || defaultStorageOption?.slug || '';

--- a/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
@@ -1,19 +1,61 @@
-import { WpcomPlansUI } from '@automattic/data-stores';
+import { AddOnMeta, WpcomPlansUI } from '@automattic/data-stores';
 import { CustomSelectControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { usePlansGridContext } from '../grid-context';
 import { getStorageStringFromFeature } from '../util';
 import type { PlanSlug, StorageOption, WPComStorageAddOnSlug } from '@automattic/calypso-products';
 
 type StorageAddOnDropdownProps = {
+	label?: string;
 	planSlug: PlanSlug;
 	storageOptions: StorageOption[];
+	showCost?: boolean;
 };
 
-export const StorageAddOnDropdown = ( { planSlug, storageOptions }: StorageAddOnDropdownProps ) => {
+type StorageAddOnOptionProps = {
+	title: string;
+	cost: string | undefined;
+	showCost: boolean;
+};
+
+const getStorageOptionPrice = (
+	storageAddOnsForPlan: ( AddOnMeta | null )[] | null,
+	storageOptionSlug: string
+) => {
+	return storageAddOnsForPlan?.find( ( addOn ) => {
+		return addOn?.featureSlugs?.includes( storageOptionSlug );
+	} )?.prices?.formattedMonthlyPrice;
+};
+
+const StorageAddOnOption = ( { title, cost, showCost }: StorageAddOnOptionProps ) => {
 	const translate = useTranslate();
+	return (
+		<>
+			{ cost && showCost ? (
+				<div>
+					<span className="storage-add-on-dropdown-option__title">{ title }</span>
+					<span className="storage-add-on-dropdown-option__cost">
+						{ ` + ${ cost }/${ translate( 'month' ) }` }
+					</span>
+				</div>
+			) : (
+				<span className="storage-add-on-dropdown-option__title">{ title }</span>
+			) }
+		</>
+	);
+};
+
+export const StorageAddOnDropdown = ( {
+	label = '',
+	planSlug,
+	storageOptions,
+	showCost = false,
+}: StorageAddOnDropdownProps ) => {
+	const { gridPlansIndex } = usePlansGridContext();
+	const { storageAddOnsForPlan } = gridPlansIndex[ planSlug ];
 	const { setSelectedStorageOptionForPlan } = useDispatch( WpcomPlansUI.store );
-	const selectedStorage = useSelect(
+	const selectedStorageOptionForPlan = useSelect(
 		( select ) => {
 			return select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug );
 		},
@@ -22,26 +64,33 @@ export const StorageAddOnDropdown = ( { planSlug, storageOptions }: StorageAddOn
 
 	// TODO: Consider transforming storageOptions outside of this component
 	const selectControlOptions = storageOptions.reduce( ( acc, storageOption ) => {
-		const title = getStorageStringFromFeature( storageOption.slug );
-		if ( title ) {
-			acc.push( {
-				key: storageOption?.slug,
-				name: title,
-			} );
-		}
+		const title = getStorageStringFromFeature( storageOption.slug ) || '';
+		const cost = getStorageOptionPrice( storageAddOnsForPlan, storageOption.slug );
+		acc.push( {
+			key: storageOption?.slug,
+			name: <StorageAddOnOption title={ title } cost={ cost } showCost={ showCost } />,
+		} );
 
 		return acc;
 	}, [] as { key: string; name: TranslateResult }[] );
 
 	const defaultStorageOption = storageOptions.find( ( storageOption ) => ! storageOption?.isAddOn );
-	const selectedOptionKey = selectedStorage || defaultStorageOption?.slug || '';
+	const selectedOptionKey = selectedStorageOptionForPlan || defaultStorageOption?.slug || '';
+	const selectedOptionPrice = getStorageOptionPrice( storageAddOnsForPlan, selectedOptionKey );
+	const selectedOptionTitle = getStorageStringFromFeature( selectedOptionKey ) || '';
 	const selectedOption = {
 		key: selectedOptionKey,
-		name: getStorageStringFromFeature( selectedOptionKey ),
+		name: (
+			<StorageAddOnOption
+				title={ selectedOptionTitle }
+				cost={ selectedOptionPrice }
+				showCost={ showCost }
+			/>
+		),
 	};
 	return (
 		<CustomSelectControl
-			label={ translate( 'Storage' ) }
+			label={ label }
 			options={ selectControlOptions }
 			value={ selectedOption }
 			onChange={ ( { selectedItem }: { selectedItem: { key: WPComStorageAddOnSlug } } ) =>

--- a/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
@@ -1,10 +1,11 @@
-import { AddOnMeta, WpcomPlansUI } from '@automattic/data-stores';
+import { WpcomPlansUI } from '@automattic/data-stores';
 import { CustomSelectControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../grid-context';
 import { getStorageStringFromFeature } from '../util';
 import type { PlanSlug, StorageOption, WPComStorageAddOnSlug } from '@automattic/calypso-products';
+import type { AddOnMeta } from '@automattic/data-stores';
 
 type StorageAddOnDropdownProps = {
 	label?: string;

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -71,10 +71,12 @@ export type UsePricingMetaForGridPlans = ( {
 	planSlugs,
 	withoutProRatedCredits,
 	storageAddOns,
+	currencyCode,
 }: {
 	planSlugs: PlanSlug[];
 	withoutProRatedCredits?: boolean;
 	storageAddOns: ( AddOnMeta | null )[] | null;
+	currencyCode?: string | null;
 } ) => { [ planSlug: string ]: PricingMetaForGridPlan } | null;
 
 // TODO clk: move to types. will consume plan properties

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -23,10 +23,9 @@ import {
 	isBusinessPlan,
 	isEcommercePlan,
 } from '@automattic/calypso-products';
-import { AddOnMeta } from '@automattic/data-stores';
 import useHighlightLabels from './use-highlight-labels';
 import usePlansFromTypes from './use-plans-from-types';
-import type { PlanIntroductoryOffer, PricedAPIPlan } from '@automattic/data-stores';
+import type { AddOnMeta, PlanIntroductoryOffer, PricedAPIPlan } from '@automattic/data-stores';
 import type { TranslateResult } from 'i18n-calypso';
 
 // TODO clk: move to plans data store

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -20,7 +20,10 @@ import {
 	type PlanSlug,
 	type FeatureObject,
 	type StorageOption,
+	isBusinessPlan,
+	isEcommercePlan,
 } from '@automattic/calypso-products';
+import { AddOnMeta } from '@automattic/data-stores';
 import useHighlightLabels from './use-highlight-labels';
 import usePlansFromTypes from './use-plans-from-types';
 import type { PlanIntroductoryOffer, PricedAPIPlan } from '@automattic/data-stores';
@@ -68,9 +71,11 @@ export type UsePricedAPIPlans = ( { planSlugs }: { planSlugs: PlanSlug[] } ) => 
 export type UsePricingMetaForGridPlans = ( {
 	planSlugs,
 	withoutProRatedCredits,
+	storageAddOns,
 }: {
 	planSlugs: PlanSlug[];
 	withoutProRatedCredits?: boolean;
+	storageAddOns: ( AddOnMeta | null )[] | null;
 } ) => { [ planSlug: string ]: PricingMetaForGridPlan } | null;
 
 // TODO clk: move to types. will consume plan properties
@@ -95,6 +100,7 @@ export type GridPlan = {
 	} | null;
 	highlightLabel?: React.ReactNode | null;
 	pricing: PricingMetaForGridPlan;
+	storageAddOnsForPlan: ( AddOnMeta | null )[] | null;
 };
 
 // TODO clk: move to plans data store
@@ -279,6 +285,7 @@ const useGridPlans = ( {
 	const pricedAPIPlans = usePricedAPIPlans( { planSlugs: availablePlanSlugs } );
 	const pricingMeta = usePricingMetaForGridPlans( {
 		planSlugs: availablePlanSlugs,
+		storageAddOns,
 	} );
 
 	// Null return would indicate that we are still loading the data. No grid without grid plans.
@@ -316,6 +323,9 @@ const useGridPlans = ( {
 						product_slug: planSlug,
 				  };
 
+		const storageAddOnsForPlan =
+			isBusinessPlan( planSlug ) || isEcommercePlan( planSlug ) ? storageAddOns : null;
+
 		return {
 			planSlug,
 			isVisible: planSlugsForIntent.includes( planSlug ),
@@ -329,6 +339,7 @@ const useGridPlans = ( {
 			cartItemForPlan,
 			highlightLabel: highlightLabels[ planSlug ],
 			pricing: pricingMeta[ planSlug ],
+			storageAddOnsForPlan,
 		};
 	} );
 };

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -141,6 +141,7 @@ interface Props {
 	 * If the subdomain generation is unsuccessful we do not show the free plan
 	 */
 	isSubdomainNotGenerated?: boolean;
+	storageAddOns: ( AddOnMeta | null )[] | null;
 }
 
 const usePlanTypesWithIntent = ( {
@@ -249,6 +250,7 @@ const useGridPlans = ( {
 	isInSignup,
 	usePlanUpgradeabilityCheck,
 	isSubdomainNotGenerated,
+	storageAddOns,
 }: Props ): Omit< GridPlan, 'features' >[] | null => {
 	const availablePlanSlugs = usePlansFromTypes( {
 		planTypes: usePlanTypesWithIntent( {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -655,7 +655,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 					label={ translate( 'Storage' ) }
 					planSlug={ planSlug }
 					storageOptions={ storageOptions }
-					showCost
+					showPrice
 				/>
 			) : (
 				storageOptions.map( ( storageOption ) => {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -280,6 +280,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 						{ this.renderPlanPrice( [ gridPlan ] ) }
 						{ this.renderBillingTimeframe( [ gridPlan ] ) }
 						{ this.renderMobileFreeDomain( gridPlan.planSlug, gridPlan.isMonthlyPlan ) }
+						{ this.renderPlanStorageOptions( [ gridPlan ] ) }
 						{ this.renderTopButtons( [ gridPlan ] ) }
 						{ this.maybeRenderRefundNotice( [ gridPlan ] ) }
 						<CardContainer
@@ -295,7 +296,6 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 						>
 							{ this.renderPreviousFeaturesIncludedTitle( [ gridPlan ] ) }
 							{ this.renderPlanFeaturesList( [ gridPlan ] ) }
-							{ this.renderPlanStorageOptions( [ gridPlan ] ) }
 						</CardContainer>
 					</div>
 				);
@@ -651,7 +651,12 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 				storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage;
 
 			const storageJSX = canUpgradeStorageForPlan ? (
-				<StorageAddOnDropdown planSlug={ planSlug } storageOptions={ storageOptions } />
+				<StorageAddOnDropdown
+					label={ translate( 'Storage' ) }
+					planSlug={ planSlug }
+					storageOptions={ storageOptions }
+					showCost
+				/>
 			) : (
 				storageOptions.map( ( storageOption ) => {
 					if ( ! storageOption?.isAddOn ) {
@@ -704,6 +709,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			plansComparisonGridRef,
 			toggleShowPlansComparisonGrid,
 			showPlansComparisonGrid,
+			showUpgradeableStorage,
 		} = this.props;
 
 		return (
@@ -774,6 +780,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 								selectedPlan={ selectedPlan }
 								selectedFeature={ selectedFeature }
 								showLegacyStorageFeature={ showLegacyStorageFeature }
+								showUpgradeableStorage={ showUpgradeableStorage }
 							/>
 							<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
 								<Button onClick={ toggleShowPlansComparisonGrid }>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -645,11 +645,13 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			}
 
 			const shouldRenderStorageTitle =
-				storageOptions.length === 1 ||
-				( intervalType !== 'yearly' && storageOptions.length > 0 ) ||
-				( ! showUpgradeableStorage && storageOptions.length > 0 ) ||
-				( ! isInSignup && storageOptions.length > 0 ) ||
-				( ! ( flowName === 'onboarding' ) && storageOptions.length > 0 );
+				storageOptions.length > 0 &&
+				( storageOptions.length === 1 ||
+					intervalType !== 'yearly' ||
+					! showUpgradeableStorage ||
+					! isInSignup ||
+					! ( flowName === 'onboarding' ) );
+
 			const canUpgradeStorageForPlan = isStorageUpgradeableForPlan(
 				storageOptions,
 				intervalType,

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -637,7 +637,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 	}
 
 	renderPlanStorageOptions( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const { translate, intervalType, isInSignup, showUpgradeableStorage } = this.props;
+		const { translate, intervalType, isInSignup, flowName, showUpgradeableStorage } = this.props;
 
 		return renderedGridPlans.map( ( { planSlug, features: { storageOptions } } ) => {
 			if ( ! options?.isTableCell && isWpcomEnterpriseGridPlan( planSlug ) ) {
@@ -646,14 +646,16 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 
 			const shouldRenderStorageTitle =
 				storageOptions.length === 1 ||
-				( intervalType !== 'yearly' && storageOptions.length > 0 ) ||
-				( ! showUpgradeableStorage && storageOptions.length > 0 ) ||
-				( ! isInSignup && storageOptions.length > 0 );
+				intervalType !== 'yearly' ||
+				! showUpgradeableStorage ||
+				! isInSignup ||
+				( ! ( flowName === 'onboarding' ) && storageOptions.length > 0 );
 			const canUpgradeStorageForPlan = isStorageUpgradeableForPlan(
 				storageOptions,
 				intervalType,
 				showUpgradeableStorage,
-				isInSignup
+				isInSignup,
+				flowName
 			);
 
 			const storageJSX = canUpgradeStorageForPlan ? (

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -47,6 +47,7 @@ import { StickyContainer } from './components/sticky-container';
 import StorageAddOnDropdown from './components/storage-add-on-dropdown';
 import PlansGridContextProvider, { type PlansIntent } from './grid-context';
 import useIsLargeCurrency from './hooks/npm-ready/use-is-large-currency';
+import { isStorageUpgradeableForPlan } from './lib/is-storage-upgradeable-for-plan';
 import { DataResponse } from './types';
 import { getStorageStringFromFeature } from './util';
 import type {
@@ -636,7 +637,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 	}
 
 	renderPlanStorageOptions( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const { translate, intervalType, showUpgradeableStorage } = this.props;
+		const { translate, intervalType, isInSignup, showUpgradeableStorage } = this.props;
 
 		return renderedGridPlans.map( ( { planSlug, features: { storageOptions } } ) => {
 			if ( ! options?.isTableCell && isWpcomEnterpriseGridPlan( planSlug ) ) {
@@ -646,9 +647,14 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			const shouldRenderStorageTitle =
 				storageOptions.length === 1 ||
 				( intervalType !== 'yearly' && storageOptions.length > 0 ) ||
-				( ! showUpgradeableStorage && storageOptions.length > 0 );
-			const canUpgradeStorageForPlan =
-				storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage;
+				( ! showUpgradeableStorage && storageOptions.length > 0 ) ||
+				( ! isInSignup && storageOptions.length > 0 );
+			const canUpgradeStorageForPlan = isStorageUpgradeableForPlan(
+				storageOptions,
+				intervalType,
+				showUpgradeableStorage,
+				isInSignup
+			);
 
 			const storageJSX = canUpgradeStorageForPlan ? (
 				<StorageAddOnDropdown

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -646,9 +646,9 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 
 			const shouldRenderStorageTitle =
 				storageOptions.length === 1 ||
-				intervalType !== 'yearly' ||
-				! showUpgradeableStorage ||
-				! isInSignup ||
+				( intervalType !== 'yearly' && storageOptions.length > 0 ) ||
+				( ! showUpgradeableStorage && storageOptions.length > 0 ) ||
+				( ! isInSignup && storageOptions.length > 0 ) ||
 				( ! ( flowName === 'onboarding' ) && storageOptions.length > 0 );
 			const canUpgradeStorageForPlan = isStorageUpgradeableForPlan(
 				storageOptions,

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -70,7 +70,7 @@ export interface PlanFeatures2023GridProps {
 	gridPlanForSpotlight?: GridPlan;
 	// allFeaturesList temporary until feature definitions are ported to calypso-products package
 	allFeaturesList: FeatureList;
-	isInSignup?: boolean;
+	isInSignup: boolean;
 	siteId?: number | null;
 	isLaunchPage?: boolean | null;
 	isReskinned?: boolean;
@@ -78,7 +78,7 @@ export interface PlanFeatures2023GridProps {
 	flowName?: string | null;
 	paidDomainName?: string;
 	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >; // used to show a wpcom free domain in the Free plan column when a paid domain is picked.
-	intervalType?: string;
+	intervalType: string;
 	currentSitePlanSlug?: string | null;
 	hidePlansFeatureComparison?: boolean;
 	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
@@ -652,13 +652,13 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 					! isInSignup ||
 					! ( flowName === 'onboarding' ) );
 
-			const canUpgradeStorageForPlan = isStorageUpgradeableForPlan(
-				storageOptions,
+			const canUpgradeStorageForPlan = isStorageUpgradeableForPlan( {
+				flowName: flowName ?? '',
 				intervalType,
-				showUpgradeableStorage,
 				isInSignup,
-				flowName
-			);
+				showUpgradeableStorage,
+				storageOptions,
+			} );
 
 			const storageJSX = canUpgradeStorageForPlan ? (
 				<StorageAddOnDropdown

--- a/client/my-sites/plan-features-2023-grid/lib/is-storage-upgradeable-for-plan.ts
+++ b/client/my-sites/plan-features-2023-grid/lib/is-storage-upgradeable-for-plan.ts
@@ -1,12 +1,19 @@
 import type { StorageOption } from '@automattic/calypso-products';
 
-export const isStorageUpgradeableForPlan = (
-	storageOptions: StorageOption[],
-	intervalType: string | undefined,
-	showUpgradeableStorage: boolean | undefined,
-	isInSignup: boolean | undefined,
-	flowName: string | null | undefined
-) =>
+export const isStorageUpgradeableForPlan = ( {
+	flowName,
+	intervalType,
+	isInSignup,
+	showUpgradeableStorage,
+	storageOptions,
+}: {
+	flowName: string;
+	intervalType: string;
+	isInSignup: boolean;
+	showUpgradeableStorage: boolean;
+	storageOptions: StorageOption[];
+} ) =>
+	// Don't show for the enterprise plan which has no storage options
 	storageOptions.length > 1 &&
 	intervalType === 'yearly' &&
 	showUpgradeableStorage &&

--- a/client/my-sites/plan-features-2023-grid/lib/is-storage-upgradeable-for-plan.ts
+++ b/client/my-sites/plan-features-2023-grid/lib/is-storage-upgradeable-for-plan.ts
@@ -4,5 +4,11 @@ export const isStorageUpgradeableForPlan = (
 	storageOptions: StorageOption[],
 	intervalType: string | undefined,
 	showUpgradeableStorage: boolean | undefined,
-	isInSignup: boolean | undefined
-) => storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage && isInSignup;
+	isInSignup: boolean | undefined,
+	flowName: string | null | undefined
+) =>
+	storageOptions.length > 1 &&
+	intervalType === 'yearly' &&
+	showUpgradeableStorage &&
+	isInSignup &&
+	flowName === 'onboarding';

--- a/client/my-sites/plan-features-2023-grid/lib/is-storage-upgradeable-for-plan.ts
+++ b/client/my-sites/plan-features-2023-grid/lib/is-storage-upgradeable-for-plan.ts
@@ -1,0 +1,8 @@
+import type { StorageOption } from '@automattic/calypso-products';
+
+export const isStorageUpgradeableForPlan = (
+	storageOptions: StorageOption[],
+	intervalType: string | undefined,
+	showUpgradeableStorage: boolean | undefined,
+	isInSignup: boolean | undefined
+) => storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage && isInSignup;

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -577,7 +577,7 @@ $mobile-card-max-width: 440px;
 			font-size: 0.75rem;
 		}
 
-		.storage-add-on-dropdown-option__cost {
+		.storage-add-on-dropdown-option__price {
 			color: var(--studio-green-40);
 
 			// Non standard rem allows us to match font size of other storage labels

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -285,6 +285,20 @@ $mobile-card-max-width: 440px;
 					fill: #55347d;
 				}
 			}
+
+			&.plan-features-2023-grid__mobile-plan-card {
+				.plan-features-2023-grid__table-item {
+					&.plan-features-2023-grid__storage {
+						padding-top: 0;
+					}
+				}
+			}
+
+			.components-custom-select-control {
+				.components-custom-select-control__button {
+					height: 40px;
+				}
+			}
 		}
 
 		.foldable-card {
@@ -557,6 +571,20 @@ $mobile-card-max-width: 440px;
 			}
 		}
 	}
+
+	.components-custom-select-control {
+		.storage-add-on-dropdown-option__title {
+			font-size: 0.75rem;
+		}
+
+		.storage-add-on-dropdown-option__cost {
+			color: var(--studio-green-40);
+
+			// Non standard rem allows us to match font size of other storage labels
+			/* stylelint-disable-next-line scales/font-sizes */
+			font-size: 0.7rem;
+		}
+	}
 }
 
 .plan-features-2023-grid__content {
@@ -576,8 +604,7 @@ $mobile-card-max-width: 440px;
 body.is-section-stepper,
 body.is-section-signup.is-white-signup,
 .is-2023-pricing-grid {
-
-	.plan-features-2023-grid__table-item.plan-features-2023-grid__table-item {
+	.plan-features-2023-grid__table-item {
 		border-right: none;
 		background-color: transparent;
 
@@ -932,6 +959,20 @@ body.is-section-signup.is-white-signup,
 			}
 			@include plans-2023-break-medium {
 				top: 55px;
+			}
+		}
+	}
+
+	.plan-comparison-grid__feature-group-row-cell {
+		.components-custom-select-control label {
+			display: none;
+		}
+
+		.components-custom-select-control__menu {
+			margin-left: 0;
+
+			li {
+				text-align: left;
 			}
 		}
 	}

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -964,8 +964,12 @@ body.is-section-signup.is-white-signup,
 	}
 
 	.plan-comparison-grid__feature-group-row-cell {
-		.components-custom-select-control label {
-			display: none;
+		.components-custom-select-control {
+			width: 100%;
+
+			label {
+				display: none;
+			}
 		}
 
 		.components-custom-select-control__menu {

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -31,7 +31,9 @@ function getTotalPrices( planPrices: PlanPrices, addOnPrice = 0 ): PlanPrices {
 		const price = totalPrices[ key ];
 
 		if ( ! ( price === null ) ) {
-			totalPrices[ key ] = price + addOnPrice;
+			// Display prices are rounded to the nearest dollar,
+			// so we do the same for the add-on price
+			totalPrices[ key ] = price + Math.round( addOnPrice );
 		}
 	}
 

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -1,4 +1,5 @@
 import { Plans, WpcomPlansUI } from '@automattic/data-stores';
+import { getCurrencyObject } from '@automattic/format-currency';
 import { useSelect } from '@wordpress/data';
 import { useSelector } from 'react-redux';
 import usePricedAPIPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-priced-api-plans';
@@ -22,6 +23,29 @@ interface Props {
 	planSlugs: PlanSlug[];
 	withoutProRatedCredits?: boolean;
 	storageAddOns?: ( AddOnMeta | null )[] | null;
+	currencyCode?: string | null;
+}
+
+/***
+ * The 2023 Pricing Grid handles prices differently than add-ons, so for the time being we need to
+ * do some conversion to calculate totals correctly.
+ *
+ * The 2023 pricing grid currently handles prices in some currencies in their smallest unit, like
+ * the Japanese Yen. For others, however, like USD, prices are not handled in their smallest unit,
+ * like the US dollar.
+ *
+ * For example, 2000 yen would be represented by the integer 2000 since a yen is the smallest unit.
+ * $20.00, however, would be represented as the integer 20, and not 2000. Since storage add-on
+ * prices are always handled in the smallest unit, we need to convert them, when appropriate, to the
+ * correct integer.
+ *
+ * We should expose a more friendly function from the format-currency package
+ */
+function convertPriceForSmallestUnit( price: number, currencyCode: string | null ) {
+	const currencyObject = getCurrencyObject( price, currencyCode || '', {
+		isSmallestUnit: true,
+	} );
+	return parseInt( currencyObject.integer.replace( /,/g, '' ) );
 }
 
 function getTotalPrices( planPrices: PlanPrices, addOnPrice = 0 ): PlanPrices {
@@ -51,6 +75,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	planSlugs,
 	withoutProRatedCredits = false,
 	storageAddOns,
+	currencyCode = '',
 }: Props ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
 	const currentSitePlanSlug = useSelector( ( state: IAppState ) =>
@@ -70,8 +95,14 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 			const storageAddOnPrices = storageAddOns?.find( ( addOn ) => {
 				return addOn?.featureSlugs?.includes( selectedStorageOption || '' );
 			} )?.prices;
-			const storageAddOnPriceMonthly = storageAddOnPrices?.monthlyPrice || 0;
-			const storageAddOnPriceYearly = storageAddOnPrices?.yearlyPrice || 0;
+			const storageAddOnPriceMonthly = convertPriceForSmallestUnit(
+				storageAddOnPrices?.monthlyPrice || 0,
+				currencyCode
+			);
+			const storageAddOnPriceYearly = convertPriceForSmallestUnit(
+				storageAddOnPrices?.yearlyPrice || 0,
+				currencyCode
+			);
 
 			const planPricesMonthly = getPlanPrices( state, {
 				planSlug,

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -1,4 +1,4 @@
-import { AddOnMeta, Plans, WpcomPlansUI } from '@automattic/data-stores';
+import { Plans, WpcomPlansUI } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
 import { useSelector } from 'react-redux';
 import usePricedAPIPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-priced-api-plans';
@@ -11,6 +11,7 @@ import {
 import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import type { PlanSlug } from '@automattic/calypso-products';
+import type { AddOnMeta } from '@automattic/data-stores';
 import type {
 	UsePricingMetaForGridPlans,
 	PricingMetaForGridPlan,

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -1,7 +1,9 @@
-import { Plans } from '@automattic/data-stores';
+import { AddOnMeta, Plans, WpcomPlansUI } from '@automattic/data-stores';
+import { useSelect } from '@wordpress/data';
 import { useSelector } from 'react-redux';
 import usePricedAPIPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-priced-api-plans';
 import { getPlanPrices } from 'calypso/state/plans/selectors';
+import { PlanPrices } from 'calypso/state/plans/types';
 import {
 	getSitePlanRawPrice,
 	isPlanAvailableForPurchase,
@@ -18,6 +20,22 @@ import type { IAppState } from 'calypso/state/types';
 interface Props {
 	planSlugs: PlanSlug[];
 	withoutProRatedCredits?: boolean;
+	storageAddOns?: ( AddOnMeta | null )[] | null;
+}
+
+function getTotalPrices( planPrices: PlanPrices, addOnPrice = 0 ): PlanPrices {
+	const totalPrices = { ...planPrices };
+	let key: keyof PlanPrices;
+
+	for ( key in totalPrices ) {
+		const price = totalPrices[ key ];
+
+		if ( ! ( price === null ) ) {
+			totalPrices[ key ] = price + addOnPrice;
+		}
+	}
+
+	return totalPrices;
 }
 
 /*
@@ -25,9 +43,11 @@ interface Props {
  * - see PricingMetaForGridPlan type for details
  * - will migrate to data-store once dependencies are resolved (when site & plans data-stores more complete)
  */
+
 const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	planSlugs,
 	withoutProRatedCredits = false,
+	storageAddOns,
 }: Props ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
 	const currentSitePlanSlug = useSelector( ( state: IAppState ) =>
@@ -35,11 +55,21 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	);
 	const pricedAPIPlans = usePricedAPIPlans( { planSlugs: planSlugs } );
 	const sitePlans = Plans.useSitePlans( { siteId: selectedSiteId } );
+	const selectedStorageOptions = useSelect( ( select ) => {
+		return select( WpcomPlansUI.store ).getSelectedStorageOptions();
+	}, [] );
 	const planPrices = useSelector( ( state: IAppState ) => {
 		return planSlugs.reduce( ( acc, planSlug ) => {
 			const availableForPurchase =
 				! currentSitePlanSlug ||
 				( selectedSiteId ? isPlanAvailableForPurchase( state, selectedSiteId, planSlug ) : false );
+			const selectedStorageOption = selectedStorageOptions?.[ planSlug ];
+			const storageAddOnPrices = storageAddOns?.find( ( addOn ) => {
+				return addOn?.featureSlugs?.includes( selectedStorageOption || '' );
+			} )?.prices;
+			const storageAddOnPriceMonthly = storageAddOnPrices?.monthlyPrice || 0;
+			const storageAddOnPriceYearly = storageAddOnPrices?.yearlyPrice || 0;
+
 			const planPricesMonthly = getPlanPrices( state, {
 				planSlug,
 				siteId: selectedSiteId || null,
@@ -52,21 +82,26 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 				returnMonthly: false,
 				returnSmallestUnit: true,
 			} );
+			const totalPricesMonthly = getTotalPrices( planPricesMonthly, storageAddOnPriceMonthly );
+			const totalPricesFull = getTotalPrices( planPricesFull, storageAddOnPriceYearly );
 
 			// raw prices for current site's plan
 			if ( selectedSiteId && currentSitePlanSlug === planSlug ) {
+				const monthlyPrice = getSitePlanRawPrice( state, selectedSiteId, planSlug, {
+					returnMonthly: true,
+					returnSmallestUnit: true,
+				} );
+				const yearlyPrice = getSitePlanRawPrice( state, selectedSiteId, planSlug, {
+					returnMonthly: false,
+					returnSmallestUnit: true,
+				} );
+
 				return {
 					...acc,
 					[ planSlug ]: {
 						originalPrice: {
-							monthly: getSitePlanRawPrice( state, selectedSiteId, planSlug, {
-								returnMonthly: true,
-								returnSmallestUnit: true,
-							} ),
-							full: getSitePlanRawPrice( state, selectedSiteId, planSlug, {
-								returnMonthly: false,
-								returnSmallestUnit: true,
-							} ),
+							monthly: monthlyPrice ? monthlyPrice + storageAddOnPriceMonthly : null,
+							full: yearlyPrice ? yearlyPrice + storageAddOnPriceYearly : null,
 						},
 						discountedPrice: {
 							monthly: null,
@@ -82,8 +117,8 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 					...acc,
 					[ planSlug ]: {
 						originalPrice: {
-							monthly: planPricesMonthly.rawPrice,
-							full: planPricesFull.rawPrice,
+							monthly: totalPricesMonthly.rawPrice,
+							full: totalPricesFull.rawPrice,
 						},
 						discountedPrice: {
 							monthly: null,
@@ -98,16 +133,16 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 				...acc,
 				[ planSlug ]: {
 					originalPrice: {
-						monthly: planPricesMonthly.rawPrice,
-						full: planPricesFull.rawPrice,
+						monthly: totalPricesMonthly.rawPrice,
+						full: totalPricesFull.rawPrice,
 					},
 					discountedPrice: {
 						monthly: withoutProRatedCredits
-							? planPricesMonthly.discountedRawPrice
-							: planPricesMonthly.planDiscountedRawPrice || planPricesMonthly.discountedRawPrice,
+							? totalPricesMonthly.discountedRawPrice
+							: totalPricesMonthly.planDiscountedRawPrice || totalPricesMonthly.discountedRawPrice,
 						full: withoutProRatedCredits
-							? planPricesFull.discountedRawPrice
-							: planPricesFull.planDiscountedRawPrice || planPricesFull.discountedRawPrice,
+							? totalPricesFull.discountedRawPrice
+							: totalPricesFull.planDiscountedRawPrice || totalPricesFull.discountedRawPrice,
 					},
 				},
 			};

--- a/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -9,6 +9,7 @@ jest.mock( 'react-redux', () => ( {
 	...jest.requireActual( 'react-redux' ),
 	useSelector: ( selector ) => selector(),
 } ) );
+jest.mock( '@wordpress/data' );
 jest.mock( 'calypso/state/plans/selectors', () => ( {
 	getPlanPrices: jest.fn(),
 } ) );

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -8,6 +8,7 @@ import {
 	isPersonalPlan,
 	PlanSlug,
 	PLAN_PERSONAL,
+	PRODUCT_1GB_SPACE,
 } from '@automattic/calypso-products';
 import { Button, Spinner } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
@@ -41,6 +42,7 @@ import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSitePlanSlug, getSiteSlug } from 'calypso/state/sites/selectors';
+import useAddOns from '../add-ons/hooks/use-add-ons';
 import { FreePlanFreeDomainDialog } from './components/free-plan-free-domain-dialog';
 import { FreePlanPaidDomainDialog } from './components/free-plan-paid-domain-dialog';
 import { LoadingPlaceHolder } from './components/loading-placeholder';
@@ -216,6 +218,9 @@ const PlansFeaturesMain = ( {
 	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
 	const translate = useTranslate();
 	const plansComparisonGridRef = useRef< HTMLDivElement >( null );
+	const storageAddOns = useAddOns( siteId as number ).filter(
+		( addOn ) => addOn?.productSlug === PRODUCT_1GB_SPACE
+	);
 	const currentPlan = useSelector( ( state: IAppState ) => getCurrentPlan( state, siteId ) );
 	const eligibleForWpcomMonthlyPlans = useSelector( ( state: IAppState ) =>
 		isEligibleForWpComMonthlyPlan( state, siteId )
@@ -337,6 +342,7 @@ const PlansFeaturesMain = ( {
 		usePlanUpgradeabilityCheck,
 		showLegacyStorageFeature,
 		isSubdomainNotGenerated: ! resolvedSubdomainName.result,
+		storageAddOns,
 	} );
 
 	const planFeaturesForFeaturesGrid = usePlanFeaturesForGridPlans( {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -218,7 +218,7 @@ const PlansFeaturesMain = ( {
 	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
 	const translate = useTranslate();
 	const plansComparisonGridRef = useRef< HTMLDivElement >( null );
-	const storageAddOns = useAddOns( siteId as number ).filter(
+	const storageAddOns = useAddOns( siteId ?? undefined ).filter(
 		( addOn ) => addOn?.productSlug === PRODUCT_1GB_SPACE
 	);
 	const currentPlan = useSelector( ( state: IAppState ) => getCurrentPlan( state, siteId ) );

--- a/client/signup/steps/add-ons/index.tsx
+++ b/client/signup/steps/add-ons/index.tsx
@@ -3,11 +3,13 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import AddOnsGrid from 'calypso/my-sites/add-ons/components/add-ons-grid';
-import useAddOns, { AddOnMeta } from 'calypso/my-sites/add-ons/hooks/use-add-ons';
+import useAddOns from 'calypso/my-sites/add-ons/hooks/use-add-ons';
 import NavigationLink from 'calypso/signup/navigation-link';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { useDispatch } from 'calypso/state';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
+import type { AddOnMeta } from '@automattic/data-stores';
+
 import './styles.scss';
 
 interface Props {

--- a/client/state/plans/selectors/get-plan-prices.ts
+++ b/client/state/plans/selectors/get-plan-prices.ts
@@ -22,29 +22,21 @@ export function getPlanPrices(
 		planSlug,
 		siteId,
 		returnMonthly,
-		returnSmallestUnit,
-	}: {
-		planSlug: PlanSlug;
-		siteId: SiteId | null;
-		returnMonthly: boolean;
-		returnSmallestUnit?: boolean;
-	}
+	}: { planSlug: PlanSlug; siteId: SiteId | null; returnMonthly: boolean }
 ): PlanPrices {
 	const plan = getPlan( planSlug );
 	const productId = plan?.getProductId();
 
 	return {
-		rawPrice: productId
-			? getPlanRawPrice( state, productId, returnMonthly, returnSmallestUnit )
-			: null,
+		rawPrice: productId ? getPlanRawPrice( state, productId, returnMonthly, true ) : null,
 		discountedRawPrice: productId
-			? getDiscountedRawPrice( state, productId, returnMonthly, returnSmallestUnit )
+			? getDiscountedRawPrice( state, productId, returnMonthly, true )
 			: null,
 		planDiscountedRawPrice:
 			siteId && planSlug
 				? getPlanDiscountedRawPrice( state, siteId, planSlug, {
 						returnMonthly,
-						returnSmallestUnit,
+						returnSmallestUnit: true,
 				  } )
 				: null,
 	};

--- a/client/state/plans/selectors/get-plan-prices.ts
+++ b/client/state/plans/selectors/get-plan-prices.ts
@@ -22,21 +22,29 @@ export function getPlanPrices(
 		planSlug,
 		siteId,
 		returnMonthly,
-	}: { planSlug: PlanSlug; siteId: SiteId | null; returnMonthly: boolean }
+		returnSmallestUnit,
+	}: {
+		planSlug: PlanSlug;
+		siteId: SiteId | null;
+		returnMonthly: boolean;
+		returnSmallestUnit?: boolean;
+	}
 ): PlanPrices {
 	const plan = getPlan( planSlug );
 	const productId = plan?.getProductId();
 
 	return {
-		rawPrice: productId ? getPlanRawPrice( state, productId, returnMonthly, true ) : null,
+		rawPrice: productId
+			? getPlanRawPrice( state, productId, returnMonthly, returnSmallestUnit )
+			: null,
 		discountedRawPrice: productId
-			? getDiscountedRawPrice( state, productId, returnMonthly, true )
+			? getDiscountedRawPrice( state, productId, returnMonthly, returnSmallestUnit )
 			: null,
 		planDiscountedRawPrice:
 			siteId && planSlug
 				? getPlanDiscountedRawPrice( state, siteId, planSlug, {
 						returnMonthly,
-						returnSmallestUnit: true,
+						returnSmallestUnit,
 				  } )
 				: null,
 	};

--- a/packages/data-stores/src/add-ons/types.ts
+++ b/packages/data-stores/src/add-ons/types.ts
@@ -1,0 +1,20 @@
+import { TranslateResult } from 'i18n-calypso';
+
+export interface AddOnMeta {
+	productSlug: string;
+	featureSlugs?: string[] | null;
+	icon: JSX.Element;
+	featured?: boolean; // irrelevant to "featureSlugs"
+	name: string | null;
+	quantity?: number; // used for determining checkout costs for quantity based products
+	description: string | null;
+	displayCost: TranslateResult | null;
+	purchased?: boolean;
+	isLoading?: boolean;
+	prices?: {
+		monthlyPrice: number;
+		yearlyPrice: number;
+		formattedMonthlyPrice: string;
+		formattedYearlyPrice: string;
+	} | null;
+}

--- a/packages/data-stores/src/add-ons/types.ts
+++ b/packages/data-stores/src/add-ons/types.ts
@@ -4,7 +4,7 @@ export interface AddOnMeta {
 	productSlug: string;
 	featureSlugs?: string[] | null;
 	icon: JSX.Element;
-	featured?: boolean; // irrelevant to "featureSlugs"
+	featured?: boolean; // used to display the popular badge in the add-ons grid
 	name: string | null;
 	quantity?: number; // used for determining checkout costs for quantity based products
 	description: string | null;

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -13,6 +13,7 @@ import * as User from './user';
 import * as WpcomPlansUI from './wpcom-plans-ui';
 export { useHappinessEngineersQuery } from './queries/use-happiness-engineers-query';
 export { useSiteIntent } from './queries/use-site-intent';
+export * from './add-ons/types';
 export * from './starter-designs-queries';
 export * from './site/types';
 export * from './templates';

--- a/packages/data-stores/src/wpcom-plans-ui/selectors.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/selectors.ts
@@ -4,3 +4,4 @@ import type { State } from './reducer';
 export const isDomainUpsellDialogShown = ( state: State ) => !! state.showDomainUpsellDialog;
 export const getSelectedStorageOptionForPlan = ( state: State, planSlug: PlanSlug ) =>
 	state.selectedStorageOptionForPlans?.[ planSlug ];
+export const getSelectedStorageOptions = ( state: State ) => state.selectedStorageOptionForPlans;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/79041#discussion_r1279224891
Issue https://github.com/Automattic/martech/issues/2025
Tracking https://github.com/Automattic/martech/issues/2023

DEPENDENT ON https://github.com/Automattic/wp-calypso/pull/81537

## Proposed Changes

* Update use-add-on hook to return monthly and yearly add-on costs
* Implement use add-on hook in plan-features-main component
* Add storageAddOns data to gridPlans
* Consume storage add-on data in the storage dropdown component, header pricing component, and billing timeframe component
* Only show add-on upsells in the `/start` flow

## GIFs
![2023-09-03 20 07 17](https://github.com/Automattic/wp-calypso/assets/5414230/fc88caaa-96e5-483e-bd21-fcff5200ce1b)

## Will Follow Up in Future PR
* Comparison grid storage add on dropdown width is too narrow for tablet resolutions ( longer currency values are wonky )
* Make the storage add-on in checkout cart a dropdown ( to allow user to switch between storage add-ons )

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test signup flows with business or ecommerce plans:
  - `/start?flags=plans%2Fupgradeable-storage`
* Verify that the storage add-on dropdown only renders for business and ecommerce plans
* Verify that the dropdown is only rendered for annual plans ( not monthly )
* Verify that the header pricing and billing timeframe changes appropriately when storage add-ons are selected
* Ensure that add-on upsells do not display in other signup `/start` flows by visiting:
  - `/start/domain?flags=plans%2Fupgradeable-storage`
  - `/start/plans-import?flags=plans%2Fupgradeable-storage`
* Ensure that add-on upsells do not display in stepper flows by visiting:
  - `setup/onboarding-media?flags=plans%2Fupgradeable-storage`
* Ensure that add-on upsells do not display in `/plans` by visiting:
  - `/plans?flags=plans%2Fupgradeable-storage`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?