### PR TITLE
Update Domain Forwarding Title Case & Font Size

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -134,8 +134,11 @@
 
 .domain-forwarding-card__accordion {
 	color: var(--studio-gray-50);
-	font-size: 0.875rem;
 	margin-bottom: 0 !important;
+
+	.foldable-card__content {
+		font-size: 0.875rem;
+	}
 
 	.form-text-input:disabled {
 		border: 1px solid var(--color-neutral-5) !important;

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -399,18 +399,20 @@ const Settings = ( {
 			return null;
 		}
 
-		let domainForwardingTitle = 'Domain Forwarding';
+		let translatedTitle;
 		if (
 			englishLocales.includes( getLocaleSlug() || '' ) ||
 			i18n.hasTranslation( 'Domain forwarding' )
 		) {
-			domainForwardingTitle = 'Domain forwarding';
+			translatedTitle = translate( 'Domain forwarding', { textOnly: true } );
+		} else {
+			translatedTitle = translate( 'Domain Forwarding', { textOnly: true } );
 		}
 
 		return (
 			<Accordion
 				className="domain-forwarding-card__accordion"
-				title={ translate( domainForwardingTitle, { textOnly: true } ) }
+				title={ translatedTitle }
 				subtitle={ translate( 'Forward your domain to another' ) }
 			>
 				<DomainForwardingCard domain={ domain } />

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -402,7 +402,7 @@ const Settings = ( {
 		return (
 			<Accordion
 				className="domain-forwarding-card__accordion"
-				title={ translate( 'Domain Forwarding', { textOnly: true } ) }
+				title={ translate( 'Domain forwarding', { textOnly: true } ) }
 				subtitle={ translate( 'Forward your domain to another' ) }
 			>
 				<DomainForwardingCard domain={ domain } />

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -399,10 +399,18 @@ const Settings = ( {
 			return null;
 		}
 
+		let domainForwardingTitle = 'Domain Forwarding';
+		if (
+			englishLocales.includes( getLocaleSlug() || '' ) ||
+			i18n.hasTranslation( 'Domain forwarding' )
+		) {
+			domainForwardingTitle = 'Domain forwarding';
+		}
+
 		return (
 			<Accordion
 				className="domain-forwarding-card__accordion"
-				title={ translate( 'Domain forwarding', { textOnly: true } ) }
+				title={ translate( domainForwardingTitle, { textOnly: true } ) }
 				subtitle={ translate( 'Forward your domain to another' ) }
 			>
 				<DomainForwardingCard domain={ domain } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1694034635568779/1694031451.357029-slack-C05CT832K2T

## Proposed Changes

* This PR updates the casing as size of the "Domain forwarding" title.

Before | After
--|--
![forward-before](https://github.com/Automattic/wp-calypso/assets/140841/1dd4d9a8-0599-43ce-a829-a1f29fb11406)  | ![forward-after](https://github.com/Automattic/wp-calypso/assets/140841/4177b602-4d4c-4499-bac0-80e8c55517fa)




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that "Domain forwarding" matches the after pic above. Note the lower case `f` and slightly larger font size.
* Ensure that languages other than English will continue to see the old translation until the new translation is complete.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?