### PR TITLE
use cards endpoint for reader tag tabs

### DIFF
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -206,7 +206,7 @@ const streamApis = {
 			} else if ( streamKeySuffix( streamKey ).includes( 'latest' ) ) {
 				return '/read/tags/posts';
 			}
-			return `/read/tags/${ streamKeySuffix( streamKey ) }/posts`;
+			return `/read/tags/${ streamKeySuffix( streamKey ) }/cards`;
 		},
 		dateProperty: 'date',
 		query: ( extras, { streamKey } ) =>

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -89,7 +89,7 @@ describe( 'streams', () => {
 					stream: 'discover:dailyprompt',
 					expected: {
 						method: 'GET',
-						path: `/read/tags/dailyprompt/posts`,
+						path: `/read/tags/dailyprompt/cards`,
 						apiNamespace: 'wpcom/v2',
 						query: {
 							...query,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-1cn-p2#comment-1396

## Proposed Changes

* Exploring the idea laid out in the p2 comment linked above based on feedback received about feed results in discover.
* This PR updates the tags tabs on the discover stream to use the /cards endpoint instead of the /posts endpoint to retrieve the feed. This is the equivalent of the 'recommended' tab, but for the individual tag in question. This results in these feeds showing more popular and higher engagement posts in these discover tabs, as opposed to the most recent posts of that tag.

Before:
<img width="753" alt="Screenshot 2023-09-07 at 9 55 29 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/d0ec49fc-4131-48a3-999e-cc45133749f3">


After:
<img width="684" alt="Screenshot 2023-09-07 at 9 55 45 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/cc33b23e-686c-4fe9-b60a-2ac8957da6b6">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the reader and take the discover tags tabs for a spin using the new endpoint.
* You should see higher quality posts as opposed to the most recent ones for each tag.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?