### PR TITLE
Assembler - Fix fonts request error because names with quotes are not found

### DIFF
--- a/packages/global-styles/src/components/font-pairing-variations/font-families-loader.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/font-families-loader.tsx
@@ -11,11 +11,17 @@ const FONT_API_BASE = 'https://fonts-api.wp.com/css2';
 
 const FONT_AXIS = 'ital,wght@0,400;0,700;1,400;1,700';
 
+// Fix to avoid error in Google Fonts API
+const removeSingleQuotes = ( fontFamily: string ) => fontFamily.replaceAll( "'", '' );
+
 const FontFamiliesLoader = ( { fontFamilies, onLoad }: Props ) => {
 	const params = useMemo(
 		() =>
 			new URLSearchParams( [
-				...fontFamilies.map( ( { fontFamily } ) => [ 'family', `${ fontFamily }:${ FONT_AXIS }` ] ),
+				...fontFamilies.map( ( { fontFamily } ) => [
+					'family',
+					`${ removeSingleQuotes( fontFamily ) }:${ FONT_AXIS }`,
+				] ),
 				[ 'display', 'swap' ],
 			] ),
 		fontFamilies


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #81424 

## Proposed Changes

* Remove single quotes from font family names in the request to Fonts API 

This is a fix to make sure the request is correct but the root issue is that some font names have single quotes.

<img width="242" alt="Screenshot 2566-09-08 at 14 23 52" src="https://github.com/Automattic/wp-calypso/assets/1881481/1becde8d-620c-4a58-8648-ff4076ad0450">

@Automattic/lego can the font names with single quotes affect other areas?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }&screen=styles&screen_parameter=fonts`
* In the screen "Pick your style > Fonts" verify the Inter font looks as expected

|BEFORE|AFTER| 
|--|--|
|<img width="351" alt="Screenshot 2566-09-08 at 14 28 57" src="https://github.com/Automattic/wp-calypso/assets/1881481/815fdfbd-aad7-4f13-9a09-a3a9919355bf">|<img width="339" alt="Screenshot 2566-09-08 at 14 18 57" src="https://github.com/Automattic/wp-calypso/assets/1881481/337321c0-896d-43fd-9153-9c0a72f1c77d">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?