### PR TITLE
Fix: don't redirect to json redirect endpoint

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -331,6 +331,10 @@ export function redirectToPermalinkIfLoggedOut( context, next ) {
 	) {
 		return next();
 	}
+
+	if ( ! context.params.post ) {
+		return next();
+	}
 	// Redirect the logged user to the permalink of the post, page, custom post type if the post is published.
 	// else the endpoint will redirect the user to the login page.
 	window.location = `https://public-api.wordpress.com/wpcom/v2/sites/${ siteFragment }/editor/redirect?path=${ context.path }`;

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -316,27 +316,20 @@ export function redirectToPermalinkIfLoggedOut( context, next ) {
 		return next();
 	}
 	const siteFragment = context.params.site || getSiteFragment( context.path );
-	const CONFIGURABLE_TYPES = [ 'jetpack-portfolio', 'jetpack-testimonial' ];
 
-	// The context.path in this case could be one of the following:
+	// Check the path is this format.
 	// - /page/{site}/{id}
 	// - /post/{site}/{id}
 	// - /edit/jetpack-portfolio/{site}/{id}
 	// - /edit/jetpack-testimonial/{site}/{id}
-	const explodedPath = context.path.split( '/' );
-	if (
-		context.path &&
-		explodedPath[ 1 ] === 'edit' &&
-		! CONFIGURABLE_TYPES.includes( explodedPath[ 2 ] )
-	) {
-		return next();
+	const postId = parseInt( context.params.post, 10 );
+	const linksToSingleView = postId > 0;
+	if ( linksToSingleView && context.path && siteFragment ) {
+		// Redirect the logged user to the permalink of the post, page, custom post type if the post is published.
+		// else the endpoint will redirect the user to the login page.
+		window.location = `https://public-api.wordpress.com/wpcom/v2/sites/${ siteFragment }/editor/redirect?path=${ context.path }`;
+		return;
 	}
-
-	if ( ! context.params.post ) {
-		return next();
-	}
-	// Redirect the logged user to the permalink of the post, page, custom post type if the post is published.
-	// else the endpoint will redirect the user to the login page.
-	window.location = `https://public-api.wordpress.com/wpcom/v2/sites/${ siteFragment }/editor/redirect?path=${ context.path }`;
-	return;
+	// Else redirect the user to the login page.
+	return next();
 }

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -319,7 +319,7 @@ export function redirectToPermalinkIfLoggedOut( context, next ) {
 	if ( ! siteFragment || ! context.path ) {
 		return next();
 	}
-	// Check the path is this format.
+	// Check if the path is in this format.
 	// - /page/{site}/{id}
 	// - /post/{site}/{id}
 	// - /edit/jetpack-portfolio/{site}/{id}

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -316,7 +316,9 @@ export function redirectToPermalinkIfLoggedOut( context, next ) {
 		return next();
 	}
 	const siteFragment = context.params.site || getSiteFragment( context.path );
-
+	if ( ! siteFragment || ! context.path ) {
+		return next();
+	}
 	// Check the path is this format.
 	// - /page/{site}/{id}
 	// - /post/{site}/{id}
@@ -324,9 +326,8 @@ export function redirectToPermalinkIfLoggedOut( context, next ) {
 	// - /edit/jetpack-testimonial/{site}/{id}
 	const postId = parseInt( context.params.post, 10 );
 	const linksToSingleView = postId > 0;
-	if ( linksToSingleView && context.path && siteFragment ) {
+	if ( linksToSingleView ) {
 		// Redirect the logged user to the permalink of the post, page, custom post type if the post is published.
-		// else the endpoint will redirect the user to the login page.
 		window.location = `https://public-api.wordpress.com/wpcom/v2/sites/${ siteFragment }/editor/redirect?path=${ context.path }`;
 		return;
 	}


### PR DESCRIPTION
This fixes an issue where we we redirecting users that were not logged in to a json redirect endpoint. 


## Proposed Changes

* The change checks that the post is set before we try to redirect the loggout user to the permalink. 
The regression was introduced in https://github.com/Automattic/wp-calypso/pull/62447
## Testing Instructions

* When you visit /post/example.com notice that you get redirected back to the login. 
* When you visit /page/enejtest10.wordpress.com/58 you should get redirected to the permalink. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
