### PR TITLE
Fix alignment issue for domain forwarding

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -330,10 +330,7 @@
 		display: flex;
 		flex-direction: row;
 		justify-content: space-between;
-
-		&.addresses {
-			justify-content: flex-start;
-		}
+		gap: 1rem;
 
 		&:first-child {
 			margin-bottom: 5px;
@@ -341,6 +338,11 @@
 
 		.source {
 			width: 35%;
+		}
+
+		.destination {
+			width: 65%;
+			overflow-wrap: anywhere;
 		}
 
 		.badge {


### PR DESCRIPTION
Context: p1694034743599179/1694031451.357029-slack-C05CT832K2T

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/b4836354-e169-4a77-9547-35a99722f9ff">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/ffdbe6f4-af59-4772-a1f6-6b9e05e4ad36">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go do domain page
* Setup a domain/subdomain forwarding
* Check if the URLs are aligned as above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you checked for TypeScript, React or other console errors?