### PR TITLE
Assembler - Fix for pattern name tooltip to show only on hover

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -63,7 +63,7 @@ const PatternListItem = ( {
 	}, [ isShown, isFirst, ref ] );
 
 	return (
-		<Tooltip text={ pattern.title }>
+		<Tooltip text={ pattern.title } inline>
 			<CompositeItem
 				{ ...composite }
 				role="option"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81200

## Proposed Changes

* Add prop `inline` for the Popover component used inside Tooltip

The tooltip HTML needs to be in the button so we can force to show it only on hover with CSS. See it in [pattern-list-renderer.scss](https://github.com/Automattic/wp-calypso/blob/c33f1f6be415ba7adf63c2995eadd0cda4081e68/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.scss#L11)

|BEFORE|AFTER|
|--|--|
|<img width="642" alt="Screenshot 2566-09-07 at 10 29 51" src="https://github.com/Automattic/wp-calypso/assets/1881481/88dc1dcf-c92d-48fc-a718-ebd8d812ee5d">|<img width="641" alt="Screenshot 2566-09-07 at 10 30 40" src="https://github.com/Automattic/wp-calypso/assets/1881481/fb22160f-3d05-4af6-9e26-a9a51c4e59fb">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }`
* Expect to see the first header pattern focused and no tooltip
* Move the focus to other patterns with the arrow up/down keys and expect to see no tooltip
* Hover patterns with the pointer and expect to see the tooltip

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?