### PR TITLE
Discover feeds - explore making feeds more recent with a post date after param.

### DIFF
--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 const DEFAULT_DISCOVER_TAGS = [ 'dailyprompt', 'wordpress' ];
 export const DEFAULT_TAB = 'recommended';
 export const LATEST_TAB = 'latest';
@@ -69,4 +71,15 @@ export function getTagsFromStreamKey( streamKey = '' ) {
 		return tags;
 	}
 	return [];
+}
+
+/**
+ * Returns the current dateTime subtracting the number of days in the input, formatted for a
+ * request.
+ *
+ * @param {number|null} daysToInclude Number of days to subtract from current datetime.
+ * @returns Formatted date to add to the query.
+ */
+export function getAfterDateForFeed( daysToInclude = 1 ) {
+	return moment().subtract( daysToInclude, 'days' ).format( 'YYYY-MM-DDTHH:mm:ssZ' );
 }

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -1,6 +1,7 @@
 import warn from '@wordpress/warning';
 import i18n from 'i18n-calypso';
 import { random, map, includes, get } from 'lodash';
+import moment from 'moment';
 import { getTagsFromStreamKey } from 'calypso/reader/discover/helper';
 import { keyForPost } from 'calypso/reader/post-key';
 import XPostHelper from 'calypso/reader/xpost-helper';
@@ -209,14 +210,21 @@ const streamApis = {
 			return `/read/tags/${ streamKeySuffix( streamKey ) }/cards`;
 		},
 		dateProperty: 'date',
-		query: ( extras, { streamKey } ) =>
-			getQueryString( {
+		query: ( extras, { streamKey } ) => {
+			const recencyInDays = 1;
+			// current dateTime subtracting recencyInDays
+			const earliestDate = moment()
+				.subtract( recencyInDays, 'days' )
+				.format( 'YYYY-MM-DDTHH:mm:ssZ' );
+			return getQueryString( {
 				...extras,
 				// Do not supply an empty fallback as null is good info for getDiscoverStreamTags
 				tags: getTagsFromStreamKey( streamKey ),
 				tag_recs_per_card: 5,
 				site_recs_per_card: 5,
-			} ),
+				after: earliestDate,
+			} );
+		},
 		apiNamespace: 'wpcom/v2',
 	},
 	site: {

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -1,8 +1,7 @@
 import warn from '@wordpress/warning';
 import i18n from 'i18n-calypso';
 import { random, map, includes, get } from 'lodash';
-import moment from 'moment';
-import { getTagsFromStreamKey } from 'calypso/reader/discover/helper';
+import { getTagsFromStreamKey, getAfterDateForFeed } from 'calypso/reader/discover/helper';
 import { keyForPost } from 'calypso/reader/post-key';
 import XPostHelper from 'calypso/reader/xpost-helper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -210,21 +209,15 @@ const streamApis = {
 			return `/read/tags/${ streamKeySuffix( streamKey ) }/cards`;
 		},
 		dateProperty: 'date',
-		query: ( extras, { streamKey } ) => {
-			const recencyInDays = 1;
-			// current dateTime subtracting recencyInDays
-			const earliestDate = moment()
-				.subtract( recencyInDays, 'days' )
-				.format( 'YYYY-MM-DDTHH:mm:ssZ' );
-			return getQueryString( {
+		query: ( extras, { streamKey } ) =>
+			getQueryString( {
 				...extras,
 				// Do not supply an empty fallback as null is good info for getDiscoverStreamTags
 				tags: getTagsFromStreamKey( streamKey ),
 				tag_recs_per_card: 5,
 				site_recs_per_card: 5,
-				after: earliestDate,
-			} );
-		},
+				after: getAfterDateForFeed(),
+			} ),
 		apiNamespace: 'wpcom/v2',
 	},
 	site: {

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -1,4 +1,5 @@
 import deepfreeze from 'deep-freeze';
+import { getAfterDateForFeed } from 'calypso/reader/discover/helper';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import {
 	requestPage as requestPageAction,
@@ -82,6 +83,7 @@ describe( 'streams', () => {
 							tag_recs_per_card: 5,
 							site_recs_per_card: 5,
 							tags: [],
+							after: getAfterDateForFeed(),
 						},
 					},
 				},
@@ -96,6 +98,7 @@ describe( 'streams', () => {
 							tag_recs_per_card: 5,
 							site_recs_per_card: 5,
 							tags: [],
+							after: getAfterDateForFeed(),
 						},
 					},
 				},


### PR DESCRIPTION
…s from the current datetime

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Explores an idea laid out in slack by @davemart-in: "limiting discover tabs to posts written in the past 5 days to help remedy this?"
* Currently, this updates the discover feeds to only show posts within the last 1 day. Build this locally and adjust the `recencyInDays` value in the code changes to get an idea of how this changes the feed. For me, 5 days didn't seem to change a much. 1 day changes things quite a bit making them very recent posts with engagement, but also may be a bit too short of a cutoff. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the discover feeds, this should effect all tabs under discover except for 'latest'.
* Test them over a couple days and compare to production. The feed results should change more often given a smaller value of `recencyInDays`.
* Spin this up locally and test similarly with other values of `recencyInDays` (2, 3, 5, etc.) to see if there are any values that might feel better on a day to day basis.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
