### PR TITLE
Domain Forwarding: Supporting multiple editions

### DIFF
--- a/client/data/domains/forwarding/use-domain-forwarding-query.ts
+++ b/client/data/domains/forwarding/use-domain-forwarding-query.ts
@@ -8,11 +8,11 @@ export type DomainForwardingObject = {
 	subdomain: string;
 	target_host: string;
 	target_path: string;
-	forward_paths: '0' | '1' | true | false;
-	is_secure: '0' | '1' | true | false;
-	is_permanent: '0' | '1' | true | false;
-	is_active: '0' | '1' | true | false;
-	source_path: string;
+	forward_paths: true | false;
+	is_secure: true | false;
+	is_permanent: true | false;
+	is_active?: true | false;
+	source_path?: string;
 };
 
 const selectForwards = (
@@ -23,13 +23,7 @@ const selectForwards = (
 	}
 
 	return response?.map( ( forwarding: DomainForwardingObject ) => {
-		return {
-			...forwarding,
-			forward_paths: forwarding.forward_paths === '1',
-			is_secure: forwarding.is_secure === '1',
-			is_permanent: forwarding.is_permanent === '1',
-			is_active: forwarding.is_active === '1',
-		};
+		return forwarding;
 	} );
 };
 
@@ -38,7 +32,7 @@ export default function useDomainForwardingQuery(
 ): UseQueryResult< DomainForwardingObject[] | null > {
 	return useQuery( {
 		queryKey: domainForwardingQueryKey( domainName ),
-		queryFn: () => wp.req.get( `/sites/all/domain/${ domainName }/redirects` ),
+		queryFn: () => wp.req.get( `/sites/all/domain/${ domainName }/redirects?new-endpoint=true` ),
 		refetchOnWindowFocus: false,
 		select: selectForwards,
 	} );

--- a/client/data/domains/forwarding/use-domain-forwarding-query.ts
+++ b/client/data/domains/forwarding/use-domain-forwarding-query.ts
@@ -1,42 +1,45 @@
-import { useQuery } from '@tanstack/react-query';
+import { UseQueryResult, useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 import { domainForwardingQueryKey } from './domain-forwarding-query-key';
 
-type DomainForwardingResponse = {
+export type DomainForwardingObject = {
 	domain_redirect_id: number;
 	domain: string;
 	subdomain: string;
 	target_host: string;
 	target_path: string;
-	forward_paths: '0' | '1';
-	is_secure: '0' | '1';
-	is_permanent: '0' | '1';
-	is_active: '0' | '1';
+	forward_paths: '0' | '1' | true | false;
+	is_secure: '0' | '1' | true | false;
+	is_permanent: '0' | '1' | true | false;
+	is_active: '0' | '1' | true | false;
 	source_path: string;
 };
 
-export default function useDomainForwardingQuery( domainName: string ) {
+const selectForwards = (
+	response: DomainForwardingObject[] | null
+): DomainForwardingObject[] | null => {
+	if ( ! response ) {
+		return null;
+	}
+
+	return response?.map( ( forwarding: DomainForwardingObject ) => {
+		return {
+			...forwarding,
+			forward_paths: forwarding.forward_paths === '1',
+			is_secure: forwarding.is_secure === '1',
+			is_permanent: forwarding.is_permanent === '1',
+			is_active: forwarding.is_active === '1',
+		};
+	} );
+};
+
+export default function useDomainForwardingQuery(
+	domainName: string
+): UseQueryResult< DomainForwardingObject[] | null > {
 	return useQuery( {
 		queryKey: domainForwardingQueryKey( domainName ),
 		queryFn: () => wp.req.get( `/sites/all/domain/${ domainName }/redirects` ),
 		refetchOnWindowFocus: false,
-		select: ( forwarding: DomainForwardingResponse ) => {
-			if ( forwarding?.domain ) {
-				return {
-					domain_redirect_id: forwarding.domain_redirect_id,
-					domain: forwarding.domain,
-					subdomain: forwarding.subdomain,
-					targetHost: forwarding.target_host,
-					targetPath: forwarding.target_path,
-					forwardPaths: forwarding.forward_paths === '1',
-					isSecure: forwarding.is_secure === '1',
-					isPermanent: forwarding.is_permanent === '1',
-					isActive: forwarding.is_active === '1',
-					sourcePath: forwarding.source_path,
-				};
-			}
-
-			return undefined;
-		},
+		select: selectForwards,
 	} );
 }

--- a/client/data/domains/forwarding/use-update-domain-forwarding-mutation.ts
+++ b/client/data/domains/forwarding/use-update-domain-forwarding-mutation.ts
@@ -3,18 +3,7 @@ import { useCallback } from 'react';
 import { DomainsApiError } from 'calypso/lib/domains/types';
 import wp from 'calypso/lib/wp';
 import { domainForwardingQueryKey } from './domain-forwarding-query-key';
-
-export type DomainForwardingUpdate = {
-	domain_redirect_id: number;
-	subdomain: string;
-	targetHost: string;
-	targetPath: string;
-	forwardPaths: boolean;
-	isSecure: boolean;
-	isPermanent: boolean;
-	isActive: boolean;
-	sourcePath: string | null;
-};
+import { DomainForwardingObject } from './use-domain-forwarding-query';
 
 export default function useUpdateDomainForwardingMutation(
 	domainName: string,
@@ -25,19 +14,8 @@ export default function useUpdateDomainForwardingMutation(
 ) {
 	const queryClient = useQueryClient();
 	const mutation = useMutation( {
-		mutationFn: ( forwarding: DomainForwardingUpdate ) =>
-			wp.req.post( `/sites/all/domain/${ domainName }/redirects`, {
-				domain_redirect_id: forwarding.domain_redirect_id,
-				domain: domainName,
-				subdomain: forwarding.subdomain,
-				target_host: forwarding.targetHost,
-				target_path: forwarding.targetPath,
-				forward_paths: forwarding.forwardPaths,
-				is_secure: forwarding.isSecure,
-				is_permanent: forwarding.isPermanent,
-				is_active: forwarding.isActive,
-				source_path: forwarding.sourcePath,
-			} ),
+		mutationFn: ( forwarding: DomainForwardingObject ) =>
+			wp.req.post( `/sites/all/domain/${ domainName }/redirects`, forwarding ),
 		...queryOptions,
 		onSuccess() {
 			queryClient.invalidateQueries( domainForwardingQueryKey( domainName ) );
@@ -48,7 +26,7 @@ export default function useUpdateDomainForwardingMutation(
 	const { mutate } = mutation;
 
 	const updateDomainForwarding = useCallback(
-		( forwarding: DomainForwardingUpdate ) => mutate( forwarding ),
+		( forwarding: DomainForwardingObject ) => mutate( forwarding ),
 		[ mutate ]
 	);
 

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -240,8 +240,6 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 			is_secure: isSecure,
 			forward_paths: forwardPaths,
 			is_permanent: isPermanent,
-			is_active: true, // always active
-			source_path: '', // we're not using this feature for now
 		} );
 
 		// TODO: open the edition of the new forwarding we just created

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -118,21 +118,21 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 		}
 	};
 
-	// Load saved forwarding into local state
+	const checkIfIsThereMainDomainForwarding = () => {
+		return data?.find( ( item ) => item.subdomain === '' );
+	};
+
 	useEffect( () => {
-		if ( isLoading || ! forwarding ) {
-			setTargetUrl( '' );
+		if ( isLoading || ! data ) {
 			return;
 		}
 
-		try {
-			if ( data?.length === 1 ) {
-				handleEdit( data[ 0 ] );
-			}
-		} catch ( e ) {
-			// ignore
+		// By default, the interface already opens with domain forwarding addition
+		if ( data?.length === 0 ) {
+			setEditingId( -1 );
+			setSourceType( 'domain' );
 		}
-	}, [ isLoading, data, setTargetUrl ] );
+	}, [ isLoading, data ] );
 
 	const handleAddForward = () => {
 		setEditingId( -1 );
@@ -404,7 +404,12 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 				className="domain-forwarding-card__fields"
 			>
 				<FormLabel>{ translate( 'Source URL' ) }</FormLabel>
-				<div className="forwards-from">
+				<div
+					className={ classNames( 'forwards-from', {
+						'has-subdomain-selector':
+							sourceType === 'domain' || ! checkIfIsThereMainDomainForwarding(),
+					} ) }
+				>
 					<FormTextInputWithAffixes
 						placeholder={ sourceType === 'domain' ? domain.domain : translate( 'Enter subdomain' ) }
 						disabled={ isLoading || sourceType === 'domain' }
@@ -414,15 +419,18 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 						className={ classNames( { 'is-error': ! isValidUrl } ) }
 						maxLength={ 1000 }
 						prefix={
-							<FormSelect
-								name="redirect_type"
-								value={ sourceType }
-								onChange={ handleDomainSubdomainChange }
-								disabled={ isLoading }
-							>
-								<option value="domain">{ translate( 'Domain' ) }</option>
-								<option value="subdomain">{ translate( 'Subdomain' ) }</option>
-							</FormSelect>
+							( ( child.subdomain === '' && child.domain_redirect_id !== 0 ) ||
+								! checkIfIsThereMainDomainForwarding() ) && (
+								<FormSelect
+									name="redirect_type"
+									value={ sourceType }
+									onChange={ handleDomainSubdomainChange }
+									disabled={ isLoading }
+								>
+									<option value="domain">{ translate( 'Domain' ) }</option>
+									<option value="subdomain">{ translate( 'Subdomain' ) }</option>
+								</FormSelect>
+							)
 						}
 						suffix={ sourceType === 'subdomain' && <FormLabel>.{ domain.domain }</FormLabel> }
 					/>

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -232,15 +232,16 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 		}
 
 		updateDomainForwarding( {
+			domain: domain.name,
 			domain_redirect_id: editingId,
 			subdomain,
-			targetHost,
-			targetPath,
-			isSecure,
-			forwardPaths,
-			isPermanent,
-			isActive: true, // always active
-			sourcePath: null, // we're not using this feature for now
+			target_host: targetHost,
+			target_path: targetPath,
+			is_secure: isSecure,
+			forward_paths: forwardPaths,
+			is_permanent: isPermanent,
+			is_active: true, // always active
+			source_path: '', // we're not using this feature for now
 		} );
 
 		// TODO: open the edition of the new forwarding we just created

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -1,4 +1,4 @@
-import { Button, FormInputValidation, Gridicon } from '@automattic/components';
+import { Badge, Button, FormInputValidation, Gridicon } from '@automattic/components';
 import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
 import { hasTranslation } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
@@ -357,16 +357,42 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 
 	const FormViewRow = ( { child: child }: { child: DomainForwardingObject } ) => (
 		<FormFieldset disabled={ isDomainForwardDisabled } className="domain-forwarding-card__fields">
-			<FormLabel>
-				<strong>{ translate( 'Source URL' ) }</strong>:{ ' ' }
-				{ child.subdomain ? child.subdomain + '.' + child.domain : child.domain }
-			</FormLabel>
-			<FormLabel>
-				<strong>{ translate( 'Destination' ) }</strong>: { child.target_host + child.target_path }
-			</FormLabel>
-			<Button borderless className="remove-redirect-button" onClick={ () => handleEdit( child ) }>
-				{ translate( 'Edit' ) }
-			</Button>
+			<div className="domain-forwarding-card__fields-row">
+				<div className="domain-forwarding-card__fields-column">
+					<Badge type={ child.subdomain === '' ? 'warning' : 'info' }>
+						{ child.subdomain !== ''
+							? translate( 'Subdomain forwarding' )
+							: translate( 'Domain forwarding' ) }
+					</Badge>
+				</div>
+				<div className="domain-forwarding-card__fields-column">
+					<Button
+						borderless
+						className="edit-redirect-button link-button"
+						onClick={ () => handleEdit( child ) }
+					>
+						{ translate( 'Edit' ) }
+					</Button>
+				</div>
+			</div>
+
+			<div className="domain-forwarding-card__fields-row addresses">
+				<div className="domain-forwarding-card__fields-column source">
+					{ translate( 'Source URL' ) }:
+				</div>
+				<div className="domain-forwarding-card__fields-column destination">
+					<strong>{ child.subdomain ? child.subdomain + '.' + child.domain : child.domain }</strong>
+				</div>
+			</div>
+
+			<div className="domain-forwarding-card__fields-row addresses">
+				<div className="domain-forwarding-card__fields-column source">
+					{ translate( 'Destination URL' ) }:
+				</div>
+				<div className="domain-forwarding-card__fields-column destination">
+					<strong>{ child.target_host + child.target_path }</strong>
+				</div>
+			</div>
 		</FormFieldset>
 	);
 
@@ -512,21 +538,30 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 					</FormSettingExplanation>
 				</Accordion>
 				{ child.domain_redirect_id !== 0 && (
-					<Button borderless className="remove-redirect-button" onClick={ () => handleDelete() }>
+					<Button
+						borderless
+						className="remove-redirect-button  link-button"
+						onClick={ () => handleDelete() }
+					>
 						{ translate( 'Remove forward' ) }
 					</Button>
 				) }
-				<FormButton
-					disabled={
-						isDomainForwardDisabled ||
-						! isValidUrl ||
-						isLoading ||
-						( forwarding && ! redirectHasChanged( child ) ) ||
-						targetUrl === ''
-					}
-				>
-					{ child.domain_redirect_id === 0 ? translate( 'Create' ) : translate( 'Save' ) }
-				</FormButton>
+				<div>
+					<FormButton
+						disabled={
+							isDomainForwardDisabled ||
+							! isValidUrl ||
+							isLoading ||
+							( forwarding && ! redirectHasChanged( child ) ) ||
+							targetUrl === ''
+						}
+					>
+						{ child.domain_redirect_id === 0 ? translate( 'Create' ) : translate( 'Save' ) }
+					</FormButton>
+					<FormButton onClick={ () => setEditingId( 0 ) } type="button" isPrimary={ false }>
+						{ translate( 'Cancel' ) }
+					</FormButton>
+				</div>
 			</FormFieldset>
 		</>
 	);
@@ -565,7 +600,11 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 					} ) }
 			</form>
 
-			<Button borderless className="add-forward-button" onClick={ () => handleAddForward() }>
+			<Button
+				borderless
+				className="add-forward-button  link-button"
+				onClick={ () => handleAddForward() }
+			>
 				{ translate( '+ Add forward' ) }
 			</Button>
 		</>

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -133,6 +133,8 @@
 }
 
 .domain-forwarding-card__accordion {
+	color: var(--studio-gray-50);
+	font-size: 0.875rem;
 	margin-bottom: 0 !important;
 
 	.form-text-input:disabled {
@@ -233,13 +235,16 @@
 		padding: 0;
 		margin-top: 15px;
 		font-weight: normal;
-		color: var(--studio-gray-60);
+
+		&:first-child {
+			margin-top: 0;
+		}
 	}
 
 	.form-fieldset {
 		background-color: var(--studio-gray-0);
 		margin-bottom: 24px;
-		padding: 0 20px 0 20px;
+		padding: 20px;
 		border-radius: 10px; /* stylelint-disable-line scales/radii */
 	}
 
@@ -294,28 +299,49 @@
 		font-weight: 400;
 	}
 
-	.form-button {
-		display: block;
-		margin-bottom: 22px;
-	}
-
-	.remove-redirect-button {
+	.link-button {
 		text-underline-offset: 0.2em;
 		padding-top: 0;
-		padding-bottom: 30px;
 		border-color: #0675c4;
 		color: #0675c4;
 		text-decoration: underline;
 
-		&:hover {
+		&:hover,
+		&:focus {
 			border-color: #044b7a;
 			color: #044b7a;
 		}
 	}
 
+	.remove-redirect-button {
+		padding-bottom: 30px;
+	}
+
 	.domain-forwarding-card__error-field {
 		height: 35px;
 		margin-top: 10px;
+	}
+
+	.domain-forwarding-card__fields-row {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+
+		&.addresses {
+			justify-content: flex-start;
+		}
+
+		&:first-child {
+			margin-bottom: 5px;
+		}
+
+		.source {
+			width: 35%;
+		}
+
+		.badge {
+			border-radius: 4px;
+		}
 	}
 }
 

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -144,10 +144,11 @@
 	.forwards-from {
 		padding-right: 30px;
 
-		input.form-text-input[type="text"] {
-
-			@include break-wide {
-				border-left: 0;
+		&.has-subdomain-selector {
+			input.form-text-input[type="text"] {
+				@include break-wide {
+					border-left: 0;
+				}
 			}
 		}
 

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -238,7 +238,7 @@
 
 	.form-fieldset {
 		background-color: var(--studio-gray-0);
-		margin-bottom: 0;
+		margin-bottom: 24px;
 		padding: 0 20px 0 20px;
 		border-radius: 10px; /* stylelint-disable-line scales/radii */
 	}
@@ -295,7 +295,8 @@
 	}
 
 	.form-button {
-		margin-top: 30px;
+		display: block;
+		margin-bottom: 22px;
 	}
 
 	.remove-redirect-button {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/81290

![image](https://github.com/Automattic/wp-calypso/assets/1044309/68d7d504-01e1-46c9-a200-de7c5398557c)

## Proposed Changes

* Added support to multiple subdomains + 1 domain forwarding edition

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this diff: D120632-code
* Create domain/subdomain forwarding and ensure they work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?