### PR TITLE
Marketplace Themes on Onboarding eligibility modal

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -46,7 +46,7 @@ const noop = () => {};
 interface ExternalProps {
 	siteId?: number | null;
 	isEligible?: boolean;
-	backUrl: string;
+	backUrl?: string;
 	onProceed: ( options: { geo_affinity?: string } ) => void;
 	standaloneProceed: boolean;
 	className?: string;

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -44,6 +44,7 @@ import './style.scss';
 const noop = () => {};
 
 interface ExternalProps {
+	siteId?: number | null;
 	isEligible?: boolean;
 	backUrl: string;
 	onProceed: ( options: { geo_affinity?: string } ) => void;
@@ -357,7 +358,7 @@ const processMarketplaceExceptions = (
 };
 
 const mapStateToProps = ( state: Record< string, unknown >, ownProps: ExternalProps ) => {
-	const siteId = getSelectedSiteId( state );
+	const siteId = getSelectedSiteId( state ) || ownProps.siteId || null;
 	const siteSlug = getSelectedSiteSlug( state );
 	let eligibilityData = ownProps.eligibilityData || getEligibility( state, siteId );
 	let isEligible = ownProps.isEligible || isEligibleForAutomatedTransfer( state, siteId );

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -53,6 +53,7 @@ interface ExternalProps {
 	eligibilityData?: EligibilityData;
 	currentContext?: string;
 	isMarketplace?: boolean;
+	isMarketplaceException?: boolean;
 	showDataCenterPicker?: boolean;
 	disableContinueButton?: boolean;
 }
@@ -321,7 +322,7 @@ EligibilityWarnings.defaultProps = {
 
 /**
  * processMarketplaceExceptions: Remove 'NO_BUSINESS_PLAN' holds if the
- * INSTALL_PURCHASED_PLUGINS feature is present.
+ * INSTALL_PURCHASED_PLUGINS feature is present or it is a marketplace exception.
  *
  * Starter plans do not have the ATOMIC feature, but they have the
  * INSTALL_PURCHASED_PLUGINS feature which allows them to buy marketplace
@@ -335,16 +336,20 @@ EligibilityWarnings.defaultProps = {
 const processMarketplaceExceptions = (
 	state: Record< string, unknown >,
 	eligibilityData: EligibilityData,
-	isEligible: boolean
+	isEligible: boolean,
+	isMarketplaceException?: boolean
 ) => {
 	// If no eligibilityHolds are defined, skip.
 	if ( typeof eligibilityData.eligibilityHolds === 'undefined' ) {
 		return { eligibilityData, isEligible };
 	}
 
-	// If missing INSTALL_PURCHASED_PLUGINS feature, skip.
+	// If not explicit exception and missing INSTALL_PURCHASED_PLUGINS feature, skip.
 	const siteId = getSelectedSiteId( state );
-	if ( ! siteHasFeature( state, siteId, WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS ) ) {
+	if (
+		! isMarketplaceException &&
+		! siteHasFeature( state, siteId, WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS )
+	) {
 		return { eligibilityData, isEligible };
 	}
 
@@ -368,7 +373,8 @@ const mapStateToProps = ( state: Record< string, unknown >, ownProps: ExternalPr
 		( { eligibilityData, isEligible } = processMarketplaceExceptions(
 			state,
 			eligibilityData,
-			isEligible
+			isEligible,
+			ownProps.isMarketplaceException
 		) );
 	}
 

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -53,7 +53,7 @@ interface ExternalProps {
 	eligibilityData?: EligibilityData;
 	currentContext?: string;
 	isMarketplace?: boolean;
-	isMarketplaceException?: boolean;
+	isOnboarding?: boolean;
 	showDataCenterPicker?: boolean;
 	disableContinueButton?: boolean;
 }
@@ -322,7 +322,7 @@ EligibilityWarnings.defaultProps = {
 
 /**
  * processMarketplaceExceptions: Remove 'NO_BUSINESS_PLAN' holds if the
- * INSTALL_PURCHASED_PLUGINS feature is present or it is a marketplace exception.
+ * INSTALL_PURCHASED_PLUGINS feature is present or is onboarding flow.
  *
  * Starter plans do not have the ATOMIC feature, but they have the
  * INSTALL_PURCHASED_PLUGINS feature which allows them to buy marketplace
@@ -332,12 +332,15 @@ EligibilityWarnings.defaultProps = {
  * 'NO_BUSINESS_PLAN' hold on atomic transfer; however, if we're about to buy a
  * marketplace addon which provides the ATOMIC feature, then we can ignore this
  * hold.
+ *
+ * The Onboarding flow takes care of upgrading the Business plan so we can
+ * can ignore the 'NO_BUSINESS_PLAN' hold.
  */
 const processMarketplaceExceptions = (
 	state: Record< string, unknown >,
 	eligibilityData: EligibilityData,
 	isEligible: boolean,
-	isMarketplaceException?: boolean
+	isOnboarding?: boolean
 ) => {
 	// If no eligibilityHolds are defined, skip.
 	if ( typeof eligibilityData.eligibilityHolds === 'undefined' ) {
@@ -347,7 +350,7 @@ const processMarketplaceExceptions = (
 	// If not explicit exception and missing INSTALL_PURCHASED_PLUGINS feature, skip.
 	const siteId = getSelectedSiteId( state );
 	if (
-		! isMarketplaceException &&
+		! isOnboarding &&
 		! siteHasFeature( state, siteId, WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS )
 	) {
 		return { eligibilityData, isEligible };
@@ -374,7 +377,7 @@ const mapStateToProps = ( state: Record< string, unknown >, ownProps: ExternalPr
 			state,
 			eligibilityData,
 			isEligible,
-			ownProps.isMarketplaceException
+			ownProps.isOnboarding
 		) );
 	}
 

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -347,7 +347,7 @@ const processMarketplaceExceptions = (
 		return { eligibilityData, isEligible };
 	}
 
-	// If not explicit exception and missing INSTALL_PURCHASED_PLUGINS feature, skip.
+	// If is not Onboarding flow and missing INSTALL_PURCHASED_PLUGINS feature, skip.
 	const siteId = getSelectedSiteId( state );
 	if (
 		! isOnboarding &&

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/eligibility-warnings-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/eligibility-warnings-modal.scss
@@ -1,0 +1,5 @@
+.eligibility-warnings-modal__dialog-content {
+	.dialog__content {
+		padding: 0;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/eligibility-warnings-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/eligibility-warnings-modal.tsx
@@ -1,6 +1,7 @@
 import { Dialog } from '@automattic/components';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import type { SiteDetails } from '@automattic/data-stores';
+import './eligibility-warnings-modal.scss';
 
 export const EligibilityWarningsModal = ( {
 	site,
@@ -17,8 +18,7 @@ export const EligibilityWarningsModal = ( {
 } ) => {
 	return (
 		<Dialog
-			additionalClassNames="plugin-details-cta__dialog-content"
-			additionalOverlayClassNames="plugin-details-cta__modal-overlay"
+			additionalClassNames="eligibility-warnings-modal__dialog-content"
 			isVisible={ isOpen }
 			onClose={ handleClose }
 			showCloseIcon={ true }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/eligibility-warnings-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/eligibility-warnings-modal.tsx
@@ -25,12 +25,10 @@ export const EligibilityWarningsModal = ( {
 		>
 			<EligibilityWarnings
 				siteId={ site?.ID }
-				currentContext="plugin-details"
 				standaloneProceed
 				isMarketplace={ isMarketplace }
 				isMarketplaceException={ isMarketplace }
 				onProceed={ handleContinue }
-				backUrl="#"
 			/>
 		</Dialog>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/eligibility-warnings-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/eligibility-warnings-modal.tsx
@@ -26,8 +26,8 @@ export const EligibilityWarningsModal = ( {
 			<EligibilityWarnings
 				siteId={ site?.ID }
 				standaloneProceed
+				isOnboarding
 				isMarketplace={ isMarketplace }
-				isMarketplaceException={ isMarketplace }
 				onProceed={ handleContinue }
 			/>
 		</Dialog>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/eligibility-warnings-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/eligibility-warnings-modal.tsx
@@ -1,0 +1,37 @@
+import { Dialog } from '@automattic/components';
+import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
+import type { SiteDetails } from '@automattic/data-stores';
+
+export const EligibilityWarningsModal = ( {
+	site,
+	isMarketplace,
+	isOpen,
+	handleClose,
+	handleContinue,
+}: {
+	site?: SiteDetails;
+	isMarketplace?: boolean;
+	isOpen: boolean;
+	handleClose: () => void;
+	handleContinue: () => void;
+} ) => {
+	return (
+		<Dialog
+			additionalClassNames="plugin-details-cta__dialog-content"
+			additionalOverlayClassNames="plugin-details-cta__modal-overlay"
+			isVisible={ isOpen }
+			onClose={ handleClose }
+			showCloseIcon={ true }
+		>
+			<EligibilityWarnings
+				siteId={ site?.ID }
+				currentContext="plugin-details"
+				standaloneProceed
+				isMarketplace={ isMarketplace }
+				isMarketplaceException={ isMarketplace }
+				onProceed={ handleContinue }
+				backUrl="#"
+			/>
+		</Dialog>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -49,6 +49,12 @@ jest.mock( 'calypso/state/themes/theme-utils', () => ( {
 	},
 } ) );
 
+jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
+	getEligibility: () => {
+		return;
+	},
+} ) );
+
 jest.mock( 'calypso/my-sites/themes/helpers', () => ( {
 	marketplaceThemeBillingProductSlug: () => {
 		return;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -40,6 +40,7 @@ import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
 import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { setActiveTheme, activateOrInstallThenActivate } from 'calypso/state/themes/actions';
 import {
 	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
@@ -116,6 +117,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isSiteAtomic( site.ID ),
 		[ site ]
 	);
+	const isJetpack = useSelector( ( state ) => site && isJetpackSite( state, site?.ID ) );
 	useEffect( () => {
 		if ( isAtomic ) {
 			exitFlow?.( `/site-editor/${ siteSlugOrId }` );
@@ -400,6 +402,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const hasEligibilityMessages =
 		! isAtomic &&
+		! isJetpack &&
 		( eligibility?.eligibilityHolds?.length || eligibility?.eligibilityWarnings?.length );
 
 	const getBadge = ( themeId: string, isLockedStyleVariation: boolean ) => (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -24,6 +24,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useRef, useState, useEffect, useMemo } from 'react';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import AsyncLoad from 'calypso/components/async-load';
+import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import { useQueryProductsList } from 'calypso/components/data/query-products-list';
 import { useQuerySiteFeatures } from 'calypso/components/data/query-site-features';
 import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
@@ -758,6 +759,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					closeModal={ closeUpgradeModal }
 					checkout={ handleCheckout }
 				/>
+				<QueryEligibility siteId={ site?.ID } />
 				<Dialog
 					additionalClassNames="plugin-details-cta__dialog-content"
 					additionalOverlayClassNames="plugin-details-cta__modal-overlay"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -768,6 +768,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					showCloseIcon={ true }
 				>
 					<EligibilityWarnings
+						siteId={ site?.ID }
 						currentContext="plugin-details"
 						standaloneProceed
 						isMarketplace={ selectedDesign?.is_externally_managed }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -40,7 +40,6 @@ import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
 import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { setActiveTheme, activateOrInstallThenActivate } from 'calypso/state/themes/actions';
 import {
 	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
@@ -113,11 +112,14 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const { goToCheckout } = useCheckout();
 
+	const isJetpack = useSelect(
+		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isJetpackSite( site.ID ),
+		[ site ]
+	);
 	const isAtomic = useSelect(
 		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isSiteAtomic( site.ID ),
 		[ site ]
 	);
-	const isJetpack = useSelector( ( state ) => site && isJetpackSite( state, site?.ID ) );
 	useEffect( () => {
 		if ( isAtomic ) {
 			exitFlow?.( `/site-editor/${ siteSlugOrId }` );

--- a/client/my-sites/themes/atomic-transfer-dialog.tsx
+++ b/client/my-sites/themes/atomic-transfer-dialog.tsx
@@ -225,8 +225,8 @@ class AtomicTransferDialog extends Component< AtomicTransferDialogProps > {
 }
 
 export default connect(
-	( state: IAppState ) => {
-		const siteId = getSelectedSiteId( state );
+	( state: IAppState, ownProps?: AtomicTransferDialogProps | { siteId: number } ) => {
+		const siteId = getSelectedSiteId( state ) ?? ownProps?.siteId;
 		const themeId = getThemeForAtomicTransferDialog( state );
 
 		if ( ! siteId ) {

--- a/client/my-sites/themes/atomic-transfer-dialog.tsx
+++ b/client/my-sites/themes/atomic-transfer-dialog.tsx
@@ -225,8 +225,8 @@ class AtomicTransferDialog extends Component< AtomicTransferDialogProps > {
 }
 
 export default connect(
-	( state: IAppState, ownProps?: AtomicTransferDialogProps | { siteId: number } ) => {
-		const siteId = getSelectedSiteId( state ) ?? ownProps?.siteId;
+	( state: IAppState ) => {
+		const siteId = getSelectedSiteId( state );
 		const themeId = getThemeForAtomicTransferDialog( state );
 
 		if ( ! siteId ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Solves #81316

## Proposed Changes

* Displays the eligibility warnings modal when the site is going to be transferred to Atomic

<img width="754" alt="CleanShot 2023-09-14 at 12 20 55@2x" src="https://github.com/Automattic/wp-calypso/assets/3519124/5d2aefd3-f2f9-455c-b68d-42aac630daf7">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The following three scenarios should be tested. The first two steps are common for all three:

* Apply the diff D118900-code to your sandbox and direct requests to the sandbox
* Go to the Design Picker page with a Marketplace theme selected `/setup/update-design/designSetup?siteSlug=:site&theme=:theme_slug`. Theme slugs such as `makoney` and `olsen-fse` can be used. 

### Business site that is not yet Atomic
* Select a site in the URL above with the business plan, but it has not been moved to Atomic. This can be achieved by upgrading a Premium or Free site to a Business plan
* Click on `Unlock Theme`
* The `Unlock this partner theme` modal is displayed with the theme. Click on `Continue`
* You should see the eligibility modal warning that the domain is going to change
* Proceed clicking on `Continue`
* You should be redirected to the Checkout with the selected Theme

### Non-business site 
* Select a site in the URL above with a non-business plan, for example a Free or Premium site
* Click on `Unlock Theme`
* The `Unlock this partner theme` modal is displayed with the Business plan and the theme. Click on `Continue`
* You should see the eligibility modal warning that the domain is going to change
* Proceed clicking on `Continue`
* You should be redirected to the Checkout with the selected Theme and the Business plan

### Business Atomic site 
* Select an Atomic site in the URL
* Click on `Unlock Theme`
* The `Unlock this partner theme` modal is displayed with the theme. Click on `Continue`
* You should be redirected to the Checkout with the selected Theme and the Business plan

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?