### PR TITLE
Jetpack Manage: Replace all references to 'Pro Dashboard' with 'Jetpa…

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
@@ -102,9 +102,7 @@ describe( '<SitesOverview>', () => {
 		);
 		expect( dashboardSubHeading ).toBeInTheDocument();
 
-		const [ emptyStateMessage ] = getAllByText(
-			"Let's get started with the Jetpack Pro Dashboard"
-		);
+		const [ emptyStateMessage ] = getAllByText( "Let's get started with Jetpack Manage" );
 		expect( emptyStateMessage ).toBeInTheDocument();
 
 		const promise = Promise.resolve();

--- a/client/jetpack-cloud/sections/partner-portal/primary/onboarding-widget/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/onboarding-widget/index.tsx
@@ -46,7 +46,7 @@ export default function OnboardingWidget( { isLicensesPage }: { isLicensesPage?:
 			stepCount: hasSites ? <Gridicon icon="checkmark" size={ 16 } /> : 1,
 			title: translate( 'Add your Jetpack sites' ),
 			description: translate(
-				'Manage features and monitor your clients’ sites by adding them to your Jetpack Pro Dashboard. To do so, connect the sites to Jetpack using your {{strong}}%(userEmail)s{{/strong}} user account.',
+				'Manage features and monitor your clients’ sites by adding them to Jetpack Manage. To do so, connect the sites to Jetpack using your {{strong}}%(userEmail)s{{/strong}} user account.',
 				{
 					args: { userEmail: user?.email ?? '' },
 					components: {
@@ -104,7 +104,7 @@ export default function OnboardingWidget( { isLicensesPage }: { isLicensesPage?:
 			} ) }
 		>
 			<h2 className="onboarding-widget__title">
-				{ translate( "Let's get started with the Jetpack Pro Dashboard" ) }
+				{ translate( "Let's get started with Jetpack Manage" ) }
 			</h2>
 
 			<div className="onboarding-widget__steps">

--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
@@ -141,7 +141,7 @@ export default function Prices() {
 				<div className="prices__description">
 					<p>
 						{ translate(
-							'The following products are available through the Licenses section. Prices are calculated daily and invoiced at the beginning of the next month. Please note that the Jetpack pro Dashboard prices will be displayed as a monthly cost. If you want to determine a yearly cost for the Agency/Pro pricing, you can take the daily cost x 365.'
+							'The following products are available through the Licenses section. Prices are calculated daily and invoiced at the beginning of the next month. Please note that Jetpack Manage prices will be displayed as a monthly cost. If you want to determine a yearly cost for the Agency/Pro pricing, you can take the daily cost x 365.'
 						) }
 					</p>
 				</div>

--- a/client/my-sites/checkout/src/components/jetpack-pro-redirect-modal/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-pro-redirect-modal/index.tsx
@@ -38,12 +38,12 @@ export default function JetpackProRedirectModal( { redirectTo, productSourceFrom
 		dispatch( recordTracksEvent( 'jetpack_dashboard_agency_checkout_redirect_modal_redirect' ) );
 	};
 
-	// Features list of Agency/Pro Dashboard.
+	// Features list of Jetpack Manage.
 	const features = [
 		translate( 'Up to 60% off our products and bundles.' ),
 		translate( 'A recurring discount (not just for the first year).' ),
 		translate( 'More flexible billing (only pay per day of use, billed monthly).' ),
-		translate( 'Access to our Pro Dashboard – manage all of your sites in one place.' ),
+		translate( 'Access to Jetpack Manage – manage all of your sites in one place.' ),
 	];
 
 	const redirectURLPage = getQueryArg( redirectTo ?? '', 'page' );


### PR DESCRIPTION
This pull request updates all text copy references to "Jetpack Pro Dashboard" by replacing them with "Jetpack Manage."

Resolves https://github.com/Automattic/jetpack-genesis/issues/22.

## Proposed Changes

* Replace all string references to `(your |the )?Jetpack Pro Dashboard` with "Jetpack Manage."

## Testing Instructions

### Checkout / redirect modal

* **In Calypso Blue**, visit `/checkout/jetpack/jetpack_ai_yearly?source=jetpack-plans`.
* Verify you see a modal when the page loads, and that modal references Jetpack Manage instead of Jetpack Pro Dashboard.

### Dashboard

* **In Calypso Green**, visit `/dashboard`.
  * Modify line of `client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx` to force `showEmptyState` to equal true.
  * Verify you see a page state that reflects no active sites (see below screenshots).
  * Verify all verbiage references Jetpack Manage instead of Jetpack Pro Dashboard.

### Licenses

* **In Calypso Green**, visit `/partner-portal/licenses`.
  * Modify line 65 of `client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx` to force `showEmptyStateContent` to equal true; or, in Redux DevTools, dispatch the following event:

```js
{
  type: 'JETPACK_PARTNER_PORTAL_LICENSE_COUNTS_RECEIVE',
  counts: { all: 0 }
}
```
  * Verify you see a page state that reflects no active sites (see below screenshots).
  * Verify all verbiage references Jetpack Manage instead of Jetpack Pro Dashboard.

### Prices

* **In Calypso Green**, visit `/partner-portal/prices`.
* Verify all verbiage references Jetpack Manage instead of Jetpack Pro Dashboard.

## Reference screenshots

### Checkout / redirect modal

![Screen Shot 2023-09-11 at 14 04 48](https://github.com/Automattic/wp-calypso/assets/670067/b0aff3dd-e230-4602-ae42-d1903f3f17bb)

### Dashboard

![Screen Shot 2023-09-11 at 13 58 14](https://github.com/Automattic/wp-calypso/assets/670067/96e5312a-7d23-425c-a053-3fc0e4063ff3)

### Partner Portal > Licenses
![Screen Shot 2023-09-11 at 13 54 19](https://github.com/Automattic/wp-calypso/assets/670067/c8e9217f-984b-462f-a8af-3e20c1441af9)

### Partner Portal > Prices

![Screen Shot 2023-09-11 at 13 54 42](https://github.com/Automattic/wp-calypso/assets/670067/c907fe61-e828-4dcf-95ab-ae2fc5ce6551)
