### PR TITLE
Fix E2E block insertion from sidebar

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -79,7 +79,10 @@ export class EditorSidebarBlockInserterComponent {
 			locator = editorParent.locator( selectors.patternResultItem( name ) ).first();
 		} else {
 			locator = editorParent
-				.getByRole( 'tabpanel', { name: 'Blocks' } )
+				// The DOM structure that hold the block options changes a LOT dependent on whether there's a search.
+				// This combined selector is not the slickest, but capture both cases.
+				// There's not an easy way to use "getByRole" to capture two cases without a lot of promise racing.
+				.locator( `.block-editor-inserter__block-list,.block-editor-block-types-list` )
 				.getByRole( 'option', { name, exact: true } )
 				.first();
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

My forms test PR (#81044) changed how we add blocks from the sidebar, but unfortunately didn't work for the cases when we search first, which actually changes the DOM structure pretty substantially! This caused a few CoBlocks scripts, which happen to search first, to break. 

Now, we use a selector that works in both search and no-search cases!

## Testing Instructions

- [x] Jetpack tests pass
- [x] GB tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
