### PR TITLE
Redirect to Customer Home from domain-upsell flow in some cases

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/domain-upsell.ts
@@ -1,11 +1,7 @@
+import { OnboardSelect, updateLaunchpadSettings, useLaunchpad } from '@automattic/data-stores';
+import { addPlanToCart, addProductsToCart, DOMAIN_UPSELL_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
-import { OnboardSelect, updateLaunchpadSettings } from 'calypso/../packages/data-stores/src';
-import {
-	addPlanToCart,
-	addProductsToCart,
-	DOMAIN_UPSELL_FLOW,
-} from 'calypso/../packages/onboarding/src';
 import { useQuery } from '../hooks/use-query';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
@@ -40,8 +36,12 @@ const domainUpsell: Flow = {
 			[]
 		);
 		const { setHideFreePlan } = useDispatch( ONBOARD_STORE );
+		const { data: { launchpad_screen: launchpadScreenOption } = {} } = useLaunchpad( siteSlug );
 
-		const returnUrl = `/setup/${ flowName ?? 'free' }/launchpad?siteSlug=${ siteSlug }`;
+		const returnUrl =
+			launchpadScreenOption === 'skipped'
+				? `/home/${ siteSlug }`
+				: `/setup/${ flowName ?? 'free' }/launchpad?siteSlug=${ siteSlug }`;
 		const encodedReturnUrl = encodeURIComponent( returnUrl );
 
 		function goBack() {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* https://github.com/Automattic/wp-calypso/pull/81363
* https://github.com/Automattic/wp-calypso/pull/80661
* https://github.com/Automattic/wp-calypso/issues/76876

## Proposed Changes

* This PR updates the `domain-upsell` Stepper flow to correctly redirect to Customer Home when users have skipped the fullscreen launchpad.
* The PR also fixes some imports to use the correct `@automattic/*` source package instead of reaching into the `src` directory.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You need to ether have a site that has the `launchad_screen` option set to `'skipped'`, or you can create a new site from `/start`, select "Write & Publish" from the goals screen, and click on "Skip for now" when you get to the fullscreen launchpad
* For the abovementioned site, navigate to `/setup/domain-upsell/domains?siteSlug=:yourSiteSlug`
* Click on the "Choose a domain later" link on the right hand side
* Verify that you're taken directly back to `/home/:siteSlug`
* Load `/setup/domain-upsell/domains?siteSlug=:yourSiteSlug` again
* Click on the "Back" link in the top left corner
* Verify that you're taken directly back to `/home/:siteSlug`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?