### PR TITLE
100-Year Plan: Home card for bundled domains fix

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -1,5 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { getPlan, isFreePlanProduct, getIntervalTypeForTerm } from '@automattic/calypso-products';
+import {
+	getPlan,
+	isFreePlanProduct,
+	getIntervalTypeForTerm,
+	is100YearPlan,
+} from '@automattic/calypso-products';
 import { Button, Card, Gridicon } from '@automattic/components';
 import { useDomainSuggestions } from '@automattic/domain-picker/src';
 import { useLocale } from '@automattic/i18n-utils';
@@ -59,6 +64,8 @@ export default function DomainUpsell() {
 
 	const searchTerm = selectedSiteSlug?.split( '.' )[ 0 ];
 
+	const is100YearPlanSite = is100YearPlan( currentPlan?.productSlug );
+
 	return (
 		<CalypsoShoppingCartProvider>
 			<RenderDomainUpsell
@@ -67,6 +74,7 @@ export default function DomainUpsell() {
 				searchTerm={ searchTerm }
 				siteSlug={ selectedSiteSlug }
 				dismissPreference={ dismissPreference }
+				is100YearPlanSite={ is100YearPlanSite }
 			/>
 		</CalypsoShoppingCartProvider>
 	);
@@ -83,6 +91,7 @@ export function RenderDomainUpsell( {
 	searchTerm,
 	siteSlug,
 	dismissPreference,
+	is100YearPlanSite,
 } ) {
 	const translate = useTranslate();
 
@@ -158,35 +167,40 @@ export function RenderDomainUpsell( {
 		page( purchaseLink );
 	};
 
+	const getCardSubtitle = () => {
+		const translateProps = {
+			components: {
+				strong: <strong />,
+			},
+			args: {
+				domainSuggestion: domainSuggestionName,
+			},
+		};
+		if ( is100YearPlanSite ) {
+			return translate(
+				"{{strong}}%(domainSuggestion)s{{/strong}} is included free with your plan. Claim it and start building a site that's easy to find, share and follow.",
+				translateProps
+			);
+		}
+		if ( ! isFreePlan && ! isMonthlyPlan ) {
+			return translate(
+				"{{strong}}%(domainSuggestion)s{{/strong}} is included free for one year with any paid plan. Claim it and start building a site that's easy to find, share and follow.",
+				translateProps
+			);
+		}
+
+		return translate(
+			"{{strong}}%(domainSuggestion)s{{/strong}} is a perfect site address. It's available and easy to find and follow. Get it now and claim a corner of the web.",
+			translateProps
+		);
+	};
+
 	const cardTitle =
 		! isFreePlan && ! isMonthlyPlan
 			? translate( 'That perfect domain is waiting' )
 			: translate( 'Own a domain. Build a site.' );
 
-	const cardSubtitle =
-		! isFreePlan && ! isMonthlyPlan
-			? translate(
-					"{{strong}}%(domainSuggestion)s{{/strong}} is included free for one year with any paid plan. Claim it and start building a site that's easy to find, share and follow.",
-					{
-						components: {
-							strong: <strong />,
-						},
-						args: {
-							domainSuggestion: domainSuggestionName,
-						},
-					}
-			  )
-			: translate(
-					"{{strong}}%(domainSuggestion)s{{/strong}} is a perfect site address. It's available and easy to find and follow. Get it now and claim a corner of the web.",
-					{
-						components: {
-							strong: <strong />,
-						},
-						args: {
-							domainSuggestion: domainSuggestionName,
-						},
-					}
-			  );
+	const cardSubtitle = getCardSubtitle();
 
 	const domainNameSVG = (
 		<svg viewBox="0 0 40 18" id="map">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/martech#2117

## Proposed Changes

* Updates the copy in the my home card for 100-year plans to not limit the bundled domain credit to one year.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to my home on a site with the 100-year plan
* Observe that the card copy has changed, and does not limit the credit to one year
* Go to the same route for any other plan, the copy will be unchanged.

![Screenshot 2023-09-08 at 11 42 36](https://github.com/Automattic/wp-calypso/assets/52675688/660d19cc-a06d-44d9-a753-ee0dfdd48b9c)
![Screenshot 2023-09-08 at 11 42 20](https://github.com/Automattic/wp-calypso/assets/52675688/59163e2d-13c2-4578-9b7b-ac60049b1571)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
