### PR TITLE
Add domain-user-transfer receiver flow

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -69,6 +69,7 @@ export class ContactDetailsFormFields extends Component {
 		shouldForceRenderOnPropChange: PropTypes.bool,
 		updateWpcomEmailCheckboxDisabled: PropTypes.bool,
 		onUpdateWpcomEmailCheckboxChange: PropTypes.func,
+		updateWpcomEmailCheckboxHidden: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -92,6 +93,7 @@ export class ContactDetailsFormFields extends Component {
 		userCountryCode: 'US',
 		shouldForceRenderOnPropChange: false,
 		updateWpcomEmailCheckboxDisabled: false,
+		updateWpcomEmailCheckboxHidden: false,
 	};
 
 	constructor( props ) {
@@ -474,19 +476,23 @@ export class ContactDetailsFormFields extends Component {
 				) }
 			>
 				<Input label={ this.props.translate( 'Email' ) } { ...emailInputFieldProps } />
-				<FormLabel
-					className={ classNames( 'email-text-input-with-checkbox__checkbox-label', {
-						'is-disabled': this.props.updateWpcomEmailCheckboxDisabled,
-					} ) }
-				>
-					<FormCheckbox
-						name="update-wpcom-email"
-						disabled={ this.props.updateWpcomEmailCheckboxDisabled }
-						onChange={ this.handleUpdateWpcomEmailCheckboxChanged }
-						checked={ this.state.updateWpcomEmail && ! this.props.updateWpcomEmailCheckboxDisabled }
-					/>
-					<span>{ this.props.translate( 'Apply contact update to My Account email.' ) }</span>
-				</FormLabel>
+				{ ! this.props.updateWpcomEmailCheckboxHidden && (
+					<FormLabel
+						className={ classNames( 'email-text-input-with-checkbox__checkbox-label', {
+							'is-disabled': this.props.updateWpcomEmailCheckboxDisabled,
+						} ) }
+					>
+						<FormCheckbox
+							name="update-wpcom-email"
+							disabled={ this.props.updateWpcomEmailCheckboxDisabled }
+							onChange={ this.handleUpdateWpcomEmailCheckboxChanged }
+							checked={
+								this.state.updateWpcomEmail && ! this.props.updateWpcomEmailCheckboxDisabled
+							}
+						/>
+						<span>{ this.props.translate( 'Apply contact update to My Account email.' ) }</span>
+					</FormLabel>
+				) }
 			</div>
 		);
 	}

--- a/client/data/domains/transfers/use-domain-transfer-receive.ts
+++ b/client/data/domains/transfers/use-domain-transfer-receive.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { DomainsApiError } from 'calypso/lib/domains/types';
 import wp from 'calypso/lib/wp';
 
