### PR TITLE
Marketplace: removes obsolette marketplace-jetpack-plugin-search flag and request to wpcom.

### DIFF
--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import languages, { LanguageSlug } from '@automattic/languages';
 import {
 	UseQueryResult,
@@ -124,10 +123,7 @@ export const getESPluginsInfiniteQueryParams = (
 	const [ searchTerm, author ] = extractSearchInformation( options.searchTerm );
 	const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE;
 	const queryKey = getPluginsListKey( [ 'DEBUG-new-site-seach' ], options, true );
-	const groupId =
-		config.isEnabled( 'marketplace-jetpack-plugin-search' ) && options.category !== 'popular'
-			? 'marketplace'
-			: 'wporg';
+	const groupId = options.category !== 'popular' ? 'marketplace' : 'wporg';
 	const queryFn = ( { pageParam = 1 } ) =>
 		search( {
 			query: searchTerm,

--- a/client/my-sites/plugins/plugins-search-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-search-results-page/index.jsx
@@ -36,8 +36,6 @@ const PluginsSearchResultPage = ( {
 	} = usePlugins( {
 		infinite: true,
 		search: searchTerm,
-		wpcomEnabled: !! searchTerm,
-		wporgEnabled: !! searchTerm,
 	} );
 
 	const dispatch = useDispatch();

--- a/client/my-sites/plugins/use-plugins/README.md
+++ b/client/my-sites/plugins/use-plugins/README.md
@@ -22,8 +22,6 @@ The `usePlugins` hook receives a set of options to be able to configure it's beh
 - `search` (string) (optional): A search term to filter plugins through search.
 - `infinite` (boolean) (optional): A flag to activate infinite fetching on the dot org plugins, right now infinite search is not supported by dotcom hooks since there is a limited amount of plugins.
 - `locale` (string) (optional): The locale that is sent to wporg endpoint.
-- `wpcomEnabled` (boolean) (optional): Enables the wordpress.com plugin fetching by default this is set to true.
-- `wporgEnabled` (boolean) (optional): Enables the wordpress.org plugin fetching by default this is set to true.
 
 ## Infinite fetching
 

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -54,9 +54,9 @@ const usePlugins = ( {
 	const categoryTags = categories[ category || '' ]?.tags || [ category ];
 	const tag = categoryTags.join( ',' );
 
-	const { localeSlug = '' } = useTranslate();
+	const translate = useTranslate();
 	const wporgPluginsOptions = {
-		locale: locale || localeSlug,
+		locale: locale || ( translate.localeSlug as string ),
 		category,
 		tag,
 		searchTerm: search,
@@ -80,7 +80,7 @@ const usePlugins = ( {
 		search,
 		tag,
 		{
-			enabled: ! WPCOM_CATEGORIES_BLOCKLIST.includes( category || '' ) && wpcomEnabled,
+			enabled: ! WPCOM_CATEGORIES_BLOCKLIST.includes( category || '' ) && wpcomEnabled && ! search,
 		}
 	) as WPCOMResponse;
 
@@ -106,15 +106,9 @@ const usePlugins = ( {
 			results = featuredPlugins?.length ?? 0;
 			break;
 		default:
-			plugins = config.isEnabled( 'marketplace-jetpack-plugin-search' )
-				? ESPlugins
-				: [ ...dotComPlugins, ...ESPlugins ];
-			isFetching = config.isEnabled( 'marketplace-jetpack-plugin-search' )
-				? isFetchingES
-				: isFetchingDotCom || isFetchingES;
-			results = config.isEnabled( 'marketplace-jetpack-plugin-search' )
-				? ESPagination?.results ?? 0
-				: ( ESPagination?.results ?? 0 ) + dotComPlugins.length;
+			plugins = ESPlugins;
+			isFetching = isFetchingES;
+			results = ESPagination?.results ?? 0;
 
 			break;
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -120,7 +120,6 @@
 		"manage/import/site-importer-endpoints": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-fetch-all-dynamic-products": true,
-		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
 		"me/account-close": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -73,7 +73,6 @@
 		"mailchimp": false,
 		"marketplace-domain-bundle": false,
 		"marketplace-fetch-all-dynamic-products": true,
-		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,

--- a/config/production.json
+++ b/config/production.json
@@ -89,7 +89,6 @@
 		"mailchimp": true,
 		"marketplace-domain-bundle": false,
 		"marketplace-fetch-all-dynamic-products": false,
-		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,
 		"me/account-close": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -85,7 +85,6 @@
 		"mailchimp": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-fetch-all-dynamic-products": true,
-		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
 		"me/account-close": true,

--- a/config/test.json
+++ b/config/test.json
@@ -66,7 +66,6 @@
 		"legal-updates-banner": true,
 		"mailchimp": true,
 		"marketplace-fetch-all-dynamic-products": true,
-		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"me/account-close": true,
 		"me/vat-details": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -93,7 +93,6 @@
 		"mailchimp": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-fetch-all-dynamic-products": true,
-		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
 		"me/account-close": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1694167202247709-slack-C02JPCHEKDY

## Proposed Changes

* Removes `marketplace-jetpack-plugin-search` flag
* Removes undesired request to wpcom for searches

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins`
* Inspect that production and this branch looks the same
* Click to any category and inspect again
* Open network tab in browser tools 
* Search for `yoast`
* Make sure that there hasn't been triggered `https://public-api.wordpress.com/wpcom/v2/marketplace/products?_envelope=1&type=all&q=yoast`
* Inspect that results look the same as in production

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?