### PR TITLE
Site Setup Flow: Load steps async

### DIFF
--- a/client/landing/stepper/declarative-flow/ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/ai-assembler.ts
@@ -9,10 +9,7 @@ import { getTheme } from 'calypso/state/themes/selectors';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
-import AISitePrompt from './internals/steps-repository/ai-site-prompt';
-import ErrorStep from './internals/steps-repository/error-step';
-import PatternAssembler from './internals/steps-repository/pattern-assembler/lazy';
-import ProcessingStep from './internals/steps-repository/processing-step';
+import { STEPS } from './internals/steps';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import { Flow, ProvidedDependencies } from './internals/types';
 import type { OnboardSelect } from '@automattic/data-stores';
@@ -57,14 +54,11 @@ const withAIAssemblerFlow: Flow = {
 
 	useSteps() {
 		return [
-			{ slug: 'site-prompt', component: AISitePrompt },
-			{ slug: 'patternAssembler', component: PatternAssembler },
-			{ slug: 'processing', component: ProcessingStep },
-			{ slug: 'error', component: ErrorStep },
-			{
-				slug: 'celebration-step',
-				asyncComponent: () => import( './internals/steps-repository/celebration-step' ),
-			},
+			STEPS.SITE_PROMPT,
+			STEPS.PATTERN_ASSEMBLER,
+			STEPS.PROCESSING,
+			STEPS.ERROR,
+			STEPS.CELEBRATION,
 		];
 	},
 

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -26,7 +26,6 @@ import DesignSetup from './internals/steps-repository/design-setup';
 import ErrorStep from './internals/steps-repository/error-step';
 import FreeSetup from './internals/steps-repository/free-setup';
 import LaunchPad from './internals/steps-repository/launchpad';
-import PatternAssembler from './internals/steps-repository/pattern-assembler/lazy';
 import Processing from './internals/steps-repository/processing-step';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import SiteCreationStep from './internals/steps-repository/site-creation-step';
@@ -55,7 +54,10 @@ const free: Flow = {
 			{ slug: 'processing', component: Processing },
 			{ slug: 'launchpad', component: LaunchPad },
 			{ slug: 'designSetup', component: DesignSetup },
-			{ slug: 'patternAssembler', component: PatternAssembler },
+			{
+				slug: 'patternAssembler',
+				asyncComponent: () => import( './internals/steps-repository/pattern-assembler' ),
+			},
 			{ slug: 'error', component: ErrorStep },
 		];
 	},

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -22,13 +22,8 @@ import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
-import DesignSetup from './internals/steps-repository/design-setup';
-import ErrorStep from './internals/steps-repository/error-step';
-import FreeSetup from './internals/steps-repository/free-setup';
-import LaunchPad from './internals/steps-repository/launchpad';
-import Processing from './internals/steps-repository/processing-step';
+import { STEPS } from './internals/steps';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
-import SiteCreationStep from './internals/steps-repository/site-creation-step';
 import {
 	AssertConditionResult,
 	AssertConditionState,
@@ -49,16 +44,13 @@ const free: Flow = {
 		}, [] );
 
 		return [
-			{ slug: 'freeSetup', component: FreeSetup },
-			{ slug: 'siteCreationStep', component: SiteCreationStep },
-			{ slug: 'processing', component: Processing },
-			{ slug: 'launchpad', component: LaunchPad },
-			{ slug: 'designSetup', component: DesignSetup },
-			{
-				slug: 'patternAssembler',
-				asyncComponent: () => import( './internals/steps-repository/pattern-assembler' ),
-			},
-			{ slug: 'error', component: ErrorStep },
+			STEPS.FREE_SETUP,
+			STEPS.PROCESSING,
+			STEPS.SITE_CREATION_STEP,
+			STEPS.LAUNCHPAD,
+			STEPS.DESIGN_SETUP,
+			STEPS.PATTERN_ASSEMBLER,
+			STEPS.ERROR,
 		];
 	},
 

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect, useState, useCallback, Suspense, lazy } from 'react';
+import React, { useEffect, useState, useCallback, useMemo, Suspense, lazy } from 'react';
 import Modal from 'react-modal';
 import { Navigate, Route, Routes, generatePath, useNavigate, useLocation } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -29,7 +29,7 @@ import { getAssemblerSource } from './analytics/record-design';
 import recordStepStart from './analytics/record-step-start';
 import StepRoute from './components/step-route';
 import StepperLoader from './components/stepper-loader';
