### PR TITLE
Import flow: Update importer URL generation logic

### DIFF
--- a/client/blocks/import/util.ts
+++ b/client/blocks/import/util.ts
@@ -78,23 +78,14 @@ export function getWpComMigrateUrl( siteSlug: string, fromSite?: string ): strin
 export function getWpComOnboardingUrl(
 	siteSlug: string,
 	platform: ImporterPlatform,
-	fromSite?: string,
-	framework: 'signup' | 'stepper' = 'signup'
+	fromSite?: string
 ): string {
 	let route;
-	switch ( framework ) {
-		case 'signup':
-			route = '/start/from/importing/{importer}?from={fromSite}&to={siteSlug}';
-			break;
 
-		case 'stepper':
-		default:
-			if ( platform === 'wordpress' && isEnabled( 'onboarding/import-redesign' ) ) {
-				route = 'importer{importer}?siteSlug={siteSlug}&from={fromSite}&option=everything';
-				break;
-			}
-			route = 'importer{importer}?siteSlug={siteSlug}&from={fromSite}';
-			break;
+	if ( platform === 'wordpress' && isEnabled( 'onboarding/import-redesign' ) ) {
+		route = 'importer{importer}?siteSlug={siteSlug}&from={fromSite}&option=everything';
+	} else {
+		route = 'importer{importer}?siteSlug={siteSlug}&from={fromSite}';
 	}
 
 	return route

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
@@ -51,8 +51,7 @@ const ImportReadyPreview: Step = function ImportStep( props ) {
 			siteSlug as string,
 			urlData.url,
 			urlData.platform,
-			isAtomicSite,
-			'stepper'
+			isAtomicSite
 		);
 
 		navigation.submit?.( { url } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/index.tsx
@@ -34,8 +34,7 @@ const ImportReady: Step = function ImportStep( props ) {
 			siteSlug as string,
 			urlData.url,
 			urlData.platform,
-			isAtomicSite,
-			'stepper'
+			isAtomicSite
 		);
 
 		navigation.submit?.( { url, platform: urlData.platform } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -14,8 +14,7 @@ export function getFinalImporterUrl(
 	targetSlug: string,
 	fromSite: string,
 	platform: ImporterPlatform,
-	isAtomicSite: boolean | null,
-	framework: 'signup' | 'stepper' = 'signup'
+	isAtomicSite: boolean | null
 ) {
 	let importerUrl;
 	const encodedFromSite = encodeURIComponent( fromSite );
@@ -30,7 +29,7 @@ export function getFinalImporterUrl(
 			);
 		} )
 	) {
-		importerUrl = getWpComOnboardingUrl( targetSlug, platform, encodedFromSite, framework );
+		importerUrl = getWpComOnboardingUrl( targetSlug, platform, encodedFromSite );
 
 		if ( platform === 'wordpress' && ! fromSite && isAtomicSite ) {
 			importerUrl = getWpOrgImporterUrl( targetSlug, platform );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -47,7 +47,6 @@ export function getFinalImporterUrl(
 
 /**
  * Stepper's redirection handlers
- * generateStepPath share the same interface/params between 'signup' & 'stepper' frameworks
  */
 export function generateStepPath( stepName: string, stepSectionName?: string ) {
 	if ( stepName === 'intent' ) {


### PR DESCRIPTION
## Proposed Changes

* Get rid of the framework param since the 'signup' flow is obsolete and removed.

We removed the old "signup" framework for building onboarding flows a year ago. There were overlapping supporting import flows on both frameworks, 'signup' and 'stepper'.

This PR removes extra parameters that are not necessary anymore.

## Testing Instructions

E2E:
* Existing e2e tests will cover the basic flow navigation

Stepper setup flow:
* Init any import flow
* Check if switching between steps are working without any problem

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?