### PR TITLE
Update default CNAME record from * to www

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
@@ -109,7 +109,7 @@ function DnsMenuOptionsButton( {
 			( record ) =>
 				record.domain !== record.data?.replace( /\.$/, '' ) &&
 				'CNAME' === record.type &&
-				'*' === record.name
+				'www' === record.name
 		);
 	}, [ dns ] );
 
@@ -120,7 +120,7 @@ function DnsMenuOptionsButton( {
 			{
 				type: 'CNAME',
 				data: `${ domainName }.`,
-				name: '*',
+				name: 'www',
 			},
 		];
 	}, [ domainName ] );

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -46,7 +46,7 @@ class DnsRecords extends Component {
 		return dns?.records?.some(
 			( record ) =>
 				record?.type === 'CNAME' &&
-				record?.name === '*' &&
+				record?.name === 'www' &&
 				record?.data === `${ selectedDomainName }.`
 		);
 	};

--- a/client/my-sites/domains/domain-management/dns/restore-default-cname-record-dialog.jsx
+++ b/client/my-sites/domains/domain-management/dns/restore-default-cname-record-dialog.jsx
@@ -30,11 +30,11 @@ function RestoreDefaultCnameRecordDialog( { onClose, visible } ) {
 			<h1>{ __( 'Restore default CNAME record' ) }</h1>
 			<p>
 				{ __(
-					'Restoring the record will create a wildcard CNAME record pointing to your WordPress.com site.'
+					'Restoring the record will create a www CNAME record pointing to your WordPress.com site.'
 				) }
 			</p>
 			<p className="restore-default-cname-record-dialog__message">
-				{ __( 'In case a wildcard CNAME record already exists, it will be deleted.' ) }
+				{ __( 'In case a www CNAME record already exists, it will be deleted.' ) }
 			</p>
 		</Dialog>
 	);


### PR DESCRIPTION
## Proposed Changes

We are changing the default CNAME record for dns zone from the wildcard one to `www`.

This PR update the action to restore the default CNAME, using the new logic.

## Testing Instructions

Open the dns management page for a domain and check this points:
- if the www cname record is set, the option should be disabled
- if the www cname record isn't set, the option should be enabled
- delete www cname record, click on the restore option and check that the record is created again.

## Pre-merge Checklist

- [ X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?