### PR TITLE
Earn: Convert ads form to typescript

### DIFF
--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -183,6 +183,7 @@ const AdsFormSettings = () => {
 
 		return (
 			<FormFieldset>
+				{ /* className undefined to resolve TS warning */ }
 				<FormLegend className={ undefined }>{ translate( 'Ads Visibility' ) }</FormLegend>
 				<FormLabel>
 					<FormRadio
@@ -192,6 +193,7 @@ const AdsFormSettings = () => {
 						onChange={ handleChange }
 						disabled={ isLoading }
 						label={ translate( 'Run ads for all users' ) }
+						// className undefined to resolve TS warning
 						className={ undefined }
 					/>
 				</FormLabel>
@@ -204,6 +206,7 @@ const AdsFormSettings = () => {
 						onChange={ handleChange }
 						disabled={ isLoading }
 						label={ translate( 'Run ads only for logged-out users (less revenue)' ) }
+						// className undefined to resolve TS warning
 						className={ undefined }
 					/>
 				</FormLabel>
@@ -216,6 +219,7 @@ const AdsFormSettings = () => {
 						onChange={ handleChange }
 						disabled={ isLoading }
 						label={ translate( 'Pause ads (no revenue)' ) }
+						// className undefined to resolve TS warning
 						className={ undefined }
 					/>
 				</FormLabel>
@@ -229,6 +233,7 @@ const AdsFormSettings = () => {
 		return (
 			<div>
 				<FormFieldset className="ads__settings-display-toggles">
+					{ /* className undefined to resolve TS warning */ }
 					<FormLegend className={ undefined }>
 						{ translate( 'Display ads below posts on' ) }
 					</FormLegend>
@@ -258,6 +263,7 @@ const AdsFormSettings = () => {
 					/>
 				</FormFieldset>
 				<FormFieldset className="ads__settings-display-toggles">
+					{ /* className undefined to resolve TS warning */ }
 					<FormLegend className={ undefined }>
 						{ translate( 'Additional ad placements' ) }
 					</FormLegend>

--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -183,9 +183,10 @@ const AdsFormSettings = () => {
 
 		return (
 			<FormFieldset>
-				{ /* className undefined to resolve TS warning */ }
-				<FormLegend className={ undefined }>{ translate( 'Ads Visibility' ) }</FormLegend>
+				{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
+				<FormLegend>{ translate( 'Ads Visibility' ) }</FormLegend>
 				<FormLabel>
+					{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
 					<FormRadio
 						name="show_to_logged_in"
 						value="yes"
@@ -193,12 +194,11 @@ const AdsFormSettings = () => {
 						onChange={ handleChange }
 						disabled={ isLoading }
 						label={ translate( 'Run ads for all users' ) }
-						// className undefined to resolve TS warning
-						className={ undefined }
 					/>
 				</FormLabel>
 
 				<FormLabel>
+					{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
 					<FormRadio
 						name="show_to_logged_in"
 						value="no"
@@ -206,12 +206,11 @@ const AdsFormSettings = () => {
 						onChange={ handleChange }
 						disabled={ isLoading }
 						label={ translate( 'Run ads only for logged-out users (less revenue)' ) }
-						// className undefined to resolve TS warning
-						className={ undefined }
 					/>
 				</FormLabel>
 
 				<FormLabel>
+					{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
 					<FormRadio
 						name="show_to_logged_in"
 						value="pause"
@@ -219,8 +218,6 @@ const AdsFormSettings = () => {
 						onChange={ handleChange }
 						disabled={ isLoading }
 						label={ translate( 'Pause ads (no revenue)' ) }
-						// className undefined to resolve TS warning
-						className={ undefined }
 					/>
 				</FormLabel>
 			</FormFieldset>
@@ -233,10 +230,8 @@ const AdsFormSettings = () => {
 		return (
 			<div>
 				<FormFieldset className="ads__settings-display-toggles">
-					{ /* className undefined to resolve TS warning */ }
-					<FormLegend className={ undefined }>
-						{ translate( 'Display ads below posts on' ) }
-					</FormLegend>
+					{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
+					<FormLegend>{ translate( 'Display ads below posts on' ) }</FormLegend>
 					<ToggleControl
 						checked={ !! settings.display_options?.display_front_page }
 						disabled={ isDisabled }
@@ -263,10 +258,8 @@ const AdsFormSettings = () => {
 					/>
 				</FormFieldset>
 				<FormFieldset className="ads__settings-display-toggles">
-					{ /* className undefined to resolve TS warning */ }
-					<FormLegend className={ undefined }>
-						{ translate( 'Additional ad placements' ) }
-					</FormLegend>
+					{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
+					<FormLegend>{ translate( 'Additional ad placements' ) }</FormLegend>
 					<ToggleControl
 						checked={ !! settings.display_options?.enable_header_ad }
 						disabled={ isDisabled }


### PR DESCRIPTION
## Proposed Changes

Refactors Earn > Ads > FormSettings component to TypeScript.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Checkout this branch and go to `http://calypso.localhost:3000/earn/YOURDOMAIN`
2) If you haven't yet, find the Ads card, enable Ads, and on the Ads page click the button to apply (it is instant).
3) Go to Ads > Settings. Confirm the page loads without issues. 
4) Confirm initial settings (if you haven't already changed them) should look like this: 
<img width="1056" alt="ad-settings" src="https://github.com/Automattic/wp-calypso/assets/21228350/aaa046d9-16ba-4502-a40b-baba46b45455">
5) Try updating various settings and saving. Confirm your new options are saved. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
