### PR TITLE
Update/81089 add upsell modal to lits

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -35,9 +35,7 @@ import { ThemeUpgradeModal as UpgradeModal } from 'calypso/components/theme-upgr
 import { ActiveTheme } from 'calypso/data/themes/use-active-theme-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { urlToSlug } from 'calypso/lib/url';
-import { marketplaceThemeBillingProductSlug } from 'calypso/my-sites/themes/helpers';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
-import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { setActiveTheme, activateOrInstallThenActivate } from 'calypso/state/themes/actions';
 import {
@@ -45,8 +43,8 @@ import {
 	getTheme,
 	isSiteEligibleForManagedExternalThemes,
 } from 'calypso/state/themes/selectors';
+import { getMarketplaceThemeProduct } from 'calypso/state/themes/selectors/get-marketplace-theme-product';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
-import { getPreferredBillingCycleProductSlug } from 'calypso/state/themes/theme-utils';
 import useCheckout from '../../../../hooks/use-checkout';
 import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
 import { useQuery } from '../../../../hooks/use-query';
@@ -344,19 +342,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const theme = useSelector( ( state ) => getTheme( state, 'wpcom', selectedDesignThemeId ) );
 	const fullLengthScreenshot = theme?.screenshots?.[ 0 ]?.replace( /\?.*/, '' );
 
-	const marketplaceThemeProducts =
-		useSelector( ( state ) =>
-			getProductsByBillingSlug( state, marketplaceThemeBillingProductSlug( selectedDesignThemeId ) )
-		) || [];
-	const marketplaceProductSlug =
-		marketplaceThemeProducts.length !== 0
-			? getPreferredBillingCycleProductSlug( marketplaceThemeProducts, PLAN_BUSINESS )
-			: null;
+	const selectedMarketplaceProduct = useSelector( ( state ) =>
+		getMarketplaceThemeProduct( state, selectedDesignThemeId )
+	);
 
-	const selectedMarketplaceProduct =
-		marketplaceThemeProducts.find(
-			( product ) => product.product_slug === marketplaceProductSlug
-		) || marketplaceThemeProducts[ 0 ];
+	const marketplaceProductSlug = selectedMarketplaceProduct?.product_slug;
 
 	const didPurchaseSelectedTheme = useSelector( ( state ) =>
 		site && selectedDesignThemeId

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1395,6 +1395,10 @@ class ThemeSheet extends Component {
 						isExternallyManagedTheme && ! isMarketplaceThemeSubscribed
 					}
 					checkout={ () => {
+						recordTracksEvent( 'calypso_theme_sheet_theme_upgrade_modal_checkout_button_click', {
+							theme_name: this.props.themeId,
+							theme_type: this.props.themeType,
+						} );
 						if ( this.props.defaultOption.action ) {
 							this.props.defaultOption.action( this.props.themeId );
 						} else {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1402,7 +1402,7 @@ class ThemeSheet extends Component {
 						if ( this.props.defaultOption.action ) {
 							this.props.defaultOption.action( this.props.themeId );
 						} else {
-							window.location.href = this.getUrl();
+							window.location.href = this.props.defaultOption.getUrl();
 						}
 					} }
 					marketplaceProduct={ this.props.selectedMarketplaceProduct }

--- a/client/state/themes/selectors/get-marketplace-theme-product.ts
+++ b/client/state/themes/selectors/get-marketplace-theme-product.ts
@@ -1,0 +1,34 @@
+import { PLAN_BUSINESS } from '@automattic/calypso-products';
+import { marketplaceThemeBillingProductSlug } from 'calypso/my-sites/themes/helpers';
+import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
+import { getPreferredBillingCycleProductSlug } from '../theme-utils';
+import type { AppState } from 'calypso/types';
+
+const getMarketplaceThemeProducts = ( state: AppState, themeId: string | null ) => {
+	const marketplaceThemeProducts = getProductsByBillingSlug(
+		state,
+		marketplaceThemeBillingProductSlug( themeId )
+	);
+	return marketplaceThemeProducts || [];
+};
+
+/**
+ * Get the Product representing the Marketplace Theme for the given themeId.
+ *
+ * Will return undefined if the themeId is null or if the themeId does not have a corresponding Marketplace Theme Product.
+ */
+export function getMarketplaceThemeProduct( state: AppState, themeId: string | null ) {
+	const marketplaceThemeProducts = getMarketplaceThemeProducts( state, themeId );
+
+	const marketplaceProductSlug =
+		marketplaceThemeProducts.length !== 0
+			? getPreferredBillingCycleProductSlug( marketplaceThemeProducts, PLAN_BUSINESS )
+			: null;
+
+	const selectedMarketplaceProduct =
+		marketplaceThemeProducts.find(
+			( product ) => product.product_slug === marketplaceProductSlug
+		) || marketplaceThemeProducts[ 0 ];
+
+	return selectedMarketplaceProduct;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81089 & #81093

## Proposed Changes

The theme showcase now uses the same <ThemeUpgradeModal> as is used in
the onboarding flows.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use calypso live
2. Go to wordpress.com/themes
3. Click on a theme and then the primary button e.g. 'Activate'
4. Check you get the behaviour documented in the table below
5. Check that you get useful tracks events

Theme type | Expected result
-------|------
 Free | You activate the theme without drama
 Free GS  | No change - it displays a bespoke modal that  i haven't borged yet
 Premium | You get a modal telling you about the premium plan that lets you continue to checkout
 Partner | You get a modal telling you about the business plan and explaining the costs
 Community | Not implemented yet in LITS, I'll hook that up in a follow-up asap. 

The modal looks like this, but the content varies depending upon the theme type:
 <img width="1555" alt="Screenshot 2023-09-07 at 16 55 53" src="https://github.com/Automattic/wp-calypso/assets/93301/98dece8b-b2eb-49f0-a301-619dad160864">

The design picker code has been refactored a tiny bit too - this should continue to work exactly as on production.

Note: Some of the wording is different to that on #81089 I think this is fine - the existing wording is basically the same and already has been translated. If you feel something is worth changing, then raise it and I'll do it as a follow up.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?