### PR TITLE
I18N: Translate subscriber stats headers

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-stats/subscriber-stats.tsx
+++ b/client/my-sites/subscribers/components/subscriber-stats/subscriber-stats.tsx
@@ -28,19 +28,19 @@ const SubscriberStats = ( { siteId, subscriptionId, userId }: SubscriberStatsPro
 		<div className="subscriber-stats">
 			<div className="subscriber-stats__list highlight-cards-list">
 				<SubscriberStatsCard
-					heading="Emails sent"
+					heading={ translate( 'Emails sent' ) }
 					isLoading={ isLoading }
 					icon={ <Icon icon={ MailIcon } /> }
 					value={ subscriberStats?.emails_sent }
 				/>
 				<SubscriberStatsCard
-					heading="Open rate"
+					heading={ translate( 'Open rate' ) }
 					isLoading={ isLoading }
 					icon={ <Icon icon={ chartBar } /> }
 					value={ `${ openRate }%` }
 				/>
 				<SubscriberStatsCard
-					heading="Click rate"
+					heading={ translate( 'Click rate' ) }
 					icon={ <Icon icon={ SelectIcon } /> }
 					isLoading={ isLoading }
 					value={ `${ clickRate }%` }


### PR DESCRIPTION
## Proposed Changes

* This PR translates the subscriber stats headers:
![image](https://github.com/Automattic/wp-calypso/assets/23708351/079fe830-56bf-4b4b-b74c-587592f8388a)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set language to a mag-16 languages and go to a test site with at least one current email subscriber
* Go to https://wordpress.com/subscribers/ and click on the name of a subscriber
* The headers should be translated ("Note: `Emails sent` is a new string and will be sent for translation" 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
