### PR TITLE
BackupBrowser: Disable restore button when site has no valid credentials

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
@@ -8,11 +8,8 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import wp from 'calypso/lib/wp';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
 import { setNodeCheckState } from 'calypso/state/rewind/browser/actions';
-import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
-import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-progress';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import canRestoreSite from 'calypso/state/rewind/selectors/can-restore-site';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { backupGranularRestorePath } from '../../paths';
 import { PREPARE_DOWNLOAD_STATUS } from './constants';
@@ -55,17 +52,7 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) ) as string;
 
-	const doesRewindNeedCredentials = useSelector( ( state ) =>
-		getDoesRewindNeedCredentials( state, siteId )
-	);
-	const isRestoreInProgress = useSelector( ( state ) => getIsRestoreInProgress( state, siteId ) );
-	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
-	const areCredentialsInvalid = useSelector( ( state ) =>
-		areJetpackCredentialsInvalid( state, siteId, 'main' )
-	);
-
-	const isRestoreDisabled =
-		doesRewindNeedCredentials || isRestoreInProgress || ( ! isAtomic && areCredentialsInvalid );
+	const isRestoreDisabled = useSelector( ( state ) => ! canRestoreSite( state, siteId ) );
 
 	const { prepareDownload, prepareDownloadStatus, downloadUrl } = usePrepareDownload( siteId );
 

--- a/client/state/rewind/selectors/can-restore-site.ts
+++ b/client/state/rewind/selectors/can-restore-site.ts
@@ -1,0 +1,18 @@
+import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
+import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
+import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-progress';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { AppState } from 'calypso/types';
+
+const canRestoreSite = ( state: AppState, siteId: number ): boolean => {
+	const doesRewindNeedCredentials = getDoesRewindNeedCredentials( state, siteId ) as boolean;
+	const isRestoreInProgress = getIsRestoreInProgress( state, siteId );
+	const isAtomic = isSiteAutomatedTransfer( state, siteId );
+	const areCredentialsInvalid = areJetpackCredentialsInvalid( state, siteId, 'main' );
+
+	return (
+		doesRewindNeedCredentials || isRestoreInProgress || ( ! isAtomic && areCredentialsInvalid )
+	);
+};
+
+export default canRestoreSite;

--- a/client/state/rewind/selectors/can-restore-site.ts
+++ b/client/state/rewind/selectors/can-restore-site.ts
@@ -10,8 +10,10 @@ const canRestoreSite = ( state: AppState, siteId: number ): boolean => {
 	const isAtomic = isSiteAutomatedTransfer( state, siteId );
 	const areCredentialsInvalid = areJetpackCredentialsInvalid( state, siteId, 'main' );
 
-	return (
-		doesRewindNeedCredentials || isRestoreInProgress || ( ! isAtomic && areCredentialsInvalid )
+	return ! (
+		doesRewindNeedCredentials ||
+		isRestoreInProgress ||
+		( ! isAtomic && areCredentialsInvalid )
 	);
 };
 

--- a/client/state/rewind/selectors/test/can-restore-site.js
+++ b/client/state/rewind/selectors/test/can-restore-site.js
@@ -1,0 +1,59 @@
+import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
+import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
+import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-progress';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import canRestoreSite from '../can-restore-site';
+
+// Mock selectors that are used in the tested selector
+jest.mock( 'calypso/state/jetpack/credentials/selectors', () => ( {
+	areJetpackCredentialsInvalid: jest.fn( () => false ),
+} ) );
+jest.mock( 'calypso/state/selectors/get-does-rewind-need-credentials', () =>
+	jest.fn( () => false )
+);
+jest.mock( 'calypso/state/selectors/get-is-restore-in-progress', () => jest.fn( () => false ) );
+jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => jest.fn( () => false ) );
+
+describe( 'canRestoreSite', () => {
+	const siteId = 12345;
+
+	beforeEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	it( 'should return true if site has no credentials', () => {
+		getDoesRewindNeedCredentials.mockReturnValue( true );
+		expect( canRestoreSite( {}, siteId ) ).toBe( true );
+	} );
+
+	it( 'should return true if there is a restore in progress', () => {
+		getIsRestoreInProgress.mockReturnValue( true );
+		expect( canRestoreSite( {}, siteId ) ).toBe( true );
+	} );
+
+	it( 'should return true if site is not atomic and credentials are invalid', () => {
+		isSiteAutomatedTransfer.mockReturnValue( false );
+		areJetpackCredentialsInvalid.mockReturnValue( true );
+		expect( canRestoreSite( {}, siteId ) ).toBe( true );
+	} );
+
+	it( 'should return false if site is atomic and credentials are invalid', () => {
+		isSiteAutomatedTransfer.mockReturnValue( true );
+		areJetpackCredentialsInvalid.mockReturnValue( true );
+		expect( canRestoreSite( {}, siteId ) ).toBe( false );
+	} );
+
+	it( 'should return false if site is atomic and credentials are valid', () => {
+		isSiteAutomatedTransfer.mockReturnValue( true );
+		areJetpackCredentialsInvalid.mockReturnValue( false );
+		expect( canRestoreSite( {}, siteId ) ).toBe( false );
+	} );
+
+	it( 'should return false if all conditions are false', () => {
+		getDoesRewindNeedCredentials.mockReturnValue( false );
+		getIsRestoreInProgress.mockReturnValue( false );
+		isSiteAutomatedTransfer.mockReturnValue( false );
+		areJetpackCredentialsInvalid.mockReturnValue( false );
+		expect( canRestoreSite( {}, siteId ) ).toBe( false );
+	} );
+} );

