### PR TITLE
Stats: add email link with subject and body contact jetpack support

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -94,8 +94,18 @@ const StatsCommercialPurchase = ( {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	const handleClick = ( event: React.MouseEvent, isOdysseyStats: boolean ) => {
-		// TODO: replace with a support ticket
-		const emailHref = 'https://jetpackme.wordpress.com/contact-support/?rel=support';
+		const emailSubject = translate( 'Jetpack Stats Commercial Classification Dispute' );
+		const emailBody = `Hi Jetpack Team,\n
+I'm writing to dispute the classification of my site '${ siteSlug }' as commercial.\n
+I can confirm that,
+- I don't have ads on my site.
+- I don't sell products/services on my site.
+- I don't promote a business on my site.\n
+Could you please take a look at my site and update the classification if necessary?\n
+Thanks\n\n`;
+		const emailHref = `mailto:support@jetpack.com?subject=${ encodeURIComponent(
+			emailSubject
+		) }&body=${ encodeURIComponent( emailBody ) }`;
 
 		event.preventDefault();
 


### PR DESCRIPTION
## Proposed Changes

* Add email link with subject and body contact jetpack support

## Testing Instructions

* Open Calypso Live Branch
* Open `/stats/purchase/:siteSlug?flags=stats/type-detectionproductType=commercial`
* Click Request update
* Ensure an email with subject and body is automatically create by the link

<img width="671" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/cd0d8d73-b9d2-4fad-aecc-a34cd2c4ea08">

![image](https://github.com/Automattic/wp-calypso/assets/1425433/397b380e-e71b-4bf0-a3bf-1a8a0ad09518)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
