### PR TITLE
I18N: Translate Video stats headers

### DIFF
--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -272,18 +272,20 @@ class VideoPressStatsModule extends Component {
 						<Card compact className={ cardClasses }>
 							<div className="videopress-stats-module__grid">
 								<div className="videopress-stats-module__header-row-wrapper">
-									<div className="videopress-stats-module__grid-header">Title</div>
-									<div className="videopress-stats-module__grid-header videopress-stats-module__grid-metric">
-										Impressions
+									<div className="videopress-stats-module__grid-header">
+										{ translate( 'Title' ) }
 									</div>
 									<div className="videopress-stats-module__grid-header videopress-stats-module__grid-metric">
-										Hours Watched
+										{ translate( 'Impressions' ) }
 									</div>
 									<div className="videopress-stats-module__grid-header videopress-stats-module__grid-metric">
-										Retention Rate
+										{ translate( 'Hours Watched' ) }
 									</div>
 									<div className="videopress-stats-module__grid-header videopress-stats-module__grid-metric">
-										Views
+										{ translate( 'Retention Rate' ) }
+									</div>
+									<div className="videopress-stats-module__grid-header videopress-stats-module__grid-metric">
+										{ translate( 'Views' ) }
 									</div>
 								</div>
 								{ completeVideoStats.map( ( row, index ) => (


### PR DESCRIPTION
## Proposed Changes

* In the video stats screen in Calypso (stats/day/videoplays/[site]), the headers aren't translated.
This PR localises the header strings:
<img width="897" alt="image" src="https://github.com/Automattic/wp-calypso/assets/23708351/f62e7be4-bc4d-400f-8bd2-4454a10ab9e3">



## Testing Instructions

* Set your account to a Mag-16 language
* Visit the stats/day/videoplays/[site] page for a specific site and confirm that the table headers are now translated.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