--- a/client/state/rewind/selectors/test/can-restore-site.js
+++ b/client/state/rewind/selectors/test/can-restore-site.js
@@ -21,39 +21,39 @@ describe( 'canRestoreSite', () => {
 		jest.resetAllMocks();
 	} );
 
-	it( 'should return true if site has no credentials', () => {
+	it( 'should return false if site has no credentials', () => {
 		getDoesRewindNeedCredentials.mockReturnValue( true );
-		expect( canRestoreSite( {}, siteId ) ).toBe( true );
+		expect( canRestoreSite( {}, siteId ) ).toBe( false );
 	} );
 
-	it( 'should return true if there is a restore in progress', () => {
+	it( 'should return false if there is a restore in progress', () => {
 		getIsRestoreInProgress.mockReturnValue( true );
-		expect( canRestoreSite( {}, siteId ) ).toBe( true );
+		expect( canRestoreSite( {}, siteId ) ).toBe( false );
 	} );
 
-	it( 'should return true if site is not atomic and credentials are invalid', () => {
+	it( 'should return false if site is not atomic and credentials are invalid', () => {
 		isSiteAutomatedTransfer.mockReturnValue( false );
 		areJetpackCredentialsInvalid.mockReturnValue( true );
+		expect( canRestoreSite( {}, siteId ) ).toBe( false );
+	} );
+
+	it( 'should return true if site is atomic and credentials are invalid', () => {
+		isSiteAutomatedTransfer.mockReturnValue( true );
+		areJetpackCredentialsInvalid.mockReturnValue( true );
 		expect( canRestoreSite( {}, siteId ) ).toBe( true );
 	} );
 
-	it( 'should return false if site is atomic and credentials are invalid', () => {
-		isSiteAutomatedTransfer.mockReturnValue( true );
-		areJetpackCredentialsInvalid.mockReturnValue( true );
-		expect( canRestoreSite( {}, siteId ) ).toBe( false );
-	} );
-
-	it( 'should return false if site is atomic and credentials are valid', () => {
+	it( 'should return true if site is atomic and credentials are valid', () => {
 		isSiteAutomatedTransfer.mockReturnValue( true );
 		areJetpackCredentialsInvalid.mockReturnValue( false );
-		expect( canRestoreSite( {}, siteId ) ).toBe( false );
+		expect( canRestoreSite( {}, siteId ) ).toBe( true );
 	} );
 
-	it( 'should return false if all conditions are false', () => {
+	it( 'should return true if all conditions are false', () => {
 		getDoesRewindNeedCredentials.mockReturnValue( false );
 		getIsRestoreInProgress.mockReturnValue( false );
 		isSiteAutomatedTransfer.mockReturnValue( false );
 		areJetpackCredentialsInvalid.mockReturnValue( false );
-		expect( canRestoreSite( {}, siteId ) ).toBe( false );
+		expect( canRestoreSite( {}, siteId ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
Similar to https://github.com/Automattic/wp-calypso/pull/69222

## Proposed Changes
* Add a new `canRestoreSite` selector that we could use in everyplace we need to validate if we could execute a restore or not. This will be helpful and portable, so we no longer need to import a bunch of selectors and use the same condition on all places we need to validate a restore button.
* Disable restore button for the following scenarios:
  * Site has no credentials
  * Site has credentials, but they are not valid, except for Atomic sites
  * Site has a restore in progress

## Testing Instructions
* Start a Jetpack Cloud or Calypso Live branch
* Add `?flags=jetpack/backup-granular` to the URL after visiting the Backup Browser.

### Site has no credentials
* Choose a site with no credentials
* Pick a file and ensure the `Restore` button is visible and disabled.
* Add working credentials to the site
* Go back and ensure the Restore button is now enabled

### Site has a restore in progress
* Execute a restore (it could be a normal restore or a granular restore)
* Go to the backup browser, pick a file and ensure the `Restore` button is visible and disabled.

### Site has credentials, but they are not valid, except for Atomic sites
* Choose a site with credentials and make it not work (maybe changing the server password)
* Go to the backup browser, pick a file and ensure the `Restore` button is visible and disabled.

## Unit tests
* Ensure unit tests are passing: `yarn run test-client client/state/rewind/selectors`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?