### PR TITLE
Paid/Free Confidence check experiment name update

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -7,7 +7,7 @@ const useIsCustomDomainAllowedOnFreePlan = (
 ): DataResponse< boolean > => {
 	const EXPERIMENT_NAME =
 		flowName === 'onboarding'
-			? 'calypso_onboarding_plans_paid_domain_on_free_plan'
+			? 'calypso_onboarding_plans_paid_domain_on_free_plan_confidence_check'
 			: 'calypso_onboardingpm_plans_paid_domain_on_free_plan';
 	const [ isLoading, assignment ] = useExperiment( EXPERIMENT_NAME, {
 		isEligible: [ 'onboarding', 'onboarding-pm' ].includes( flowName ?? '' ) && hasPaidDomainName,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -286,7 +286,9 @@ class DomainsStep extends Component {
 		switch ( flowName ) {
 			case 'onboarding':
 				if ( isPurchasingItem ) {
-					loadExperimentAssignment( 'calypso_onboarding_plans_paid_domain_on_free_plan' );
+					loadExperimentAssignment(
+						'calypso_onboarding_plans_paid_domain_on_free_plan_confidence_check'
+					);
 				} else {
 					loadExperimentAssignment(
 						'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3'

--- a/packages/data-stores/src/domain-suggestions/queries.ts
+++ b/packages/data-stores/src/domain-suggestions/queries.ts
@@ -70,7 +70,7 @@ export function useGetWordPressSubdomain( paidDomainName: string ) {
 		quantity: 1,
 		include_wordpressdotcom: true,
 		include_dotblogsubdomain: false,
-		only_wordpressdotcom: true,
+		only_wordpressdotcom: false,
 		vendor: 'dot',
 	} );
 }

--- a/packages/data-stores/src/domain-suggestions/queries.ts
+++ b/packages/data-stores/src/domain-suggestions/queries.ts
@@ -70,7 +70,7 @@ export function useGetWordPressSubdomain( paidDomainName: string ) {
 		quantity: 1,
 		include_wordpressdotcom: true,
 		include_dotblogsubdomain: false,
-		only_wordpressdotcom: false,
+		only_wordpressdotcom: true,
 		vendor: 'dot',
 	} );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 

- https://github.com/Automattic/wp-calypso/pull/80647
- 21394-explat-experiment

#Fixes Automattic/growth-foundations#186

## Proposed Changes

* Change the experiment name to the confidence check experiment `calypso_onboarding_plans_paid_domain_on_free_plan_confidence_check`
* Fixes the domain generation where domain were not generating for some domain queries.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the assignments works as expected. (Should show the domain purchase allowed modal)
<img width="805" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/ba9eb78c-c1a0-4916-a862-e4b8b90f398e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?