### PR TITLE
Fix ul and ol elements in the Odie messages

### DIFF
--- a/client/odie/message/style.scss
+++ b/client/odie/message/style.scss
@@ -11,6 +11,12 @@
 	line-height: 1.4;
 	color: #000;
 	flex-direction: column;
+
+	ol,
+	ul {
+		margin: 0 0 1.5em 1.5em;
+		width: calc(100% - 1.5em);
+	}
 }
 
 .odie-chatbox-message.odyssus-chatbox-message-user {


### PR DESCRIPTION
Odie is not correctly showing the messages in markdown when they are `ol`, `ul` elements

## Proposed Changes

Change the CSS styling so it correctly displays `ul`, `ol` html elements.

## Testing Instructions

1. Be proxied
2. Go to plans page
3. Append ?flags=odie to the URL
4. Ask Wapuu to list benefits in markdown on having a domain
5. Check that the messages has correct styling (eg. text is not overflown)

