### PR TITLE
Site Preview: Avoid the redirection due to timeout

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -308,16 +308,18 @@ export default class WebPreviewContent extends Component {
 
 			// To prevent iframe firing the onload event before the embedded page sends the
 			// partially-loaded message, we add a waiting period here.
-			this.loadingTimeoutTimer = setTimeout( () => {
-				debug( 'preview loading timeout' );
+			if ( ! this.props.disableTimeoutRedirect ) {
+				this.loadingTimeoutTimer = setTimeout( () => {
+					debug( 'preview loading timeout' );
 
-				if ( this.props.showClose ) {
-					window.open( this.state.iframeUrl, '_blank' );
-					this.props.onClose();
-				} else {
-					window.location.replace( this.state.iframeUrl );
-				}
-			}, loadingTimeout );
+					if ( this.props.showClose ) {
+						window.open( this.state.iframeUrl, '_blank' );
+						this.props.onClose();
+					} else {
+						window.location.replace( this.state.iframeUrl );
+					}
+				}, loadingTimeout );
+			}
 		} else {
 			this.setState( { loaded: true, isLoadingSubpage: false } );
 			if ( this.loadingTimeoutTimer ) {
@@ -516,6 +518,8 @@ WebPreviewContent.propTypes = {
 	inlineCss: PropTypes.string,
 	// Uses the CSS selector to scroll to it
 	scrollToSelector: PropTypes.string,
+	// disable the redirection due to the timeout
+	disableTimeoutRedirect: PropTypes.bool,
 };
 
 WebPreviewContent.defaultProps = {
@@ -541,4 +545,5 @@ WebPreviewContent.defaultProps = {
 	autoHeight: false,
 	inlineCss: null,
 	scrollToSelector: null,
+	disableTimeoutRedirect: false,
 };

--- a/client/landing/stepper/declarative-flow/internals/components/site-preview/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/site-preview/index.tsx
@@ -83,6 +83,7 @@ const SitePreview = ( {
 				defaultViewportDevice={ defaultDevice }
 				devicesToShow={ devicesToShow }
 				showSiteAddressBar={ false }
+				disableTimeoutRedirect
 			/>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1694152983677509-slack-CRWCHQGUB

## Proposed Changes

* Introduce a new property called `disableTimeoutRedirect` to `<WebPreview />` component to disable the redirection due to the timeout
* Set the `disableTimeoutRedirect` to true on the `<SitePreview />` that is used by Launchpad

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* Finish the onboarding flow
* When you land on the Launchpad, open the DevTool to throttle your network
* Refresh the page and ensure the page won't be redirected to the preview

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?