### PR TITLE
SiteSelector: Redirect to /backup when switching site while on granular-restore page

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -510,7 +510,7 @@ const navigateToSite =
 				}
 
 				// Jetpack Cloud: default to /backups/ when in the details of a particular backup
-				if ( path.match( /^\/backup\/.*\/(download|restore|contents)/ ) ) {
+				if ( path.match( /^\/backup\/.*\/(download|restore|contents|granular-restore)/ ) ) {
 					return '/backup';
 				}
 
@@ -575,7 +575,7 @@ const navigateToSite =
 			}
 
 			// Jetpack Cloud: default to /backups/ when in the details of a particular backup
-			if ( path.match( /^\/backup\/.*\/(download|restore|contents)/ ) ) {
+			if ( path.match( /^\/backup\/.*\/(download|restore|contents|granular-restore)/ ) ) {
 				path = '/backup';
 			}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fixes an issue where changing sites while on the granular-restore page will result in an error by adding granular-restore to the regex test for returning to /backup
* Similar to https://github.com/Automattic/wp-calypso/pull/78448

## Testing Instructions

* Start a Jetpack Cloud or Calypso Live branch
* Select one of your sites with a Jetpack VaultPress Backup plan.
* Navigate to VaultPress Backup page
* Pick one date with a backup available (use the calendar and click on any date marked with a dot).
* Click on Actions (+) and then on View files button to access the backup contents page.
* If using a live branch, ensure the granular restores feature is enabled by adding `?flags=jetpack/backup-granular`
* Click on an individual file in the Backup Browser to expand its details
* Click on the 'Restore' button
* On the Restore confirmation screen use the Site Selector on the left side bar to select a different site
* Ensure you navigate to the /backup landing page for the site selected and don't see an error

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?