### PR TITLE
Stats: Release new changes for streamlining purchase flow

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -188,7 +188,7 @@
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": false,
-		"stats/type-detection": false,
+		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -122,7 +122,7 @@
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": false,
-		"stats/type-detection": false,
+		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/production.json
+++ b/config/production.json
@@ -151,7 +151,7 @@
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": false,
-		"stats/type-detection": false,
+		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -145,7 +145,7 @@
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": false,
-		"stats/type-detection": false,
+		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/test.json
+++ b/config/test.json
@@ -101,7 +101,7 @@
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": false,
-		"stats/type-detection": false,
+		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -155,7 +155,7 @@
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": false,
-		"stats/type-detection": false,
+		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* release recent changes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* visit the purchase page and verify that the page loads without issues

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?