### PR TITLE
Migration Trial: fix migrate and expired plan redirect conflicts

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -287,37 +287,35 @@ function isPathAllowedForDIFMInProgressSite( path, slug, domains, contextParams 
 function onSelectedSiteAvailable( context ) {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
-
-	// If migration is in progress, only /migrate paths should be loaded for the site
-	const isMigrationInProgress = isSiteMigrationInProgress( state, selectedSite.ID );
-
-	if ( isMigrationInProgress && ! startsWith( context.pathname, '/migrate/' ) ) {
-		page.redirect( `/migrate/${ selectedSite.slug }` );
-		return false;
-	}
+	// Use getSitePlanSlug() as it ignores expired plans.
+	const currentPlanSlug = getSitePlanSlug( state, selectedSite.ID );
 
 	// If we had a trial plan, and the user doesn't have an active paid plan, redirect to fullpage trial expired page.
-	if ( wasTrialSite( state, selectedSite.ID ) ) {
-		// Use getSitePlanSlug() as it ignores expired plans.
-		const currentPlanSlug = getSitePlanSlug( state, selectedSite.ID );
+	if (
+		wasTrialSite( state, selectedSite.ID ) &&
+		[ PLAN_FREE, PLAN_JETPACK_FREE ].includes( currentPlanSlug )
+	) {
+		const permittedPathPrefixes = [
+			'/checkout/',
+			'/domains/',
+			'/email/',
+			'/export/',
+			'/plans/my-plan/trial-expired/',
+			'/purchases/',
+			'/settings/delete-site/',
+		];
 
-		if ( [ PLAN_FREE, PLAN_JETPACK_FREE ].includes( currentPlanSlug ) ) {
-			const permittedPathPrefixes = [
-				'/checkout/',
-				'/domains/',
-				'/email/',
-				'/export/',
-				'/plans/my-plan/trial-expired/',
-				'/purchases/',
-				'/settings/delete-site/',
-			];
-
-			if ( ! permittedPathPrefixes.some( ( prefix ) => context.pathname.startsWith( prefix ) ) ) {
-				page.redirect( `/plans/my-plan/trial-expired/${ selectedSite.slug }` );
-				return false;
-			}
-
-			context.hideLeftNavigation = true;
+		if ( ! permittedPathPrefixes.some( ( prefix ) => context.pathname.startsWith( prefix ) ) ) {
+			page.redirect( `/plans/my-plan/trial-expired/${ selectedSite.slug }` );
+			return false;
+		}
+		context.hideLeftNavigation = true;
+	} else {
+		// If migration is in progress, only /migrate paths should be loaded for the site
+		const isMigrationInProgress = isSiteMigrationInProgress( state, selectedSite.ID );
+		if ( isMigrationInProgress && ! startsWith( context.pathname, '/migrate/' ) ) {
+			page.redirect( `/migrate/${ selectedSite.slug }` );
+			return false;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81386

## Proposed Changes

Currently we redirect users to /migrate if user is in the middle of migration when you go to the dashboard, but we also redirect users to `/plans/my-plan/trial-expired/:site_slug` if a user has an expired trial plan. But we don't have condition check with users in both status so users will keep bouncing between /migrate and /trial-expired page.

In this PR, we change the way we handle the redirection, if a user has a expired trial plan, they shouldn't run the `/migrate` check at all.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up free site and go through the migration flow. Turn the site into a migration trial site.
* Kick off the migration.
* Go to wp-admin store and make your trial site expire.
* Navigate to `http://calypso.localhost:3000/plans/my-plan/trial-expired/${site_slug}` and make sure it shows the upgrade plan screen and not bouncing between screens.
* Check the production site with the same URL and you'll see the site bouncing between /migrate and /trial-expired page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?