### PR TITLE
Domain Management i1: Mobile layout

### DIFF
--- a/packages/domains-table/src/bulk-actions-toolbar/style.scss
+++ b/packages/domains-table/src/bulk-actions-toolbar/style.scss
@@ -13,6 +13,13 @@
 .domains-table-bulk-actions-toolbar__select.select-dropdown {
 	height: var(--domains-table-toolbar-height);
 	z-index: 1; // Needed for the dropdown to appear overtop of the checkboxes
+	@media ( max-width: 480px) {
+		width: 100%;
+
+		.select-dropdown__container {
+			min-width: 100%;
+		}
+	}
 
 	.select-dropdown__header {
 		height: var(--domains-table-toolbar-height);

--- a/packages/domains-table/src/bulk-actions-toolbar/style.scss
+++ b/packages/domains-table/src/bulk-actions-toolbar/style.scss
@@ -3,6 +3,14 @@
 	flex-direction: row;
 	align-items: center;
 	gap: 20px;
+
+	@media ( max-width: 480px) {
+		flex-direction: column;
+		align-items: flex-start;
+		button {
+			width: 100%;
+		}
+	}
 }
 
 .domains-table-bulk-actions-toolbar__icon {

--- a/packages/domains-table/src/domains-table-filters/index.tsx
+++ b/packages/domains-table/src/domains-table-filters/index.tsx
@@ -1,8 +1,11 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon, SelectDropdown } from '@automattic/components';
 import SearchControl, { SearchIcon } from '@automattic/search';
 import { isMobile } from '@automattic/viewport';
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
+import { useDomainsTable } from '../domains-table/domains-table';
+import { domainsTableColumns } from '../domains-table-header/columns';
 
 import './style.scss';
 
@@ -17,8 +20,37 @@ interface DomainsTableFiltersProps {
 
 export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersProps ) => {
 	const { __ } = useI18n();
-	const [ search, setSearch ] = useState( filter.query );
 
+	const { sortKey, sortDirection, onSortChange, setShowBulkActions, showBulkActions } =
+		useDomainsTable();
+
+	const options: any[] = [];
+	const sortName = domainsTableColumns.find( ( column ) => column.name === sortKey )?.label;
+	const selectedSort = `${ sortName } ${ sortDirection }`;
+
+	domainsTableColumns
+		.filter( ( column ) => column.label !== null )
+		.forEach( ( column ) => {
+			options.push(
+				<SelectDropdown.Item
+					key={ `${ column.name }asc` }
+					onClick={ () => onSortChange( column, 'asc' ) }
+				>
+					{ column.label } Asc
+				</SelectDropdown.Item>
+			);
+
+			options.push(
+				<SelectDropdown.Item
+					key={ `${ column.name }desc` }
+					onClick={ () => onSortChange( column, 'desc' ) }
+				>
+					{ column.label } Desc
+				</SelectDropdown.Item>
+			);
+		} );
+
+	const [ search, setSearch ] = useState( filter.query );
 	const isMobileDevice = isMobile();
 
 	const handleSearchChange = ( query: string ) => {
@@ -48,9 +80,36 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 				disableAutocorrect={ true }
 			/>
 			{ isMobileDevice && (
-				<Button primary={ Boolean( search ) } onClick={ handleSearch }>
-					{ __( 'Filter' ) }
-				</Button>
+				<>
+					<Button primary={ Boolean( search ) } onClick={ handleSearch }>
+						{ __( 'Filter' ) }
+					</Button>
+
+					<div className="domains-table-mobile-cards-controls">
+						<SelectDropdown
+							selectedText={ selectedSort }
+							className="domains-table-mobile-cards-sort-dropdown"
+						>
+							{ options }
+						</SelectDropdown>
+
+						<DropdownMenu
+							className="domains-table-mobile-cards-overflow"
+							icon={ <Gridicon icon="ellipsis" /> }
+							label={ __( 'Domain actions' ) }
+						>
+							{ () => (
+								<MenuGroup>
+									<MenuItem onClick={ () => setShowBulkActions( ! showBulkActions ) }>
+										{ showBulkActions
+											? __( 'Disable Bulk Actions ' )
+											: __( 'Enable Bulk Actions ' ) }
+									</MenuItem>
+								</MenuGroup>
+							) }
+						</DropdownMenu>
+					</div>
+				</>
 			) }
 		</div>
 	);

--- a/packages/domains-table/src/domains-table-filters/index.tsx
+++ b/packages/domains-table/src/domains-table-filters/index.tsx
@@ -27,7 +27,8 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 	const options: any[] = [];
 	const selected = domainsTableColumns.find( ( column ) => column.name === sortKey );
 	const sortName = selected?.sortLabel || selected?.label;
-	const selectedSort = `${ sortName } ${ sortDirection }`;
+	const arrow = sortDirection === 'asc' ? '↓' : '↑';
+	const selectedSort = `${ sortName } ${ arrow }`;
 
 	domainsTableColumns
 		.filter( ( column ) => column.label !== null )
@@ -37,7 +38,7 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 					key={ `${ column.name }asc` }
 					onClick={ () => onSortChange( column, 'asc' ) }
 				>
-					{ column?.sortLabel || column?.label } Asc
+					{ column?.sortLabel || column?.label } ↑
 				</SelectDropdown.Item>
 			);
 
@@ -46,7 +47,7 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 					key={ `${ column.name }desc` }
 					onClick={ () => onSortChange( column, 'desc' ) }
 				>
-					{ column?.sortLabel || column?.label } Desc
+					{ column?.sortLabel || column?.label } ↓
 				</SelectDropdown.Item>
 			);
 		} );

--- a/packages/domains-table/src/domains-table-filters/index.tsx
+++ b/packages/domains-table/src/domains-table-filters/index.tsx
@@ -1,9 +1,8 @@
-import { Button, Gridicon, SelectDropdown } from '@automattic/components';
+import { Gridicon, SelectDropdown } from '@automattic/components';
 import SearchControl, { SearchIcon } from '@automattic/search';
 import { isMobile } from '@automattic/viewport';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { useState } from 'react';
 import { useDomainsTable } from '../domains-table/domains-table';
 import { domainsTableColumns } from '../domains-table-header/columns';
 
@@ -25,7 +24,8 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 		useDomainsTable();
 
 	const options: any[] = [];
-	const sortName = domainsTableColumns.find( ( column ) => column.name === sortKey )?.label;
+	const selected = domainsTableColumns.find( ( column ) => column.name === sortKey );
+	const sortName = selected?.sortLabel || selected?.label;
 	const selectedSort = `${ sortName } ${ sortDirection }`;
 
 	domainsTableColumns
@@ -36,7 +36,7 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 					key={ `${ column.name }asc` }
 					onClick={ () => onSortChange( column, 'asc' ) }
 				>
-					{ column.label } Asc
+					{ column?.sortLabel || column?.label } Asc
 				</SelectDropdown.Item>
 			);
 
@@ -45,35 +45,19 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 					key={ `${ column.name }desc` }
 					onClick={ () => onSortChange( column, 'desc' ) }
 				>
-					{ column.label } Desc
+					{ column?.sortLabel || column?.label } Desc
 				</SelectDropdown.Item>
 			);
 		} );
 
-	const [ search, setSearch ] = useState( filter.query );
 	const isMobileDevice = isMobile();
