### PR TITLE
Design Picker: Clean up design-picker-pattern-assembler flag

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -48,9 +48,7 @@ import { getPreferredBillingCycleProductSlug } from 'calypso/state/themes/theme-
 import useCheckout from '../../../../hooks/use-checkout';
 import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
 import { useQuery } from '../../../../hooks/use-query';
-import { useSite } from '../../../../hooks/use-site';
-import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
-import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
+import { useSiteData } from '../../../../hooks/use-site-data';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import {
 	getDesignEventProps,
@@ -95,10 +93,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		[]
 	);
 
-	const site = useSite();
-	const siteSlug = useSiteSlugParam();
-	const siteId = useSiteIdParam();
-	const siteSlugOrId = siteSlug ? siteSlug : siteId;
+	const { site, siteSlug, siteSlugOrId } = useSiteData();
 	const siteTitle = site?.name;
 	const siteDescription = site?.description;
 	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -206,7 +206,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const { data: selectedDesignDetails } = useStarterDesignBySlug( selectedDesign?.slug || '', {
 		enabled: isPreviewingDesign && selectedDesignHasStyleVariations,
 		select: ( design: Design ) => {
-			if ( isDesignFirstFlow && selectedDesignDetails?.style_variations ) {
+			if ( isDesignFirstFlow && design?.style_variations ) {
 				design.style_variations = [];
 			}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -132,6 +132,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	// ********** Logic for fetching designs
 	const selectStarterDesigns = ( allDesigns: StarterDesigns ) => {
+		// The design-first flow doesn't support premium themes and custom styles.
 		if ( isDesignFirstFlow ) {
 			allDesigns.designs = allDesigns.designs.filter( ( design ) => design.is_premium === false );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -13,7 +13,6 @@ import {
 	UnifiedDesignPicker,
 	useCategorizationFromApi,
 	getDesignPreviewUrl,
-	isBlankCanvasDesign,
 	isAssemblerDesign,
 	isAssemblerSupported,
 } from '@automattic/design-picker';
@@ -81,7 +80,6 @@ import type { AnyAction } from 'redux';
 import type { ThunkAction } from 'redux-thunk';
 
 const SiteIntent = Onboard.SiteIntent;
-const SITE_ASSEMBLER_AVAILABLE_INTENTS: string[] = [ SiteIntent.Build, SiteIntent.Write ];
 
 const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const queryParams = useQuery();
@@ -134,18 +132,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	// ********** Logic for fetching designs
 	const selectStarterDesigns = ( allDesigns: StarterDesigns ) => {
-		const blankCanvasDesignOffset = allDesigns.designs.findIndex( isBlankCanvasDesign );
-		if ( blankCanvasDesignOffset !== -1 ) {
-			// Extract the blank canvas design first and then insert it into the last one for the build and write intents
-			const blankCanvasDesign = allDesigns.designs.splice( blankCanvasDesignOffset, 1 );
-			if (
-				isEnabled( 'signup/design-picker-pattern-assembler' ) &&
-				SITE_ASSEMBLER_AVAILABLE_INTENTS.includes( intent )
-			) {
-				allDesigns.designs.push( ...blankCanvasDesign );
-			}
-		}
-
 		if ( isDesignFirstFlow ) {
 			allDesigns.designs = allDesigns.designs.filter( ( design ) => design.is_premium === false );
 

--- a/client/landing/stepper/hooks/use-site-data.ts
+++ b/client/landing/stepper/hooks/use-site-data.ts
@@ -1,0 +1,17 @@
+import { useSite } from './use-site';
+import { useSiteIdParam } from './use-site-id-param';
+import { useSiteSlugParam } from './use-site-slug-param';
+
+export const useSiteData = () => {
+	const site = useSite();
+	const siteSlug = useSiteSlugParam();
+	const siteId = useSiteIdParam();
+	const siteSlugOrId = siteSlug ? siteSlug : siteId;
+
+	return {
+		site,
+		siteSlug,
+		siteId,
+		siteSlugOrId,
+	};
+};

--- a/config/development.json
+++ b/config/development.json
@@ -176,7 +176,6 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/design-picker-pattern-assembler": true,
 		"signup/design-picker-preview-colors": true,
 		"signup/design-picker-preview-fonts": true,
 		"signup/professional-email-step": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -110,7 +110,6 @@
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,
-		"signup/design-picker-pattern-assembler": true,
 		"signup/design-picker-preview-colors": true,
 		"signup/design-picker-preview-fonts": true,
 		"signup/professional-email-step": false,

--- a/config/production.json
+++ b/config/production.json
@@ -137,7 +137,6 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/design-picker-pattern-assembler": true,
 		"signup/design-picker-preview-colors": true,
 		"signup/design-picker-preview-fonts": true,
 		"signup/professional-email-step": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -133,7 +133,6 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/design-picker-pattern-assembler": true,
 		"signup/design-picker-preview-colors": true,
 		"signup/design-picker-preview-fonts": true,
 		"signup/professional-email-step": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -143,7 +143,6 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/design-picker-pattern-assembler": true,
 		"signup/design-picker-preview-colors": true,
 		"signup/design-picker-preview-fonts": true,
 		"signup/professional-email-step": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Clean up `signup/design-picker-pattern-assembler` flag since it's enabled for a long time
* Add comments to describe design-first flow doesn't support premium themes and custom styles
* Fix warnings as the `selectedDesignDetails` variation is not defined in the select function
* Introduce `useSiteData` so we can use it to get the site, siteId, siteSlug, siteSlugOrId, etc

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_site>
* Continue to the Design Picker
* Ensure everything works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?