### PR TITLE
Jetpack Manage: Add missing track events for WPCOM hosting feature.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/wpcom-atomic-hosting-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/wpcom-atomic-hosting-notification.tsx
@@ -1,5 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import checkIcon from 'calypso/assets/images/jetpack/jetpack-green-checkmark.svg';
 import Banner from 'calypso/components/banner';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
@@ -31,6 +32,16 @@ export default function WPCOMAtomicHostingNotification( {
 	};
 
 	const siteSlug = urlToSlug( selectedSite );
+
+	useEffect( () => {
+		// Track event when this notification is displayed.
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_agency_dashboard_wpcom_hosting_notification_view', {
+				site: selectedSite,
+				licenseItem,
+			} )
+		);
+	}, [ dispatch, licenseItem, selectedSite ] );
 
 	const extraContent = (
 		<div className="site-add-license-notification__license-banner-wp-buttons">
@@ -82,7 +93,7 @@ export default function WPCOMAtomicHostingNotification( {
 				horizontal
 				iconPath={ checkIcon }
 				onDismiss={ () =>
-					handleOnClick( 'calypso_jetpack_agency_dashboard_wpcom_hosting-notification_dismiss' )
+					handleOnClick( 'calypso_jetpack_agency_dashboard_wpcom_hosting_notification_dismiss' )
 				}
 				extraContent={ extraContent }
 			/>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -168,6 +168,10 @@ export default function SiteStatusContent( {
 				? `https://wordpress.com/home/${ urlToSlug( siteUrl ) }`
 				: `/activity-log/${ urlToSlug( siteUrl ) }`;
 
+		const handleSiteClick = () => {
+			dispatch( recordTracksEvent( 'calypso_jetpack_agency_dashboard_site_link_click' ) );
+		};
+
 		return (
 			<>
 				{ isBulkManagementActive ? (
@@ -190,6 +194,7 @@ export default function SiteStatusContent( {
 						compact
 						href={ siteRedirectURL }
 						target={ isWPCOMAtomicSiteCreationEnabled && isWPCOMAtomicSite ? '_blank' : '_self' }
+						onClick={ handleSiteClick }
 					>
 						{ WPCOMHostedSiteBadgeColumn }
 						{ siteUrl }

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -1,7 +1,9 @@
 import { Button, JetpackLogo, WooLogo, CloudLogo } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import Tooltip from 'calypso/components/tooltip';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import FeatureItem from './feature-item';
 
 import './style.scss';
@@ -22,6 +24,7 @@ interface PlanInfo {
 }
 
 export default function CardContent( { planSlug }: { planSlug: string } ) {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const tooltipRef = useRef< HTMLDivElement | null >( null );
 	const [ showPopover, setShowPopover ] = useState( false );
@@ -32,6 +35,17 @@ export default function CardContent( { planSlug }: { planSlug: string } ) {
 				return <CloudLogo />;
 			case JETPACK_HOSTING_WPCOM_ECOMMERCE:
 				return <WooLogo />;
+			default:
+				return null;
+		}
+	};
+
+	const getCTAEventName = ( planSlug: string ) => {
+		switch ( planSlug ) {
+			case JETPACK_HOSTING_WPCOM_BUSINESS:
+				return 'calypso_jetpack_agency_dashboard_wpcom_atomic_hosting_business_cta_click';
+			case JETPACK_HOSTING_WPCOM_ECOMMERCE:
+				return 'calypso_jetpack_agency_dashboard_wpcom_atomic_hosting_ecommerce_cta_click';
 			default:
 				return null;
 		}
@@ -67,6 +81,10 @@ export default function CardContent( { planSlug }: { planSlug: string } ) {
 
 	const plan = getPlanInfo( planSlug );
 
+	const onCTAClick = useCallback( () => {
+		dispatch( recordTracksEvent( getCTAEventName( planSlug ) ) );
+	}, [ dispatch, planSlug ] );
+
 	if ( ! plan ) {
 		return null;
 	}
@@ -82,7 +100,7 @@ export default function CardContent( { planSlug }: { planSlug: string } ) {
 					{ plan.interval === 'day' && translate( '/USD per license per day' ) }
 					{ plan.interval === 'month' && translate( '/USD per license per month' ) }
 				</div>
-				<Button className="wpcom-atomic-hosting__card-button" primary>
+				<Button className="wpcom-atomic-hosting__card-button" primary onClick={ onCTAClick }>
 					{ translate( 'Get %(title)s', {
 						args: {
 							title: plan.title,

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/index.tsx
@@ -1,6 +1,9 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import Layout from '../../layout';
 import LayoutHeader from '../../layout/header';
 import CardContent from './card-content';
@@ -9,12 +12,18 @@ import './style.scss';
 
 export default function WPCOMAtomicHosting() {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const title = translate( 'Create a new WordPress.com site' );
 
 	const plansToBeDisplayed = [
 		'JETPACK_HOSTING_WPCOM_BUSINESS',
 		'JETPACK_HOSTING_WPCOM_ECOMMERCE',
 	]; // Get the plans from the API
+
+	useEffect( () => {
+		// Track page view
+		dispatch( recordTracksEvent( 'calypso_partner_portal_wpcom_atomic_hosting_page_view' ) );
+	}, [ dispatch ] );
 
 	return (
 		<Layout title={ title } wide>

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/index.tsx
@@ -22,7 +22,9 @@ export default function WPCOMAtomicHosting() {
 
 	useEffect( () => {
 		// Track page view
-		dispatch( recordTracksEvent( 'calypso_partner_portal_wpcom_atomic_hosting_page_view' ) );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_agency_dashboard_wpcom_atomic_hosting_page_view' )
+		);
 	}, [ dispatch ] );
 
 	return (


### PR DESCRIPTION
This PR adds missing track events for the new WPCOM Atomic site hosting feature in Jetpack Manage.

Related to https://github.com/Automattic/jetpack-avalon/issues/15

## Proposed Changes


* Add tracking event when displaying the WPCOM Site creation notification banner.
* Add tracking event when the 'Site' link in the Dashboard table is clicked.
* Add tracking event when the 'Business' or 'ECommerce' plan CTA button is clicked on the Site creation page.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - [2c49b-pb]. Make sure to switch it back to the previous type.

### Site Column ###
<img width="820" alt="Screen Shot 2023-09-11 at 4 04 38 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/bad3125c-00ff-47d0-bb99-974d8f106c86">

* Use the live link below and go to `/dashboard`
* Click any Site link in the dashboard table. 
* Confirm that the `calypso_jetpack_agency_dashboard_site_link_click` event is tracked.

### WPCOM Atomic Site creation Notification Banner ### 
<img width="1426" alt="Screen Shot 2023-09-11 at 3 18 16 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f3fbb9df-e4a1-4e3e-8693-97b102ecd149">

* Refer to the test instruction in #81173
* Confirm that the `calypso_jetpack_agency_dashboard_wpcom_hosting_notification_view` event is tracked when the notification banner is displayed.

### 'Business' and 'ECommerce' CTA button ###

<img width="1455" alt="Screen Shot 2023-09-11 at 2 21 56 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/51760bb7-4fc8-4bbb-b3a6-fad32b781ec7">

* Use the live link below and go to `/partner-portal/create-site`
* Click both CTA buttons and confirm that `calypso_jetpack_agency_dashboard_wpcom_atomic_hosting_business_cta_click` and `calypso_jetpack_agency_dashboard_wpcom_atomic_hosting_ecommerce_cta_click` events are tracked.

### To verify if the track event is dispatched ###
In your browser's network tab. Filter all requests to `t.gif`. This should display all requests with the event name in the payload.
<img width="1031" alt="Screen Shot 2023-09-11 at 4 45 44 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/5ddc3912-64d6-4a23-a59a-07f1a694ba0f">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
