### PR TITLE
Paid Stats: Fix link to the commercial plan flow

### DIFF
--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -217,6 +217,7 @@ const StatsPurchasePage = ( {
 											redirectUri={ query.redirect_uri ?? '' }
 											from={ query.from ?? '' }
 											disableFreeProduct={ isFreeOwned || supportCommercialUse || isPWYWOwned }
+											productType={ query.productType }
 										/>
 									) }
 								</>

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -217,7 +217,6 @@ const StatsPurchasePage = ( {
 											redirectUri={ query.redirect_uri ?? '' }
 											from={ query.from ?? '' }
 											disableFreeProduct={ isFreeOwned || supportCommercialUse || isPWYWOwned }
-											productType={ query.productType }
 										/>
 									) }
 								</>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -54,6 +54,7 @@ interface StatsSingleItemPersonalPurchasePageProps {
 		currency_code: string;
 	};
 	disableFreeProduct: boolean;
+	productType: string;
 }
 
 interface StatsPersonalPurchaseProps {
@@ -67,6 +68,7 @@ interface StatsPersonalPurchaseProps {
 	from: string;
 	adminUrl: string;
 	disableFreeProduct: boolean;
+	productType: string;
 }
 
 const COMPONENT_CLASS_NAME = 'stats-purchase-single';
@@ -189,6 +191,7 @@ const StatsPersonalPurchase = ( {
 	from,
 	adminUrl,
 	disableFreeProduct = false,
+	productType,
 }: StatsPersonalPurchaseProps ) => {
 	const translate = useTranslate();
 	const sliderStepPrice = pwywProduct.cost / MIN_STEP_SPLITS;
@@ -205,6 +208,12 @@ const StatsPersonalPurchase = ( {
 	const handlePlanSwap = ( e: React.MouseEvent ) => {
 		e.preventDefault();
 		recordTracksEvent( `calypso_stats_plan_switched_from_personal_to_commercial` );
+
+		// Check for productType to determine navigation
+		if ( productType ) {
+			const purchasePath = `/stats/purchase/${ siteSlug }?productType=commercial&flags=stats/type-detection`;
+			window.location.href = purchasePath;
+		}
 	};
 
 	return (
@@ -241,6 +250,7 @@ const StatsSingleItemPersonalPurchasePage = ( {
 	maxSliderPrice,
 	pwywProduct,
 	disableFreeProduct,
+	productType,
 }: StatsSingleItemPersonalPurchasePageProps ) => {
 	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 
@@ -254,6 +264,7 @@ const StatsSingleItemPersonalPurchasePage = ( {
 				maxSliderPrice={ maxSliderPrice }
 				pwywProduct={ pwywProduct }
 				disableFreeProduct={ disableFreeProduct }
+				productType={ productType }
 			/>
 		</StatsSingleItemPagePurchaseFrame>
 	);

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -54,7 +54,6 @@ interface StatsSingleItemPersonalPurchasePageProps {
 		currency_code: string;
 	};
 	disableFreeProduct: boolean;
-	productType: string;
 }
 
 interface StatsPersonalPurchaseProps {
@@ -68,7 +67,6 @@ interface StatsPersonalPurchaseProps {
 	from: string;
 	adminUrl: string;
 	disableFreeProduct: boolean;
-	productType: string;
 }
 
 const COMPONENT_CLASS_NAME = 'stats-purchase-single';
@@ -191,7 +189,6 @@ const StatsPersonalPurchase = ( {
 	from,
 	adminUrl,
 	disableFreeProduct = false,
-	productType,
 }: StatsPersonalPurchaseProps ) => {
 	const translate = useTranslate();
 	const sliderStepPrice = pwywProduct.cost / MIN_STEP_SPLITS;
@@ -209,11 +206,8 @@ const StatsPersonalPurchase = ( {
 		e.preventDefault();
 		recordTracksEvent( `calypso_stats_plan_switched_from_personal_to_commercial` );
 
-		// Check for productType to determine navigation
-		if ( productType ) {
-			const purchasePath = `/stats/purchase/${ siteSlug }?productType=commercial&flags=stats/type-detection`;
-			window.location.href = purchasePath;
-		}
+		const purchasePath = `/stats/purchase/${ siteSlug }?productType=commercial&flags=stats/type-detection`;
+		window.location.href = purchasePath;
 	};
 
 	return (
@@ -250,7 +244,6 @@ const StatsSingleItemPersonalPurchasePage = ( {
 	maxSliderPrice,
 	pwywProduct,
 	disableFreeProduct,
-	productType,
 }: StatsSingleItemPersonalPurchasePageProps ) => {
 	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 
@@ -264,7 +257,6 @@ const StatsSingleItemPersonalPurchasePage = ( {
 				maxSliderPrice={ maxSliderPrice }
 				pwywProduct={ pwywProduct }
 				disableFreeProduct={ disableFreeProduct }
-				productType={ productType }
 			/>
 		</StatsSingleItemPagePurchaseFrame>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81379

## Proposed Changes

* This PR fixes the link to the commercial plan flow in the new/single purchase pages without breaking the original functionality (The new flow is behind a feature flag, so some customers still use the old wizard).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start with a fresh JN instance with Jetpack included. Once you connect the site you will be able to see it in Calypso.
* Once connected, head to the purchase page for the website and apply ?flags=stats/type-detection.
* Purchase a free plan (select the slider down to $0)
* Return to the purchase page again at `/stats/purchase/{site_URL}?flags=stats/type-detection`
* Click `Upgrade my Stats`
* Locate the text `This plan is for personal sites only. If your site is used for a commercial activity, you will need to choose a commercial plan` and click the link
* Ensure it redirects to correct commercial plan upgrade screen
* Verify this link still works on previous wizard/upgrade screen also
 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?