### PR TITLE
Earn modal: allow deep linking without Stripe connection

### DIFF
--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -168,7 +168,7 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 						{ renderEllipsisMenu( currentProduct?.ID ?? null ) }
 					</CompactCard>
 				) ) }
-			{ hasLoadedFeatures && showAddEditDialog && hasStripeFeature && connectedAccountId && (
+			{ hasLoadedFeatures && showAddEditDialog && (
 				<RecurringPaymentsPlanAddEditModal
 					closeDialog={ closeDialog }
 					product={ Object.assign( product ?? {}, {


### PR DESCRIPTION
Allow deep-linking to earn page with "add payment plan" modal open without needing to have Stripe connected first.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Backend has been already modified to allow adding paid plans without stripe being connected, so this will just open the possibility in the UI.

## Proposed Changes
- Remove "is stripe connected" check for deep linking into "add paid plans" modal.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open link such as `/earn/payments-plans/YOUR_SITE#add-newsletter-payment-plan` for a site which doesn't have Stripe connected yet.
* Try adding and removing paid plans

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?