### PR TITLE
Earn: Convert memberships index to typescript

### DIFF
--- a/client/my-sites/earn/controller.ts
+++ b/client/my-sites/earn/controller.ts
@@ -1,6 +1,7 @@
 import page from 'page';
 import { createElement, FC } from 'react';
 import Main from './main';
+import { Query } from './types';
 import type { Context as PageJSContext } from 'page';
 
 export default {
@@ -17,7 +18,7 @@ export default {
 		}
 
 		context.primary = createElement(
-			Main as FC< { section: string; path: string; query: string } >,
+			Main as FC< { section: string; path: string; query: Query } >,
 			{
 				section: context.params.section,
 				path: context.path,

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -14,7 +14,7 @@ import WordAdsPayments from 'calypso/my-sites/earn/ads/payments';
 import WordAdsEarnings from 'calypso/my-sites/stats/wordads/earnings';
 import WordAdsHighlightsSection from 'calypso/my-sites/stats/wordads/highlights-section';
 import { useSelector } from 'calypso/state';
-import { canAccessWordAds } from 'calypso/state/sites/selectors';
+import { canAccessWordAds, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import AdsWrapper from './ads/wrapper';
 import Home from './home';
@@ -25,18 +25,19 @@ import ReferAFriendSection from './refer-a-friend';
 
 type EarningsMainProps = {
 	section: string;
-	adsProgramName: string;
 	query: Query;
 	path: string;
 };
 
-const EarningsMain = ( { section, adsProgramName, query, path }: EarningsMainProps ) => {
+const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 	const translate = useTranslate();
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const canAccessAds = useSelector( ( state ) => canAccessWordAds( state, site?.ID ) );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
+	const adsProgramName = isJetpack ? 'Ads' : 'WordAds';
 
 	const layoutTitles = {
-		earnings: translate( '%(wordads)s Earnings', { args: { wordads: adsProgramName } } ),
+		earnings: translate( '%(wordads)s hiEarnings', { args: { wordads: adsProgramName } } ),
 		settings: translate( '%(wordads)s Settings', { args: { wordads: adsProgramName } } ),
 		payments: translate( 'Recurring Payments' ),
 		'payments-plans': translate( 'Recurring Payments plans' ),

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -19,9 +19,9 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import AdsWrapper from './ads/wrapper';
 import Home from './home';
 import MembershipsSection from './memberships';
-import { Query } from './memberships/index';
 import MembershipsProductsSection from './memberships/products';
 import ReferAFriendSection from './refer-a-friend';
+import { Query } from './types';
 
 type EarningsMainProps = {
 	section: string;

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -19,13 +19,14 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import AdsWrapper from './ads/wrapper';
 import Home from './home';
 import MembershipsSection from './memberships';
+import { Query } from './memberships/index';
 import MembershipsProductsSection from './memberships/products';
 import ReferAFriendSection from './refer-a-friend';
 
 type EarningsMainProps = {
 	section: string;
 	adsProgramName: string;
-	query: string;
+	query: Query;
 	path: string;
 };
 

--- a/client/my-sites/earn/memberships/index.tsx
+++ b/client/my-sites/earn/memberships/index.tsx
@@ -1,4 +1,4 @@
-import { Card, Button, Dialog, Gridicon, LoadingPlaceholder } from '@automattic/components';
+import { Card, Button, Dialog, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { englishLocales, localizeUrl, useLocale } from '@automattic/i18n-utils';
 import { saveAs } from 'browser-filesaver';
@@ -122,7 +122,7 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 
 	function renderEarnings() {
 		if ( ! site ) {
-			return <LoadingPlaceholder />;
+			return <LoadingEllipsis />;
 		}
 
 		return (
@@ -351,7 +351,7 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 
 	function renderManagePlans() {
 		if ( ! site ) {
-			return <LoadingPlaceholder />;
+			return <LoadingEllipsis />;
 		}
 
 		return (
@@ -728,7 +728,7 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 	}
 
 	if ( ! site ) {
-		return <LoadingPlaceholder />;
+		return <LoadingEllipsis />;
 	}
 
 	return (

--- a/client/my-sites/earn/memberships/index.tsx
+++ b/client/my-sites/earn/memberships/index.tsx
@@ -1,8 +1,8 @@
 import { Card, Button, Dialog, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
-import { englishLocales, localizeUrl, useLocale } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { saveAs } from 'browser-filesaver';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { orderBy } from 'lodash';
 import { useState, useEffect, useCallback, MouseEvent, ReactNode } from 'react';
 import { shallowEqual } from 'react-redux';
@@ -78,7 +78,6 @@ type Subscriber = {
 
 function MembershipsSection( { query }: MembershipsSectionProps ) {
 	const translate = useTranslate();
-	const locale = useLocale();
 	const dispatch = useDispatch();
 	const moment = useLocalizedMoment();
 	const source = getSource();
@@ -648,22 +647,11 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 						) }
 					</div>
 					<div>
-						<h3>
-							{ englishLocales.includes( locale ) || i18n.hasTranslation( 'Simple fees structure' )
-								? translate( 'Simple fees structure' )
-								: translate( 'No membership fees' ) }
-						</h3>
+						<h3>{ translate( 'Simple fees structure' ) }</h3>
 						<p>
 							<CommissionFees commission={ commission } siteSlug={ site?.slug } />
 						</p>
-						<p>
-							{ preventWidows(
-								englishLocales.includes( locale ) ||
-									i18n.hasTranslation( 'No fixed monthly or annual fees charged.' )
-									? translate( 'No fixed monthly or annual fees charged.' )
-									: translate( 'No monthly or annual fees charged.' )
-							) }
-						</p>
+						<p>{ preventWidows( translate( 'No fixed monthly or annual fees charged.' ) ) }</p>
 					</div>
 					<div>
 						<h3>{ translate( 'Join thousands of others' ) }</h3>

--- a/client/my-sites/earn/memberships/index.tsx
+++ b/client/my-sites/earn/memberships/index.tsx
@@ -44,7 +44,7 @@ import { ADD_NEWSLETTER_PAYMENT_PLAN_HASH, LAUNCHPAD_HASH } from './constants';
 
 import './style.scss';
 
-type Query = {
+export type Query = {
 	stripe_connect_success?: string;
 	stripe_connect_cancelled?: string;
 };

--- a/client/my-sites/earn/memberships/index.tsx
+++ b/client/my-sites/earn/memberships/index.tsx
@@ -40,17 +40,13 @@ import {
 } from 'calypso/state/memberships/subscribers/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import CommissionFees from '../components/commission-fees';
+import { Query } from '../types';
 import { ADD_NEWSLETTER_PAYMENT_PLAN_HASH, LAUNCHPAD_HASH } from './constants';
 
 import './style.scss';
 
-export type Query = {
-	stripe_connect_success?: string;
-	stripe_connect_cancelled?: string;
-};
-
 type MembershipsSectionProps = {
-	query: Query;
+	query?: Query;
 };
 
 type Subscriber = {

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -23,16 +23,14 @@ import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import RecurringPaymentsPlanAddEditModal from '../components/add-edit-plan-modal';
-import { Product } from '../types';
+import { Product, Query } from '../types';
 import { ADD_NEW_PAYMENT_PLAN_HASH, ADD_NEWSLETTER_PAYMENT_PLAN_HASH } from './constants';
 import RecurringPaymentsPlanDeleteModal from './delete-plan-modal';
 import MembershipsSection from './';
 import './style.scss';
 
 type MembersProductsSectionProps = {
-	query?: {
-		[ key: string ]: string;
-	};
+	query?: Query;
 };
 
 const showAddEditDialogInitially =

--- a/client/my-sites/earn/types.ts
+++ b/client/my-sites/earn/types.ts
@@ -12,3 +12,7 @@ export type Product = {
 	type?: string;
 	is_editable?: boolean;
 };
+
+export type Query = {
+	[ key: string ]: string;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Updates the Earn > Membership > Index component to TypeScript. 

To resolve some TS issues and ensure consistency, I also extracted a Query type to types.ts, and imported that in the file being refactored as well as two others. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Checkout this branch and go to http://calypso.localhost:3000/earn/YOURDOMAIN
2) If you haven't already, connect stripe via the Collect payments card
3) Once connected, click around and confirm things work as expected. Try adding / editing / deleting plans.
4) Review the file in your editor and confirm no typescript errors. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
