### PR TITLE
Add Akismet products into the Jetpack cancellation survey flow.

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -41,6 +41,7 @@ interface Props {
 	onClickFinalConfirm: () => void;
 	flowType: string;
 	translate?: () => void;
+	isAkismet?: boolean;
 }
 
 const CancelJetpackForm: React.FC< Props > = ( {
@@ -440,6 +441,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 				<JetpackCancellationSurvey
 					onAnswerChange={ onSurveyAnswerChange }
 					selectedAnswerId={ surveyAnswerId }
+					isAkismet={ !! props?.isAkismet }
 				/>
 			);
 		}

--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -277,7 +277,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 
 			dispatch(
 				submitSurvey(
-					'calypso-cancel-jetpack',
+					props.isAkismet ? 'calypso-cancel-akismet' : 'calypso-cancel-jetpack',
 					purchase.siteId,
 					enrichedSurveyData( surveyData, purchase )
 				)

--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-benefits-step.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-benefits-step.tsx
@@ -7,6 +7,7 @@ import {
 	isJetpackSearchSlug,
 	isJetpackBoostSlug,
 	isJetpackVideoPressSlug,
+	isAkismetProduct,
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
@@ -145,6 +146,10 @@ const JetpackBenefitsStep: React.FC< Props > = ( props ) => {
 		} else if ( ( JETPACK_SEARCH_PRODUCTS as ReadonlyArray< string > ).includes( productSlug ) ) {
 			return translate(
 				"Once you remove your subscription, you will no longer have Jetpack's enhanced search experience."
+			);
+		} else if ( isAkismetProduct( { productSlug: productSlug } ) ) {
+			return translate(
+				"Once you remove your subscription, Akismet will no longer be blocking spam from your sites' comments and forms."
 			);
 		} else if ( hasBenefitsToShow( productSlug ) ) {
 			return translate(

--- a/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/jetpack-cancellation-survey.tsx
@@ -14,11 +14,13 @@ interface Choice {
 interface JetpackCancellationSurveyProps {
 	selectedAnswerId: string | null;
 	onAnswerChange: ( answerId: string | null, answerText: TranslateResult | string ) => void;
+	isAkismet?: boolean;
 }
 
 export default function JetpackCancellationSurvey( {
 	selectedAnswerId,
 	onAnswerChange,
+	isAkismet = false,
 }: JetpackCancellationSurveyProps ) {
 	const translate = useTranslate();
 	const [ customAnswerText, setCustomAnswerText ] = useState( '' );
@@ -117,10 +119,14 @@ export default function JetpackCancellationSurvey( {
 		);
 	};
 
+	const headerText = isAkismet
+		? translate( 'Before you go, help us improve Akismet' )
+		: translate( 'Before you go, help us improve Jetpack' );
+
 	return (
 		<>
 			<FormattedHeader
-				headerText={ translate( 'Before you go, help us improve Jetpack' ) }
+				headerText={ headerText }
 				subHeaderText={ translate( 'Please let us know why you are cancelling.' ) }
 				align="center"
 				isSecondary={ true }

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -4,6 +4,7 @@ import {
 	getPlan,
 	isJetpackPlan,
 	isJetpackProduct,
+	isAkismetProduct,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
@@ -306,7 +307,7 @@ class CancelPurchaseButton extends Component {
 		}
 
 		const disableButtons = this.state.disabled || this.props.disabled;
-		const { isJetpack, purchaseListUrl, activeSubscriptions } = this.props;
+		const { isJetpack, isAkismet, purchaseListUrl, activeSubscriptions } = this.props;
 		const closeDialogAndProceed = () => {
 			this.closeDialog();
 			return onClick();
@@ -342,7 +343,7 @@ class CancelPurchaseButton extends Component {
 					/>
 				) }
 
-				{ isJetpack && (
+				{ ( isJetpack || isAkismet ) && (
 					<CancelJetpackForm
 						disableButtons={ disableButtons }
 						purchase={ purchase }
@@ -383,6 +384,7 @@ class CancelPurchaseButton extends Component {
 export default connect(
 	( state, { purchase } ) => ( {
 		isJetpack: purchase && ( isJetpackPlan( purchase ) || isJetpackProduct( purchase ) ),
+		isAkismet: purchase && isAkismetProduct( purchase ),
 	} ),
 	{
 		clearPurchases,

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -352,6 +352,7 @@ class CancelPurchaseButton extends Component {
 						onClose={ this.closeDialog }
 						onClickFinalConfirm={ this.submitCancelAndRefundPurchase }
 						flowType={ getPurchaseCancellationFlowType( purchase ) }
+						isAkismet={ isAkismet }
 					/>
 				) }
 


### PR DESCRIPTION
This PR includes Akismet products into the Jetpack cancellation survey flow which will help us gain further data and insights into why users decide to cancel Akismet.

Related to: https://github.com/orgs/Automattic/projects/724/views/1?pane=issue&itemId=37724977
Project Thread: pbNhbs-87a-p2

## Proposed Changes

* Display the Jetpack cancellation survey when Akismet products are cancelled.

## Testing Instructions

- Sandbox `public-api.wordpress.com` and USE_STORE_SANDBOX.
- Purchase any paid Akismet product (https://akismet.com/pricing/).
- Spin up this PR -OR- use the Calypso Live (direct link) link below.
- Go to `/me/purchases` and locate the Akismet product you just purchased.
- Click the Akismet product, then click "Cancel subscription"
- Again click the "Cancel Subscription" button.
- Verify you see a popup that says,  "Are you sure you want to remove your subscription?" like the following screenshot:
- 
![Markup 2023-09-05 at 18 25 45](https://github.com/Automattic/wp-calypso/assets/11078128/25f3e43d-29e8-4e06-85fe-a9503ad3c95e)

- Click the "Next step" button.
- Verify you see the Cancellation survey popout that looks like the following screenshot:

![Screenshot on 2023-09-05 at 18-56-38](https://github.com/Automattic/wp-calypso/assets/11078128/a120aba3-f57d-4aa1-b47e-1c44ba60ee7e)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?