### PR TITLE
Launchpad: Add the skip behavior for the Build intent

### DIFF
--- a/client/landing/stepper/declarative-flow/build.ts
+++ b/client/landing/stepper/declarative-flow/build.ts
@@ -1,3 +1,4 @@
+import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { useFlowProgress, BUILD_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -65,10 +66,13 @@ const build: Flow = {
 			return providedDependencies;
 		};
 
-		const goNext = () => {
+		const goNext = async () => {
 			switch ( _currentStep ) {
 				case 'launchpad':
-					return window.location.assign( `/view/${ siteId ?? siteSlug }` );
+					if ( siteSlug ) {
+						await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );
+					}
+					return window.location.assign( `/home/${ siteId ?? siteSlug }` );
 				default:
 					return navigate( 'freeSetup' );
 			}

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -94,7 +94,7 @@ describe(
 				await page.waitForURL( /launchpad/, { waitUntil: 'networkidle' } );
 				await page.getByRole( 'button', { name: 'Skip for now' } ).click( { timeout: 20 * 1000 } );
 
-				// Launchpad redirects to `/view` when skipped.
+				// Launchpad redirects to `/home` when skipped.
 				await page.waitForURL( /home/ );
 			} );
 		} );

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -95,7 +95,7 @@ describe(
 				await page.getByRole( 'button', { name: 'Skip for now' } ).click( { timeout: 20 * 1000 } );
 
 				// Launchpad redirects to `/view` when skipped.
-				await page.waitForURL( /view/ );
+				await page.waitForURL( /home/ );
 			} );
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* https://github.com/Automattic/wp-calypso/pull/80661
* D120528-code
* https://github.com/Automattic/jetpack/pull/32810

## Proposed Changes

* This PR adds the skip behavior for the Build intent. Skipping the fullscreen launchpad should redirect the users to Customer Home with the pre-launch launchpad. 
* After completing the Launch task, the post-launch Launchpad should be displayed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply the D120528-code to your sandbox
- Apply the https://github.com/Automattic/jetpack/pull/32810 to your sandbox. Since it was merged but not deployed yet you may need to run the following command:
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin trunk
```
- Access calypso.live
- Create a site with `/start`, use the `build` intent
![Screen Shot 2023-09-01 at 14 50 05](https://github.com/Automattic/wp-calypso/assets/1234758/c8e97365-3c3a-45e7-86b8-f88fb6a22238)
- Continue through the flow until you reach the fullscreen Launchpad
- Click on the `Skip for now` button
![Screen Shot 2023-09-01 at 14 52 46](https://github.com/Automattic/wp-calypso/assets/1234758/29386c7c-a8a2-4ccd-9b93-4c79c56c1c37)
- You should be redirected to the Customer Home with the pre-launch launchpad
- Click on the `Launch site` task
- You should see a celebration modal and then post-launch launchpad after you close the modal.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?