### PR TITLE
Flaky Jetpack E2E: change button text to exact.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -103,7 +103,7 @@ export class PublishedPostPage {
 		// can choose from.
 		// However, we don't know for sure whether a site owner has set up any
 		// newsletter plans.
-		const continueButton = iframe.getByRole( 'button', { name: /continue/i } );
+		const continueButton = iframe.getByRole( 'button', { name: 'Continue', exact: true } );
 		const freeTrialLink = iframe.getByRole( 'link', {
 			name: 'Free - Get a glimpse of the newsletter',
 		} );

--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -110,7 +110,7 @@ export class PublishedPostPage {
 
 		await continueButton.or( freeTrialLink ).waitFor();
 		if ( await freeTrialLink.isVisible() ) {
-			freeTrialLink.click();
+			await freeTrialLink.click();
 		}
 
 		await continueButton.click();


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80730, https://github.com/Automattic/wp-calypso/issues/81547.

Fixes https://github.com/Automattic/wp-calypso/issues/81547.

## Proposed Changes

This PR changes the text match from a regex match to an exact text match.

This is because the main button shown when a newsletter plan is enabled for the site also has the word 'continue'. This resulted in the POM matching on both locators (freeTrialLink and continueButton) and reporting a failure.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?