### PR TITLE
Update log queries to use GET method

### DIFF
--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -58,7 +58,7 @@ export function useSiteLogsQuery(
 		queryFn: () => {
 			const logTypeFragment = params.logType === 'php' ? 'error-logs' : 'logs';
 			const path = `/sites/${ siteId }/hosting/${ logTypeFragment }`;
-			return wpcom.req.post(
+			return wpcom.req.get(
 				{ path, apiNamespace: 'wpcom/v2' },
 				{
 					start: params.start,

--- a/client/my-sites/site-monitoring/hooks/use-site-logs-downloader.ts
+++ b/client/my-sites/site-monitoring/hooks/use-site-logs-downloader.ts
@@ -167,7 +167,7 @@ export const useSiteLogsDownloader = ( {
 
 		do {
 			await wpcom.req
-				.post(
+				.get(
 					{
 						path,
 						apiNamespace: 'wpcom/v2',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3167

## Proposed Changes

In this diff, I propose to update log queries to use GET endpoint instead of POST to follow refactoring from D120785-code.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

See D120785-code.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?