### PR TITLE
i18n: Fix 'Invalid Date' in PostTrendsDay tooltip in non-English

### DIFF
--- a/client/my-sites/stats/post-trends/day.jsx
+++ b/client/my-sites/stats/post-trends/day.jsx
@@ -1,13 +1,13 @@
 import { Icon, postContent } from '@wordpress/icons';
 import classNames from 'classnames';
-import { localize, getLocaleSlug } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { createRef, PureComponent, Fragment } from 'react';
 import Tooltip from 'calypso/components/tooltip';
 
 class PostTrendsDay extends PureComponent {
 	static propTypes = {
-		label: PropTypes.string,
+		date: PropTypes.object,
 		className: PropTypes.string,
 		postCount: PropTypes.number,
 	};
@@ -16,7 +16,6 @@ class PostTrendsDay extends PureComponent {
 		postCount: 0,
 	};
 
-	localeSlug = getLocaleSlug();
 	state = { showPopover: false };
 	dayRef = createRef();
 
@@ -30,10 +29,9 @@ class PostTrendsDay extends PureComponent {
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	buildTooltipData = () => {
-		const { label, postCount } = this.props;
-		const date = new Date( label );
-		const weekDay = date.toLocaleDateString( this.localeSlug, { weekday: 'long' } );
-		const formattedDate = date.toLocaleDateString( this.localeSlug, {
+		const { date, postCount, locale } = this.props;
+		const weekDay = date.toLocaleDateString( locale, { weekday: 'long' } );
+		const formattedDate = date.toLocaleDateString( locale, {
 			month: 'long',
 			day: 'numeric',
 			year: 'numeric',

--- a/client/my-sites/stats/post-trends/week.jsx
+++ b/client/my-sites/stats/post-trends/week.jsx
@@ -13,7 +13,6 @@ class PostTrendsWeek extends Component {
 		max: PropTypes.number,
 		streakData: PropTypes.object,
 		moment: PropTypes.func,
-		userLocale: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -23,7 +22,7 @@ class PostTrendsWeek extends Component {
 
 	getDayComponents() {
 		const days = [];
-		const { month, startDate, streakData, max, moment, userLocale } = this.props;
+		const { month, startDate, streakData, max, moment } = this.props;
 
 		for ( let i = 0; i < 7; i++ ) {
 			const dayDate = moment( startDate ).locale( 'en' ).add( i, 'day' );
@@ -50,7 +49,7 @@ class PostTrendsWeek extends Component {
 				<Day
 					key={ dayDate.format( 'MMDD' ) }
 					className={ classNames.join( ' ' ) }
-					label={ dayDate.locale( userLocale ).format( 'L' ) }
+					date={ dayDate.toDate() }
 					postCount={ postCount }
 				/>
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 679-gh-Automattic/i18n-issues

## Proposed Changes

* The `PostTrendsDay` component was trying to parse a date string, passed from its parent using the moment's `L` format for English using the `new Date()` constructor. However, the Date constructor appears to take into account the current page language, and since the parent is always using English to format the string, it resulted in getting "Invalid Date" object in some cases.
* This PR will pass the date object, instead of formatted string, so that it avoids doing unnecessary date formatting and parsing.


**Before:**
![CleanShot 2023-09-11 at 13 26 53](https://github.com/Automattic/wp-calypso/assets/2722412/5ee56a9c-7e62-4fd1-8f37-9a09f8ee4279)

**After:**
![CleanShot 2023-09-11 at 13 26 26](https://github.com/Automattic/wp-calypso/assets/2722412/c6986ff2-ef55-4721-ab3e-ee3b664ccb3b)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change UI to Spanish. It could probably be tested with other Mag-16 locales, but I've confirmed that it can be reproduced in Spanish.
* Go to `wordpress.com/stats/insights/[site]`.
* In the Post Activity section, hover over a date that is > 12 (for example Match 14, May 24, etc.), confirm the tooltip is rendering "Invalid Date".
* Open calypso.live build and repeat the same steps.
* Confirm the date in the tooltip is now properly parsed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