-type TransferInfo = {
+export type TransferInfo = {
 	address1: string;
 	address2: string;
 	city: string;
@@ -19,7 +19,7 @@ type TransferInfo = {
 	termsAccepted: boolean;
 };
 
-export default function useDomainTransferReceive(
+export function useDomainTransferReceive(
 	domainName: string,
 	queryOptions: {
 		onSuccess?: () => void;

--- a/client/data/domains/transfers/use-domain-transfer-receive.ts
+++ b/client/data/domains/transfers/use-domain-transfer-receive.ts
@@ -1,0 +1,52 @@
+import { useMutation } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { DomainsApiError } from 'calypso/lib/domains/types';
+import wp from 'calypso/lib/wp';
+
+type ContactInfo = {
+	address1: string;
+	address2: string;
+	city: string;
+	countryCode: string;
+	email: string;
+	fax: string;
+	firstName: string;
+	lastName: string;
+	organization: string;
+	phone: string;
+	postalCode: string;
+	state: string;
+};
+
+type ReceiveTransferInfo = {
+	contactInfo: ContactInfo;
+	termsAccepted: boolean;
+};
+
+export default function useDomainTransferReceive(
+	domainName: string,
+	queryOptions: {
+		onSuccess?: () => void;
+		onError?: ( error: DomainsApiError ) => void;
+	}
+) {
+	const mutation = useMutation( {
+		mutationFn: ( transferInfo: ReceiveTransferInfo ) =>
+			wp.req.post( `/sites/all/domains/${ domainName }/receive-transfer`, {
+				transferInfo,
+			} ),
+		...queryOptions,
+		onSuccess() {
+			queryOptions.onSuccess?.();
+		},
+	} );
+
+	const { mutate } = mutation;
+
+	const domainTransferReceive = useCallback(
+		( transferInfo: ReceiveTransferInfo ) => mutate( transferInfo ),
+		[ mutate ]
+	);
+
+	return { domainTransferReceive, ...mutation };
+}

--- a/client/data/domains/transfers/use-domain-transfer-receive.ts
+++ b/client/data/domains/transfers/use-domain-transfer-receive.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { DomainsApiError } from 'calypso/lib/domains/types';
 import wp from 'calypso/lib/wp';
 
-type ContactInfo = {
+type TransferInfo = {
 	address1: string;
 	address2: string;
 	city: string;
@@ -16,10 +16,6 @@ type ContactInfo = {
 	phone: string;
 	postalCode: string;
 	state: string;
-};
-
-type ReceiveTransferInfo = {
-	contactInfo: ContactInfo;
 	termsAccepted: boolean;
 };
 
@@ -31,9 +27,21 @@ export default function useDomainTransferReceive(
 	}
 ) {
 	const mutation = useMutation( {
-		mutationFn: ( transferInfo: ReceiveTransferInfo ) =>
+		mutationFn: ( info: TransferInfo ) =>
 			wp.req.post( `/sites/all/domains/${ domainName }/receive-transfer`, {
-				transferInfo,
+				address1: info.address1,
+				address2: info.address2,
+				city: info.city,
+				country_code: info.countryCode,
+				email: info.email,
+				fax: info.fax,
+				first_name: info.firstName,
+				last_name: info.lastName,
+				organization: info.organization,
+				phone: info.phone,
+				postal_code: info.postalCode,
+				state: info.state,
+				terms_accepted: info.termsAccepted,
 			} ),
 		...queryOptions,
 		onSuccess() {
@@ -44,7 +52,7 @@ export default function useDomainTransferReceive(
 	const { mutate } = mutation;
 
 	const domainTransferReceive = useCallback(
-		( transferInfo: ReceiveTransferInfo ) => mutate( transferInfo ),
+		( transferInfo: TransferInfo ) => mutate( transferInfo ),
 		[ mutate ]
 	);
 

--- a/client/landing/stepper/declarative-flow/domain-user-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-user-transfer.ts
@@ -1,0 +1,39 @@
+// import { useSiteIdParam } from '../hooks/use-site-id-param';
+// import { useSiteSlug } from '../hooks/use-site-slug';
+import DomainContactInfo from './internals/steps-repository/domain-contact-info';
+import type { Flow, ProvidedDependencies } from './internals/types';
+
+const domainUserTransfer: Flow = {
+	name: 'domain-user-transfer',
+	useSteps() {
+		return [ { slug: 'domain-contact-info', component: DomainContactInfo } ];
+	},
+
+	useStepNavigation( _currentStep, navigate ) {
+		// const siteId = useSiteIdParam();
+		// const siteSlug = useSiteSlug();
+
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			return providedDependencies;
+		}
+
+		const goBack = () => {
+			return;
+		};
+
+		const goNext = () => {
+			switch ( _currentStep ) {
+				case 'contact-info':
+					return navigate( '/manage/domains' );
+			}
+		};
+
+		const goToStep = ( step: string ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+};
+
+export default domainUserTransfer;

--- a/client/landing/stepper/declarative-flow/domain-user-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-user-transfer.ts
@@ -1,5 +1,3 @@
-// import { useSiteIdParam } from '../hooks/use-site-id-param';
-// import { useSiteSlug } from '../hooks/use-site-slug';
 import DomainContactInfo from './internals/steps-repository/domain-contact-info';
 import type { Flow, ProvidedDependencies } from './internals/types';
 
@@ -10,9 +8,6 @@ const domainUserTransfer: Flow = {
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
-		// const siteId = useSiteIdParam();
-		// const siteSlug = useSiteSlug();
-
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			return providedDependencies;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -100,8 +100,8 @@ function ContactInfo( {
 	}
 
 	function submitForm( contactInfo ) {
-		domainTransferReceive( { ...contactInfo } );
-		onSubmit( { ...contactInfo } );
+		domainTransferReceive( contactInfo );
+		onSubmit?.( contactInfo );
 	}
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -7,7 +7,10 @@ import { useDispatch } from 'react-redux';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import ContactDetailsFormFields from 'calypso/components/domains/contact-details-form-fields';
 import FormattedHeader from 'calypso/components/formatted-header';
-import useDomainTransferReceive from 'calypso/data/domains/transfers/use-domain-transfer-receive';
+import {
+	useDomainTransferReceive,
+	TransferInfo,
+} from 'calypso/data/domains/transfers/use-domain-transfer-receive';
 import { useDomainParams } from 'calypso/landing/stepper/hooks/use-domain-params';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wp from 'calypso/lib/wp';
@@ -99,7 +102,7 @@ function ContactInfo( {
 			} );
 	}
 
-	function submitForm( contactInfo ) {
+	function submitForm( contactInfo: TransferInfo ) {
 		domainTransferReceive( contactInfo );
 		onSubmit?.( contactInfo );
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -1,0 +1,89 @@
+import { useI18n } from '@wordpress/react-i18n';
+import { useTranslate } from 'i18n-calypso';
+import { StepContainer } from 'calypso/../packages/onboarding/src';
+import ContactDetailsFormFields from 'calypso/components/domains/contact-details-form-fields';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { useDomainParams } from 'calypso/landing/stepper/hooks/use-domain-params';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wp from 'calypso/lib/wp';
+import {
+	domainManagementContactsPrivacy,
+	domainManagementEdit,
+} from 'calypso/my-sites/domains/paths';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import type { StepProps } from '../../types';
+
+import './styles.scss';
+
+export default function DomainContactInfo( { navigation }: StepProps ) {
+	const { submit } = navigation;
+	const { __ } = useI18n();
+
+	const handleSubmit = () => {
+		submit?.();
+	};
+
+	return (
+		<StepContainer
+			hideBack
+			stepName="domain-contact-info"
+			isLargeSkipLayout={ false }
+			formattedHeader={
+				<FormattedHeader
+					id="domain-contact-info__header"
+					headerText={ __( 'Enter your contact informaiton' ) }
+					subHeaderText={ __(
+						'Domain owners are required to provide correct contact information.'
+					) }
+				/>
+			}
+			stepContent={ <ContactInfo onSubmit={ handleSubmit } /> }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+}
+
+function ContactInfo( { onSubmit }: { onSubmit: () => void } ) {
+	const translate = useTranslate();
+	const { domain } = useDomainParams();
+
+	function getIsFieldDisabled( fieldName: string ) {
+		return false;
+	}
+
+	function validate() {}
+
+	function handleContactDetailsChange() {}
+
+	return (
+		<form>
+			<ContactDetailsFormFields
+				eventFormName="Edit Contact Info"
+				contactDetails={ {
+					firstName: '',
+					lastName: '',
+					organization: '',
+					email: '',
+					phone: '',
+					address1: '',
+					address2: '',
+					city: '',
+					state: '',
+					postalCode: '',
+					countryCode: '',
+					fax: '',
+				} }
+				needsFax={ domain?.endsWith( '.nl' ) }
+				getIsFieldDisabled={ getIsFieldDisabled }
+				onContactDetailsChange={ handleContactDetailsChange }
+				onSubmit={ onSubmit }
+				onValidate={ validate }
+				labelTexts={ { submitButton: translate( 'Receive domain transfer' ) } }
+				disableSubmitButton={ false }
+				isSubmitting={ false }
+				updateWpcomEmailCheckboxHidden={ true }
+				cancelHidden={ true }
+			></ContactDetailsFormFields>
+		</form>
+	);
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -1,6 +1,8 @@
 import { camelToSnakeCase, mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/js-utils';
+import { CheckboxControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import ContactDetailsFormFields from 'calypso/components/domains/contact-details-form-fields';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -50,12 +52,14 @@ function ContactInfo( {
 	const translate = useTranslate();
 	const { domain } = useDomainParams();
 
+	const [ termsAccepted, setTermsAccepted ] = useState( false );
+
 	function getIsFieldDisabled() {
 		return false;
 	}
 
 	function validate(
-		fieldValues: Record< string, string | number >,
+		fieldValues: Record< string, unknown >,
 		onComplete: ( nullOrError: null | Error, data?: Record< string, unknown > | undefined ) => void
 	) {
 		wp.req
@@ -75,6 +79,10 @@ function ContactInfo( {
 			.catch( ( error: Error ) => {
 				onComplete( error );
 			} );
+	}
+
+	function submitForm( contactInfo ) {
+		onSubmit( { ...contactInfo, termsAccepted } );
 	}
 
 	return (
@@ -97,7 +105,7 @@ function ContactInfo( {
 				} }
 				needsFax={ domain?.endsWith( '.nl' ) }
 				getIsFieldDisabled={ getIsFieldDisabled }
-				onSubmit={ onSubmit }
+				onSubmit={ submitForm }
 				onValidate={ validate }
 				labelTexts={ { submitButton: translate( 'Receive domain transfer' ) } }
 				disableSubmitButton={ false }
@@ -105,6 +113,11 @@ function ContactInfo( {
 				updateWpcomEmailCheckboxHidden={ true }
 				cancelHidden={ true }
 			></ContactDetailsFormFields>
+			<CheckboxControl
+				label="I agree to the terms of service"
+				checked={ true }
+				onChange={ setTermsAccepted }
+			/>
 		</form>
 	);
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -1,8 +1,8 @@
+import { Gridicon } from '@automattic/components';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { camelToSnakeCase, mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/js-utils';
-import { CheckboxControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import ContactDetailsFormFields from 'calypso/components/domains/contact-details-form-fields';
@@ -47,9 +47,9 @@ function ContactInfo( {
 		| undefined;
 } ) {
 	const translate = useTranslate();
+	const localizeUrl = useLocalizeUrl();
 	const { domain } = useDomainParams();
 	const dispatch = useDispatch();
-	const [ termsAccepted, setTermsAccepted ] = useState( false );
 
 	const { domainTransferReceive } = useDomainTransferReceive( domain ?? '', {
 		onSuccess() {
@@ -100,12 +100,12 @@ function ContactInfo( {
 	}
 
 	function submitForm( contactInfo ) {
-		domainTransferReceive( { ...contactInfo, termsAccepted } );
-		onSubmit( { ...contactInfo, termsAccepted } );
+		domainTransferReceive( { ...contactInfo } );
+		onSubmit( { ...contactInfo } );
 	}
 
 	return (
-		<form>
+		<form className="domain-contact-info">
 			<ContactDetailsFormFields
 				eventFormName="Edit Contact Info"
 				contactDetails={ {
@@ -126,17 +126,39 @@ function ContactInfo( {
 				getIsFieldDisabled={ getIsFieldDisabled }
 				onSubmit={ submitForm }
 				onValidate={ validate }
-				labelTexts={ { submitButton: translate( 'Receive domain transfer' ) } }
-				disableSubmitButton={ ! termsAccepted }
+				labelTexts={ { submitButton: translate( 'Accept domain transfer' ) } }
 				isSubmitting={ false }
 				updateWpcomEmailCheckboxHidden={ true }
 				cancelHidden={ true }
-			></ContactDetailsFormFields>
-			<CheckboxControl
-				label="I agree to the terms of service"
-				checked={ termsAccepted }
-				onChange={ setTermsAccepted }
-			/>
+			>
+				<div className="domain-contact-info__terms">
+					<strong>{ translate( 'By accepting this transfer' ) }</strong>
+				</div>
+				<div className="domain-contact-info__term">
+					<Gridicon icon="info-outline" size={ 18 } />
+					<p>
+						{ translate(
+							'You agree to the {{a}}Domain Registration Agreement{{/a}} for %(domainName)s.',
+							{
+								args: {
+									domainName: domain ?? '',
+								},
+								components: {
+									a: (
+										<a
+											href={ localizeUrl(
+												'https://wordpress.com/automattic-domain-name-registration-agreement/'
+											) }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
+						) }
+					</p>
+				</div>
+			</ContactDetailsFormFields>
 		</form>
 	);
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -27,7 +27,7 @@ export default function DomainContactInfo( { navigation }: StepProps ) {
 			formattedHeader={
 				<FormattedHeader
 					id="domain-contact-info__header"
-					headerText={ __( 'Enter your contact informaiton' ) }
+					headerText={ __( 'Enter your contact information' ) }
 					subHeaderText={ __(
 						'Domain owners are required to provide correct contact information.'
 					) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -135,13 +135,10 @@ function ContactInfo( {
 				cancelHidden={ true }
 			>
 				<div className="domain-contact-info__terms">
-					<strong>{ translate( 'By accepting this transfer' ) }</strong>
-				</div>
-				<div className="domain-contact-info__term">
 					<Gridicon icon="info-outline" size={ 18 } />
 					<p>
 						{ translate(
-							'You agree to the {{a}}Domain Registration Agreement{{/a}} for %(domainName)s.',
+							'By accepting this transfer, you agree to the {{a}}Domain Registration Agreement{{/a}} for %(domainName)s.',
 							{
 								args: {
 									domainName: domain ?? '',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
@@ -5,17 +5,12 @@ $font-family: "SF Pro Text", $sans;
 $heading-font-family: "SF Pro Display", $sans;
 
 .domain-contact-info {
-
 	.domain-contact-info__terms {
-		font-size: 0.875rem;
-	}
-
-	.domain-contact-info__term {
 		padding-left: 24px;
 		position: relative;
-		font-size: $font-body-extra-small;
+		font-size: $font-body-small;
 
-		margin-left: 5px;
+		margin-left: 0;
 		margin-top: 10px;
 
 		> svg {
@@ -32,7 +27,7 @@ $heading-font-family: "SF Pro Display", $sans;
 		}
 
 		p {
-			font-size: $font-body-extra-small;
+			font-size: $font-body-small;
 			margin: 0;
 			word-break: break-word;
 		}
@@ -42,7 +37,7 @@ $heading-font-family: "SF Pro Display", $sans;
 		margin-bottom: 15px;
 	}
 	.contact-details-form-fields__extra-fields {
-		margin-bottom: 15px;
+		margin-bottom: 20px;
 	}
 
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
@@ -4,6 +4,46 @@
 $font-family: "SF Pro Text", $sans;
 $heading-font-family: "SF Pro Display", $sans;
 
-.domain-user-transfer {
-	margin: 0;
+.domain-contact-info {
+
+	.domain-contact-info__terms {
+		font-size: 0.875rem;
+	}
+
+	.domain-contact-info__term {
+		padding-left: 24px;
+		position: relative;
+		font-size: $font-body-extra-small;
+
+		margin-bottom: 4px;
+		margin-left: 12px;
+		margin-top: 4px;
+
+		> svg {
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 16px;
+			height: 16px;
+
+			.rtl & {
+				left: auto;
+				right: 0;
+			}
+		}
+
+		p {
+			font-size: $font-body-extra-small;
+			margin: 0;
+			word-break: break-word;
+		}
+	}
+
+	.contact-details-form-fields__contact-details {
+		margin-bottom: 15px;
+	}
+	.contact-details-form-fields__extra-fields {
+		margin-bottom: 15px;
+	}
+
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
@@ -1,0 +1,9 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@automattic/onboarding/styles/mixins";
+
+$font-family: "SF Pro Text", $sans;
+$heading-font-family: "SF Pro Display", $sans;
+
+.domain-user-transfer {
+	margin: 0;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
@@ -15,9 +15,8 @@ $heading-font-family: "SF Pro Display", $sans;
 		position: relative;
 		font-size: $font-body-extra-small;
 
-		margin-bottom: 4px;
-		margin-left: 12px;
-		margin-top: 4px;
+		margin-left: 5px;
+		margin-top: 10px;
 
 		> svg {
 			position: absolute;

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -115,8 +115,12 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	[ 'plugin-bundle' ]: () =>
 		import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' ),
+
 	[ 'hundred-year-plan' ]: () =>
 		import( /* webpackChunkName: "hundred-year-plan" */ './hundred-year-plan' ),
+
+	'domain-user-transfer': () =>
+		import( /* webpackChunkName: "domain-user-transfer-flow" */ './domain-user-transfer' ),
 };
 
 const videoPressTvFlows: Record< string, () => Promise< { default: Flow } > > = config.isEnabled(

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/transfer-domain-to-any-user.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/transfer-domain-to-any-user.tsx
@@ -34,11 +34,6 @@ import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 import './style.scss';
 
-const noticeOptions = {
-	duration: 5000,
-	id: `domain-transfer-notification`,
-};
-
 export default function TransferDomainToAnyUser( {
 	domains,
 	hasSiteDomainsLoaded,
@@ -74,10 +69,9 @@ export default function TransferDomainToAnyUser( {
 			},
 			onError() {
 				dispatch(
-					errorNotice(
-						translate( 'An error occurred while initiating the domain transfer.' ),
-						noticeOptions
-					)
+					errorNotice( translate( 'An error occurred while initiating the domain transfer.' ), {
+						duration: 5000,
+					} )
 				);
 			},
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3598

## Proposed Changes

* Adds a stepper flow for receiving domain transfers

Todo:
- [x] Waiting on a backend implementation in D121090-code - can test with this currently but it's a WIP - update 2: can now use D122231-code
- [x] Contact info is validated and sent
- [x] Term agreement is checked and sent 
- [x] Term agreement details are figured out (we'll need to link to them)
- [ ] Figure out what to do post transfer, it may end up being an async process and we'll want to direct them to a checkout thank you page or something while we poll for transfer completion

## Testing Instructions

* Apply D121090-code
* Test the transfer succeeds http://calypso.localhost:3000/setup/domain-user-transfer/domain-contact-info?domain=test345678.blog

![Screenshot 2023-09-08 at 13-55-36 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/ffb77c7b-70b6-4a17-b60f-292abe8fc040)