-
-	const handleSearchChange = ( query: string ) => {
-		if ( query === '' ) {
-			setSearch( '' );
-			onSearch( '' );
-		} else if ( isMobileDevice ) {
-			setSearch( query );
-		} else {
-			onSearch( query );
-		}
-	};
-
-	const handleSearch = () => {
-		onSearch( search );
-	};
 
 	return (
 		<div className="domains-table-filter">
 			<SearchControl
 				searchIcon={ <SearchIcon /> }
 				className="domains-table-filter__search"
-				onSearch={ handleSearchChange }
+				onSearch={ onSearch }
 				defaultValue={ filter.query }
 				isReskinned
 				placeholder={ __( 'Search by domain…' ) }
@@ -81,10 +65,6 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 			/>
 			{ isMobileDevice && (
 				<>
-					<Button primary={ Boolean( search ) } onClick={ handleSearch }>
-						{ __( 'Filter' ) }
-					</Button>
-
 					<div className="domains-table-mobile-cards-controls">
 						<SelectDropdown
 							selectedText={ selectedSort }

--- a/packages/domains-table/src/domains-table-filters/index.tsx
+++ b/packages/domains-table/src/domains-table-filters/index.tsx
@@ -1,7 +1,7 @@
 import { Gridicon, SelectDropdown } from '@automattic/components';
 import SearchControl, { SearchIcon } from '@automattic/search';
 import { isMobile } from '@automattic/viewport';
-import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { DropdownMenu, MenuGroup, MenuItem, ToggleControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useDomainsTable } from '../domains-table/domains-table';
 import { domainsTableColumns } from '../domains-table-header/columns';
@@ -14,6 +14,7 @@ export interface DomainsTableFilter {
 
 interface DomainsTableFiltersProps {
 	onSearch( query: string ): void;
+
 	filter: DomainsTableFilter;
 }
 
@@ -73,17 +74,18 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 							{ options }
 						</SelectDropdown>
 
-						<DropdownMenu
-							className="domains-table-mobile-cards-overflow"
-							icon={ <Gridicon icon="ellipsis" /> }
-							label={ __( 'Domain actions' ) }
-						>
+						<DropdownMenu icon={ <Gridicon icon="ellipsis" /> } label={ __( 'Domain actions' ) }>
 							{ () => (
 								<MenuGroup>
-									<MenuItem onClick={ () => setShowBulkActions( ! showBulkActions ) }>
-										{ showBulkActions
-											? __( 'Disable Bulk Actions ' )
-											: __( 'Enable Bulk Actions ' ) }
+									<MenuItem
+										onClick={ () => setShowBulkActions( ! showBulkActions ) }
+										className="domains-table-mobile-cards-controls-bulk-toggle"
+									>
+										<ToggleControl
+											label={ __( 'Bulk actions ' ) }
+											onChange={ () => setShowBulkActions( ! showBulkActions ) }
+											checked={ showBulkActions }
+										/>
 									</MenuItem>
 								</MenuGroup>
 							) }

--- a/packages/domains-table/src/domains-table-filters/index.tsx
+++ b/packages/domains-table/src/domains-table-filters/index.tsx
@@ -1,5 +1,9 @@
+import { Button } from '@automattic/components';
 import SearchControl, { SearchIcon } from '@automattic/search';
+import { isMobile } from '@automattic/viewport';
 import { useI18n } from '@wordpress/react-i18n';
+import { useState } from 'react';
+
 import './style.scss';
 
 export interface DomainsTableFilter {
@@ -13,18 +17,41 @@ interface DomainsTableFiltersProps {
 
 export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersProps ) => {
 	const { __ } = useI18n();
+	const [ search, setSearch ] = useState( filter.query );
+
+	const isMobileDevice = isMobile();
+
+	const handleSearchChange = ( query: string ) => {
+		if ( query === '' ) {
+			setSearch( '' );
+			onSearch( '' );
+		} else if ( isMobileDevice ) {
+			setSearch( query );
+		} else {
+			onSearch( query );
+		}
+	};
+
+	const handleSearch = () => {
+		onSearch( search );
+	};
 
 	return (
 		<div className="domains-table-filter">
 			<SearchControl
 				searchIcon={ <SearchIcon /> }
 				className="domains-table-filter__search"
-				onSearch={ ( query ) => onSearch( query.trim() ) }
+				onSearch={ handleSearchChange }
 				defaultValue={ filter.query }
 				isReskinned
 				placeholder={ __( 'Search by domain…' ) }
 				disableAutocorrect={ true }
 			/>
+			{ isMobileDevice && (
+				<Button primary={ Boolean( search ) } onClick={ handleSearch }>
+					{ __( 'Filter' ) }
+				</Button>
+			) }
 		</div>
 	);
 };

--- a/packages/domains-table/src/domains-table-filters/style.scss
+++ b/packages/domains-table/src/domains-table-filters/style.scss
@@ -3,10 +3,13 @@
 
 .domains-table-filter {
 	display: flex;
-	flex-direction: column;
-	align-items: center;
 	justify-content: space-between;
-	gap: 16px;
+
+	@media ( max-width: 480px ) {
+		flex-direction: column;
+		align-items: center;
+		gap: 16px;
+	}
 
 	> button {
 		width: 100%;

--- a/packages/domains-table/src/domains-table-filters/style.scss
+++ b/packages/domains-table/src/domains-table-filters/style.scss
@@ -1,6 +1,17 @@
 @import "@automattic/onboarding/styles/mixins";
 @import "@automattic/typography/styles/variables";
 
+.domains-table-mobile-cards-controls-bulk-toggle {
+	.components-base-control.components-toggle-control {
+		margin-bottom: 0;
+		width: 100%;
+	}
+
+	.components-form-toggle {
+		order: 2;
+	}
+}
+
 .domains-table-filter {
 	display: flex;
 	justify-content: space-between;

--- a/packages/domains-table/src/domains-table-filters/style.scss
+++ b/packages/domains-table/src/domains-table-filters/style.scss
@@ -6,9 +6,12 @@
 	align-items: center;
 	justify-content: space-between;
 
-	.search-component.domains-table-filter__search {
-		max-width: 50%;
+	@media ( min-width: 480px ) {
+		.search-component.domains-table-filter__search {
+			max-width: 50%;
+		}
 	}
+
 
 	&__search {
 		--color-surface: var(--studio-white);

--- a/packages/domains-table/src/domains-table-filters/style.scss
+++ b/packages/domains-table/src/domains-table-filters/style.scss
@@ -3,8 +3,14 @@
 
 .domains-table-filter {
 	display: flex;
+	flex-direction: column;
 	align-items: center;
 	justify-content: space-between;
+	gap: 16px;
+
+	> button {
+		width: 100%;
+	}
 
 	@media ( min-width: 480px ) {
 		.search-component.domains-table-filter__search {

--- a/packages/domains-table/src/domains-table-header/columns.ts
+++ b/packages/domains-table/src/domains-table-header/columns.ts
@@ -11,6 +11,7 @@ export const domainsTableColumns: DomainsTableColumn[] = [
 				_n( '%(count)d domain', '%(count)d domains', count, __i18n_text_domain__ ),
 				{ count }
 			),
+		sortLabel: __( 'Domain', __i18n_text_domain__ ),
 		isSortable: true,
 		initialSortDirection: 'asc',
 		supportsOrderSwitching: true,

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -14,6 +14,7 @@ export type DomainsTableColumn =
 	| {
 			name: string;
 			label: string | ( ( count: number ) => string ) | null;
+			sortLabel?: string;
 			isSortable: true;
 			initialSortDirection: 'asc' | 'desc';
 			supportsOrderSwitching?: boolean;
@@ -31,6 +32,7 @@ export type DomainsTableColumn =
 	| {
 			name: string;
 			label: string | ( ( count: number ) => string ) | null;
+			sortLabel?: string;
 			isSortable?: false;
 			initialSortDirection?: never;
 			supportsOrderSwitching?: never;

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -232,6 +232,7 @@ test( 'Parenthetical username is removed from owner column', async () => {
 		blog_id: 123,
 		primary_domain: true,
 		owner: 'Joe Blogs (joeblogs)',
+		current_user_is_owner: false,
 	} );
 
 	const fetchSiteDomains = jest.fn().mockResolvedValue( {
@@ -240,16 +241,12 @@ test( 'Parenthetical username is removed from owner column', async () => {
 
 	const fetchSite = jest.fn().mockResolvedValue( { ID: 123, name: 'Primary Domain Blog' } );
 
-	render(
-		<DomainsTableRow
-			domain={ primaryPartial }
-			fetchSiteDomains={ fetchSiteDomains }
-			fetchSite={ fetchSite }
-			isAllSitesView
-			isSelected={ false }
-			onSelect={ noop }
-		/>
-	);
+	render( <DomainsTableRow domain={ primaryPartial } />, {
+		domains: [ primaryPartial ],
+		isAllSitesView: true,
+		fetchSite,
+		fetchSiteDomains,
+	} );
 
 	await waitFor( () => expect( screen.queryByText( 'Joe Blogs' ) ).toBeInTheDocument() );
 } );
@@ -260,6 +257,7 @@ test( `Doesn't strip parentheses used in the name portion of the owner field`, a
 		blog_id: 123,
 		primary_domain: true,
 		owner: 'Joe (Danger) Blogs (joeblogs)',
+		current_user_is_owner: false,
 	} );
 
 	const fetchSiteDomains = jest.fn().mockResolvedValue( {
@@ -268,16 +266,12 @@ test( `Doesn't strip parentheses used in the name portion of the owner field`, a
 
 	const fetchSite = jest.fn().mockResolvedValue( { ID: 123, name: 'Primary Domain Blog' } );
 
-	render(
-		<DomainsTableRow
-			domain={ primaryPartial }
-			fetchSiteDomains={ fetchSiteDomains }
-			fetchSite={ fetchSite }
-			isAllSitesView
-			isSelected={ false }
-			onSelect={ noop }
-		/>
-	);
+	render( <DomainsTableRow domain={ primaryPartial } />, {
+		domains: [ primaryPartial ],
+		fetchSite,
+		fetchSiteDomains,
+		isAllSitesView: true,
+	} );
 
 	await waitFor( () => expect( screen.queryByText( 'Joe (Danger) Blogs' ) ).toBeInTheDocument() );
 } );

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -4,28 +4,24 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { renderWithProvider, testDomain, testPartialDomain } from '../../test-utils';
+import { DomainsTable } from '../domains-table';
 import { DomainsTableRow } from '../domains-table-row';
 
-const noop = jest.fn();
-
-const render = ( el ) =>
+const render = ( el, props ) =>
 	renderWithProvider( el, {
 		wrapper: ( { children } ) => (
-			<table>
+			<DomainsTable { ...props }>
 				<tbody>{ children }</tbody>
-			</table>
+			</DomainsTable>
 		),
 	} );
 
 test( 'domain name is rendered in the row', () => {
-	render(
-		<DomainsTableRow
-			domain={ testPartialDomain( { domain: 'example1.com' } ) }
-			isAllSitesView
-			isSelected={ false }
-			onSelect={ noop }
-		/>
-	);
+	const partialDomain = testPartialDomain( { domain: 'example1.com' } );
+	render( <DomainsTableRow domain={ partialDomain } />, {
+		domains: [ partialDomain ],
+		isAllSitesView: true,
+	} );
 
 	expect( screen.queryByText( 'example1.com' ) ).toBeInTheDocument();
 } );
@@ -37,14 +33,10 @@ test( 'wpcom domains do not link to management interface', async () => {
 		wpcom_domain: true,
 	} );
 
-	render(
-		<DomainsTableRow
-			domain={ partialDomain }
-			isAllSitesView
-			isSelected={ false }
-			onSelect={ noop }
-		/>
-	);
+	render( <DomainsTableRow domain={ partialDomain } />, {
+		domains: [ partialDomain ],
+		isAllSitesView: true,
+	} );
 
 	expect( screen.getByText( 'example.wordpress.com' ) ).not.toHaveAttribute( 'href' );
 } );
@@ -60,15 +52,11 @@ test( 'domain name links to management interface', async () => {
 		options: { is_redirect: false },
 	} );
 
-	const { rerender } = render(
-		<DomainsTableRow
-			domain={ partialDomain }
-			fetchSite={ fetchSite }
-			isAllSitesView
-			isSelected={ false }
-			onSelect={ noop }
-		/>
-	);
+	const { rerender } = render( <DomainsTableRow domain={ partialDomain } />, {
+		domains: [ partialDomain ],
+		isAllSitesView: true,
+		fetchSite,
+	} );
 
 	// Expect the row to fetch detailed site data
 	expect( fetchSite ).toHaveBeenCalledWith( 123 );
@@ -89,13 +77,11 @@ test( 'domain name links to management interface', async () => {
 
 	// Test site-specific link
 	rerender(
-		<DomainsTableRow
-			domain={ partialDomain }
-			fetchSite={ fetchSite }
-			isAllSitesView={ false }
-			isSelected={ false }
-			onSelect={ noop }
-		/>
+		<DomainsTable domains={ [ partialDomain ] } fetchSite={ fetchSite } isAllSitesView={ false }>
+			<tbody>
+				<DomainsTableRow domain={ partialDomain } />
+			</tbody>
+		</DomainsTable>
 	);
 
 	expect( screen.getByRole( 'link', { name: 'example.com' } ) ).toHaveAttribute(
@@ -129,16 +115,12 @@ test( `redirect links use the site's unmapped URL for the site slug`, async () =
 		domains: [ fullRedirectDomain, fullUnmappedDomain ],
 	} );
 
-	const { rerender } = render(
-		<DomainsTableRow
-			domain={ partialRedirectDomain }
-			fetchSiteDomains={ fetchSiteDomains }
-			fetchSite={ fetchSite }
-			isAllSitesView
-			isSelected={ false }
-			onSelect={ noop }
-		/>
-	);
+	const { rerender } = render( <DomainsTableRow domain={ partialRedirectDomain } />, {
+		domains: [ partialRedirectDomain ],
+		fetchSite,
+		fetchSiteDomains,
+		isAllSitesView: true,
+	} );
 
 	expect( fetchSiteDomains ).toHaveBeenCalledWith( 123 );
 
@@ -151,13 +133,15 @@ test( `redirect links use the site's unmapped URL for the site slug`, async () =
 
 	// Test site-specific link
 	rerender(
-		<DomainsTableRow
-			domain={ partialRedirectDomain }
+		<DomainsTable
+			domains={ [ partialRedirectDomain ] }
 			fetchSiteDomains={ fetchSiteDomains }
 			isAllSitesView={ false }
-			isSelected={ false }
-			onSelect={ noop }
-		/>
+		>
+			<tbody>
+				<DomainsTableRow domain={ partialRedirectDomain } />
+			</tbody>
+		</DomainsTable>
 	);
 
 	expect( screen.getByRole( 'link', { name: 'redirect.blog' } ) ).toHaveAttribute(
@@ -184,16 +168,12 @@ test( 'transfer domains link to the transfer management interface', async () => 
 		options: { is_redirect: false },
 	} );
 
-	const { rerender } = render(
-		<DomainsTableRow
-			domain={ partialDomain }
-			fetchSiteDomains={ fetchSiteDomains }
-			fetchSite={ fetchSite }
-			isAllSitesView
-			isSelected={ false }
-			onSelect={ noop }
-		/>
-	);
+	const { rerender } = render( <DomainsTableRow domain={ partialDomain } />, {
+		domains: [ partialDomain ],
+		fetchSite,
+		fetchSiteDomains,
+		isAllSitesView: true,
+	} );
 
 	expect( fetchSiteDomains ).toHaveBeenCalledWith( 123 );
 
@@ -206,13 +186,15 @@ test( 'transfer domains link to the transfer management interface', async () => 
 
 	// Test site-specific link
 	rerender(
-		<DomainsTableRow
-			domain={ partialDomain }
+		<DomainsTable
+			domains={ [ partialDomain ] }
 			fetchSiteDomains={ fetchSiteDomains }
 			isAllSitesView={ false }
-			isSelected={ false }
-			onSelect={ noop }
-		/>
+		>
+			<tbody>
+				<DomainsTableRow domain={ partialDomain } />
+			</tbody>
+		</DomainsTable>
 	);
 
 	expect( screen.getByRole( 'link', { name: 'example.com' } ) ).toHaveAttribute(
@@ -234,16 +216,12 @@ test( 'when a site is associated with a domain, display its name', async () => {
 
 	const fetchSite = jest.fn().mockResolvedValue( { ID: 123, name: 'Primary Domain Blog' } );
 
-	render(
-		<DomainsTableRow
-			domain={ primaryPartial }
-			fetchSiteDomains={ fetchSiteDomains }
-			fetchSite={ fetchSite }
-			isAllSitesView
-			isSelected={ false }
-			onSelect={ noop }
-		/>
-	);
+	render( <DomainsTableRow domain={ primaryPartial } />, {
+		domains: [ primaryPartial ],
+		fetchSite,
+		fetchSiteDomains,
+		isAllSitesView: true,
+	} );
 
 	await waitFor( () => expect( screen.queryByText( 'Primary Domain Blog' ) ).toBeInTheDocument() );
 } );
@@ -327,16 +305,12 @@ describe( 'site linking ctas', () => {
 			options: { is_redirect: false },
 		} );
 
-		render(
-			<DomainsTableRow
-				domain={ primaryPartial }
-				fetchSiteDomains={ fetchSiteDomains }
-				fetchSite={ fetchSite }
-				isAllSitesView
-				isSelected={ false }
-				onSelect={ noop }
-			/>
-		);
+		render( <DomainsTableRow domain={ primaryPartial } />, {
+			domains: [ primaryPartial ],
+			fetchSite,
+			fetchSiteDomains,
+			isAllSitesView: true,
+		} );
 
 		await waitFor( () => {
 			const createLink = screen.queryByText( 'Add site' );
@@ -389,14 +363,10 @@ describe( 'registered until cell', () => {
 			expiry: '2024-08-01T00:00:00+00:00',
 		} );
 
-		render(
-			<DomainsTableRow
-				domain={ partialDomain }
-				isAllSitesView
-				isSelected={ false }
-				onSelect={ noop }
-			/>
-		);
+		render( <DomainsTableRow domain={ partialDomain } />, {
+			domains: [ partialDomain ],
+			isAllSitesView: true,
+		} );
 
 		expect( screen.getByText( 'Aug 1, 2024' ) ).toBeInTheDocument();
 	} );
@@ -409,14 +379,10 @@ describe( 'registered until cell', () => {
 			has_registration: false,
 		} );
 
-		render(
-			<DomainsTableRow
-				domain={ partialDomain }
-				isAllSitesView
-				isSelected={ false }
-				onSelect={ noop }
-			/>
-		);
+		render( <DomainsTableRow domain={ partialDomain } />, {
+			domains: [ partialDomain ],
+			isAllSitesView: true,
+		} );
 
 		expect( screen.getByText( '-' ) ).toBeInTheDocument();
 	} );

--- a/packages/domains-table/src/domains-table/domains-table-body.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-body.tsx
@@ -5,35 +5,12 @@ import { DomainsTableRow } from './domains-table-row';
 import './style.scss';
 
 export function DomainsTableBody() {
-	const {
-		selectedDomains,
-		filteredData,
-		hideOwnerColumn,
-		handleSelectDomain,
-		isAllSitesView,
-		fetchSiteDomains,
-		domainStatusPurchaseActions,
-		onDomainsRequiringAttentionChange,
-		fetchSite,
-		domainResults,
-	} = useDomainsTable();
+	const { filteredData } = useDomainsTable();
 
 	return (
 		<tbody>
 			{ filteredData.map( ( domain ) => (
-				<DomainsTableRow
-					key={ getDomainId( domain ) }
-					domain={ domain }
-					isSelected={ selectedDomains.has( getDomainId( domain ) ) }
-					onSelect={ handleSelectDomain }
-					fetchSiteDomains={ fetchSiteDomains }
-					fetchSite={ fetchSite }
-					isAllSitesView={ isAllSitesView }
-					domainStatusPurchaseActions={ domainStatusPurchaseActions }
-					hideOwnerColumn={ hideOwnerColumn }
-					onDomainsRequiringAttentionChange={ onDomainsRequiringAttentionChange }
-					pendingUpdates={ domainResults.get( domain.domain ) || [] }
-				/>
+				<DomainsTableRow key={ getDomainId( domain ) } domain={ domain } />
 			) ) }
 		</tbody>
 	);

--- a/packages/domains-table/src/domains-table/domains-table-email-indicator.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-email-indicator.tsx
@@ -1,0 +1,36 @@
+import { PartialDomainData } from '@automattic/data-stores';
+import { useI18n } from '@wordpress/react-i18n';
+//eslint-disable-next-line no-restricted-imports
+import { useGetMailboxes } from 'calypso/data/emails/use-get-mailboxes';
+
+export const DomainsTableEmailIndicator = ( {
+	domain,
+	siteSlug,
+}: {
+	domain: PartialDomainData;
+	siteSlug?: string;
+} ) => {
+	const { __ } = useI18n();
+	const { data: mailboxes = [], isLoading } = useGetMailboxes( domain.blog_id, {
+		retry: 2,
+	} );
+
+	if ( isLoading || ! siteSlug ) {
+		//todo show skeleton
+		return null;
+	}
+
+	if ( mailboxes.length === 0 ) {
+		return (
+			<a className="add-email-button" href={ `/email/${ domain.domain }/manage/${ siteSlug }` }>
+				+ { __( 'Add email ' ) }
+			</a>
+		);
+	}
+
+	return (
+		<>
+			{ __( 'Email ' ) } { mailboxes.length }
+		</>
+	);
+};

--- a/packages/domains-table/src/domains-table/domains-table-email-indicator.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-email-indicator.tsx
@@ -1,3 +1,4 @@
+import { LoadingPlaceholder } from '@automattic/components';
 import { PartialDomainData } from '@automattic/data-stores';
 import { useI18n } from '@wordpress/react-i18n';
 //eslint-disable-next-line no-restricted-imports
@@ -16,8 +17,7 @@ export const DomainsTableEmailIndicator = ( {
 	} );
 
 	if ( isLoading || ! siteSlug ) {
-		//todo show skeleton
-		return null;
+		return <LoadingPlaceholder style={ { width: '50%' } } />;
 	}
 
 	if ( mailboxes.length === 0 ) {

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
@@ -1,3 +1,4 @@
+import { LoadingPlaceholder } from '@automattic/components';
 import { PartialDomainData } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
@@ -27,6 +28,7 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 		pendingUpdates,
 		shouldDisplayPrimaryDomainLabel,
 		showBulkActions,
+		isLoadingSiteDomainsDetails,
 	} = useDomainRow( domain );
 
 	return (
@@ -74,12 +76,16 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 
 			<div>
 				<span className="domains-table-mobile-card-label"> { __( 'Status' ) } </span>
-				<DomainsTableStatusCell
-					siteSlug={ siteSlug }
-					currentDomainData={ currentDomainData }
-					domainStatusPurchaseActions={ domainStatusPurchaseActions }
-					pendingUpdates={ pendingUpdates }
-				/>
+				{ isLoadingSiteDomainsDetails ? (
+					<LoadingPlaceholder style={ { width: '50%' } } />
+				) : (
+					<DomainsTableStatusCell
+						siteSlug={ siteSlug }
+						currentDomainData={ currentDomainData }
+						domainStatusPurchaseActions={ domainStatusPurchaseActions }
+						pendingUpdates={ pendingUpdates }
+					/>
+				) }
 			</div>
 		</div>
 	);

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
@@ -59,14 +59,14 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 			</div>
 
 			<div>
-				<span className="domains-table-mobile-card-label"> Expires / renews on </span>
+				<span className="domains-table-mobile-card-label"> { __( 'Expires / renews on' ) } </span>
 				<span className="domains-table-mobile-card-registered-date">
 					<DomainsTableRegisteredUntilCell domain={ domain } />
 				</span>
 			</div>
 
 			<div>
-				<span className="domains-table-mobile-card-label"> Status </span>
+				<span className="domains-table-mobile-card-label"> { __( 'Status' ) } </span>
 				<DomainsTableStatusCell
 					siteSlug={ siteSlug }
 					currentDomainData={ currentDomainData }

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
@@ -4,6 +4,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { PrimaryDomainLabel } from '../primary-domain-label/index';
 import { useDomainRow } from '../use-domain-row';
+import { DomainsTableEmailIndicator } from './domains-table-email-indicator';
 import { DomainsTableRegisteredUntilCell } from './domains-table-registered-until-cell';
 import { DomainsTableRowActions } from './domains-table-row-actions';
 import { DomainsTableStatusCell } from './domains-table-status-cell';
@@ -56,6 +57,11 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 						domainName={ domain.domain }
 					/>
 				</div>
+			</div>
+
+			<div className="domains-table-mobile-card-email">
+				<span className="domains-table-mobile-card-label"> { __( 'Email' ) } </span>
+				<DomainsTableEmailIndicator domain={ domain } siteSlug={ siteSlug } />
 			</div>
 
 			<div>

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
@@ -26,13 +26,14 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 		domainStatusPurchaseActions,
 		pendingUpdates,
 		shouldDisplayPrimaryDomainLabel,
+		showBulkActions,
 	} = useDomainRow( domain );
 
 	return (
 		<div className="domains-table-mobile-card" ref={ ref }>
 			<div>
 				<div className="domains-table-mobile-card-header">
-					{ ! domain.wpcom_domain && (
+					{ ! domain.wpcom_domain && showBulkActions && (
 						<CheckboxControl
 							__nextHasNoMarginBottom
 							checked={ isSelected }

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
@@ -1,0 +1,74 @@
+import { PartialDomainData } from '@automattic/data-stores';
+import { CheckboxControl } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import { useDomainRow } from '../use-domain-row';
+import { DomainsTableRegisteredUntilCell } from './domains-table-registered-until-cell';
+import { DomainsTableRowActions } from './domains-table-row-actions';
+import { DomainsTableStatusCell } from './domains-table-status-cell';
+
+type Props = {
+	domain: PartialDomainData;
+};
+
+export const DomainsTableMobileCard = ( { domain }: Props ) => {
+	const { __ } = useI18n();
+
+	const {
+		ref,
+		siteSlug,
+		currentDomainData,
+		userCanAddSiteToDomain,
+		isSelected,
+		handleSelectDomain,
+		domainStatusPurchaseActions,
+		pendingUpdates,
+	} = useDomainRow( domain );
+
+	return (
+		<div className="domains-table-mobile-card" ref={ ref }>
+			<div>
+				<div className="domains-table-mobile-card-header">
+					{ ! domain.wpcom_domain && (
+						<CheckboxControl
+							__nextHasNoMarginBottom
+							checked={ isSelected }
+							onChange={ () => handleSelectDomain( domain ) }
+							/* translators: Label for a checkbox control that selects a domain name.*/
+							aria-label={ sprintf( __( 'Tick box for %(domain)s', __i18n_text_domain__ ), {
+								domain: domain.domain,
+							} ) }
+							size={ 20 }
+						/>
+					) }
+					<span className="domains-table__domain-name">{ domain.domain }</span>
+				</div>
+
+				<div>
+					<DomainsTableRowActions
+						canConnectDomainToASite={ userCanAddSiteToDomain }
+						siteSlug={ siteSlug }
+						domainName={ domain.domain }
+					/>
+				</div>
+			</div>
+
+			<div>
+				<span className="domains-table-mobile-card-label"> Expires / renews on </span>
+				<span className="domains-table-mobile-card-registered-date">
+					<DomainsTableRegisteredUntilCell domain={ domain } />
+				</span>
+			</div>
+
+			<div>
+				<span className="domains-table-mobile-card-label"> Status </span>
+				<DomainsTableStatusCell
+					siteSlug={ siteSlug }
+					currentDomainData={ currentDomainData }
+					domainStatusPurchaseActions={ domainStatusPurchaseActions }
+					pendingUpdates={ pendingUpdates }
+				/>
+			</div>
+		</div>
+	);
+};

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
@@ -2,6 +2,7 @@ import { PartialDomainData } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import { PrimaryDomainLabel } from '../primary-domain-label/index';
 import { useDomainRow } from '../use-domain-row';
 import { DomainsTableRegisteredUntilCell } from './domains-table-registered-until-cell';
 import { DomainsTableRowActions } from './domains-table-row-actions';
@@ -23,6 +24,7 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 		handleSelectDomain,
 		domainStatusPurchaseActions,
 		pendingUpdates,
+		shouldDisplayPrimaryDomainLabel,
 	} = useDomainRow( domain );
 
 	return (
@@ -41,7 +43,10 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 							size={ 20 }
 						/>
 					) }
-					<span className="domains-table__domain-name">{ domain.domain }</span>
+					<div>
+						{ shouldDisplayPrimaryDomainLabel && <PrimaryDomainLabel /> }
+						<span className="domains-table__domain-name">{ domain.domain }</span>
+					</div>
 				</div>
 
 				<div>

--- a/packages/domains-table/src/domains-table/domains-table-mobile-cards.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-cards.tsx
@@ -1,11 +1,9 @@
 import { CheckboxControl } from '@wordpress/components';
-import { useI18n } from '@wordpress/react-i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { useDomainsTable } from './domains-table';
 import { DomainsTableMobileCard } from './domains-table-mobile-card';
 
 export const DomainsTableMobileCards = () => {
-	const { __ } = useI18n();
-
 	const {
 		showBulkActions,
 		filteredData,
@@ -20,14 +18,32 @@ export const DomainsTableMobileCards = () => {
 		<div className="domains-table-mobile-cards">
 			<div className="domains-table__bulk-action-container">
 				{ showBulkActions && canSelectAnyDomains && (
-					<CheckboxControl
-						data-testid="domains-select-all-checkbox"
-						__nextHasNoMarginBottom
-						onChange={ changeBulkSelection }
-						indeterminate={ bulkSelectionStatus === 'some-domains' }
-						checked={ bulkSelectionStatus === 'all-domains' }
-						aria-label={ __( 'Select all tick boxes for domains in table', __i18n_text_domain__ ) }
-					/>
+					<div className="domains-table-mobile-cards-select-all">
+						<CheckboxControl
+							data-testid="domains-select-all-checkbox"
+							__nextHasNoMarginBottom
+							onChange={ changeBulkSelection }
+							indeterminate={ bulkSelectionStatus === 'some-domains' }
+							checked={ bulkSelectionStatus === 'all-domains' }
+							aria-label={ __(
+								'Select all tick boxes for domains in table',
+								__i18n_text_domain__
+							) }
+						/>
+						<span>
+							{ ' ' }
+							{ sprintf(
+								/* translators: Heading which displays the number of domains in a table */
+								_n(
+									'Select %(count)d domain',
+									'Select all %(count)d domains',
+									filteredData.length,
+									__i18n_text_domain__
+								),
+								{ count: filteredData.length }
+							) }{ ' ' }
+						</span>
+					</div>
 				) }
 			</div>
 			{ filteredData.map( ( domain ) => (

--- a/packages/domains-table/src/domains-table/domains-table-mobile-cards.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-cards.tsx
@@ -1,10 +1,32 @@
+import { CheckboxControl } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { useDomainsTable } from './domains-table';
 import { DomainsTableMobileCard } from './domains-table-mobile-card';
 
 export const DomainsTableMobileCards = () => {
-	const { filteredData } = useDomainsTable();
+	const { __ } = useI18n();
 
-	return filteredData.map( ( domain ) => (
-		<DomainsTableMobileCard key={ domain.domain } domain={ domain } />
-	) );
+	const { filteredData, canSelectAnyDomains, changeBulkSelection, getBulkSelectionStatus } =
+		useDomainsTable();
+	const bulkSelectionStatus = getBulkSelectionStatus();
+
+	return (
+		<div className="domains-table-mobile-cards">
+			<div className="domains-table__bulk-action-container">
+				{ canSelectAnyDomains && (
+					<CheckboxControl
+						data-testid="domains-select-all-checkbox"
+						__nextHasNoMarginBottom
+						onChange={ changeBulkSelection }
+						indeterminate={ bulkSelectionStatus === 'some-domains' }
+						checked={ bulkSelectionStatus === 'all-domains' }
+						aria-label={ __( 'Select all tick boxes for domains in table', __i18n_text_domain__ ) }
+					/>
+				) }
+			</div>
+			{ filteredData.map( ( domain ) => (
+				<DomainsTableMobileCard key={ domain.domain } domain={ domain } />
+			) ) }
+		</div>
+	);
 };

--- a/packages/domains-table/src/domains-table/domains-table-mobile-cards.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-cards.tsx
@@ -1,0 +1,10 @@
+import { useDomainsTable } from './domains-table';
+import { DomainsTableMobileCard } from './domains-table-mobile-card';
+
+export const DomainsTableMobileCards = () => {
+	const { filteredData } = useDomainsTable();
+
+	return filteredData.map( ( domain ) => (
+		<DomainsTableMobileCard key={ domain.domain } domain={ domain } />
+	) );
+};

--- a/packages/domains-table/src/domains-table/domains-table-mobile-cards.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-cards.tsx
@@ -6,14 +6,20 @@ import { DomainsTableMobileCard } from './domains-table-mobile-card';
 export const DomainsTableMobileCards = () => {
 	const { __ } = useI18n();
 
-	const { filteredData, canSelectAnyDomains, changeBulkSelection, getBulkSelectionStatus } =
-		useDomainsTable();
+	const {
+		showBulkActions,
+		filteredData,
+		canSelectAnyDomains,
+		changeBulkSelection,
+		getBulkSelectionStatus,
+	} = useDomainsTable();
+
 	const bulkSelectionStatus = getBulkSelectionStatus();
 
 	return (
 		<div className="domains-table-mobile-cards">
 			<div className="domains-table__bulk-action-container">
-				{ canSelectAnyDomains && (
+				{ showBulkActions && canSelectAnyDomains && (
 					<CheckboxControl
 						data-testid="domains-select-all-checkbox"
 						__nextHasNoMarginBottom

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,10 +1,5 @@
 import { LoadingPlaceholder } from '@automattic/components';
-import {
-	DomainUpdateStatus,
-	PartialDomainData,
-	SiteDomainsQueryFnData,
-	SiteDetails,
-} from '@automattic/data-stores';
+import { PartialDomainData } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -13,7 +8,6 @@ import { useDomainRow } from '../use-domain-row';
 import { domainInfoContext } from '../utils/constants';
 import { getDomainTypeText } from '../utils/get-domain-type-text';
 import { domainManagementLink } from '../utils/paths';
-import { DomainStatusPurchaseActions } from '../utils/resolve-domain-status';
 import { DomainsTableRegisteredUntilCell } from './domains-table-registered-until-cell';
 import { DomainsTableRowActions } from './domains-table-row-actions';
 import { DomainsTableSiteCell } from './domains-table-site-cell';
@@ -21,17 +15,6 @@ import { DomainsTableStatusCell } from './domains-table-status-cell';
 
 interface DomainsTableRowProps {
 	domain: PartialDomainData;
-	isAllSitesView: boolean;
-	isSelected: boolean;
-	hideOwnerColumn?: boolean;
-	onSelect( domain: PartialDomainData ): void;
-	domainStatusPurchaseActions?: DomainStatusPurchaseActions;
-	onDomainsRequiringAttentionChange?( domainsRequiringAttention: number ): void;
-	fetchSiteDomains?: (
-		siteIdOrSlug: number | string | null | undefined
-	) => Promise< SiteDomainsQueryFnData >;
-	fetchSite?: ( siteIdOrSlug: number | string | null | undefined ) => Promise< SiteDetails >;
-	pendingUpdates: DomainUpdateStatus[];
 }
 
 export function DomainsTableRow( { domain }: DomainsTableRowProps ) {

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -106,7 +106,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 				) }
 			</td>
 			<td>
-				{ shouldDisplayPrimaryDomainLabel && <PrimaryDomainLabel /> }
+				{ ! shouldDisplayPrimaryDomainLabel && <PrimaryDomainLabel /> }
 				{ isManageableDomain ? (
 					<a
 						className="domains-table__domain-name"

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -3,12 +3,14 @@ import {
 	DomainUpdateStatus,
 	PartialDomainData,
 	SiteDomainsQueryFnData,
+	SiteDetails,
 } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { PrimaryDomainLabel } from '../primary-domain-label';
 import { useDomainRow } from '../use-domain-row';
+import { domainInfoContext } from '../utils/constants';
 import { getDomainTypeText } from '../utils/get-domain-type-text';
 import { domainManagementLink } from '../utils/paths';
 import { DomainStatusPurchaseActions } from '../utils/resolve-domain-status';

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -3,23 +3,15 @@ import {
 	DomainUpdateStatus,
 	PartialDomainData,
 	SiteDomainsQueryFnData,
-	useSiteDomainsQuery,
-	useSiteQuery,
-	SiteDetails,
 } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo, useState } from 'react';
-import { useInView } from 'react-intersection-observer';
 import { PrimaryDomainLabel } from '../primary-domain-label';
-import { countDomainsRequiringAttention } from '../utils';
-import { createSiteDomainObject } from '../utils/assembler';
-import { domainInfoContext } from '../utils/constants';
+import { useDomainRow } from '../use-domain-row';
 import { getDomainTypeText } from '../utils/get-domain-type-text';
 import { domainManagementLink } from '../utils/paths';
-import { DomainStatusPurchaseActions, resolveDomainStatus } from '../utils/resolve-domain-status';
+import { DomainStatusPurchaseActions } from '../utils/resolve-domain-status';
 import { DomainsTableRegisteredUntilCell } from './domains-table-registered-until-cell';
 import { DomainsTableRowActions } from './domains-table-row-actions';
 import { DomainsTableSiteCell } from './domains-table-site-cell';
@@ -37,105 +29,31 @@ interface DomainsTableRowProps {
 		siteIdOrSlug: number | string | null | undefined
 	) => Promise< SiteDomainsQueryFnData >;
 	fetchSite?: ( siteIdOrSlug: number | string | null | undefined ) => Promise< SiteDetails >;
-	pendingUpdates?: DomainUpdateStatus[];
+	pendingUpdates: DomainUpdateStatus[];
 }
 
-export function DomainsTableRow( {
-	domain,
-	isAllSitesView,
-	isSelected,
-	hideOwnerColumn = false,
-	onSelect,
-	fetchSiteDomains,
-	fetchSite,
-	domainStatusPurchaseActions,
-	onDomainsRequiringAttentionChange,
-	pendingUpdates = [],
-}: DomainsTableRowProps ) {
+export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 	const { __ } = useI18n();
-	const translate = useTranslate();
-	const { ref, inView } = useInView( { triggerOnce: true } );
 
-	const { data: allSiteDomains, isLoading: isLoadingSiteDomainsDetails } = useSiteDomainsQuery(
-		domain.blog_id,
-		{
-			enabled: inView,
-			...( fetchSiteDomains && { queryFn: () => fetchSiteDomains( domain.blog_id ) } ),
-			select: ( state ) => state.domains.map( createSiteDomainObject ),
-		}
-	);
-
-	const currentDomainData = useMemo( () => {
-		return allSiteDomains?.find( ( d ) => d.name === domain.domain );
-	}, [ allSiteDomains, domain.domain ] );
-
-	const isPrimaryDomain = useMemo(
-		() => allSiteDomains?.find( ( d ) => d.isPrimary )?.name === domain.domain,
-		[ allSiteDomains, domain.domain ]
-	);
-
-	const { data: site, isLoading: isLoadingSiteDetails } = useSiteQuery( domain.blog_id, {
-		enabled: inView,
-		...( fetchSite && { queryFn: () => fetchSite( domain.blog_id ) } ),
-	} );
-
-	const siteSlug = useMemo( () => {
-		if ( ! site?.URL ) {
-			// Fall back to the site's ID if we're still loading detailed site data
-			return domain.blog_id.toString( 10 );
-		}
-
-		if ( site.options.is_redirect && site.options.unmapped_url ) {
-			return new URL( site.options.unmapped_url ).host;
-		}
-
-		return new URL( site.URL ).host.replace( /\//g, '::' );
-	}, [ site, domain.blog_id ] );
-
-	const isLoadingRowDetails = isLoadingSiteDetails || isLoadingSiteDomainsDetails;
-
-	const domainsRequiringAttention = useMemo( () => {
-		if ( ! currentDomainData || isLoadingRowDetails ) {
-			return null;
-		}
-		return countDomainsRequiringAttention(
-			allSiteDomains?.map( ( domain ) =>
-				resolveDomainStatus( domain, {
-					siteSlug: siteSlug,
-					getMappingErrors: true,
-					translate,
-					isPurchasedDomain: domainStatusPurchaseActions?.isPurchasedDomain?.( currentDomainData ),
-					isCreditCardExpiring:
-						domainStatusPurchaseActions?.isCreditCardExpiring?.( currentDomainData ),
-				} )
-			)
-		);
-	}, [
-		allSiteDomains,
-		currentDomainData,
-		domainStatusPurchaseActions,
+	const {
+		ref,
+		site,
 		siteSlug,
-		translate,
 		isLoadingRowDetails,
-	] );
-
-	useEffect( () => {
-		if ( typeof domainsRequiringAttention === 'number' && domainsRequiringAttention > 0 ) {
-			onDomainsRequiringAttentionChange?.( domainsRequiringAttention );
-		}
-	}, [ domainsRequiringAttention, onDomainsRequiringAttentionChange ] );
-
-	const isManageableDomain = ! domain.wpcom_domain;
-	const shouldDisplayPrimaryDomainLabel = ! isAllSitesView && isPrimaryDomain;
-
-	const [ placeholderWidth ] = useState( () => {
-		const MIN = 40;
-		const MAX = 100;
-
-		return Math.floor( Math.random() * ( MAX - MIN + 1 ) ) + MIN;
-	} );
-
-	const userCanAddSiteToDomain = currentDomainData?.currentUserCanCreateSiteFromDomainOnly ?? false;
+		placeholderWidth,
+		currentDomainData,
+		userCanAddSiteToDomain,
+		shouldDisplayPrimaryDomainLabel,
+		isManageableDomain,
+		isLoadingSiteDetails,
+		isLoadingSiteDomainsDetails,
+		isSelected,
+		handleSelectDomain,
+		isAllSitesView,
+		hideOwnerColumn,
+		domainStatusPurchaseActions,
+		pendingUpdates,
+	} = useDomainRow( domain );
 
 	const renderSiteCell = () => {
 		if ( site && currentDomainData ) {
@@ -179,7 +97,7 @@ export function DomainsTableRow( {
 					<CheckboxControl
 						__nextHasNoMarginBottom
 						checked={ isSelected }
-						onChange={ () => onSelect( domain ) }
+						onChange={ () => handleSelectDomain( domain ) }
 						/* translators: Label for a checkbox control that selects a domain name.*/
 						aria-label={ sprintf( __( 'Tick box for %(domain)s', __i18n_text_domain__ ), {
 							domain: domain.domain,

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -106,7 +106,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 				) }
 			</td>
 			<td>
-				{ ! shouldDisplayPrimaryDomainLabel && <PrimaryDomainLabel /> }
+				{ shouldDisplayPrimaryDomainLabel && <PrimaryDomainLabel /> }
 				{ isManageableDomain ? (
 					<a
 						className="domains-table__domain-name"

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -67,10 +67,7 @@ type Value = {
 	handleUpdateContactInfo: () => void;
 	changeBulkSelection: () => void;
 	getBulkSelectionStatus: () => 'all-domains' | 'some-domains' | 'no-domains';
-	onSortChange: (
-		selectedColumn: DomainsTableColumn,
-		direction: 'asc' | 'desc' | undefined
-	) => void;
+	onSortChange: ( selectedColumn: DomainsTableColumn, direction?: 'asc' | 'desc' ) => void;
 	handleSelectDomain: ( domain: PartialDomainData ) => void;
 	onDomainsRequiringAttentionChange: ( domainsRequiringAttention: number ) => void;
 	fetchSiteDomains?: (
@@ -81,8 +78,8 @@ type Value = {
 	completedJobs: JobStatus[];
 	domainResults: Map< string, DomainUpdateStatus[] >;
 	handleRestartDomainStatusPolling: () => void;
-	showBulkActions;
-	setShowBulkActions: () => void;
+	showBulkActions: boolean;
+	setShowBulkActions: ( showBulkActions: boolean ) => void;
 };
 
 const Context = createContext< Value | undefined >( undefined );
@@ -107,7 +104,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		sortDirection: 'asc',
 	} );
 
-	const [ showBulkActions, setShowBulkActions ] = useState( ! isMobile() );
+	const [ showBulkActions, setShowBulkActions ] = useState( Boolean( ! isMobile() ) );
 	const [ selectedDomains, setSelectedDomains ] = useState( () => new Set< string >() );
 	const [ filter, setFilter ] = useState< DomainsTableFilter >( () => ( { query: '' } ) );
 	const [ domainsRequiringAttention, setDomainsRequiringAttention ] = useState<
@@ -217,10 +214,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		return null;
 	}
 
-	const onSortChange = (
-		selectedColumn: DomainsTableColumn,
-		direction: 'asc' | 'desc' | undefined
-	) => {
+	const onSortChange = ( selectedColumn: DomainsTableColumn, direction?: 'asc' | 'desc' ) => {
 		if ( ! selectedColumn.isSortable ) {
 			return;
 		}

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -9,6 +9,7 @@ import {
 	JobStatus,
 } from '@automattic/data-stores';
 import { useFuzzySearch } from '@automattic/search';
+import { isMobile } from '@automattic/viewport';
 import { useQueries } from '@tanstack/react-query';
 import { addQueryArgs } from '@wordpress/url';
 import page from 'page';
@@ -66,7 +67,10 @@ type Value = {
 	handleUpdateContactInfo: () => void;
 	changeBulkSelection: () => void;
 	getBulkSelectionStatus: () => 'all-domains' | 'some-domains' | 'no-domains';
-	onSortChange: ( selectedColumn: DomainsTableColumn ) => void;
+	onSortChange: (
+		selectedColumn: DomainsTableColumn,
+		direction: 'asc' | 'desc' | undefined
+	) => void;
 	handleSelectDomain: ( domain: PartialDomainData ) => void;
 	onDomainsRequiringAttentionChange: ( domainsRequiringAttention: number ) => void;
 	fetchSiteDomains?: (
@@ -77,6 +81,8 @@ type Value = {
 	completedJobs: JobStatus[];
 	domainResults: Map< string, DomainUpdateStatus[] >;
 	handleRestartDomainStatusPolling: () => void;
+	showBulkActions;
+	setShowBulkActions: () => void;
 };
 
 const Context = createContext< Value | undefined >( undefined );
@@ -101,6 +107,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		sortDirection: 'asc',
 	} );
 
+	const [ showBulkActions, setShowBulkActions ] = useState( ! isMobile() );
 	const [ selectedDomains, setSelectedDomains ] = useState( () => new Set< string >() );
 	const [ filter, setFilter ] = useState< DomainsTableFilter >( () => ( { query: '' } ) );
 	const [ domainsRequiringAttention, setDomainsRequiringAttention ] = useState<
@@ -210,17 +217,21 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		return null;
 	}
 
-	const onSortChange = ( selectedColumn: DomainsTableColumn ) => {
+	const onSortChange = (
+		selectedColumn: DomainsTableColumn,
+		direction: 'asc' | 'desc' | undefined
+	) => {
 		if ( ! selectedColumn.isSortable ) {
 			return;
 		}
 
 		const newSortDirection =
-			selectedColumn.name === sortKey &&
+			direction ||
+			( selectedColumn.name === sortKey &&
 			selectedColumn.supportsOrderSwitching &&
 			sortDirection === 'asc'
 				? 'desc'
-				: selectedColumn.initialSortDirection;
+				: selectedColumn.initialSortDirection );
 
 		setSort( {
 			sortKey: selectedColumn.name,
@@ -321,6 +332,8 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		completedJobs,
 		domainResults,
 		handleRestartDomainStatusPolling,
+		showBulkActions,
+		setShowBulkActions,
 	};
 
 	return (

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -1,7 +1,9 @@
+import { isMobile } from '@automattic/viewport';
 import { DomainsTable as InternalDomainsTable, DomainsTablePropsNoChildren } from './domains-table';
 import { DomainsTableBody } from './domains-table-body';
 import { DomainsTableBulkUpdateNotice } from './domains-table-bulk-update-notice';
 import { DomainsTableHeader } from './domains-table-header';
+import { DomainsTableMobileCards } from './domains-table-mobile-cards';
 import { DomainsTableToolbar } from './domains-table-toolbar';
 
 import './style.scss';
@@ -11,10 +13,14 @@ export function DomainsTable( props: DomainsTablePropsNoChildren ) {
 		<InternalDomainsTable { ...props }>
 			<DomainsTableBulkUpdateNotice />
 			<DomainsTableToolbar />
-			<table>
-				<DomainsTableHeader />
-				<DomainsTableBody />
-			</table>
+			{ isMobile() ? (
+				<DomainsTableMobileCards />
+			) : (
+				<table>
+					<DomainsTableHeader />
+					<DomainsTableBody />
+				</table>
+			) }
 		</InternalDomainsTable>
 	);
 }

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -205,4 +205,16 @@
 	&-registered-date {
 		font-size: $font-body-small;
 	}
+
+	&-email {
+		a.add-email-button {
+			color: var(--studio-blue-50);
+			font-size: $font-body-small;
+			font-style: normal;
+			font-weight: 400;
+			line-height: 20px; /* 142.857% */
+			letter-spacing: -0.15px;
+			text-decoration: underline;
+		}
+	}
 }

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -2,8 +2,25 @@
 @import "@automattic/onboarding/styles/mixins";
 
 
+@media ( max-width: 480px) {
+	html,
+	body,
+	#wpcom,
+	#content {
+		overflow-y: hidden;
+		height: 100vh;
+		main[role="main"] {
+			overflow-y: hidden;
+			height: 100vh;
+		}
+	}
+}
+
+
 .domains-table {
 	--domains-table-toolbar-height: 40px;
+	height: 100%;
+	overflow-y: hidden;
 
 	border-collapse: collapse;
 
@@ -160,6 +177,15 @@
 
 	@include break-large {
 		display: block;
+	}
+}
+
+.domains-table-mobile-cards {
+	height: 100%;
+	overflow-y: auto;
+	padding: 0 4px;
+	.domains-table__bulk-action-container {
+		margin-top: 16px;
 	}
 }
 

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -5,6 +5,12 @@
 .domains-table {
 	--domains-table-toolbar-height: 40px;
 
+	border-collapse: collapse;
+
+	@media ( max-width: 480px ) {
+		padding: 16px;
+	}
+
 	table {
 		margin-top: 30px;
 		border-collapse: collapse;
@@ -63,10 +69,13 @@
 
 	.domains-table-row__status-cell {
 		display: flex;
-		width: 100px;
 		align-items: center;
 		gap: 4px;
 		font-size: $font-body-small;
+
+		@media ( min-width: 480px) {
+			width: 100px;
+		}
 
 		&__status-success,
 		&__status-verifying,
@@ -151,5 +160,48 @@
 
 	@include break-large {
 		display: block;
+	}
+}
+
+.domains-table-mobile-card {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 16px 0;
+	border-bottom: 1px solid #f0f0f0;
+
+	&-header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+
+		.domains-table__domain-name {
+			text-align: left;
+		}
+
+		.components-checkbox-control__input,
+		.components-checkbox-control__checked {
+			width: 20px;
+			height: 20px;
+		}
+	}
+
+	> div {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	&-label {
+		font-size: $font-body-small;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 20px;
+		letter-spacing: -0.15px;
+		color: var(--gray-gray-60);
+	}
+
+	&-registered-date {
+		font-size: $font-body-small;
 	}
 }

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -179,6 +179,7 @@
 			text-align: left;
 		}
 
+		.components-base-control,
 		.components-checkbox-control__input,
 		.components-checkbox-control__checked {
 			width: 20px;

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -182,7 +182,17 @@
 
 .domains-table-mobile-cards {
 	height: 100%;
+	overflow-x: visible;
 	overflow-y: auto;
+
+	.domains-table-mobile-cards-select-all {
+		display: flex;
+		align-items: center;
+		span {
+			font-size: smaller;
+		}
+	}
+
 	.domains-table__bulk-action-container {
 		margin-top: 16px;
 	}

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -25,7 +25,7 @@
 	border-collapse: collapse;
 
 	@media ( max-width: 480px ) {
-		padding: 16px;
+		padding: 13px;
 	}
 
 	table {
@@ -181,9 +181,9 @@
 }
 
 .domains-table-mobile-cards {
-	height: 100%;
-	overflow-x: visible;
+	height: calc(100vh - 280px);
 	overflow-y: auto;
+	padding: 3px;
 
 	.domains-table-mobile-cards-select-all {
 		display: flex;

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -183,9 +183,25 @@
 .domains-table-mobile-cards {
 	height: 100%;
 	overflow-y: auto;
-	padding: 0 4px;
 	.domains-table__bulk-action-container {
 		margin-top: 16px;
+	}
+
+	&-controls {
+		width: 100%;
+		display: flex;
+		gap: 16px;
+	}
+
+	&-sort-dropdown {
+		width: 100%;
+		flex-grow: 1;
+		.select-dropdown__container {
+			width: 100%;
+			.select-dropdown__header {
+				text-transform: capitalize;
+			}
+		}
 	}
 }
 

--- a/packages/domains-table/src/type-declarations.d.ts
+++ b/packages/domains-table/src/type-declarations.d.ts
@@ -6,3 +6,5 @@ declare module '*.svg' {
 }
 
 declare module 'calypso/components/notice';
+
+declare module 'calypso/lib/wp';

--- a/packages/domains-table/src/use-domain-row.ts
+++ b/packages/domains-table/src/use-domain-row.ts
@@ -19,6 +19,7 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 		selectedDomains,
 		handleSelectDomain,
 		domainResults,
+		showBulkActions,
 	} = useDomainsTable();
 
 	const translate = useTranslate();
@@ -124,5 +125,6 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 		domainStatusPurchaseActions,
 		pendingUpdates: domainResults.get( domain.domain ) || [],
 		currentDomainData,
+		showBulkActions,
 	};
 };

--- a/packages/domains-table/src/use-domain-row.ts
+++ b/packages/domains-table/src/use-domain-row.ts
@@ -1,0 +1,128 @@
+import { PartialDomainData, useSiteDomainsQuery, useSiteQuery } from '@automattic/data-stores';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useMemo, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+import { useDomainsTable } from './domains-table/domains-table';
+import { getDomainId } from './get-domain-id';
+import { countDomainsRequiringAttention } from './utils';
+import { createSiteDomainObject } from './utils/assembler';
+import { resolveDomainStatus } from './utils/resolve-domain-status';
+
+export const useDomainRow = ( domain: PartialDomainData ) => {
+	const {
+		hideOwnerColumn,
+		isAllSitesView,
+		fetchSiteDomains,
+		domainStatusPurchaseActions,
+		onDomainsRequiringAttentionChange,
+		fetchSite,
+		selectedDomains,
+		handleSelectDomain,
+		domainResults,
+	} = useDomainsTable();
+
+	const translate = useTranslate();
+	const { ref, inView } = useInView( { triggerOnce: true } );
+
+	const { data: allSiteDomains, isLoading: isLoadingSiteDomainsDetails } = useSiteDomainsQuery(
+		domain.blog_id,
+		{
+			enabled: inView,
+			...( fetchSiteDomains && { queryFn: () => fetchSiteDomains( domain.blog_id ) } ),
+			select: ( state ) => state.domains.map( createSiteDomainObject ),
+		}
+	);
+
+	const currentDomainData = allSiteDomains?.find( ( d ) => d.name === domain.domain );
+
+	const isPrimaryDomain = useMemo(
+		() => allSiteDomains?.find( ( d ) => d.isPrimary )?.name === domain.domain,
+		[ allSiteDomains, domain.domain ]
+	);
+
+	const { data: site, isLoading: isLoadingSiteDetails } = useSiteQuery( domain.blog_id, {
+		enabled: inView,
+		...( fetchSite && { queryFn: () => fetchSite( domain.blog_id ) } ),
+	} );
+
+	const siteSlug = useMemo( () => {
+		if ( ! site?.URL ) {
+			// Fall back to the site's ID if we're still loading detailed site data
+			return domain.blog_id.toString( 10 );
+		}
+
+		if ( site.options.is_redirect && site.options.unmapped_url ) {
+			return new URL( site.options.unmapped_url ).host;
+		}
+
+		return new URL( site.URL ).host.replace( /\//g, '::' );
+	}, [ site, domain.blog_id ] );
+
+	const isLoadingRowDetails = isLoadingSiteDetails || isLoadingSiteDomainsDetails;
+
+	const domainsRequiringAttention = useMemo( () => {
+		if ( ! currentDomainData || isLoadingRowDetails ) {
+			return null;
+		}
+		return countDomainsRequiringAttention(
+			allSiteDomains?.map( ( domain ) =>
+				resolveDomainStatus( domain, {
+					siteSlug: siteSlug,
+					getMappingErrors: true,
+					translate,
+					isPurchasedDomain: domainStatusPurchaseActions?.isPurchasedDomain?.( currentDomainData ),
+					isCreditCardExpiring:
+						domainStatusPurchaseActions?.isCreditCardExpiring?.( currentDomainData ),
+				} )
+			)
+		);
+	}, [
+		allSiteDomains,
+		currentDomainData,
+		domainStatusPurchaseActions,
+		siteSlug,
+		translate,
+		isLoadingRowDetails,
+	] );
+
+	useEffect( () => {
+		if ( typeof domainsRequiringAttention === 'number' && domainsRequiringAttention > 0 ) {
+			onDomainsRequiringAttentionChange?.( domainsRequiringAttention );
+		}
+	}, [ domainsRequiringAttention, onDomainsRequiringAttentionChange ] );
+
+	const isManageableDomain = ! domain.wpcom_domain;
+	const shouldDisplayPrimaryDomainLabel = ! isAllSitesView && isPrimaryDomain;
+
+	const [ placeholderWidth ] = useState( () => {
+		const MIN = 40;
+		const MAX = 100;
+
+		return Math.floor( Math.random() * ( MAX - MIN + 1 ) ) + MIN;
+	} );
+
+	const userCanAddSiteToDomain = currentDomainData?.currentUserCanCreateSiteFromDomainOnly ?? false;
+
+	const isSelected = selectedDomains.has( getDomainId( domain ) );
+
+	return {
+		ref,
+		site,
+		siteSlug,
+		isManageableDomain,
+		userCanAddSiteToDomain,
+		domainsRequiringAttention,
+		hideOwnerColumn,
+		placeholderWidth,
+		shouldDisplayPrimaryDomainLabel,
+		isLoadingRowDetails,
+		isLoadingSiteDetails,
+		isLoadingSiteDomainsDetails,
+		isSelected,
+		handleSelectDomain,
+		isAllSitesView,
+		domainStatusPurchaseActions,
+		pendingUpdates: domainResults.get( domain.domain ) || [],
+		currentDomainData,
+	};
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3564

## Proposed Changes

It should be functional now but it still needs some work. 

Done:

* Use a card layout on mobile
* Rework header section with mobile controls
   -  Add a button which must be pressed to filter
   -  Adds a sort dropdown 
   - Add an overflow menu where you can toggle bulk selection
* Supports email (untested)
   - will show the count of inboxes
   - allows adding new email if no inboxes
* Refactors state into a reusable hook

Not done:
* Unit tests

It's incomplete, but as it refactors some of the code, I wanted to create a draft PR so there is some visibility on incoming changes. 

https://github.com/Automattic/wp-calypso/assets/6851384/27e51598-6326-4184-99cc-9966f5a6ad76

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try it out at `/domains/manage`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?