### PR TITLE
Paid Stats: Adjust title of first step to be "Select your site type"

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -68,25 +68,14 @@ const ProductCard = ( {
 	const personalLabel = translate( 'Personal site' );
 	const commercialLabel = translate( 'Commercial site' );
 	const personalProductTitle = translate( 'What is Jetpack Stats worth to you?' );
-	const commercialProductTitle = translate( 'Upgrade your Jetpack Stats' );
 
 	// Default titles for no site type selected.
-	let typeSelectionScreenLabel = translate( 'Select your site type', {
+	const typeSelectionScreenLabel = translate( 'Select your site type', {
 		args: {
 			site: siteSlug,
 		},
 	} );
-	let purchaseScreenLabel = personalProductTitle;
-
-	if ( siteType === TYPE_PERSONAL ) {
-		typeSelectionScreenLabel = personalLabel;
-		purchaseScreenLabel = personalProductTitle;
-	}
-
-	if ( siteType === TYPE_COMMERCIAL ) {
-		typeSelectionScreenLabel = commercialLabel;
-		purchaseScreenLabel = commercialProductTitle;
-	}
+	const purchaseScreenLabel = personalProductTitle;
 
 	const showCelebration =
 		siteType &&

--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -71,17 +71,12 @@ const ProductCard = ( {
 	const commercialProductTitle = translate( 'Upgrade your Jetpack Stats' );
 
 	// Default titles for no site type selected.
-	let typeSelectionScreenLabel = translate( 'What type of site is %(site)s?', {
+	let typeSelectionScreenLabel = translate( 'Select your site type', {
 		args: {
 			site: siteSlug,
 		},
 	} );
 	let purchaseScreenLabel = personalProductTitle;
-
-	if ( ! siteSlug ) {
-		// Default to a generic label if no site slug is provided.
-		typeSelectionScreenLabel = translate( 'Which type is your site?' );
-	}
 
 	if ( siteType === TYPE_PERSONAL ) {
 		typeSelectionScreenLabel = personalLabel;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81488

## Proposed Changes

* This PR adjusts title of the Wizard's first step to be "Select your site type" instead of "What Type of Site is.." and  "Personal/Commercial site"

## Testing Instructions

* Load the Calypso live branch
* Go to `stats/purchase/{siteURL}`
* If it is a wpcom simple site, append the flag `flags=stats/paid-wpcom-stats`
* Check that the wizard step one title shows "Select your site type"
* Check that once you select a site type, step 2 is shown and the step one title remains as "Select your site type"

| Step 1 Before  |  Step 1 After |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/30754158/545b2974-e0c9-4e60-920a-166f88bc05d2)  | ![image](https://github.com/Automattic/wp-calypso/assets/30754158/e88bcbbd-231b-440b-b74f-8ad66021d4d5)  |

|  Step 2 Before  |  Step 2 After |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/30754158/7c9e75d9-623c-46da-8986-2c7eaa347054)  | ![image](https://github.com/Automattic/wp-calypso/assets/30754158/ec7dda88-2a74-484f-afa9-ed6d6fa8897e) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?