### PR TITLE
Subscribers page: add link to migrate subscribers from another wp.com site

### DIFF
--- a/client/my-sites/site-settings/subscriptions.jsx
+++ b/client/my-sites/site-settings/subscriptions.jsx
@@ -80,11 +80,7 @@ const Subscriptions = ( {
 			</CompactCard>
 
 			<CompactCard href={ viewFollowersSubscribersLink }>
-				{ translate( 'View your email followers' ) }
-			</CompactCard>
-
-			<CompactCard href={ 'https://wordpress.com/manage/' + selectedSiteId }>
-				{ translate( 'Migrate followers from another site' ) }
+				{ translate( 'View or add subscribers' ) }
 			</CompactCard>
 		</div>
 	);

--- a/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
@@ -6,7 +6,10 @@ import { useDispatch } from 'react-redux';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { addQueryArgs } from 'calypso/lib/url';
+import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
+import { useSelector } from 'calypso/state';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { useRecordExport } from '../../tracks';
 import '../shared/popover-style.scss';
 
@@ -23,7 +26,9 @@ const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) =
 		{ page: 'subscribers', blog: siteId, blog_subscribers: 'csv', type: 'all' },
 		'https://dashboard.wordpress.com/wp-admin/index.php'
 	);
+	const { grandTotal } = useSubscribersPage();
 	const recordExport = useRecordExport();
+	const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
 
 	const onDownloadCsvClick = () => {
 		dispatch(
@@ -34,6 +39,14 @@ const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) =
 		);
 		recordExport();
 	};
+
+	const hasSubscribers = grandTotal > 0;
+	const hasMultipleSites = currentUserSiteCount && currentUserSiteCount > 1;
+
+	// No point showing the dropdown if they don't have subscribers or sites
+	if ( ! hasSubscribers && ! hasMultipleSites ) {
+		return null;
+	}
 
 	return (
 		<div className="subscriber-popover__container">
@@ -55,9 +68,16 @@ const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) =
 				className="subscriber-popover"
 				focusOnShow={ false }
 			>
-				<PopoverMenuItem href={ downloadCsvLink } onClick={ onDownloadCsvClick }>
-					{ translate( 'Download subscribers as CSV' ) }
-				</PopoverMenuItem>
+				{ hasSubscribers && (
+					<PopoverMenuItem href={ downloadCsvLink } onClick={ onDownloadCsvClick }>
+						{ translate( 'Download subscribers as CSV' ) }
+					</PopoverMenuItem>
+				) }
+				{ hasMultipleSites && (
+					<PopoverMenuItem href={ `https://wordpress.com/manage/${ siteId }` }>
+						{ translate( 'Migrate subscribers from another WordPress.com site' ) }
+					</PopoverMenuItem>
+				) }
 			</PopoverMenu>
 		</div>
 	);

--- a/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
@@ -11,7 +11,7 @@ type SubscribersHeaderProps = {
 };
 
 const SubscribersHeader = ( { navigationItems, selectedSiteId }: SubscribersHeaderProps ) => {
-	const { grandTotal, setShowAddSubscribersModal } = useSubscribersPage();
+	const { setShowAddSubscribersModal } = useSubscribersPage();
 
 	return (
 		<FixedNavigationHeader navigationItems={ navigationItems }>
@@ -23,7 +23,7 @@ const SubscribersHeader = ( { navigationItems, selectedSiteId }: SubscribersHead
 				<Gridicon icon="plus" size={ 24 } />
 				{ translate( 'Add subscribers' ) }
 			</Button>
-			{ grandTotal ? <SubscribersHeaderPopover siteId={ selectedSiteId } /> : null }
+			<SubscribersHeaderPopover siteId={ selectedSiteId } />
 		</FixedNavigationHeader>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/77670

Another placement for this link could be under "add subscribers" modal

## Proposed Changes

* Add link to subscribers page under dropdown
* Remove the link from Discussion settings (available for Atomic only)

**Before**

<img width="301" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/0fd56fb7-b73e-4965-aec8-b69a45aeafe8">

<img width="736" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/e490725d-feeb-4ace-95cc-24f219483701">

**After**

<img width="473" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/62c1229b-1c72-41ec-b81a-7b737da0e9ec">

<img width="765" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/b51fc0c0-8103-4278-98c3-dc582c786988">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On atomic site, visit "Discussion settings". Scroll down, and see the link gone.
* On any site, see "Subscribers" page and check 3 dots dropdown
* If you don't have 2+ sites, the migrate link won't show.
* If you don't have subscribers, the export link won't show.
* If either of above is the case, you don't see 3 dots menu at all.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?