### PR TITLE
Subscription Management: Launch individual subscription page on Reader portal.

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-row.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { isValidId } from '@automattic/data-stores/src/reader';
@@ -158,11 +157,7 @@ const SiteRow = ( {
 				return feedUrl;
 			}
 
-			if ( config.isEnabled( 'reader/individual-subscription-page' ) ) {
-				return `/read/subscriptions/${ subscriptionId }`;
-			}
-
-			return feedUrl;
+			return `/read/subscriptions/${ subscriptionId }`;
 		}
 
 		if ( isSubscriptionsPortal ) {

--- a/config/development.json
+++ b/config/development.json
@@ -163,7 +163,6 @@
 		"reader/full-errors": true,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,
-		"reader/individual-subscription-page": true,
 		"recommend-plugins": true,
 		"redirect-fallback-browsers": false,
 		"rum-tracking/logstash": true,


### PR DESCRIPTION
Fixes #81149

## Proposed Changes

* Ship individual subscription page on Reader

## Testing Instructions

* Go to `/read/subscriptions`.
* Click on a subscription.
* It should go to `/read/subscriptions/<subscription_id>`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?