### PR TITLE
Fix lack of padding under comment form button

### DIFF
--- a/client/blocks/comments/form.scss
+++ b/client/blocks/comments/form.scss
@@ -19,7 +19,7 @@
 	button:not(.components-button) {
 		opacity: 0;
 		position: absolute;
-		margin: 16px 0 -19px;
+		margin: 16px 0 0;
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {


### PR DESCRIPTION
## Description

@niranjan-uma-shankar pointed out that there was a lack of padding below the inline comment button within the reader.

## Before
<img width="643" alt="before" src="https://github.com/Automattic/wp-calypso/assets/5634774/512c9fd3-c1ff-48e5-8165-0a31ae2be40d">

## After
<img width="651" alt="after" src="https://github.com/Automattic/wp-calypso/assets/5634774/2263839b-66c7-448e-aae4-bbf948d51f51">

## Testing
- Click the Calypso Live button
- Head to the reader
- Look for a post with a comment box, but no comments and click into it