### PR TITLE
Flaky Jetpack E2E: fix flaky interaction of the editor block toolbar for the AI Assistant block flow.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
@@ -20,7 +20,7 @@ interface ValidationData {
 	keywords: string[];
 }
 
-const TIMEOUT = 30 * 1000;
+const TIMEOUT = 15 * 1000;
 
 /**
  * Represents the flow of using the AI Assistant block.
@@ -102,16 +102,16 @@ export class AIAssistantFlow implements BlockFlow {
 	 * @param {Locator} block Locator to the block.
 	 */
 	private async waitForQuery( block: Locator ) {
-		const handle = await block.elementHandle();
-
-		// This is an attempt to wait for the AI block to fully finish rendering
-		// before interacting with the toolbar.
-		await Promise.all( [
-			block
+		try {
+			await block
 				.getByRole( 'button', { name: 'Stop request' } )
-				.waitFor( { state: 'detached', timeout: TIMEOUT } ),
-			handle?.waitForElementState( 'stable', { timeout: TIMEOUT } ),
-		] );
+				.waitFor( { state: 'detached', timeout: TIMEOUT } );
+		} catch {
+			// Stop the generation request after the timeout is met.
+			// AI Assistant block will retain any generated
+			// text up to this point.
+			await block.getByRole( 'button', { name: 'Stop request' } ).click();
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
@@ -20,9 +20,9 @@ interface ValidationData {
 	keywords: string[];
 }
 
-const TIMEOUT = 15 * 1000;
+const TIMEOUT = 30 * 1000;
 
-/**
+/**it com
  * Represents the flow of using the AI Assistant block.
  */
 export class AIAssistantFlow implements BlockFlow {

--- a/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
@@ -56,10 +56,13 @@ export class EditorBlockToolbarComponent {
 
 		if ( identifier.name ) {
 			// Accessible names don't need to have the selector built.
-			await editorParent.getByRole( 'button', { name: identifier.name } ).click();
+			const locator = editorParent.getByRole( 'button', { name: identifier.name } );
+			await locator.waitFor();
+			await locator.click();
 		} else {
 			// Other identifers need to have the selector built.
 			const locator = editorParent.locator( selectors.button( identifier ) );
+			await locator.waitFor();
 			await locator.click();
 		}
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Locator, Page } from 'playwright';
 import { envVariables } from '../..';
 import { EditorComponent } from './editor-component';
 
@@ -54,17 +54,19 @@ export class EditorBlockToolbarComponent {
 	async clickPrimaryButton( identifier: BlockToolbarButtonIdentifier ): Promise< void > {
 		const editorParent = await this.editor.parent();
 
+		let locator: Locator;
 		if ( identifier.name ) {
 			// Accessible names don't need to have the selector built.
-			const locator = editorParent.getByRole( 'button', { name: identifier.name } );
-			await locator.waitFor();
-			await locator.click();
+			locator = editorParent.getByRole( 'button', { name: identifier.name } );
 		} else {
 			// Other identifers need to have the selector built.
-			const locator = editorParent.locator( selectors.button( identifier ) );
-			await locator.waitFor();
-			await locator.click();
+			locator = editorParent.locator( selectors.button( identifier ) );
 		}
+
+		const handle = await locator.elementHandle();
+		await handle?.waitForElementState( 'stable' );
+
+		await locator.click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-popover-menu-component.ts
@@ -26,6 +26,7 @@ export class EditorPopoverMenuComponent {
 		const editorParent = await this.editor.parent();
 
 		const locator = editorParent.getByRole( 'menuitem', { name: name } );
+		await locator.waitFor();
 		await locator.click();
 	}
 }


### PR DESCRIPTION
Related to: https://github.com/Automattic/wp-calypso/issues/81547 and https://github.com/Automattic/wp-calypso/issues/81547.

Fixes https://github.com/Automattic/wp-calypso/issues/81547.

## Proposed Changes

This PR uses the `elementHandle` and `waitForElementState` to wait for the teditor toolbar element to be stable before interaction.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [ ] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?