### PR TITLE
Reader: Add tooltips to icon buttons

### DIFF
--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -2,8 +2,9 @@ import { Gridicon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import { omitBy } from 'lodash';
 import PropTypes from 'prop-types';
-import { createElement } from 'react';
+import { createElement, useRef, useState } from 'react';
 import { connect } from 'react-redux';
+import Tooltip from 'calypso/components/tooltip';
 import { getPostTotalCommentsCount } from 'calypso/state/comments/selectors';
 
 import './style.scss';
@@ -12,6 +13,8 @@ const noop = () => {};
 
 function CommentButton( props ) {
 	const { commentCount, href, onClick, tagName, target, icon } = props;
+	const commentRef = useRef();
+	const [ tooltip, setTooltip ] = useState( false );
 
 	return createElement(
 		tagName,
@@ -21,13 +24,18 @@ function CommentButton( props ) {
 				href: 'a' === tagName ? href : null,
 				onClick,
 				target: 'a' === tagName ? target : null,
-				title: translate( 'Comment' ),
+				onMouseEnter: () => setTooltip( true ),
+				onMouseLeave: () => setTooltip( false ),
+				ref: commentRef,
 			},
 			( prop ) => prop === null
 		),
 		icon || <Gridicon icon="comment" size={ props.size } className="comment-button__icon" />,
 		<span className="comment-button__label">
 			{ commentCount > 0 && <span className="comment-button__label-count">{ commentCount }</span> }
+			<Tooltip isVisible={ tooltip } position="bottom" context={ commentRef.current }>
+				{ translate( 'Comment' ) }
+			</Tooltip>
 		</span>
 	);
 }

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -1,8 +1,10 @@
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
+import { useRef, useState } from 'react';
 import ShareButton from 'calypso/blocks/reader-share';
 import { shouldShowReblog } from 'calypso/blocks/reader-share/helper';
+import Tooltip from 'calypso/components/tooltip';
 import { useSelector } from 'calypso/state';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import CommentLikeButtonContainer from './comment-likes';
