### PR TITLE
Paid Stats: Refactor givenSiteId for the purchase page

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -641,17 +641,11 @@ export function emailSummary( context, next ) {
 }
 
 export function purchase( context, next ) {
-	const givenSiteId = context.params.site;
-	const isCommercial = getSiteOption( context.store.getState(), givenSiteId, 'is_commercial' );
-
 	context.primary = (
 		<AsyncLoad
 			require="calypso/my-sites/stats/stats-purchase"
 			placeholder={ PageLoading }
 			query={ context.query }
-			options={ {
-				isCommercial,
-			} }
 		/>
 	);
 	next();

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -38,7 +38,6 @@ const StatsPurchasePage = ( {
 	query,
 }: {
 	query: { redirect_uri: string; from: string; productType: 'commercial' | 'personal' };
-	options: { isCommercial: boolean | null };
 } ) => {
 	const translate = useTranslate();
 	const isTypeDetectionEnabled = config.isEnabled( 'stats/type-detection' );

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -17,7 +17,7 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Main from 'calypso/components/main';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug, getSiteOption } from 'calypso/state/sites/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useStatsPurchases from '../hooks/use-stats-purchases';
@@ -36,7 +36,6 @@ import StatsPurchaseWizard, {
 
 const StatsPurchasePage = ( {
 	query,
-	options,
 }: {
 	query: { redirect_uri: string; from: string; productType: 'commercial' | 'personal' };
 	options: { isCommercial: boolean | null };
@@ -49,6 +48,8 @@ const StatsPurchasePage = ( {
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
+
+	const isCommercial = useSelector( ( state ) => getSiteOption( state, siteId, 'is_commercial' ) );
 
 	const { isRequestingSitePurchases, isFreeOwned, isPWYWOwned, isCommercialOwned } =
 		useStatsPurchases( siteId );
@@ -83,11 +84,11 @@ const StatsPurchasePage = ( {
 	const [ initialStep, initialSiteType ] = useMemo( () => {
 		// if the site is detected as commercial
 		if ( isTypeDetectionEnabled ) {
-			if ( options.isCommercial && ! isCommercialOwned ) {
+			if ( isCommercial && ! isCommercialOwned ) {
 				return [ SCREEN_PURCHASE, TYPE_COMMERCIAL ];
 			}
 			// If the site is detected as personal
-			else if ( options.isCommercial === false && ! isCommercialOwned ) {
+			else if ( isCommercial === false && ! isCommercialOwned ) {
 				return [ SCREEN_PURCHASE, TYPE_PERSONAL ];
 			}
 		}
@@ -97,7 +98,7 @@ const StatsPurchasePage = ( {
 		}
 		// if nothing is owned don't specify the type
 		return [ SCREEN_TYPE_SELECTION, null ];
-	}, [ isPWYWOwned, isCommercialOwned, options.isCommercial, isTypeDetectionEnabled ] );
+	}, [ isPWYWOwned, isCommercialOwned, isCommercial, isTypeDetectionEnabled ] );
 
 	const maxSliderPrice = commercialMonthlyProduct?.cost;
 
@@ -163,7 +164,7 @@ const StatsPurchasePage = ( {
 						{
 							// blog doesn't have any plan but is not categorised as either personal or commectial - show old purchase wizard
 							( redirectToPersonal || redirectToCommercial || showPurchasePage ) &&
-								options.isCommercial === null && (
+								isCommercial === null && (
 									<StatsPurchaseWizard
 										siteSlug={ siteSlug }
 										commercialProduct={ commercialProduct }
@@ -183,7 +184,7 @@ const StatsPurchasePage = ( {
 							( redirectToPersonal || redirectToCommercial || showPurchasePage ) && (
 								<>
 									{ ( redirectToCommercial ||
-										( ! redirectToPersonal && ! isCommercialOwned && options.isCommercial ) ) && (
+										( ! redirectToPersonal && ! isCommercialOwned && isCommercial ) ) && (
 										<div className="stats-purchase-page__notice">
 											<StatsSingleItemPagePurchase
 												siteSlug={ siteSlug ?? '' }
@@ -198,7 +199,7 @@ const StatsPurchasePage = ( {
 									{ ( redirectToPersonal ||
 										( ! redirectToCommercial &&
 											! isCommercialOwned &&
-											options.isCommercial === false ) ) && (
+											isCommercial === false ) ) && (
 										<StatsSingleItemPersonalPurchasePage
 											siteSlug={ siteSlug || '' }
 											maxSliderPrice={ maxSliderPrice ?? 10 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81332

## Proposed Changes

* This PR moves the `isCommercial` constant declaration out of the controller _(where it sometimes fails because `givenSiteId` could, in some cases, be the site slug)_ and into the purchase page, where we can reliably use the siteId with the selector. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This is a little tricky to test right now as we don't have `isCommercial` flagged sites to test with. 
* Navigate to `/stats/purchase/{siteURL}` to ensure that the purchase page still works as expected with no troubles
* Check that the general code changes look good 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?