### PR TITLE
I18N: Translate data-centers in Hosting onboarding flow

### DIFF
--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -26,7 +26,9 @@ const DataCenterOptions = [
 	{
 		value: 'bur',
 		name: 'geo_affinity',
-		label: translate( 'US West' ),
+		get label(): string {
+			return translate( 'US West' );
+		},
 		thumbnail: {
 			imageUrl: burImg,
 		},
@@ -34,7 +36,9 @@ const DataCenterOptions = [
 	{
 		value: 'dfw',
 		name: 'geo_affinity',
-		label: translate( 'US Central' ),
+		get label(): string {
+			return translate( 'US Central' );
+		},
 		thumbnail: {
 			imageUrl: dfwImg,
 		},
@@ -42,7 +46,9 @@ const DataCenterOptions = [
 	{
 		value: 'dca',
 		name: 'geo_affinity',
-		label: translate( 'US East' ),
+		get label(): string {
+			return translate( 'US East' );
+		},
 		thumbnail: {
 			imageUrl: dcaImg,
 		},
@@ -50,7 +56,9 @@ const DataCenterOptions = [
 	{
 		value: 'ams',
 		name: 'geo_affinity',
-		label: translate( 'EU West' ),
+		get label(): string {
+			return translate( 'EU West' );
+		},
 		thumbnail: {
 			imageUrl: amsImg,
 		},


### PR DESCRIPTION
## Proposed Changes

* The data center locations in the Hosting onboarding flow are currently not translated.  This diff wraps the properties in getters to refresh the strings once the locale is updated. 

## Testing Instructions
* Change your language to mag-16 language
* Start at `start/hosting`
* After validating your user, select "Create a site"
* Select "Custom data center"
* Confirm that the data center locations are now translated:
<img width="700" alt="image" src="https://github.com/Automattic/wp-calypso/assets/23708351/502e5293-ea2d-49e3-adb8-753152b5111d">
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
