### PR TITLE
state: refactor away from `_.mapKeys`

### DIFF
--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -446,7 +446,7 @@ export function edits( state = {}, action ) {
 
 			// if new post (edited with a transient postId of '') has been just saved and assigned
 			// a real numeric ID, rewrite the state key with the new postId.
-			if ( postId === '' && action.savedPost ) {
+			if ( postId === '' && action.savedPost && state[ siteId ] ) {
 				const newPostId = action.savedPost.ID;
 				state = {
 					...state,

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -450,10 +450,12 @@ export function edits( state = {}, action ) {
 				const newPostId = action.savedPost.ID;
 				state = {
 					...state,
-					[ siteId ]: Object.entries( state[ siteId ] ).reduce( ( acc, [ key, value ] ) => {
-						acc[ key === '' ? newPostId : key ] = value;
-						return acc;
-					}, {} ),
+					[ siteId ]: Object.fromEntries(
+						Object.entries( state[ siteId ] ).map( ( [ key, value ] ) => [
+							key === '' ? newPostId : key,
+							value,
+						] )
+					),
 				};
 			}
 

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -11,7 +11,6 @@ import {
 	merge,
 	findKey,
 	mapValues,
-	mapKeys,
 } from 'lodash';
 import PostQueryManager from 'calypso/lib/query-manager/post';
 import withQueryManager from 'calypso/lib/query-manager/with-query-manager';
@@ -451,9 +450,10 @@ export function edits( state = {}, action ) {
 				const newPostId = action.savedPost.ID;
 				state = {
 					...state,
-					[ siteId ]: mapKeys( state[ siteId ], ( value, key ) =>
-						key === '' ? newPostId : key
-					),
+					[ siteId ]: Object.entries( state[ siteId ] ).reduce( ( acc, [ key, value ] ) => {
+						acc[ key === '' ? newPostId : key ] = value;
+						return acc;
+					}, {} ),
 				};
 			}
 

--- a/client/state/sites/domains/assembler.js
+++ b/client/state/sites/domains/assembler.js
@@ -11,10 +11,12 @@ function assembleGoogleAppsSubscription( googleAppsSubscription ) {
 		return;
 	}
 
-	return Object.entries( googleAppsSubscription ).reduce( ( acc, [ key, value ] ) => {
-		acc[ camelCase( key ) ] = value;
-		return acc;
-	}, {} );
+	return Object.fromEntries(
+		Object.entries( googleAppsSubscription ).map( ( [ key, value ] ) => [
+			camelCase( key ),
+			value,
+		] )
+	);
 }
 
 function assembleCurrentUserCannotAddEmailReason( reason ) {

--- a/client/state/sites/domains/assembler.js
+++ b/client/state/sites/domains/assembler.js
@@ -1,4 +1,4 @@
-import { camelCase, mapKeys } from 'lodash';
+import { camelCase } from 'lodash';
 import {
 	getDomainRegistrationAgreementUrl,
 	getDomainType,
@@ -11,7 +11,10 @@ function assembleGoogleAppsSubscription( googleAppsSubscription ) {
 		return;
 	}
 
-	return mapKeys( googleAppsSubscription, ( value, key ) => camelCase( key ) );
+	return Object.entries( googleAppsSubscription ).reduce( ( acc, [ key, value ] ) => {
+		acc[ camelCase( key ) ] = value;
+		return acc;
+	}, {} );
 }
 
 function assembleCurrentUserCannotAddEmailReason( reason ) {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -1,5 +1,5 @@
 import { translate, getLocaleSlug } from 'i18n-calypso';
-import { sortBy, camelCase, mapKeys, get, filter, map, flatten } from 'lodash';
+import { sortBy, camelCase, get, filter, map, flatten } from 'lodash';
 import moment from 'moment';
 import { PUBLICIZE_SERVICES_LABEL_ICON } from './constants';
 
@@ -312,7 +312,10 @@ export const normalizers = {
 			return null;
 		}
 
-		return mapKeys( data.stats, ( value, key ) => camelCase( key ) );
+		return Object.entries( data.stats ).reduce( ( acc, [ key, value ] ) => {
+			acc[ camelCase( key ) ] = value;
+			return acc;
+		}, {} );
 	},
 
 	/**

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -312,10 +312,9 @@ export const normalizers = {
 			return null;
 		}
 
-		return Object.entries( data.stats ).reduce( ( acc, [ key, value ] ) => {
-			acc[ camelCase( key ) ] = value;
-			return acc;
-		}, {} );
+		return Object.fromEntries(
+			Object.entries( data.stats ).map( ( [ key, value ] ) => [ camelCase( key ), value ] )
+		);
 	},
 
 	/**

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -796,7 +796,11 @@ describe( 'loading stored state with dynamic reducers', () => {
 	const withKeyPrefix = ( keyPrefix ) => {
 		const keyPrefixRe = new RegExp( `^${ keyPrefix }:` );
 		return withPersistence( ( state = {} ) => state, {
-			serialize: ( state ) => mapKeys( state, ( value, key ) => `${ keyPrefix }:${ key }` ),
+			serialize: ( state ) =>
+				Object.entries( state ).reduce( ( acc, [ key, value ] ) => {
+					acc[ `${ keyPrefix }:${ key }` ] = value;
+					return acc;
+				}, {} ),
 			deserialize: ( persisted ) =>
 				mapKeys( persisted, ( value, key ) => key.replace( keyPrefixRe, '' ) ),
 		} );

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -3,7 +3,6 @@
  */
 
 import { withStorageKey } from '@automattic/state-utils';
-import { mapKeys } from 'lodash';
 import * as browserStorage from 'calypso/lib/browser-storage';
 import { isSupportSession } from 'calypso/lib/user/support-user-interop';
 import { createReduxStore } from 'calypso/state';
@@ -797,12 +796,21 @@ describe( 'loading stored state with dynamic reducers', () => {
 		const keyPrefixRe = new RegExp( `^${ keyPrefix }:` );
 		return withPersistence( ( state = {} ) => state, {
 			serialize: ( state ) =>
-				Object.entries( state ).reduce( ( acc, [ key, value ] ) => {
-					acc[ `${ keyPrefix }:${ key }` ] = value;
-					return acc;
-				}, {} ),
+				Object.fromEntries(
+					Object.entries( state ).reduce( ( acc, [ key, value ] ) => [
+						`${ keyPrefix }:${ key }`,
+						value,
+					] )
+				),
 			deserialize: ( persisted ) =>
-				mapKeys( persisted, ( value, key ) => key.replace( keyPrefixRe, '' ) ),
+				persisted
+					? Object.fromEntries(
+							Object.entries( persisted ).map( ( [ key, value ] ) => [
+								key.replace( keyPrefixRe, '' ),
+								value,
+							] )
+					  )
+					: {},
 		} );
 	};
 

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -797,10 +797,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 		return withPersistence( ( state = {} ) => state, {
 			serialize: ( state ) =>
 				Object.fromEntries(
-					Object.entries( state ).reduce( ( acc, [ key, value ] ) => [
-						`${ keyPrefix }:${ key }`,
-						value,
-					] )
+					Object.entries( state ).map( ( [ key, value ] ) => [ `${ keyPrefix }:${ key }`, value ] )
 				),
 			deserialize: ( persisted ) =>
 				persisted

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -1,4 +1,4 @@
-import { get, includes, map, mapKeys, omit, omitBy, some, startsWith } from 'lodash';
+import { get, includes, map, omit, omitBy, some, startsWith } from 'lodash';
 import { DEFAULT_THEME_QUERY } from './constants';
 
 /**
@@ -65,7 +65,12 @@ export function normalizeWpcomTheme( theme ) {
 		download_uri: 'download',
 	};
 
-	return mapKeys( theme, ( value, key ) => get( attributesMap, key, key ) );
+	return theme
+		? Object.entries( theme ).reduce( ( acc, [ key, value ] ) => {
+				acc[ attributesMap[ key ] ?? key ] = value;
+				return acc;
+		  }, {} )
+		: {};
 }
 
 /**
@@ -82,9 +87,15 @@ export function normalizeWporgTheme( theme ) {
 		download_link: 'download',
 	};
 
-	const normalizedTheme = mapKeys( omit( theme, [ 'sections', 'author' ] ), ( value, key ) =>
-		get( attributesMap, key, key )
-	);
+	const normalizedTheme = theme
+		? Object.entries( theme ).reduce( ( acc, [ key, value ] ) => {
+				if ( [ 'sections', 'author' ].includes( key ) ) {
+					return acc;
+				}
+				acc[ attributesMap[ key ] ?? key ] = value;
+				return acc;
+		  }, {} )
+		: {};
 
 	const description = get( theme, [ 'sections', 'description' ] );
 	if ( description ) {

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -65,12 +65,13 @@ export function normalizeWpcomTheme( theme ) {
 		download_uri: 'download',
 	};
 
-	return theme
-		? Object.entries( theme ).reduce( ( acc, [ key, value ] ) => {
-				acc[ attributesMap[ key ] ?? key ] = value;
-				return acc;
-		  }, {} )
-		: {};
+	if ( ! theme ) {
+		return {};
+	}
+
+	return Object.fromEntries(
+		Object.entries( theme ).map( ( [ key, value ] ) => [ attributesMap[ key ] ?? key, value ] )
+	);
 }
 
 /**
@@ -87,15 +88,12 @@ export function normalizeWporgTheme( theme ) {
 		download_link: 'download',
 	};
 
-	const normalizedTheme = theme
-		? Object.entries( theme ).reduce( ( acc, [ key, value ] ) => {
-				if ( [ 'sections', 'author' ].includes( key ) ) {
-					return acc;
-				}
-				acc[ attributesMap[ key ] ?? key ] = value;
-				return acc;
-		  }, {} )
-		: {};
+	const normalizedTheme = Object.fromEntries(
+		Object.entries( omit( theme, [ 'sections', 'author' ] ) ).map( ( [ key, value ] ) => [
+			attributesMap[ key ] ?? key,
+			value,
+		] )
+	);
 
 	const description = get( theme, [ 'sections', 'description' ] );
 	if ( description ) {


### PR DESCRIPTION
## Proposed Changes

* Refactor away from `_.mapKeys` in Calypso state related files (`client/state`)

## Testing Instructions

* Changes are covered by unit tests, verify they still pass

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
