### PR TITLE
Stats: Fixing multiple purchase screens showing up at the same time

### DIFF
--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -171,7 +171,7 @@ const StatsPurchasePage = ( {
 						}
 						{
 							// blog doesn't have any plan but is not categorised as either personal or commectial - show old purchase wizard
-							( redirectToPersonal || redirectToCommercial || showPurchasePage ) &&
+							( ( ! redirectToPersonal && ! redirectToCommercial ) || showPurchasePage ) &&
 								isCommercial === null && (
 									<StatsPurchaseWizard
 										siteSlug={ siteSlug }

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -414,7 +414,7 @@
 		margin-bottom: 24px;
 	}
 
-	.components-button + .components-button {
+	.components-button + button.components-button {
 		margin-left: 12px;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81491

## Proposed Changes

* fixing condition for rendering new purchase screen components (previously the old screen sometimes was visible with the new screen)
* updating CSS for links to affect only buttons

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open live branch or a local branch and apply `stats/type-detection` feature flag
* verify that you can only see one purchase screen or ownership confirmation page (not a mix of old purchase wizard and new page)
* (step 1) have one page without any plan and verify that you see the correct layout
* (step 2) purchase a free plan with another page
* (step 3) visit the purchase page again and click on the upgrade button
* (step 4) purchase PWYW plan, repeat step 3
* (step 5) purchase a commercial plan, repeat step 3
* verify steps 1 to 5 with the commercial status of the website set to `false` (`isCommercial` variable)
* verify steps 1, 5 and 3 with the commercial status set to `true`
* extra: test with another site steps 4 and 5 (skip 2), and with another one only step 5 (skip 2 and 4)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?