### PR TITLE
Stats: Add an option to contact support for a classification update

### DIFF
--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -192,6 +192,7 @@ const StatsPurchasePage = ( {
 												siteId={ siteId }
 												redirectUri={ query.redirect_uri ?? '' }
 												from={ query.from ?? '' }
+												isCommercial
 											/>
 										</div>
 									) }

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -50,7 +50,9 @@ const StatsPurchasePage = ( {
 	);
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 
-	const isCommercial = useSelector( ( state ) => getSiteOption( state, siteId, 'is_commercial' ) );
+	const isCommercial = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'is_commercial' )
+	) as boolean;
 
 	const { isRequestingSitePurchases, isFreeOwned, isPWYWOwned, supportCommercialUse } =
 		useStatsPurchases( siteId );
@@ -199,7 +201,7 @@ const StatsPurchasePage = ( {
 												siteId={ siteId }
 												redirectUri={ query.redirect_uri ?? '' }
 												from={ query.from ?? '' }
-												isCommercial
+												isCommercial={ isCommercial }
 											/>
 										</div>
 									) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -94,7 +94,7 @@ const StatsCommercialPurchase = ( {
 
 	const handleClick = ( event: React.MouseEvent, isOdysseyStats: boolean ) => {
 		// TODO: replace with a support ticket
-		const emailHref = 'mailto:user@example.com?subject=Subject&body=message%20goes%20here';
+		const emailHref = 'https://jetpackme.wordpress.com/contact-support/?rel=support';
 
 		event.preventDefault();
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -40,7 +40,7 @@ interface StatsSingleItemPagePurchaseProps {
 	redirectUri: string;
 	from: string;
 	siteId: number | null;
-	isCommercial: boolean;
+	isCommercial: boolean | null;
 }
 
 interface StatsSingleItemPersonalPurchasePageProps {
@@ -280,7 +280,7 @@ const StatsSingleItemPagePurchase = ( {
 				adminUrl={ adminUrl || '' }
 				redirectUri={ redirectUri }
 				from={ from }
-				showClassificationDispute={ isCommercial }
+				showClassificationDispute={ !! isCommercial }
 			/>
 		</StatsSingleItemPagePurchaseFrame>
 	);

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -7,6 +7,7 @@
 	--jp-white: #fff;
 	--jp-green-50: #008710;
 	--gray-gray-50: #646970;
+	--stats-purchase-left-min-width: 500px;
 	--stats-purchase-left-max-width: 700px;
 	--stats-purchase-right-width: 456px;
 }
@@ -77,7 +78,7 @@
 
 	.stats-purchase-wizard__card-inner--left {
 		padding: 64px;
-		min-width: 500px;
+		min-width: var(--stats-purchase-left-min-width);
 		max-width: var(--stats-purchase-left-max-width);
 		box-sizing: border-box;
 	}
@@ -391,6 +392,7 @@
 
 .stats-purchase-single__additional-card-panel {
 	margin-top: 32px;
+	width: var(--stats-purchase-left-min-width); // avoid jumping when tab content is added to the document
 
 	.stats-purchase-single__card-panel {
 		border-radius: 4px;

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -5,6 +5,7 @@
 	--jp-black: #000;
 	--jp-white: #fff;
 	--jp-green-50: #008710;
+	--gray-gray-50: #646970;
 	--stats-purchase-left-max-width: 700px;
 	--stats-purchase-right-width: 456px;
 }
@@ -293,10 +294,10 @@
 
 	.components-panel__body-toggle.components-button {
 		padding: 16px;
+	}
 
-		.components-panel__arrow {
-			display: none;
-		}
+	.components-panel__arrow {
+		display: none;
 	}
 
 	.components-base-control__field {
@@ -345,5 +346,57 @@
 
 	.components-button + .components-button {
 		margin-left: 12px;
+	}
+}
+
+.stats-purchase-single__additional-card-panel {
+	margin-top: 32px;
+
+	.stats-purchase-single__card-panel {
+		border-radius: 4px;
+	}
+
+	.components-panel__arrow {
+		display: block;
+	}
+
+	.components-panel__body {
+		padding: 0;
+
+		&.is-opened {
+			padding: 12px 16px 12px 24px;
+
+			.components-panel__body-title {
+				.components-panel__body-toggle {
+					padding: 16px; // default to the original padding due to negative margins from an opened panel
+				}
+			}
+		}
+	}
+
+	.components-panel__body-title {
+		.components-panel__body-toggle {
+			padding: 12px 16px 12px 24px;
+			font-size: var(--font-body);
+			line-height: 24px;
+			color: var(--jp-black);
+		}
+	}
+
+	p {
+		color: var(--gray-gray-50);
+		font-size: var(--font-body);
+		font-weight: 400;
+		line-height: 24px;
+	}
+
+	ul {
+		margin-bottom: 24px;
+
+		label {
+			font-size: var(--font-body);
+			line-height: 24px;
+			color: var(--jp-black);
+		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80259

## Proposed Changes

* Add a mechanism to contact support and request an update of a site classification

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* due to missing site classification this can only be tested locally
* force your environment to classify sites as commercial (`isCommercial` variable in the main purchase component)
* go to stats and apply `stats/type-detection` feature flag
* trigger commercial purchase flow
* verify that the section at the bottom is visible like on the screenshot below
* remove the forced classification
* verify that the section at the bottom **is not** visible like on the screenshot below

<img width="942" alt="SCR-20230906-khfp" src="https://github.com/Automattic/wp-calypso/assets/112354940/a6dabb72-b19e-4a46-a7af-5dde696b30c4">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?