### PR TITLE
Stats: add commercial use support for Complete plans

### DIFF
--- a/client/my-sites/stats/hooks/use-stats-purchases.ts
+++ b/client/my-sites/stats/hooks/use-stats-purchases.ts
@@ -47,9 +47,7 @@ export default function useStatsPurchases( siteId: number | null ) {
 	const supportCommercialUse = useMemo(
 		() =>
 			isCommercialOwned ||
-			JETPACK_COMPLETE_PLANS.some( ( plan ) => {
-				isProductOwned( sitePurchases, plan );
-			} ),
+			JETPACK_COMPLETE_PLANS.some( ( plan ) => isProductOwned( sitePurchases, plan ) ),
 		[ sitePurchases, isCommercialOwned ]
 	);
 

--- a/client/my-sites/stats/hooks/use-stats-purchases.ts
+++ b/client/my-sites/stats/hooks/use-stats-purchases.ts
@@ -1,4 +1,5 @@
 import {
+	JETPACK_COMPLETE_PLANS,
 	PRODUCT_JETPACK_STATS_BI_YEARLY,
 	PRODUCT_JETPACK_STATS_FREE,
 	PRODUCT_JETPACK_STATS_MONTHLY,
@@ -43,10 +44,20 @@ export default function useStatsPurchases( siteId: number | null ) {
 		return isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_PWYW_YEARLY );
 	}, [ sitePurchases ] );
 
