### PR TITLE
Jetpack E2E: add block tests.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/gif.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/gif.ts
@@ -1,0 +1,57 @@
+import { BlockFlow, EditorContext, PublishedPostContext } from '.';
+
+interface ConfigurationData {
+	query: string;
+}
+
+const blockParentSelector = '[aria-label="Block: GIF"]';
+
+/**
+ * Class representing the flow of using a Tiled Gallery block in the editor.
+ */
+export class GifFlow implements BlockFlow {
+	private configurationData: ConfigurationData;
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData data with which to configure and validate the block
+	 */
+	constructor( configurationData: ConfigurationData ) {
+		this.configurationData = configurationData;
+	}
+
+	blockSidebarName = 'GIF';
+	blockEditorSelector = blockParentSelector;
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		const block = editorCanvas.getByRole( 'document', { name: 'Block: GIF' } );
+
+		await block.getByRole( 'textbox' ).fill( this.configurationData.query );
+		await block.getByRole( 'button', { name: 'Search' } ).click();
+
+		await block
+			.frameLocator( `iframe[src="${ this.configurationData.query }"]` )
+			.locator( '.embed' )
+			.waitFor();
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		await context.page
+			.getByRole( 'main' )
+			.frameLocator( `iframe[src="${ this.configurationData.query }"]` )
+			.getByRole( 'document' )
+			.waitFor();
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/gif.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/gif.ts
@@ -7,7 +7,7 @@ interface ConfigurationData {
 const blockParentSelector = '[aria-label="Block: GIF"]';
 
 /**
- * Class representing the flow of using a Tiled Gallery block in the editor.
+ * Class representing the flow of using a GIF block in the editor.
  */
 export class GifFlow implements BlockFlow {
 	private configurationData: ConfigurationData;

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/image-compare.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/image-compare.ts
@@ -1,0 +1,89 @@
+import { createTestFile } from '../../../media-helper';
+import { TestFile } from '../../../types';
+import { BlockFlow, EditorContext, PublishedPostContext } from '.';
+
+interface ConfigurationData {
+	image1Path: string;
+	image2Path: string;
+}
+
+const blockParentSelector = '[aria-label="Block: Image Compare"]';
+
+/**
+ * Class representing the flow of using a Tiled Gallery block in the editor.
+ */
+export class ImageCompareFlow implements BlockFlow {
+	private configurationData: ConfigurationData;
+	private preparedImageFileNames: TestFile[];
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData data with which to configure and validate the block
+	 */
+	constructor( configurationData: ConfigurationData ) {
+		this.configurationData = configurationData;
+		this.preparedImageFileNames = [];
+	}
+
+	blockSidebarName = 'Image Compare';
+	blockEditorSelector = blockParentSelector;
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		const block = editorCanvas.getByRole( 'document', { name: 'Block: Image Compare' } );
+
+		const image1UploadInput = block.locator( 'input' ).first();
+		const image2UploadInput = block.locator( 'input' ).last();
+
+		const testFile1 = await createTestFile( this.configurationData.image1Path );
+		const testFile2 = await createTestFile( this.configurationData.image2Path );
+		this.preparedImageFileNames.push( testFile1 );
+		this.preparedImageFileNames.push( testFile2 );
+
+		await image1UploadInput.setInputFiles( testFile1.fullpath );
+		await image2UploadInput.setInputFiles( testFile2.fullpath );
+
+		// Slider is shown once the images are uploaded and ready.
+		await block.getByRole( 'slider' ).waitFor();
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		const slider = context.page.getByRole( 'slider', { name: 'Slide to compare images' } );
+		const originalBoundingBox = await slider.boundingBox();
+
+		await slider.waitFor();
+		// Hover over the slider not at the centre of the bounding box,
+		// because the left/right arrows intercept the clicks.
+		await slider.hover( { position: { x: 10, y: 10 } } );
+
+		// It's uncertain what the number here refers to. It could be the
+		// pixels, but the slider clearly doesn't move by 100px when the
+		// test runs.
+		await context.page.mouse.down();
+		await context.page.mouse.move( -100, 0 );
+		await context.page.mouse.up();
+
+		const newBoundingBox = await slider.boundingBox();
+
+		if ( ! originalBoundingBox || ! newBoundingBox ) {
+			throw new Error( `Image Compare: Failed to obtain at least one or both bounding boxes.` );
+		}
+		// The slider should have moved.
+		if ( originalBoundingBox.x === newBoundingBox.x ) {
+			throw new Error(
+				`Image Compare: slider did not move, expected slider position to be different from ${ originalBoundingBox.x }`
+			);
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/image-compare.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/image-compare.ts
@@ -10,7 +10,7 @@ interface ConfigurationData {
 const blockParentSelector = '[aria-label="Block: Image Compare"]';
 
 /**
- * Class representing the flow of using a Tiled Gallery block in the editor.
+ * Class representing the flow of using a Image Compare block in the editor.
  */
 export class ImageCompareFlow implements BlockFlow {
 	private configurationData: ConfigurationData;

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -27,6 +27,7 @@ export * from './paywall';
 export * from './form-ai';
 export * from './image-compare';
 export * from './map';
+export * from './gif';
 
 /* Types */
 export * from './types';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -26,6 +26,7 @@ export * from './ad';
 export * from './paywall';
 export * from './form-ai';
 export * from './image-compare';
+export * from './map';
 
 /* Types */
 export * from './types';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -25,6 +25,7 @@ export * from './form-patterns';
 export * from './ad';
 export * from './paywall';
 export * from './form-ai';
+export * from './image-compare';
 
 /* Types */
 export * from './types';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/map.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/map.ts
@@ -1,0 +1,56 @@
+import { BlockFlow, EditorContext, PublishedPostContext } from '.';
+
+interface ConfigurationData {
+	address: string;
+}
+
+const blockParentSelector = '[aria-label="Block: Map"]';
+
+/**
+ * Class representing the flow of using a Tiled Gallery block in the editor.
+ */
+export class MapFlow implements BlockFlow {
+	private configurationData: ConfigurationData;
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData data with which to configure and validate the block
+	 */
+	constructor( configurationData: ConfigurationData ) {
+		this.configurationData = configurationData;
+	}
+
+	blockSidebarName = 'Map';
+	blockEditorSelector = blockParentSelector;
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of test execution
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		const block = editorCanvas.getByRole( 'document', { name: 'Block: Map' } );
+
+		// Enter the supplied address.
+		await editorCanvas
+			.getByRole( 'textbox', { name: 'Add a marker' } )
+			.fill( this.configurationData.address );
+
+		// Wait for the popover.
+		await editorCanvas.locator( '.components-popover' ).getByRole( 'listbox' ).waitFor();
+		await context.page.keyboard.press( 'Enter' );
+
+		await block.locator( '.wp-block-jetpack-map-marker' ).waitFor();
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at the point of test execution
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		await context.page.getByRole( 'main' ).locator( '.wp-block-jetpack-map' ).waitFor();
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/map.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/map.ts
@@ -7,7 +7,7 @@ interface ConfigurationData {
 const blockParentSelector = '[aria-label="Block: Map"]';
 
 /**
- * Class representing the flow of using a Tiled Gallery block in the editor.
+ * Class representing the flow of using a Map block in the editor.
  */
 export class MapFlow implements BlockFlow {
 	private configurationData: ConfigurationData;

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/map.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/map.ts
@@ -34,12 +34,11 @@ export class MapFlow implements BlockFlow {
 		const block = editorCanvas.getByRole( 'document', { name: 'Block: Map' } );
 
 		// Enter the supplied address.
-		await editorCanvas
-			.getByRole( 'textbox', { name: 'Add a marker' } )
-			.fill( this.configurationData.address );
+		const editorParent = await context.editorPage.getEditorParent();
+		await editorParent.getByPlaceholder( 'Add a marker' ).fill( this.configurationData.address );
 
 		// Wait for the popover.
-		await editorCanvas.locator( '.components-popover' ).getByRole( 'listbox' ).waitFor();
+		await editorParent.locator( '.components-popover' ).getByRole( 'listbox' ).waitFor();
 		await context.page.keyboard.press( 'Enter' );
 
 		await block.locator( '.wp-block-jetpack-map-marker' ).waitFor();

--- a/packages/calypso-e2e/src/lib/blocks/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/index.ts
@@ -9,6 +9,7 @@ export * from './file-block';
 export * from './logos-block';
 export * from './paragraph-block';
 export * from './videopress-block';
+export * from './story-block';
 
 export * from './block-flows';
 export * from './block-object-models';

--- a/packages/calypso-e2e/src/lib/blocks/story-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/story-block.ts
@@ -24,7 +24,7 @@ export class StoryBlock {
 	}
 
 	/**
-	 * Configure the block in the editor with the configuration data from the constructor
+	 * Given an array of TestFiles, uploads the files to the Story block.
 	 *
 	 * @param {TestFile[]} files List of files to be uploaded.
 	 */

--- a/packages/calypso-e2e/src/lib/blocks/story-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/story-block.ts
@@ -1,0 +1,52 @@
+import { Page } from 'playwright';
+import { TestFile } from '../../types';
+import { EditorComponent } from '../components';
+
+/**
+ * Class representing the flow of using a Story block in the editor.
+ */
+export class StoryBlock {
+	// Static properties.
+	static blockName = 'Story';
+	static blockEditorSelector = `div[aria-label="Block: ${ StoryBlock.blockName }"]`;
+
+	private page: Page;
+	private editor: EditorComponent;
+
+	/**
+	 * Constructs an instance of this block.
+	 *
+	 * @param {Page} page The underlying page object.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+		this.editor = new EditorComponent( page );
+	}
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {TestFile[]} files List of files to be uploaded.
+	 */
+	async upload( files: TestFile[] ): Promise< void > {
+		const editorCanvas = await this.editor.canvas();
+
+		for ( const file of files ) {
+			// Use of "raw" CSS locators here due to the Story block
+			// causing issues with accessibility locators.
+			// @see: https://github.com/Automattic/jetpack/issues/32976
+			const input = editorCanvas.locator( 'div.components-form-file-upload' ).locator( 'input' );
+			await input.setInputFiles( file.fullpath );
+			await editorCanvas.locator( '.wp-story-loading-spinner' ).waitFor( { state: 'hidden' } );
+		}
+	}
+
+	/**
+	 * Validates block on the page.
+	 *
+	 * @param {Page} page Page on which to verify the presence of the block.
+	 */
+	static async validatePublishedContent( page: Page ) {
+		await page.locator( '.wp-block-jetpack-story' ).waitFor();
+	}
+}

--- a/test/e2e/specs/blocks/blocks__jetpack-media.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-media.ts
@@ -1,0 +1,20 @@
+/**
+ * @group gutenberg
+ * @group jetpack-wpcom-integration
+ */
+import {
+	BlockFlow,
+	SlideshowBlockFlow,
+	TiledGalleryBlockFlow,
+	ImageCompareFlow,
+} from '@automattic/calypso-e2e';
+import { TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH } from '../constants';
+import { createBlockTests } from './shared/block-smoke-testing';
+
+const blockFlows: BlockFlow[] = [
+	new SlideshowBlockFlow( { imagePaths: [ TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH ] } ),
+	new TiledGalleryBlockFlow( { imagePaths: [ TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH ] } ),
+	new ImageCompareFlow( { image1Path: TEST_IMAGE_PATH, image2Path: ALT_TEST_IMAGE_PATH } ),
+];
+
+createBlockTests( 'Blocks: Jetpack Media', blockFlows );

--- a/test/e2e/specs/blocks/blocks__jetpack-other.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-other.ts
@@ -2,12 +2,13 @@
  * @group gutenberg
  * @group jetpack-wpcom-integration
  */
-import { BlockFlow, StarRatingBlock, MapFlow } from '@automattic/calypso-e2e';
+import { BlockFlow, StarRatingBlock, MapFlow, GifFlow } from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
 	new StarRatingBlock( { rating: 3.5 } ),
 	new MapFlow( { address: '1455 Quebec St, Vancouver, BC V6A 3Z7' } ),
+	new GifFlow( { query: 'https://giphy.com/embed/MDJ9IbxxvDUQM' } ),
 ];
 
 createBlockTests( 'Blocks: Other Jetpack Blocks', blockFlows );

--- a/test/e2e/specs/blocks/blocks__jetpack-other.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-other.ts
@@ -7,6 +7,7 @@ import {
 	SlideshowBlockFlow,
 	StarRatingBlock,
 	TiledGalleryBlockFlow,
+	ImageCompareFlow,
 } from '@automattic/calypso-e2e';
 import { TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH } from '../constants';
 import { createBlockTests } from './shared/block-smoke-testing';
@@ -14,6 +15,7 @@ import { createBlockTests } from './shared/block-smoke-testing';
 const blockFlows: BlockFlow[] = [
 	new SlideshowBlockFlow( { imagePaths: [ TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH ] } ),
 	new TiledGalleryBlockFlow( { imagePaths: [ TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH ] } ),
+	new ImageCompareFlow( { image1Path: TEST_IMAGE_PATH, image2Path: ALT_TEST_IMAGE_PATH } ),
 	new StarRatingBlock( { rating: 3.5 } ),
 ];
 

--- a/test/e2e/specs/blocks/blocks__jetpack-other.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-other.ts
@@ -2,21 +2,12 @@
  * @group gutenberg
  * @group jetpack-wpcom-integration
  */
-import {
-	BlockFlow,
-	SlideshowBlockFlow,
-	StarRatingBlock,
-	TiledGalleryBlockFlow,
-	ImageCompareFlow,
-} from '@automattic/calypso-e2e';
-import { TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH } from '../constants';
+import { BlockFlow, StarRatingBlock, MapFlow } from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
-	new SlideshowBlockFlow( { imagePaths: [ TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH ] } ),
-	new TiledGalleryBlockFlow( { imagePaths: [ TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH ] } ),
-	new ImageCompareFlow( { image1Path: TEST_IMAGE_PATH, image2Path: ALT_TEST_IMAGE_PATH } ),
 	new StarRatingBlock( { rating: 3.5 } ),
+	new MapFlow( { address: '1455 Quebec St, Vancouver, BC V6A 3Z7' } ),
 ];
 
 createBlockTests( 'Blocks: Other Jetpack Blocks', blockFlows );

--- a/test/e2e/specs/blocks/blocks__jetpack-other.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-other.ts
@@ -2,13 +2,24 @@
  * @group gutenberg
  * @group jetpack-wpcom-integration
  */
-import { BlockFlow, StarRatingBlock, MapFlow, GifFlow } from '@automattic/calypso-e2e';
+import {
+	BlockFlow,
+	StarRatingBlock,
+	MapFlow,
+	GifFlow,
+	envVariables,
+} from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
 	new StarRatingBlock( { rating: 3.5 } ),
-	new MapFlow( { address: '1455 Quebec St, Vancouver, BC V6A 3Z7' } ),
 	new GifFlow( { query: 'https://giphy.com/embed/MDJ9IbxxvDUQM' } ),
 ];
+
+// Private sites change behaivor of the Map block.
+// @see: https://github.com/Automattic/jetpack/issues/32991
+if ( envVariables.ATOMIC_VARIATION !== 'private' ) {
+	blockFlows.push( new MapFlow( { address: '1455 Quebec St, Vancouver, BC V6A 3Z7' } ) );
+}
 
 createBlockTests( 'Blocks: Other Jetpack Blocks', blockFlows );

--- a/test/e2e/specs/blocks/blocks__story.ts
+++ b/test/e2e/specs/blocks/blocks__story.ts
@@ -1,0 +1,81 @@
+/**
+ * @group gutenberg
+ * @group jetpack-wpcom-integration
+ */
+
+import {
+	DataHelper,
+	MediaHelper,
+	EditorPage,
+	TestAccount,
+	StoryBlock,
+	envVariables,
+	getTestAccountByFeature,
+	envToFeatureKey,
+	TestFile,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+import { ALT_TEST_IMAGE_PATH, TEST_IMAGE_PATH } from '../constants';
+
+declare const browser: Browser;
+
+/**
+ * Isolated block test for the Story block due to accessiblity issues,
+ * making it unable to be run using the BlockFlow pattern.
+ *
+ * @see https://github.com/Automattic/jetpack/issues/32976
+ *
+ * Keywords: Jetpack, Media Block, Story
+ */
+describe( DataHelper.createSuiteTitle( 'Blocks: Jetpack Story' ), function () {
+	const features = envToFeatureKey( envVariables );
+	const accountName = getTestAccountByFeature( features );
+	const testFiles: TestFile[] = [];
+
+	let page: Page;
+	let testAccount: TestAccount;
+	let editorPage: EditorPage;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+
+		testAccount = new TestAccount( accountName );
+		await testAccount.authenticate( page );
+
+		for ( const path of [ TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH ] ) {
+			const testFile = await MediaHelper.createTestFile( path );
+			testFiles.push( testFile );
+		}
+	} );
+
+	it( 'Start new post', async function () {
+		editorPage = new EditorPage( page );
+
+		await editorPage.visit( 'post', { siteSlug: testAccount.getSiteURL( { protocol: false } ) } );
+		await editorPage.enterTitle( DataHelper.getRandomPhrase() );
+	} );
+
+	it( 'Add Story block', async function () {
+		await editorPage.addBlockFromSidebar( StoryBlock.blockName, StoryBlock.blockEditorSelector, {
+			noSearch: true,
+		} );
+	} );
+
+	it( 'Upload images', async function () {
+		const storyBlock = new StoryBlock( page );
+		await storyBlock.upload( testFiles );
+	} );
+
+	it( 'Publish and visit post', async function () {
+		// Must separate out the publish and visit steps here.
+		// The single call used elsewhere checks whether
+		// `getByRole('main')` resolves, which will fail with the Story
+		// block due to https://github.com/Automattic/jetpack/issues/32976.
+		const postURL = await editorPage.publish();
+		await page.goto( postURL.href );
+	} );
+
+	it( 'Validate the published post', async function () {
+		await StoryBlock.validatePublishedContent( page );
+	} );
+} );


### PR DESCRIPTION
Related to: https://github.com/Automattic/wp-calypso/issues/80730.

## Proposed Changes

This PR adds multiple block tests categorized under Important tasks.

Key flows/blocks:
- GIF block
- Map block
- Image compare block
- Story block

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [ ] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?