### PR TITLE
Magic Link: Always create an account.

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -262,6 +262,7 @@ class MagicLogin extends Component {
 			...( this.props.isJetpackLogin && config.isEnabled( 'jetpack/magic-link-signup' )
 				? { isJetpackMagicLinkSignUpEnabled: true }
 				: {} ),
+			createAccountForNewUser: true,
 		};
 
 		return (


### PR DESCRIPTION

## Proposed Changes

* Make Magic link request create an account when the current email doesn't have one and the email gets confirmed.

<img width="923" alt="Screenshot 2023-09-08 at 12 38 34" src="https://github.com/Automattic/wp-calypso/assets/87168/84d42ecb-bca8-4e30-8bab-26311e494ad2">


### Before
<img width="913" alt="Screenshot 2023-09-08 at 12 39 11" src="https://github.com/Automattic/wp-calypso/assets/87168/83ccb9f1-f4a5-421d-9079-b7ccfa87651e">

### After
<img width="915" alt="Screenshot 2023-09-08 at 13 31 01" src="https://github.com/Automattic/wp-calypso/assets/87168/f38bd4bd-6eab-4ce1-8471-e399eb4c035e">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit http://calypso.localhost:3000/log-in/link and request a Magic link for an email that hasn't a WPCOM account.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?