### PR TITLE
Flaky Jetpack E2E: wait for banner to load before clicking on the Promote button.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/advertising-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/advertising-page.ts
@@ -60,6 +60,12 @@ export class AdvertisingPage {
 		name: string,
 		{ row, postTitle }: { row?: number; postTitle?: string } = {}
 	) {
+		// Wait for the posts and the banner to finish loading.
+		await Promise.all( [
+			this.page.getByRole( 'main' ).locator( 'span.count' ).waitFor(),
+			this.page.getByRole( 'main' ).locator( '.posts-list-banner__container' ).waitFor(),
+		] );
+
 		if ( row !== undefined && row >= 0 ) {
 			await this.page
 				.getByRole( 'row' )

--- a/packages/calypso-e2e/src/lib/pages/advertising-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/advertising-page.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright';
+import { envVariables } from '../..';
 import { getCalypsoURL } from '../../data-helper';
 import { clickNavTab } from '../../element-helper';
 
@@ -60,8 +61,10 @@ export class AdvertisingPage {
 		name: string,
 		{ row, postTitle }: { row?: number; postTitle?: string } = {}
 	) {
-		// Wait for promote the banner to finish loading.
-		await this.page.getByRole( 'main' ).locator( '.posts-list-banner__container' ).waitFor();
+		// Wait for promote the banner to finish loading on desktop.
+		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
+			await this.page.getByRole( 'main' ).locator( '.posts-list-banner__container' ).waitFor();
+		}
 
 		if ( row !== undefined && row >= 0 ) {
 			await this.page

--- a/packages/calypso-e2e/src/lib/pages/advertising-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/advertising-page.ts
@@ -60,11 +60,8 @@ export class AdvertisingPage {
 		name: string,
 		{ row, postTitle }: { row?: number; postTitle?: string } = {}
 	) {
-		// Wait for the posts and the banner to finish loading.
-		await Promise.all( [
-			this.page.getByRole( 'main' ).locator( 'span.count' ).waitFor(),
-			this.page.getByRole( 'main' ).locator( '.posts-list-banner__container' ).waitFor(),
-		] );
+		// Wait for promote the banner to finish loading.
+		await this.page.getByRole( 'main' ).locator( '.posts-list-banner__container' ).waitFor();
 
 		if ( row !== undefined && row >= 0 ) {
 			await this.page

--- a/test/e2e/specs/tools/advertising__promote.ts
+++ b/test/e2e/specs/tools/advertising__promote.ts
@@ -35,7 +35,7 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 	DataHelper.createSuiteTitle( 'Advertising: Promote' ),
 	function () {
 		const pageTitle = DataHelper.getRandomPhrase();
-		const snippet = Array( 5 ).fill( DataHelper.getRandomPhrase() ).toString();
+		const snippet = Array( 2 ).fill( DataHelper.getRandomPhrase() ).toString();
 
 		let newPostDetails: PostResponse;
 		let page: Page;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/81548, https://github.com/Automattic/wp-calypso/issues/80730.

Fixes https://github.com/Automattic/wp-calypso/issues/81548.

## Proposed Changes

This PR adds a wait for the banner to load before clicking on the Promote button. This is because sometimes, Playwright clicks on the Promote button just as the banner is loading, resulting in raciness and flaky tests as a result.

Additionally, this PR reduces the character count of the Blaze campaign description text.

## Testing Instructions

Running an iteration with just the Advertising: Promote spec in the suite, we see this results in a pass for every AT user.

![image](https://github.com/Automattic/wp-calypso/assets/6549265/4da0d14a-83e9-4282-b0bd-45ac634d0415)

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?