### PR TITLE
Add-ons: Use integer values for currency in useAddOnDisplayCost

### DIFF
--- a/client/my-sites/add-ons/hooks/use-add-on-display-cost.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-display-cost.ts
@@ -8,7 +8,7 @@ const useAddOnDisplayCost = ( productSlug: string, quantity?: number ) => {
 
 	return useSelector( ( state ) => {
 		const product = getProductBySlug( state, productSlug );
-		let cost = product?.cost;
+		let cost = product?.cost_smallest_unit;
 		const currencyCode = getProductCurrencyCode( state, productSlug );
 
 		if ( ! ( cost && currencyCode ) ) {
@@ -25,12 +25,13 @@ const useAddOnDisplayCost = ( productSlug: string, quantity?: number ) => {
 			} );
 
 		if ( priceTier ) {
-			cost = priceTier?.maximum_price / 100;
+			cost = priceTier?.maximum_price;
 		}
 
 		if ( product?.product_term === 'month' ) {
 			const formattedCost = formatCurrency( cost, currencyCode, {
 				stripZeros: true,
+				isSmallestUnit: true,
 			} );
 			return translate( '%(formattedCost)s/month, billed monthly', {
 				/* Translators: $formattedCost: monthly price formatted with currency */
@@ -42,6 +43,7 @@ const useAddOnDisplayCost = ( productSlug: string, quantity?: number ) => {
 
 		const monthlyCost = formatCurrency( cost / 12, currencyCode, {
 			stripZeros: true,
+			isSmallestUnit: true,
 		} );
 
 		return translate( '%(monthlyCost)s/month, billed yearly', {


### PR DESCRIPTION
## Proposed Changes

The React hook `useAddOnDisplayCost()` finds the cost of a product, then creates a formatted string to display it to the user. Originally it used the float version of the cost (the `cost` property) but in https://github.com/Automattic/wp-calypso/pull/76754 additional logic was added to respect the `maximum_price` property of price tiers which uses the currency's smallest unit (this is eventually how all prices will be sent to the client). The currency formatting library has a feature, `isSmallestUnit`, that allows using these integer prices, but in that PR the developer chose to divide the integer by 100 instead to return it to a float. This will not work for currencies which do not have decimal prices.

In this PR we change all costs in `useAddOnDisplayCost()` to use integer pricing.

## Testing Instructions

I'm not sure, but presumably we can follow the test instructions in https://github.com/Automattic/wp-calypso/pull/76754 with JPY as the currency.

Hopefully this will fix https://github.com/Automattic/martech/issues/2151