### PR TITLE
Add upsell banner when user request auth code or unlock the domain

### DIFF
--- a/client/lib/domains/types.ts
+++ b/client/lib/domains/types.ts
@@ -53,6 +53,7 @@ export type ResponseDomain = {
 	aRecordsRequiredForMapping?: Array< string >;
 	autoRenewalDate: string;
 	autoRenewing: boolean;
+	availablePromos?: Array< string >;
 	beginTransferUntilDate: string;
 	blogId: number;
 	bundledPlanSubscriptionId: string | number | null | undefined;

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -353,6 +353,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 						</b>
 					</p>
 					<RenewButton
+						primary
 						purchase={ purchase }
 						selectedSite={ selectedSite }
 						subscriptionId={ parseInt( domain?.subscriptionId ?? '', 10 ) }

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -339,7 +339,10 @@ const TransferPage = ( props: TransferPageProps ) => {
 	const renderUpsellDiscount = () => {
 		return (
 			<div className="transfer-page__upsell-discount">
-				<p>TBD Upsell messagge</p>
+				<p>
+					Are you sure you want to transfer your domain? Renew now and you can enjoy an instant 10%
+					discount!
+				</p>
 				<RenewButton
 					purchase={ purchase }
 					selectedSite={ selectedSite }

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -338,20 +338,29 @@ const TransferPage = ( props: TransferPageProps ) => {
 
 	const renderUpsellDiscount = () => {
 		return (
-			<div className="transfer-page__upsell-discount">
-				<p>
-					Are you sure you want to transfer your domain? Renew now and you can enjoy an instant 10%
-					discount!
-				</p>
-				<RenewButton
-					purchase={ purchase }
-					selectedSite={ selectedSite }
-					subscriptionId={ parseInt( domain?.subscriptionId ?? '', 10 ) }
-					tracksProps={ { source: 'test-registered-domain-transfer-out' } }
-					customLabel={ __( 'Renew' ) }
-					disabled={ isLoadingPurchase }
-				/>
-			</div>
+			<>
+				<div key="separator" className="transfer-page__item-separator" />
+				<div className="transfer-page__upsell-discount">
+					<p>
+						{ __( 'Are you sure you want to transfer your domain?' ) }
+						<br />
+						<b>
+							{
+								// translators: promotional offer for domain renewal
+								__( 'Renew now and get a 10% discount!' )
+							}
+						</b>
+					</p>
+					<RenewButton
+						purchase={ purchase }
+						selectedSite={ selectedSite }
+						subscriptionId={ parseInt( domain?.subscriptionId ?? '', 10 ) }
+						tracksProps={ { source: 'test-registered-domain-transfer-out' } }
+						customLabel={ __( 'Renew now' ) }
+						disabled={ isLoadingPurchase }
+					/>
+				</div>
+			</>
 		);
 	};
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
 import ActionCard from 'calypso/components/action-card';
 import CardHeading from 'calypso/components/card-heading';
 import QueryDomainInfo from 'calypso/components/data/query-domain-info';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
 import Main from 'calypso/components/main';
@@ -23,6 +24,7 @@ import AftermarketAutcionNotice from 'calypso/my-sites/domains/domain-management
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
 import NonTransferrableDomainNotice from 'calypso/my-sites/domains/domain-management/components/domain/non-transferrable-domain-notice';
 import DomainHeader from 'calypso/my-sites/domains/domain-management/components/domain-header';
+import RenewButton from 'calypso/my-sites/domains/domain-management/edit/card/renew-button';
 import SelectIpsTag from 'calypso/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag';
 import {
 	domainManagementEdit,
@@ -33,6 +35,7 @@ import {
 	isUnderDomainManagementAll,
 } from 'calypso/my-sites/domains/paths';
 import { useDispatch } from 'calypso/state';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import {
 	getDomainLockError,
 	getDomainTransferCodeError,
@@ -41,6 +44,11 @@ import {
 import { updateDomainLock } from 'calypso/state/domains/transfer/actions';
 import { getDomainWapiInfoByDomainName } from 'calypso/state/domains/transfer/selectors';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import {
+	getByPurchaseId,
+	hasLoadedSitePurchasesFromServer,
+	isFetchingSitePurchases,
+} from 'calypso/state/purchases/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isPrimaryDomainBySiteId from 'calypso/state/selectors/is-primary-domain-by-site-id';
@@ -50,7 +58,6 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import TransferUnavailableNotice from '../transfer-unavailable-notice';
 import type { TransferPageProps } from './types';
 import type { AppState } from 'calypso/types';
-
 import './style.scss';
 
 // The types for ToggleControl are missing `disabled`, but it is listed in the
@@ -71,16 +78,34 @@ const TransferPage = ( props: TransferPageProps ) => {
 		isDomainInfoLoading,
 		isDomainLocked,
 		isDomainOnly,
+		isLoadingPurchase,
 		isMapping,
 		isSupportSession,
+		purchase,
 		selectedDomainName,
 		selectedSite,
 	} = props;
 	const { __ } = useI18n();
 	const [ isRequestingTransferCode, setIsRequestingTransferCode ] = useState( false );
 	const [ isLockingOrUnlockingDomain, setIsLockingOrUnlockingDomain ] = useState( false );
+	const [ showUpsellDiscount, setShowUpsellDiscount ] = useState( false );
 	const domain = getSelectedDomain( props );
 	const hasEnTranslation = useHasEnTranslation();
+	const canUsePreventTransferPromo =
+		domain?.availablePromos?.length && domain?.availablePromos?.length > 0;
+
+	const updateLastTransferOutIntent = async () => {
+		try {
+			await wpcom.req.post(
+				`/me/domains/${ selectedDomainName }/update-last-transfer-out-intent/`,
+				{}
+			);
+			setShowUpsellDiscount( true );
+		} catch {
+			// Nothing needs to be done here. If the request fails, the user will not see the upsell banner.
+		}
+	};
+
 	const renderHeader = () => {
 		const items = [
 			{
@@ -197,6 +222,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 	const toggleDomainLock = async () => {
 		setIsLockingOrUnlockingDomain( true );
 		const lock = ! isDomainLocked;
+		setShowUpsellDiscount( ! lock );
 
 		try {
 			await wpcom.req.post( `/domains/${ selectedDomainName }/transfer/`, {
@@ -212,6 +238,10 @@ const TransferPage = ( props: TransferPageProps ) => {
 					getNoticeOptions( selectedDomainName )
 				)
 			);
+
+			if ( canUsePreventTransferPromo && isDomainLocked ) {
+				updateLastTransferOutIntent();
+			}
 		} catch {
 			dispatch( errorNotice( getDomainLockError( lock ), getNoticeOptions( selectedDomainName ) ) );
 		} finally {
@@ -238,6 +268,9 @@ const TransferPage = ( props: TransferPageProps ) => {
 					getNoticeOptions( selectedDomainName )
 				)
 			);
+			if ( canUsePreventTransferPromo ) {
+				updateLastTransferOutIntent();
+			}
 		} catch ( error ) {
 			dispatch(
 				errorNotice(
@@ -303,6 +336,22 @@ const TransferPage = ( props: TransferPageProps ) => {
 		);
 	};
 
+	const renderUpsellDiscount = () => {
+		return (
+			<div className="transfer-page__upsell-discount">
+				<p>TBD Upsell messagge</p>
+				<RenewButton
+					purchase={ purchase }
+					selectedSite={ selectedSite }
+					subscriptionId={ parseInt( domain?.subscriptionId ?? '', 10 ) }
+					tracksProps={ { source: 'test-registered-domain-transfer-out' } }
+					customLabel={ __( 'Renew' ) }
+					disabled={ isLoadingPurchase }
+				/>
+			</div>
+		);
+	};
+
 	const renderTransferMessage = () => {
 		const registrationDatePlus60Days = moment.utc( domain?.registrationDate ).add( 60, 'days' );
 		const supportLink = moment.utc().isAfter( registrationDatePlus60Days )
@@ -343,6 +392,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 				<Button primary={ false } busy={ isRequestingTransferCode } onClick={ requestTransferCode }>
 					{ __( 'Get authorization code' ) }
 				</Button>
+				{ showUpsellDiscount && renderUpsellDiscount() }
 			</>
 		);
 	};
@@ -406,6 +456,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 	return (
 		<Main className="transfer-page" wideLayout>
 			<QueryDomainInfo domainName={ selectedDomainName } />
+			{ selectedSite?.ID && ! purchase && <QuerySitePurchases siteId={ selectedSite?.ID } /> }
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderHeader() }
 			<Layout>
@@ -436,15 +487,21 @@ const transferPageComponent = connect( ( state: AppState, ownProps: TransferPage
 	const domain = getSelectedDomain( ownProps );
 	const siteId = getSelectedSiteId( state );
 	const domainInfo = getDomainWapiInfoByDomainName( state, ownProps.selectedDomainName );
+	const currentUserId = getCurrentUserId( state );
+	const subscriptionId = domain && domain.subscriptionId;
+	const purchase = subscriptionId ? getByPurchaseId( state, parseInt( subscriptionId, 10 ) ) : null;
 	return {
 		currentRoute: getCurrentRoute( state ),
 		isAtomic: isSiteAutomatedTransfer( state, siteId ) ?? false,
 		isDomainInfoLoading: ! domainInfo.hasLoadedFromServer,
 		isDomainLocked: domainInfo.data?.locked,
 		isDomainOnly: isDomainOnlySite( state, siteId ) ?? false,
+		isLoadingPurchase:
+			isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
 		isMapping: Boolean( domain ) && isMappedDomain( domain ),
 		isPrimaryDomain: isPrimaryDomainBySiteId( state, siteId, ownProps.selectedDomainName ),
 		isSupportSession: isSupportSession( state ),
+		purchase: purchase && purchase.userId === currentUserId ? purchase : null,
 	};
 } )( TransferPage );
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -345,10 +345,11 @@ const TransferPage = ( props: TransferPageProps ) => {
 						{ __( 'Are you sure you want to transfer your domain?' ) }
 						<br />
 						<b>
-							{
-								// translators: promotional offer for domain renewal
-								__( 'Renew now and get a 10% discount!' )
-							}
+							{ sprintf(
+								/* translators: %s is the percentage of the discount */
+								__( 'Renew now and get a %s discount!' ),
+								'10%'
+							) }
 						</b>
 					</p>
 					<RenewButton

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -102,7 +102,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 				{}
 			);
 			setShowUpsellDiscount( true );
-			recordTracksEvent( 'calypso_show_discount_on_domain_transfer_out', {
+			recordTracksEvent( 'calypso_show_discount_on_domain_transfer_out_intent', {
 				domain: selectedDomainName,
 				source: 'domain_get_auth_code',
 			} );
@@ -230,7 +230,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 		setShowUpsellDiscount( ! lock );
 
 		if ( showUpsellDiscount ) {
-			recordTracksEvent( 'calypso_show_discount_on_domain_transfer_out', {
+			recordTracksEvent( 'calypso_show_discount_on_domain_transfer_out_intent', {
 				domain: selectedDomainName,
 				source: 'domain_unlocked',
 			} );
@@ -369,7 +369,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 						purchase={ purchase }
 						selectedSite={ selectedSite }
 						subscriptionId={ parseInt( domain?.subscriptionId ?? '', 10 ) }
-						tracksProps={ { source: 'test-registered-domain-transfer-out' } }
+						tracksProps={ { source: 'prevent-transfer-out-upsell' } }
 						customLabel={ __( 'Renew now' ) }
 						disabled={ isLoadingPurchase }
 					/>

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, Card, Spinner } from '@automattic/components';
 import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
@@ -101,6 +102,10 @@ const TransferPage = ( props: TransferPageProps ) => {
 				{}
 			);
 			setShowUpsellDiscount( true );
+			recordTracksEvent( 'calypso_show_discount_on_domain_transfer_out', {
+				domain: selectedDomainName,
+				source: 'domain_get_auth_code',
+			} );
 		} catch {
 			// Nothing needs to be done here. If the request fails, the user will not see the upsell banner.
 		}
@@ -223,6 +228,13 @@ const TransferPage = ( props: TransferPageProps ) => {
 		setIsLockingOrUnlockingDomain( true );
 		const lock = ! isDomainLocked;
 		setShowUpsellDiscount( ! lock );
+
+		if ( showUpsellDiscount ) {
+			recordTracksEvent( 'calypso_show_discount_on_domain_transfer_out', {
+				domain: selectedDomainName,
+				source: 'domain_unlocked',
+			} );
+		}
 
 		try {
 			await wpcom.req.post( `/domains/${ selectedDomainName }/transfer/`, {

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
@@ -128,6 +128,10 @@
 		@include placeholder();
 	}
 
+	.transfer-page__upsell-discount {
+		text-align: center;
+	}
+
 	@include breakpoint-deprecated( ">1280px" ) {
 		.layout__column--main {
 			padding-right: 24px;

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
@@ -130,6 +130,10 @@
 
 	.transfer-page__upsell-discount {
 		text-align: center;
+
+		p {
+			font-size: $font-body-large;
+		}
 	}
 
 	@include breakpoint-deprecated( ">1280px" ) {

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/types.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/types.tsx
@@ -1,5 +1,6 @@
 import type { SiteDetails } from '@automattic/data-stores';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { Purchase } from 'calypso/lib/purchases/types';
 import type { NoticeActionCreator } from 'calypso/state/notices/types';
 import type { ReactNode } from 'react';
 
@@ -11,9 +12,11 @@ export type TransferPageProps = {
 	isDomainInfoLoading: boolean;
 	isDomainLocked: boolean;
 	isDomainOnly: boolean;
+	isLoadingPurchase: boolean;
 	isMapping: boolean;
 	isPrimaryDomain: boolean;
 	isSupportSession: boolean;
+	purchase: Purchase | null;
 	selectedDomainName: string;
 	selectedSite: SiteDetails;
 	successNotice: ( notice: string, options: Record< string, unknown > ) => NoticeActionCreator;

--- a/client/state/sites/domains/assembler.js
+++ b/client/state/sites/domains/assembler.js
@@ -58,6 +58,7 @@ export const createSiteDomainObject = ( domain ) => {
 		aftermarketAuctionEnd: String( domain.aftermarket_auction_end ?? '' ),
 		aftermarketAuctionStart: String( domain.aftermarket_auction_start ?? '' ),
 		autoRenewing: Boolean( domain.auto_renewing ),
+		availablePromos: domain.available_promos,
 		beginTransferUntilDate: String( domain.begin_transfer_until_date ),
 		blogId: Number( domain.blog_id ),
 		bundledPlanSubscriptionId: domain.bundled_plan_subscription_id,

--- a/packages/data-stores/src/queries/use-site-domains-query.ts
+++ b/packages/data-stores/src/queries/use-site-domains-query.ts
@@ -109,6 +109,7 @@ export interface DomainData {
 	must_remove_privacy_before_contact_update: boolean;
 	registry_expiry_date: string;
 	subdomain_part: string;
+	available_promos: [];
 }
 
 export interface SiteDomainsQueryFnData {

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -338,6 +338,7 @@ export interface Domain {
 	product_slug?: any;
 	owner: string;
 	is_pending_icann_verification?: boolean;
+	available_promos?: string[];
 }
 
 export interface SiteSettings {

--- a/packages/domains-table/src/test-utils.tsx
+++ b/packages/domains-table/src/test-utils.tsx
@@ -153,6 +153,7 @@ export function testDomain(
 		must_remove_privacy_before_contact_update: false,
 		registry_expiry_date: '',
 		subdomain_part: '',
+		available_promos: [],
 		...defaults,
 	};
 

--- a/packages/domains-table/src/utils/assembler.ts
+++ b/packages/domains-table/src/utils/assembler.ts
@@ -58,6 +58,7 @@ export const createSiteDomainObject = ( domain: DomainData ) => {
 		aftermarketAuctionEnd: String( domain.aftermarket_auction_end ?? '' ),
 		aftermarketAuctionStart: String( domain.aftermarket_auction_start ?? '' ),
 		autoRenewing: Boolean( domain.auto_renewing ),
+		available_promos: domain.available_promos,
 		beginTransferUntilDate: String( domain.begin_transfer_until_date ),
 		blogId: Number( domain.blog_id ),
 		bundledPlanSubscriptionId: domain.bundled_plan_subscription_id,

--- a/packages/domains-table/src/utils/types.ts
+++ b/packages/domains-table/src/utils/types.ts
@@ -53,6 +53,7 @@ export type ResponseDomain = {
 	aRecordsRequiredForMapping?: Array< string >;
 	autoRenewalDate: string;
 	autoRenewing: boolean;
+	availablePromos?: Array< string >;
 	beginTransferUntilDate: string;
 	blogId: number;
 	bundledPlanSubscriptionId: string | number | null | undefined;


### PR DESCRIPTION
## Proposed Changes

This PR enables in Calypso the new promo discount on transfer out (it depends on server code D120788-code).

Basically, if a user disables the transfer lock or request the auth code in the transfer management page, a banner is displayed, showing a message and a button to renew the domain with a discount (the discount is valid only one time for each domain).

![prevent-transfer-discount](https://github.com/Automattic/wp-calypso/assets/2797601/9f0c10da-3792-4670-a006-984b6bcf5057)


## Testing Instructions
1) apply this patch locally
2) register a new `.com` domain (use `store_sandbox`)
3) visit the domain transfer page and click on "Get Auth Code" button
4) verify that the banner is displayed
5) click on the banner, verify that the discount is applied and complete the checkout
6) repeat step 3 and check that the banner is not displayed

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [Z] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?SS