### PR TITLE
Jetpack Partner Portal: implement a tooltip for the feature items in the create site page

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -2,6 +2,7 @@ import { Button, JetpackLogo, WooLogo, CloudLogo } from '@automattic/components'
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import Tooltip from 'calypso/components/tooltip';
+import FeatureItem from './feature-item';
 
 import './style.scss';
 
@@ -14,8 +15,8 @@ interface PlanInfo {
 	description: string;
 	price: string;
 	interval: string;
-	wpcomFeatures: string[];
-	jetpackFeatures: string[];
+	wpcomFeatures: Array< { text: string; tooltipText: string } >;
+	jetpackFeatures: Array< { text: string; tooltipText: string } >;
 	storage: string;
 	logo: JSX.Element | null;
 }
@@ -43,10 +44,21 @@ export default function CardContent( { planSlug }: { planSlug: string } ) {
 			description: 'Plan description goes here',
 			price: '$25',
 			interval: 'month',
-			wpcomFeatures: [ 'Feature 1', 'Feature 2', 'Feature 3', 'Feature 4', 'Feature 5' ],
+			wpcomFeatures: [
+				{ text: 'Feature 1', tooltipText: 'Tooltip for Feature 1' },
+				{ text: 'Feature 2', tooltipText: 'Tooltip for Feature 2' },
+				{ text: 'Feature 3', tooltipText: 'Tooltip for Feature 3' },
+				{ text: 'Feature 4', tooltipText: 'Tooltip for Feature 4' },
+				{ text: 'Feature 5', tooltipText: 'Tooltip for Feature 5' },
+			],
 			jetpackFeatures:
 				planSlug === JETPACK_HOSTING_WPCOM_BUSINESS
-					? [ 'Feature 1', 'Feature 2', 'Feature 3', 'Feature 4' ]
+					? [
+							{ text: 'Feature 1', tooltipText: 'Tooltip for Feature 1' },
+							{ text: 'Feature 2', tooltipText: 'Tooltip for Feature 2' },
+							{ text: 'Feature 3', tooltipText: 'Tooltip for Feature 3' },
+							{ text: 'Feature 4', tooltipText: 'Tooltip for Feature 4' },
+					  ]
 					: [],
 			storage: '50GB',
 			logo: getLogo( planSlug ),
@@ -85,13 +97,12 @@ export default function CardContent( { planSlug }: { planSlug: string } ) {
 						} ) }
 					</div>
 					{ plan.wpcomFeatures.length > 0 &&
-						plan.wpcomFeatures.map( ( feature ) => (
-							<div
-								key={ feature.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase() }
-								className="wpcom-atomic-hosting__card-feature"
-							>
-								{ feature }
-							</div>
+						plan.wpcomFeatures.map( ( { text, tooltipText } ) => (
+							<FeatureItem
+								key={ text.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase() }
+								feature={ text }
+								tooltipText={ tooltipText }
+							/>
 						) ) }
 				</div>
 				{ plan.jetpackFeatures.length > 0 && (
@@ -112,13 +123,12 @@ export default function CardContent( { planSlug }: { planSlug: string } ) {
 								'Security, performance and growth tools made by the WordPress experts.'
 							) }
 						</Tooltip>
-						{ plan.jetpackFeatures.map( ( feature ) => (
-							<div
-								key={ feature.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase() }
-								className="wpcom-atomic-hosting__card-feature"
-							>
-								{ feature }
-							</div>
+						{ plan.jetpackFeatures.map( ( { text, tooltipText } ) => (
+							<FeatureItem
+								key={ text.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase() }
+								feature={ text }
+								tooltipText={ tooltipText }
+							/>
 						) ) }
 					</div>
 				) }

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/feature-item.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/feature-item.tsx
@@ -1,0 +1,31 @@
+import { useRef, useState } from 'react';
+import Tooltip from 'calypso/components/tooltip';
+
+interface Props {
+	feature: string;
+	tooltipText: string;
+}
+
+export default function FeatureItem( { feature, tooltipText }: Props ) {
+	const tooltipRef = useRef< HTMLDivElement | null >( null );
+	const [ showPopover, setShowPopover ] = useState( false );
+
+	return (
+		<>
+			<div
+				onMouseEnter={ () => setShowPopover( true ) }
+				onMouseLeave={ () => setShowPopover( false ) }
+				onMouseDown={ () => setShowPopover( false ) }
+				role="button"
+				tabIndex={ 0 }
+				ref={ tooltipRef }
+				className="wpcom-atomic-hosting__card-feature"
+			>
+				{ feature }
+			</div>
+			<Tooltip context={ tooltipRef.current } isVisible={ showPopover } position="top">
+				{ tooltipText }
+			</Tooltip>
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/style.scss
@@ -58,6 +58,7 @@
 	margin-block: 8px;
 	color: var(--studio-gray-80);
 	font-size: 0.75rem;
+	width: fit-content;
 }
 
 .wpcom-atomic-hosting__card-button {


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-avalon/issues/55

## Proposed Changes

This PR implements a tooltip to all the feature items of WPCOM hosting plans on the create site page.

## Testing Instructions

- Open the Jetpack Cloud live link.
- Append the URL with /partner-portal/create-site and verify the below screen is shown.
- Hover over the feature items and verify that the tooltip is shown for all the feature items.

<img width="352" alt="Screenshot 2023-09-04 at 3 18 26 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3dc7976c-9012-428a-a1a8-cda3367fbd26">

<img width="221" alt="Screenshot 2023-09-04 at 3 18 29 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/23ab92af-2e16-4469-9f7c-73f2f19319f4">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?