### PR TITLE
Checkout: Remove fallback translations for line item sublabels

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -27,7 +27,7 @@ import {
 } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import styled from '@emotion/styled';
-import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useState, PropsWithChildren } from 'react';
 import { getLabel, DefaultLineItemSublabel } from './checkout-labels';
 import { getItemIntroductoryOfferDisplay } from './introductory-offer';
@@ -731,12 +731,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		return (
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
-				{ getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( '%(price)s per month' )
-					? translate( '%(price)s per month', { args: { price } } )
-					: translate( '%(sublabel)s: %(price)s per month', {
-							textOnly: true,
-							args: { sublabel: '_', price },
-					  } ).replace( '_:', '' ) }
+				{ translate( '%(price)s per month', { args: { price } } ) }
 			</>
 		);
 	}
@@ -745,12 +740,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		return (
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
-				{ getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( '%(price)s per year' )
-					? translate( '%(price)s per year', { args: { price } } )
-					: translate( '%(sublabel)s: %(price)s per year', {
-							textOnly: true,
-							args: { sublabel: '_', price },
-					  } ).replace( '_:', '' ) }
+				{ translate( '%(price)s per year', { args: { price } } ) }
 			</>
 		);
 	}
@@ -759,12 +749,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		return (
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
-				{ getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( '%(price)s per two years' )
-					? translate( '%(price)s per two years', { args: { price } } )
-					: translate( '%(sublabel)s: %(price)s per two years', {
-							textOnly: true,
-							args: { sublabel: '_', price },
-					  } ).replace( '_:', '' ) }
+				{ translate( '%(price)s per two years', { args: { price } } ) }
 			</>
 		);
 	}
@@ -773,12 +758,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		return (
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
-				{ getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( '%(price)s per three years' )
-					? translate( '%(price)s per three years', { args: { price } } )
-					: translate( '%(sublabel)s: %(price)s per three years', {
-							textOnly: true,
-							args: { sublabel: '_', price },
-					  } ).replace( '_:', '' ) }
+				{ translate( '%(price)s per three years', { args: { price } } ) }
 			</>
 		);
 	}


### PR DESCRIPTION
## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/80987 to remove the fallback translations now that the full translations are complete.

## Testing Instructions

None should be required as this just removes fallbacks.