### PR TITLE
Add an A/B test for quick responses in the Help Center

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -487,7 +487,7 @@ export const HelpCenterContactForm = () => {
 	const getCTALabel = () => {
 		const showingHelpOrGPTResults = showingSearchResults || showingGPTResponse;
 
-		if ( experimentAssignment?.variationName === 'no_quick_response' ) {
+		if ( noQuickResponseExperimentVariation === 'no_quick_response' ) {
 			if ( ! showingGPTResponse && ! showingSearchResults ) {
 				if ( mode === 'EMAIL' ) {
 					return __( 'Email us', __i18n_text_domain__ );

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -494,13 +494,13 @@ export const HelpCenterContactForm = () => {
 		 if ( experimentAssignment?.variationName === 'no_quick_response' ) {
             if ( ! showingGPTResponse && ! showingSearchResults ) {
                 if ( mode === 'EMAIL' ) {
-                    return **__**( 'Email us', __i18n_text_domain__ );
+                    return __( 'Email us', __i18n_text_domain__ );
                 }
                 if ( mode === 'CHAT' ) {
-                    return **__**( 'Chat with us', __i18n_text_domain__ );
+                    return __( 'Chat with us', __i18n_text_domain__ );
                 }
                 if ( mode === 'FORUM' ) {
-                    return **__**( 'Submit', __i18n_text_domain__ );
+                    return __( 'Submit', __i18n_text_domain__ );
                 }
             }
         }

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -16,6 +16,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useDebounce } from 'use-debounce';
+import { useExperiment } from 'calypso/lib/explat';
 import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { getQueryArgs } from 'calypso/lib/query-args';
@@ -186,6 +187,15 @@ export const HelpCenterContactForm = () => {
 	const [ debouncedMessage ] = useDebounce( message || '', 500 );
 	const [ debouncedSubject ] = useDebounce( subject || '', 500 );
 
+	const [ , experimentAssignment ] = useExperiment(
+		'calypso_helpcenter_quick_response_deflection_rate'
+	);
+
+	if ( experimentAssignment?.variationName === 'no_quick_response' ) {
+		params.set( 'disable-gpt', 'true' );
+		params.set( 'show-gpt', 'false' );
+	}
+
 	const enableGPTResponse =
 		config.isEnabled( 'help/gpt-response' ) && ! ( params.get( 'disable-gpt' ) === 'true' );
 
@@ -262,12 +272,14 @@ export const HelpCenterContactForm = () => {
 
 	function handleCTA() {
 		if ( ! enableGPTResponse && ! showingSearchResults ) {
-			params.set( 'show-results', 'true' );
-			navigate( {
-				pathname: '/contact-form',
-				search: params.toString(),
-			} );
-			return;
+			if ( experimentAssignment?.variationName === 'control' ) {
+				params.set( 'show-results', 'true' );
+				navigate( {
+					pathname: '/contact-form',
+					search: params.toString(),
+				} );
+				return;
+			}
 		}
 
 		if ( ! showingGPTResponse && enableGPTResponse ) {
@@ -330,7 +342,6 @@ export const HelpCenterContactForm = () => {
 							}`
 						);
 					}
-
 					const kayakoMessage = [ ...ticketMeta, '\n', message ].join( '\n' );
 
 					submitTicket( {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -491,6 +491,20 @@ export const HelpCenterContactForm = () => {
 	const getCTALabel = () => {
 		const showingHelpOrGPTResults = showingSearchResults || showingGPTResponse;
 
+		 if ( experimentAssignment?.variationName === 'no_quick_response' ) {
+            if ( ! showingGPTResponse && ! showingSearchResults ) {
+                if ( mode === 'EMAIL' ) {
+                    return **__**( 'Email us', __i18n_text_domain__ );
+                }
+                if ( mode === 'CHAT' ) {
+                    return **__**( 'Chat with us', __i18n_text_domain__ );
+                }
+                if ( mode === 'FORUM' ) {
+                    return **__**( 'Submit', __i18n_text_domain__ );
+                }
+            }
+        }
+
 		if ( ! showingGPTResponse && ! showingSearchResults ) {
 			return __( 'Continue', __i18n_text_domain__ );
 		}

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -16,7 +16,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useDebounce } from 'use-debounce';
-import { useExperiment } from 'calypso/lib/explat';
 import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { getQueryArgs } from 'calypso/lib/query-args';
@@ -123,6 +122,7 @@ export const HelpCenterContactForm = () => {
 		hasActiveChats,
 		isEligibleForChat,
 		isLoading: isLoadingChatStatus,
+		noQuickResponseExperimentVariation,
 	} = useChatStatus();
 	useZendeskMessaging(
 		'zendesk_support_chat_key',
@@ -187,11 +187,7 @@ export const HelpCenterContactForm = () => {
 	const [ debouncedMessage ] = useDebounce( message || '', 500 );
 	const [ debouncedSubject ] = useDebounce( subject || '', 500 );
 
-	const [ , experimentAssignment ] = useExperiment(
-		'calypso_helpcenter_quick_response_deflection_rate'
-	);
-
-	if ( experimentAssignment?.variationName === 'no_quick_response' ) {
+	if ( noQuickResponseExperimentVariation === 'no_quick_response' ) {
 		params.set( 'disable-gpt', 'true' );
 		params.set( 'show-gpt', 'false' );
 	}
@@ -272,7 +268,7 @@ export const HelpCenterContactForm = () => {
 
 	function handleCTA() {
 		if ( ! enableGPTResponse && ! showingSearchResults ) {
-			if ( experimentAssignment?.variationName === 'control' ) {
+			if ( noQuickResponseExperimentVariation === 'control' ) {
 				params.set( 'show-results', 'true' );
 				navigate( {
 					pathname: '/contact-form',

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -491,19 +491,19 @@ export const HelpCenterContactForm = () => {
 	const getCTALabel = () => {
 		const showingHelpOrGPTResults = showingSearchResults || showingGPTResponse;
 
-		 if ( experimentAssignment?.variationName === 'no_quick_response' ) {
-            if ( ! showingGPTResponse && ! showingSearchResults ) {
-                if ( mode === 'EMAIL' ) {
-                    return __( 'Email us', __i18n_text_domain__ );
-                }
-                if ( mode === 'CHAT' ) {
-                    return __( 'Chat with us', __i18n_text_domain__ );
-                }
-                if ( mode === 'FORUM' ) {
-                    return __( 'Submit', __i18n_text_domain__ );
-                }
-            }
-        }
+		if ( experimentAssignment?.variationName === 'no_quick_response' ) {
+			if ( ! showingGPTResponse && ! showingSearchResults ) {
+				if ( mode === 'EMAIL' ) {
+					return __( 'Email us', __i18n_text_domain__ );
+				}
+				if ( mode === 'CHAT' ) {
+					return __( 'Chat with us', __i18n_text_domain__ );
+				}
+				if ( mode === 'FORUM' ) {
+					return __( 'Submit', __i18n_text_domain__ );
+				}
+			}
+		}
 
 		if ( ! showingGPTResponse && ! showingSearchResults ) {
 			return __( 'Continue', __i18n_text_domain__ );

--- a/packages/help-center/src/hooks/use-chat-status.ts
+++ b/packages/help-center/src/hooks/use-chat-status.ts
@@ -37,5 +37,6 @@ export default function useChatStatus(
 		isPrecancellationChatOpen: Boolean( chatStatus?.is_precancellation_chat_open ),
 		supportActivity,
 		supportLevel: chatStatus?.supportLevel,
+		noQuickResponseExperimentVariation: chatStatus?.no_quick_response_variation,
 	};
 }

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -95,6 +95,7 @@ export interface ChatAvailability {
 	availability: Availability;
 	is_presales_chat_open: boolean;
 	is_precancellation_chat_open: boolean;
+	no_quick_response_variation: string;
 }
 
 export interface OtherSupportAvailability {


### PR DESCRIPTION
## Proposed Changes

I am adding an A/B test to disbale the "Quick Response" screen when a user contacts support through the Help Center. Users in the no_quick_response group will not see a quick response before they are able to email or chat with support.

## Testing Instructions


1.  Test together with D120784-code. Checkout this branch and test locally. Edit https://github.com/Automattic/wp-calypso/blob/e7116dc7eef0893a24df7841139fbfe35eab9277/packages/help-center/src/data/use-support-availability.ts#L35: Set the value to 0 so that eligibility and experiment assignment are fetched from the backend every time you access support.
2. Assign yourself to the experiment calypso_helpcenter_quick_response_deflection_rate as a user in the control group.
3. On a site with a paid plan, click on the "?" in the top right of your dashboard to open the help center
4. Enter a question of your choice and you will be shown a list of recommended resources. Click on the 'Still need help' button.
5. Choose "Live chat" from the list of options to contact support. You may need to wait a while or try again if there is no availability.
6. On the contact from, click 'Continue'.
7. Assert that your are shown a "Quick response" or, if none can be retrieved, a message that says so.
8. Assert that you can click 'Continue' and a chat box opens. Let them know that you're testing.
9. Go back to step 5 and choose 'Email'. Repeat steps 6 and 7. Assert that the 'Continue' button is blue but DO NOT submit an email. Doing so will prevent you from being able to test this step again.
10. Assign yourself to the experiment calypso_helpcenter_quick_response_deflection_rate as a user in the no_quick_response group.
11. Repeat steps 3 to 6. Assert that you are not shown a "Quick response" and that the chat box opens right away.
12. Repeat step 9. You may test submitting an email now.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
