### PR TITLE
Jetpack: update link to troubleshooting connection document

### DIFF
--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -71,9 +71,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 			<ErrorNotice
 				errorType={ errorType }
 				errorText={ translate( 'Jetpack can’t establish a connection to your site’s database.' ) }
-				noticeActionHref={ localizeUrl(
-					'https://wordpress.com/support/why-is-my-site-down/#theres-an-issue-with-your-sites-jetpack-connection'
-				) }
+				noticeActionHref="https://jetpack.com/support/reconnecting-reinstalling-jetpack/"
 				noticeActionText={ translate( 'Learn how to fix' ) }
 				isAtomic={ siteIsAutomatedTransfer }
 			/>
@@ -159,9 +157,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 				errorText={ translate(
 					"Jetpack can’t communicate with your site because it hasn't seen your site for 7 days."
 				) }
-				noticeActionHref={ localizeUrl(
-					'https://wordpress.com/support/resolve-jetpack-errors/#jetpack-plugin-is-deactivated'
-				) }
+				noticeActionHref="https://jetpack.com/support/reconnecting-reinstalling-jetpack/"
 				noticeActionText={ translate( 'Learn how to fix' ) }
 				isAtomic={ siteIsAutomatedTransfer }
 			/>
@@ -175,9 +171,7 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 				errorText={ translate(
 					'We can’t communicate with your site because the Jetpack plugin is deactivated.'
 				) }
-				noticeActionHref={ localizeUrl(
-					'https://wordpress.com/support/resolve-jetpack-errors/#jetpack-plugin-is-deactivated'
-				) }
+				noticeActionHref="https://jetpack.com/support/reconnecting-reinstalling-jetpack/"
 				noticeActionText={ translate( 'Learn how to reactivate Jetpack' ) }
 				isAtomic={ siteIsAutomatedTransfer }
 			/>

--- a/client/my-sites/site-indicator/index.jsx
+++ b/client/my-sites/site-indicator/index.jsx
@@ -1,5 +1,4 @@
 import { Button, Gridicon } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -215,7 +214,7 @@ export class SiteIndicator extends Component {
 					{ translate( 'Jetpack can’t communicate with your site.' ) }
 					<Button
 						plain
-						href={ localizeUrl( 'https://wordpress.com/support/why-is-my-site-down/' ) }
+						href="https://jetpack.com/support/reconnecting-reinstalling-jetpack/"
 						target="_blank"
 						onClick={ this.handleJetpackConnectionHealthSidebarLinkClick }
 					>


### PR DESCRIPTION
Fixes #81233

## Proposed Changes

Update the support doc to something that's a bit more helpful.

## Testing Instructions

* Check the links mentioned in #81233

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
