### PR TITLE
Newsletter Categories: Add newsletter categories to Subscribers page

### DIFF
--- a/client/data/newsletter-categories/types.ts
+++ b/client/data/newsletter-categories/types.ts
@@ -12,6 +12,7 @@ export type Category = {
 };
 
 export type NewsletterCategories = {
+	enabled: boolean;
 	newsletterCategories: NewsletterCategory[];
 };
 

--- a/client/data/newsletter-categories/use-mark-as-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-mark-as-newsletter-category-mutation.tsx
@@ -41,7 +41,7 @@ const useMarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 				) as NewsletterCategory;
 
 				const updatedData = {
-					...oldData,
+					enabled: oldData?.enabled || false,
 					newsletterCategories: [
 						...( oldData?.newsletterCategories ? oldData.newsletterCategories : [] ),
 						newNewsletterCategory,

--- a/client/data/newsletter-categories/use-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-newsletter-categories-query.tsx
@@ -7,13 +7,17 @@ type NewsletterCategoryQueryProps = {
 };
 
 type NewsletterCategoryResponse = {
+	enabled: boolean;
 	newsletter_categories: NewsletterCategory[];
 };
 
 const convertNewsletterCategoryResponse = (
 	response: NewsletterCategoryResponse
 ): NewsletterCategories => {
-	return { newsletterCategories: response.newsletter_categories };
+	return {
+		enabled: response.enabled,
+		newsletterCategories: response.newsletter_categories,
+	};
 };
 
 export const getNewsletterCategoriesKey = ( siteId?: string | number ) => [

--- a/client/data/newsletter-categories/use-subscriber-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-subscriber-newsletter-categories-query.tsx
@@ -3,7 +3,7 @@ import request from 'wpcom-proxy-request';
 import { NewsletterCategories, NewsletterCategory } from './types';
 
 type NewsletterCategoryQueryProps = {
-	siteId: number;
+	siteId?: number;
 	subscriptionId?: number;
 };
 

--- a/client/data/newsletter-categories/use-subscriber-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-subscriber-newsletter-categories-query.tsx
@@ -4,16 +4,17 @@ import { NewsletterCategories, NewsletterCategory } from './types';
 
 type NewsletterCategoryQueryProps = {
 	siteId: number;
+	subscriptionId?: number;
 };
 
 type NewsletterCategoryResponse = {
 	newsletter_categories: NewsletterCategory[];
 };
 
-export const getSubscriberNewsletterCategoriesKey = ( siteId?: string | number ) => [
-	`newsletter-categories`,
-	siteId,
-];
+export const getSubscriberNewsletterCategoriesKey = (
+	siteId?: string | number,
+	subscriptionId?: number
+) => [ `newsletter-categories`, siteId, subscriptionId ];
 
 const convertNewsletterCategoryResponse = (
 	response: NewsletterCategoryResponse
@@ -23,12 +24,15 @@ const convertNewsletterCategoryResponse = (
 
 const useSubscriberNewsletterCategories = ( {
 	siteId,
+	subscriptionId,
 }: NewsletterCategoryQueryProps ): UseQueryResult< NewsletterCategories > => {
 	return useQuery( {
-		queryKey: getSubscriberNewsletterCategoriesKey( siteId ),
+		queryKey: getSubscriberNewsletterCategoriesKey( siteId, subscriptionId ),
 		queryFn: () =>
 			request< NewsletterCategoryResponse >( {
-				path: `/sites/${ siteId }/newsletter-categories/subscriptions`,
+				path: `/sites/${ siteId }/newsletter-categories/subscriptions${
+					subscriptionId ? `/${ subscriptionId }` : ''
+				}`,
 				apiVersion: '2',
 				apiNamespace: 'wpcom/v2',
 			} ).then( convertNewsletterCategoryResponse ),

--- a/client/data/newsletter-categories/use-subscriber-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-subscriber-newsletter-categories-query.tsx
@@ -8,6 +8,7 @@ type NewsletterCategoryQueryProps = {
 };
 
 type NewsletterCategoryResponse = {
+	enabled: boolean;
 	newsletter_categories: NewsletterCategory[];
 };
 
@@ -18,9 +19,10 @@ export const getSubscriberNewsletterCategoriesKey = (
 
 const convertNewsletterCategoryResponse = (
 	response: NewsletterCategoryResponse
-): NewsletterCategories => {
-	return { newsletterCategories: response.newsletter_categories };
-};
+): NewsletterCategories => ( {
+	enabled: response.enabled,
+	newsletterCategories: response.newsletter_categories,
+} );
 
 const useSubscriberNewsletterCategories = ( {
 	siteId,

--- a/client/data/newsletter-categories/use-unmark-as-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-unmark-as-newsletter-category-mutation.tsx
@@ -37,7 +37,7 @@ const useUnmarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 
 			queryClient.setQueryData( cacheKey, ( oldData?: NewsletterCategories ) => {
 				const updatedData = {
-					...oldData,
+					enabled: oldData?.enabled || false,
 					newsletterCategories:
 						oldData?.newsletterCategories.filter(
 							( category: NewsletterCategory ) => category.id !== categoryId

--- a/client/my-sites/subscribers/components/subscriber-details/styles.scss
+++ b/client/my-sites/subscribers/components/subscriber-details/styles.scss
@@ -20,8 +20,7 @@
 		}
 
 		.subscriber-details__content-column {
-			flex-basis: 33.3%;
-			flex-grow: 1;
+			flex: 1 1 0;
 			overflow: hidden;
 			word-wrap: break-word;
 		}

--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import TimeSince from 'calypso/components/time-since';
-import useSubscriberNewsletterCategories from 'calypso/data/newsletter-categories/use-subscriber-newsletter-categories-query';
+import { NewsletterCategory } from 'calypso/data/newsletter-categories/types';
 import { useSubscriptionPlans } from '../../hooks';
 import { Subscriber } from '../../types';
 import { SubscriberProfile } from '../subscriber-profile';
@@ -15,6 +15,8 @@ type SubscriberDetailsProps = {
 	siteId: number;
 	subscriptionId?: number;
 	userId?: number;
+	newsletterCategoriesEnabled?: boolean;
+	newsletterCategories?: NewsletterCategory[];
 };
 
 const SubscriberDetails = ( {
@@ -22,16 +24,14 @@ const SubscriberDetails = ( {
 	siteId,
 	subscriptionId,
 	userId,
+	newsletterCategoriesEnabled,
+	newsletterCategories,
 }: SubscriberDetailsProps ) => {
 	const translate = useTranslate();
 	const subscriptionPlans = useSubscriptionPlans( subscriber );
-	const { data: newsletterCategoriesResult } = useSubscriberNewsletterCategories( {
-		siteId,
-		subscriptionId: subscriptionId || subscriber.subscription_id,
-	} );
 	const newsletterCategoryNames = useMemo(
-		() => newsletterCategoriesResult?.newsletterCategories.map( ( category ) => category.name ),
-		[ newsletterCategoriesResult?.newsletterCategories ]
+		() => newsletterCategories?.map( ( category ) => category.name ),
+		[ newsletterCategories ]
 	);
 	const { avatar, date_subscribed, display_name, email_address, country, url } = subscriber;
 
@@ -67,19 +67,18 @@ const SubscriberDetails = ( {
 							dateFormat="LL"
 						/>
 					</div>
-					{ config.isEnabled( 'settings/newsletter-categories' ) &&
-						newsletterCategoriesResult?.enabled && (
-							<div className="subscriber-details__content-column">
-								<div className="subscriber-details__content-label">
-									{ translate( 'Receives emails for' ) }
-								</div>
-								<div className="subscriber-details__content-value">
-									{ newsletterCategoryNames
-										? newsletterCategoryNames.join( ', ' )
-										: translate( 'Not subscribed to any newsletter categories' ) }
-								</div>
+					{ config.isEnabled( 'settings/newsletter-categories' ) && newsletterCategoriesEnabled && (
+						<div className="subscriber-details__content-column">
+							<div className="subscriber-details__content-label">
+								{ translate( 'Receives emails for' ) }
 							</div>
-						) }
+							<div className="subscriber-details__content-value">
+								{ newsletterCategoryNames
+									? newsletterCategoryNames.join( ', ' )
+									: translate( 'Not subscribed to any newsletter categories' ) }
+							</div>
+						</div>
+					) }
 					<div className="subscriber-details__content-column">
 						<div className="subscriber-details__content-label">{ translate( 'Plan' ) }</div>
 						{ subscriptionPlans &&

--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -67,18 +67,19 @@ const SubscriberDetails = ( {
 							dateFormat="LL"
 						/>
 					</div>
-					{ newsletterCategoriesResult?.enabled && (
-						<div className="subscriber-details__content-column">
-							<div className="subscriber-details__content-label">
-								{ translate( 'Receives emails for' ) }
+					{ config.isEnabled( 'settings/newsletter-categories' ) &&
+						newsletterCategoriesResult?.enabled && (
+							<div className="subscriber-details__content-column">
+								<div className="subscriber-details__content-label">
+									{ translate( 'Receives emails for' ) }
+								</div>
+								<div className="subscriber-details__content-value">
+									{ newsletterCategoryNames
+										? newsletterCategoryNames.join( ', ' )
+										: translate( 'Not subscribed to any newsletter categories' ) }
+								</div>
 							</div>
-							<div className="subscriber-details__content-value">
-								{ newsletterCategoryNames
-									? newsletterCategoryNames.join( ', ' )
-									: translate( 'Not subscribed to any newsletter categories' ) }
-							</div>
-						</div>
-					) }
+						) }
 					<div className="subscriber-details__content-column">
 						<div className="subscriber-details__content-label">{ translate( 'Plan' ) }</div>
 						{ subscriptionPlans &&

--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -25,13 +25,13 @@ const SubscriberDetails = ( {
 }: SubscriberDetailsProps ) => {
 	const translate = useTranslate();
 	const subscriptionPlans = useSubscriptionPlans( subscriber );
-	const newsletterCategories = useSubscriberNewsletterCategories( {
+	const { data: newsletterCategoriesResult } = useSubscriberNewsletterCategories( {
 		siteId,
 		subscriptionId: subscriptionId || subscriber.subscription_id,
 	} );
 	const newsletterCategoryNames = useMemo(
-		() => newsletterCategories.data?.newsletterCategories.map( ( category ) => category.name ),
-		[ newsletterCategories.data?.newsletterCategories ]
+		() => newsletterCategoriesResult?.newsletterCategories.map( ( category ) => category.name ),
+		[ newsletterCategoriesResult?.newsletterCategories ]
 	);
 	const { avatar, date_subscribed, display_name, email_address, country, url } = subscriber;
 
@@ -67,16 +67,18 @@ const SubscriberDetails = ( {
 							dateFormat="LL"
 						/>
 					</div>
-					<div className="subscriber-details__content-column">
-						<div className="subscriber-details__content-label">
-							{ translate( 'Receives emails for' ) }
+					{ newsletterCategoriesResult?.enabled && (
+						<div className="subscriber-details__content-column">
+							<div className="subscriber-details__content-label">
+								{ translate( 'Receives emails for' ) }
+							</div>
+							<div className="subscriber-details__content-value">
+								{ newsletterCategoryNames
+									? newsletterCategoryNames.join( ', ' )
+									: translate( 'Not subscribed to any newsletter categories' ) }
+							</div>
 						</div>
-						<div className="subscriber-details__content-value">
-							{ newsletterCategoryNames
-								? newsletterCategoryNames.join( ', ' )
-								: translate( 'Not subscribed to any newsletter categories' ) }
-						</div>
-					</div>
+					) }
 					<div className="subscriber-details__content-column">
 						<div className="subscriber-details__content-label">{ translate( 'Plan' ) }</div>
 						{ subscriptionPlans &&

--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -1,6 +1,8 @@
 import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import TimeSince from 'calypso/components/time-since';
+import useSubscriberNewsletterCategories from 'calypso/data/newsletter-categories/use-subscriber-newsletter-categories-query';
 import { useSubscriptionPlans } from '../../hooks';
 import { Subscriber } from '../../types';
 import { SubscriberProfile } from '../subscriber-profile';
@@ -23,6 +25,14 @@ const SubscriberDetails = ( {
 }: SubscriberDetailsProps ) => {
 	const translate = useTranslate();
 	const subscriptionPlans = useSubscriptionPlans( subscriber );
+	const newsletterCategories = useSubscriberNewsletterCategories( {
+		siteId,
+		subscriptionId: subscriptionId || subscriber.subscription_id,
+	} );
+	const newsletterCategoryNames = useMemo(
+		() => newsletterCategories.data?.newsletterCategories.map( ( category ) => category.name ),
+		[ newsletterCategories.data?.newsletterCategories ]
+	);
 	const { avatar, date_subscribed, display_name, email_address, country, url } = subscriber;
 
 	const notApplicableLabel = translate( 'N/A', {
@@ -56,6 +66,16 @@ const SubscriberDetails = ( {
 							date={ date_subscribed }
 							dateFormat="LL"
 						/>
+					</div>
+					<div className="subscriber-details__content-column">
+						<div className="subscriber-details__content-label">
+							{ translate( 'Receives emails for' ) }
+						</div>
+						<div className="subscriber-details__content-value">
+							{ newsletterCategoryNames
+								? newsletterCategoryNames.join( ', ' )
+								: translate( 'Not subscribed to any newsletter categories' ) }
+						</div>
 					</div>
 					<div className="subscriber-details__content-column">
 						<div className="subscriber-details__content-label">{ translate( 'Plan' ) }</div>

--- a/client/my-sites/subscribers/subscriber-details-page.tsx
+++ b/client/my-sites/subscribers/subscriber-details-page.tsx
@@ -1,10 +1,11 @@
-import { Spinner } from '@wordpress/components';
+import { Spinner } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useDispatch } from 'react-redux';
 import { Item } from 'calypso/components/breadcrumb';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import Main from 'calypso/components/main';
+import useSubscriberNewsletterCategories from 'calypso/data/newsletter-categories/use-subscriber-newsletter-categories-query';
 import { useSelector } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -39,11 +40,19 @@ const SubscriberDetailsPage = ( {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 
-	const { data: subscriber, isLoading } = useSubscriberDetailsQuery(
+	const { data: subscriber, isLoading: isLoadingDetails } = useSubscriberDetailsQuery(
 		selectedSiteId,
 		subscriptionId,
 		userId
 	);
+
+	const { data: newsletterCategoriesData, isLoading: isLoadingNewsletterCategories } =
+		useSubscriberNewsletterCategories( {
+			siteId: selectedSiteId as number,
+			subscriptionId: subscriptionId || subscriber?.subscription_id,
+		} );
+
+	const isLoading = isLoadingDetails || isLoadingNewsletterCategories;
 
 	const pageArgs = {
 		currentPage: pageNumber,
@@ -105,6 +114,8 @@ const SubscriberDetailsPage = ( {
 					siteId={ selectedSiteId }
 					subscriptionId={ subscriptionId }
 					userId={ userId }
+					newsletterCategoriesEnabled={ newsletterCategoriesData?.enabled }
+					newsletterCategories={ newsletterCategoriesData?.newsletterCategories }
 				/>
 			) }
 			<UnsubscribeModal


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/81366

## Proposed Changes

* Add newsletter categories to Subscribers page
* Update `useSubscriberNewsletterCategories` to accept `subscriptionId` param
* Use the same loading state when fetching subscriber details and newsletter categories

## Testing Instructions

* Apply this PR to your local
* Use a site with some predefined Newsletter Categories
* Go to http://calypso.localhost:3000/subscribers/{site-slug}
* Open a WPcom subscriber by clicking on the ellipsis button, and then on View
* You should see all the Newsletter Categories that the user is subscribed to
* Go back and open an external subscriber
* You should see all the Newsletter Categories that the user is subscribed to
* Check for sites with Newsletter Categories disabled, the "Receives emails for" column should not be displayed
* Check with the `settings/newsletter-categories` feature flag disabled, the "Receives emails for" column should not be displayed

<img width="1107" alt="Screenshot 2023-09-05 at 11 23 15" src="https://github.com/Automattic/wp-calypso/assets/3113712/018b708a-0844-46d0-807c-83fef96dec77">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?