### PR TITLE
Stats: force open commercial purchase page for commercial notice upgrade link

### DIFF
--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -8,7 +8,7 @@ import { StatsNoticeProps } from './types';
 
 const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) => {
 	const from = isOdysseyStats ? 'jetpack' : 'calypso';
-	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/paid-stats&from=${ from }-stats-commercial-site-upgrade-notice`;
+	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/type-detection&from=${ from }-stats-commercial-site-upgrade-notice&productType=commercial`;
 	if ( ! isOdysseyStats ) {
 		return purchasePath;
 	}


### PR DESCRIPTION
Related: #81485

## Proposed Changes

* Pass `productType=commercial` to force Commercial purchase page for commercial upgrade notice

This shouldn't be a big issue as the purchase page would detect isCommercial option too, but just in case.

## Testing Instructions

* Open Calypso Live Branch
* Open `/stats/day/:siteSlug?flags=stats/type-detection`
* Set `isCommercial=true` at

https://github.com/Automattic/wp-calypso/blob/2d4f63d24cd68724b2df1acf74658cbaaad5f1b9/client/my-sites/stats/stats-purchase/index.tsx#L53

and

https://github.com/Automattic/wp-calypso/blob/2d4f63d24cd68724b2df1acf74658cbaaad5f1b9/client/my-sites/stats/stats-notices/index.tsx#L50

* Ensure you see the commercial upgrade notice
* Click Upgrade my Stats
* Ensure you are taken directly to Commercial purchase page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?