### PR TITLE
Pro Dashboard: Hotwire Jetpack Cloud links to redirect to WPCOM for atomic sites

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -41,6 +41,7 @@ export class SiteSelector extends Component {
 		isPlaceholder: PropTypes.bool,
 		sites: PropTypes.array,
 		siteBasePath: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
+		wpcomSiteBasePath: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		showAddNewSite: PropTypes.bool,
 		showAllSites: PropTypes.bool,
 		indicator: PropTypes.bool,
@@ -70,6 +71,7 @@ export class SiteSelector extends Component {
 		showAllSites: false,
 		showHiddenSites: false,
 		siteBasePath: false,
+		wpcomSiteBasePath: false,
 		indicator: false,
 		hideSelected: false,
 		selected: null,
@@ -487,13 +489,19 @@ export class SiteSelector extends Component {
 }
 
 const navigateToSite =
-	( siteId, { allSitesPath, allSitesSingleUser, siteBasePath } ) =>
+	( siteId, { allSitesPath, allSitesSingleUser, siteBasePath, wpcomSiteBasePath } ) =>
 	( dispatch, getState ) => {
 		const state = getState();
 		const site = getSite( state, siteId );
-		const pathname = getPathnameForSite();
-		if ( pathname ) {
-			page( pathname );
+
+		// We will need to open a new tab if we have wpcomSiteBasePath prop and current site is an Atomic site.
+		if ( site?.is_wpcom_atomic && wpcomSiteBasePath ) {
+			window.open( getCompleteSiteURL( wpcomSiteBasePath ) );
+		} else {
+			const pathname = getPathnameForSite();
+			if ( pathname ) {
+				page( pathname );
+			}
 		}
 
 		function getPathnameForSite() {
@@ -516,29 +524,7 @@ const navigateToSite =
 
 				return path;
 			} else if ( siteBasePath ) {
-				const base = getSiteBasePath();
-
-				// Record original URL type. The original URL should be a path-absolute URL, e.g. `/posts`.
-				const urlType = determineUrlType( base );
-
-				// Get URL parts and modify the path.
-				const { origin, pathname: urlPathname, search } = getUrlParts( base );
-				const newPathname = `${ urlPathname }/${ site.slug }`;
-
-				try {
-					// Get an absolute URL from the original URL, the modified path, and some defaults.
-					const absoluteUrl = getUrlFromParts( {
-						origin: origin || window.location.origin,
-						pathname: newPathname,
-						search,
-					} );
-
-					// Format the absolute URL down to the original URL type.
-					return format( absoluteUrl, urlType );
-				} catch {
-					// Invalid URLs will cause `getUrlFromParts` to throw. Return `null` in that case.
-					return null;
-				}
+				return getCompleteSiteURL( getSiteBasePath() );
 			}
 		}
 
@@ -580,6 +566,30 @@ const navigateToSite =
 			}
 
 			return path;
+		}
+
+		function getCompleteSiteURL( base ) {
+			// Record original URL type. The original URL should be a path-absolute URL, e.g. `/posts`.
+			const urlType = determineUrlType( base );
+
+			// Get URL parts and modify the path.
+			const { origin, pathname: urlPathname, search } = getUrlParts( base );
+			const newPathname = `${ urlPathname }/${ site.slug }`;
+
+			try {
+				// Get an absolute URL from the original URL, the modified path, and some defaults.
+				const absoluteUrl = getUrlFromParts( {
+					origin: origin || window.location.origin,
+					pathname: newPathname,
+					search,
+				} );
+
+				// Format the absolute URL down to the original URL type.
+				return format( absoluteUrl, urlType );
+			} catch {
+				// Invalid URLs will cause `getUrlFromParts` to throw. Return `null` in that case.
+				return null;
+			}
 		}
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
@@ -32,6 +32,9 @@ const DashboardSidebar: FunctionComponent< Props > = ( { path } ) => {
 
 	const isPluginsPage = path.includes( '/plugins' );
 	const isPluginManagementEnabled = config.isEnabled( 'jetpack/plugin-management' );
+	const isWPCOMAtomicSiteCreationEnabled = config.isEnabled(
+		'jetpack/pro-dashboard-wpcom-atomic-hosting'
+	);
 
 	return (
 		<div>
@@ -40,7 +43,9 @@ const DashboardSidebar: FunctionComponent< Props > = ( { path } ) => {
 				showAllSites
 				allSitesPath={ path }
 				siteBasePath="/backup"
-				wpcomSiteBasePath="https://wordpress.com/home"
+				wpcomSiteBasePath={
+					isWPCOMAtomicSiteCreationEnabled ? 'https://wordpress.com/home' : false
+				}
 			/>
 			<Sidebar className="sidebar__jetpack-cloud">
 				<SidebarRegion>

--- a/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
@@ -35,7 +35,13 @@ const DashboardSidebar: FunctionComponent< Props > = ( { path } ) => {
 
 	return (
 		<div>
-			<SiteSelector showAddNewSite showAllSites allSitesPath={ path } siteBasePath="/backup" />
+			<SiteSelector
+				showAddNewSite
+				showAllSites
+				allSitesPath={ path }
+				siteBasePath="/backup"
+				wpcomSiteBasePath="https://wordpress.com/home"
+			/>
 			<Sidebar className="sidebar__jetpack-cloud">
 				<SidebarRegion>
 					<CurrentSite

--- a/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sidebar/index.tsx
@@ -43,9 +43,7 @@ const DashboardSidebar: FunctionComponent< Props > = ( { path } ) => {
 				showAllSites
 				allSitesPath={ path }
 				siteBasePath="/backup"
-				wpcomSiteBasePath={
-					isWPCOMAtomicSiteCreationEnabled ? 'https://wordpress.com/home' : false
-				}
+				wpcomSiteBasePath={ isWPCOMAtomicSiteCreationEnabled && 'https://wordpress.com/home' }
 			/>
 			<Sidebar className="sidebar__jetpack-cloud">
 				<SidebarRegion>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -163,6 +163,11 @@ export default function SiteStatusContent( {
 			</div>
 		);
 
+		const siteRedirectURL =
+			isWPCOMAtomicSiteCreationEnabled && isWPCOMAtomicSite
+				? `https://wordpress.com/home/${ urlToSlug( siteUrl ) }`
+				: `/activity-log/${ urlToSlug( siteUrl ) }`;
+
 		return (
 			<>
 				{ isBulkManagementActive ? (
@@ -179,12 +184,7 @@ export default function SiteStatusContent( {
 					/>
 				) }
 				{ isLargeScreen ? (
-					<Button
-						className="sites-overview__row-text"
-						borderless
-						compact
-						href={ `/activity-log/${ urlToSlug( siteUrl ) }` }
-					>
+					<Button className="sites-overview__row-text" borderless compact href={ siteRedirectURL }>
 						{ WPCOMHostedSiteBadgeColumn }
 						{ siteUrl }
 						<SiteBackupStaging siteId={ siteId } />

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -184,7 +184,13 @@ export default function SiteStatusContent( {
 					/>
 				) }
 				{ isLargeScreen ? (
-					<Button className="sites-overview__row-text" borderless compact href={ siteRedirectURL }>
+					<Button
+						className="sites-overview__row-text"
+						borderless
+						compact
+						href={ siteRedirectURL }
+						target={ isWPCOMAtomicSiteCreationEnabled && isWPCOMAtomicSite ? '_blank' : '_self' }
+					>
 						{ WPCOMHostedSiteBadgeColumn }
 						{ siteUrl }
 						<SiteBackupStaging siteId={ siteId } />


### PR DESCRIPTION
This PR updates the **Site Selector** and the **Site** column in the Jetpack cloud to redirect users to Calypso Blue when selecting a site.
<img width="1728" alt="Screen Shot 2023-09-05 at 6 50 52 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9c9ff618-4301-4d65-a3b8-2b5c6f907f3c">

Related to https://github.com/orgs/Automattic/projects/756/views/5?pane=issue&itemId=36723037

## Proposed Changes
* Update **SiteSelector** to include `wpcomSiteBasePath` prop to support atomic site-specific base path.
* Update the Dashboard Table '**Site**' column to support Atomic site link.


## Testing Instructions

**Site Selector**
1. Checkout this branch using `git checkout add/hotwiring-wpcom-atomic-site-to-calypso-blue`
1. To temporarily load all sites (including Atomic sites) in the site selector, we must remove the Jetpack site filter in our environment. To do this, modify the **jetpack-cloud-development.json** file in your local environment and set `site_filter` to an empty array.
  ```
   "site_filter": [ "" ],
  ```
3. Once you have updated your environment, start Jetpack cloud on your local machine using `yarn start-jetpack-cloud`
4. Goto http://jetpack.cloud.localhost:3000/dashboard
5. Select an atomic site in the sidebar and confirm that a new tab to `https://wordpress.com/home/<SITE>` opens up.
6. Select a Jetpack site and confirm that it redirects to the Jetpack cloud `/backup` page.

**Site column**
1. To load Atomic sites in the Dashboard table, apply **D120449** patch and sandbox public-api.wordpress.com.
2. Refresh the Dashboard page, and Atomic sites should now appear in the table.
3. Confirm that clicking the Site name for Atomic sites will open a new tab to `https://wordpress.com/home/<SITE>`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
