### PR TITLE
Jetpack Manage: Adjust styles to align the check and close icon with the header text

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/style.scss
@@ -10,15 +10,25 @@
 }
 
 .site-add-license-notification__license-banner-wp {
-	.banner {
+	.banner.card {
 		border-width: 1px 1px 1px 4px;
 		border-style: solid;
 		border-color: var(--studio-green-40);
 		border-radius: 4px 2px 2px 4px;
+		align-items: flex-start;
 
 		.banner__description {
 			max-width: 90%;
 		}
+	}
+
+	// Align the banner icon with the text
+	svg.banner__close-icon {
+		top: 22px;
+	}
+
+	.banner__icon-no-circle {
+		padding-block-start: 0;
 	}
 
 	.site-add-license-notification__license-banner-wp-buttons {
@@ -28,6 +38,7 @@
 		flex-wrap: wrap;
 
 		.button {
+			padding-block: 4px;
 
 			.gridicon {
 				margin-inline-start: 8px;
@@ -38,6 +49,7 @@
 
 			&.is-borderless {
 				text-decoration: underline;
+				padding-block: 0;
 
 				.gridicon {
 					color: var(--color-neutral-80);


### PR DESCRIPTION
This change we requested here: https://github.com/Automattic/wp-calypso/pull/81173#issuecomment-1700919665

However, this was missed due to the commit not being pushed before the PR was merged.

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/wpcom-notification-banner-style` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Open `/jetpack-cloud/sections/partner-portal/hooks/use-assign-licenses-to-site.ts#L97` and add `type: 'wpcom-hosting',` so it looks like

```
return {
	selectedSite: selectedSite?.domain || '',
	selectedProducts: apiRequests,
	type: 'wpcom-hosting',
};
```

4. Click on the `...` on any site > Click `Issue new license` > Select and issue a license > Verify that you are redirected to the dashboard and below notification is shown. Note: This will be shown only when we assign a WPCOM atomic hosting plan which has not yet been added.
5. Verify this banner looks good and all the different devices.

<img width="1613" alt="264929125-e7cc0cdd-62d1-418a-8079-0a3b9275194c" src="https://github.com/Automattic/wp-calypso/assets/10586875/0c59da49-0a00-4e29-9d0e-757f5b211115">

<img width="376" alt="264929137-99a2c1f0-b277-46ab-a454-156a0436e4bb" src="https://github.com/Automattic/wp-calypso/assets/10586875/295ab01b-8dae-408b-b028-9dca1e51d4b5">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?