### PR TITLE
SaaS Plugins: Display price as "Start for free"

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -17,7 +17,10 @@ import { useLocalizedPlugins, siteObjectsToSiteIds } from 'calypso/my-sites/plug
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import { getSitesWithPlugin, getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
-import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
+import {
+	isMarketplaceProduct as isMarketplaceProductSelector,
+	isSaasProduct as isSaasProductSelector,
+} from 'calypso/state/products-list/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -266,6 +269,7 @@ function InstalledInOrPricing( {
 	const { isPreinstalledPremiumPlugin } = usePreinstalledPremiumPlugin( plugin.slug );
 	const active = isWpcomPreinstalled || isPluginActive;
 	const isLoggedIn = useSelector( isUserLoggedIn );
+	const isSaasProduct = useSelector( ( state ) => isSaasProductSelector( state, plugin.slug ) );
 
 	if ( isPreinstalledPremiumPlugin ) {
 		return <PreinstalledPremiumPluginBrowserItemPricing plugin={ plugin } />;
@@ -298,14 +302,15 @@ function InstalledInOrPricing( {
 		<div className="plugins-browser-item__pricing">
 			<PluginPrice plugin={ plugin } billingPeriod={ IntervalLength.MONTHLY }>
 				{ ( { isFetching, price, period } ) => {
-					if ( plugin.isSaasProduct ) {
-						// SaaS products do not display a price
+					if ( isSaasProduct ) {
+						// SaaS products displays `Start for free`
 						return (
 							<>
+								{ translate( 'Start for free' ) }
 								{ ! canInstallPlugins && isLoggedIn && (
-									<span className="plugins-browser-item__requires-plan-upgrade">
+									<div className="plugins-browser-item__period">
 										{ translate( 'Requires a plan upgrade' ) }
-									</span>
+									</div>
 								) }
 							</>
 						);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3690

## Proposed Changes

* Update SaaS check for plugin card to use the `isSaasProduct` selector
* Display the price as `Start for free`

| Lower than Business  | Business and higher |
| ------------- | ------------- |
|![CleanShot 2023-09-11 at 17 21 32@2x](https://github.com/Automattic/wp-calypso/assets/5039531/f40e5cd3-7610-467b-973b-30429b11e6e9)| ![CleanShot 2023-09-11 at 17 18 26@2x](https://github.com/Automattic/wp-calypso/assets/5039531/fec8a18b-5084-41be-937d-0d6a662a0fb6)


## Testing Instructions

* Go to `/plugins/browse/paid/:site` with a lower than Business plan
* You should see mailpoet display the `Start for free` label
* Go to `/plugins/browse/paid/:site` with Business or higher plan
* You should see mailpoet display the `Start for free` label

* On production you should see the a price displayed



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
