### PR TITLE
Add context to stats and ai translations

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -172,12 +172,12 @@ export const getJetpackProductsShortNames = (): Record< string, TranslateResult 
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY ]: translate( 'Social', {
 			context: 'Jetpack product name',
 		} ),
-		[ PRODUCT_JETPACK_STATS_BI_YEARLY ]: translate( 'Stats' ),
-		[ PRODUCT_JETPACK_STATS_YEARLY ]: translate( 'Stats' ),
-		[ PRODUCT_JETPACK_STATS_MONTHLY ]: translate( 'Stats' ),
-		[ PRODUCT_JETPACK_AI_MONTHLY ]: translate( 'AI' ),
-		[ PRODUCT_JETPACK_AI_YEARLY ]: translate( 'AI' ),
-		[ PRODUCT_JETPACK_AI_BI_YEARLY ]: translate( 'AI' ),
+		[ PRODUCT_JETPACK_STATS_BI_YEARLY ]: translate( 'Stats', { context: 'Jetpack product name' } ),
+		[ PRODUCT_JETPACK_STATS_YEARLY ]: translate( 'Stats', { context: 'Jetpack product name' } ),
+		[ PRODUCT_JETPACK_STATS_MONTHLY ]: translate( 'Stats', { context: 'Jetpack product name' } ),
+		[ PRODUCT_JETPACK_AI_MONTHLY ]: translate( 'AI', { context: 'Jetpack product name' } ),
+		[ PRODUCT_JETPACK_AI_YEARLY ]: translate( 'AI', { context: 'Jetpack product name' } ),
+		[ PRODUCT_JETPACK_AI_BI_YEARLY ]: translate( 'AI', { context: 'Jetpack product name' } ),
 	};
 };
 
@@ -197,10 +197,10 @@ export const getJetpackProductsDisplayNames = (): Record< string, TranslateResul
 		</>
 	);
 	const backup = translate( 'VaultPress Backup' );
-	const search = translate( 'Site Search' );
-	const stats = translate( 'Stats (Personal)' );
-	const statsFree = translate( 'Stats (Free)' );
-	const statsCommercial = translate( 'Stats' );
+	const search = translate( 'Site Search', { context: 'Jetpack product name' } );
+	const stats = translate( 'Stats (Personal)', { context: 'Jetpack product name' } );
+	const statsFree = translate( 'Stats (Free)', { context: 'Jetpack product name' } );
+	const statsCommercial = translate( 'Stats', { context: 'Jetpack product name' } );
 	const scan = translate( 'Scan' );
 	const scanRealtime = (
 		<>
@@ -212,13 +212,13 @@ export const getJetpackProductsDisplayNames = (): Record< string, TranslateResul
 		</>
 	);
 	const videoPress = translate( 'VideoPress' );
-	const aiAssistant = translate( 'AI' );
+	const aiAssistant = translate( 'AI', { context: 'Jetpack product name' } );
 	const antiSpam = translate( 'Akismet {{s}}Anti-spam{{/s}}', {
 		components: {
 			s: <span style={ { whiteSpace: 'nowrap' } } />,
 		},
 	} );
-	const boost = translate( 'Boost' );
+	const boost = translate( 'Boost', { context: 'Jetpack product name' } );
 	const socialBasic = translate( 'Social', { context: 'Jetpack product name' } );
 	const socialAdvanced = translate( 'Social', { context: 'Jetpack product name' } );
 


### PR DESCRIPTION
## Proposed Changes

* Add context to AI and Stats translations so they do not get translated

## Testing Instructions

1. Visit the calypso live link or checkout this branch locally
2. Go to `es/pricing`
3. Make sure AI and Stats are not translated
![image](https://github.com/Automattic/wp-calypso/assets/65001528/d82e825f-8a62-4f3e-a7fa-06b108fcaa33)
![image](https://github.com/Automattic/wp-calypso/assets/65001528/a2277423-4f6b-41ea-a746-ea64b39aa175)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?