### PR TITLE
Stats: Adjust Personal purchase page styling for WPCOM sites

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -82,6 +82,20 @@ const PersonalPurchase = ( {
 
 	return (
 		<div>
+			<div className={ `${ COMPONENT_CLASS_NAME }__benefits` }>
+				{ subscriptionValue === 0 ? (
+					<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--not-included` }>
+						<li>{ translate( 'No access to upcoming features' ) }</li>
+						<li>{ translate( 'No priority support' ) }</li>
+					</ul>
+				) : (
+					<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--included` }>
+						<li>{ translate( 'Instant access to upcoming features' ) }</li>
+						<li>{ translate( 'Priority support' ) }</li>
+					</ul>
+				) }
+			</div>
+
 			<div className={ `${ COMPONENT_CLASS_NAME }__notice` }>
 				{ translate(
 					'This plan is for personal sites only. If your site is used for a commercial activity, {{Button}}you will need to choose a commercial plan{{/Button}}.',
@@ -108,23 +122,6 @@ const PersonalPurchase = ( {
 					},
 				} ) }
 			</p>
-
-			<div className={ `${ COMPONENT_CLASS_NAME }__benefits` }>
-				{ subscriptionValue === 0 ? (
-					<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--not-included` }>
-						<li>{ translate( 'No access to upcoming features' ) }</li>
-						<li>{ translate( 'No priority support' ) }</li>
-					</ul>
-				) : (
-					<>
-						<p>{ translate( 'Benefits:' ) }</p>
-						<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--included` }>
-							<li>{ translate( 'Instant access to upcoming features' ) }</li>
-							<li>{ translate( 'Priority support' ) }</li>
-						</ul>
-					</>
-				) }
-			</div>
 
 			{ subscriptionValue === 0 && (
 				<div className={ `${ COMPONENT_CLASS_NAME }__persnal-checklist` }>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -1,9 +1,15 @@
-import { PricingSlider, RenderThumbFunction } from '@automattic/components';
+import {
+	PricingSlider,
+	RenderThumbFunction,
+	Button as CalypsoButton,
+} from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Button, CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
+import { useSelector } from 'calypso/state';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
 import { COMPONENT_CLASS_NAME, MIN_STEP_SPLITS } from './stats-purchase-wizard';
 
@@ -13,6 +19,7 @@ interface PersonalPurchaseProps {
 	defaultStartingValue: number;
 	handlePlanSwap: ( e: React.MouseEvent< HTMLAnchorElement, MouseEvent > ) => void;
 	currencyCode: string;
+	siteId: number | null;
 	siteSlug: string;
 	sliderSettings: {
 		sliderStepPrice: number;
@@ -32,6 +39,7 @@ const PersonalPurchase = ( {
 	defaultStartingValue,
 	handlePlanSwap,
 	currencyCode,
+	siteId,
 	siteSlug,
 	sliderSettings,
 	adminUrl,
@@ -79,6 +87,10 @@ const PersonalPurchase = ( {
 
 	const handleClick = ( e: React.MouseEvent< HTMLAnchorElement, MouseEvent > ) =>
 		handlePlanSwap( e );
+
+	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
+	// The button of @automattic/components has built-in color scheme support for Calypso.
+	const ButtonComponent = isWPCOMSite ? CalypsoButton : Button;
 
 	return (
 		<div>
@@ -166,7 +178,7 @@ const PersonalPurchase = ( {
 				</div>
 			) }
 
-			<p>
+			<p className={ `${ COMPONENT_CLASS_NAME }__personal-tos` }>
 				{ translate(
 					`By clicking the button below, you agree to our {{a}}Terms of Service{{/a}} and to {{b}}share details{{/b}} with WordPress.com.`,
 					{
@@ -185,18 +197,20 @@ const PersonalPurchase = ( {
 			</p>
 
 			{ subscriptionValue === 0 ? (
-				<Button
+				<ButtonComponent
 					variant="primary"
+					primary={ isWPCOMSite ? true : undefined }
 					disabled={ ! isAdsChecked || ! isSellingChecked || ! isBusinessChecked }
 					onClick={ () =>
 						gotoCheckoutPage( { from, type: 'free', siteSlug, adminUrl, redirectUri } )
 					}
 				>
 					{ translate( 'Continue with Jetpack Stats for free' ) }
-				</Button>
+				</ButtonComponent>
 			) : (
-				<Button
+				<ButtonComponent
 					variant="primary"
+					primary={ isWPCOMSite ? true : undefined }
 					onClick={ () =>
 						gotoCheckoutPage( {
 							from,
@@ -208,12 +222,8 @@ const PersonalPurchase = ( {
 						} )
 					}
 				>
-					{ translate( 'Get Jetpack Stats for %(value)s per month', {
-						args: {
-							value: formatCurrency( subscriptionValue * sliderStepPrice, currencyCode ),
-						},
-					} ) }
-				</Button>
+					{ translate( 'Get Stats Personal' ) }
+				</ButtonComponent>
 			) }
 		</div>
 	);

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -129,7 +129,7 @@ const PersonalPurchase = ( {
 			/>
 
 			<p className={ `${ COMPONENT_CLASS_NAME }__average-price` }>
-				{ translate( 'The average person pays %(value)s per month', {
+				{ translate( 'Our users pay %(value)s per month on average', {
 					args: {
 						value: formatCurrency( defaultStartingValue * sliderStepPrice, currencyCode ),
 					},

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -106,6 +106,7 @@ const PersonalPurchase = ( {
 					}
 				) }
 			</div>
+
 			<PricingSlider
 				className={ `${ COMPONENT_CLASS_NAME }__slider` }
 				value={ subscriptionValue }
@@ -116,7 +117,7 @@ const PersonalPurchase = ( {
 			/>
 
 			<p className={ `${ COMPONENT_CLASS_NAME }__average-price` }>
-				{ translate( 'Our users pay %(value)s per month on average', {
+				{ translate( 'The average person pays %(value)s per month', {
 					args: {
 						value: formatCurrency( defaultStartingValue * sliderStepPrice, currencyCode ),
 					},

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -54,6 +54,7 @@ interface StatsSingleItemPersonalPurchasePageProps {
 }
 
 interface StatsPersonalPurchaseProps {
+	siteId: number | null;
 	siteSlug: string;
 	maxSliderPrice: number;
 	pwywProduct: {
@@ -105,6 +106,7 @@ const StatsCommercialPurchase = ( {
 };
 
 const StatsPersonalPurchase = ( {
+	siteId,
 	siteSlug,
 	maxSliderPrice,
 	pwywProduct,
@@ -140,6 +142,7 @@ const StatsPersonalPurchase = ( {
 				defaultStartingValue={ defaultStartingValue }
 				handlePlanSwap={ ( e ) => handlePlanSwap( e ) }
 				currencyCode={ pwywProduct?.currency_code }
+				siteId={ siteId }
 				siteSlug={ siteSlug }
 				sliderSettings={ {
 					minSliderPrice: disableFreeProduct ? sliderStepPrice : 0,
@@ -170,6 +173,7 @@ const StatsSingleItemPersonalPurchasePage = ( {
 	return (
 		<StatsSingleItemPagePurchaseFrame>
 			<StatsPersonalPurchase
+				siteId={ siteId }
 				siteSlug={ siteSlug }
 				adminUrl={ adminUrl || '' }
 				redirectUri={ redirectUri }

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -46,6 +46,34 @@
 				padding: 8px 32px;
 			}
 		}
+
+		.stats-purchase-wizard__notice {
+			color: var(--studio-yellow-80);
+
+			.is-link {
+				color: var(--studio-yellow-80);
+			}
+		}
+
+		.stats-purchase-wizard__personal-tos {
+			display: none;
+		}
+
+		.jp-components-pricing-slider__track.jp-components-pricing-slider__track-0 {
+			background-color: var(--color-primary);
+		}
+
+		.jp-components-pricing-slider__thumb {
+			border-radius: 2px;
+			border-color: var(--color-primary);
+		}
+
+		// On holding thumb styling
+		.jp-components-pricing-slider--is-holding {
+			.jp-components-pricing-slider__thumb {
+				box-shadow: 0 6px 8px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04), 0 0 0 3px rgba(var(--color-primary-rgb), 0.25);
+			}
+		}
 	}
 }
 

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -24,11 +24,11 @@
 
 			h1 {
 				font-family: $font-recoleta;
-				color: #101517;
+				color: var(--studio-gray-100);
 				font-size: $font-headline-small;
 				font-style: normal;
 				font-weight: 400;
-				line-height: 40px; /* 111.111% */
+				line-height: 40px;
 			}
 
 			.stats-purchase-wizard__pricing-value {
@@ -111,7 +111,7 @@
 
 	.stats-purchase-wizard__average-price {
 		margin-bottom: 3em;
-		color: #2c3338;
+		color: var(--studio-gray-80);
 		text-align: center;
 	}
 
@@ -194,7 +194,7 @@
 		}
 
 		.stats-purchase-wizard__pricing-cadency {
-			color: #787c82;
+			color: var(--studio-gray-40);
 		}
 	}
 
@@ -292,8 +292,8 @@
 			&:hover,
 			&:active,
 			&:focus {
-				background: #2c3338;
-				border-color: #2c3338;
+				background: var(--studio-gray-80);
+				border-color: var(--studio-gray-80);
 			}
 
 			&[disabled],
@@ -353,7 +353,7 @@
 
 	.stats-purchase-wizard__notice {
 		padding: 8px 12px;
-		background: #f5e6b3;
+		background: var(--studio-yellow-5);
 		border-radius: 4px;
 
 		.is-link {
@@ -366,7 +366,7 @@
 	}
 
 	.stats-purchase-wizard__notice--green {
-		background-color: #d0e6b8;
+		background-color: var(--studio-jetpack-green-5);
 	}
 
 	.stats-purchase-wizard__control--checkbox {

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -110,6 +110,7 @@
 	}
 
 	.stats-purchase-wizard__average-price {
+		font-size: $font-body-small;
 		margin-bottom: 3em;
 		color: var(--studio-gray-80);
 		text-align: center;
@@ -352,7 +353,7 @@
 	}
 
 	.stats-purchase-wizard__notice {
-		padding: 8px 12px;
+		padding: 12px 16px;
 		background: var(--studio-yellow-5);
 		border-radius: 4px;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80888 

## Proposed Changes

* Use `getIsSiteWPCOM` to adjust styling for the Stats `Personal` purchase page of WPCOM sites.
* Refactor styles with variables.
* Fixed shared copy and styling between Stats `Personal` and `Commercial` purchase pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the change with the Calypso Live link.
* Navigate to the Stats Personal purchase page of a `Jetpack` site with the feature flag: `/stats/purchase/{jetpack-site-slug}?flags=stats/type-detection,stats/paid-wpcom-stats&productType=personal`.
* Ensure the page styling works as previously.
* Navigate to the Stats Personal purchase page of a `Simple or Atomic` site with the feature flag: `/stats/purchase/{wpcom-site-slug}?flags=stats/type-detection,stats/paid-wpcom-stats&productType=personal`.
* Ensure the page styling is in line with the design.

<img width="1174" alt="截圖 2023-09-06 下午11 27 57" src="https://github.com/Automattic/wp-calypso/assets/6869813/9aab934a-b096-498e-80bb-2c6e96bfdf1c">

|Jetpack site|WPCOM site|
|-|-|
|<img width="1232" alt="截圖 2023-09-06 下午11 12 45" src="https://github.com/Automattic/wp-calypso/assets/6869813/2d0a1860-8a4b-4e63-8b43-993408b65232">|<img width="1263" alt="截圖 2023-09-06 下午11 12 23" src="https://github.com/Automattic/wp-calypso/assets/6869813/e9403a5c-b2c0-40f7-ba1a-d30fac660604">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?