### PR TITLE
Newsletter categories: Add blog sticker feature flag check for newsletter categories

### DIFF
--- a/client/data/newsletter-categories/index.ts
+++ b/client/data/newsletter-categories/index.ts
@@ -1,4 +1,5 @@
 export { default as useCategoriesQuery } from './use-categories-query';
+export { default as useNewsletterCategoriesFeatureEnabled } from './use-newsletter-categories-feature-enabled';
 export { default as useNewsletterCategoriesQuery } from './use-newsletter-categories-query';
 export { default as useMarkAsNewsletterCategoryMutation } from './use-mark-as-newsletter-category-mutation';
 export { default as useUnmarkAsNewsletterCategoryMutation } from './use-unmark-as-newsletter-category-mutation';

--- a/client/data/newsletter-categories/test/use-newsletter-categories-feature-enabled.tsx
+++ b/client/data/newsletter-categories/test/use-newsletter-categories-feature-enabled.tsx
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import request from 'wpcom-proxy-request';
+import useNewsletterCategoriesFeatureEnabled from '../use-newsletter-categories-feature-enabled';
+
+jest.mock( 'wpcom-proxy-request', () => jest.fn() );
+
+describe( 'useNewsletterCategoriesFeatureEnabled', () => {
+	let queryClient: QueryClient;
+	let wrapper: any;
+
+	beforeEach( () => {
+		( request as jest.MockedFunction< typeof request > ).mockReset();
+
+		queryClient = new QueryClient( {
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		} );
+
+		wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should return true when newsletter-categories is in the response', async () => {
+		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( [
+			'newsletter-categories',
+			'some-other-category',
+		] );
+
+		const { result } = renderHook( () => useNewsletterCategoriesFeatureEnabled( { siteId: 123 } ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( result.current ).toBe( true ) );
+
+		expect( result.current ).toEqual( true );
+	} );
+
+	it( 'should return false when newsletter-categories is not in the response', async () => {
+		( request as jest.MockedFunction< typeof request > ).mockResolvedValue( [
+			'some-other-category',
+		] );
+
+		const { result } = renderHook( () => useNewsletterCategoriesFeatureEnabled( { siteId: 123 } ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( result.current ).toBe( false ) );
+
+		expect( result.current ).toEqual( false );
+	} );
+} );

--- a/client/data/newsletter-categories/use-newsletter-categories-feature-enabled.ts
+++ b/client/data/newsletter-categories/use-newsletter-categories-feature-enabled.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import request from 'wpcom-proxy-request';
+
+type useNewsletterCategoriesFeatureEnabledProps = {
+	siteId?: string | number;
+};
+
+const useNewsletterCategoriesFeatureEnabled = ( {
+	siteId,
+}: useNewsletterCategoriesFeatureEnabledProps ): boolean => {
+	const { data } = useQuery< string[] >( {
+		queryKey: [ 'blog-stickers', siteId ],
+		queryFn: () => request( { path: `/sites/${ siteId }/blog-stickers` } ),
+		enabled: !! siteId,
+	} );
+
+	return data ? data.includes( 'newsletter-categories' ) : false;
+};
+
+export default useNewsletterCategoriesFeatureEnabled;

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -2,8 +2,11 @@ import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
+import { useNewsletterCategoriesFeatureEnabled } from 'calypso/data/newsletter-categories';
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { NewsletterCategoriesSettings } from '../newsletter-categories-settings';
 import { SubscriptionOptions } from '../settings-reading/main';
 import { EmailsTextSetting } from './EmailsTextSetting';
@@ -48,6 +51,7 @@ export const NewsletterSettingsSection = ( {
 		subscription_options,
 		sm_enabled,
 	} = fields;
+	const siteId = useSelector( getSelectedSiteId ) as number;
 
 	// Update subscription_options form fields when savedSubscriptionOptions changes.
 	// This makes sure the form fields hold the current value after saving.
@@ -58,9 +62,11 @@ export const NewsletterSettingsSection = ( {
 		scrollToAnchor( { offset: 15 } );
 	}, [ savedSubscriptionOptions ] );
 
+	const newsletterCategoriesEnabled = useNewsletterCategoriesFeatureEnabled( { siteId } );
+
 	return (
 		<>
-			{ config.isEnabled( 'settings/newsletter-categories' ) && (
+			{ config.isEnabled( 'settings/newsletter-categories' ) && newsletterCategoriesEnabled && (
 				<Card className="site-settings__card">
 					<NewsletterCategoriesSettings
 						disabled={ disabled }


### PR DESCRIPTION
## Proposed Changes

A new hook "useNewsletterCategoriesFeatureEnabled" has been added to check if the newsletter categories feature is enabled for a particular site. The hook uses data fetched from the `/sites/<siteid>/blog-stickers` endpoint. This was implemented with the intent of providing more controlled feature access. Updates have been made in corresponding files to utilize this new hook. Relied on react-query for data fetching. I added unit tests for the new hook as well.


## Testing Instructions

- Apply this PR
- Visit `http://calypso.localhost:3000/settings/newsletter/<yoursite>`
- The Newsletter Category settings should not show
- Now add the blog sticker `newsletter-categories` to your blog using this command on your sandbox: `wp blog-stickers add --sticker=newsletter-categories --who=yourusername --url=urlofyoursite --blog_id=blogidofyoursite`
- Refresh the page
- The Newsletter Category settings should now show

Run the test: `yarn test-client client/data/newsletter-categories/test/use-newsletter-categories-feature-enabled`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?