### PR TITLE
Earn: Refactor ad payments to typescript

### DIFF
--- a/client/my-sites/earn/ads/payments.tsx
+++ b/client/my-sites/earn/ads/payments.tsx
@@ -9,24 +9,58 @@ import { useSelector } from 'calypso/state';
 import { getWordadsSettings } from 'calypso/state/selectors/get-wordads-settings';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getWordAdsPayments } from 'calypso/state/wordads/payments/selectors';
+import type { BadgeType } from '@automattic/components';
+
+type Payment = {
+	id: number;
+	paymentDate: string;
+	amount: number;
+	status: string;
+	paypalEmail: string;
+	description: string;
+};
+
+type Payments = Payment[];
+
+type WordAdSettings = {
+	optimized_ads: boolean;
+	paypal: string;
+	show_to_logged_in: string;
+	tos: string;
+	display_options: {
+		display_front_page: boolean;
+		display_post: boolean;
+		display_page: boolean;
+		enable_header_ad: boolean;
+		second_belowpost: boolean;
+		sidebar: boolean;
+		display_archive: boolean;
+	};
+	ccpa_enabled: boolean;
+	ccpa_privacy_policy_url: string;
+};
 
 const WordAdsPayments = () => {
+	console.log( 'erick is here' );
 	const translate = useTranslate();
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const payments = useSelector( ( state ) => getWordAdsPayments( state, siteId ) );
-	const wordAdsSettings = useSelector( ( state ) => getWordadsSettings( state, siteId ) );
+	const payments: Payments = useSelector( ( state ) => getWordAdsPayments( state, siteId ?? 0 ) );
+	const wordAdsSettings: WordAdSettings = useSelector( ( state ) =>
+		getWordadsSettings( state, siteId )
+	);
 
-	function statusToType( status ) {
+	function statusToType( status: string ) {
 		const map = {
 			paid: 'success',
 			pending: 'info',
 			failed: 'error',
 		};
-		return map[ status ] || 'warning';
+		return map[ status as keyof typeof map ] || 'warning';
 	}
 
-	function paymentsTable( currentPayments, type ) {
-		const rows = [];
+	function paymentsTable( currentPayments: Payments, type: string ) {
+		const rows: React.ReactNode[] = [];
+		// const rows: NodeListOf< Element > = [];
 		const classes = classNames( 'payments_history' );
 
 		currentPayments.forEach( ( payment ) => {
@@ -43,7 +77,10 @@ const WordAdsPayments = () => {
 					</td>
 					<td className="ads__payments-history-value">${ numberFormat( payment.amount, 2 ) }</td>
 					<td className="ads__payments-history-value">
-						<Badge className="ads__payments-history-badge" type={ statusToType( payment.status ) }>
+						<Badge
+							className="ads__payments-history-badge"
+							type={ statusToType( payment.status ) as BadgeType }
+						>
 							{ payment.status }
 						</Badge>
 					</td>
@@ -78,7 +115,7 @@ const WordAdsPayments = () => {
 		);
 	}
 
-	function notices( currentPayments, currentWordAdsSettings ) {
+	function notices( currentPayments: Payments, currentWordAdsSettings: WordAdSettings ) {
 		if ( ! currentPayments || ! currentWordAdsSettings ) {
 			return null;
 		}

--- a/client/my-sites/earn/ads/payments.tsx
+++ b/client/my-sites/earn/ads/payments.tsx
@@ -59,7 +59,6 @@ const WordAdsPayments = () => {
 
 	function paymentsTable( currentPayments: Payments, type: string ) {
 		const rows: React.ReactNode[] = [];
-		// const rows: NodeListOf< Element > = [];
 		const classes = classNames( 'payments_history' );
 
 		currentPayments.forEach( ( payment ) => {

--- a/client/my-sites/earn/ads/payments.tsx
+++ b/client/my-sites/earn/ads/payments.tsx
@@ -41,7 +41,6 @@ type WordAdSettings = {
 };
 
 const WordAdsPayments = () => {
-	console.log( 'erick is here' );
 	const translate = useTranslate();
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const payments: Payments = useSelector( ( state ) => getWordAdsPayments( state, siteId ?? 0 ) );

--- a/client/state/wordads/payments/selectors.js
+++ b/client/state/wordads/payments/selectors.js
@@ -5,7 +5,7 @@ import 'calypso/state/wordads/init';
  *
  * @param   {Object} state  Global State
  * @param   {number} siteId Site Id
- * @returns {Object}        WordAds Error
+ * @returns {Array}         Array of Payment or WordAds Error
  */
 export function getWordAdsPayments( state, siteId ) {
 	return state.wordads?.payments?.[ siteId ] ?? [];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Refactors the Earn > Ads > Payments component to TypeScript. Follow up to https://github.com/Automattic/wp-calypso/pull/81034 and part of effort to update Earn-related code.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Checkout this branch and go to `http://calypso.localhost:3000/earn/YOURDOMAIN`
2) Test Ads pages to confirm they look and behave the same as before: 
   - If you haven't yet, find the Ads card and enable Ads. 
   - Click around on the ads dashboard and confirm everything loads as expect. 
3) Bonus: I don't have a personal site with ad revenue to check earning stats. I tested this by using the Switch to User functionality. I went to an active WordPress.com site with ads and confirmed totals still show. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
