### PR TITLE
Allow /settings/start-site-transfer access for domain only sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -243,6 +243,7 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		// Any page under `/domains/manage/all` should be accessible in domain-only sites now that we allow multiple domains in them
 		'/domains/manage/all/',
 		'/email/all/',
+		'/settings/start-site-transfer/',
 		// Add A Domain > Search for a domain
 		domainAddNew( slug ),
 		// Add A Domain > Use a domain I own


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3638

## Proposed Changes

* Allows /settings/start-site-transfer access for domain only sites.

## Testing Instructions

* With a user viewing a domain only site, take the site slug and try to load this url: `http://calypso.localhost:3000/settings/start-site-transfer/:site`
* Before PR: This route should redirect to `/domains/manage`.
* After PR: This route should load the site transfer screen.

![Screenshot 2023-09-05 at 15-50-44 test345678 blog — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/b9d3921a-c3b9-4d47-9931-729e90a5ab36)
