### PR TITLE
VideoPress UserIntent: Filter items based on referrer, log referrer

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
@@ -12,6 +12,7 @@ import OtherIntentImage from 'calypso/assets/images/onboarding/videopress-onboar
 import PortfolioIntentImage from 'calypso/assets/images/onboarding/videopress-onboarding-intent/intent-portfolio.png';
 import SingleVideoIntentImage from 'calypso/assets/images/onboarding/videopress-onboarding-intent/intent-single-video.png';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CloseIcon from '../intro/icons/close-icon';
 import VideoPressOnboardingIntentItem from './intent-item';
@@ -29,6 +30,8 @@ const VideoPressOnboardingIntent: Step = ( { navigation } ) => {
 	const { __ } = useI18n();
 	const [ intentClickNumber, setIntentClicksNumber ] = useState( 1 );
 	const [ modal, setModal ] = useState< ReactElement | null >( null );
+	const urlQueryParams = useQuery();
+	const fromReferrer = urlQueryParams.get( 'from' ) ?? '';
 
 	const { submit } = navigation;
 
@@ -117,14 +120,16 @@ const VideoPressOnboardingIntent: Step = ( { navigation } ) => {
 					isComingSoon={ true }
 					onClick={ onUploadVideoIntentClicked }
 				/>
-				<VideoPressOnboardingIntentItem
-					title={ __( 'Add video to an existing site' ) }
-					description={ __(
-						'All the advantages and features from VideoPress, on your own WordPress site.'
-					) }
-					image={ JetpackIntentImage }
-					onClick={ onJetpackIntentClicked }
-				/>
+				{ 'vpcom' !== fromReferrer && (
+					<VideoPressOnboardingIntentItem
+						title={ __( 'Add video to an existing site' ) }
+						description={ __(
+							'All the advantages and features from VideoPress, on your own WordPress site.'
+						) }
+						image={ JetpackIntentImage }
+						onClick={ onJetpackIntentClicked }
+					/>
+				) }
 				<VideoPressOnboardingIntentItem
 					title={ __( 'Start a blog with video content' ) }
 					description={ __( 'Use advanced media formats to enhance your storytelling.' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/index.tsx
@@ -43,6 +43,7 @@ const VideoPressOnboardingIntent: Step = ( { navigation } ) => {
 		recordTracksEvent( 'calypso_videopress_onboarding_intent_clicked', {
 			intent,
 			click_number: intentClickNumber,
+			referrer: fromReferrer,
 		} );
 		setIntentClicksNumber( intentClickNumber + 1 );
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/greenhouse/issues/1832

## Proposed Changes

* added support for a `from` query param (if `referrer` - or something else - makes more sense I can change)
* Filter Intent options based on `vpcom` value in `from` (hide Jetpack option, but we can hide others if it makes sense)
* record the referrer

| vpcom referrer | all other referrers |
| ----- | ----- |
| <img width="1262" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4081020/38b14ae2-0daa-4d08-a139-64cc8c384283"> | <img width="1261" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4081020/eb5cbdca-7cd1-4428-9e1e-70a2a628ce23"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* visit `/setup/videopress/intro`
* you should see all of the User Intent items
* visit `/setup/videopress/intro?from=testing`
* you should still see ALL of the User Intent items
* visit `/setup/videopress/intro?from=vpcom`
* you should NOT see the Jetpack option, all other options should be present

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?