### PR TITLE
Assembler - Fix focus styles and alignment in category buttons

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-category-list.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-category-list.scss
@@ -1,5 +1,25 @@
 .pattern-category-list {
-	.components-item.navigator-item {
-		margin: 0 -5px;
+	button {
+		margin: 0 -11px;
+		border-radius: 2px;
+
+		.navigator-item {
+			margin: 0;
+			padding: 0 5px 0 11px;
+			width: auto;
+
+			&.navigator-item--active {
+				border-radius: 2px;
+			}
+		}
+
+		&:focus-visible {
+			border-color: var(--color-primary);
+			box-shadow: 0 0 0 2px var(--color-primary-light);
+
+			.navigator-item {
+				color: var(--studio-blue-50);
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81439
Closes #80676

## Proposed Changes
In category buttons:
* Fix focus styles
* Fix horizontal alignment and padding

**Note on complexity:** This fix is a bit tricky because the buttons in the sections screen should have the same style as in the main screen but the HTML structure differs. On the main screen, the `button` itself is `navigator-item` but on the sections screen `navigator-item` is a child of `button`.

**Note on accessibility via keyboard keys:** On the main screen, the buttons are navigable via the `tab` key. However, on the Sections screen, the category buttons use `CompositeItem` which makes them navigable via the `arrow` keys once the list gets the focus. I think this is okay and not an issue. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }`
* On the main screen `Design your own`, verify the look of the button `Header` on hover, on focus, and when is active 
* Click `Sections` and verify that the `Blog Posts` button has the exact same look as the `Header` button on hover, on focus, and when is active 

### Comparing alignment on screens

#### BEFORE

|Main screen|Sections screen|
|--|--|
|<img width="348" alt="Screenshot 2566-09-11 at 15 33 57" src="https://github.com/Automattic/wp-calypso/assets/1881481/5b252e44-6274-447b-8393-6c014fd15d03">|<img width="348" alt="Screenshot 2566-09-11 at 15 38 10" src="https://github.com/Automattic/wp-calypso/assets/1881481/4918f820-dca0-463f-9fdb-fedb69ece5ca">|

#### AFTER

|Main screen|Sections screen|
|--|--|
|<img width="348" alt="Screenshot 2566-09-11 at 15 33 57" src="https://github.com/Automattic/wp-calypso/assets/1881481/5b252e44-6274-447b-8393-6c014fd15d03">|<img width="348" alt="Screenshot 2566-09-11 at 15 34 20" src="https://github.com/Automattic/wp-calypso/assets/1881481/74efc1c9-87b9-4d4e-b1e2-f480fbb96326">|

### Focus styles on Sections screen

|BEFORE|AFTER|
|--|--|
|<img width="349" alt="Screenshot 2566-09-11 at 15 23 40" src="https://github.com/Automattic/wp-calypso/assets/1881481/53656450-0a14-4586-8776-99b6435e2939">|<img width="349" alt="Screenshot 2566-09-11 at 15 29 32" src="https://github.com/Automattic/wp-calypso/assets/1881481/00e3d5bf-478c-49a6-a8c6-8b783444dd3c">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?