### PR TITLE
User Intent: Survey urls and copy adjustments.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
@@ -96,13 +96,13 @@ const VideoPressOnboardingIntent: Step = ( { navigation } ) => {
 		<>
 			<div className="videopress-onboarding-intent__step-content">
 				<VideoPressOnboardingIntentItem
-					title={ __( 'Get a video portfolio' ) }
+					title={ __( 'Showcase your work' ) }
 					description={ __( 'Share your work with the world.' ) }
 					image={ PortfolioIntentImage }
 					onClick={ onVideoPortfolioIntentClicked }
 				/>
 				<VideoPressOnboardingIntentItem
-					title={ __( 'Create a channel for your videos' ) }
+					title={ __( 'Create a community' ) }
 					description={ __(
 						'The easiest way to upload videos and create a community around them.'
 					) }
@@ -111,7 +111,7 @@ const VideoPressOnboardingIntent: Step = ( { navigation } ) => {
 					onClick={ onVideoChannelIntentClicked }
 				/>
 				<VideoPressOnboardingIntentItem
-					title={ __( 'Upload a video' ) }
+					title={ __( 'Share a video' ) }
 					description={ __( 'Just put a video on the internet.' ) }
 					image={ SingleVideoIntentImage }
 					isComingSoon={ true }
@@ -176,7 +176,7 @@ const VideoPressOnboardingIntent: Step = ( { navigation } ) => {
 			formattedHeader={
 				<FormattedHeader
 					id="videopress-onboarding-intent-header"
-					headerText={ __( 'What would you like to do?' ) }
+					headerText={ __( 'What would you like to use video for?' ) }
 					subHeaderText={ __(
 						'Choose an option to continue, or let us know what you’re looking for.'
 					) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-channel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-channel.tsx
@@ -22,6 +22,7 @@ const VideoPressOnboardingIntentModalChannel: React.FC< IntroModalContentProps >
 			onSubmit={ onSubmit }
 			isComingSoon={ true }
 			surveyTitle={ translate( 'Which additional features are you looking for?' ) }
+			surveyUrl="https://automattic.crowdsignal.net/video-channel-survey"
 			source="channel"
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-video-upload.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-video-upload.tsx
@@ -25,6 +25,7 @@ const VideoPressOnboardingIntentModalVideoUpload: React.FC< IntroModalContentPro
 			onSubmit={ onSubmit }
 			isComingSoon={ true }
 			surveyTitle={ translate( 'Are you interested in specific features?' ) }
+			surveyUrl="https://automattic.crowdsignal.net/video-upload-survey"
 			source="video"
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
@@ -20,6 +20,7 @@ export interface VideoPressOnboardingIntentModalContentProps extends IntroModalC
 	};
 	isComingSoon?: boolean;
 	surveyTitle?: string;
+	surveyUrl?: string;
 	source?: string;
 }
 
@@ -30,6 +31,7 @@ const VideoPressOnboardingIntentModal: React.FC< VideoPressOnboardingIntentModal
 	actionButton,
 	isComingSoon,
 	surveyTitle,
+	surveyUrl,
 	onSubmit,
 	source,
 	children,
@@ -202,7 +204,7 @@ const VideoPressOnboardingIntentModal: React.FC< VideoPressOnboardingIntentModal
 					/>
 				</div>
 			</div>
-			{ surveyTitle && (
+			{ surveyTitle && surveyUrl && (
 				<div className="videopress-intro-modal__survey">
 					<div className="videopress-intro-modal__survey-info">
 						<div className="videopress-intro-modal__survey-title">{ surveyTitle }</div>
@@ -212,12 +214,7 @@ const VideoPressOnboardingIntentModal: React.FC< VideoPressOnboardingIntentModal
 							) }
 						</div>
 					</div>
-					<Button
-						className="intro__button button-survey"
-						href="https://automattic.survey.fm/videopress-onboarding-user-intent-survey"
-						target="_blank"
-						plain
-					>
+					<Button className="intro__button button-survey" href={ surveyUrl } target="_blank" plain>
 						{ translate( 'Answer the survey' ) }
 						<Icon icon={ arrowRight } />
 					</Button>


### PR DESCRIPTION

## Proposed Changes

* Change survey urls to new ones.
* Slightly adjust copy of intent heading and titles.

## Testing Instructions

* checkout branch
* visit http://calypso.localhost:3000/setup/videopress/intro
* Heading is different and some intent items have different titles.
* Follow the survey links and you should land into the appropriate survey.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?