### PR TITLE
Jetpack Manage: Change "Setup" to "Set up" in atomic site actions

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/get-action-event-name.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/get-action-event-name.ts
@@ -26,9 +26,9 @@ const actionEventNames: ActionEventNames = {
 		large_screen: 'calypso_jetpack_agency_dashboard_site_settings_large_screen',
 		small_screen: 'calypso_jetpack_agency_dashboard_site_settings_small_screen',
 	},
-	setup_site: {
-		large_screen: 'calypso_jetpack_agency_dashboard_setup_site_large_screen',
-		small_screen: 'calypso_jetpack_agency_dashboard_setup_site_small_screen',
+	set_up_site: {
+		large_screen: 'calypso_jetpack_agency_dashboard_set_up_site_large_screen',
+		small_screen: 'calypso_jetpack_agency_dashboard_set_up_site_small_screen',
 	},
 	change_domain: {
 		large_screen: 'calypso_jetpack_agency_dashboard_change_domain_large_screen',

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
@@ -36,9 +36,9 @@ export default function useSiteActions(
 
 		return [
 			{
-				name: translate( 'Setup site' ),
+				name: translate( 'Set up site' ),
 				href: `https://wordpress.com/home/${ siteSlug }`,
-				onClick: () => handleClickMenuItem( 'setup_site' ),
+				onClick: () => handleClickMenuItem( 'set_up_site' ),
 				isExternalLink: true,
 				isEnabled: isWPCOMAtomicSiteCreationEnabled,
 			},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/wpcom-atomic-hosting-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/wpcom-atomic-hosting-notification.tsx
@@ -42,7 +42,7 @@ export default function WPCOMAtomicHostingNotification( {
 					handleOnClick( 'calypso_jetpack_agency_dashboard_setup_site_in_wp_admin_click' )
 				}
 			>
-				{ translate( 'Setup site in wp-admin' ) }
+				{ translate( 'Set up site in wp-admin' ) }
 				<span>
 					<Gridicon icon="external" size={ 18 } />
 				</span>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -192,7 +192,7 @@ export type AllowedActionTypes =
 	| 'visit_wp_admin'
 	| 'clone_site'
 	| 'site_settings'
-	| 'setup_site'
+	| 'set_up_site'
 	| 'change_domain'
 	| 'hosting_configuration';
 

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/use-license-actions.ts
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/use-license-actions.ts
@@ -33,9 +33,9 @@ export default function useLicenseActions(
 		const licenseState = getLicenseState( attachedAt, revokedAt );
 		return [
 			{
-				name: translate( 'Setup site' ),
+				name: translate( 'Set up site' ),
 				href: `https://wordpress.com/home/${ siteSlug }`,
-				onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_site_setup_click' ),
+				onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_site_set_up_click' ),
 				isExternalLink: true,
 				isEnabled: true,
 			},


### PR DESCRIPTION
## Proposed Changes

This PR fixes the typo that was mentioned here: https://github.com/Automattic/wp-calypso/pull/81173#discussion_r1317568510.

## Testing Instructions

Follow the testing instructions here: 

- https://github.com/Automattic/wp-calypso/pull/81173
- https://github.com/Automattic/wp-calypso/pull/81345
- https://github.com/Automattic/wp-calypso/pull/81263

and verify the action name is changed from `Setup site` to `Set up site`, and the button text is changed from `Setup site in wp-admin` to `Set up site in wp-admin`

Dashboard actions

<img width="305" alt="Screenshot 2023-09-07 at 1 14 03 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d3704d3e-3040-40b4-a4c1-8658c4d9bb1d">

------

License notification

<img width="1535" alt="Screenshot 2023-09-07 at 1 15 30 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/5801feb3-ae3b-40dc-9041-28e788b8104a">

-----

License actions

<img width="308" alt="Screenshot 2023-09-07 at 1 16 38 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/344bb4a5-ff47-41f1-9fc3-acc7b596859d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?