+	const supportCommercialUse = useMemo(
+		() =>
+			isCommercialOwned ||
+			JETPACK_COMPLETE_PLANS.some( ( plan ) => {
+				isProductOwned( sitePurchases, plan );
+			} ),
+		[ sitePurchases, isCommercialOwned ]
+	);
+
 	return {
 		isRequestingSitePurchases,
 		isFreeOwned,
 		isPWYWOwned,
 		isCommercialOwned,
+		supportCommercialUse,
 	};
 }

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -50,7 +50,7 @@ const StatsPurchasePage = ( {
 
 	const isCommercial = useSelector( ( state ) => getSiteOption( state, siteId, 'is_commercial' ) );
 
-	const { isRequestingSitePurchases, isFreeOwned, isPWYWOwned, isCommercialOwned } =
+	const { isRequestingSitePurchases, isFreeOwned, isPWYWOwned, supportCommercialUse } =
 		useStatsPurchases( siteId );
 
 	useEffect( () => {
@@ -83,25 +83,25 @@ const StatsPurchasePage = ( {
 	const [ initialStep, initialSiteType ] = useMemo( () => {
 		// if the site is detected as commercial
 		if ( isTypeDetectionEnabled ) {
-			if ( isCommercial && ! isCommercialOwned ) {
+			if ( isCommercial && ! supportCommercialUse ) {
 				return [ SCREEN_PURCHASE, TYPE_COMMERCIAL ];
 			}
 			// If the site is detected as personal
-			else if ( isCommercial === false && ! isCommercialOwned ) {
+			else if ( isCommercial === false && ! supportCommercialUse ) {
 				return [ SCREEN_PURCHASE, TYPE_PERSONAL ];
 			}
 		}
 
-		if ( isPWYWOwned && ! isCommercialOwned ) {
+		if ( isPWYWOwned && ! supportCommercialUse ) {
 			return [ SCREEN_PURCHASE, TYPE_COMMERCIAL ];
 		}
 		// if nothing is owned don't specify the type
 		return [ SCREEN_TYPE_SELECTION, null ];
-	}, [ isPWYWOwned, isCommercialOwned, isCommercial, isTypeDetectionEnabled ] );
+	}, [ isPWYWOwned, supportCommercialUse, isCommercial, isTypeDetectionEnabled ] );
 
 	const maxSliderPrice = commercialMonthlyProduct?.cost;
 
-	const showPurchasePage = ! isCommercialOwned && ! isFreeOwned && ! isPWYWOwned;
+	const showPurchasePage = ! supportCommercialUse && ! isFreeOwned && ! isPWYWOwned;
 	const redirectToPersonal = query?.productType === 'personal';
 	const redirectToCommercial = query?.productType === 'commercial';
 	const isNoticeScreenRedirect = redirectToPersonal || redirectToCommercial;
@@ -125,12 +125,12 @@ const StatsPurchasePage = ( {
 				) }
 				{ ! isLoading && ! isTypeDetectionEnabled && (
 					<>
-						{ isCommercialOwned && (
+						{ supportCommercialUse && (
 							<div className="stats-purchase-page__notice">
 								<StatsPurchaseNotice siteSlug={ siteSlug } />
 							</div>
 						) }
-						{ ! isCommercialOwned && (
+						{ ! supportCommercialUse && (
 							<StatsPurchaseWizard
 								siteSlug={ siteSlug }
 								commercialProduct={ commercialProduct }
@@ -139,7 +139,7 @@ const StatsPurchasePage = ( {
 								siteId={ siteId }
 								redirectUri={ query.redirect_uri ?? '' }
 								from={ query.from ?? '' }
-								disableFreeProduct={ isFreeOwned || isCommercialOwned || isPWYWOwned }
+								disableFreeProduct={ isFreeOwned || supportCommercialUse || isPWYWOwned }
 								initialStep={ initialStep }
 								initialSiteType={ initialSiteType }
 							/>
@@ -154,7 +154,7 @@ const StatsPurchasePage = ( {
 								<StatsPurchaseNoticePage
 									siteId={ siteId }
 									siteSlug={ siteSlug }
-									isCommercialOwned={ isCommercialOwned }
+									isCommercialOwned={ supportCommercialUse }
 									isFreeOwned={ isFreeOwned }
 									isPWYWOwned={ isPWYWOwned }
 								/>
@@ -172,7 +172,7 @@ const StatsPurchasePage = ( {
 										siteId={ siteId }
 										redirectUri={ query.redirect_uri ?? '' }
 										from={ query.from ?? '' }
-										disableFreeProduct={ isFreeOwned || isCommercialOwned || isPWYWOwned }
+										disableFreeProduct={ isFreeOwned || supportCommercialUse || isPWYWOwned }
 										initialStep={ initialStep }
 										initialSiteType={ initialSiteType }
 									/>
@@ -183,7 +183,7 @@ const StatsPurchasePage = ( {
 							( redirectToPersonal || redirectToCommercial || showPurchasePage ) && (
 								<>
 									{ ( redirectToCommercial ||
-										( ! redirectToPersonal && ! isCommercialOwned && isCommercial ) ) && (
+										( ! redirectToPersonal && ! supportCommercialUse && isCommercial ) ) && (
 										<div className="stats-purchase-page__notice">
 											<StatsSingleItemPagePurchase
 												siteSlug={ siteSlug ?? '' }
@@ -197,7 +197,7 @@ const StatsPurchasePage = ( {
 									) }
 									{ ( redirectToPersonal ||
 										( ! redirectToCommercial &&
-											! isCommercialOwned &&
+											! supportCommercialUse &&
 											isCommercial === false ) ) && (
 										<StatsSingleItemPersonalPurchasePage
 											siteSlug={ siteSlug || '' }
@@ -206,7 +206,7 @@ const StatsPurchasePage = ( {
 											siteId={ siteId }
 											redirectUri={ query.redirect_uri ?? '' }
 											from={ query.from ?? '' }
-											disableFreeProduct={ isFreeOwned || isCommercialOwned || isPWYWOwned }
+											disableFreeProduct={ isFreeOwned || supportCommercialUse || isPWYWOwned }
 										/>
 									) }
 								</>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
@@ -47,7 +47,7 @@ const StatsCommercialOwned = ( { siteSlug } ) => {
 			<h1>{ translate( 'You have already purchased Jetpack Stats Commercial!' ) }</h1>
 			<p>
 				{ translate(
-					'It appears that you have already purchased a license for this product, and it has been successfully activated. You now have access to:'
+					'It appears that you have already purchased a license or a plan that supports this product, and it has been successfully activated. You now have access to:'
 				) }
 			</p>
 			<StatsBenefitsCommercial />


### PR DESCRIPTION
Related to #81377 

## Proposed Changes

- Add `supportCommercialUse` to `useStatsPurchases`
- If a site has Stats Commercial or any of the Complete plans, then the site supports commercial use

## Testing Instructions

* Purchase a Complete license for a site
* Open Calypso Live Branch `/stats/purchase/:siteSlug?flags=type-detection`
* Ensure you see the following screen instead of a purchase page

<img width="1170" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/9dd088f2-5f54-4a13-8a28-d1078d18ac08">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?