### PR TITLE
BackupBrowser: Add loading placeholder for granular restore page

### DIFF
--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -25,7 +25,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { backupContentsPath } from '../paths';
 import Error from './error';
-import Loading from './loading';
+import GranularRestoreLoading from './loading-placeholder/granular-restore';
 import ProgressBar from './progress-bar';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
 import CheckYourEmail from './rewind-flow-notice/check-your-email';
@@ -274,7 +274,7 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 
 	const render = () => {
 		if ( loading ) {
-			return <Loading />;
+			return <GranularRestoreLoading />;
 		} else if ( shouldRenderConfirmation ) {
 			return renderConfirm();
 		} else if ( isInProgress ) {

--- a/client/my-sites/backup/rewind-flow/loading-placeholder/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/loading-placeholder/granular-restore.tsx
@@ -1,34 +1,36 @@
 import { LoadingPlaceholder } from '@automattic/components';
-import { css } from '@emotion/css';
 import { FunctionComponent } from 'react';
+import './style.scss';
 
 const GranularRestoreLoading: FunctionComponent = () => {
+	const RestoreLoadingPlaceholder = () => (
+		<LoadingPlaceholder className="granular-restore__loading" />
+	);
+
 	return (
 		<>
 			<div className="rewind-flow__header">
-				<LoadingPlaceholder
-					className={ css( { maxWidth: '48px', height: '48px', marginBottom: '4px' } ) }
-				/>
+				<RestoreLoadingPlaceholder />
 			</div>
 			<div className="rewind-flow__title">
-				<LoadingPlaceholder className={ css( { height: '36px' } ) } />
+				<RestoreLoadingPlaceholder />
 			</div>
 			<div className="rewind-flow__progress-bar">
 				<div className="rewind-flow__progress-bar-header">
 					<div className="rewind-flow__progress-bar-message">
-						<LoadingPlaceholder className={ css( { minWidth: '210px', height: '24px' } ) } />
+						<RestoreLoadingPlaceholder />
 					</div>
 					<div className="rewind-flow__progress-bar-percent">
-						<LoadingPlaceholder className={ css( { minWidth: '86px', height: '24px' } ) } />
+						<RestoreLoadingPlaceholder />
 					</div>
 				</div>
-				<LoadingPlaceholder className={ css( { height: '9px' } ) } />
+				<RestoreLoadingPlaceholder />
 			</div>
 			<div className="rewind-flow__info">
-				<LoadingPlaceholder className={ css( { height: '24px' } ) } />
+				<RestoreLoadingPlaceholder />
 			</div>
 			<div className="rewind-flow-notice">
-				<LoadingPlaceholder className={ css( { minWidth: '100%', height: '88px' } ) } />
+				<RestoreLoadingPlaceholder />
 			</div>
 		</>
 	);

--- a/client/my-sites/backup/rewind-flow/loading-placeholder/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/loading-placeholder/granular-restore.tsx
@@ -15,18 +15,18 @@ const GranularRestoreLoading: FunctionComponent = () => {
 			</div>
 			<div className="rewind-flow__progress-bar">
 				<div className="rewind-flow__progress-bar-header">
-					<p className="rewind-flow__progress-bar-message">
+					<div className="rewind-flow__progress-bar-message">
 						<LoadingPlaceholder className={ css( { minWidth: '210px', height: '24px' } ) } />
-					</p>
-					<p className="rewind-flow__progress-bar-percent">
+					</div>
+					<div className="rewind-flow__progress-bar-percent">
 						<LoadingPlaceholder className={ css( { minWidth: '86px', height: '24px' } ) } />
-					</p>
+					</div>
 				</div>
 				<LoadingPlaceholder className={ css( { height: '9px' } ) } />
 			</div>
-			<p className="rewind-flow__info">
+			<div className="rewind-flow__info">
 				<LoadingPlaceholder className={ css( { height: '24px' } ) } />
-			</p>
+			</div>
 			<div className="rewind-flow-notice">
 				<LoadingPlaceholder className={ css( { minWidth: '100%', height: '88px' } ) } />
 			</div>

--- a/client/my-sites/backup/rewind-flow/loading-placeholder/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/loading-placeholder/granular-restore.tsx
@@ -1,0 +1,37 @@
+import { LoadingPlaceholder } from '@automattic/components';
+import { css } from '@emotion/css';
+import { FunctionComponent } from 'react';
+
+const GranularRestoreLoading: FunctionComponent = () => {
+	return (
+		<>
+			<div className="rewind-flow__header">
+				<LoadingPlaceholder
+					className={ css( { maxWidth: '48px', height: '48px', marginBottom: '4px' } ) }
+				/>
+			</div>
+			<div className="rewind-flow__title">
+				<LoadingPlaceholder className={ css( { height: '36px' } ) } />
+			</div>
+			<div className="rewind-flow__progress-bar">
+				<div className="rewind-flow__progress-bar-header">
+					<p className="rewind-flow__progress-bar-message">
+						<LoadingPlaceholder className={ css( { minWidth: '210px', height: '24px' } ) } />
+					</p>
+					<p className="rewind-flow__progress-bar-percent">
+						<LoadingPlaceholder className={ css( { minWidth: '86px', height: '24px' } ) } />
+					</p>
+				</div>
+				<LoadingPlaceholder className={ css( { height: '9px' } ) } />
+			</div>
+			<p className="rewind-flow__info">
+				<LoadingPlaceholder className={ css( { height: '24px' } ) } />
+			</p>
+			<div className="rewind-flow-notice">
+				<LoadingPlaceholder className={ css( { minWidth: '100%', height: '88px' } ) } />
+			</div>
+		</>
+	);
+};
+
+export default GranularRestoreLoading;

--- a/client/my-sites/backup/rewind-flow/loading-placeholder/style.scss
+++ b/client/my-sites/backup/rewind-flow/loading-placeholder/style.scss
@@ -1,0 +1,40 @@
+.rewind-flow__header .granular-restore__loading {
+	height: 48px;
+	margin-bottom: 4px;
+	max-width: 48px;
+}
+
+.rewind-flow__title .granular-restore__loading {
+	height: 36px;
+}
+
+.rewind-flow__progress-bar-header {
+	.granular-restore__loading {
+		height: 24px;
+	}
+
+	.rewind-flow__progress-bar-message .granular-restore__loading {
+		min-width: 210px;
+	}
+
+	.rewind-flow__progress-bar-percent .granular-restore__loading {
+		min-width: 86px;
+	}
+}
+
+.rewind-flow__progress-bar > .granular-restore__loading {
+	height: 9px;
+}
+
+.rewind-flow__info {
+	margin-bottom: 1.5em;
+
+	.granular-restore__loading {
+		height: 24px;
+	}
+}
+
+.rewind-flow-notice .granular-restore__loading {
+	height: 88px;
+	min-width: 100%;
+}

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -222,9 +222,11 @@ a.rewind-flow-notice__title-warning:visited {
 
 	.rewind-flow__header {
 		display: block;
-		text-align: left;
-		padding-bottom: 8px;
+		line-height: 0;
+		margin-bottom: 8px;
+		padding-bottom: 0;
 		padding-top: 0;
+		text-align: left;
 	}
 
 	.rewind-flow__title {


### PR DESCRIPTION
## Proposed Changes
* Add a loading placeholder for granular restore page with more details.
  * Given that the full restore page has a bit different style, we are not pushing this placeholder there yet.

## Screenshot
| Before | After |
|---|---|
| ![image](https://github.com/Automattic/wp-calypso/assets/1488641/980387cf-e096-4ea5-aaaf-0ff3e99c9159) | ![image](https://github.com/Automattic/wp-calypso/assets/1488641/f94e1aa0-f239-44c9-9e76-57670eb52257) |

## Demo video
| Before | After |
|---|---|
| <video src="https://github.com/Automattic/wp-calypso/assets/1488641/eba9b22f-d2cf-4bc7-9257-bae8b799bf76" /> | <video src="https://github.com/Automattic/wp-calypso/assets/1488641/67e581df-e81d-4f31-944d-7331e245dc83" /> |



## Testing Instructions
* Navigate to the backup browser and pick a file.
* Click on `Restore` and it should redirect you to the granular restore confirmation page.
* Click on `Confirm restore`.
* It should display the granular loading placeholder and then start the restore. You can use the `After` demo video for reference.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?