### PR TITLE
 Allow users to enter DNS values in FQDN format (with a trailing period)

### DIFF
--- a/client/state/domains/dns/test/utils.js
+++ b/client/state/domains/dns/test/utils.js
@@ -14,5 +14,53 @@ describe( 'utils', () => {
 
 			expect( Object.values( errors ).every( isEmpty ) ).toBe( true );
 		} );
+
+		test( 'should return no errors for a valid CNAME record (with trailing dot and length 254)', () => {
+			const initialData = {
+				type: 'CNAME',
+				name: 'example.foo.com',
+				data: 'abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1.com.',
+			};
+
+			const errors = validateAllFields( initialData );
+
+			expect( Object.values( errors ).every( isEmpty ) ).toBe( true );
+		} );
+
+		test( 'should return no error for a valid CNAME record (no trailing dot and length 253)', () => {
+			const initialData = {
+				type: 'CNAME',
+				name: 'example.foo.com',
+				data: 'abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1.com',
+			};
+
+			const errors = validateAllFields( initialData );
+
+			expect( Object.values( errors ).every( isEmpty ) ).toBe( true );
+		} );
+
+		test( 'should return errors for a invalid CNAME record (with trailing dot and length 255)', () => {
+			const initialData = {
+				type: 'CNAME',
+				name: 'example.foo.com',
+				data: 'abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz12.com.',
+			};
+
+			const errors = validateAllFields( initialData );
+
+			expect( Object.values( errors ).every( isEmpty ) ).toBe( false );
+		} );
+
+		test( 'should return error for a invalid CNAME record (no trailing dot and length 254)', () => {
+			const initialData = {
+				type: 'CNAME',
+				name: 'example.foo.com',
+				data: 'abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz1234567890.abcdefghijklmnopqrstuvwxyz12.com',
+			};
+
+			const errors = validateAllFields( initialData );
+
+			expect( Object.values( errors ).every( isEmpty ) ).toBe( false );
+		} );
 	} );
 } );

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -37,7 +37,9 @@ function validateField( { name, value, type, domainName } ) {
 }
 
 function isValidDomain( name, type ) {
-	if ( name.length > 253 ) {
+	const maxLength = name.endsWith( '.' ) ? 254 : 253;
+
+	if ( name.length > maxLength ) {
 		return false;
 	}
 
@@ -45,7 +47,7 @@ function isValidDomain( name, type ) {
 		return true;
 	}
 
-	return /^([a-z0-9-_]{1,63}\.)*[a-z0-9-]{1,63}\.[a-z]{2,63}$/i.test( name );
+	return /^([a-z0-9-_]{1,63}\.)*[a-z0-9-]{1,63}\.[a-z]{2,63}(\.)?$/i.test( name );
 }
 
 function isValidName( name, type, domainName ) {


### PR DESCRIPTION
## Proposed Changes

Some users are requested from their service provider to include trailing dots when creating their dns records in WordPress.com.

This PR update the data field validation function, allowing trailing dots in:
- CNAME data field
- MX data field
- SRV target field

Note: so server updates are required, since trailing dot are allowed in the endpoint

## Testing Instructions

Create a new CNAME/MX record, using a FQDN and verify that the record is saved correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?