### PR TITLE
Allow /people access for domain only sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -243,6 +243,7 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		// Any page under `/domains/manage/all` should be accessible in domain-only sites now that we allow multiple domains in them
 		'/domains/manage/all/',
 		'/email/all/',
+		'/people/',
 		'/settings/start-site-transfer/',
 		// Add A Domain > Search for a domain
 		domainAddNew( slug ),


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3606

## Proposed Changes

* Enables access to the /people (users) routes when viewing a domain only site.

## Testing Instructions

* Using a domain only site, accessing this url: `http://calypso.localhost:3000/people/team/:site`
* Before PR: redirects to `/domains/manage`
* After PR: loads the user management screens: `/people/team/:site` and you should be able to navigate between all user screens.

![Screenshot 2023-09-05 at 16-02-49 Users ‹ test345678 blog — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/4f667430-e796-435e-a263-a4a1b5982b78)
![Screenshot 2023-09-05 at 16-03-32 View Team Member ‹ test345678 blog — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/7424d7c6-1396-46c9-b705-c4a50e7bab38)

Note, you won't see users in the sidebar menu, but you can sandbox https://github.com/Automattic/jetpack/pull/32822 if you'd like to see it for testing.

This should be ok to deploy standalone as we won't show the menu item until the JP change is deployed.