### PR TITLE
Fix crowded spacing on product card prices.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -4,6 +4,13 @@
 .item-price .display-price {
 	display: block;
 
+	.display-price__prices {
+		flex: 0 1 auto;
+	}
+	.display-price__details {
+		flex: 1;
+	}
+
 	.plan-price__currency-symbol,
 	.plan-price__integer,
 	.plan-price__fraction {
@@ -43,7 +50,10 @@
 	&__expiration-date {
 		color: var(--studio-gray-50);
 		font-size: 0.75rem;
-		line-height: 24px;
+		@include break-mobile {
+			//Mimic line-height: 24px, but with padding instead, so that the text can wrap to a new line correctly.
+			padding: 0.301rem 0 0.3rem;
+		}
 	}
 
 	@include break-mobile {
@@ -54,7 +64,13 @@
 }
 
 .item-price .display-price:not(.is-placeholder) {
-	max-height: 24px;
+	@include break-mobile {
+		max-height: 24px;
+	}
+
+	.plan-price {
+		font-weight: 700;
+	}
 
 	.plan-price.is-original {
 		color: var(--studio-gray-50);

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
@@ -42,12 +42,14 @@
 		@media screen and (min-width: 320px) {
 			display: flex;
 			min-height: 24px;
+			align-items: center;
 		}
 	}
 
 	.featured-item-card .item-price .display-price .display-price__billing-time-frame {
 		@media screen and (min-width: 320px) {
 			margin-top: 0;
+			padding-left: 3px;
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes some spacing issues that occur in other currencies.

See Slack discussion: p1682508012934699-slack-C01264051NE

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR is a 2nd take on https://github.com/Automattic/wp-calypso/pull/80939, which had to be reverted. It messed around with the behavior and appearance of the currency symbol, which was undesired.
This PR, on the contrary does not interfere with the behavior or appearance of the currency symbol and merely fixes up the spacing of the prices and billing time-frame text.

Github task: https://github.com/orgs/Automattic/projects/724/views/1?pane=issue&itemId=35361597

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

If you're currently located in the US, follow these steps:

- First you'll need to sandbox `public-api.sandbox.com`.
- Then in WPCOM edit file, `public.api/geo.php`, line 20. - Return a non-US locale in the country_short property.
For Example: `'country_short' => 'FR', //$location->country_short`,

Then:

1. Make sure you're currency is set to USD in Store Admin.
2. Spin up this PR locally (Calypso blue and green) -OR: Use the Calypso Live links below.
3. In Calypso blue (wordpress.com env), go to: /plans/:SITE  (Replace :SITE with the site slug of a connected Jetpack site)
4. Verify the currency is displaying as US$, as opposed to just $
5. Verify the appearance of the prices look better, spacing is better, etc. (See before & after screenshots).
6. View the pricing cards in Mobile view and verify things still look better. (See before & after screenshots).
7. Go to /jetpack/connect/store and verify the same changes appear here and everything looks good/better. Inspect the Mobile view too.
8. Also go to Calypso green (Jetpack Cloud) - /pricing page and verify the same changes appear here and everything looks good/better. Inspect the Mobile view too.

#### Screenshots

Calypso blue (Desktop)

BEFORE | AFTER
----- | -----
![Markup 2023-09-06 at 12 42 07](https://github.com/Automattic/wp-calypso/assets/11078128/ec6c1af8-1443-4d3f-9eb4-382690d1e4c9) | ![Screenshot on 2023-09-06 at 11-58-50](https://github.com/Automattic/wp-calypso/assets/11078128/30505422-a749-4597-ac91-c0449f9a9a76)

Calypso blue (Mobile)

BEFORE | AFTER
----- | -----
![Markup 2023-09-06 at 12 03 52](https://github.com/Automattic/wp-calypso/assets/11078128/8e7a1c3b-b13e-4d04-b061-16af1381f8d7) | ![Screenshot on 2023-09-06 at 12-04-14](https://github.com/Automattic/wp-calypso/assets/11078128/8f5b9738-6a71-4248-8321-5502d2b986ea)


Calypso green (Desktop)

BEFORE | AFTER
----- | -----
![Markup 2023-09-06 at 12 46 42](https://github.com/Automattic/wp-calypso/assets/11078128/c76c5354-2ae7-4d73-aea0-53ffbdc2d99b) | ![Screenshot on 2023-09-06 at 12-46-57](https://github.com/Automattic/wp-calypso/assets/11078128/3c6249d8-e9b1-4141-bc32-d422126f5235)

Calypso green (Mobile)
BEFORE | AFTER
----- | -----
![Markup 2023-09-06 at 12 49 32](https://github.com/Automattic/wp-calypso/assets/11078128/6592657c-18de-48d5-9220-10906dbb09e1) | ![Screenshot on 2023-09-06 at 12-50-00](https://github.com/Automattic/wp-calypso/assets/11078128/5a8d325c-32f7-488c-8d8d-15a9f7a5b94c)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?