### PR TITLE
Hide an unnecessary button in `ThankYouModal` while loading

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -66,6 +66,12 @@ class ThanksModal extends Component {
 	}
 
 	static getDerivedStateFromProps( nextProps, prevState ) {
+		if ( nextProps.isLivePreviewStarted ) {
+			return {
+				isVisible: true,
+				wasInstalling: false,
+			};
+		}
 		if ( nextProps.shouldRedirectToThankYouPage ) {
 			return {
 				isVisible: false,
@@ -327,9 +333,11 @@ class ThanksModal extends Component {
 	};
 
 	render() {
-		const { currentTheme, hasActivated, doesThemeBundleUsableSoftware } = this.props;
+		const { currentTheme, hasActivated, doesThemeBundleUsableSoftware, isLivePreviewStarted } =
+			this.props;
 
-		const shouldDisplayContent = hasActivated && currentTheme && ! doesThemeBundleUsableSoftware;
+		const shouldDisplayContent =
+			hasActivated && currentTheme && ! doesThemeBundleUsableSoftware && ! isLivePreviewStarted;
 
 		return (
 			<Dialog

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -235,17 +235,18 @@ class ThanksModal extends Component {
 		);
 	};
 
-	getEditSiteLabel = () => {
-		const { shouldEditHomepageWithGutenberg, hasActivated, isFSEActive, isLivePreviewStarted } =
-			this.props;
+	getLoadingLabel = () => {
+		const { isLivePreviewStarted } = this.props;
 
 		if ( isLivePreviewStarted ) {
 			return this.props.translate( 'Preparing the live preview…' );
 		}
 
-		if ( ! hasActivated ) {
-			return this.props.translate( 'Activating theme…' );
-		}
+		return this.props.translate( 'Activating theme…' );
+	};
+
+	getEditSiteLabel = () => {
+		const { shouldEditHomepageWithGutenberg, isFSEActive } = this.props;
 
 		if ( isFSEActive ) {
 			return (
@@ -279,12 +280,7 @@ class ThanksModal extends Component {
 	);
 
 	getButtons = ( shouldDisplayContent ) => {
-		const {
-			shouldEditHomepageWithGutenberg,
-			hasActivated,
-			isFSEActive,
-			doesThemeBundleUsableSoftware,
-		} = this.props;
+		const { shouldEditHomepageWithGutenberg, isFSEActive } = this.props;
 
 		const firstButton = shouldEditHomepageWithGutenberg
 			? {
@@ -293,19 +289,21 @@ class ThanksModal extends Component {
 					onClick: this.trackVisitSite,
 					href: this.props.siteUrl,
 					target: '_blank',
+					disabled: false,
 			  }
 			: {
 					action: 'learn',
 					label: this.props.translate( 'Learn about this theme' ),
 					onClick: this.learnThisTheme,
 					href: this.props.detailsUrl,
+					disabled: false,
 			  };
 
 		const primaryButton = {
 			action: 'customizeSite',
 			label: this.getEditSiteLabel(),
 			isPrimary: true,
-			disabled: ! hasActivated || doesThemeBundleUsableSoftware,
+			disabled: false,
 			onClick: isFSEActive ? this.goToSiteEditor : this.goToCustomizer,
 			href: this.props.customizeUrl,
 			target: shouldEditHomepageWithGutenberg || isFSEActive ? null : '_blank',
@@ -316,16 +314,16 @@ class ThanksModal extends Component {
 		 * in such a short loading moment.
 		 */
 		if ( ! shouldDisplayContent ) {
-			return [ primaryButton ];
+			return [
+				{
+					...primaryButton,
+					label: this.getLoadingLabel(),
+					disabled: true,
+				},
+			];
 		}
 
-		return [
-			{
-				...firstButton,
-				disabled: ! hasActivated || doesThemeBundleUsableSoftware,
-			},
-			primaryButton,
-		];
+		return [ firstButton, primaryButton ];
 	};
 
 	render() {

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -278,7 +278,7 @@ class ThanksModal extends Component {
 		</span>
 	);
 
-	getButtons = () => {
+	getButtons = ( shouldDisplayContent ) => {
 		const {
 			shouldEditHomepageWithGutenberg,
 			hasActivated,
@@ -301,20 +301,30 @@ class ThanksModal extends Component {
 					href: this.props.detailsUrl,
 			  };
 
+		const primaryButton = {
+			action: 'customizeSite',
+			label: this.getEditSiteLabel(),
+			isPrimary: true,
+			disabled: ! hasActivated || doesThemeBundleUsableSoftware,
+			onClick: isFSEActive ? this.goToSiteEditor : this.goToCustomizer,
+			href: this.props.customizeUrl,
+			target: shouldEditHomepageWithGutenberg || isFSEActive ? null : '_blank',
+		};
+
+		/**
+		 * It does not make sense to show "Learn about this theme" or "View site" buttons
+		 * in such a short loading moment.
+		 */
+		if ( ! shouldDisplayContent ) {
+			return [ primaryButton ];
+		}
+
 		return [
 			{
 				...firstButton,
 				disabled: ! hasActivated || doesThemeBundleUsableSoftware,
 			},
-			{
-				action: 'customizeSite',
-				label: this.getEditSiteLabel(),
-				isPrimary: true,
-				disabled: ! hasActivated || doesThemeBundleUsableSoftware,
-				onClick: isFSEActive ? this.goToSiteEditor : this.goToCustomizer,
-				href: this.props.customizeUrl,
-				target: shouldEditHomepageWithGutenberg || isFSEActive ? null : '_blank',
-			},
+			primaryButton,
 		];
 	};
 
@@ -327,7 +337,7 @@ class ThanksModal extends Component {
 			<Dialog
 				className="themes__thanks-modal"
 				isVisible={ this.state.isVisible }
-				buttons={ this.getButtons() }
+				buttons={ this.getButtons( shouldDisplayContent ) }
 				onClose={ this.onCloseModal }
 			>
 				{ shouldDisplayContent ? this.renderContent() : this.renderLoading() }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Hide an unnecessary button in ThankYouModal while loading. See pdtkmj-1JP-p2#comment-3256 in more detail.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Partner themes activation

before

https://github.com/Automattic/wp-calypso/assets/5287479/2cbe91e2-732c-45f2-aa86-fbfdc43317ff

after 

https://github.com/Automattic/wp-calypso/assets/5287479/8d646ec3-84df-4903-8fa6-5bc1061ad7b8

- Prepare an Atomic site.
- Go to the Theme Detail page of a partner theme, which is the only theme type that shows ThankYouModal after activating a theme. https://github.com/Automattic/wp-calypso/pull/78156
- Activate the theme.
- Verify only one button displays while loading.

### Live Preview - install&preview

<img width="1434" alt="Screen Shot 2023-09-04 at 13 23 56" src="https://github.com/Automattic/wp-calypso/assets/5287479/50b12a00-8ed2-432e-8226-4d7875307fb5">

- Prepare an Atomic site.
- Go to the Theme Detail page that is Live Preview compatible AND not installed on your site yet. 
- Click the "Live Preview" button.
- Verify only one button displays while loading. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?