### PR TITLE
Add handling for 1 month intro discounts in Jetpack 2 year upsell

### DIFF
--- a/client/my-sites/checkout/src/components/item-variation-picker/util.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/util.ts
@@ -15,7 +15,11 @@ export function getItemVariantCompareToPrice(
 	}
 
 	// Ignore a 1 month discount when calculating the discount percentage
-	if ( compareTo.introductoryInterval === 1 && compareTo.introductoryTerm === 'month' ) {
+	if (
+		variant.termIntervalInMonths === 24 &&
+		compareTo.introductoryInterval === 1 &&
+		compareTo.introductoryTerm === 'month'
+	) {
 		return compareTo.priceBeforeDiscounts * 2;
 	}
 

--- a/client/my-sites/checkout/src/components/item-variation-picker/util.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/util.ts
@@ -14,6 +14,11 @@ export function getItemVariantCompareToPrice(
 		return undefined;
 	}
 
+	// Ignore a 1 month discount when calculating the discount percentage
+	if ( compareTo.introductoryInterval === 1 && compareTo.introductoryTerm === 'month' ) {
+		return compareTo.priceBeforeDiscounts * 2;
+	}
+
 	// CompareTo price with introductory offers (For Jetpack)
 	if (
 		compareTo.introductoryInterval === 1 &&
@@ -33,10 +38,18 @@ export function getItemVariantDiscountPercentage(
 	compareTo?: WPCOMProductVariant
 ): number {
 	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
+
+	// Ignore intro discount if it is a 1 month only discount
+	const variantPrice =
+		variant.introductoryInterval === 1 && variant.introductoryTerm === 'month'
+			? variant.priceBeforeDiscounts
+			: variant.priceInteger;
+
 	// Extremely low "discounts" are possible if the price of the longer term has been rounded
 	// if they cannot be rounded to at least a percentage point we should not show them.
 	const discountPercentage = compareToPriceForVariantTerm
-		? Math.round( 100 - ( variant.priceInteger / compareToPriceForVariantTerm ) * 100 )
+		? Math.round( 100 - ( variantPrice / compareToPriceForVariantTerm ) * 100 )
 		: 0;
+
 	return discountPercentage;
 }


### PR DESCRIPTION
## Proposed Changes

* Ignore 1 month intro discounts when calculating the 2 year upsell discount percentage

Slack: p1694166055541249-slack-C02LK1W8T4Z

## Testing Instructions

1. Use the Calypso live link or checkout this branch locally
2. Go to `/checkout/jetpack/jetpack_social_advanced_yearly`
3. Make sure the upsell discount percentage is calculated correctly
![image](https://github.com/Automattic/wp-calypso/assets/65001528/bbca9451-7567-4a41-9e45-9134555cb977)
4. Check other products to make sure they still work as well
(stats)
![image](https://github.com/Automattic/wp-calypso/assets/65001528/e48e71ee-5e3f-4829-aecc-8cbcff2f634f)
(backup)
![image](https://github.com/Automattic/wp-calypso/assets/65001528/2574dfdd-e2c6-499b-8d19-f1247e86524d)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?