### PR TITLE
GF Signup: Handle subdomain empty result edge case for the plans page

### DIFF
--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -133,7 +133,7 @@ interface Props {
 	/**
 	 * If the subdomain generation is unsuccessful we do not show the free plan
 	 */
-	isSubdomainGenerated?: boolean;
+	isSubdomainGenerated: boolean;
 }
 
 const usePlanTypesWithIntent = ( {
@@ -223,7 +223,7 @@ const usePlanTypesWithIntent = ( {
 	// Filters out the free plan unless a valid subdomain is generated.
 	// This is because, on a free plan,  a custom domain can only redirect to the hosted site.
 	// To effectively communicate this, a valid subdomain is necessary.
-	if ( isSubdomainGenerated === false ) {
+	if ( ! isSubdomainGenerated ) {
 		planTypes = planTypes.filter( ( planType ) => planType !== TYPE_FREE );
 	}
 
@@ -241,6 +241,7 @@ const useGridPlans = ( {
 	hideEnterprisePlan,
 	isInSignup,
 	usePlanUpgradeabilityCheck,
+	isSubdomainGenerated,
 }: Props ): Omit< GridPlan, 'features' >[] | null => {
 	const availablePlanSlugs = usePlansFromTypes( {
 		planTypes: usePlanTypesWithIntent( {
@@ -248,6 +249,7 @@ const useGridPlans = ( {
 			selectedPlan,
 			sitePlanSlug,
 			hideEnterprisePlan,
+			isSubdomainGenerated,
 		} ),
 		term,
 	} );
@@ -257,6 +259,7 @@ const useGridPlans = ( {
 			selectedPlan,
 			sitePlanSlug,
 			hideEnterprisePlan,
+			isSubdomainGenerated,
 		} ),
 		term,
 	} );

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -129,6 +129,11 @@ interface Props {
 		[ key: string ]: boolean;
 	};
 	showLegacyStorageFeature?: boolean;
+
+	/**
+	 * If the subdomain generation is unsuccessful we do not show the free plan
+	 */
+	isSubdomainGenerated?: boolean;
 }
 
 const usePlanTypesWithIntent = ( {
@@ -136,7 +141,11 @@ const usePlanTypesWithIntent = ( {
 	selectedPlan,
 	sitePlanSlug,
 	hideEnterprisePlan,
-}: Pick< Props, 'intent' | 'selectedPlan' | 'sitePlanSlug' | 'hideEnterprisePlan' > ): string[] => {
+	isSubdomainGenerated,
+}: Pick<
+	Props,
+	'intent' | 'selectedPlan' | 'sitePlanSlug' | 'hideEnterprisePlan' | 'isSubdomainGenerated'
+> ): string[] => {
 	const isEnterpriseAvailable = ! hideEnterprisePlan;
 	const isBloggerAvailable =
 		( selectedPlan && isBloggerPlan( selectedPlan ) ) ||
@@ -209,6 +218,13 @@ const usePlanTypesWithIntent = ( {
 			break;
 		default:
 			planTypes = availablePlanTypes;
+	}
+
+	// Filters out the free plan unless a valid subdomain is generated.
+	// This is because, on a free plan,  a custom domain can only redirect to the hosted site.
+	// To effectively communicate this, a valid subdomain is necessary.
+	if ( isSubdomainGenerated === false ) {
+		planTypes = planTypes.filter( ( planType ) => planType !== TYPE_FREE );
 	}
 
 	return planTypes;

--- a/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -133,7 +133,7 @@ interface Props {
 	/**
 	 * If the subdomain generation is unsuccessful we do not show the free plan
 	 */
-	isSubdomainGenerated: boolean;
+	isSubdomainNotGenerated?: boolean;
 }
 
 const usePlanTypesWithIntent = ( {
@@ -141,10 +141,10 @@ const usePlanTypesWithIntent = ( {
 	selectedPlan,
 	sitePlanSlug,
 	hideEnterprisePlan,
-	isSubdomainGenerated,
+	isSubdomainNotGenerated = false,
 }: Pick<
 	Props,
-	'intent' | 'selectedPlan' | 'sitePlanSlug' | 'hideEnterprisePlan' | 'isSubdomainGenerated'
+	'intent' | 'selectedPlan' | 'sitePlanSlug' | 'hideEnterprisePlan' | 'isSubdomainNotGenerated'
 > ): string[] => {
 	const isEnterpriseAvailable = ! hideEnterprisePlan;
 	const isBloggerAvailable =
@@ -220,10 +220,10 @@ const usePlanTypesWithIntent = ( {
 			planTypes = availablePlanTypes;
 	}
 
-	// Filters out the free plan unless a valid subdomain is generated.
+	// Filters out the free plan  isSubdomainNotGenerated
 	// This is because, on a free plan,  a custom domain can only redirect to the hosted site.
 	// To effectively communicate this, a valid subdomain is necessary.
-	if ( ! isSubdomainGenerated ) {
+	if ( isSubdomainNotGenerated ) {
 		planTypes = planTypes.filter( ( planType ) => planType !== TYPE_FREE );
 	}
 
@@ -241,7 +241,7 @@ const useGridPlans = ( {
 	hideEnterprisePlan,
 	isInSignup,
 	usePlanUpgradeabilityCheck,
-	isSubdomainGenerated,
+	isSubdomainNotGenerated,
 }: Props ): Omit< GridPlan, 'features' >[] | null => {
 	const availablePlanSlugs = usePlansFromTypes( {
 		planTypes: usePlanTypesWithIntent( {
@@ -249,7 +249,7 @@ const useGridPlans = ( {
 			selectedPlan,
 			sitePlanSlug,
 			hideEnterprisePlan,
-			isSubdomainGenerated,
+			isSubdomainNotGenerated,
 		} ),
 		term,
 	} );
@@ -259,7 +259,7 @@ const useGridPlans = ( {
 			selectedPlan,
 			sitePlanSlug,
 			hideEnterprisePlan,
-			isSubdomainGenerated,
+			isSubdomainNotGenerated,
 		} ),
 		term,
 	} );

--- a/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
@@ -1,4 +1,6 @@
+import configApi from '@automattic/calypso-config';
 import { DomainSuggestions } from '@automattic/data-stores';
+import { logToLogstash } from 'calypso/lib/logstash';
 import type { DataResponse } from 'calypso/my-sites/plan-features-2023-grid/types';
 
 export function useGetFreeSubdomainSuggestion( query: string ): {
@@ -7,15 +9,28 @@ export function useGetFreeSubdomainSuggestion( query: string ): {
 } {
 	const {
 		data: wordPressSubdomainSuggestions,
-		isInitialLoading,
+		isInitialLoading: isLoading,
 		isError,
 		invalidateCache: invalidateDomainSuggestionCache,
 	} = DomainSuggestions.useGetWordPressSubdomain( query );
 
+	const result = ( ! isError && wordPressSubdomainSuggestions?.[ 0 ] ) || undefined;
+
+	if ( ! isLoading && ! result ) {
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: `Sub domain suggestion wasn't available for query: ${ query }`,
+			severity: 'warn',
+			properties: {
+				env: configApi( 'env_id' ),
+			},
+		} );
+	}
+
 	return {
 		wpcomFreeDomainSuggestion: {
-			isLoading: isInitialLoading,
-			result: ( ! isError && wordPressSubdomainSuggestions?.[ 0 ] ) || undefined,
+			isLoading,
+			result,
 		},
 		invalidateDomainSuggestionCache,
 	};

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -640,7 +640,7 @@ const PlansFeaturesMain = ( {
 				) ) }
 			{ isDisplayingPlansNeededForFeature() && <SecondaryFormattedHeader siteSlug={ siteSlug } /> }
 			{ ( isLoadingGridPlans || resolvedSubdomainName.isLoading ) && <Spinner size={ 30 } /> }
-			{ ( ! isLoadingGridPlans || ! resolvedSubdomainName.isLoading ) && (
+			{ ! isLoadingGridPlans && ! resolvedSubdomainName.isLoading && (
 				<>
 					{ ! hidePlanSelector && <PlanTypeSelector { ...planTypeSelectorProps } /> }
 					<div

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -336,7 +336,7 @@ const PlansFeaturesMain = ( {
 		hideEnterprisePlan,
 		usePlanUpgradeabilityCheck,
 		showLegacyStorageFeature,
-		isSubdomainGenerated: !! resolvedSubdomainName.result,
+		isSubdomainNotGenerated: ! resolvedSubdomainName.result,
 	} );
 
 	const planFeaturesForFeaturesGrid = usePlanFeaturesForGridPlans( {

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -14,6 +14,10 @@ jest.mock( 'calypso/my-sites/plans-features-main/components/plan-type-selector',
 	<div>PlanTypeSelector</div>
 ) );
 jest.mock( '../hooks/use-plan-intent-from-site-meta', () => jest.fn() );
+jest.mock( '../hooks/use-suggested-free-domain-from-paid-domain', () => () => ( {
+	wpcomFreeDomainSuggestion: { isLoading: false, result: { domain_name: 'suggestion.com' } },
+	invalidateDomainSuggestionCache: () => {},
+} ) );
 jest.mock( 'calypso/state/purchases/selectors', () => ( {
 	getByPurchaseId: jest.fn(),
 } ) );

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -113,7 +113,7 @@
 		pointer-events: none;
 		animation: button__busy-animation 3000ms infinite linear;
 		background-size: 120px 100%;
-		background-image: linear-gradient(-45deg, var(--color-neutral-0) 28%, var(--color-surface) 28%, var(--color-surface) 72%, var(--color-neutral-0) 72%);
+		background-image: linear-gradient(-45deg, var(--color-neutral-10) 28%, var(--studio-gray-5) 28%, var(--studio-gray-5) 72%, var(--color-neutral-10) 72%);
 	}
 
 	&.dashicons {

--- a/packages/data-stores/src/domain-suggestions/queries.ts
+++ b/packages/data-stores/src/domain-suggestions/queries.ts
@@ -70,7 +70,7 @@ export function useGetWordPressSubdomain( paidDomainName: string ) {
 		quantity: 1,
 		include_wordpressdotcom: true,
 		include_dotblogsubdomain: false,
-		only_wordpressdotcom: true,
+		only_wordpressdotcom: false,
 		vendor: 'dot',
 	} );
 }


### PR DESCRIPTION
## Bug resolved

- The upsell modal breaks whenever the domain suggestion returns a null result.

<img width="561" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/ab065a4d-2a13-409e-bea0-11d42ddb48e2">

## Proposed Changes
* ~This change will  completely bypass the modal whenever the subdomain returns an empty result.~
* Show a loader in place ofthe pricing grid until subdomain suggestion is loaded
![image](https://github.com/Automattic/wp-calypso/assets/3422709/2253a4ec-3d62-4cac-b6e0-112bd92bf61b)

* Hide free plan if a subdomain fails to be generated.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- The best way to test this change is to check this change out locally and try to see how the plans step reacts based on the parameters below. (Might need to be hardcoded as shown below)
- Check combination of loading as well as an empty result.
https://github.com/Automattic/wp-calypso/blob/f99fd1f456a088d28bc5ecc6521e267fbdd1c43d/client/my-sites/plans-features-main/index.tsx#L253-L263


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?