### PR TITLE
Paid Stats: Remove second step from wizard when a type hasn’t been selected yet.

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -196,44 +196,46 @@ const ProductCard = ( {
 									</div>
 								</PanelRow>
 							</PanelBody>
-							<PanelBody
-								title={ secondStepTitleNode }
-								opened={ wizardStep === SCREEN_PURCHASE }
-								className={ classNames( `${ COMPONENT_CLASS_NAME }__card-panel-title` ) }
-							>
-								<PanelRow>
-									{ siteType === TYPE_PERSONAL ? (
-										<PersonalPurchase
-											subscriptionValue={ subscriptionValue }
-											setSubscriptionValue={ setSubscriptionValue }
-											defaultStartingValue={ defaultStartingValue }
-											handlePlanSwap={ ( e ) => handlePlanSwap( e ) }
-											currencyCode={ pwywProduct?.currency_code }
-											siteSlug={ siteSlug }
-											sliderSettings={ {
-												minSliderPrice: disableFreeProduct ? sliderStepPrice : 0,
-												sliderStepPrice,
-												maxSliderPrice,
-												uiEmojiHeartTier,
-												uiImageCelebrationTier,
-											} }
-											adminUrl={ adminUrl }
-											redirectUri={ redirectUri }
-											from={ from }
-										/>
-									) : (
-										<CommercialPurchase
-											planValue={ commercialProduct?.cost }
-											currencyCode={ commercialProduct?.currency_code }
-											siteSlug={ siteSlug }
-											commercialProduct={ commercialProduct }
-											adminUrl={ adminUrl }
-											redirectUri={ redirectUri }
-											from={ from }
-										/>
-									) }
-								</PanelRow>
-							</PanelBody>
+							{ siteType && wizardStep === SCREEN_PURCHASE && (
+								<PanelBody
+									title={ secondStepTitleNode }
+									opened={ wizardStep === SCREEN_PURCHASE }
+									className={ classNames( `${ COMPONENT_CLASS_NAME }__card-panel-title` ) }
+								>
+									<PanelRow>
+										{ siteType === TYPE_PERSONAL ? (
+											<PersonalPurchase
+												subscriptionValue={ subscriptionValue }
+												setSubscriptionValue={ setSubscriptionValue }
+												defaultStartingValue={ defaultStartingValue }
+												handlePlanSwap={ ( e ) => handlePlanSwap( e ) }
+												currencyCode={ pwywProduct?.currency_code }
+												siteSlug={ siteSlug }
+												sliderSettings={ {
+													minSliderPrice: disableFreeProduct ? sliderStepPrice : 0,
+													sliderStepPrice,
+													maxSliderPrice,
+													uiEmojiHeartTier,
+													uiImageCelebrationTier,
+												} }
+												adminUrl={ adminUrl }
+												redirectUri={ redirectUri }
+												from={ from }
+											/>
+										) : (
+											<CommercialPurchase
+												planValue={ commercialProduct?.cost }
+												currencyCode={ commercialProduct?.currency_code }
+												siteSlug={ siteSlug }
+												commercialProduct={ commercialProduct }
+												adminUrl={ adminUrl }
+												redirectUri={ redirectUri }
+												from={ from }
+											/>
+										) }
+									</PanelRow>
+								</PanelBody>
+							) }
 						</Panel>
 					</div>
 					<div className={ `${ COMPONENT_CLASS_NAME }__card-inner--right` }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81488

## Proposed Changes

* This PR removes the second step when a type hasn’t been selected yet. This makes sense to not show it until it is needed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the Calypso live branch
* Go to `stats/purchase/{siteURL}`
* If it is a wpcom simple site, append the flag `flags=stats/paid-wpcom-stats`
* Check that the wizard only displays step 1, and step 2 is not visible. 
* Check that once you select a site type, step 2 is shown

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/30754158/2dfad152-ea9f-4028-8271-2269e9e59edb)  | ![image](https://github.com/Automattic/wp-calypso/assets/30754158/2adbbf57-953a-4e89-9fd9-84588e0b1944)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?