### PR TITLE
100-Year Plan: Fix domain upsell under stats>insights

### DIFF
--- a/client/blocks/domain-tip/index.jsx
+++ b/client/blocks/domain-tip/index.jsx
@@ -1,4 +1,8 @@
-import { FEATURE_CUSTOM_DOMAIN, isFreePlanProduct } from '@automattic/calypso-products';
+import {
+	FEATURE_CUSTOM_DOMAIN,
+	isFreePlanProduct,
+	PLAN_100_YEARS,
+} from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
@@ -55,6 +59,20 @@ class DomainTip extends Component {
 		);
 	}
 
+	getDomainUpsellNudgeText() {
+		const siteHas100YearPlan = this.props.site?.plan?.product_slug === PLAN_100_YEARS;
+
+		if ( ! this.props.hasDomainCredit ) {
+			return this.props.translate( 'Purchase a custom domain for your site.' );
+		}
+
+		if ( siteHas100YearPlan ) {
+			return this.props.translate( 'Your plan includes a free custom domain. Grab this one!' );
+		}
+
+		return 'Your plan includes a free custom domain for one year. Grab this one!';
+	}
+
 	render() {
 		if ( this.props.isIneligible ) {
 			return null;
@@ -84,13 +102,7 @@ class DomainTip extends Component {
 					tracksClickName="calypso_upgrade_nudge_cta_click"
 					feature={ FEATURE_CUSTOM_DOMAIN }
 					href={ `/domains/add/${ this.props.siteSlug }` }
-					description={
-						this.props.hasDomainCredit
-							? this.props.translate(
-									'Your plan includes a free custom domain for one year. Grab this one!'
-							  )
-							: this.props.translate( 'Purchase a custom domain for your site.' )
-					}
+					description={ this.getDomainUpsellNudgeText() }
 					forceDisplay
 					title={ title }
 					showIcon

--- a/client/blocks/domain-tip/index.jsx
+++ b/client/blocks/domain-tip/index.jsx
@@ -70,7 +70,9 @@ class DomainTip extends Component {
 			return this.props.translate( 'Your plan includes a free custom domain. Grab this one!' );
 		}
 
-		return 'Your plan includes a free custom domain for one year. Grab this one!';
+		return this.props.translate(
+			'Your plan includes a free custom domain for one year. Grab this one!'
+		);
 	}
 
 	render() {

--- a/client/blocks/domain-tip/index.jsx
+++ b/client/blocks/domain-tip/index.jsx
@@ -1,7 +1,7 @@
 import {
 	FEATURE_CUSTOM_DOMAIN,
 	isFreePlanProduct,
-	PLAN_100_YEARS,
+	is100YearPlan,
 } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -60,7 +60,7 @@ class DomainTip extends Component {
 	}
 
 	getDomainUpsellNudgeText() {
-		const siteHas100YearPlan = this.props.site?.plan?.product_slug === PLAN_100_YEARS;
+		const siteHas100YearPlan = is100YearPlan( this.props.site?.plan?.product_slug );
 
 		if ( ! this.props.hasDomainCredit ) {
 			return this.props.translate( 'Purchase a custom domain for your site.' );


### PR DESCRIPTION
Shows the correct description for domain bundling for the 100 year plan.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/martech#2118

## Proposed Changes

* Changes the domain upsell nudge text for 100-year plans (these have 100 years of bundled domain registration).
* No changes for other plans

## Testing Instructions

* Go to stats>insights on a "simple" site with a 100-year plan
* You'll see that we don't show the "for one year" part.
* Go to the same page for another plan, e.g. premium (with a bundled domain credit). You'll see the same copy as in prod.


![Screenshot 2023-09-08 at 11 24 37](https://github.com/Automattic/wp-calypso/assets/52675688/42cf19d2-f597-4be5-8df4-797aaf2bccfa)
![Screenshot 2023-09-08 at 11 24 27](https://github.com/Automattic/wp-calypso/assets/52675688/fa681d4c-4b66-437f-87ea-86a18b5100e1)
![Screenshot 2023-09-08 at 11 22 09](https://github.com/Automattic/wp-calypso/assets/52675688/88a8e1cc-8112-465e-ba31-a929c585eac2)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
