### PR TITLE
Plans: Add ability to highlight plan features

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -1,13 +1,4 @@
-import {
-	getPlan,
-	PLAN_FREE,
-	FEATURE_CUSTOM_DOMAIN,
-	FEATURE_NEWSLETTER_IMPORT_SUBSCRIBERS_FREE,
-	FEATURE_UNLIMITED_SUBSCRIBERS,
-	FEATURE_PAYMENT_TRANSACTION_FEES_10,
-	FEATURE_PAYMENT_TRANSACTION_FEES_8,
-	FEATURE_PAYMENT_TRANSACTION_FEES_4,
-} from '@automattic/calypso-products';
+import { getPlan, PLAN_FREE } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import {
 	DOMAIN_UPSELL_FLOW,
@@ -34,6 +25,7 @@ import { connect } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import useHighlightedFeatures from 'calypso/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import PlanFAQ from 'calypso/my-sites/plans-features-main/components/plan-faq';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -101,6 +93,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		? reduxHideFreePlan && 'plans-blog-onboarding' === plansIntent
 		: reduxHideFreePlan;
 
+	const highlightedFeatures = useHighlightedFeatures( plansIntent );
+
 	const onSelectPlan = ( selectedPlan: any ) => {
 		if ( selectedPlan ) {
 			recordTracksEvent( 'calypso_signup_plan_select', {
@@ -143,23 +137,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		setDomain( freeDomainSuggestion );
 	};
 
-	/*
-	 * Could abstract this more by utilizing methods like
-	 * getPlanPersonalDetails().getNewsletterHighlightedFeatures() and
-	 * getPremiumPersonalDetails().getNewsletterHighlightedFeatures()
-	 * in @automattic/calypso-products, but would need more refactoring.
-	 */
-	const getHighlightedFeatures = () =>
-		isNewsletterFlow( flowName )
-			? [
-					FEATURE_CUSTOM_DOMAIN,
-					FEATURE_NEWSLETTER_IMPORT_SUBSCRIBERS_FREE,
-					FEATURE_UNLIMITED_SUBSCRIBERS,
-					FEATURE_PAYMENT_TRANSACTION_FEES_10,
-					FEATURE_PAYMENT_TRANSACTION_FEES_8,
-					FEATURE_PAYMENT_TRANSACTION_FEES_4,
-			  ]
-			: [];
 	const plansFeaturesList = () => {
 		if ( ! props.plansLoaded ) {
 			return renderLoading();
@@ -185,7 +162,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					intent={ plansIntent }
 					removePaidDomain={ removePaidDomain }
 					setSiteUrlAsFreeDomainSuggestion={ setSiteUrlAsFreeDomainSuggestion }
-					highlightedFeatures={ getHighlightedFeatures() }
+					highlightedFeatures={ highlightedFeatures }
 				/>
 				{ props.shouldIncludeFAQ && <PlanFAQ /> }
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -93,7 +93,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		? reduxHideFreePlan && 'plans-blog-onboarding' === plansIntent
 		: reduxHideFreePlan;
 
-	const highlightedFeatures = useHighlightedFeatures( plansIntent );
+	const highlightedFeatures = useHighlightedFeatures( plansIntent, isInSignup );
 
 	const onSelectPlan = ( selectedPlan: any ) => {
 		if ( selectedPlan ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -1,4 +1,13 @@
-import { getPlan, PLAN_FREE } from '@automattic/calypso-products';
+import {
+	getPlan,
+	PLAN_FREE,
+	FEATURE_CUSTOM_DOMAIN,
+	FEATURE_NEWSLETTER_IMPORT_SUBSCRIBERS_FREE,
+	FEATURE_UNLIMITED_SUBSCRIBERS,
+	FEATURE_PAYMENT_TRANSACTION_FEES_10,
+	FEATURE_PAYMENT_TRANSACTION_FEES_8,
+	FEATURE_PAYMENT_TRANSACTION_FEES_4,
+} from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import {
 	DOMAIN_UPSELL_FLOW,
@@ -134,6 +143,23 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		setDomain( freeDomainSuggestion );
 	};
 
+	/*
+	 * Could abstract this more by utilizing methods like
+	 * getPlanPersonalDetails().getNewsletterHighlightedFeatures() and
+	 * getPremiumPersonalDetails().getNewsletterHighlightedFeatures()
+	 * in @automattic/calypso-products, but would need more refactoring.
+	 */
+	const getHighlightedFeatures = () =>
+		isNewsletterFlow( flowName )
+			? [
+					FEATURE_CUSTOM_DOMAIN,
+					FEATURE_NEWSLETTER_IMPORT_SUBSCRIBERS_FREE,
+					FEATURE_UNLIMITED_SUBSCRIBERS,
+					FEATURE_PAYMENT_TRANSACTION_FEES_10,
+					FEATURE_PAYMENT_TRANSACTION_FEES_8,
+					FEATURE_PAYMENT_TRANSACTION_FEES_4,
+			  ]
+			: [];
 	const plansFeaturesList = () => {
 		if ( ! props.plansLoaded ) {
 			return renderLoading();
@@ -159,6 +185,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					intent={ plansIntent }
 					removePaidDomain={ removePaidDomain }
 					setSiteUrlAsFreeDomainSuggestion={ setSiteUrlAsFreeDomainSuggestion }
+					highlightedFeatures={ getHighlightedFeatures() }
 				/>
 				{ props.shouldIncludeFAQ && <PlanFAQ /> }
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -25,7 +25,6 @@ import { connect } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import useHighlightedFeatures from 'calypso/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import PlanFAQ from 'calypso/my-sites/plans-features-main/components/plan-faq';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -92,8 +91,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	const hideFreePlan = plansIntent
 		? reduxHideFreePlan && 'plans-blog-onboarding' === plansIntent
 		: reduxHideFreePlan;
-
-	const highlightedFeatures = useHighlightedFeatures( plansIntent, isInSignup );
 
 	const onSelectPlan = ( selectedPlan: any ) => {
 		if ( selectedPlan ) {
@@ -162,7 +159,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					intent={ plansIntent }
 					removePaidDomain={ removePaidDomain }
 					setSiteUrlAsFreeDomainSuggestion={ setSiteUrlAsFreeDomainSuggestion }
-					highlightedFeatures={ highlightedFeatures }
 				/>
 				{ props.shouldIncludeFAQ && <PlanFAQ /> }
 			</div>

--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -94,7 +94,8 @@ const PlanFeatures2023GridFeatures: React.FC< {
 
 				const isHighlightedFeature = selectedFeature
 					? currentFeature.getSlug() === selectedFeature
-					: currentFeature.getSlug() === FEATURE_CUSTOM_DOMAIN ||
+					: currentFeature?.isHighlighted ||
+					  currentFeature.getSlug() === FEATURE_CUSTOM_DOMAIN ||
 					  ! currentFeature.availableForCurrentPlan;
 
 				const divClasses = classNames( '', getPlanClass( planSlug ), {

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -27,9 +27,11 @@ import type { PricedAPIPlan } from '@automattic/data-stores';
 import type { TranslateResult } from 'i18n-calypso';
 
 // TODO clk: move to plans data store
+// Note: This type is duplicated in ../../../types.ts. Should prob be defined just once.
 export type TransformedFeatureObject = FeatureObject & {
 	availableForCurrentPlan: boolean;
 	availableOnlyForAnnualPlans: boolean;
+	isHighlighted?: boolean;
 };
 
 // TODO clk: move to plans data store

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -27,7 +27,6 @@ import type { PricedAPIPlan } from '@automattic/data-stores';
 import type { TranslateResult } from 'i18n-calypso';
 
 // TODO clk: move to plans data store
-// Note: This type is duplicated in ../../../types.ts. Should prob be defined just once.
 export type TransformedFeatureObject = FeatureObject & {
 	availableForCurrentPlan: boolean;
 	availableOnlyForAnnualPlans: boolean;

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
@@ -1,0 +1,42 @@
+import {
+	FEATURE_CUSTOM_DOMAIN,
+	FEATURE_NEWSLETTER_IMPORT_SUBSCRIBERS_FREE,
+	FEATURE_UNLIMITED_SUBSCRIBERS,
+	FEATURE_PAYMENT_TRANSACTION_FEES_10,
+	FEATURE_PAYMENT_TRANSACTION_FEES_8,
+	FEATURE_PAYMENT_TRANSACTION_FEES_4,
+} from '@automattic/calypso-products';
+import type { PlansIntent } from './use-grid-plans';
+
+/**
+ * Returns an array of features that, if they exist for a
+ * particular Plan on a pricing table, will be highlighted
+ * (ie, moved to the top of the list, and bolded).
+ *
+ * If the specified features don't exist for a particular
+ * Plan, they will be ignored.
+ *
+ * The highlightedFeatures can be passed as a
+ * prop to the PlansFeaturesMain. See example in
+ * PlansWrapper component in stepper onboarding.
+ *
+ * The Logic for processing the highlightedFeatures
+ * lives in the adjacent usePlanFeaturesForGridPlans hook.
+ *
+ * TODO clk: move to plans data store
+ */
+const useHighlightedFeatures = ( intent: PlansIntent | null ): string[] => {
+	if ( 'plans-newsletter' === intent ) {
+		return [
+			FEATURE_CUSTOM_DOMAIN,
+			FEATURE_NEWSLETTER_IMPORT_SUBSCRIBERS_FREE,
+			FEATURE_UNLIMITED_SUBSCRIBERS,
+			FEATURE_PAYMENT_TRANSACTION_FEES_10,
+			FEATURE_PAYMENT_TRANSACTION_FEES_8,
+			FEATURE_PAYMENT_TRANSACTION_FEES_4,
+		];
+	}
+	return [];
+};
+
+export default useHighlightedFeatures;

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
@@ -8,10 +8,13 @@ import {
 } from '@automattic/calypso-products';
 import type { PlansIntent } from './use-grid-plans';
 
-interface Props {
+export type UseHighlightedFeatures = ( {
+	intent,
+	isInSignup,
+}: {
 	intent: PlansIntent | undefined;
 	isInSignup?: boolean;
-}
+} ) => string[] | null;
 
 /**
  * Returns an array of features that, if they exist for a
@@ -26,7 +29,7 @@ interface Props {
  *
  * TODO clk: move to plans data store
  */
-const useHighlightedFeatures = ( { intent, isInSignup }: Props ): string[] | null => {
+const useHighlightedFeatures: UseHighlightedFeatures = ( { intent, isInSignup } ) => {
 	if ( isInSignup && intent && 'plans-newsletter' === intent ) {
 		return [
 			FEATURE_CUSTOM_DOMAIN,

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
@@ -25,7 +25,12 @@ import type { PlansIntent } from './use-grid-plans';
  *
  * TODO clk: move to plans data store
  */
-const useHighlightedFeatures = ( intent: PlansIntent | null ): string[] => {
+const useHighlightedFeatures = ( intent: PlansIntent | null, isInSignup: boolean ): string[] => {
+	// For now, this hook and higlighting features only applies during signup.
+	if ( ! isInSignup ) {
+		return [];
+	}
+
 	if ( 'plans-newsletter' === intent ) {
 		return [
 			FEATURE_CUSTOM_DOMAIN,
@@ -36,6 +41,7 @@ const useHighlightedFeatures = ( intent: PlansIntent | null ): string[] => {
 			FEATURE_PAYMENT_TRANSACTION_FEES_4,
 		];
 	}
+
 	return [];
 };
 

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
@@ -8,6 +8,11 @@ import {
 } from '@automattic/calypso-products';
 import type { PlansIntent } from './use-grid-plans';
 
+interface Props {
+	intent: PlansIntent | undefined;
+	isInSignup?: boolean;
+}
+
 /**
  * Returns an array of features that, if they exist for a
  * particular Plan on a pricing table, will be highlighted
@@ -21,10 +26,7 @@ import type { PlansIntent } from './use-grid-plans';
  *
  * TODO clk: move to plans data store
  */
-const useHighlightedFeatures = (
-	intent: PlansIntent | undefined,
-	isInSignup = false
-): string[] => {
+const useHighlightedFeatures = ( { intent, isInSignup }: Props ): string[] => {
 	if ( isInSignup && intent && 'plans-newsletter' === intent ) {
 		return [
 			FEATURE_CUSTOM_DOMAIN,

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
@@ -16,18 +16,16 @@ import type { PlansIntent } from './use-grid-plans';
  * If the specified features don't exist for a particular
  * Plan, they will be ignored.
  *
- * The highlightedFeatures can be passed as a
- * prop to the PlansFeaturesMain. See example in
- * PlansWrapper component in stepper onboarding.
- *
  * The Logic for processing the highlightedFeatures
  * lives in the adjacent usePlanFeaturesForGridPlans hook.
  *
  * TODO clk: move to plans data store
  */
-const useHighlightedFeatures = ( intent: PlansIntent | null, isInSignup: boolean ): string[] => {
-	// Hook only returns highlighted features during signup
-	if ( 'plans-newsletter' === intent && isInSignup ) {
+const useHighlightedFeatures = (
+	intent: PlansIntent | undefined,
+	isInSignup = false
+): string[] => {
+	if ( isInSignup && intent && 'plans-newsletter' === intent ) {
 		return [
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_NEWSLETTER_IMPORT_SUBSCRIBERS_FREE,

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
@@ -26,7 +26,7 @@ interface Props {
  *
  * TODO clk: move to plans data store
  */
-const useHighlightedFeatures = ( { intent, isInSignup }: Props ): string[] => {
+const useHighlightedFeatures = ( { intent, isInSignup }: Props ): string[] | null => {
 	if ( isInSignup && intent && 'plans-newsletter' === intent ) {
 		return [
 			FEATURE_CUSTOM_DOMAIN,
@@ -38,7 +38,7 @@ const useHighlightedFeatures = ( { intent, isInSignup }: Props ): string[] => {
 		];
 	}
 
-	return [];
+	return null;
 };
 
 export default useHighlightedFeatures;

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
@@ -26,12 +26,8 @@ import type { PlansIntent } from './use-grid-plans';
  * TODO clk: move to plans data store
  */
 const useHighlightedFeatures = ( intent: PlansIntent | null, isInSignup: boolean ): string[] => {
-	// For now, this hook and higlighting features only applies during signup.
-	if ( ! isInSignup ) {
-		return [];
-	}
-
-	if ( 'plans-newsletter' === intent ) {
+	// Hook only returns highlighted features during signup
+	if ( 'plans-newsletter' === intent && isInSignup ) {
 		return [
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_NEWSLETTER_IMPORT_SUBSCRIBERS_FREE,

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
@@ -21,7 +21,8 @@ export type UseHighlightedFeatures = ( {
  * particular Plan on a pricing table, will be highlighted
  * (ie, moved to the top of the list, and bolded).
  *
- * If the specified features don't exist for a particular
+ * Will only affect wpcomeFeatures, not jetpackFeatures. And
+ * if the specified features don't exist for a particular
  * Plan, they will be ignored.
  *
  * The Logic for processing the highlightedFeatures

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
@@ -12,7 +12,7 @@ export type UseHighlightedFeatures = ( {
 	intent,
 	isInSignup,
 }: {
-	intent: PlansIntent | undefined;
+	intent: PlansIntent | null;
 	isInSignup?: boolean;
 } ) => string[] | null;
 

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
@@ -38,7 +38,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 	showLegacyStorageFeature,
 	isInSignup,
 } ) => {
-	const highlightedFeatures = useHighlightedFeatures( intent ?? null, isInSignup );
+	const highlightedFeatures = useHighlightedFeatures( { intent, isInSignup } );
 
 	return planSlugs.reduce( ( acc, planSlug ) => {
 		const planConstantObj = applyTestFiltersToPlansList( planSlug, undefined );

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
@@ -40,6 +40,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 	return planSlugs.reduce( ( acc, planSlug ) => {
 		const planConstantObj = applyTestFiltersToPlansList( planSlug, undefined );
 		const isMonthlyPlan = isMonthly( planSlug );
+		const hasHightlightedFeatures = highlightedFeatures && highlightedFeatures.length > 0;
 
 		let wpcomFeatures: FeatureObject[] = [];
 		let jetpackFeatures: FeatureObject[] = [];
@@ -88,19 +89,25 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 			};
 		} );
 
-		if ( highlightedFeatures && highlightedFeatures.length > 0 ) {
-			highlightedFeatures.reverse().forEach( ( slug ) => {
-				const feature = wpcomFeatures.find( ( feature ) => feature.getSlug() === slug );
-				if ( feature ) {
-					const availableOnlyForAnnualPlans = annualPlansOnlyFeatures.includes( feature.getSlug() );
-					wpcomFeaturesTransformed.unshift( {
-						...feature,
-						availableOnlyForAnnualPlans,
-						availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
-						isHighlighted: true,
-					} );
-				}
-			} );
+		if ( hasHightlightedFeatures ) {
+			// slice() and reverse() are neede to the preserve order of features
+			highlightedFeatures
+				.slice()
+				.reverse()
+				.forEach( ( slug ) => {
+					const feature = wpcomFeatures.find( ( feature ) => feature.getSlug() === slug );
+					if ( feature ) {
+						const availableOnlyForAnnualPlans = annualPlansOnlyFeatures.includes(
+							feature.getSlug()
+						);
+						wpcomFeaturesTransformed.unshift( {
+							...feature,
+							availableOnlyForAnnualPlans,
+							availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
+							isHighlighted: true,
+						} );
+					}
+				} );
 		}
 
 		const topFeature = selectedFeature
@@ -118,7 +125,10 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 
 		if ( annualPlansOnlyFeatures.length > 0 ) {
 			wpcomFeatures.forEach( ( feature ) => {
-				if ( feature === topFeature ) {
+				// topFeature and highlightedFeatures are already added to the list above
+				const isHighlightedFeature =
+					hasHightlightedFeatures && highlightedFeatures.includes( feature.getSlug() );
+				if ( feature === topFeature || isHighlightedFeature ) {
 					return;
 				}
 

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
@@ -43,7 +43,6 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 	return planSlugs.reduce( ( acc, planSlug ) => {
 		const planConstantObj = applyTestFiltersToPlansList( planSlug, undefined );
 		const isMonthlyPlan = isMonthly( planSlug );
-		const hasHightlightedFeatures = highlightedFeatures && highlightedFeatures.length > 0;
 
 		let wpcomFeatures: FeatureObject[] = [];
 		let jetpackFeatures: FeatureObject[] = [];
@@ -92,7 +91,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 			};
 		} );
 
-		if ( hasHightlightedFeatures ) {
+		if ( highlightedFeatures ) {
 			// slice() and reverse() are neede to the preserve order of features
 			highlightedFeatures
 				.slice()
@@ -130,7 +129,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 			wpcomFeatures.forEach( ( feature ) => {
 				// topFeature and highlightedFeatures are already added to the list above
 				const isHighlightedFeature =
-					hasHightlightedFeatures && highlightedFeatures.includes( feature.getSlug() );
+					highlightedFeatures && highlightedFeatures.includes( feature.getSlug() );
 				if ( feature === topFeature || isHighlightedFeature ) {
 					return;
 				}

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
@@ -22,7 +22,7 @@ export type UsePlanFeaturesForGridPlans = ( {
 	intent?: PlansIntent;
 	selectedFeature?: string | null;
 	showLegacyStorageFeature?: boolean;
-	isInSignup: boolean;
+	isInSignup?: boolean;
 } ) => { [ planSlug: string ]: PlanFeaturesForGridPlan };
 
 /*

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
@@ -1,5 +1,6 @@
 import { applyTestFiltersToPlansList, isMonthly } from '@automattic/calypso-products';
 import getPlanFeaturesObject from 'calypso/my-sites/plan-features-2023-grid/lib/get-plan-features-object';
+import useHighlightedFeatures from './use-highlighted-features';
 import type { FeatureObject, FeatureList, PlanSlug } from '@automattic/calypso-products';
 import type {
 	TransformedFeatureObject,
@@ -14,14 +15,14 @@ export type UsePlanFeaturesForGridPlans = ( {
 	intent,
 	showLegacyStorageFeature,
 	selectedFeature,
-	highlightedFeatures,
+	isInSignup,
 }: {
 	planSlugs: PlanSlug[];
 	allFeaturesList: FeatureList;
 	intent?: PlansIntent;
 	selectedFeature?: string | null;
 	showLegacyStorageFeature?: boolean;
-	highlightedFeatures: string[];
+	isInSignup: boolean;
 } ) => { [ planSlug: string ]: PlanFeaturesForGridPlan };
 
 /*
@@ -35,8 +36,10 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 	intent,
 	selectedFeature,
 	showLegacyStorageFeature,
-	highlightedFeatures,
+	isInSignup,
 } ) => {
+	const highlightedFeatures = useHighlightedFeatures( intent ?? null, isInSignup );
+
 	return planSlugs.reduce( ( acc, planSlug ) => {
 		const planConstantObj = applyTestFiltersToPlansList( planSlug, undefined );
 		const isMonthlyPlan = isMonthly( planSlug );

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
@@ -14,12 +14,14 @@ export type UsePlanFeaturesForGridPlans = ( {
 	intent,
 	showLegacyStorageFeature,
 	selectedFeature,
+	highlightedFeatures,
 }: {
 	planSlugs: PlanSlug[];
 	allFeaturesList: FeatureList;
 	intent?: PlansIntent;
 	selectedFeature?: string | null;
 	showLegacyStorageFeature?: boolean;
+	highlightedFeatures: string[];
 } ) => { [ planSlug: string ]: PlanFeaturesForGridPlan };
 
 /*
@@ -33,12 +35,13 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 	intent,
 	selectedFeature,
 	showLegacyStorageFeature,
+	highlightedFeatures,
 } ) => {
 	return planSlugs.reduce( ( acc, planSlug ) => {
 		const planConstantObj = applyTestFiltersToPlansList( planSlug, undefined );
 		const isMonthlyPlan = isMonthly( planSlug );
 
-		let wpcomFeatures = [];
+		let wpcomFeatures: FeatureObject[] = [];
 		let jetpackFeatures: FeatureObject[] = [];
 
 		if ( 'plans-newsletter' === intent ) {
@@ -84,6 +87,21 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 				availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
 			};
 		} );
+
+		if ( highlightedFeatures && highlightedFeatures.length > 0 ) {
+			highlightedFeatures.reverse().forEach( ( slug ) => {
+				const feature = wpcomFeatures.find( ( feature ) => feature.getSlug() === slug );
+				if ( feature ) {
+					const availableOnlyForAnnualPlans = annualPlansOnlyFeatures.includes( feature.getSlug() );
+					wpcomFeaturesTransformed.unshift( {
+						...feature,
+						availableOnlyForAnnualPlans,
+						availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
+						isHighlighted: true,
+					} );
+				}
+			} );
+		}
 
 		const topFeature = selectedFeature
 			? wpcomFeatures.find( ( feature ) => feature.getSlug() === selectedFeature )

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
@@ -38,7 +38,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 	showLegacyStorageFeature,
 	isInSignup,
 } ) => {
-	const highlightedFeatures = useHighlightedFeatures( { intent, isInSignup } );
+	const highlightedFeatures = useHighlightedFeatures( { intent: intent ?? null, isInSignup } );
 
 	return planSlugs.reduce( ( acc, planSlug ) => {
 		const planConstantObj = applyTestFiltersToPlansList( planSlug, undefined );

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -4,6 +4,7 @@ import type { TranslateResult } from 'i18n-calypso';
 export type TransformedFeatureObject = FeatureObject & {
 	availableForCurrentPlan: boolean;
 	availableOnlyForAnnualPlans: boolean;
+	isHighlighted?: boolean;
 };
 
 export interface PlanActionOverrides {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -150,6 +150,8 @@ export interface PlansFeaturesMainProps {
 	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
 	showLegacyStorageFeature?: boolean;
 	isSpotlightOnCurrentPlan?: boolean;
+	// Can pass array of features that will be bolded and pushed to top of feature list
+	highlightedFeatures: string[];
 }
 
 const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
@@ -209,6 +211,7 @@ const PlansFeaturesMain = ( {
 	isLaunchPage = false,
 	showLegacyStorageFeature = false,
 	isSpotlightOnCurrentPlan,
+	highlightedFeatures = [],
 }: PlansFeaturesMainProps ) => {
 	const [ isFreePlanPaidDomainDialogOpen, setIsFreePlanPaidDomainDialogOpen ] = useState( false );
 	const [ isFreePlanFreeDomainDialogOpen, setIsFreePlanFreeDomainDialogOpen ] = useState( false );
@@ -337,6 +340,7 @@ const PlansFeaturesMain = ( {
 		intent,
 		selectedFeature,
 		showLegacyStorageFeature,
+		highlightedFeatures,
 	} );
 
 	const planFeaturesForComparisonGrid = useRestructuredPlanFeaturesForComparisonGrid( {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -150,8 +150,6 @@ export interface PlansFeaturesMainProps {
 	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
 	showLegacyStorageFeature?: boolean;
 	isSpotlightOnCurrentPlan?: boolean;
-	// Can pass array of features that will be bolded and pushed to top of feature list
-	highlightedFeatures: string[];
 }
 
 const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
@@ -211,7 +209,6 @@ const PlansFeaturesMain = ( {
 	isLaunchPage = false,
 	showLegacyStorageFeature = false,
 	isSpotlightOnCurrentPlan,
-	highlightedFeatures = [],
 }: PlansFeaturesMainProps ) => {
 	const [ isFreePlanPaidDomainDialogOpen, setIsFreePlanPaidDomainDialogOpen ] = useState( false );
 	const [ isFreePlanFreeDomainDialogOpen, setIsFreePlanFreeDomainDialogOpen ] = useState( false );
@@ -340,7 +337,7 @@ const PlansFeaturesMain = ( {
 		intent,
 		selectedFeature,
 		showLegacyStorageFeature,
-		highlightedFeatures,
+		isInSignup,
 	} );
 
 	const planFeaturesForComparisonGrid = useRestructuredPlanFeaturesForComparisonGrid( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

- Adds the ability to pass an array of features that will be highlighted on the plans page.
- Highlight specific features for newsletter-related plans during stepper-based onboarding
- This is an alternative to https://github.com/Automattic/wp-calypso/pull/81247 following [this discussion](https://github.com/Automattic/wp-calypso/pull/81247#discussion_r1311412343).

![highlighted](https://github.com/Automattic/wp-calypso/assets/21228350/7e403705-abfb-47e3-b73a-1f351ebecdf3)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Checkout this branch and start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro
2) Proceed to Plans page and confirm that features are highlighted as in screenshot above (should see features for domain and/or importing and/or transaction fees at top - which appears for which plan is determined separated). 
3) Also confirm the same does not happen outside of signup. Continue through to launchpad with your new site from step 2, Skip to Dashboard, and click Upgrade in the WordPress dashboard. You'll see another plans page. Confirm plans page looks like it usually does: 

<img width="1043" alt="upgrade plans" src="https://github.com/Automattic/wp-calypso/assets/21228350/b01514d5-1a33-4916-aae6-b432c6151fe0">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
