### PR TITLE
Jetpack Partner Portal: Add actions to the WPCOM hosting license

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -60,7 +60,7 @@ export default function LicensePreview( {
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl ? getUrlParts( siteUrl ).hostname || siteUrl : '';
 
-	const site = useSelector( ( state ) => ( blogId ? getSite( state, blogId ) : null ) );
+	const site = useSelector( ( state ) => getSite( state, blogId as number ) );
 
 	const open = useCallback( () => {
 		setOpen( ! isOpen );
@@ -107,8 +107,8 @@ export default function LicensePreview( {
 		}
 	}, [] );
 
-	const isAtomic = site?.is_wpcom_atomic;
-	const isSiteAtomic = isEnabled( 'jetpack/pro-dashboard-wpcom-atomic-hosting' ) && isAtomic;
+	const isSiteAtomic =
+		isEnabled( 'jetpack/pro-dashboard-wpcom-atomic-hosting' ) && site?.is_wpcom_atomic;
 
 	return (
 		<div

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Badge, Button, Gridicon } from '@automattic/components';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
@@ -19,6 +20,9 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { infoNotice, errorNotice } from 'calypso/state/notices/actions';
 import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
+import LicenseActions from './license-actions';
+
 import './style.scss';
 
 interface Props {
@@ -55,6 +59,8 @@ export default function LicensePreview( {
 	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl ? getUrlParts( siteUrl ).hostname || siteUrl : '';
+
+	const site = useSelector( ( state ) => ( blogId ? getSite( state, blogId ) : null ) );
 
 	const open = useCallback( () => {
 		setOpen( ! isOpen );
@@ -100,6 +106,9 @@ export default function LicensePreview( {
 			);
 		}
 	}, [] );
+
+	const isAtomic = site?.is_wpcom_atomic;
+	const isSiteAtomic = isEnabled( 'jetpack/pro-dashboard-wpcom-atomic-hosting' ) && isAtomic;
 
 	return (
 		<div
@@ -183,9 +192,20 @@ export default function LicensePreview( {
 				</div>
 
 				<div>
-					<Button onClick={ open } className="license-preview__toggle" borderless>
-						<Gridicon icon={ isOpen ? 'chevron-up' : 'chevron-down' } />
-					</Button>
+					{ isSiteAtomic ? (
+						<LicenseActions
+							siteUrl={ siteUrl }
+							licenseKey={ licenseKey }
+							product={ product }
+							attachedAt={ attachedAt }
+							revokedAt={ revokedAt }
+							licenseType={ licenseType }
+						/>
+					) : (
+						<Button onClick={ open } className="license-preview__toggle" borderless>
+							<Gridicon icon={ isOpen ? 'chevron-up' : 'chevron-down' } />
+						</Button>
+					) }
 				</div>
 			</LicenseListItem>
 

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/license-actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/license-actions.tsx
@@ -1,0 +1,75 @@
+import { Button, Gridicon } from '@automattic/components';
+import classnames from 'classnames';
+import { useState, useRef } from 'react';
+import PopoverMenu from 'calypso/components/popover-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import RevokeLicenseDialog from '../revoke-license-dialog';
+import useLicenseActions from './use-license-actions';
+import type { LicenceAction, LicenseType } from '../types';
+
+interface Props {
+	licenseKey: string;
+	product: string;
+	siteUrl: string | null;
+	attachedAt: string | null;
+	revokedAt: string | null;
+	licenseType: LicenseType;
+}
+
+export default function LicenseActions( {
+	siteUrl,
+	licenseKey,
+	product,
+	attachedAt,
+	revokedAt,
+	licenseType,
+}: Props ) {
+	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
+
+	const [ isOpen, setIsOpen ] = useState( false );
+	const [ openModal, setOpenModal ] = useState< string | null >( null );
+
+	const licenseActions = useLicenseActions( siteUrl, attachedAt, revokedAt, licenseType );
+
+	const handleActionClick = ( action: LicenceAction ) => {
+		action.onClick();
+		action.openModal && setOpenModal( action.openModal );
+	};
+
+	return (
+		<>
+			<Button borderless compact onClick={ () => setIsOpen( true ) } ref={ buttonActionRef }>
+				<Gridicon icon="ellipsis" size={ 18 } />
+			</Button>
+			<PopoverMenu
+				context={ buttonActionRef.current }
+				isVisible={ isOpen }
+				onClose={ () => setIsOpen( false ) }
+				position="bottom left"
+			>
+				{ licenseActions
+					.filter( ( action ) => action.isEnabled )
+					.map( ( action ) => (
+						<PopoverMenuItem
+							key={ action.name }
+							isExternalLink={ action?.isExternalLink }
+							onClick={ () => handleActionClick( action ) }
+							href={ action?.href }
+							className={ classnames( 'license-actions__menu-item', action?.className ) }
+						>
+							{ action.name }
+						</PopoverMenuItem>
+					) ) }
+			</PopoverMenu>
+
+			{ openModal === 'revoke-license' && (
+				<RevokeLicenseDialog
+					licenseKey={ licenseKey }
+					product={ product }
+					siteUrl={ siteUrl }
+					onClose={ () => setOpenModal( null ) }
+				/>
+			) }
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/license-actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/license-actions.tsx
@@ -5,7 +5,7 @@ import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import RevokeLicenseDialog from '../revoke-license-dialog';
 import useLicenseActions from './use-license-actions';
-import type { LicenceAction, LicenseType } from '../types';
+import type { LicenseAction, LicenseType } from '../types';
 
 interface Props {
 	licenseKey: string;
@@ -27,13 +27,15 @@ export default function LicenseActions( {
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
 
 	const [ isOpen, setIsOpen ] = useState( false );
-	const [ openModal, setOpenModal ] = useState< string | null >( null );
+	const [ showRevokeDialog, setShowRevokeDialog ] = useState( false );
 
 	const licenseActions = useLicenseActions( siteUrl, attachedAt, revokedAt, licenseType );
 
-	const handleActionClick = ( action: LicenceAction ) => {
+	const handleActionClick = ( action: LicenseAction ) => {
 		action.onClick();
-		action.openModal && setOpenModal( action.openModal );
+		if ( action.type === 'revoke' ) {
+			setShowRevokeDialog( true );
+		}
 	};
 
 	return (
@@ -62,12 +64,12 @@ export default function LicenseActions( {
 					) ) }
 			</PopoverMenu>
 
-			{ openModal === 'revoke-license' && (
+			{ showRevokeDialog && (
 				<RevokeLicenseDialog
 					licenseKey={ licenseKey }
 					product={ product }
 					siteUrl={ siteUrl }
-					onClose={ () => setOpenModal( null ) }
+					onClose={ () => setShowRevokeDialog( false ) }
 				/>
 			) }
 		</>

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -150,3 +150,55 @@
 		opacity: 0;
 	}
 }
+
+a,
+button {
+	&.license-actions__menu-item {
+		margin: 0 -1px;
+		border-style: solid;
+		border-color: var(--studio-gray-5);
+		border-width: 0 0 1px;
+		font-size: 0.875rem;
+		height: 40px;
+		box-sizing: border-box;
+		color: var(--studio-black);
+		display: flex;
+		align-items: center;
+		padding: 0 16px;
+		min-width: 200px;
+
+		&:last-child {
+			margin-bottom: 5px;
+			border-bottom-width: 0;
+		}
+
+		&:first-child {
+			margin-top: 5px;
+		}
+
+		&:hover,
+		&:focus {
+			border-style: solid;
+			border-color: var(--studio-gray-5);
+			border-width: 0 0 1px;
+			background: var(--studio-black);
+			cursor: pointer;
+			color: var(--studio-white);
+
+			&:last-child {
+				border-bottom-width: 0;
+			}
+		}
+
+		svg.gridicon {
+			vertical-align: middle;
+			position: absolute;
+			right: 10px;
+			top: unset;
+		}
+
+		&.is-destructive {
+			color: var(--studio-red-50);
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/use-license-actions.ts
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/use-license-actions.ts
@@ -1,7 +1,8 @@
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import {
 	LicenseState,
-	LicenceAction,
+	LicenseAction,
 	LicenseType,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
@@ -14,65 +15,67 @@ export default function useLicenseActions(
 	attachedAt: string | null,
 	revokedAt: string | null,
 	licenseType: LicenseType
-): LicenceAction[] {
+): LicenseAction[] {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	if ( ! siteUrl ) {
-		return [];
-	}
+	return useMemo( () => {
+		if ( ! siteUrl ) {
+			return [];
+		}
 
-	const siteSlug = urlToSlug( siteUrl );
-	const debugUrl = `https://jptools.wordpress.com/debug/?url=${ siteUrl }`;
+		const siteSlug = urlToSlug( siteUrl );
 
-	const handleClickMenuItem = ( eventName: string ) => {
-		dispatch( recordTracksEvent( eventName ) );
-	};
+		const handleClickMenuItem = ( eventName: string ) => {
+			dispatch( recordTracksEvent( eventName ) );
+		};
 
-	const licenseState = getLicenseState( attachedAt, revokedAt );
-
-	return [
-		{
-			name: translate( 'Setup site' ),
-			href: `https://wordpress.com/home/${ siteSlug }`,
-			onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_site_setup_click' ),
-			isExternalLink: true,
-			isEnabled: true,
-		},
-		{
-			name: translate( 'Change domain' ),
-			href: `https://wordpress.com/domains/manage/${ siteSlug }`,
-			onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_change_domain_click' ),
-			isExternalLink: true,
-			isEnabled: true,
-		},
-		{
-			name: translate( 'Hosting configuration' ),
-			href: `https://wordpress.com/hosting-config/${ siteSlug }`,
-			onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_hosting_configuration_click' ),
-			isExternalLink: true,
-			isEnabled: true,
-		},
-		{
-			name: translate( 'Edit site in WP Admin' ),
-			href: `${ siteUrl }/wp-admin/admin.php?page=jetpack#/dashboard`,
-			onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_edit_site_click' ),
-			isExternalLink: true,
-			isEnabled: true,
-		},
-		{
-			name: translate( 'Debug site' ),
-			href: debugUrl,
-			onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_debug_site_click' ),
-			isExternalLink: true,
-			isEnabled: licenseState === LicenseState.Attached && !! debugUrl,
-		},
-		{
-			name: translate( 'Revoke' ),
-			onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_hosting_configuration_click' ),
-			openModal: 'revoke-license',
-			isEnabled: licenseState !== LicenseState.Revoked && licenseType === LicenseType.Partner,
-			className: 'is-destructive',
-		},
-	];
+		const licenseState = getLicenseState( attachedAt, revokedAt );
+		return [
+			{
+				name: translate( 'Setup site' ),
+				href: `https://wordpress.com/home/${ siteSlug }`,
+				onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_site_setup_click' ),
+				isExternalLink: true,
+				isEnabled: true,
+			},
+			{
+				name: translate( 'Change domain' ),
+				href: `https://wordpress.com/domains/manage/${ siteSlug }`,
+				onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_change_domain_click' ),
+				isExternalLink: true,
+				isEnabled: true,
+			},
+			{
+				name: translate( 'Hosting configuration' ),
+				href: `https://wordpress.com/hosting-config/${ siteSlug }`,
+				onClick: () =>
+					handleClickMenuItem( 'calypso_jetpack_licenses_hosting_configuration_click' ),
+				isExternalLink: true,
+				isEnabled: true,
+			},
+			{
+				name: translate( 'Edit site in WP Admin' ),
+				href: `${ siteUrl }/wp-admin/admin.php?page=jetpack#/dashboard`,
+				onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_edit_site_click' ),
+				isExternalLink: true,
+				isEnabled: true,
+			},
+			{
+				name: translate( 'Debug site' ),
+				href: `https://jptools.wordpress.com/debug/?url=${ siteUrl }`,
+				onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_debug_site_click' ),
+				isExternalLink: true,
+				isEnabled: licenseState === LicenseState.Attached,
+			},
+			{
+				name: translate( 'Revoke' ),
+				onClick: () =>
+					handleClickMenuItem( 'calypso_jetpack_licenses_hosting_configuration_click' ),
+				type: 'revoke',
+				isEnabled: licenseState !== LicenseState.Revoked && licenseType === LicenseType.Partner,
+				className: 'is-destructive',
+			},
+		];
+	}, [ attachedAt, dispatch, licenseType, revokedAt, siteUrl, translate ] );
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/use-license-actions.ts
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/use-license-actions.ts
@@ -1,0 +1,78 @@
+import { useTranslate } from 'i18n-calypso';
+import {
+	LicenseState,
+	LicenceAction,
+	LicenseType,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getLicenseState } from '../utils';
+
+export default function useLicenseActions(
+	siteUrl: string | null,
+	attachedAt: string | null,
+	revokedAt: string | null,
+	licenseType: LicenseType
+): LicenceAction[] {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	if ( ! siteUrl ) {
+		return [];
+	}
+
+	const siteSlug = urlToSlug( siteUrl );
+	const debugUrl = `https://jptools.wordpress.com/debug/?url=${ siteUrl }`;
+
+	const handleClickMenuItem = ( eventName: string ) => {
+		dispatch( recordTracksEvent( eventName ) );
+	};
+
+	const licenseState = getLicenseState( attachedAt, revokedAt );
+
+	return [
+		{
+			name: translate( 'Setup site' ),
+			href: `https://wordpress.com/home/${ siteSlug }`,
+			onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_site_setup_click' ),
+			isExternalLink: true,
+			isEnabled: true,
+		},
+		{
+			name: translate( 'Change domain' ),
+			href: `https://wordpress.com/domains/manage/${ siteSlug }`,
+			onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_change_domain_click' ),
+			isExternalLink: true,
+			isEnabled: true,
+		},
+		{
+			name: translate( 'Hosting configuration' ),
+			href: `https://wordpress.com/hosting-config/${ siteSlug }`,
+			onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_hosting_configuration_click' ),
+			isExternalLink: true,
+			isEnabled: true,
+		},
+		{
+			name: translate( 'Edit site in WP Admin' ),
+			href: `${ siteUrl }/wp-admin/admin.php?page=jetpack#/dashboard`,
+			onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_edit_site_click' ),
+			isExternalLink: true,
+			isEnabled: true,
+		},
+		{
+			name: translate( 'Debug site' ),
+			href: debugUrl,
+			onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_debug_site_click' ),
+			isExternalLink: true,
+			isEnabled: licenseState === LicenseState.Attached && !! debugUrl,
+		},
+		{
+			name: translate( 'Revoke' ),
+			onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_hosting_configuration_click' ),
+			openModal: 'revoke-license',
+			isEnabled: licenseState !== LicenseState.Revoked && licenseType === LicenseType.Partner,
+			className: 'is-destructive',
+		},
+	];
+}

--- a/client/jetpack-cloud/sections/partner-portal/types.ts
+++ b/client/jetpack-cloud/sections/partner-portal/types.ts
@@ -34,3 +34,13 @@ export interface AssignLicenceProps {
 	selectedSite?: SiteDetails | null;
 	suggestedProduct?: string;
 }
+
+export interface LicenceAction {
+	name: string;
+	isEnabled: boolean;
+	href?: string;
+	onClick: () => void;
+	openModal?: string;
+	isExternalLink?: boolean;
+	className?: string;
+}

--- a/client/jetpack-cloud/sections/partner-portal/types.ts
+++ b/client/jetpack-cloud/sections/partner-portal/types.ts
@@ -35,12 +35,12 @@ export interface AssignLicenceProps {
 	suggestedProduct?: string;
 }
 
-export interface LicenceAction {
+export interface LicenseAction {
 	name: string;
 	isEnabled: boolean;
 	href?: string;
 	onClick: () => void;
-	openModal?: string;
+	type?: string;
 	isExternalLink?: boolean;
 	className?: string;
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-avalon/issues/44

## Proposed Changes

This PR implements adding actions(Setup site, Change domain, Edit site in WP Admin, Hosting configuration, Debug site & Revoke) to the Licenses table row when a WPCOM hosting license is displayed.

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 31d88-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/actions-to-wpcom-hosting-license` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Visit the [Licenses](http://jetpack.cloud.localhost:3001/partner-portal/licenses) page.
4. Since we currently don't include WPCOM atomic sites, we must modify the code to test and verify these changes > Go to `/jetpack-cloud/sections/partner-portal/license-preview/index.tsx#L110` and replace the line with:

```
const isAtomic = !! blogId;
```

5. Verify that you can see the `...` actions icon instead of the down arrow icon. > Click the `...` icon and verify you can see the actions as shown below. > Verify all the actions work as expected.
6. Verify the actions look good on small-screen devices
7. Verify that events are tracked when any action is clicked. 

<img width="244" alt="Screenshot 2023-09-04 at 1 01 54 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/5aaae564-86ea-4d93-a698-fd8160ce44c9">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?