### PR TITLE
Stats: update wizard phrasing

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -71,7 +71,7 @@ const ProductCard = ( {
 	const commercialProductTitle = translate( 'Upgrade your Jetpack Stats' );
 
 	// Default titles for no site type selected.
-	let typeSelectionScreenLabel = translate( 'What site type is %(site)s?', {
+	let typeSelectionScreenLabel = translate( 'What type of site is %(site)s?', {
 		args: {
 			site: siteSlug,
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81488

## Proposed Changes

* This small PR updates the phrasing on the purchase wizard from `What site type is {site title}`  to `What type of site is {site title}`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the Calypso live branch
* Navigate to a site which does not already have a JP stats plan
* Go to `stats/purchase/{siteURL}`
* If it is a wpcom simple site, append the flag `flags=stats/paid-wpcom-stats`
* Check that the phrasing reads `What type of site is {site title}`

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/30754158/351f836b-7735-4ecb-8ad8-32b25638b72e)  | ![image](https://github.com/Automattic/wp-calypso/assets/30754158/5e9ce50e-5e47-46d8-b647-c8d38ace2e59)  |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?