### PR TITLE
Updated comment field placeholder text

### DIFF
--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -148,7 +148,7 @@ class PostCommentForm extends Component {
 					<Gravatar user={ this.props.currentUser } />
 					<AutoresizingFormTextarea
 						value={ this.getCommentText() }
-						placeholder={ translate( 'Enter your comment here…' ) }
+						placeholder={ translate( 'Add a comment…' ) }
 						onKeyUp={ this.handleKeyUp }
 						onKeyDown={ this.handleKeyDown }
 						onFocus={ this.handleFocus }


### PR DESCRIPTION
## Description

@osullivanchris mentioned that the placeholder text that we show within inline comments could be a bit more approachable and less robotic. In this PR we'll update it everywhere.

## Before
![before](https://github.com/Automattic/wp-calypso/assets/5634774/f2ff90c0-3c72-4f89-a59d-5165abadfc06)

## After
![after](https://github.com/Automattic/wp-calypso/assets/5634774/64bde4d6-29aa-4fd8-931c-c281989b03b4)

## Testing

- Click Calypso live link below
- Head to the reader
- View inline comment placeholder