### PR TITLE
Reader share / reblog - open reader reblogging in new tab

### DIFF
--- a/client/blocks/reader-share/reblog.jsx
+++ b/client/blocks/reader-share/reblog.jsx
@@ -33,8 +33,7 @@ const ReaderReblogSelection = ( props ) => {
 		);
 		window.open(
 			`/post/${ slug }?${ buildQuerystringForPost( props.post, props.comment ) }`,
-			'reblog post',
-			'width=550,height=420,resizeable,scrollbars'
+			'_blank'
 		);
 		props.closeMenu();
 		return true;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Updates the reader reblogging action to open the editor in a new tab instead of the separate compressed window.

![reblog-new-tab](https://github.com/Automattic/wp-calypso/assets/28742426/a37e6a63-7dc4-40a9-8efb-df327a1bdaf8)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test reblogging posts and comments from within the Reader.
* Verify the editor is opened in a new tab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