@@ -27,6 +29,8 @@ const CommentActions = ( {
 	const showCancelReplyButton = activeReplyCommentId === commentId;
 	const hasSites = !! useSelector( getPrimarySiteId );
 	const showReblogButton = shouldShowReblog( post, hasSites );
+	const replyRef = useRef();
+	const [ tooltip, setTooltip ] = useState( false );
 
 	// Only render actions for non placeholders
 	if ( isPlaceholder ) {
@@ -46,9 +50,18 @@ const CommentActions = ( {
 				</Button>
 			) }
 			{ showReplyButton && (
-				<Button className="comments__comment-actions-reply" onClick={ handleReply }>
+				<Button
+					className="comments__comment-actions-reply"
+					onClick={ handleReply }
+					onMouseEnter={ () => setTooltip( true ) }
+					onMouseLeave={ () => setTooltip( false ) }
+					ref={ replyRef }
+				>
 					<Gridicon icon="reply" size={ 18 } />
 					<span className="comments__comment-actions-reply-label">{ translate( 'Reply' ) }</span>
+					<Tooltip isVisible={ tooltip } position="bottom" context={ replyRef.current }>
+						{ translate( 'Reply' ) }
+					</Tooltip>
 				</Button>
 			) }
 			{ showReblogButton && (

--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -1,7 +1,8 @@
 import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { createElement, Component } from 'react';
+import { createElement, createRef, Component } from 'react';
+import Tooltip from 'calypso/components/tooltip';
 
 import './style.scss';
 
@@ -28,6 +29,9 @@ class FollowButton extends Component {
 		tagName: 'button',
 		disabled: false,
 	};
+
+	buttonRef = createRef();
+	state = { tooltip: false };
 
 	toggleFollow = ( event ) => {
 		if ( event ) {
@@ -75,14 +79,30 @@ class FollowButton extends Component {
 			</span>
 		);
 
+		const tooltipElement = (
+			<Tooltip
+				isVisible={ this.state.tooltip }
+				position="bottom"
+				context={ this.buttonRef.current }
+			>
+				{ label }
+			</Tooltip>
+		);
+
 		return createElement(
 			this.props.tagName,
 			{
 				onClick: this.toggleFollow,
+				onMouseEnter: () => {
+					this.setState( { tooltip: true } );
+				},
+				onMouseLeave: () => {
+					this.setState( { tooltip: false } );
+				},
+				ref: this.buttonRef,
 				className: menuClasses.join( ' ' ),
-				title: label,
 			},
-			[ followingIcon, followIcon, followLabelElement ]
+			[ followingIcon, followIcon, followLabelElement, tooltipElement ]
 		);
 	}
 }

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -3,8 +3,9 @@ import classNames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
 import { omitBy } from 'lodash';
 import PropTypes from 'prop-types';
-import { createElement, PureComponent } from 'react';
+import { createElement, PureComponent, createRef } from 'react';
 import { connect } from 'react-redux';
+import Tooltip from 'calypso/components/tooltip';
 import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl } from 'calypso/lib/paths';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -12,6 +13,9 @@ import LikeIcons from './icons';
 import './style.scss';
 
 class LikeButton extends PureComponent {
+	likeRef = createRef();
+	state = { tooltip: false };
+
 	static propTypes = {
 		liked: PropTypes.bool,
 		showZeroCount: PropTypes.bool,
@@ -95,6 +99,22 @@ class LikeButton extends PureComponent {
 			</span>
 		);
 
+		const tooltipElement = (
+			<Tooltip isVisible={ this.state.tooltip } position="bottom" context={ this.likeRef.current }>
+				{ this.props.liked ? translate( 'Liked' ) : translate( 'Like' ) }
+			</Tooltip>
+		);
+
+		const mouseEnter = ( e ) => {
+			this.setState( { tooltip: true } );
+			return onMouseEnter( e );
+		};
+
+		const mouseLeave = ( e ) => {
+			this.setState( { tooltip: false } );
+			return onMouseLeave( e );
+		};
+
 		const likeIcons = icon || <LikeIcons size={ this.props.iconSize } />;
 		const href = isLink ? `/stats/post/${ postId }/${ slug }` : null;
 		return createElement(
@@ -104,14 +124,15 @@ class LikeButton extends PureComponent {
 					href,
 					className: classNames( containerClasses ),
 					onClick: ! isLink ? this.toggleLiked : null,
-					onMouseEnter,
-					onMouseLeave,
-					title: this.props.liked ? translate( 'Liked' ) : translate( 'Like' ),
+					onMouseEnter: mouseEnter,
+					onMouseLeave: mouseLeave,
+					ref: this.likeRef,
 				},
 				( prop ) => prop === null
 			),
 			likeIcons,
-			labelElement
+			labelElement,
+			tooltipElement
 		);
 	}
 }

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -107,12 +107,12 @@ class LikeButton extends PureComponent {
 
 		const mouseEnter = ( e ) => {
 			this.setState( { tooltip: true } );
-			return onMouseEnter( e );
+			return onMouseEnter && onMouseEnter( e );
 		};
 
 		const mouseLeave = ( e ) => {
 			this.setState( { tooltip: false } );
-			return onMouseLeave( e );
+			return onMouseLeave && onMouseLeave( e );
 		};
 
 		const likeIcons = icon || <LikeIcons size={ this.props.iconSize } />;

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -34,7 +34,6 @@ const ReaderPostActions = ( props ) => {
 		className,
 		visitUrl,
 		fullPost,
-		translate,
 		showFollow,
 	} = props;
 
@@ -74,9 +73,7 @@ const ReaderPostActions = ( props ) => {
 						href={ visitUrl || post.URL }
 						iconSize={ iconSize }
 						onClick={ onPermalinkVisit }
-					>
-						{ translate( 'Visit' ) }
-					</ReaderVisitLink>
+					></ReaderVisitLink>
 				</li>
 			) }
 			{ showViews && (

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -28,7 +28,7 @@
 		.reader-visit-link {
 			align-items: center;
 			box-sizing: border-box;
-			display: flex;
+			display: inline-flex;
 			gap: 4px;
 		}
 		@include breakpoint-deprecated( "<660px" ) {

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -5,6 +5,7 @@ import { defer } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
+import Tooltip from 'calypso/components/tooltip';
 import ReaderShareIcon from 'calypso/reader/components/icons/share-icon';
 import * as stats from 'calypso/reader/stats';
 import { preloadEditor } from 'calypso/sections-preloaders';
@@ -26,6 +27,7 @@ class ReaderShare extends Component {
 
 	state = {
 		showingMenu: false,
+		tooltip: false,
 	};
 
 	constructor( props ) {
@@ -110,16 +112,28 @@ class ReaderShare extends Component {
 		return (
 			// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
 			<div className="reader-share" onClick={ ( event ) => event.preventDefault() }>
+				<Tooltip
+					isVisible={ this.state.tooltip }
+					position="bottom"
+					context={ this.shareButton.current }
+				>
+					{ this.props.isReblogSelection ? translate( 'Reblog' ) : translate( 'Share' ) }
+				</Tooltip>
 				<Button
 					borderless
 					className={ buttonClasses }
 					compact={ this.props.iconSize === 18 }
 					key="button"
 					onClick={ this.toggle }
-					onMouseEnter={ preloadEditor }
+					onMouseEnter={ () => {
+						this.setState( { tooltip: true } );
+						preloadEditor();
+					} }
+					onMouseLeave={ () => {
+						this.setState( { tooltip: false } );
+					} }
 					onTouchStart={ preloadEditor }
 					ref={ this.shareButton }
-					title={ this.props.isReblogSelection ? translate( 'Reblog' ) : translate( 'Share' ) }
 				>
 					{ ! this.props.isReblogSelection ? (
 						ReaderShareIcon( {

--- a/client/blocks/reader-views/index.jsx
+++ b/client/blocks/reader-views/index.jsx
@@ -1,12 +1,25 @@
+import { translate } from 'i18n-calypso';
+import { useRef, useState } from 'react';
 import BarChart from 'calypso/assets/images/icons/bar-chart.svg';
 import SVGIcon from 'calypso/components/svg-icon';
+import Tooltip from 'calypso/components/tooltip';
 import './style.scss';
 
 const ReaderViews = ( { viewCount } ) => {
+	const buttonRef = useRef();
+	const [ tooltip, setTooltip ] = useState( false );
 	return (
-		<div className="reader-views">
+		<div
+			className="reader-views"
+			ref={ buttonRef }
+			onMouseEnter={ () => setTooltip( true ) }
+			onMouseLeave={ () => setTooltip( false ) }
+		>
 			<SVGIcon classes="reader-views__icon" name="bar-chart" size="20" icon={ BarChart } />
 			<span className="reader-views__view-count">{ viewCount }</span>
+			<Tooltip isVisible={ tooltip } position="bottom left" context={ buttonRef.current }>
+				{ translate( 'Views' ) }
+			</Tooltip>
 		</div>
 	);
 };

--- a/client/blocks/reader-views/style.scss
+++ b/client/blocks/reader-views/style.scss
@@ -1,5 +1,5 @@
 .reader-views {
-	display: flex;
+	display: inline-flex;
 }
 
 .reader-views__view-count {

--- a/client/blocks/reader-visit-link/index.jsx
+++ b/client/blocks/reader-visit-link/index.jsx
@@ -1,41 +1,51 @@
+import { translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { useRef, useState } from 'react';
 import ExternalLink from 'calypso/components/external-link';
+import Tooltip from 'calypso/components/tooltip';
 import ReaderExternalIcon from 'calypso/reader/components/icons/external-icon';
 
 import './style.scss';
 
 const noop = () => {};
 
-class ReaderVisitLink extends Component {
-	static propTypes = {
-		href: PropTypes.string,
-		iconSize: PropTypes.number,
-		onClick: PropTypes.func,
-	};
+const ReaderVisitLink = ( props ) => {
+	const linkRef = useRef();
+	const [ tooltip, setTooltip ] = useState( false );
 
-	static defaultProps = {
-		iconSize: 24,
-		onClick: noop,
-	};
+	return (
+		<ExternalLink
+			className="reader-visit-link"
+			href={ props.href }
+			target="_blank"
+			icon={ true }
+			showIconFirst={ true }
+			iconSize={ 24 }
+			iconClassName="reader-visit-link__icon"
+			iconComponent={ ReaderExternalIcon( { iconSize: 20 } ) }
+			onClick={ props.onClick }
+			ref={ linkRef }
+			onMouseEnter={ () => setTooltip( true ) }
+			onMouseLeave={ () => setTooltip( false ) }
+		>
+			<span className="reader-visit-link__label">{ props.children }</span>
 
-	render() {
-		return (
-			<ExternalLink
-				className="reader-visit-link"
-				href={ this.props.href }
-				target="_blank"
-				icon={ true }
-				showIconFirst={ true }
-				iconSize={ 24 }
-				iconClassName="reader-visit-link__icon"
-				iconComponent={ ReaderExternalIcon( { iconSize: 20 } ) }
-				onClick={ this.props.onClick }
-			>
-				<span className="reader-visit-link__label">{ this.props.children }</span>
-			</ExternalLink>
-		);
-	}
-}
+			<Tooltip isVisible={ tooltip } position="bottom left" context={ linkRef.current }>
+				{ translate( 'Views' ) }
+			</Tooltip>
+		</ExternalLink>
+	);
+};
+
+ReaderVisitLink.propTypes = {
+	href: PropTypes.string,
+	iconSize: PropTypes.number,
+	onClick: PropTypes.func,
+};
+
+ReaderVisitLink.defaultProps = {
+	iconSize: 24,
+	onClick: noop,
+};
 
 export default ReaderVisitLink;

--- a/client/blocks/reader-visit-link/index.jsx
+++ b/client/blocks/reader-visit-link/index.jsx
@@ -31,7 +31,10 @@ const ReaderVisitLink = ( props ) => {
 			<span className="reader-visit-link__label">{ props.children }</span>
 
 			<Tooltip isVisible={ tooltip } position="bottom left" context={ linkRef.current }>
-				{ translate( 'Views' ) }
+				{
+					// translators: The label of an external link to view the post
+					translate( 'Visit' )
+				}
 			</Tooltip>
 		</ExternalLink>
 	);


### PR DESCRIPTION
Follows up on https://github.com/Automattic/wp-calypso/pull/80220 as part of pe7F0s-19J-p2.

This PR adds tooltips to the reader buttons: 

Buttons are also shown on the post details page and conversations tab.


### Testing instructions
Mouse over icon buttons on reader pages (including conversations page)
All icon buttons without a label should have a tooltip.

