### PR TITLE
Add domain transfer request queries

### DIFF
--- a/client/data/domains/transfers/domain-transfer-request-query-key.ts
+++ b/client/data/domains/transfers/domain-transfer-request-query-key.ts
@@ -1,0 +1,5 @@
+import { QueryKey } from '@tanstack/react-query';
+
+export function domainTransferRequestQueryKey( siteSlug: string, domainName: string ): QueryKey {
+	return [ 'domain-transfer-request', siteSlug, domainName ];
+}

--- a/client/data/domains/transfers/use-domain-transfer-request-delete.ts
+++ b/client/data/domains/transfers/use-domain-transfer-request-delete.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { DomainsApiError } from 'calypso/lib/domains/types';
+import wp from 'calypso/lib/wp';
+import { domainTransferRequestQueryKey } from './domain-transfer-request-query-key';
+
+export default function useDomainTransferRequestDelete(
+	siteSlug: string,
+	domainName: string,
+	queryOptions: {
+		onSuccess?: () => void;
+		onError?: ( error: DomainsApiError ) => void;
+	}
+) {
+	const queryClient = useQueryClient();
+	const mutation = useMutation( {
+		mutationFn: () =>
+			wp.req.post( `/sites/${ siteSlug }/domains/${ domainName }/transfer-to-any-user/delete` ),
+		...queryOptions,
+		onSuccess() {
+			queryClient.removeQueries( domainTransferRequestQueryKey( siteSlug, domainName ) );
+			queryOptions.onSuccess?.();
+		},
+	} );
+
+	const { mutate } = mutation;
+
+	const domainTransferRequestDelete = useCallback( mutate, [ mutate ] );
+
+	return { domainTransferRequestDelete, ...mutation };
+}

--- a/client/data/domains/transfers/use-domain-transfer-request-query.ts
+++ b/client/data/domains/transfers/use-domain-transfer-request-query.ts
@@ -1,0 +1,21 @@
+import { UseQueryResult, useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import { domainTransferRequestQueryKey } from './domain-transfer-request-query-key';
+
+export type DomainTransferRequest = {
+	email: string;
+	requested_at: string;
+};
+
+export default function useDomainTransferRequestQuery(
+	siteSlug: string,
+	domainName: string
+): UseQueryResult< DomainTransferRequest | null > {
+	return useQuery( {
+		queryKey: domainTransferRequestQueryKey( siteSlug, domainName ),
+		queryFn: () =>
+			wp.req.get( `/sites/${ siteSlug }/domains/${ domainName }/transfer-to-any-user` ),
+		refetchOnWindowFocus: false,
+		select: ( data: DomainTransferRequest ) => data,
+	} );
+}

--- a/client/data/domains/transfers/use-domain-transfer-request-update.ts
+++ b/client/data/domains/transfers/use-domain-transfer-request-update.ts
@@ -1,0 +1,33 @@
+import { useMutation } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { DomainsApiError } from 'calypso/lib/domains/types';
+import wp from 'calypso/lib/wp';
+
+export default function useDomainTransferRequestUpdate(
+	siteSlug: string,
+	domainName: string,
+	queryOptions: {
+		onSuccess?: () => void;
+		onError?: ( error: DomainsApiError ) => void;
+	}
+) {
+	const mutation = useMutation( {
+		mutationFn: ( email: string ) =>
+			wp.req.post( `/sites/${ siteSlug }/domains/${ domainName }/transfer-to-any-user`, {
+				email,
+			} ),
+		...queryOptions,
+		onSuccess() {
+			queryOptions.onSuccess?.();
+		},
+	} );
+
+	const { mutate } = mutation;
+
+	const domainTransferRequestUpdate = useCallback(
+		( email: string ) => mutate( email ),
+		[ mutate ]
+	);
+
+	return { domainTransferRequestUpdate, ...mutation };
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3734

Related to https://github.com/Automattic/dotcom-forge/issues/3685 / https://github.com/Automattic/dotcom-forge/issues/3596

## Proposed Changes

* Defines calypso side domain transfer data hooks for fetch, update, and delete being introduced in D120926-code

## Testing Instructions

* Patch with D120926-code
* Visit domain transfer screen with the flag enabled: http://calypso.localhost:3000/domains/manage/all/test345678.blog/transfer/test345678.blog?flags=domains/transfer-to-any-user
* The transfer request should still send and save the backend option.

No clear way to test the delete/get methods, we'll be needing them for https://github.com/Automattic/dotcom-forge/issues/3685 so can fix them then if it's required.
