### PR TITLE
Creating experiment for Onboarding PM flow to skip domain step

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -123,8 +123,28 @@ class DomainsStep extends Component {
 		}
 		this.setCurrentFlowStep = this.setCurrentFlowStep.bind( this );
 		this.state = {
+			...this.state,
 			currentStep: null,
+			shouldSkipStep: 'loading',
 		};
+		if ( this.state.shouldSkipStep === true ) {
+			this.props.goToNextStep();
+		}
+		this.domainExperiment = loadExperimentAssignment( 'onboarding_pm_skip_domain' );
+	}
+
+	componentWillMount() {
+		this.domainExperiment.then( ( experiment ) => {
+			if ( this.props?.flowName === 'onboarding-pm' && experiment.variationName === 'treatment' ) {
+				recordTracksEvent( 'calypso_experiment_onboarding_pm_skip_domain_step', {} );
+				this.props.goToNextStep();
+			} else {
+				this.setState( {
+					...this.state,
+					shouldSkipStep: false,
+				} );
+			}
+		} );
 	}
 
 	componentDidMount() {
@@ -885,32 +905,34 @@ class DomainsStep extends Component {
 		const headerText = this.getHeaderText();
 		const fallbackSubHeaderText = this.getSubHeaderText();
 
-		return (
-			<StepWrapper
-				flowName={ this.props.flowName }
-				stepName={ this.props.stepName }
-				backUrl={ backUrl }
-				positionInFlow={ this.props.positionInFlow }
-				headerText={ headerText }
-				subHeaderText={ fallbackSubHeaderText }
-				isExternalBackUrl={ isExternalBackUrl }
-				fallbackHeaderText={ headerText }
-				fallbackSubHeaderText={ fallbackSubHeaderText }
-				shouldHideNavButtons={ this.shouldHideNavButtons() }
-				stepContent={
-					<div>
-						<QueryProductsList />
-						{ this.renderContent() }
-					</div>
-				}
-				allowBackFirstStep={ !! backUrl }
-				backLabelText={ backLabelText }
-				hideSkip={ true }
-				goToNextStep={ this.handleSkip }
-				align={ isReskinned ? 'left' : 'center' }
-				isWideLayout={ isReskinned }
-			/>
-		);
+		if ( this.state.shouldSkipStep === false ) {
+			return (
+				<StepWrapper
+					flowName={ this.props.flowName }
+					stepName={ this.props.stepName }
+					backUrl={ backUrl }
+					positionInFlow={ this.props.positionInFlow }
+					headerText={ headerText }
+					subHeaderText={ fallbackSubHeaderText }
+					isExternalBackUrl={ isExternalBackUrl }
+					fallbackHeaderText={ headerText }
+					fallbackSubHeaderText={ fallbackSubHeaderText }
+					shouldHideNavButtons={ this.shouldHideNavButtons() }
+					stepContent={
+						<div>
+							<QueryProductsList />
+							{ this.renderContent() }
+						</div>
+					}
+					allowBackFirstStep={ !! backUrl }
+					backLabelText={ backLabelText }
+					hideSkip={ true }
+					goToNextStep={ this.handleSkip }
+					align={ isReskinned ? 'left' : 'center' }
+					isWideLayout={ isReskinned }
+				/>
+			);
+		}
 	}
 }
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -13,6 +13,7 @@ import JetpackLogo from 'calypso/components/jetpack-logo';
 import WooCommerceConnectCartHeader from 'calypso/components/woocommerce-connect-cart-header';
 import { initGoogleRecaptcha, recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getSocialServiceFromClientId } from 'calypso/lib/login';
 import {
 	isCrowdsignalOAuth2Client,
@@ -374,7 +375,6 @@ export class UserStep extends Component {
 
 	/**
 	 * Handle Social service authentication flow result (OAuth2 or OpenID Connect)
-	 *
 	 * @param {string} service      The name of the social service
 	 * @param {string} access_token An OAuth2 acccess token
 	 * @param {string} id_token     (Optional) a JWT id_token which contains the signed user info
@@ -614,6 +614,9 @@ export class UserStep extends Component {
 
 		if ( this.userCreationCompletedAndHasHistory( this.props ) ) {
 			return null; // return nothing so that we don't see the error message and the sign up form.
+		}
+		if ( this.props.flowName === 'onboarding-pm' ) {
+			loadExperimentAssignment( 'onboarding_pm_skip_domain' );
 		}
 
 		// TODO: decouple hideBack flag from the flow name.

--- a/config/development.json
+++ b/config/development.json
@@ -30,7 +30,7 @@
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
 	"features": {
-		"ad-tracking": false,
+		"ad-tracking": true,
 		"akismet/siteless-checkout": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,


### PR DESCRIPTION
This PR implements a test for the `onboarding-pm` flow that skips the domain step.

The test uses the Explat test name `onboarding_pm_skip_domain`. That experiment will use a new event `calypso_experiment_onboarding_pm_skip_domain_step` as an exposure event. That event needs to be verified before the test can be setup

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
