### PR TITLE
Move credit card expiration check further down

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -227,16 +227,6 @@ export function resolveDomainStatus(
 				};
 			}
 
-			if ( purchase && shouldRenderExpiringCreditCard( purchase ) ) {
-				return {
-					statusText: translate( 'Action required' ),
-					statusClass: 'status-error',
-					status: translate( 'Action required' ),
-					icon: 'info',
-					listStatusWeight: 600,
-				};
-			}
-
 			if ( domain.isPendingIcannVerification && domain.isIcannVerificationSuspended ) {
 				return {
 					statusText: translate( 'Suspended' ),
@@ -525,6 +515,16 @@ export function resolveDomainStatus(
 					icon: 'info',
 					noticeText: noticeText,
 					listStatusWeight: 400,
+				};
+			}
+
+			if ( purchase && shouldRenderExpiringCreditCard( purchase ) ) {
+				return {
+					statusText: translate( 'Action required' ),
+					statusClass: 'status-error',
+					status: translate( 'Action required' ),
+					icon: 'info',
+					listStatusWeight: 600,
 				};
 			}
 


### PR DESCRIPTION
## Proposed Changes

I noticed that the for registered domain, the `resolveDomainStatus` has a check about credit card expiration and autorenew. This check has a fairly high priority, but there is no message associated. I moved this control further down: this way it won't prevent other message from being displayed. This is just a temporary fix, since the status calculation will be moved on the back sooner.

## Testing Instructions

I think that a quick code inspection is enough for this PR.

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?