### PR TITLE
Stats: Modify products upgrade link according to the "is_commercial" classifier on the Add-Ons page

### DIFF
--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -134,7 +134,8 @@ const useModifiedActionPrimary = (
 					false,
 					addOnMeta.productSlug === PRODUCT_JETPACK_STATS_YEARLY ? 'commercial' : 'personal'
 				);
-				page.show( purchaseUrl );
+				// TODO: Remove the feature flag once we enable Paid Stats for WPCOM sites.
+				page.show( purchaseUrl + ',stats/paid-wpcom-stats' );
 				window.scrollTo( 0, 0 );
 			},
 		};

--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -9,8 +9,9 @@ import { Card, CardBody, CardFooter, CardHeader } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
+import { getStatsPurchaseURL } from 'calypso/my-sites/stats/stats-purchase/stats-purchase-notice';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { AddOnMeta } from '../hooks/use-add-ons';
 
 type ActionPrimary = {
@@ -116,7 +117,7 @@ const useModifiedActionPrimary = (
 	addOnMeta: AddOnMeta
 ) => {
 	const translate = useTranslate();
-	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 
 	// Add special handling for Jetpack Stats, which uses its own special purchase page.
 	if (
@@ -128,7 +129,12 @@ const useModifiedActionPrimary = (
 			text: translate( 'Upgrade Stats' ),
 			handler: () => {
 				// Navigate to the stats purchase page, scrolled to the top.
-				page.show( `/stats/purchase/${ siteSlug }` );
+				const purchaseUrl = getStatsPurchaseURL(
+					siteId,
+					false,
+					addOnMeta.productSlug === PRODUCT_JETPACK_STATS_YEARLY ? 'commercial' : 'personal'
+				);
+				page.show( purchaseUrl );
 				window.scrollTo( 0, 0 );
 			},
 		};

--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -1,4 +1,8 @@
-import { PRODUCT_JETPACK_STATS_PWYW_YEARLY, PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
+import {
+	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
+	PRODUCT_JETPACK_STATS_YEARLY,
+	PRODUCT_1GB_SPACE,
+} from '@automattic/calypso-products';
 import { Badge, Button, Gridicon, Spinner } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Card, CardBody, CardFooter, CardHeader } from '@wordpress/components';
@@ -115,7 +119,11 @@ const useModifiedActionPrimary = (
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
 
 	// Add special handling for Jetpack Stats, which uses its own special purchase page.
-	if ( addOnMeta.productSlug === PRODUCT_JETPACK_STATS_PWYW_YEARLY ) {
+	if (
+		[ PRODUCT_JETPACK_STATS_PWYW_YEARLY, PRODUCT_JETPACK_STATS_YEARLY ].includes(
+			addOnMeta.productSlug
+		)
+	) {
 		return {
 			text: translate( 'Upgrade Stats' ),
 			handler: () => {

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -21,6 +21,7 @@ import {
 import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-transaction-filters';
 import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import { usePastBillingTransactions } from 'calypso/state/sites/hooks/use-billing-history';
+import { getSiteOption } from 'calypso/state/sites/selectors';
 import { STORAGE_LIMIT } from '../constants';
 import customDesignIcon from '../icons/custom-design';
 import jetpackAIIcon from '../icons/jetpack-ai';
@@ -152,6 +153,9 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 			}
 		}
 
+		// Determine which Stats Add-On to show based on the site's commercial classification.
+		const isSiteMarkedCommercial = getSiteOption( state, siteId, 'is_commercial' );
+
 		return addOnsActive
 			.filter( ( addOn ) => {
 				// if a user already has purchased a storage upgrade
@@ -178,6 +182,24 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 				) {
 					return false;
 				}
+
+				// Hide Stats Personal add-on if the site is marked as commercial.
+				if (
+					isSiteMarkedCommercial === true &&
+					PRODUCT_JETPACK_STATS_PWYW_YEARLY === addOn.productSlug
+				) {
+					return false;
+				}
+
+				// Hide Stats Commercial add-on if the site is not marked as commercial.
+				if (
+					isSiteMarkedCommercial !== true &&
+					PRODUCT_JETPACK_STATS_YEARLY === addOn.productSlug
+				) {
+					return false;
+				}
+
+				// TODO: Show the Stats Commercial add-on for a commercial site that has purchased the Personal plan.
 
 				// remove Jetpack Stats add-on if the site already has a paid stats feature through a paid plan.
 				if (

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -3,6 +3,7 @@ import {
 	FEATURE_STATS_PAID,
 	PRODUCT_JETPACK_AI_MONTHLY,
 	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
+	PRODUCT_JETPACK_STATS_YEARLY,
 	PRODUCT_WPCOM_CUSTOM_DESIGN,
 	PRODUCT_WPCOM_UNLIMITED_THEMES,
 	PRODUCT_1GB_SPACE,
@@ -113,6 +114,17 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 				'Upgrade Jetpack Stats to unlock priority support and all upcoming premium features.'
 			),
 		},
+		{
+			productSlug: PRODUCT_JETPACK_STATS_YEARLY,
+			featureSlugs: useAddOnFeatureSlugs( PRODUCT_JETPACK_STATS_YEARLY ),
+			icon: jetpackStatsIcon,
+			overrides: null,
+			displayCost: useAddOnDisplayCost( PRODUCT_JETPACK_STATS_YEARLY ),
+			featured: true,
+			description: translate(
+				'Upgrade Jetpack Stats to unlock priority support and all upcoming premium features.'
+			),
+		},
 	];
 
 	// if upgrade is bought - show as manage
@@ -159,7 +171,9 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 				// TODO: Remove this check once paid WPCOM stats is live.
 				// gate the Jetpack Stats add-on on a feature flag
 				if (
-					addOn.productSlug === PRODUCT_JETPACK_STATS_PWYW_YEARLY &&
+					[ PRODUCT_JETPACK_STATS_PWYW_YEARLY, PRODUCT_JETPACK_STATS_YEARLY ].includes(
+						addOn.productSlug
+					) &&
 					! config.isEnabled( 'stats/paid-wpcom-stats' )
 				) {
 					return false;
@@ -167,7 +181,9 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 
 				// remove Jetpack Stats add-on if the site already has a paid stats feature through a paid plan.
 				if (
-					addOn.productSlug === PRODUCT_JETPACK_STATS_PWYW_YEARLY &&
+					[ PRODUCT_JETPACK_STATS_PWYW_YEARLY, PRODUCT_JETPACK_STATS_YEARLY ].includes(
+						addOn.productSlug
+					) &&
 					siteFeatures?.active?.includes( FEATURE_STATS_PAID )
 				) {
 					return false;

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -193,7 +193,7 @@ const useAddOns = ( siteId?: number ): ( AddOnMeta | null )[] => {
 
 				// Hide Stats Commercial add-on if the site is not marked as commercial.
 				if (
-					isSiteMarkedCommercial !== true &&
+					isSiteMarkedCommercial === false &&
 					PRODUCT_JETPACK_STATS_YEARLY === addOn.productSlug
 				) {
 					return false;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
@@ -11,7 +11,7 @@ import {
 } from './stats-purchase-shared';
 import './styles.scss';
 
-export const getStatsPurchaseURL = ( siteId, isOdysseyStats, productType = 'commercial' ) => {
+const getStatsPurchaseURL = ( siteId, isOdysseyStats, productType = 'commercial' ) => {
 	const purchasePath = `/stats/purchase/${ siteId }?productType=${ productType }&flags=stats/type-detection`;
 
 	if ( ! isOdysseyStats ) {
@@ -169,4 +169,4 @@ const StatsPurchaseNoticePage = ( {
 	);
 };
 
-export { StatsPurchaseNoticePage, StatsPurchaseNotice };
+export { StatsPurchaseNoticePage, StatsPurchaseNotice, getStatsPurchaseURL };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80258 

## Proposed Changes

* Introduce the `is_commercial` option to determine the Add-On card for Stats products.
* Navigate to the respective purchase page according to the `Add-Ons` card product.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the change with the Calypso Live link.
* Navigate to the `Add-Ons` page for a Simple site with the feature flag: `/add-ons/{site-slug}?flags=stats/paid-wpcom-stats`.
* Ensure the `Add-Ons` product card displays according to the site's `is_commercial` status.
* Ensure the `Upgrade Stats` button directs to the correct purchase page for Stats PWYW and Commercial products.

|Non-commercial site|Commercial site|
|-|-|
|<img width="1118" alt="截圖 2023-09-06 下午12 11 15" src="https://github.com/Automattic/wp-calypso/assets/6869813/ce8dca8c-4a32-4ae6-986d-50eb59dd6dd1">|<img width="1157" alt="截圖 2023-09-06 下午12 10 14" src="https://github.com/Automattic/wp-calypso/assets/6869813/ae779fa3-a466-4e55-86db-9cf2e54a7851">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?