### PR TITLE
Jetpack Manage: Add page-view tracking to the Licenses page

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -12,6 +12,7 @@ import {
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
@@ -24,7 +25,6 @@ import LayoutHeader from '../../layout/header';
 import LicenseSearch from '../../license-search';
 import OnboardingWidget from '../onboarding-widget';
 import Banners from './banners';
-
 import './style.scss';
 
 interface Props {
@@ -65,6 +65,11 @@ export default function Licenses( {
 
 	return (
 		<Layout className="licenses" title={ translate( 'Licenses' ) } wide>
+			<PageViewTracker
+				title="Partner Portal > Licenses"
+				path="/partner-portal/licenses/:filter"
+				properties={ { filter } }
+			/>
 			<QueryJetpackPartnerPortalLicenseCounts />
 
 			{ isAgencyUser && <Banners /> }


### PR DESCRIPTION
This pull request adds page-view tracking to the Licenses page in Jetpack Manage (née Partner Portal). This tracking includes which filter (if any) is active when the page initially loads. NOTE: Because selecting a new filter does not trigger a page reload, likewise it does not trigger a new page-view event.

Resolves https://github.com/Automattic/jetpack-genesis/issues/23.

## Proposed Changes

* Add `<PageViewTracker />` to `partner-portal/primary/licenses/index.tsx`, with the corresponding `path` and `title` values for the Licenses page, as well as the value of `filter` in the event's extra properties collection.

## Testing Instructions

1. Load this pull request in your testing environment (e.g., the below-posted Jetpack Cloud live environment link).
2. Visit `/partner-portal/licenses`.
3. In your browser's development console, verify a request is sent to `t.gif` with information indicating a `calypso_page_view` event.
4. Verify the event contains the correct parameters:
  * `path` should be `/partner-portal/licenses`
  * `filter` should correspond to the filter you chose (though the exact string may differ)
5. Complete steps 1-4 for at least one other filter type by selecting another filter and refreshing the page.