### PR TITLE
Update text styles for launchpad checklist items

### DIFF
--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -14,7 +14,7 @@
 	padding: 16px 0;
 	width: 100%;
 	margin: 0;
-	color: var(--color-text);
+	color: var(--color-neutral-100);
 
 	&.is-placeholder {
 		padding: 16px 0 16px 0;
@@ -95,7 +95,7 @@
 	a,
 	a:visited {
 		text-decoration: underline;
-		color: var(--color-text);
+		color: var(--color-neutral-100);
 
 		&:hover {
 			color: var(--studio-blue-50);
@@ -104,7 +104,7 @@
 }
 
 .checklist-item__task-content:hover .checklist-item__subtext {
-	color: var(--color-text);
+	color: var(--color-neutral-100);
 }
 
 .checklist__has-primary-action .checklist-item__task:nth-last-child(2) {
@@ -129,17 +129,16 @@
 .checklist-item__task.completed.disabled,
 .checklist-item__task.completed.enabled {
 	.checklist-item__text {
-		color: var(--studio-gray-50);
+		color: var(--color-neutral-40);
 		font-weight: 400;
-		text-decoration: line-through;
 	}
 
 	.checklist-item__chevron,
 	.checklist-item__checkmark {
-		fill: var(--studio-gray-50);
+		fill: var(--color-neutral-40);
 	}
 	.checklist-item__counter {
-		color: var(--studio-gray-50);
+		color: var(--color-neutral-40);
 		font-weight: 400;
 		margin-right: 0;
 	}


### PR DESCRIPTION
Fixes #79747
Related to p9Jlb4-8Sp-p2

## Proposed Changes

* This PR updates the text styles for checklist items in the launchpad as per this design update: p9Jlb4-8Sp-p2
* There are three changes in the PR:
   - The text colour for checklist items has changed from `--color-text` to `--color-neutral-100`, which resolve to `--studio-gray-80` and `--studio-gray-100`, respectively
   - The text colour for completed checklist items has changed from `--studio-gray-50` to `--color-neutral-40`, where the latter resolves to `--studio-gray-40`
   - We've removed the strikethrough for completed checklist items 

## Testing Instructions

* Run this branch locally or via the Calypso.live branch
* Use an existing, unlaunched site that is still showing the fullscreen launchpad, or create a new site via `/start` that has the "Write & Publish" intent
* Navigate to `/home/:yourSiteSlug`, which should redirect to the fullscreen launchpad
* Verify that we're showing the lighter text for completed tasks, darker text for tasks requiring action, and no strikethrough for any tasks
* Work through the task list and then Launch your site
* Verify that you see the post-launch build checklist in Customer Home
* Verify that we're showing the lighter text for completed tasks, darker text for tasks requiring action, and no strikethrough for any tasks

## Screenshots

### Full-screen launchpad

**Before**
<img width="1438" alt="Screenshot 2023-09-04 at 13 58 17" src="https://github.com/Automattic/wp-calypso/assets/3376401/6709b03c-6ec2-48a9-b7f1-4857968712c6">

**After**
<img width="1438" alt="Screenshot 2023-09-04 at 13 58 10" src="https://github.com/Automattic/wp-calypso/assets/3376401/16e6d208-7994-4fec-a8a4-e816e219efae">

### Customer Home launchpad

**Before**
<img width="1237" alt="Screenshot 2023-09-04 at 13 52 49" src="https://github.com/Automattic/wp-calypso/assets/3376401/7d6ddf6d-8bff-4214-96ff-9876486add0e">

**After**
<img width="1237" alt="Screenshot 2023-09-04 at 13 51 07" src="https://github.com/Automattic/wp-calypso/assets/3376401/1875e847-d1f0-46f6-99fc-d2df777767fa">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [N/A] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [N/A] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?