### PR TITLE
Fix broken link to Built By from the Cancel flow

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -157,8 +157,8 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 					acceptButtonText={ translate( 'Get help building my site' ) }
 					onAccept={ () => {
 						recordTracksEvent( 'calypso_cancellation_upsell_step_buily_by_click' );
+						window.location.replace( builtByURL );
 					} }
-					acceptButtonUrl={ builtByURL }
 					onDecline={ props.onDeclineUpsell }
 					image={ imgBuiltBy }
 				>


### PR DESCRIPTION
The html a tag won't work for landpack pages because it tries to go through calypso routing and hangs.

There are a few workarounds, the quickest seems to be to use location.href or a similar redirect. I'm using replace because there's another place where we do the same for consistency

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Use window.location.replace instead of a href to make loading this landpack page work.

## Testing Instructions

* With the Store Sandbox enabled, buy Business
* Go to /me/purchase and click Cancel
* Select that I couldn't finish / need professional to help

<img width="749" alt="Screenshot 2023-09-08 at 18 54 57" src="https://github.com/Automattic/wp-calypso/assets/82778/7d865999-1898-497c-aeba-1e60030c61e5">

The get help button needs to work and point to a landing page outside Calypso

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
