### PR TITLE
Assembler: Navigate to the sections screen with the category list

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -7,6 +7,8 @@ export const NAVIGATOR_PATHS = {
 	MAIN_HEADER: '/main/header',
 	MAIN_FOOTER: '/main/footer',
 	MAIN_PATTERNS: '/main/:categorySlug',
+	SECTIONS: '/sections',
+	SECTIONS_PATTERNS: '/sections/:categorySlug',
 	STYLES: '/styles',
 	STYLES_COLORS: '/styles/colors',
 	STYLES_FONTS: '/styles/fonts',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
@@ -1,6 +1,6 @@
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { NAVIGATOR_PATHS } from '../constants';
+import { NAVIGATOR_PATHS, INITIAL_CATEGORY } from '../constants';
 import type { ScreenName } from '../types';
 
 export type UseScreenOptions = {
@@ -16,6 +16,11 @@ const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ) => 
 			name: 'main',
 			title: translate( 'Design your own' ),
 			initialPath: NAVIGATOR_PATHS.MAIN_HEADER,
+		},
+		sections: {
+			name: 'sections',
+			title: translate( 'Sections' ),
+			initialPath: `${ NAVIGATOR_PATHS.SECTIONS }/${ INITIAL_CATEGORY }`,
 		},
 		styles: {
 			name: 'styles',
@@ -43,6 +48,7 @@ const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ) => 
 
 	const previousScreens = {
 		main: null,
+		sections: screens.main,
 		styles: screens.main,
 		upsell: screens.styles,
 		activation: options.shouldUnlockGlobalStyles ? screens.upsell : screens.styles,
@@ -51,6 +57,7 @@ const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ) => 
 
 	const nextScreens = {
 		main: screens.styles,
+		sections: screens.main,
 		styles: ( () => {
 			if ( options.shouldUnlockGlobalStyles ) {
 				return screens.upsell;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -51,6 +51,7 @@ import ScreenConfirmation from './screen-confirmation';
 import ScreenFontPairings from './screen-font-pairings';
 import ScreenMain from './screen-main';
 import ScreenPatternListPanel from './screen-pattern-list-panel';
+import ScreenSections from './screen-sections';
 import ScreenStyles from './screen-styles';
 import ScreenUpsell from './screen-upsell';
 import { encodePatternId, getShuffledPattern, injectCategoryToPattern } from './utils';
@@ -539,15 +540,21 @@ const PatternAssembler = ( {
 				<NavigatorScreen path={ NAVIGATOR_PATHS.MAIN } partialMatch>
 					<ScreenMain
 						onMainItemSelect={ onMainItemSelect }
-						recordTracksEvent={ recordTracksEvent }
 						surveyDismissed={ surveyDismissed }
 						setSurveyDismissed={ setSurveyDismissed }
 						hasSections={ sections.length > 0 }
 						hasHeader={ !! header }
 						hasFooter={ !! footer }
+						onContinueClick={ onContinue }
+					/>
+				</NavigatorScreen>
+
+				<NavigatorScreen path={ NAVIGATOR_PATHS.SECTIONS } partialMatch>
+					<ScreenSections
 						categories={ categories }
 						patternsMapByCategory={ patternsMapByCategory }
 						onContinueClick={ onContinue }
+						recordTracksEvent={ recordTracksEvent }
 					/>
 				</NavigatorScreen>
 
@@ -590,6 +597,19 @@ const PatternAssembler = ( {
 						recordTracksEvent={ recordTracksEvent }
 					/>
 				</NavigatorScreen>
+
+				<NavigatorScreen path={ NAVIGATOR_PATHS.SECTIONS_PATTERNS }>
+					<ScreenPatternListPanel
+						categories={ categories }
+						selectedHeader={ header }
+						selectedSections={ sections }
+						selectedFooter={ footer }
+						patternsMapByCategory={ patternsMapByCategory }
+						onSelect={ onSelect }
+						recordTracksEvent={ recordTracksEvent }
+					/>
+				</NavigatorScreen>
+
 				<NavigatorScreen path={ NAVIGATOR_PATHS.STYLES_COLORS }>
 					<ScreenColorPalettes
 						siteId={ site?.ID }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -405,7 +405,12 @@ const PatternAssembler = ( {
 			screen_to: currentScreen.nextScreen.name,
 		} );
 
-		navigator.goTo( currentScreen.nextScreen.initialPath );
+		navigator.goTo( currentScreen.nextScreen.initialPath, {
+			// We have to replace the path if the screens of previous and next are the same.
+			// Otherwise, the behavior of the Back button might be weird when you navigate
+			// to the current screen again.
+			replace: currentScreen.previousScreen?.name === currentScreen.nextScreen?.name,
+		} );
 	};
 
 	const globalStylesUpgradeProps = useGlobalStylesUpgradeProps( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-category-list.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-category-list.scss
@@ -1,8 +1,5 @@
 .pattern-category-list {
-	margin: 10px -11px 0 -11px;
-
 	.components-item.navigator-item {
-		padding-left: 42px;
-		margin: 0;
+		margin: 0 -5px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-category-list.tsx
@@ -54,11 +54,7 @@ const PatternCategoryList = ( {
 							aria-label={ label }
 							aria-describedby={ description }
 							aria-current={ isActive }
-							onClick={ () => {
-								if ( ! isActive ) {
-									onSelectCategory( name );
-								}
-							} }
+							onClick={ () => onSelectCategory( name ) }
 						>
 							<NavigatorItem active={ isActive }>{ label }</NavigatorItem>
 						</CompositeItem>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
@@ -12,6 +12,7 @@
 	overflow-y: auto;
 	box-sizing: border-box;
 	transform: translateX(0);
+	// Preserve spaces for the scrollbar to prevent unwanted layout change
 	scrollbar-gutter: stable;
 	font-family: "SF Pro Text", $sans;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -79,7 +79,6 @@ const ScreenMain = ( {
 							onClick={ () =>
 								handleNavigatorItemSelect( 'section', NAVIGATOR_PATHS.SECTIONS, INITIAL_CATEGORY )
 							}
-							hasNestedItems
 						>
 							{ translate( 'Sections' ) }
 						</NavigatorItem>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-sections.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-sections.tsx
@@ -1,0 +1,68 @@
+import { NavigatorHeader } from '@automattic/onboarding';
+import {
+	Button,
+	__experimentalVStack as VStack,
+	__experimentalUseNavigator as useNavigator,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { NAVIGATOR_PATHS } from './constants';
+import { PATTERN_ASSEMBLER_EVENTS } from './events';
+import { useScreen } from './hooks';
+import NavigatorTitle from './navigator-title';
+import PatternCategoryList from './pattern-category-list';
+import { Pattern, Category } from './types';
+
+interface Props {
+	categories: Category[];
+	patternsMapByCategory: { [ key: string ]: Pattern[] };
+	onContinueClick: () => void;
+	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
+}
+
+const ScreenSections = ( {
+	categories,
+	patternsMapByCategory,
+	onContinueClick,
+	recordTracksEvent,
+}: Props ) => {
+	const translate = useTranslate();
+	const { title } = useScreen( 'sections' );
+	const { params, goTo } = useNavigator();
+	const selectedCategory = params.categorySlug as string;
+
+	const onSelectSectionCategory = ( category: string ) => {
+		goTo( `${ NAVIGATOR_PATHS.SECTIONS }/${ category }`, { replace: true } );
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.CATEGORY_LIST_CATEGORY_CLICK, {
+			pattern_category: category,
+		} );
+	};
+
+	return (
+		<>
+			<NavigatorHeader
+				title={ <NavigatorTitle title={ title } /> }
+				description={ translate(
+					'Find the right patterns for you be exploring the list of categories below'
+				) }
+				hideBack
+			/>
+			<div className="screen-container__body">
+				<VStack spacing="4">
+					<PatternCategoryList
+						categories={ categories }
+						patternsMapByCategory={ patternsMapByCategory }
+						selectedCategory={ selectedCategory }
+						onSelectCategory={ onSelectSectionCategory }
+					/>
+				</VStack>
+			</div>
+			<div className="screen-container__footer">
+				<Button className="pattern-assembler__button" variant="primary" onClick={ onContinueClick }>
+					{ translate( 'Save and continue' ) }
+				</Button>
+			</div>
+		</>
+	);
+};
+
+export default ScreenSections;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-sections.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-sections.tsx
@@ -1,3 +1,4 @@
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { NavigatorHeader } from '@automattic/onboarding';
 import {
 	Button,
@@ -29,6 +30,7 @@ const ScreenSections = ( {
 	const { title } = useScreen( 'sections' );
 	const { params, goTo } = useNavigator();
 	const selectedCategory = params.categorySlug as string;
+	const hasEnTranslation = useHasEnTranslation();
 
 	const onSelectSectionCategory = ( category: string ) => {
 		const nextPath =
@@ -46,9 +48,17 @@ const ScreenSections = ( {
 		<>
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ title } /> }
-				description={ translate(
-					'Find the right patterns for you be exploring the list of categories below'
-				) }
+				description={
+					hasEnTranslation(
+						'Find the right patterns for you by exploring the list of categories below.'
+					)
+						? translate(
+								'Find the right patterns for you by exploring the list of categories below.'
+						  )
+						: translate(
+								'Find the section patterns for your homepage by exploring the categories below.'
+						  )
+				}
 				hideBack
 			/>
 			<div className="screen-container__body">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-sections.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-sections.tsx
@@ -31,7 +31,12 @@ const ScreenSections = ( {
 	const selectedCategory = params.categorySlug as string;
 
 	const onSelectSectionCategory = ( category: string ) => {
-		goTo( `${ NAVIGATOR_PATHS.SECTIONS }/${ category }`, { replace: true } );
+		const nextPath =
+			category !== selectedCategory
+				? `${ NAVIGATOR_PATHS.SECTIONS }/${ category }`
+				: NAVIGATOR_PATHS.SECTIONS;
+
+		goTo( nextPath, { replace: true } );
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.CATEGORY_LIST_CATEGORY_CLICK, {
 			pattern_category: category,
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -300,8 +300,6 @@ $font-family: "SF Pro Text", $sans;
 		margin: 0 -16px 32px;
 		margin-bottom: 32px;
 		overflow-y: auto;
-		// Reserve space for the scrollbar to prevent unwanted layout change
-		scrollbar-gutter: stable;
 
 		&.screen-category-list__body {
 			// Reduces .navigator-header margin

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -34,7 +34,7 @@ export type PanelObject = {
 	selectedPatterns?: Pattern[];
 };
 
-export type ScreenName = 'main' | 'styles' | 'confirmation' | 'activation' | 'upsell';
+export type ScreenName = 'main' | 'sections' | 'styles' | 'confirmation' | 'activation' | 'upsell';
 
 export type Tag = {
 	slug: string;

--- a/packages/onboarding/src/navigator/navigator-buttons/index.tsx
+++ b/packages/onboarding/src/navigator/navigator-buttons/index.tsx
@@ -5,7 +5,7 @@ import {
 	FlexItem,
 } from '@wordpress/components';
 import { isRTL } from '@wordpress/i18n';
-import { Icon, chevronLeft, chevronRight, chevronDown, check } from '@wordpress/icons';
+import { Icon, chevronLeft, chevronRight, check } from '@wordpress/icons';
 import classnames from 'classnames';
 import './style.scss';
 
@@ -16,21 +16,13 @@ interface NavigatorItemProps {
 	onClick?: () => void;
 	checked?: boolean;
 	active?: boolean;
-	hasNestedItems?: boolean;
 }
 
 interface NavigatorButtonAsItemProps extends NavigatorItemProps {
 	path: string;
 }
 
-export function NavigatorItem( {
-	icon,
-	checked,
-	active,
-	hasNestedItems,
-	children,
-	...props
-}: NavigatorItemProps ) {
+export function NavigatorItem( { icon, checked, active, children, ...props }: NavigatorItemProps ) {
 	const content = icon ? (
 		<HStack justify="flex-start">
 			<Icon className="navigator-item__icon" icon={ checked ? check : icon } size={ 24 } />
@@ -52,7 +44,7 @@ export function NavigatorItem( {
 		>
 			<HStack justify="space-between">
 				{ content }
-				<Icon icon={ active && hasNestedItems ? chevronDown : forwardIcon } size={ 24 } />
+				<Icon icon={ forwardIcon } size={ 24 } />
 			</HStack>
 		</Item>
 	);

--- a/test/e2e/specs/onboarding/ftme__site-assembler.ts
+++ b/test/e2e/specs/onboarding/ftme__site-assembler.ts
@@ -100,6 +100,7 @@ describe( 'Site Assembler', () => {
 		it( 'Select "Sections"', async function () {
 			await siteAssemblerFlow.clickLayoutComponentType( 'Sections' );
 			await siteAssemblerFlow.selectLayoutComponent( { index: 0 } );
+			await siteAssemblerFlow.clickButton( 'Save and continue' );
 
 			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 2 );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/81436

## Proposed Changes

* Add the Sections screen back. It shows the category list on the sidebar and patterns with the selected category on the panel next to the sidebar

**Screenshots**

![image](https://github.com/Automattic/wp-calypso/assets/13596067/0a44aaef-15fe-490f-9e2d-822faa6282e1)

**Demo**

https://github.com/Automattic/wp-calypso/assets/13596067/bacadfeb-853b-461c-9f8a-1dc8dd58f306

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase
* Select the Assembler CTA
* On the Assembler screen
  * Click “Sections”
  * Ensure the sidebar becomes the category list, and the first category is preselected
  * Click “< Back to Design your own” or “Save and continue”
  * Ensure the sidebar goes back to the previous one with “Header”, “Sections” and “Footer”

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?