### PR TITLE
Staging Sites: Navigate away from the domains page when on a staging site

### DIFF
--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -174,11 +174,11 @@ export default function () {
 
 	page(
 		'/domains/add',
-		stagingSiteNotSupportedRedirect,
 		siteSelection,
 		domainsController.domainsAddHeader,
 		domainsController.redirectToUseYourDomainIfVipSite(),
 		domainsController.jetpackNoDomainsWarning,
+		stagingSiteNotSupportedRedirect,
 		sites,
 		makeLayout,
 		clientRender
@@ -186,10 +186,10 @@ export default function () {
 
 	page(
 		'/domains/add/mapping',
-		stagingSiteNotSupportedRedirect,
 		siteSelection,
 		domainsController.domainsAddHeader,
 		domainsController.jetpackNoDomainsWarning,
+		stagingSiteNotSupportedRedirect,
 		sites,
 		makeLayout,
 		clientRender
@@ -197,10 +197,10 @@ export default function () {
 
 	page(
 		'/domains/add/transfer',
-		stagingSiteNotSupportedRedirect,
 		siteSelection,
 		domainsController.domainsAddHeader,
 		domainsController.jetpackNoDomainsWarning,
+		stagingSiteNotSupportedRedirect,
 		sites,
 		makeLayout,
 		clientRender
@@ -208,10 +208,10 @@ export default function () {
 
 	page(
 		'/domains/add/site-redirect',
-		stagingSiteNotSupportedRedirect,
 		siteSelection,
 		domainsController.domainsAddRedirectHeader,
 		domainsController.jetpackNoDomainsWarning,
+		stagingSiteNotSupportedRedirect,
 		sites,
 		makeLayout,
 		clientRender
@@ -219,12 +219,12 @@ export default function () {
 
 	page(
 		'/domains/add/:domain',
-		stagingSiteNotSupportedRedirect,
 		siteSelection,
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/add' ),
 		domainsController.redirectToUseYourDomainIfVipSite(),
 		domainsController.jetpackNoDomainsWarning,
+		stagingSiteNotSupportedRedirect,
 		domainsController.domainSearch,
 		makeLayout,
 		clientRender
@@ -232,11 +232,11 @@ export default function () {
 
 	page(
 		'/domains/add/:domain/email/:siteSlug',
-		stagingSiteNotSupportedRedirect,
 		siteSelection,
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/add' ),
 		domainsController.jetpackNoDomainsWarning,
+		stagingSiteNotSupportedRedirect,
 		domainsController.emailUpsellForDomainRegistration,
 		makeLayout,
 		clientRender
@@ -244,22 +244,22 @@ export default function () {
 
 	page(
 		'/domains/add/suggestion/:suggestion/:domain',
-		stagingSiteNotSupportedRedirect,
 		siteSelection,
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/add' ),
 		domainsController.redirectToUseYourDomainIfVipSite(),
 		domainsController.jetpackNoDomainsWarning,
+		stagingSiteNotSupportedRedirect,
 		domainsController.redirectToDomainSearchSuggestion
 	);
 
 	page(
 		'/domains/add/mapping/:domain',
-		stagingSiteNotSupportedRedirect,
 		siteSelection,
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/add/mapping' ),
 		domainsController.jetpackNoDomainsWarning,
+		stagingSiteNotSupportedRedirect,
 		domainsController.mapDomain,
 		makeLayout,
 		clientRender
@@ -267,10 +267,10 @@ export default function () {
 
 	page(
 		paths.domainMappingSetup( ':site', ':domain' ),
-		stagingSiteNotSupportedRedirect,
 		siteSelection,
 		navigation,
 		domainsController.jetpackNoDomainsWarning,
+		stagingSiteNotSupportedRedirect,
 		domainsController.mapDomainSetup,
 		makeLayout,
 		clientRender
@@ -278,11 +278,11 @@ export default function () {
 
 	page(
 		'/domains/add/site-redirect/:domain',
-		stagingSiteNotSupportedRedirect,
 		siteSelection,
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/add/site-redirect' ),
 		domainsController.jetpackNoDomainsWarning,
+		stagingSiteNotSupportedRedirect,
 		domainsController.siteRedirect,
 		makeLayout,
 		clientRender
@@ -290,11 +290,11 @@ export default function () {
 
 	page(
 		paths.domainTransferIn( ':domain' ),
-		stagingSiteNotSupportedRedirect,
 		siteSelection,
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/add/transfer' ),
 		domainsController.jetpackNoDomainsWarning,
+		stagingSiteNotSupportedRedirect,
 		domainsController.transferDomain,
 		makeLayout,
 		clientRender
@@ -302,11 +302,11 @@ export default function () {
 
 	page(
 		paths.domainUseYourDomain( ':site' ),
-		stagingSiteNotSupportedRedirect,
 		siteSelection,
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/add' ),
 		domainsController.jetpackNoDomainsWarning,
+		stagingSiteNotSupportedRedirect,
 		domainsController.useYourDomain,
 		makeLayout,
 		clientRender
@@ -314,11 +314,11 @@ export default function () {
 
 	page(
 		paths.domainUseMyDomain( ':site' ),
-		stagingSiteNotSupportedRedirect,
 		siteSelection,
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/add' ),
 		domainsController.jetpackNoDomainsWarning,
+		stagingSiteNotSupportedRedirect,
 		domainsController.useMyDomain,
 		makeLayout,
 		clientRender
@@ -326,11 +326,11 @@ export default function () {
 
 	page(
 		paths.domainManagementTransferInPrecheck( ':site', ':domain' ),
-		stagingSiteNotSupportedRedirect,
 		siteSelection,
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/manage' ),
 		domainsController.jetpackNoDomainsWarning,
+		stagingSiteNotSupportedRedirect,
 		domainsController.transferDomainPrecheck,
 		makeLayout,
 		clientRender
@@ -346,10 +346,10 @@ export default function () {
 
 	page(
 		'/domains/:site',
-		stagingSiteNotSupportedRedirect,
 		siteSelection,
 		navigation,
 		domainsController.jetpackNoDomainsWarning,
+		stagingSiteNotSupportedRedirect,
 		domainManagementController.domainManagementIndex,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/dotcom-forge/issues/3048

When a user lands on the domains search page but the active site is a staging site, an error will be shown because staging sites do not have the option to manage domains.

## Proposed Changes

When a user lands on the search domains site while the current site is a staging site, navigate to the dashboard/home.

## Testing Instructions

1. Create a Business site
2. Activate hosting features and add a staging site
3. Navigate to Upgrades -> Domains on the production site
4. Click 'Add a domain' and then 'Search for a domain'
5. Search for the domain
6. Switch context to the staging site in the left sidebar selector
7. Confirm that you navigate to the homepage and not to the domains search page.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?