### PR TITLE
Refetch whois data with each mount of ContactDisplay

### DIFF
--- a/client/my-sites/domains/domain-management/contacts-privacy/contact-display.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/contact-display.jsx
@@ -26,6 +26,10 @@ class ContactDisplay extends PureComponent {
 
 		const contactInformation = findRegistrantWhois( whoisData );
 
+		if ( isEmpty( contactInformation ) ) {
+			return null;
+		}
+
 		return (
 			<div className="contact-display">
 				<div className="contact-display__content">

--- a/client/my-sites/domains/domain-management/contacts-privacy/contact-display.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/contact-display.jsx
@@ -11,9 +11,12 @@ class ContactDisplay extends PureComponent {
 		selectedDomainName: PropTypes.string.isRequired,
 	};
 
+	hasRequestedWhois = false;
+
 	fetchWhois = () => {
-		if ( isEmpty( this.props.whoisData ) && ! isEmpty( this.props.selectedDomainName ) ) {
+		if ( ! this.hasRequestedWhois && ! isEmpty( this.props.selectedDomainName ) ) {
 			this.props.requestWhois( this.props.selectedDomainName );
+			this.hasRequestedWhois = true;
 		}
 	};
 

--- a/client/my-sites/domains/domain-management/contacts-privacy/contact-display.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/contact-display.jsx
@@ -15,6 +15,12 @@ class ContactDisplay extends PureComponent {
 		this.fetchWhois();
 	}
 
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.selectedDomainName !== this.props.selectedDomainName ) {
+			this.fetchWhois();
+		}
+	}
+
 	fetchWhois = () => {
 		if ( ! isEmpty( this.props.selectedDomainName ) ) {
 			this.props.requestWhois( this.props.selectedDomainName );

--- a/client/my-sites/domains/domain-management/contacts-privacy/contact-display.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/contact-display.jsx
@@ -11,12 +11,13 @@ class ContactDisplay extends PureComponent {
 		selectedDomainName: PropTypes.string.isRequired,
 	};
 
-	hasRequestedWhois = false;
+	componentDidMount() {
+		this.fetchWhois();
+	}
 
 	fetchWhois = () => {
-		if ( ! this.hasRequestedWhois && ! isEmpty( this.props.selectedDomainName ) ) {
+		if ( ! isEmpty( this.props.selectedDomainName ) ) {
 			this.props.requestWhois( this.props.selectedDomainName );
-			this.hasRequestedWhois = true;
 		}
 	};
 
@@ -24,11 +25,6 @@ class ContactDisplay extends PureComponent {
 		const { whoisData } = this.props;
 
 		const contactInformation = findRegistrantWhois( whoisData );
-
-		if ( isEmpty( contactInformation ) ) {
-			this.fetchWhois();
-			return null;
-		}
 
 		return (
 			<div className="contact-display">


### PR DESCRIPTION
With bulk domain updates now being possible we can't rely on the redux store having the latest data because whois data may have been updated by an async job without redux being involved.

Refetch the whois data with each mount so we can be sure we have the latest data.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
