### PR TITLE
chore: turn off `jsdoc/tag-lines` rule for E2E directories.

### DIFF
--- a/packages/calypso-e2e/.eslintrc.js
+++ b/packages/calypso-e2e/.eslintrc.js
@@ -21,5 +21,6 @@ module.exports = {
 			'error',
 			{ argsIgnorePattern: '^_', ignoreRestSiblings: true },
 		],
+		'jsdoc/tag-lines': [ 'off' ],
 	},
 };

--- a/test/e2e/.eslintrc.js
+++ b/test/e2e/.eslintrc.js
@@ -41,5 +41,7 @@ module.exports = {
 		// The rule hasn't had the intended results (encouraging owners to re-enable and fix their tests).
 		// See GitHub issue #64870 for context (https://github.com/Automattic/wp-calypso/issues/64870).
 		'jest/no-disabled-tests': 'off',
+
+		'jsdoc/tag-lines': [ 'off' ],
 	},
 };


### PR DESCRIPTION
## Proposed Changes

This PR turns off the `jsdoc/tag-lines` eslint rule for E2E directories to prevent a lot of empty changes.

This rule started being applied suddenly about a few days ago for me. In the interest of preventing a lot of unrelated changes from polluting PRs, I have decided to turn off this rule for both `packages/calypso-e2e` and `test/e2e` directories.

## Testing Instructions


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?