### PR TITLE
Revert "Disable Live Preview on Atomic sites"

### DIFF
--- a/client/state/themes/selectors/get-is-live-preview-supported.ts
+++ b/client/state/themes/selectors/get-is-live-preview-supported.ts
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed';
 import { AppState } from 'calypso/types';
@@ -88,14 +87,6 @@ const isNotCompatibleThemes = ( themeId: string ) => {
  */
 export const getIsLivePreviewSupported = ( state: AppState, themeId: string, siteId: number ) => {
 	if ( ! config.isEnabled( 'themes/block-theme-previews' ) ) {
-		return false;
-	}
-
-	/**
-	 * This is temporary condition to disable Block Theme Previews on Atomic sites.
-	 * FIXME: Remove this condition once we addressed https://github.com/WordPress/gutenberg/issues/53284.
-	 */
-	if ( isSiteWpcomAtomic( state, siteId ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#81337

We’re not planning to ship to Simple sites first anymore. p1694051684667749/1693971014.421589-slack-CRWCHQGUB