### PR TITLE
Handling the case of 100 year plans which have 100 years of domain re…

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -1,14 +1,39 @@
-import { localize } from 'i18n-calypso';
+import { PLAN_100_YEARS } from '@automattic/calypso-products';
+import { localize, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import customDomainBloggerImage from 'calypso/assets/images/illustrations/custom-domain-blogger.svg';
 import customDomainImage from 'calypso/assets/images/illustrations/custom-domain.svg';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import { getRegisteredDomains } from 'calypso/lib/domains';
+import { useSelector } from 'calypso/state';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getSitePlan } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const useGetBundledDomainDescription = ( onlyBlogDomain ) => {
+	const translate = useTranslate();
+	const currentSitePlan = useSelector( ( state ) => {
+		const siteId = getSelectedSiteId( state );
+		return getSitePlan( state, siteId );
+	} );
+	const is100YearPlanSite = currentSitePlan?.product_slug === PLAN_100_YEARS;
+
+	if ( onlyBlogDomain ) {
+		return translate(
+			'Your plan includes a free .blog domain for one year, which gives your site a more professional, branded feel.'
+		);
+	} else if ( is100YearPlanSite ) {
+		return translate(
+			'Your plan includes a free custom domain, which gives your site a more professional, branded feel.'
+		);
+	}
+	return translate(
+		'Your plan includes a free custom domain for one year, which gives your site a more professional, branded feel.'
+	);
+};
 
 const CustomDomainPurchaseDetail = ( {
 	selectedSite,
@@ -19,6 +44,8 @@ const CustomDomainPurchaseDetail = ( {
 	translate,
 } ) => {
 	const customDomainIcon = onlyBlogDomain ? customDomainBloggerImage : customDomainImage;
+	const description = useGetBundledDomainDescription( onlyBlogDomain );
+
 	if ( hasDomainCredit ) {
 		return (
 			<PurchaseDetail
@@ -28,15 +55,7 @@ const CustomDomainPurchaseDetail = ( {
 						? translate( 'Select your .blog domain' )
 						: translate( 'Select your custom domain' )
 				}
-				description={
-					onlyBlogDomain
-						? translate(
-								'Your plan includes a free .blog domain for one year, which gives your site a more professional, branded feel.'
-						  )
-						: translate(
-								'Your plan includes a free custom domain for one year, which gives your site a more professional, branded feel.'
-						  )
-				}
+				description={ description }
 				buttonText={ translate( 'Claim your free domain' ) }
 				href={ `/domains/add/${ selectedSite.slug }` }
 			/>

--- a/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -1,4 +1,4 @@
-import { PLAN_100_YEARS } from '@automattic/calypso-products';
+import { is100YearPlan } from '@automattic/calypso-products';
 import { localize, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -19,7 +19,7 @@ const useGetBundledDomainDescription = ( onlyBlogDomain ) => {
 		const siteId = getSelectedSiteId( state );
 		return getSitePlan( state, siteId );
 	} );
-	const is100YearPlanSite = currentSitePlan?.product_slug === PLAN_100_YEARS;
+	const is100YearPlanSite = is100YearPlan( currentSitePlan?.product_slug );
 
 	if ( onlyBlogDomain ) {
 		return translate(


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/martech#2119

## Proposed Changes

* This shows the correct description under "my plan" when a 100 year plan has a bundled 100 years of domain registration.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to my-plan on a site with the 100-year plan and confirm that the copy is updated
* Go to the same page for any other plan, e.g. Commerce or Business, and confirm that the copy is not changed.

![Screenshot 2023-09-08 at 11 03 42](https://github.com/Automattic/wp-calypso/assets/52675688/f86eab8f-603a-4dd0-a4ca-dc8507f31f55)
![Screenshot 2023-09-08 at 11 02 26](https://github.com/Automattic/wp-calypso/assets/52675688/376dd744-fdf2-4393-bfa0-ea76086f7043)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
