### PR TITLE
Theme Showcase: Track clicks on the active theme

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -104,9 +104,7 @@ class ThemesSelection extends Component {
 
 	onScreenshotClick = ( themeId, resultsRank ) => {
 		trackClick( 'theme', 'screenshot' );
-		if ( ! this.props.isThemeActive( themeId ) ) {
-			this.recordSearchResultsClick( themeId, resultsRank, 'screenshot_info' );
-		}
+		this.recordSearchResultsClick( themeId, resultsRank, 'screenshot_info' );
 		this.props.onScreenshotClick && this.props.onScreenshotClick( themeId );
 	};
 

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -73,7 +73,13 @@ class ThemesSelection extends Component {
 		}
 	}
 
-	recordSearchResultsClick = ( themeId, resultsRank, action, variation = '@theme' ) => {
+	recordSearchResultsClick = (
+		themeId,
+		resultsRank,
+		action,
+		variation = '@theme',
+		isActiveTheme = false
+	) => {
 		const { query, filterString, themes } = this.props;
 		const search_taxonomies = filterString;
 		const search_term = search_taxonomies + ( query.search || '' );
@@ -82,6 +88,7 @@ class ThemesSelection extends Component {
 			search_term: search_term || null,
 			search_taxonomies,
 			theme: themeId,
+			is_active_theme: isActiveTheme,
 			style_variation: variation,
 			results_rank: resultsRank + 1,
 			results: themes.map( property( 'id' ) ).join(),
@@ -104,7 +111,13 @@ class ThemesSelection extends Component {
 
 	onScreenshotClick = ( themeId, resultsRank ) => {
 		trackClick( 'theme', 'screenshot' );
-		this.recordSearchResultsClick( themeId, resultsRank, 'screenshot_info' );
+		this.recordSearchResultsClick(
+			themeId,
+			resultsRank,
+			'screenshot_info',
+			'@theme',
+			this.props.isThemeActive( themeId )
+		);
 		this.props.onScreenshotClick && this.props.onScreenshotClick( themeId );
 	};
 


### PR DESCRIPTION
Related to #https://github.com/Automattic/wp-calypso/issues/81409

## Proposed Changes

* We now track all the clicks that happen on the Theme Showcase's results regardless of if the theme is an actual result or the active theme.

## Testing Instructions
* Open the Calypso live link in this PR.
* Navigate to `{live link}/themes/{site slug}`
* Open your browser's Network tab in developer tools and filter by `t.gif`
* Click on the first result in the Theme Showcase (it should be the active theme)
* A `calypso_themeshowcase_theme_click` event must be triggered, the event must have the `is_active_theme` property set to true.
* Repeat with a theme that isn't active, you should get the same result except that the `is_active_theme` property should be false.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?