-import { AssertConditionState, Flow, StepperStep } from './types';
+import { AssertConditionState, Flow, StepperStep, StepProps } from './types';
 import './global.scss';
 import type { OnboardSelect, StepperInternalSelect } from '@automattic/data-stores';
 
@@ -49,6 +49,19 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	Modal.setAppElement( '#wpcom' );
 	const flowSteps = flow.useSteps();
 	const stepPaths = flowSteps.map( ( step ) => step.slug );
+	const stepComponents: Record< string, React.FC< StepProps > > = useMemo(
+		() =>
+			flowSteps.reduce(
+				( acc, flowStep ) => ( {
+					...acc,
+					[ flowStep.slug ]:
+						'asyncComponent' in flowStep ? lazy( flowStep.asyncComponent ) : flowStep.component,
+				} ),
+				{}
+			),
+		[]
+	);
+
 	const location = useLocation();
 	const currentStepRoute = location.pathname.split( '/' )[ 2 ]?.replace( /\/+$/, '' );
 	const { __ } = useI18n();
@@ -188,7 +201,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 				return <></>;
 		}
 
-		const StepComponent = 'asyncComponent' in step ? lazy( step.asyncComponent ) : step.component;
+		const StepComponent = stepComponents[ step.slug ];
 
 		return (
 			<StepComponent

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/styles.scss
@@ -2,7 +2,7 @@
 
 $font-family: "SF Pro Text", $sans;
 
-.free-setup {
+.free-setup.step-container {
 	.step-container__content {
 		display: flex;
 		justify-content: center;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/lazy.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/lazy.tsx
@@ -1,3 +1,0 @@
-import { lazy } from 'react';
-
-export default lazy( () => import( /* webpackChunkName: 'pattern-assembler-step' */ '.' ) );

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -1,0 +1,146 @@
+const STEPS = {
+	BLOGGER_STARTING_POINT: {
+		slug: 'bloggerStartingPoint',
+		asyncComponent: () => import( './steps-repository/blogger-starting-point' ),
+	},
+
+	BUSINESS_INFO: {
+		slug: 'businessInfo',
+		asyncComponent: () => import( './steps-repository/business-info' ),
+	},
+
+	COURSES: { slug: 'courses', asyncComponent: () => import( './steps-repository/courses' ) },
+
+	DESIGN_SETUP: {
+		slug: 'designSetup',
+		asyncComponent: () => import( './steps-repository/design-setup' ),
+	},
+
+	DIFM_STARTING_POINT: {
+		slug: 'difmStartingPoint',
+		asyncComponent: () => import( './steps-repository/difm-starting-point' ),
+	},
+
+	EDIT_EMAIL: {
+		slug: 'editEmail',
+		asyncComponent: () => import( './steps-repository/edit-email' ),
+	},
+
+	ERROR: { slug: 'error', asyncComponent: () => import( './steps-repository/error-step' ) },
+
+	GOALS: { slug: 'goals', asyncComponent: () => import( './steps-repository/goals' ) },
+
+	IMPORT: { slug: 'import', asyncComponent: () => import( './steps-repository/import' ) },
+
+	IMPORT_LIGHT: {
+		slug: 'importLight',
+		asyncComponent: () => import( './steps-repository/import-light' ),
+	},
+
+	IMPORT_LIST: {
+		slug: 'importList',
+		asyncComponent: () => import( './steps-repository/import-list' ),
+	},
+
+	IMPORT_READY: {
+		slug: 'importReady',
+		asyncComponent: () => import( './steps-repository/import-ready' ),
+	},
+
+	IMPORT_READY_NOT: {
+		slug: 'importReadyNot',
+		asyncComponent: () => import( './steps-repository/import-ready-not' ),
+	},
+
+	IMPORT_READY_PREVIEW: {
+		slug: 'importReadyPreview',
+		asyncComponent: () => import( './steps-repository/import-ready-preview' ),
+	},
+
+	IMPORT_READY_WPCOM: {
+		slug: 'importReadyWpcom',
+		asyncComponent: () => import( './steps-repository/import-ready-wpcom' ),
+	},
+
+	IMPORTER_BLOGGER: {
+		slug: 'importerBlogger',
+		asyncComponent: () => import( './steps-repository/importer-blogger' ),
+	},
+
+	IMPORTER_MEDIUM: {
+		slug: 'importerMedium',
+		asyncComponent: () => import( './steps-repository/importer-medium' ),
+	},
+
+	IMPORTER_SQUARESPACE: {
+		slug: 'importerSquarespace',
+		asyncComponent: () => import( './steps-repository/importer-squarespace' ),
+	},
+
+	IMPORTER_WIX: {
+		slug: 'importerWix',
+		asyncComponent: () => import( './steps-repository/importer-wix' ),
+	},
+
+	IMPORTER_WORDPRESS: {
+		slug: 'importerWordpress',
+		asyncComponent: () => import( './steps-repository/importer-wordpress' ),
+	},
+
+	INTENT: {
+		slug: 'intent',
+		asyncComponent: () => import( './steps-repository/intent-step' ),
+	},
+
+	MIGRATION_TRAIL: {
+		slug: 'migrationTrial',
+		asyncComponent: () => import( './steps-repository/migration-trial' ),
+	},
+
+	OPTIONS: {
+		slug: 'options',
+		asyncComponent: () => import( './steps-repository/site-options' ),
+	},
+
+	PATTERN_ASSEMBLER: {
+		slug: 'patternAssembler',
+		asyncComponent: () => import( './steps-repository/pattern-assembler' ),
+	},
+
+	PROCESSING: {
+		slug: 'processing',
+		asyncComponent: () => import( './steps-repository/processing-step' ),
+	},
+
+	STORE_ADDRESS: {
+		slug: 'storeAddress',
+		asyncComponent: () => import( './steps-repository/store-address' ),
+	},
+
+	VERIFY_EMAIL: {
+		slug: 'verifyEmail',
+		asyncComponent: () => import( './steps-repository/import-verify-email' ),
+	},
+
+	WOO_CONFIRM: {
+		slug: 'wooConfirm',
+		asyncComponent: () => import( './steps-repository/woo-confirm' ),
+	},
+
+	WOO_INSTALL_PLUGINS: {
+		slug: 'wooInstallPlugins',
+		asyncComponent: () => import( './steps-repository/woo-install-plugins' ),
+	},
+
+	WOO_TRANSFER: {
+		slug: 'wooTransfer',
+		asyncComponent: () => import( './steps-repository/woo-transfer' ),
+	},
+
+	WOO_VERIFY_EMAIL: {
+		slug: 'wooVerifyEmail',
+		asyncComponent: () => import( './steps-repository/woo-verify-email' ),
+	},
+};
+
+export default STEPS;

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -33,6 +33,11 @@ export const STEPS = {
 
 	ERROR: { slug: 'error', asyncComponent: () => import( './steps-repository/error-step' ) },
 
+	FREE_SETUP: {
+		slug: 'freeSetup',
+		asyncComponent: () => import( './steps-repository/free-setup' ),
+	},
+
 	GOALS: { slug: 'goals', asyncComponent: () => import( './steps-repository/goals' ) },
 
 	IMPORT: { slug: 'import', asyncComponent: () => import( './steps-repository/import' ) },
@@ -97,6 +102,8 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/intent-step' ),
 	},
 
+	LAUNCHPAD: { slug: 'launchpad', asyncComponent: () => import( './steps-repository/launchpad' ) },
+
 	OPTIONS: {
 		slug: 'options',
 		asyncComponent: () => import( './steps-repository/site-options' ),
@@ -110,6 +117,11 @@ export const STEPS = {
 	PROCESSING: {
 		slug: 'processing',
 		asyncComponent: () => import( './steps-repository/processing-step' ),
+	},
+
+	SITE_CREATION_STEP: {
+		slug: 'siteCreationStep',
+		asyncComponent: () => import( './steps-repository/site-creation-step' ),
 	},
 
 	STORE_ADDRESS: {

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -1,4 +1,4 @@
-const STEPS = {
+export const STEPS = {
 	BLOGGER_STARTING_POINT: {
 		slug: 'bloggerStartingPoint',
 		asyncComponent: () => import( './steps-repository/blogger-starting-point' ),
@@ -92,11 +92,6 @@ const STEPS = {
 		asyncComponent: () => import( './steps-repository/intent-step' ),
 	},
 
-	MIGRATION_TRAIL: {
-		slug: 'migrationTrial',
-		asyncComponent: () => import( './steps-repository/migration-trial' ),
-	},
-
 	OPTIONS: {
 		slug: 'options',
 		asyncComponent: () => import( './steps-repository/site-options' ),
@@ -115,6 +110,11 @@ const STEPS = {
 	STORE_ADDRESS: {
 		slug: 'storeAddress',
 		asyncComponent: () => import( './steps-repository/store-address' ),
+	},
+
+	TRIAL_ACKNOWLEDGE: {
+		slug: 'trialAcknowledge',
+		asyncComponent: () => import( './steps-repository/trial-acknowledge' ),
 	},
 
 	VERIFY_EMAIL: {
@@ -142,5 +142,3 @@ const STEPS = {
 		asyncComponent: () => import( './steps-repository/woo-verify-email' ),
 	},
 };
-
-export default STEPS;

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -124,6 +124,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/site-creation-step' ),
 	},
 
+	SITE_PROMPT: {
+		slug: 'site-prompt',
+		asyncComponent: () => import( './steps-repository/ai-site-prompt' ),
+	},
+
 	STORE_ADDRESS: {
 		slug: 'storeAddress',
 		asyncComponent: () => import( './steps-repository/store-address' ),

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -9,6 +9,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/business-info' ),
 	},
 
+	CELEBRATION: {
+		slug: 'celebration-step',
+		asyncComponent: () => import( './steps-repository/celebration-step' ),
+	},
+
 	COURSES: { slug: 'courses', asyncComponent: () => import( './steps-repository/courses' ) },
 
 	DESIGN_SETUP: {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -20,6 +20,7 @@ import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { STEPS } from './internals/steps';
 import { redirect } from './internals/steps-repository/import/util';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import {
@@ -59,134 +60,37 @@ const siteSetupFlow: Flow = {
 
 	useSteps() {
 		return [
-			{ slug: 'goals', asyncComponent: () => import( './internals/steps-repository/goals' ) },
-			{
-				slug: 'intent',
-				asyncComponent: () => import( './internals/steps-repository/intent-step' ),
-			},
-			{
-				slug: 'options',
-				asyncComponent: () => import( './internals/steps-repository/site-options' ),
-			},
-			{
-				slug: 'designSetup',
-				asyncComponent: () => import( './internals/steps-repository/design-setup' ),
-			},
-			{
-				slug: 'patternAssembler',
-				asyncComponent: () => import( './internals/steps-repository/pattern-assembler' ),
-			},
-			{
-				slug: 'bloggerStartingPoint',
-				asyncComponent: () => import( './internals/steps-repository/blogger-starting-point' ),
-			},
-			{ slug: 'courses', asyncComponent: () => import( './internals/steps-repository/courses' ) },
-			{ slug: 'import', asyncComponent: () => import( './internals/steps-repository/import' ) },
-			...( isEnabled( 'onboarding/import-light' )
-				? [
-						{
-							slug: 'importLight',
-							asyncComponent: () => import( './internals/steps-repository/import-light' ),
-						},
-				  ]
-				: [] ),
-			{
-				slug: 'importList',
-				asyncComponent: () => import( './internals/steps-repository/import-list' ),
-			},
-			{
-				slug: 'importReady',
-				asyncComponent: () => import( './internals/steps-repository/import-ready' ),
-			},
-			{
-				slug: 'importReadyNot',
-				asyncComponent: () => import( './internals/steps-repository/import-ready-not' ),
-			},
-			{
-				slug: 'importReadyWpcom',
-				asyncComponent: () => import( './internals/steps-repository/import-ready-wpcom' ),
-			},
-			{
-				slug: 'importReadyPreview',
-				asyncComponent: () => import( './internals/steps-repository/import-ready-preview' ),
-			},
-			{
-				slug: 'importerWix',
-				asyncComponent: () => import( './internals/steps-repository/importer-wix' ),
-			},
-			{
-				slug: 'importerBlogger',
-				asyncComponent: () => import( './internals/steps-repository/importer-blogger' ),
-			},
-			{
-				slug: 'importerMedium',
-				asyncComponent: () => import( './internals/steps-repository/importer-medium' ),
-			},
-			{
-				slug: 'importerSquarespace',
-				asyncComponent: () => import( './internals/steps-repository/importer-squarespace' ),
-			},
-			{
-				slug: 'importerWordpress',
-				asyncComponent: () => import( './internals/steps-repository/importer-wordpress' ),
-			},
-			{
-				slug: 'verifyEmail',
-				asyncComponent: () => import( './internals/steps-repository/import-verify-email' ),
-			},
-			{
-				slug: 'trialAcknowledge',
-				asyncComponent: () => import( './internals/steps-repository/trial-acknowledge' ),
-			},
-			{
-				slug: 'businessInfo',
-				asyncComponent: () => import( './internals/steps-repository/business-info' ),
-			},
-			{
-				slug: 'storeAddress',
-				asyncComponent: () => import( './internals/steps-repository/store-address' ),
-			},
-			{
-				slug: 'processing',
-				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
-			},
-			{ slug: 'error', asyncComponent: () => import( './internals/steps-repository/error-step' ) },
-			{
-				slug: 'wooTransfer',
-				asyncComponent: () => import( './internals/steps-repository/woo-transfer' ),
-			},
-			{
-				slug: 'wooInstallPlugins',
-				asyncComponent: () => import( './internals/steps-repository/woo-install-plugins' ),
-			},
-			...( isEnabled( 'signup/woo-verify-email' )
-				? [
-						{
-							slug: 'wooVerifyEmail',
-							asyncComponent: () => import( './internals/steps-repository/woo-verify-email' ),
-						},
-				  ]
-				: [] ),
-			{
-				slug: 'wooConfirm',
-				asyncComponent: () => import( './internals/steps-repository/woo-confirm' ),
-			},
-			{
-				slug: 'editEmail',
-				asyncComponent: () => import( './internals/steps-repository/edit-email' ),
-			},
-			...( isEnabled( 'signup/woo-verify-email' )
-				? [
-						{
-							slug: 'editEmail',
-							asyncComponent: () => import( './internals/steps-repository/edit-email' ),
-						},
-				  ]
-				: [] ),
-			{
-				slug: 'difmStartingPoint',
-				asyncComponent: () => import( './internals/steps-repository/difm-starting-point' ),
-			},
+			STEPS.GOALS,
+			STEPS.INTENT,
+			STEPS.OPTIONS,
+			STEPS.DESIGN_SETUP,
+			STEPS.PATTERN_ASSEMBLER,
+			STEPS.BLOGGER_STARTING_POINT,
+			STEPS.COURSES,
+			STEPS.IMPORT,
+			STEPS.IMPORT_LIGHT,
+			STEPS.IMPORT_LIST,
+			STEPS.IMPORT_READY,
+			STEPS.IMPORT_READY_NOT,
+			STEPS.IMPORT_READY_WPCOM,
+			STEPS.IMPORT_READY_PREVIEW,
+			STEPS.IMPORTER_WIX,
+			STEPS.IMPORTER_BLOGGER,
+			STEPS.IMPORTER_MEDIUM,
+			STEPS.IMPORTER_SQUARESPACE,
+			STEPS.IMPORTER_WORDPRESS,
+			STEPS.VERIFY_EMAIL,
+			STEPS.TRIAL_ACKNOWLEDGE,
+			STEPS.BUSINESS_INFO,
+			STEPS.STORE_ADDRESS,
+			STEPS.PROCESSING,
+			STEPS.ERROR,
+			STEPS.WOO_TRANSFER,
+			STEPS.WOO_INSTALL_PLUGINS,
+			STEPS.WOO_VERIFY_EMAIL,
+			STEPS.WOO_CONFIRM,
+			STEPS.EDIT_EMAIL,
+			STEPS.DIFM_STARTING_POINT,
 		];
 	},
 	useStepNavigation( currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -20,39 +20,8 @@ import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
-import StartingPointStep from './internals/steps-repository/blogger-starting-point';
-import BusinessInfo from './internals/steps-repository/business-info';
-import CoursesStep from './internals/steps-repository/courses';
-import DesignSetup from './internals/steps-repository/design-setup';
-import DIFMStartingPoint from './internals/steps-repository/difm-starting-point';
-import EditEmail from './internals/steps-repository/edit-email';
-import ErrorStep from './internals/steps-repository/error-step';
-import GoalsStep from './internals/steps-repository/goals';
-import ImportStep from './internals/steps-repository/import';
 import { redirect } from './internals/steps-repository/import/util';
-import ImportLight from './internals/steps-repository/import-light';
-import ImportList from './internals/steps-repository/import-list';
-import ImportReady from './internals/steps-repository/import-ready';
-import ImportReadyNot from './internals/steps-repository/import-ready-not';
-import ImportReadyPreview from './internals/steps-repository/import-ready-preview';
-import ImportReadyWpcom from './internals/steps-repository/import-ready-wpcom';
-import ImportVerifyEmail from './internals/steps-repository/import-verify-email';
-import ImporterBlogger from './internals/steps-repository/importer-blogger';
-import ImporterMedium from './internals/steps-repository/importer-medium';
-import ImporterSquarespace from './internals/steps-repository/importer-squarespace';
-import ImporterWix from './internals/steps-repository/importer-wix';
-import ImporterWordpress from './internals/steps-repository/importer-wordpress';
-import IntentStep from './internals/steps-repository/intent-step';
-import PatternAssembler from './internals/steps-repository/pattern-assembler/lazy';
-import ProcessingStep from './internals/steps-repository/processing-step';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
-import SiteOptions from './internals/steps-repository/site-options';
-import StoreAddress from './internals/steps-repository/store-address';
-import TrialAcknowledge from './internals/steps-repository/trial-acknowledge';
-import WooConfirm from './internals/steps-repository/woo-confirm';
-import WooInstallPlugins from './internals/steps-repository/woo-install-plugins';
-import WooTransfer from './internals/steps-repository/woo-transfer';
-import WooVerifyEmail from './internals/steps-repository/woo-verify-email';
 import {
 	AssertConditionResult,
 	AssertConditionState,
@@ -90,44 +59,134 @@ const siteSetupFlow: Flow = {
 
 	useSteps() {
 		return [
-			{ slug: 'goals', component: GoalsStep },
-			{ slug: 'intent', component: IntentStep },
-			{ slug: 'options', component: SiteOptions },
-			{ slug: 'designSetup', component: DesignSetup },
-			{ slug: 'patternAssembler', component: PatternAssembler },
-			{ slug: 'bloggerStartingPoint', component: StartingPointStep },
-			{ slug: 'courses', component: CoursesStep },
-			{ slug: 'import', component: ImportStep },
+			{ slug: 'goals', asyncComponent: () => import( './internals/steps-repository/goals' ) },
+			{
+				slug: 'intent',
+				asyncComponent: () => import( './internals/steps-repository/intent-step' ),
+			},
+			{
+				slug: 'options',
+				asyncComponent: () => import( './internals/steps-repository/site-options' ),
+			},
+			{
+				slug: 'designSetup',
+				asyncComponent: () => import( './internals/steps-repository/design-setup' ),
+			},
+			{
+				slug: 'patternAssembler',
+				asyncComponent: () => import( './internals/steps-repository/pattern-assembler' ),
+			},
+			{
+				slug: 'bloggerStartingPoint',
+				asyncComponent: () => import( './internals/steps-repository/blogger-starting-point' ),
+			},
+			{ slug: 'courses', asyncComponent: () => import( './internals/steps-repository/courses' ) },
+			{ slug: 'import', asyncComponent: () => import( './internals/steps-repository/import' ) },
 			...( isEnabled( 'onboarding/import-light' )
-				? [ { slug: 'importLight', component: ImportLight } ]
+				? [
+						{
+							slug: 'importLight',
+							asyncComponent: () => import( './internals/steps-repository/import-light' ),
+						},
+				  ]
 				: [] ),
-			{ slug: 'importList', component: ImportList },
-			{ slug: 'importReady', component: ImportReady },
-			{ slug: 'importReadyNot', component: ImportReadyNot },
-			{ slug: 'importReadyWpcom', component: ImportReadyWpcom },
-			{ slug: 'importReadyPreview', component: ImportReadyPreview },
-			{ slug: 'importerWix', component: ImporterWix },
-			{ slug: 'importerBlogger', component: ImporterBlogger },
-			{ slug: 'importerMedium', component: ImporterMedium },
-			{ slug: 'importerSquarespace', component: ImporterSquarespace },
-			{ slug: 'importerWordpress', component: ImporterWordpress },
-			{ slug: 'verifyEmail', component: ImportVerifyEmail },
-			{ slug: 'trialAcknowledge', component: TrialAcknowledge },
-			{ slug: 'businessInfo', component: BusinessInfo },
-			{ slug: 'storeAddress', component: StoreAddress },
-			{ slug: 'processing', component: ProcessingStep },
-			{ slug: 'error', component: ErrorStep },
-			{ slug: 'wooTransfer', component: WooTransfer },
-			{ slug: 'wooInstallPlugins', component: WooInstallPlugins },
+			{
+				slug: 'importList',
+				asyncComponent: () => import( './internals/steps-repository/import-list' ),
+			},
+			{
+				slug: 'importReady',
+				asyncComponent: () => import( './internals/steps-repository/import-ready' ),
+			},
+			{
+				slug: 'importReadyNot',
+				asyncComponent: () => import( './internals/steps-repository/import-ready-not' ),
+			},
+			{
+				slug: 'importReadyWpcom',
+				asyncComponent: () => import( './internals/steps-repository/import-ready-wpcom' ),
+			},
+			{
+				slug: 'importReadyPreview',
+				asyncComponent: () => import( './internals/steps-repository/import-ready-preview' ),
+			},
+			{
+				slug: 'importerWix',
+				asyncComponent: () => import( './internals/steps-repository/importer-wix' ),
+			},
+			{
+				slug: 'importerBlogger',
+				asyncComponent: () => import( './internals/steps-repository/importer-blogger' ),
+			},
+			{
+				slug: 'importerMedium',
+				asyncComponent: () => import( './internals/steps-repository/importer-medium' ),
+			},
+			{
+				slug: 'importerSquarespace',
+				asyncComponent: () => import( './internals/steps-repository/importer-squarespace' ),
+			},
+			{
+				slug: 'importerWordpress',
+				asyncComponent: () => import( './internals/steps-repository/importer-wordpress' ),
+			},
+			{
+				slug: 'verifyEmail',
+				asyncComponent: () => import( './internals/steps-repository/import-verify-email' ),
+			},
+			{
+				slug: 'trialAcknowledge',
+				asyncComponent: () => import( './internals/steps-repository/trial-acknowledge' ),
+			},
+			{
+				slug: 'businessInfo',
+				asyncComponent: () => import( './internals/steps-repository/business-info' ),
+			},
+			{
+				slug: 'storeAddress',
+				asyncComponent: () => import( './internals/steps-repository/store-address' ),
+			},
+			{
+				slug: 'processing',
+				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
+			},
+			{ slug: 'error', asyncComponent: () => import( './internals/steps-repository/error-step' ) },
+			{
+				slug: 'wooTransfer',
+				asyncComponent: () => import( './internals/steps-repository/woo-transfer' ),
+			},
+			{
+				slug: 'wooInstallPlugins',
+				asyncComponent: () => import( './internals/steps-repository/woo-install-plugins' ),
+			},
 			...( isEnabled( 'signup/woo-verify-email' )
-				? [ { slug: 'wooVerifyEmail', component: WooVerifyEmail } ]
+				? [
+						{
+							slug: 'wooVerifyEmail',
+							asyncComponent: () => import( './internals/steps-repository/woo-verify-email' ),
+						},
+				  ]
 				: [] ),
-			{ slug: 'wooConfirm', component: WooConfirm },
-			{ slug: 'editEmail', component: EditEmail },
+			{
+				slug: 'wooConfirm',
+				asyncComponent: () => import( './internals/steps-repository/woo-confirm' ),
+			},
+			{
+				slug: 'editEmail',
+				asyncComponent: () => import( './internals/steps-repository/edit-email' ),
+			},
 			...( isEnabled( 'signup/woo-verify-email' )
-				? [ { slug: 'editEmail', component: EditEmail } ]
+				? [
+						{
+							slug: 'editEmail',
+							asyncComponent: () => import( './internals/steps-repository/edit-email' ),
+						},
+				  ]
 				: [] ),
-			{ slug: 'difmStartingPoint', component: DIFMStartingPoint },
+			{
+				slug: 'difmStartingPoint',
+				asyncComponent: () => import( './internals/steps-repository/difm-starting-point' ),
+			},
 		];
 	},
 	useStepNavigation( currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -13,7 +13,6 @@ import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import DesignSetup from './internals/steps-repository/design-setup';
 import ErrorStep from './internals/steps-repository/error-step';
-import PatternAssembler from './internals/steps-repository/pattern-assembler/lazy';
 import Processing from './internals/steps-repository/processing-step';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import { ProvidedDependencies } from './internals/types';
@@ -28,7 +27,10 @@ const updateDesign: Flow = {
 	useSteps() {
 		return [
 			{ slug: 'designSetup', component: DesignSetup },
-			{ slug: 'patternAssembler', component: PatternAssembler },
+			{
+				slug: 'patternAssembler',
+				asyncComponent: () => import( './internals/steps-repository/pattern-assembler' ),
+			},
 			{ slug: 'processing', component: Processing },
 			{ slug: 'error', component: ErrorStep },
 		];

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -11,9 +11,7 @@ import { useQuery } from '../hooks/use-query';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
-import DesignSetup from './internals/steps-repository/design-setup';
-import ErrorStep from './internals/steps-repository/error-step';
-import Processing from './internals/steps-repository/processing-step';
+import { STEPS } from './internals/steps';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import { ProvidedDependencies } from './internals/types';
 import type { Flow } from './internals/types';
@@ -25,15 +23,7 @@ const updateDesign: Flow = {
 		return translate( 'Choose Design' );
 	},
 	useSteps() {
-		return [
-			{ slug: 'designSetup', component: DesignSetup },
-			{
-				slug: 'patternAssembler',
-				asyncComponent: () => import( './internals/steps-repository/pattern-assembler' ),
-			},
-			{ slug: 'processing', component: Processing },
-			{ slug: 'error', component: ErrorStep },
-		];
+		return [ STEPS.DESIGN_SETUP, STEPS.PATTERN_ASSEMBLER, STEPS.PROCESSING, STEPS.ERROR ];
 	},
 
 	useStepNavigation( currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -10,7 +10,6 @@ import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import ErrorStep from './internals/steps-repository/error-step';
-import PatternAssembler from './internals/steps-repository/pattern-assembler/lazy';
 import ProcessingStep from './internals/steps-repository/processing-step';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import { Flow, ProvidedDependencies } from './internals/types';
@@ -56,7 +55,10 @@ const withThemeAssemblerFlow: Flow = {
 
 	useSteps() {
 		return [
-			{ slug: 'patternAssembler', component: PatternAssembler },
+			{
+				slug: 'patternAssembler',
+				asyncComponent: () => import( './internals/steps-repository/pattern-assembler' ),
+			},
 			{ slug: 'processing', component: ProcessingStep },
 			{ slug: 'error', component: ErrorStep },
 			{

--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -9,8 +9,7 @@ import { getTheme } from 'calypso/state/themes/selectors';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
-import ErrorStep from './internals/steps-repository/error-step';
-import ProcessingStep from './internals/steps-repository/processing-step';
+import { STEPS } from './internals/steps';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import { Flow, ProvidedDependencies } from './internals/types';
 import type { OnboardSelect } from '@automattic/data-stores';
@@ -54,18 +53,7 @@ const withThemeAssemblerFlow: Flow = {
 	},
 
 	useSteps() {
-		return [
-			{
-				slug: 'patternAssembler',
-				asyncComponent: () => import( './internals/steps-repository/pattern-assembler' ),
-			},
-			{ slug: 'processing', component: ProcessingStep },
-			{ slug: 'error', component: ErrorStep },
-			{
-				slug: 'celebration-step',
-				asyncComponent: () => import( './internals/steps-repository/celebration-step' ),
-			},
-		];
+		return [ STEPS.PATTERN_ASSEMBLER, STEPS.PROCESSING, STEPS.ERROR, STEPS.CELEBRATION ];
 	},
 
 	useStepNavigation( _currentStep, navigate ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Use `node bin/make-stepper-flow-async.js site-setup-flow` to make the site-setup flow to load steps async
* Memo the async component that is wrapped with the lazy to avoid getting the new one on every render
* Centralize the step definitions so we don't need to define a theme on every flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Go through the flow
* Ensure everything works as expected and all styles look good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?