### PR TITLE
Subscriptions Management: Introduce use-site-subscription-query hook

### DIFF
--- a/client/blocks/reader-site-subscription/details.tsx
+++ b/client/blocks/reader-site-subscription/details.tsx
@@ -21,6 +21,7 @@ import SiteSubscriptionSettings from './settings';
 import './styles.scss';
 
 const SiteSubscriptionDetails = ( {
+	subscriptionId,
 	subscriberCount,
 	dateSubscribed,
 	siteIcon,
@@ -89,7 +90,7 @@ const SiteSubscriptionDetails = ( {
 			setShowUnsubscribeModal( true );
 		} else {
 			const emailId = getQueryArgs()?.email_id as string;
-			unsubscribe( { blog_id: blogId, url, emailId } );
+			unsubscribe( { blog_id: blogId, url, emailId, subscriptionId } );
 		}
 	};
 
@@ -209,6 +210,7 @@ const SiteSubscriptionDetails = ( {
 			{ siteSubscribed && (
 				<>
 					<SiteSubscriptionSettings
+						subscriptionId={ subscriptionId }
 						blogId={ blogId }
 						notifyMeOfNewPosts={ !! deliveryMethods.notification?.send_posts }
 						emailMeNewPosts={ !! deliveryMethods.email?.send_posts }

--- a/client/blocks/reader-site-subscription/helpers.tsx
+++ b/client/blocks/reader-site-subscription/helpers.tsx
@@ -3,11 +3,12 @@ import { getCurrencyObject } from '@automattic/format-currency';
 import moment from 'moment';
 
 export type SiteSubscriptionDetailsProps = {
+	subscriptionId: number;
 	subscriberCount: number;
 	dateSubscribed: string;
 	siteIcon: string | null;
 	name: string;
-	blogId: string;
+	blogId: number;
 	deliveryMethods: Reader.SiteSubscriptionDeliveryMethods;
 	url: string;
 	paymentDetails: Reader.SiteSubscriptionPaymentDetails[];

--- a/client/blocks/reader-site-subscription/index.tsx
+++ b/client/blocks/reader-site-subscription/index.tsx
@@ -38,7 +38,8 @@ const ReaderSiteSubscription = () => {
 						</Notice>
 					) : (
 						<SiteSubscriptionDetails
-							blogId={ blogId }
+							subscriptionId={ data.ID }
+							blogId={ Number( blogId ) }
 							name={ data.name }
 							subscriberCount={ data.subscriber_count }
 							dateSubscribed={ data.date_subscribed }

--- a/client/blocks/reader-site-subscription/settings.tsx
+++ b/client/blocks/reader-site-subscription/settings.tsx
@@ -3,14 +3,16 @@ import { useTranslate } from 'i18n-calypso';
 import { SiteSettings } from 'calypso/landing/subscriptions/components/settings';
 
 type SiteSubscriptionSettingsProps = {
+	subscriptionId: number;
 	notifyMeOfNewPosts: boolean;
 	emailMeNewPosts: boolean;
 	deliveryFrequency: Reader.EmailDeliveryFrequency;
 	emailMeNewComments: boolean;
-	blogId: string;
+	blogId: number;
 };
 
 const SiteSubscriptionSettings = ( {
+	subscriptionId,
 	blogId,
 	notifyMeOfNewPosts,
 	emailMeNewPosts,
@@ -20,13 +22,13 @@ const SiteSubscriptionSettings = ( {
 	const translate = useTranslate();
 
 	const { mutate: updateNotifyMeOfNewPosts, isLoading: updatingNotifyMeOfNewPosts } =
-		SubscriptionManager.useSiteNotifyMeOfNewPostsMutation( blogId );
+		SubscriptionManager.useSiteNotifyMeOfNewPostsMutation();
 	const { mutate: updateEmailMeNewPosts, isLoading: updatingEmailMeNewPosts } =
-		SubscriptionManager.useSiteEmailMeNewPostsMutation( blogId );
+		SubscriptionManager.useSiteEmailMeNewPostsMutation();
 	const { mutate: updateDeliveryFrequency, isLoading: updatingFrequency } =
-		SubscriptionManager.useSiteDeliveryFrequencyMutation( blogId );
+		SubscriptionManager.useSiteDeliveryFrequencyMutation();
 	const { mutate: updateEmailMeNewComments, isLoading: updatingEmailMeNewComments } =
-		SubscriptionManager.useSiteEmailMeNewCommentsMutation( blogId );
+		SubscriptionManager.useSiteEmailMeNewCommentsMutation();
 
 	return (
 		<div className="site-subscription-settings">
@@ -35,25 +37,25 @@ const SiteSubscriptionSettings = ( {
 				// NotifyMeOfNewPosts
 				notifyMeOfNewPosts={ notifyMeOfNewPosts }
 				onNotifyMeOfNewPostsChange={ ( send_posts ) =>
-					updateNotifyMeOfNewPosts( { blog_id: blogId, send_posts } )
+					updateNotifyMeOfNewPosts( { blog_id: blogId, send_posts, subscriptionId } )
 				}
 				updatingNotifyMeOfNewPosts={ updatingNotifyMeOfNewPosts }
 				// EmailMeNewPosts
 				emailMeNewPosts={ emailMeNewPosts }
 				onEmailMeNewPostsChange={ ( send_posts ) =>
-					updateEmailMeNewPosts( { blog_id: blogId, send_posts } )
+					updateEmailMeNewPosts( { blog_id: blogId, send_posts, subscriptionId } )
 				}
 				updatingEmailMeNewPosts={ updatingEmailMeNewPosts }
 				// DeliveryFrequency
 				deliveryFrequency={ deliveryFrequency }
 				onDeliveryFrequencyChange={ ( delivery_frequency ) =>
-					updateDeliveryFrequency( { blog_id: blogId, delivery_frequency } )
+					updateDeliveryFrequency( { blog_id: blogId, delivery_frequency, subscriptionId } )
 				}
 				updatingFrequency={ updatingFrequency }
 				// EmailMeNewComments
 				emailMeNewComments={ emailMeNewComments }
 				onEmailMeNewCommentsChange={ ( send_comments ) =>
-					updateEmailMeNewComments( { blog_id: blogId, send_comments } )
+					updateEmailMeNewComments( { blog_id: blogId, send_comments, subscriptionId } )
 				}
 				updatingEmailMeNewComments={ updatingEmailMeNewComments }
 			/>

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
@@ -169,7 +169,7 @@ const SiteRow = ( {
 
 	const handleNotifyMeOfNewPostsChange = ( send_posts: boolean ) => {
 		// Update post notification settings
-		updateNotifyMeOfNewPosts( { blog_id, send_posts } );
+		updateNotifyMeOfNewPosts( { blog_id, send_posts, subscriptionId: Number( subscriptionId ) } );
 
 		// Record tracks event
 		recordNotificationsToggle( send_posts, { blog_id } );
@@ -177,7 +177,7 @@ const SiteRow = ( {
 
 	const handleEmailMeNewPostsChange = ( send_posts: boolean ) => {
 		// Update post emails settings
-		updateEmailMeNewPosts( { blog_id, send_posts } );
+		updateEmailMeNewPosts( { blog_id, send_posts, subscriptionId: Number( subscriptionId ) } );
 
 		// Record tracks event
 		recordPostEmailsToggle( send_posts, { blog_id } );
@@ -185,7 +185,11 @@ const SiteRow = ( {
 
 	const handleEmailMeNewCommentsChange = ( send_comments: boolean ) => {
 		// Update comment emails settings
-		updateEmailMeNewComments( { blog_id, send_comments } );
+		updateEmailMeNewComments( {
+			blog_id,
+			send_comments,
+			subscriptionId: Number( subscriptionId ),
+		} );
 
 		// Record tracks event
 		recordCommentEmailsToggle( send_comments, { blog_id } );
@@ -193,7 +197,11 @@ const SiteRow = ( {
 
 	const handleDeliveryFrequencyChange = ( delivery_frequency: Reader.EmailDeliveryFrequency ) => {
 		// Update post emails delivery frequency
-		updateDeliveryFrequency( { blog_id, delivery_frequency } );
+		updateDeliveryFrequency( {
+			blog_id,
+			delivery_frequency,
+			subscriptionId: Number( subscriptionId ),
+		} );
 
 		// Record tracks event
 		recordPostEmailsSetFrequency( { blog_id, delivery_frequency } );

--- a/client/reader/hooks/use-site-subscription-query.ts
+++ b/client/reader/hooks/use-site-subscription-query.ts
@@ -1,0 +1,20 @@
+import { Reader } from '@automattic/data-stores';
+import { useQuery } from '@tanstack/react-query';
+
+const useSiteSubscriptionQuery = ( subscriptionId?: number ) => {
+	const { isLoggedIn, id } = Reader.useIsLoggedIn();
+	return useQuery( {
+		queryKey: [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ],
+		queryFn: async () => {
+			return Reader.callApi< Reader.SiteSubscriptionDetails< string > >( {
+				path: '/read/subscriptions/' + subscriptionId,
+				isLoggedIn,
+				apiNamespace: 'wpcom/v2',
+				apiVersion: '2',
+			} );
+		},
+		enabled: typeof subscriptionId === 'number' && subscriptionId >= 0,
+	} );
+};
+
+export default useSiteSubscriptionQuery;

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -53,13 +53,14 @@ export const SubscriptionManager = {
 	useUserSettingsQuery,
 };
 
+export { useIsLoggedIn };
 export {
 	EmailDeliveryFrequency,
 	PostSubscriptionsSortBy,
 	SiteSubscriptionsFilterBy,
 	SiteSubscriptionsSortBy,
 } from './constants';
-export { isErrorResponse, isSiteSubscriptionDetails, isValidId } from './helpers';
+export { callApi, isErrorResponse, isSiteSubscriptionDetails, isValidId } from './helpers';
 export { UnsubscribedFeedsSearchProvider, useUnsubscribedFeedsSearch } from './contexts';
 export { useReadFeedSearchQuery, useReadFeedSiteQuery, useReadFeedQuery } from './queries';
 

--- a/packages/data-stores/src/reader/mutations/test/use-site-delivery-frequency-mutation.test.tsx
+++ b/packages/data-stores/src/reader/mutations/test/use-site-delivery-frequency-mutation.test.tsx
@@ -4,6 +4,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
 import React, { useEffect } from 'react';
+import { EmailDeliveryFrequency } from '../../constants';
 import { callApi } from '../../helpers';
 import useSiteDeliveryFrequencyMutation from '../../mutations/use-site-delivery-frequency-mutation';
 
@@ -17,6 +18,7 @@ jest.mock( '../../hooks', () => ( {
 jest.mock( '../../helpers', () => ( {
 	callApi: jest.fn(),
 	applyCallbackToPages: jest.fn(),
+	buildQueryKey: jest.fn(),
 } ) );
 
 const client = new QueryClient();
@@ -30,8 +32,9 @@ describe( 'useSiteDeliveryFrequencyMutation()', () => {
 			const { mutate } = useSiteDeliveryFrequencyMutation();
 			useEffect( () => {
 				mutate( {
-					delivery_frequency: 'daily',
+					delivery_frequency: EmailDeliveryFrequency.Daily,
 					blog_id: '123',
+					subscriptionId: 456,
 				} );
 			}, [ mutate ] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/81388

## Proposed Changes

* Introduce a new `use-subscription-details-query` hook in the reader.
  * This hook queries data from  `/wpcom/v2/read/subscriptions/${subscriptionId}`
  * In the near future, it's intended to replace the current `SubscriptionManagement.useSiteSubscriptionDetails` hook from `@automattic/data-stores`
* Optimistic updates have been implemented for the query on mutations affecting the data returned by the hook.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test for no regressions in the current optimistic update logic in the subscriptions portal
Especially on: 
- http://calypso.localhost:3000/read/subscriptions/sites
- http://calypso.localhost:3000/subscriptions/sites
- `http://calypso.localhost:3000/subscriptions/site/${siteId}`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?