### PR TITLE
state: refactor away from `_.concat`

### DIFF
--- a/client/state/data-layer/wpcom/read/tags/utils.js
+++ b/client/state/data-layer/wpcom/read/tags/utils.js
@@ -1,4 +1,3 @@
-import { map, compact, concat } from 'lodash';
 import { decodeEntities } from 'calypso/lib/formatting';
 
 /**
@@ -18,15 +17,14 @@ export function fromApi( apiResponse ) {
 		throw new Error( `invalid tags response: ${ JSON.stringify( apiResponse ) }` );
 	}
 
-	const tags = compact(
-		concat(
-			[],
+	const tags = []
+		.concat(
 			typeof apiResponse.tag === 'object' && apiResponse.tag,
 			Array.isArray( apiResponse.tags ) && apiResponse.tags
 		)
-	);
+		.filter( Boolean );
 
-	return map( tags, ( tag ) => ( {
+	return tags.map( ( tag ) => ( {
 		id: tag.ID,
 		description: decodeEntities( tag.description ),
 		displayName: decodeEntities( tag.display_name ),

--- a/client/state/posts/utils/apply-post-edits.js
+++ b/client/state/posts/utils/apply-post-edits.js
@@ -1,4 +1,4 @@
-import { cloneDeep, concat, find, map, mergeWith, reduce, reject } from 'lodash';
+import { cloneDeep, find, map, mergeWith, reduce, reject } from 'lodash';
 
 /*
  * Applies a metadata edit operation (either update or delete) to an existing array of
@@ -12,7 +12,7 @@ function applyMetadataEdit( metadata, edit ) {
 			if ( find( metadata, { key } ) ) {
 				return map( metadata, ( m ) => ( m.key === key ? { key, value } : m ) );
 			}
-			return concat( metadata || [], { key, value } );
+			return ( Array.isArray( metadata ) ? metadata : [] ).concat( { key, value } );
 		}
 		case 'delete': {
 			// Remove a value from the metadata array. If the key is not present,

--- a/client/state/posts/utils/merge-post-edits.js
+++ b/client/state/posts/utils/merge-post-edits.js
@@ -1,10 +1,10 @@
-import { cloneDeep, concat, find, mergeWith, reduce, reject } from 'lodash';
+import { cloneDeep, find, mergeWith, reduce, reject } from 'lodash';
 
 function mergeMetadataEdits( edits, nextEdits ) {
 	// remove existing edits that get updated in `nextEdits`
 	const newEdits = reject( edits, ( edit ) => find( nextEdits, { key: edit.key } ) );
 	// append the new edits at the end
-	return concat( newEdits, nextEdits );
+	return newEdits.concat( nextEdits );
 }
 
 /**

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -1,5 +1,5 @@
 import { translate, getLocaleSlug } from 'i18n-calypso';
-import { sortBy, camelCase, mapKeys, get, filter, map, concat, flatten } from 'lodash';
+import { sortBy, camelCase, mapKeys, get, filter, map, flatten } from 'lodash';
 import moment from 'moment';
 import { PUBLICIZE_SERVICES_LABEL_ICON } from './constants';
 
@@ -112,7 +112,7 @@ export function buildExportArray( data, parent = null ) {
 			return buildExportArray( child, label );
 		} );
 
-		exportData = concat( exportData, flatten( childData ) );
+		exportData = exportData.concat( flatten( childData ) );
 	}
 
 	return exportData;


### PR DESCRIPTION
## Proposed Changes

PR refactors away from `_.concat` in `client/state`.

## Testing Instructions

* Changes are well covered by unit tests, verify they pass.
* As with a lot of lodash methods it's good practice to ensure we don't accidentally miss guards for whether we operate on the expected data structure (in this case arrays).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
