### PR TITLE
Assembler: Fix custom styles selection affect Design Picker theme previews

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -51,7 +51,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	const currentStepRoute = location.pathname.split( '/' )[ 2 ]?.replace( /\/+$/, '' );
 	const { __ } = useI18n();
 	const navigate = useNavigate();
-	const { search } = useLocation();
 	const { setStepData } = useDispatch( STEPPER_INTERNAL_STORE );
 	const intent = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
@@ -105,7 +104,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 
 		const _path = path.includes( '?' ) // does path contain search params
 			? generatePath( `/${ flow.variantSlug ?? flow.name }/${ path }` )
-			: generatePath( `/${ flow.variantSlug ?? flow.name }/${ path }${ search }` );
+			: generatePath( `/${ flow.variantSlug ?? flow.name }/${ path }${ window.location.search }` );
 
 		navigate( _path, { state: stepPaths } );
 		setPreviousProgress( stepProgress?.progress ?? 0 );
@@ -228,7 +227,9 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 					path="*"
 					element={
 						<Navigate
-							to={ `/${ flow.variantSlug ?? flow.name }/${ stepPaths[ 0 ] }${ search }` }
+							to={ `/${ flow.variantSlug ?? flow.name }/${ stepPaths[ 0 ] }${
+								window.location.search
+							}` }
 							replace
 						/>
 					}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -177,6 +177,14 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 		);
 	};
 
+	const resetRecipe = () => {
+		setHeader( null );
+		setSections( [] );
+		setFooter( null );
+		setColorVariation( null );
+		setFontVariation( null );
+	};
+
 	return {
 		header,
 		footer,
@@ -188,6 +196,7 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 		setSections,
 		setColorVariation,
 		setFontVariation,
+		resetRecipe,
 	};
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -119,6 +119,7 @@ const PatternAssembler = ( {
 		setSections,
 		setColorVariation,
 		setFontVariation,
+		resetRecipe,
 	} = useRecipe( site?.ID, dotcomPatterns, categories );
 
 	const {
@@ -440,6 +441,7 @@ const PatternAssembler = ( {
 			setResetCustomStyles( false );
 		}
 
+		// Go back to the previous screen
 		if ( currentScreen.previousScreen ) {
 			if ( navigator.location.isInitial && currentScreen.name !== INITIAL_SCREEN ) {
 				navigator.goTo( currentScreen.previousScreen.initialPath, { replace: true } );
@@ -454,12 +456,14 @@ const PatternAssembler = ( {
 			return;
 		}
 
+		// Go back to the previous step
 		const patterns = getPatterns();
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.BACK_CLICK, {
 			has_selected_patterns: patterns.length > 0,
 			pattern_count: patterns.length,
 		} );
 
+		resetRecipe();
 		goBack?.();
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/81615

## Proposed Changes

* Clean up the recipe when going back to the previous step so the custom styles from the Assembler won't affect the Design Preview

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Continue to the Design Picker
* Select the "Design your own" button next to the categories
* On the Assembler screen, continue to select custom styles
* Go back to the Design Picker
* Preview a theme without the style variations
* Ensure there isn't any custom styles that are preselected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?