### PR TITLE
Add line-break for compact card

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -174,6 +174,7 @@
 
 		.reader-post-card__title-link {
 			display: -webkit-box;
+			line-break: anywhere;
 			-webkit-line-clamp: 2;
 			-webkit-box-orient: vertical;
 			overflow: hidden;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -174,10 +174,10 @@
 
 		.reader-post-card__title-link {
 			display: -webkit-box;
-			line-break: anywhere;
 			-webkit-line-clamp: 2;
 			-webkit-box-orient: vertical;
 			overflow: hidden;
+			max-width: 344px;
 		}
 
 		.reader-post-card__post-media {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -177,6 +177,7 @@
 			-webkit-line-clamp: 2;
 			-webkit-box-orient: vertical;
 			overflow: hidden;
+			overflow-wrap: anywhere;
 			max-width: 344px;
 		}
 


### PR DESCRIPTION
## Description

I noticed today that if there is a long string with no spaces that the compact card can become malformed.

## Before
<img width="670" alt="CleanShot 2023-09-08 at 07 55 59@2x" src="https://github.com/Automattic/wp-calypso/assets/5634774/ab3956a5-5715-4c4a-8bda-a59fe4bf8fdd">

## After
<img width="622" alt="CleanShot 2023-09-08 at 07 59 15@2x" src="https://github.com/Automattic/wp-calypso/assets/5634774/1ee379c7-0f53-4c6d-95a4-40f3df4d3b0d">

## Testing

- Click Calypso Live link
- Head to discover section of the reader
- Right click on any card title and edit it to show the following title: `Are you holding a grudge?.About?.#Dailywritingprompt.`