### PR TITLE
Jetpack E2E: update test expectaion for Subscribe flow.

### DIFF
--- a/test/e2e/specs/users/newsletter__subscribe-remove.ts
+++ b/test/e2e/specs/users/newsletter__subscribe-remove.ts
@@ -15,7 +15,6 @@ import {
 	EmailClient,
 	SecretsManager,
 	SubscribersPage,
-	SubscriptionManagementPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { skipDescribeIf } from '../../jest-helpers';
@@ -91,17 +90,6 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 			// @see: rWPGIT4ed687fb18bc-code
 			it( 'User is taken to the blog home page', async function () {
 				await page.waitForURL( new RegExp( testAccount.getSiteURL( { protocol: false } ) ) );
-			} );
-
-			it( 'Subscribed site is listed in Subscription Management page', async function () {
-				await page.goto( DataHelper.getCalypsoURL( 'subscriptions/sites/en' ), {
-					waitUntil: 'domcontentloaded',
-				} );
-
-				const subscriptionManagementPage = new SubscriptionManagementPage( page );
-				await subscriptionManagementPage.validateSiteSubscribed(
-					testAccount.getSiteURL( { protocol: false } )
-				);
 			} );
 		} );
 

--- a/test/e2e/specs/users/newsletter__subscribe-remove.ts
+++ b/test/e2e/specs/users/newsletter__subscribe-remove.ts
@@ -88,8 +88,8 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 
 			// Updated expecataion.
 			// @see: rWPGIT4ed687fb18bc-code
-			it( 'User is taken to the blog home page', async function () {
-				await page.waitForURL( new RegExp( testAccount.getSiteURL( { protocol: false } ) ) );
+			it( 'User is taken to the blog home page with token', async function () {
+				await page.waitForURL( new RegExp( newPostDetails.URL + '?token=.*' ) );
 			} );
 		} );
 

--- a/test/e2e/specs/users/newsletter__subscribe-remove.ts
+++ b/test/e2e/specs/users/newsletter__subscribe-remove.ts
@@ -87,7 +87,17 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 				await page.goto( confirmationURL as string );
 			} );
 
-			it( 'Land in Subscription Management page', async function () {
+			// Updated expecataion.
+			// @see: rWPGIT4ed687fb18bc-code
+			it( 'User is taken to the blog home page', async function () {
+				await page.waitForURL( new RegExp( testAccount.getSiteURL( { protocol: false } ) ) );
+			} );
+
+			it( 'Subscribed site is listed in Subscription Management page', async function () {
+				await page.goto( DataHelper.getCalypsoURL( 'subscriptions/sites/en' ), {
+					waitUntil: 'domcontentloaded',
+				} );
+
 				const subscriptionManagementPage = new SubscriptionManagementPage( page );
 				await subscriptionManagementPage.validateSiteSubscribed(
 					testAccount.getSiteURL( { protocol: false } )

--- a/test/e2e/specs/users/newsletter__subscribe-remove.ts
+++ b/test/e2e/specs/users/newsletter__subscribe-remove.ts
@@ -88,7 +88,7 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 
 			// Updated expecataion.
 			// @see: rWPGIT4ed687fb18bc-code
-			it( 'User is taken to the blog home page with token', async function () {
+			it( 'User is taken to the blog post', async function () {
 				await page.waitForURL( new RegExp( newPostDetails.URL + '?token=.*' ) );
 			} );
 		} );


### PR DESCRIPTION
Related to rWPGIT4ed687fb18bc-code.

## Proposed Changes

This PR updates the expectation for the Subscribe flow.

## Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Calypso E2E (desktop)
  - [ ] Jetpack E2E Simple (mobile)
  - [ ] Jetpack E2E Simple (desktop)
  - [ ] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?