### PR TITLE
Checkout: add checkbox for accepting ToS of 100 year plan

### DIFF
--- a/client/my-sites/checkout/src/components/accept-terms-of-service-checkbox.tsx
+++ b/client/my-sites/checkout/src/components/accept-terms-of-service-checkbox.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { localize, LocalizeProps } from 'i18n-calypso';
+import { localize, LocalizeProps, TranslateResult } from 'i18n-calypso';
 import { useState } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -47,18 +47,23 @@ const ErrorMessage = styled.small`
 interface ExternalProps {
 	isAccepted: boolean;
 	isSubmitted: boolean;
+	message: TranslateResult;
+	errorMessage?: TranslateResult;
 	onChange: ( isAccepted: boolean ) => void;
 }
 
 type Props = ExternalProps & LocalizeProps;
 
-function ThirdPartyDevsAccount( { isAccepted, isSubmitted, onChange, translate }: Props ) {
+function AcceptTermsOfServiceCheckbox( {
+	isAccepted,
+	isSubmitted,
+	message,
+	errorMessage,
+	onChange,
+	translate,
+}: Props ) {
 	const [ touched, setTouched ] = useState( false );
 	const displayErrorMessage = ( isSubmitted || touched ) && ! isAccepted;
-
-	const message = translate(
-		'You agree that an account may be created on a third party developer’s site related to the products you have purchased.'
-	);
 
 	const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		onChange( event.target.checked );
@@ -74,11 +79,13 @@ function ThirdPartyDevsAccount( { isAccepted, isSubmitted, onChange, translate }
 				/>
 				<MessageWrapper displayErrorMessage={ displayErrorMessage }>{ message }</MessageWrapper>
 				{ displayErrorMessage && (
-					<ErrorMessage>{ translate( 'The terms above need to be accepted' ) }</ErrorMessage>
+					<ErrorMessage>
+						{ errorMessage || translate( 'The terms above need to be accepted' ) }
+					</ErrorMessage>
 				) }
 			</CheckboxTermsWrapper>
 		</FormLabel>
 	);
 }
 
-export default localize( ThirdPartyDevsAccount );
+export default localize( AcceptTermsOfServiceCheckbox );

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -38,6 +38,7 @@ import {
 	hasDomainRegistration,
 	hasTransferProduct,
 	hasDIFMProduct,
+	has100YearPlan as cartHas100YearPlan,
 } from 'calypso/lib/cart-values/cart-items';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
@@ -61,6 +62,7 @@ import { validateContactDetails } from '../lib/contact-validation';
 import getContactDetailsType from '../lib/get-contact-details-type';
 import { updateCartContactDetailsForCheckout } from '../lib/update-cart-contact-details-for-checkout';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
+import AcceptTermsOfServiceCheckbox from './accept-terms-of-service-checkbox';
 import badge14Src from './assets/icons/badge-14.svg';
 import badge7Src from './assets/icons/badge-7.svg';
 import badgeGenericSrc from './assets/icons/badge-generic.svg';
@@ -74,7 +76,6 @@ import { GoogleDomainsCopy } from './google-transfers-copy';
 import JetpackCheckoutSidebarPlanUpsell from './jetpack-checkout-sidebar-plan-upsell';
 import PaymentMethodStepContent from './payment-method-step';
 import SecondaryCartPromotions from './secondary-cart-promotions';
-import ThirdPartyDevsAccount from './third-party-plugins-developer-account';
 import WPCheckoutOrderReview from './wp-checkout-order-review';
 import WPCheckoutOrderSummary from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
@@ -309,12 +310,19 @@ export default function WPCheckout( {
 		return responseCart?.products?.some( ( p ) => isMarketplaceProduct( state, p.product_slug ) );
 	} );
 
+	const has100YearPlan = cartHas100YearPlan( responseCart );
+
 	const [ is3PDAccountConsentAccepted, setIs3PDAccountConsentAccepted ] = useState( false );
+	const [ is100YearPlanTermsAccepted, setIs100YearPlanTermsAccepted ] = useState( false );
 	const [ isSubmitted, setIsSubmitted ] = useState( false );
 
 	const validateForm = async () => {
 		setIsSubmitted( true );
 		if ( hasMarketplaceProduct && ! is3PDAccountConsentAccepted ) {
+			return false;
+		}
+
+		if ( has100YearPlan && ! is100YearPlanTermsAccepted ) {
 			return false;
 		}
 		return true;
@@ -566,10 +574,21 @@ export default function WPCheckout( {
 							<>
 								<PaymentMethodStepContent />
 								{ hasMarketplaceProduct && (
-									<ThirdPartyDevsAccount
+									<AcceptTermsOfServiceCheckbox
 										isAccepted={ is3PDAccountConsentAccepted }
 										onChange={ setIs3PDAccountConsentAccepted }
 										isSubmitted={ isSubmitted }
+										message={ translate(
+											'You agree that an account may be created on a third party developer’s site related to the products you have purchased.'
+										) }
+									/>
+								) }
+								{ has100YearPlan && (
+									<AcceptTermsOfServiceCheckbox
+										isAccepted={ is100YearPlanTermsAccepted }
+										onChange={ setIs100YearPlanTermsAccepted }
+										isSubmitted={ isSubmitted }
+										message={ translate( 'I have read and agree to all of the above.' ) }
 									/>
 								) }
 							</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#2152

## Proposed Changes

* Adds a checkbox to the checkout screen when the 100-year plan is in the cart with the text "I have read and agree to all of the above.". This checkbox needs to be checked before starting to process the payment.
* This refactors an existing component, `ThirdPartyDevsAccount`, which was added via #65414, to accept a `message` prop and an optional `errorMessage` prop to make this component re-usable for similar use cases.

<img width="908" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/3f0277eb-be94-401a-bf14-9d3795c717ed">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Testing the 100 year plan

* Go to `/checkout/<site slug>/wp_com_hundred_year_bundle_centennially`.
* Confirm that you can see the checkbox.
* Confirm that if the checkbox is unchecked, you are unable to submit the form. Also confirm that you can see the error message.
<img width="783" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/b30ebe54-ce6e-454d-8a97-3684f2a7a5ee">
 
* Confirm that after checking the checkbox you are able to complete the purchase.

### Testing for regressions
* Confirm that you can follow the testing instructions in #65414.
* Confirm that the checkbox is not shown if the 100 year plan is not in the cart.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?