### PR TITLE
Newsletter Categories: Add Newsletter Categories to Subscription Management page

### DIFF
--- a/client/blocks/reader-site-subscription/details.tsx
+++ b/client/blocks/reader-site-subscription/details.tsx
@@ -18,6 +18,7 @@ import {
 	getPaymentInterval,
 } from './helpers';
 import SiteSubscriptionSettings from './settings';
+import SubscribeToNewsletterCategories from './subscribe-to-newsletter-categories';
 import './styles.scss';
 
 const SiteSubscriptionDetails = ( {
@@ -221,11 +222,17 @@ const SiteSubscriptionDetails = ( {
 						emailMeNewComments={ !! deliveryMethods.email?.send_comments }
 					/>
 
+					{ !! deliveryMethods.email?.send_posts && (
+						<SubscribeToNewsletterCategories siteId={ blogId } />
+					) }
+
 					<hr className="subscriptions__separator" />
 
 					{ /* TODO: Move to SiteSubscriptionInfo component when payment details are in. */ }
 					<div className="site-subscription-info">
-						<h2 className="site-subscription-info__heading">{ translate( 'Subscription' ) }</h2>
+						<h2 className="site-subscription-info__heading">
+							{ translate( 'Subscription details' ) }
+						</h2>
 						<dl className="site-subscription-info__list">
 							<dt>{ translate( 'Date' ) }</dt>
 							<dd>

--- a/client/blocks/reader-site-subscription/styles.scss
+++ b/client/blocks/reader-site-subscription/styles.scss
@@ -136,6 +136,10 @@
 				}
 			}
 		}
+
+		&__loading {
+			margin-bottom: 20px;
+		}
 	}
 
 	&__unsubscribe-button.components-button {

--- a/client/blocks/reader-site-subscription/subscribe-to-newsletter-categories.tsx
+++ b/client/blocks/reader-site-subscription/subscribe-to-newsletter-categories.tsx
@@ -4,7 +4,6 @@ import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import {
-	useNewsletterCategoriesQuery,
 	useNewsletterCategorySubscriptionMutation,
 	useSubscribedNewsletterCategories,
 } from 'calypso/data/newsletter-categories';
@@ -15,10 +14,9 @@ type SubscribeToNewsletterCategoriesProps = {
 
 const SubscribeToNewsletterCategories = ( { siteId }: SubscribeToNewsletterCategoriesProps ) => {
 	const translate = useTranslate();
-	const { data: newsletterCategoriesData, isLoading: isLoadingCategories } =
-		useNewsletterCategoriesQuery( { siteId } );
-	const { data: subscribedNewsletterCategoriesData, isLoading: isLoadingSubscribedCategories } =
-		useSubscribedNewsletterCategories( { siteId } );
+	const { data: subscribedNewsletterCategoriesData, isLoading } = useSubscribedNewsletterCategories(
+		{ siteId }
+	);
 	const { mutate, isLoading: isSaving } = useNewsletterCategorySubscriptionMutation( siteId );
 
 	const subscribedCategoryIds = useMemo(
@@ -40,7 +38,7 @@ const SubscribeToNewsletterCategories = ( { siteId }: SubscribeToNewsletterCateg
 
 	if (
 		! config.isEnabled( 'settings/newsletter-categories' ) ||
-		! newsletterCategoriesData?.enabled
+		! subscribedNewsletterCategoriesData?.enabled
 	) {
 		return null;
 	}
@@ -51,7 +49,7 @@ const SubscribeToNewsletterCategories = ( { siteId }: SubscribeToNewsletterCateg
 			<div className="site-subscription-info">
 				<h2 className="site-subscription-info__heading">{ translate( 'Subscription' ) }</h2>
 
-				{ isLoadingCategories || isLoadingSubscribedCategories ? (
+				{ isLoading ? (
 					<div className="site-subscription-info__loading">
 						<Spinner />
 					</div>
@@ -59,22 +57,24 @@ const SubscribeToNewsletterCategories = ( { siteId }: SubscribeToNewsletterCateg
 					<dl className="site-subscription-info__list">
 						<dt>{ translate( 'Subscribed to' ) }</dt>
 						<dd>
-							{ newsletterCategoriesData?.newsletterCategories.map( ( newletterCategory ) => (
-								<div className="setting-item" key={ newletterCategory.id }>
-									<ToggleControl
-										checked={ subscribedCategoryIds?.includes( newletterCategory.id ) }
-										onChange={ () => handleToggle( newletterCategory.id ) }
-										disabled={ isSaving }
-										label={ newletterCategory.name }
-									/>
-									<p className="setting-item__hint">
-										{ translate( 'Receive emails for new posts in %s', {
-											args: [ newletterCategory.name ],
-											comment: 'Name of the site that the user tried to resubscribe to.',
-										} ) }
-									</p>
-								</div>
-							) ) }
+							{ subscribedNewsletterCategoriesData?.newsletterCategories.map(
+								( newletterCategory ) => (
+									<div className="setting-item" key={ newletterCategory.id }>
+										<ToggleControl
+											checked={ newletterCategory.subscribed }
+											onChange={ () => handleToggle( newletterCategory.id ) }
+											disabled={ isSaving }
+											label={ newletterCategory.name }
+										/>
+										<p className="setting-item__hint">
+											{ translate( 'Receive emails for new posts in %s', {
+												args: [ newletterCategory.name ],
+												comment: 'Name of the site that the user tried to resubscribe to.',
+											} ) }
+										</p>
+									</div>
+								)
+							) }
 						</dd>
 					</dl>
 				) }

--- a/client/blocks/reader-site-subscription/subscribe-to-newsletter-categories.tsx
+++ b/client/blocks/reader-site-subscription/subscribe-to-newsletter-categories.tsx
@@ -1,3 +1,5 @@
+import config from '@automattic/calypso-config';
+import { Spinner } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -49,7 +51,10 @@ const SubscribeToNewsletterCategories = ( { siteId }: SubscribeToNewsletterCateg
 		);
 	};
 
-	if ( ! newsletterCategoriesData?.enabled ) {
+	if (
+		! config.isEnabled( 'settings/newsletter-categories' ) ||
+		! newsletterCategoriesData?.enabled
+	) {
 		return null;
 	}
 
@@ -59,6 +64,11 @@ const SubscribeToNewsletterCategories = ( { siteId }: SubscribeToNewsletterCateg
 			<div className="site-subscription-info">
 				<h2 className="site-subscription-info__heading">{ translate( 'Subscription' ) }</h2>
 
+				{ isLoadingCategories || isLoadingSubscribedCategories ? (
+					<div className="site-subscription-info__loading">
+						<Spinner />
+					</div>
+				) : (
 				<dl className="site-subscription-info__list">
 					<dt>{ translate( 'Subscribed to' ) }</dt>
 					<dd>
@@ -80,6 +90,7 @@ const SubscribeToNewsletterCategories = ( { siteId }: SubscribeToNewsletterCateg
 						) ) }
 					</dd>
 				</dl>
+				) }
 			</div>
 		</>
 	);

--- a/client/blocks/reader-site-subscription/subscribe-to-newsletter-categories.tsx
+++ b/client/blocks/reader-site-subscription/subscribe-to-newsletter-categories.tsx
@@ -1,0 +1,88 @@
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import {
+	useNewsletterCategoriesQuery,
+	useNewsletterCategorySubscriptionMutation,
+	useSubscribedNewsletterCategories,
+} from 'calypso/data/newsletter-categories';
+import { NewsletterCategory } from 'calypso/data/newsletter-categories/types';
+
+type SubscribeToNewsletterCategoriesProps = {
+	siteId: number;
+};
+
+const convertToMutationFormat = (
+	allCategories: NewsletterCategory[],
+	subscribedCategoryIds: number[]
+) =>
+	allCategories.map( ( category ) => ( {
+		term_id: category.id,
+		subscribe: subscribedCategoryIds.includes( category.id ),
+	} ) );
+
+const SubscribeToNewsletterCategories = ( { siteId }: SubscribeToNewsletterCategoriesProps ) => {
+	const translate = useTranslate();
+	const { data: newsletterCategoriesData } = useNewsletterCategoriesQuery( { siteId } );
+	const { data: subscribedNewsletterCategoriesData } = useSubscribedNewsletterCategories( {
+		siteId,
+	} );
+	const subscribedCategoryIds = useMemo(
+		() =>
+			subscribedNewsletterCategoriesData?.newsletterCategories
+				.filter( ( category ) => !! category.subscribed )
+				.map( ( category ) => category.id ) || [],
+		[ subscribedNewsletterCategoriesData ]
+	);
+	const { mutate, isLoading } = useNewsletterCategorySubscriptionMutation( siteId );
+
+	const handleToggle = ( categoryId: number ) => {
+		const updatedSubscribedCategoryIds = subscribedCategoryIds?.includes( categoryId )
+			? subscribedCategoryIds?.filter( ( id ) => id !== categoryId )
+			: [ ...subscribedCategoryIds, categoryId ];
+
+		mutate(
+			convertToMutationFormat(
+				newsletterCategoriesData?.newsletterCategories || [],
+				updatedSubscribedCategoryIds
+			)
+		);
+	};
+
+	if ( ! newsletterCategoriesData?.enabled ) {
+		return null;
+	}
+
+	return (
+		<>
+			<hr className="subscriptions__separator" />
+			<div className="site-subscription-info">
+				<h2 className="site-subscription-info__heading">{ translate( 'Subscription' ) }</h2>
+
+				<dl className="site-subscription-info__list">
+					<dt>{ translate( 'Subscribed to' ) }</dt>
+					<dd>
+						{ newsletterCategoriesData?.newsletterCategories.map( ( newletterCategory ) => (
+							<div className="setting-item" key={ newletterCategory.id }>
+								<ToggleControl
+									checked={ subscribedCategoryIds?.includes( newletterCategory.id ) }
+									onChange={ () => handleToggle( newletterCategory.id ) }
+									disabled={ isLoading }
+									label={ newletterCategory.name }
+								/>
+								<p className="setting-item__hint">
+									{ translate( 'Receive emails for new posts in %s', {
+										args: [ newletterCategory.name ],
+										comment: 'Name of the site that the user tried to resubscribe to.',
+									} ) }
+								</p>
+							</div>
+						) ) }
+					</dd>
+				</dl>
+			</div>
+		</>
+	);
+};
+
+export default SubscribeToNewsletterCategories;

--- a/client/data/newsletter-categories/index.ts
+++ b/client/data/newsletter-categories/index.ts
@@ -3,3 +3,5 @@ export { default as useNewsletterCategoriesFeatureEnabled } from './use-newslett
 export { default as useNewsletterCategoriesQuery } from './use-newsletter-categories-query';
 export { default as useMarkAsNewsletterCategoryMutation } from './use-mark-as-newsletter-category-mutation';
 export { default as useUnmarkAsNewsletterCategoryMutation } from './use-unmark-as-newsletter-category-mutation';
+export { default as useSubscribedNewsletterCategories } from './use-subscribed-newsletter-categories-query';
+export { default as useNewsletterCategorySubscriptionMutation } from './use-newsletter-category-subscription-mutation';

--- a/client/data/newsletter-categories/test/use-subscribed-newsletter-categories-query.test.tsx
+++ b/client/data/newsletter-categories/test/use-subscribed-newsletter-categories-query.test.tsx
@@ -6,11 +6,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import request from 'wpcom-proxy-request';
-import useSubscriberNewsletterCategories from '../use-subscriber-newsletter-categories-query';
+import useSubscribedNewsletterCategories from '../use-subscribed-newsletter-categories-query';
 
 jest.mock( 'wpcom-proxy-request', () => jest.fn() );
 
-describe( 'useSubscriberNewsletterCategories', () => {
+describe( 'useSubscribedNewsletterCategories', () => {
 	let queryClient: QueryClient;
 	let wrapper: any;
 
@@ -56,7 +56,7 @@ describe( 'useSubscriberNewsletterCategories', () => {
 			],
 		} );
 
-		const { result } = renderHook( () => useSubscriberNewsletterCategories( { siteId: 123 } ), {
+		const { result } = renderHook( () => useSubscribedNewsletterCategories( { siteId: 123 } ), {
 			wrapper,
 		} );
 
@@ -89,7 +89,7 @@ describe( 'useSubscriberNewsletterCategories', () => {
 			newsletter_categories: [],
 		} );
 
-		const { result } = renderHook( () => useSubscriberNewsletterCategories( { siteId: 123 } ), {
+		const { result } = renderHook( () => useSubscribedNewsletterCategories( { siteId: 123 } ), {
 			wrapper,
 		} );
 
@@ -103,7 +103,7 @@ describe( 'useSubscriberNewsletterCategories', () => {
 			success: true,
 		} );
 
-		renderHook( () => useSubscriberNewsletterCategories( { siteId: 123 } ), {
+		renderHook( () => useSubscribedNewsletterCategories( { siteId: 123 } ), {
 			wrapper,
 		} );
 

--- a/client/data/newsletter-categories/types.ts
+++ b/client/data/newsletter-categories/types.ts
@@ -24,3 +24,8 @@ export type NewsletterCategory = {
 	parent: number;
 	subscribed?: boolean;
 };
+
+export type NewsletterCategoriesResponse = {
+	enabled: boolean;
+	newsletter_categories: NewsletterCategory[];
+};

--- a/client/data/newsletter-categories/use-categories-query.tsx
+++ b/client/data/newsletter-categories/use-categories-query.tsx
@@ -2,9 +2,11 @@ import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import request from 'wpcom-proxy-request';
 import type { Category } from './types';
 
+export const getCategoriesKey = ( siteId?: string | number ) => [ 'categories', siteId ];
+
 const useCategoriesQuery = ( siteId?: string | number ): UseQueryResult< Category[] > => {
 	return useQuery( {
-		queryKey: [ 'categories', siteId ],
+		queryKey: getCategoriesKey( siteId ),
 		queryFn: () =>
 			request< Category[] >( {
 				path: `/sites/${ siteId }/categories`,

--- a/client/data/newsletter-categories/use-mark-as-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-mark-as-newsletter-category-mutation.tsx
@@ -60,8 +60,8 @@ const useMarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 		onError: ( error, variables, context ) => {
 			queryClient.setQueryData( cacheKey, context?.previousData );
 		},
-		onSettled: () => {
-			queryClient.invalidateQueries( cacheKey );
+		onSettled: async () => {
+			await queryClient.invalidateQueries( cacheKey );
 		},
 	} );
 };

--- a/client/data/newsletter-categories/use-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-newsletter-categories-query.tsx
@@ -1,18 +1,13 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import request from 'wpcom-proxy-request';
-import { NewsletterCategories, NewsletterCategory } from './types';
+import { NewsletterCategories, NewsletterCategoriesResponse } from './types';
 
 type NewsletterCategoryQueryProps = {
 	siteId?: string | number;
 };
 
-type NewsletterCategoryResponse = {
-	enabled: boolean;
-	newsletter_categories: NewsletterCategory[];
-};
-
-const convertNewsletterCategoryResponse = (
-	response: NewsletterCategoryResponse
+export const convertNewsletterCategoriesResponse = (
+	response: NewsletterCategoriesResponse
 ): NewsletterCategories => {
 	return {
 		enabled: response.enabled,
@@ -31,11 +26,11 @@ const useNewsletterCategories = ( {
 	return useQuery( {
 		queryKey: getNewsletterCategoriesKey( siteId ),
 		queryFn: () =>
-			request< NewsletterCategoryResponse >( {
+			request< NewsletterCategoriesResponse >( {
 				path: `/sites/${ siteId }/newsletter-categories`,
 				apiVersion: '2',
 				apiNamespace: 'wpcom/v2',
-			} ).then( convertNewsletterCategoryResponse ),
+			} ).then( convertNewsletterCategoriesResponse ),
 		enabled: !! siteId,
 	} );
 };

--- a/client/data/newsletter-categories/use-newsletter-category-subscription-mutation.tsx
+++ b/client/data/newsletter-categories/use-newsletter-category-subscription-mutation.tsx
@@ -1,15 +1,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import request from 'wpcom-proxy-request';
-import { NewsletterCategories } from './types';
+import { NewsletterCategories, NewsletterCategoriesResponse } from './types';
 import { getSubscribedNewsletterCategoriesKey } from './use-subscribed-newsletter-categories-query';
 
 type NewsletterCategorySubscription = {
 	term_id: number;
 	subscribe: boolean;
-};
-
-type NewsletterCategorySubscriptionResponse = {
-	success: boolean;
 };
 
 const useNewsletterCategorySubscriptionMutation = ( siteId: string | number ) => {
@@ -18,7 +14,7 @@ const useNewsletterCategorySubscriptionMutation = ( siteId: string | number ) =>
 
 	return useMutation( {
 		mutationFn: async ( categorySubscriptions: NewsletterCategorySubscription[] ) => {
-			return await request< NewsletterCategorySubscriptionResponse >( {
+			return await request< NewsletterCategoriesResponse >( {
 				path: `/sites/${ siteId }/newsletter-categories/subscriptions`,
 				method: 'POST',
 				apiVersion: '2',

--- a/client/data/newsletter-categories/use-newsletter-category-subscription-mutation.tsx
+++ b/client/data/newsletter-categories/use-newsletter-category-subscription-mutation.tsx
@@ -63,8 +63,8 @@ const useNewsletterCategorySubscriptionMutation = ( siteId: string | number ) =>
 		onError: ( error, variables, context ) => {
 			queryClient.setQueryData( subscribedCategoriesCacheKey, context?.previousData );
 		},
-		onSettled: () => {
-			queryClient.invalidateQueries( subscribedCategoriesCacheKey );
+		onSettled: async () => {
+			await queryClient.invalidateQueries( subscribedCategoriesCacheKey );
 		},
 	} );
 };

--- a/client/data/newsletter-categories/use-newsletter-category-subscription-mutation.tsx
+++ b/client/data/newsletter-categories/use-newsletter-category-subscription-mutation.tsx
@@ -1,0 +1,73 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import request from 'wpcom-proxy-request';
+import { NewsletterCategories } from './types';
+import { getNewsletterCategoriesKey } from './use-newsletter-categories-query';
+import { getSubscribedNewsletterCategoriesKey } from './use-subscribed-newsletter-categories-query';
+
+type NewsletterCategorySubscription = {
+	term_id: number;
+	subscribe: boolean;
+};
+
+type NewsletterCategorySubscriptionResponse = {
+	success: boolean;
+};
+
+const useNewsletterCategorySubscriptionMutation = ( siteId: string | number ) => {
+	const queryClient = useQueryClient();
+	const subscribedCategoriesCacheKey = getSubscribedNewsletterCategoriesKey( siteId );
+	const categoriesCacheKey = getNewsletterCategoriesKey( siteId );
+
+	return useMutation( {
+		mutationFn: async ( categorySubscriptions: NewsletterCategorySubscription[] ) => {
+			return await request< NewsletterCategorySubscriptionResponse >( {
+				path: `/sites/${ siteId }/newsletter-categories/subscriptions`,
+				method: 'POST',
+				apiVersion: '2',
+				apiNamespace: 'wpcom/v2',
+				body: { categories: categorySubscriptions },
+			} );
+		},
+		onMutate: async ( categorySubscriptions: NewsletterCategorySubscription[] ) => {
+			await queryClient.cancelQueries( subscribedCategoriesCacheKey );
+
+			const previousData = queryClient.getQueryData< NewsletterCategories >(
+				subscribedCategoriesCacheKey
+			);
+			const categories = queryClient.getQueryData< NewsletterCategories >( categoriesCacheKey );
+
+			queryClient.setQueryData(
+				subscribedCategoriesCacheKey,
+				( oldData?: NewsletterCategories ) => {
+					const subscribedCategoryIds = categorySubscriptions
+						.filter( ( categorySubscription ) => categorySubscription.subscribe )
+						.map( ( categorySubscription ) => categorySubscription.term_id );
+
+					const newSubscribedCategories =
+						categories?.newsletterCategories.map( ( category ) => ( {
+							...category,
+							subscribed: subscribedCategoryIds.includes( category.id ),
+						} ) ) || [];
+
+					const updatedData = {
+						...oldData,
+						enabled: oldData?.enabled || false,
+						newsletterCategories: newSubscribedCategories,
+					};
+
+					return updatedData;
+				}
+			);
+
+			return { previousData };
+		},
+		onError: ( error, variables, context ) => {
+			queryClient.setQueryData( subscribedCategoriesCacheKey, context?.previousData );
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries( subscribedCategoriesCacheKey );
+		},
+	} );
+};
+
+export default useNewsletterCategorySubscriptionMutation;

--- a/client/data/newsletter-categories/use-subscribed-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-subscribed-newsletter-categories-query.tsx
@@ -12,7 +12,7 @@ type NewsletterCategoryResponse = {
 	newsletter_categories: NewsletterCategory[];
 };
 
-export const getSubscriberNewsletterCategoriesKey = (
+export const getSubscribedNewsletterCategoriesKey = (
 	siteId?: string | number,
 	subscriptionId?: number
 ) => [ `newsletter-categories`, siteId, subscriptionId ];
@@ -24,12 +24,12 @@ const convertNewsletterCategoryResponse = (
 	newsletterCategories: response.newsletter_categories,
 } );
 
-const useSubscriberNewsletterCategories = ( {
+const useSubscribedNewsletterCategories = ( {
 	siteId,
 	subscriptionId,
 }: NewsletterCategoryQueryProps ): UseQueryResult< NewsletterCategories > => {
 	return useQuery( {
-		queryKey: getSubscriberNewsletterCategoriesKey( siteId, subscriptionId ),
+		queryKey: getSubscribedNewsletterCategoriesKey( siteId, subscriptionId ),
 		queryFn: () =>
 			request< NewsletterCategoryResponse >( {
 				path: `/sites/${ siteId }/newsletter-categories/subscriptions${
@@ -42,4 +42,4 @@ const useSubscriberNewsletterCategories = ( {
 	} );
 };
 
-export default useSubscriberNewsletterCategories;
+export default useSubscribedNewsletterCategories;

--- a/client/data/newsletter-categories/use-subscribed-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-subscribed-newsletter-categories-query.tsx
@@ -15,7 +15,7 @@ type NewsletterCategoryResponse = {
 export const getSubscribedNewsletterCategoriesKey = (
 	siteId?: string | number,
 	subscriptionId?: number
-) => [ `newsletter-categories`, siteId, subscriptionId ];
+) => [ 'subscribed-newsletter-categories', siteId, subscriptionId ];
 
 const convertNewsletterCategoryResponse = (
 	response: NewsletterCategoryResponse

--- a/client/data/newsletter-categories/use-unmark-as-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-unmark-as-newsletter-category-mutation.tsx
@@ -52,8 +52,8 @@ const useUnmarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 		onError: ( error, variables, context ) => {
 			queryClient.setQueryData( cacheKey, context?.previousData );
 		},
-		onSettled: () => {
-			queryClient.invalidateQueries( cacheKey );
+		onSettled: async () => {
+			await queryClient.invalidateQueries( cacheKey );
 		},
 	} );
 };

--- a/client/landing/subscriptions/components/settings/styles.scss
+++ b/client/landing/subscriptions/components/settings/styles.scss
@@ -1,14 +1,14 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/variables";
 
-$setting-item-margin-bottom: 16px;
+$setting-item-margin-bottom: 20px;
 
 .settings {
 	.setting-item {
 		margin-bottom: $setting-item-margin-bottom;
 
 		&__hint {
-			margin-top: 16px;
+			margin-top: 8px;
 			color: $studio-gray-50;
 			font-size: $font-body-extra-small;
 			text-align: left;

--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -30,7 +30,10 @@ const SubscriberDetails = ( {
 	const translate = useTranslate();
 	const subscriptionPlans = useSubscriptionPlans( subscriber );
 	const newsletterCategoryNames = useMemo(
-		() => newsletterCategories?.map( ( category ) => category.name ),
+		() =>
+			newsletterCategories
+				?.filter( ( category ) => !! category.subscribed )
+				.map( ( category ) => category.name ),
 		[ newsletterCategories ]
 	);
 	const { avatar, date_subscribed, display_name, email_address, country, url } = subscriber;

--- a/client/my-sites/subscribers/subscriber-details-page.tsx
+++ b/client/my-sites/subscribers/subscriber-details-page.tsx
@@ -5,7 +5,7 @@ import { useDispatch } from 'react-redux';
 import { Item } from 'calypso/components/breadcrumb';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import Main from 'calypso/components/main';
-import useSubscriberNewsletterCategories from 'calypso/data/newsletter-categories/use-subscriber-newsletter-categories-query';
+import { useSubscribedNewsletterCategories } from 'calypso/data/newsletter-categories';
 import { useSelector } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -46,8 +46,8 @@ const SubscriberDetailsPage = ( {
 		userId
 	);
 
-	const { data: newsletterCategoriesData, isLoading: isLoadingNewsletterCategories } =
-		useSubscriberNewsletterCategories( {
+	const { data: subscribedNewsletterCategoriesData, isLoading: isLoadingNewsletterCategories } =
+		useSubscribedNewsletterCategories( {
 			siteId: selectedSiteId as number,
 			subscriptionId: subscriptionId || subscriber?.subscription_id,
 		} );
@@ -114,8 +114,8 @@ const SubscriberDetailsPage = ( {
 					siteId={ selectedSiteId }
 					subscriptionId={ subscriptionId }
 					userId={ userId }
-					newsletterCategoriesEnabled={ newsletterCategoriesData?.enabled }
-					newsletterCategories={ newsletterCategoriesData?.newsletterCategories }
+					newsletterCategoriesEnabled={ subscribedNewsletterCategoriesData?.enabled }
+					newsletterCategories={ subscribedNewsletterCategoriesData?.newsletterCategories }
 				/>
 			) }
 			<UnsubscribeModal


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/81367

## Proposed Changes

* Create SubscribeToNewsletterCategories component
* Create useNewsletterCategorySubscriptionMutation hook
* Add Newsletter Categories to Subscription Management page 
* Code improvements/Fixes
  * Rename `useSubscriberNewsletterCategories` to `useSubscribedNewsletterCategories`
  * Export getCategoriesKey
  * Fix Subscriber Details displayed categories (it was missing subscribed filter)

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/subscriptions/sites
* Open a site with Newsletter Categories enabled
* You should see the list of Newsletter Categories with toggles
* The subscribed categories should be displayed as a toggle on
* Click to toggle off one of the categories and refresh the page to see if it was unsubscribed properly

<img width="354" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/b57e362b-ba9d-4384-b955-3b8ad894f9e5">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?