### PR TITLE
wp-babel-makepot: Add `decorators` preset

### DIFF
--- a/packages/wp-babel-makepot/cli.js
+++ b/packages/wp-babel-makepot/cli.js
@@ -51,11 +51,12 @@ program
 		const filesGlob = files.trim().replace( /^~/, os.homedir() ).split( /\s/gm );
 		const ignore = program.ignore && program.ignore.split( ',' );
 
-		const { dir, base, output, linesFilter } = program;
+		const { preset, dir, base, output, linesFilter } = program;
 
 		filesGlob.forEach( ( pattern ) => {
 			glob.sync( pattern, { nodir: true, absolute: true, ignore } ).forEach( ( filepath ) =>
 				makePot( filepath, {
+					preset,
 					base,
 					dir,
 				} )

--- a/packages/wp-babel-makepot/index.js
+++ b/packages/wp-babel-makepot/index.js
@@ -1,5 +1,5 @@
 const babel = require( '@babel/core' );
-const defaultPreset = require( './presets' ).default;
+const presets = require( './presets' );
 
 /**
  * Merge options object with existing babel-i18n plugin options.
@@ -18,9 +18,10 @@ const mergeOptions = ( preset, options = {} ) => {
 	return preset;
 };
 
-module.exports = ( filepath, options = {} ) => {
+module.exports = ( filepath, options = { preset: 'default' } ) => {
 	try {
-		return babel.transformFileSync( filepath, mergeOptions( defaultPreset, options ) );
+		const { preset, ...restOptions } = options;
+		return babel.transformFileSync( filepath, mergeOptions( presets[ preset ], restOptions ) );
 	} catch ( error ) {
 		console.error( filepath, error );
 	}

--- a/packages/wp-babel-makepot/index.js
+++ b/packages/wp-babel-makepot/index.js
@@ -18,9 +18,9 @@ const mergeOptions = ( preset, options = {} ) => {
 	return preset;
 };
 
-module.exports = ( filepath, options = { preset: 'default' } ) => {
+module.exports = ( filepath, options = {} ) => {
 	try {
-		const { preset, ...restOptions } = options;
+		const { preset = 'default', ...restOptions } = options;
 		return babel.transformFileSync( filepath, mergeOptions( presets[ preset ], restOptions ) );
 	} catch ( error ) {
 		console.error( filepath, error );

--- a/packages/wp-babel-makepot/package.json
+++ b/packages/wp-babel-makepot/package.json
@@ -29,7 +29,7 @@
 		"@babel/cli": "^7.17.6",
 		"@babel/core": "^7.17.5",
 		"@babel/plugin-proposal-class-properties": "^7.16.7",
-		"@babel/plugin-proposal-decorators": "^7.16.7",
+		"@babel/plugin-proposal-decorators": "^7.22.15",
 		"@babel/preset-env": "^7.16.11",
 		"@babel/preset-react": "^7.16.7",
 		"@babel/preset-typescript": "^7.16.7",

--- a/packages/wp-babel-makepot/package.json
+++ b/packages/wp-babel-makepot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wp-babel-makepot",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"description": "A utility for extracting translatable strings from JavaScript source.",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",

--- a/packages/wp-babel-makepot/package.json
+++ b/packages/wp-babel-makepot/package.json
@@ -29,6 +29,7 @@
 		"@babel/cli": "^7.17.6",
 		"@babel/core": "^7.17.5",
 		"@babel/plugin-proposal-class-properties": "^7.16.7",
+		"@babel/plugin-proposal-decorators": "^7.22.15",
 		"@babel/preset-env": "^7.16.11",
 		"@babel/preset-react": "^7.16.7",
 		"@babel/preset-typescript": "^7.16.7",

--- a/packages/wp-babel-makepot/package.json
+++ b/packages/wp-babel-makepot/package.json
@@ -29,7 +29,7 @@
 		"@babel/cli": "^7.17.6",
 		"@babel/core": "^7.17.5",
 		"@babel/plugin-proposal-class-properties": "^7.16.7",
-		"@babel/plugin-proposal-decorators": "^7.22.15",
+		"@babel/plugin-proposal-decorators": "^7.16.7",
 		"@babel/preset-env": "^7.16.11",
 		"@babel/preset-react": "^7.16.7",
 		"@babel/preset-typescript": "^7.16.7",

--- a/packages/wp-babel-makepot/presets/decorators.js
+++ b/packages/wp-babel-makepot/presets/decorators.js
@@ -1,0 +1,9 @@
+const defaultPreset = require( './default' );
+
+module.exports = {
+	...defaultPreset,
+	plugins: [
+		[ '@babel/plugin-proposal-decorators', { version: '2023-05' } ],
+		...defaultPreset.plugins,
+	],
+};

--- a/packages/wp-babel-makepot/presets/decorators.js
+++ b/packages/wp-babel-makepot/presets/decorators.js
@@ -3,7 +3,7 @@ const defaultPreset = require( './default' );
 module.exports = {
 	...defaultPreset,
 	plugins: [
-		[ '@babel/plugin-proposal-decorators', { version: '2023-05' } ],
+		[ '@babel/plugin-proposal-decorators', { version: 'legacy' } ],
 		...defaultPreset.plugins,
 	],
 };

--- a/packages/wp-babel-makepot/presets/index.js
+++ b/packages/wp-babel-makepot/presets/index.js
@@ -1,4 +1,5 @@
 const path = require( 'path' );
+const decoratorsPreset = require( './decorators' );
 const defaultPreset = require( './default' );
 
 /**
@@ -29,6 +30,7 @@ const extendBaseOptions = ( { presets = [], plugins = [], ...rest } ) => ( {
 
 const presets = {
 	default: extendBaseOptions( defaultPreset ),
+	decorators: extendBaseOptions( decoratorsPreset ),
 };
 
 module.exports = presets;

--- a/packages/wp-babel-makepot/test/__snapshots__/index.js.snap
+++ b/packages/wp-babel-makepot/test/__snapshots__/index.js.snap
@@ -55,6 +55,10 @@ msgid_plural \\"Second param should be extracted as plural instead of context\\"
 msgstr[0] \\"\\"
 msgstr[1] \\"\\"
 
+#: test/examples/typescript-decorators.ts:5
+msgid \\"Decorator Preset\\"
+msgstr \\"\\"
+
 #: test/examples/typescript-react.tsx:8
 msgid \\"Typescript react component string\\"
 msgstr \\"\\"
@@ -110,6 +114,7 @@ Array [
   "output/test-examples-react-2.jsx.pot",
   "output/test-examples-translate-1.js.pot",
   "output/test-examples-translate-2.js.pot",
+  "output/test-examples-typescript-decorators.ts.pot",
   "output/test-examples-typescript-react.tsx.pot",
   "output/test-examples-wordpress-i18n.js.pot",
 ]
@@ -214,12 +219,21 @@ exports[`makePot pot files should match their snapshots 6`] = `
 "msgid \\"\\"
 msgstr \\"Content-Type: text/plain; charset=utf-8\\\\n\\"
 
+#: test/examples/typescript-decorators.ts:5
+msgid \\"Decorator Preset\\"
+msgstr \\"\\""
+`;
+
+exports[`makePot pot files should match their snapshots 7`] = `
+"msgid \\"\\"
+msgstr \\"Content-Type: text/plain; charset=utf-8\\\\n\\"
+
 #: test/examples/typescript-react.tsx:8
 msgid \\"Typescript react component string\\"
 msgstr \\"\\""
 `;
 
-exports[`makePot pot files should match their snapshots 7`] = `
+exports[`makePot pot files should match their snapshots 8`] = `
 "msgid \\"\\"
 msgstr \\"Content-Type: text/plain; charset=utf-8\\\\n\\"
 

--- a/packages/wp-babel-makepot/test/examples/typescript-decorators.ts
+++ b/packages/wp-babel-makepot/test/examples/typescript-decorators.ts
@@ -1,0 +1,7 @@
+@DecoratorClass( 'example' )
+class ExamlpeClass {
+	@DecoratorMethod( 'example' )
+	public async getItem( @DecoratorParam( 'example' ) id?: number ): string {
+		return translate( 'Decorator Preset' );
+	}
+}

--- a/packages/wp-babel-makepot/test/index.js
+++ b/packages/wp-babel-makepot/test/index.js
@@ -20,9 +20,10 @@ describe( 'makePot', () => {
 
 		fs.mkdirSync( path.join( potOutputDir, 'payload' ), { recursive: true } );
 
-		examplesPaths.forEach( ( filepath ) =>
-			makePot( filepath, { dir: potOutputDir, base: baseDir } )
-		);
+		examplesPaths.forEach( ( filepath ) => {
+			const preset = filepath.includes( 'decorators' ) ? 'decorators' : 'default';
+			makePot( filepath, { preset, dir: potOutputDir, base: baseDir } );
+		} );
 
 		concatPot( potOutputDir, concatenatedPotOutputPath );
 	} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1750,7 +1750,7 @@ __metadata:
     "@babel/cli": ^7.17.6
     "@babel/core": ^7.17.5
     "@babel/plugin-proposal-class-properties": ^7.16.7
-    "@babel/plugin-proposal-decorators": ^7.16.7
+    "@babel/plugin-proposal-decorators": ^7.22.15
     "@babel/preset-env": ^7.16.11
     "@babel/preset-react": ^7.16.7
     "@babel/preset-typescript": ^7.16.7
@@ -2448,7 +2448,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-decorators@npm:^7.16.7":
+"@babel/plugin-proposal-decorators@npm:^7.22.15":
   version: 7.22.15
   resolution: "@babel/plugin-proposal-decorators@npm:7.22.15"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1750,6 +1750,7 @@ __metadata:
     "@babel/cli": ^7.17.6
     "@babel/core": ^7.17.5
     "@babel/plugin-proposal-class-properties": ^7.16.7
+    "@babel/plugin-proposal-decorators": ^7.22.15
     "@babel/preset-env": ^7.16.11
     "@babel/preset-react": ^7.16.7
     "@babel/preset-typescript": ^7.16.7
@@ -2109,6 +2110,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-annotate-as-pure@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-annotate-as-pure@npm:7.22.5"
+  dependencies:
+    "@babel/types": ^7.22.5
+  checksum: 5a80dc364ddda26b334bbbc0f6426cab647381555ef7d0cd32eb284e35b867c012ce6ce7d52a64672ed71383099c99d32765b3d260626527bb0e3470b0f58e45
+  languageName: node
+  linkType: hard
+
 "@babel/helper-builder-binary-assignment-operator-visitor@npm:^7.18.6":
   version: 7.21.5
   resolution: "@babel/helper-builder-binary-assignment-operator-visitor@npm:7.21.5"
@@ -2149,6 +2159,25 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: f875a1367d0569a7217c6ff97666755b3d305b698e263a888a42dc9a5494d64fdf3224accfb47548c6f7150c986e877cdda99501c674297b51e8f69a52ce6f82
+  languageName: node
+  linkType: hard
+
+"@babel/helper-create-class-features-plugin@npm:^7.22.15":
+  version: 7.22.15
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.22.15"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.22.5
+    "@babel/helper-environment-visitor": ^7.22.5
+    "@babel/helper-function-name": ^7.22.5
+    "@babel/helper-member-expression-to-functions": ^7.22.15
+    "@babel/helper-optimise-call-expression": ^7.22.5
+    "@babel/helper-replace-supers": ^7.22.9
+    "@babel/helper-skip-transparent-expression-wrappers": ^7.22.5
+    "@babel/helper-split-export-declaration": ^7.22.6
+    semver: ^6.3.1
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 2ae5759fe8845fda99b34f2ba6cd0794fc860213d14c93a87aa9180960252bce621157a79c373b7fbb423b25a55fb0e20eae0d5f8e4ad5ef22dc70e7c2af3805
   languageName: node
   linkType: hard
 
@@ -2216,6 +2245,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-member-expression-to-functions@npm:^7.22.15, @babel/helper-member-expression-to-functions@npm:^7.22.5":
+  version: 7.22.15
+  resolution: "@babel/helper-member-expression-to-functions@npm:7.22.15"
+  dependencies:
+    "@babel/types": ^7.22.15
+  checksum: 531de203316dd14b0cb64b756f65fedacc8bfb8072e0e9ca92b1df6833d92f821277ef95ab4d148b6f8e0dc368d29e05a8f1cc7a0b87fd7c0cb2f0b25fbacc70
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-imports@npm:^7.16.7, @babel/helper-module-imports@npm:^7.18.6, @babel/helper-module-imports@npm:^7.21.4, @babel/helper-module-imports@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-module-imports@npm:7.22.5"
@@ -2247,6 +2285,15 @@ __metadata:
   dependencies:
     "@babel/types": ^7.18.6
   checksum: f1352ebc5d9abae6088e7d9b4b6b445c406ba552ef61e967ec77d005ff65752265b002b6faaf16cc293f9e37753760ef05c1f4b26cda1039256917022ba5669c
+  languageName: node
+  linkType: hard
+
+"@babel/helper-optimise-call-expression@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-optimise-call-expression@npm:7.22.5"
+  dependencies:
+    "@babel/types": ^7.22.5
+  checksum: 31b41a764fc3c585196cf5b776b70cf4705c132e4ce9723f39871f215f2ddbfb2e28a62f9917610f67c8216c1080482b9b05f65dd195dae2a52cef461f2ac7b8
   languageName: node
   linkType: hard
 
@@ -2285,6 +2332,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-replace-supers@npm:^7.22.9":
+  version: 7.22.9
+  resolution: "@babel/helper-replace-supers@npm:7.22.9"
+  dependencies:
+    "@babel/helper-environment-visitor": ^7.22.5
+    "@babel/helper-member-expression-to-functions": ^7.22.5
+    "@babel/helper-optimise-call-expression": ^7.22.5
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 9ef42e0d1f81d3377c96449c82666d54daea86db9f352915d2aff7540008cd65f23574bc97a74308b6203f7a8c6bf886d1cc1fa24917337d3d12ea93cb2a53a8
+  languageName: node
+  linkType: hard
+
 "@babel/helper-simple-access@npm:^7.21.5, @babel/helper-simple-access@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-simple-access@npm:7.22.5"
@@ -2300,6 +2360,15 @@ __metadata:
   dependencies:
     "@babel/types": ^7.20.0
   checksum: 8529fb760ffbc3efc22ec5a079039fae65f40a90e9986642a85c1727aabdf6a79929546412f6210593970d2f97041f73bdd316e481d61110d6edcac1f97670a9
+  languageName: node
+  linkType: hard
+
+"@babel/helper-skip-transparent-expression-wrappers@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.22.5"
+  dependencies:
+    "@babel/types": ^7.22.5
+  checksum: ab7fa2aa709ab49bb8cd86515a1e715a3108c4bb9a616965ba76b43dc346dee66d1004ccf4d222b596b6224e43e04cbc5c3a34459501b388451f8c589fbc3691
   languageName: node
   linkType: hard
 
@@ -2323,6 +2392,13 @@ __metadata:
   version: 7.22.5
   resolution: "@babel/helper-validator-identifier@npm:7.22.5"
   checksum: 2ff1d3833154d17ccf773b8a71fdc0cd0e7356aa8033179d0e3133787dfb33d97796cbff8b92a97c56268205337dfc720227aeddc677c1bc08ae1b67a95252d7
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.22.15":
+  version: 7.22.15
+  resolution: "@babel/helper-validator-identifier@npm:7.22.15"
+  checksum: 0473ccfd123cf872206eb916ec506f8963f75db50413560d4d1674aed4cd5d9354826c2514474d6cd40637d3bdc515ba87e8035b4bed683ba62cb607e0081aaf
   languageName: node
   linkType: hard
 
@@ -2445,6 +2521,21 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.12.0
   checksum: b46eb08badd7943c7bdf06fa6f1bb171e00f26d3c25e912205f735ccc321d1dbe8d023d97491320017e0e5d083b7aab3104f5a661535597d278a6c833c97eb79
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-decorators@npm:^7.22.15":
+  version: 7.22.15
+  resolution: "@babel/plugin-proposal-decorators@npm:7.22.15"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": ^7.22.15
+    "@babel/helper-plugin-utils": ^7.22.5
+    "@babel/helper-replace-supers": ^7.22.9
+    "@babel/helper-split-export-declaration": ^7.22.6
+    "@babel/plugin-syntax-decorators": ^7.22.10
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 1af2367ef3bd3d459146b95e066e009a15e55c178cd73368e7a063248f9a079114a1da56d0b3a442a2afd6ba1f0ebb2027fc3813d1548b8319fc45560158baea
   languageName: node
   linkType: hard
 
@@ -2639,6 +2730,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 4464bf9115f4a2d02ce1454411baf9cfb665af1da53709c5c56953e5e2913745b0fcce82982a00463d6facbdd93445c691024e310b91431a1e2f024b158f6371
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-decorators@npm:^7.22.10":
+  version: 7.22.10
+  resolution: "@babel/plugin-syntax-decorators@npm:7.22.10"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.22.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: cf606ef13ed98b3adf560ede27a873c0ab37e884c762a6f15493c881f5a78b67f24dcdd5c70e8cd8f39dbe4b23475cb98619729812f29feb2dcc241130195e7c
   languageName: node
   linkType: hard
 
@@ -3516,6 +3618,17 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.22.5
     to-fast-properties: ^2.0.0
   checksum: 2473295056520432ec0b5fe2dc7b37914292d211ccdbc2cb05650f9c44d5168a760bca0f492a9fff7c72459defee15cd48ef152e74961cfdc03144c7a4b8bec8
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.22.15":
+  version: 7.22.15
+  resolution: "@babel/types@npm:7.22.15"
+  dependencies:
+    "@babel/helper-string-parser": ^7.22.5
+    "@babel/helper-validator-identifier": ^7.22.15
+    to-fast-properties: ^2.0.0
+  checksum: 9324743c1586c59737b7590bbc44acc0b46317b66971fd98867ef4cfa1252ecdab2237a1a62437f579af8a2b41d998aa3efb9e8f0939d7de5f0781e91c7ac1ae
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2101,16 +2101,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-annotate-as-pure@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/helper-annotate-as-pure@npm:7.18.6"
-  dependencies:
-    "@babel/types": ^7.18.6
-  checksum: e413cd022e1e21232c1ce98f3e1198ec5f4774c7eceb81155a45f9cb6d8481f3983c52f83252309856668e728c751f0340d29854b604530a694899208df6bcc3
-  languageName: node
-  linkType: hard
-
-"@babel/helper-annotate-as-pure@npm:^7.22.5":
+"@babel/helper-annotate-as-pure@npm:^7.18.6, @babel/helper-annotate-as-pure@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-annotate-as-pure@npm:7.22.5"
   dependencies:
@@ -2143,26 +2134,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-create-class-features-plugin@npm:^7.16.7, @babel/helper-create-class-features-plugin@npm:^7.18.6, @babel/helper-create-class-features-plugin@npm:^7.21.0":
-  version: 7.21.8
-  resolution: "@babel/helper-create-class-features-plugin@npm:7.21.8"
-  dependencies:
-    "@babel/helper-annotate-as-pure": ^7.18.6
-    "@babel/helper-environment-visitor": ^7.21.5
-    "@babel/helper-function-name": ^7.21.0
-    "@babel/helper-member-expression-to-functions": ^7.21.5
-    "@babel/helper-optimise-call-expression": ^7.18.6
-    "@babel/helper-replace-supers": ^7.21.5
-    "@babel/helper-skip-transparent-expression-wrappers": ^7.20.0
-    "@babel/helper-split-export-declaration": ^7.18.6
-    semver: ^6.3.0
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: f875a1367d0569a7217c6ff97666755b3d305b698e263a888a42dc9a5494d64fdf3224accfb47548c6f7150c986e877cdda99501c674297b51e8f69a52ce6f82
-  languageName: node
-  linkType: hard
-
-"@babel/helper-create-class-features-plugin@npm:^7.22.15":
+"@babel/helper-create-class-features-plugin@npm:^7.16.7, @babel/helper-create-class-features-plugin@npm:^7.18.6, @babel/helper-create-class-features-plugin@npm:^7.21.0, @babel/helper-create-class-features-plugin@npm:^7.22.15":
   version: 7.22.15
   resolution: "@babel/helper-create-class-features-plugin@npm:7.22.15"
   dependencies:
@@ -2236,15 +2208,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-member-expression-to-functions@npm:^7.21.5":
-  version: 7.21.5
-  resolution: "@babel/helper-member-expression-to-functions@npm:7.21.5"
-  dependencies:
-    "@babel/types": ^7.21.5
-  checksum: 126ba589e32220e984ea4dcf0ebfb58bddb2addda3194fd14d1a182471422260cd266be29ed286fa570e21fc2ab422758ba9aa4c7a12ec8e7127a06deb1d1eb0
-  languageName: node
-  linkType: hard
-
 "@babel/helper-member-expression-to-functions@npm:^7.22.15, @babel/helper-member-expression-to-functions@npm:^7.22.5":
   version: 7.22.15
   resolution: "@babel/helper-member-expression-to-functions@npm:7.22.15"
@@ -2279,16 +2242,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-optimise-call-expression@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/helper-optimise-call-expression@npm:7.18.6"
-  dependencies:
-    "@babel/types": ^7.18.6
-  checksum: f1352ebc5d9abae6088e7d9b4b6b445c406ba552ef61e967ec77d005ff65752265b002b6faaf16cc293f9e37753760ef05c1f4b26cda1039256917022ba5669c
-  languageName: node
-  linkType: hard
-
-"@babel/helper-optimise-call-expression@npm:^7.22.5":
+"@babel/helper-optimise-call-expression@npm:^7.18.6, @babel/helper-optimise-call-expression@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-optimise-call-expression@npm:7.22.5"
   dependencies:
@@ -2318,21 +2272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-replace-supers@npm:^7.18.6, @babel/helper-replace-supers@npm:^7.20.7, @babel/helper-replace-supers@npm:^7.21.5":
-  version: 7.21.5
-  resolution: "@babel/helper-replace-supers@npm:7.21.5"
-  dependencies:
-    "@babel/helper-environment-visitor": ^7.21.5
-    "@babel/helper-member-expression-to-functions": ^7.21.5
-    "@babel/helper-optimise-call-expression": ^7.18.6
-    "@babel/template": ^7.20.7
-    "@babel/traverse": ^7.21.5
-    "@babel/types": ^7.21.5
-  checksum: 05c1f7665e712643ea787990e93c7bed8165c9b9893a83ca085b82da4578ea6645fb1587371f64d39575b1d81c9cd28968777cf8c74cd55122ef53a8a21f313a
-  languageName: node
-  linkType: hard
-
-"@babel/helper-replace-supers@npm:^7.22.9":
+"@babel/helper-replace-supers@npm:^7.18.6, @babel/helper-replace-supers@npm:^7.20.7, @babel/helper-replace-supers@npm:^7.22.9":
   version: 7.22.9
   resolution: "@babel/helper-replace-supers@npm:7.22.9"
   dependencies:
@@ -2354,16 +2294,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-skip-transparent-expression-wrappers@npm:^7.20.0":
-  version: 7.20.0
-  resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.20.0"
-  dependencies:
-    "@babel/types": ^7.20.0
-  checksum: 8529fb760ffbc3efc22ec5a079039fae65f40a90e9986642a85c1727aabdf6a79929546412f6210593970d2f97041f73bdd316e481d61110d6edcac1f97670a9
-  languageName: node
-  linkType: hard
-
-"@babel/helper-skip-transparent-expression-wrappers@npm:^7.22.5":
+"@babel/helper-skip-transparent-expression-wrappers@npm:^7.20.0, @babel/helper-skip-transparent-expression-wrappers@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.22.5"
   dependencies:
@@ -2388,14 +2319,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.19.1, @babel/helper-validator-identifier@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/helper-validator-identifier@npm:7.22.5"
-  checksum: 2ff1d3833154d17ccf773b8a71fdc0cd0e7356aa8033179d0e3133787dfb33d97796cbff8b92a97c56268205337dfc720227aeddc677c1bc08ae1b67a95252d7
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-identifier@npm:^7.22.15":
+"@babel/helper-validator-identifier@npm:^7.19.1, @babel/helper-validator-identifier@npm:^7.22.15, @babel/helper-validator-identifier@npm:^7.22.5":
   version: 7.22.15
   resolution: "@babel/helper-validator-identifier@npm:7.22.15"
   checksum: 0473ccfd123cf872206eb916ec506f8963f75db50413560d4d1674aed4cd5d9354826c2514474d6cd40637d3bdc515ba87e8035b4bed683ba62cb607e0081aaf
@@ -3610,18 +3534,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.2.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.5, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.5, @babel/types@npm:^7.22.0, @babel/types@npm:^7.22.5, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
-  version: 7.22.5
-  resolution: "@babel/types@npm:7.22.5"
-  dependencies:
-    "@babel/helper-string-parser": ^7.22.5
-    "@babel/helper-validator-identifier": ^7.22.5
-    to-fast-properties: ^2.0.0
-  checksum: 2473295056520432ec0b5fe2dc7b37914292d211ccdbc2cb05650f9c44d5168a760bca0f492a9fff7c72459defee15cd48ef152e74961cfdc03144c7a4b8bec8
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.22.15":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.9, @babel/types@npm:^7.2.0, @babel/types@npm:^7.20.5, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.5, @babel/types@npm:^7.22.0, @babel/types@npm:^7.22.15, @babel/types@npm:^7.22.5, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.22.15
   resolution: "@babel/types@npm:7.22.15"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1750,7 +1750,7 @@ __metadata:
     "@babel/cli": ^7.17.6
     "@babel/core": ^7.17.5
     "@babel/plugin-proposal-class-properties": ^7.16.7
-    "@babel/plugin-proposal-decorators": ^7.22.15
+    "@babel/plugin-proposal-decorators": ^7.16.7
     "@babel/preset-env": ^7.16.11
     "@babel/preset-react": ^7.16.7
     "@babel/preset-typescript": ^7.16.7
@@ -2524,7 +2524,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-decorators@npm:^7.22.15":
+"@babel/plugin-proposal-decorators@npm:^7.16.7":
   version: 7.22.15
   resolution: "@babel/plugin-proposal-decorators@npm:7.22.15"
   dependencies:


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add new preset with `@babel/plugin-proposal-decorators`.
* Fix `--preset` option to actually set the preferred preset. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests pass `yarn workspace @automattic/wp-babel-makepot test`.
* Running `yarn translate` in the root of the wp-calypso repository works the same as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
