### PR TITLE
Blog Onboarding: Hide post publish modals when publish the first post

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/first-post-published-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/first-post-published-modal/index.tsx
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { isURL } from '@wordpress/url';
 import React from 'react';
 import { useShouldShowFirstPostPublishedModal } from '../../../dotcom-fse/lib/first-post-published-modal/should-show-first-post-published-modal-context';
+import useSiteIntent from '../../../dotcom-fse/lib/site-intent/use-site-intent';
 import NuxModal from '../nux-modal';
 import postPublishedImage from './images/post-published.svg';
 
@@ -20,7 +21,7 @@ type CoreEditorPlaceholder = {
 /**
  * Show the first post publish modal
  */
-const FirstPostPublishedModal: React.FC = () => {
+const FirstPostPublishedModalInner: React.FC = () => {
 	const { link } = useSelect(
 		( select ) => ( select( 'core/editor' ) as CoreEditorPlaceholder ).getCurrentPost(),
 		[]
@@ -104,6 +105,14 @@ const FirstPostPublishedModal: React.FC = () => {
 			onOpen={ () => recordTracksEvent( 'calypso_editor_wpcom_first_post_published_modal_show' ) }
 		/>
 	);
+};
+
+const FirstPostPublishedModal = () => {
+	const { siteIntent: intent } = useSiteIntent();
+	if ( intent === 'write' ) {
+		return <FirstPostPublishedModalInner />;
+	}
+	return null;
 };
 
 export default FirstPostPublishedModal;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { START_WRITING_FLOW, DESIGN_FIRST_FLOW } from '@automattic/onboarding';
 import { Modal, Button, ExternalLink } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState, createInterpolateElement } from '@wordpress/element';
@@ -12,11 +13,13 @@ import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
 import { useShouldShowFirstPostPublishedModal } from '../../../dotcom-fse/lib/first-post-published-modal/should-show-first-post-published-modal-context';
 import useShouldShowSellerCelebrationModal from '../../../dotcom-fse/lib/seller-celebration-modal/use-should-show-seller-celebration-modal';
+import useSiteIntent from '../../../dotcom-fse/lib/site-intent/use-site-intent';
 import useShouldShowVideoCelebrationModal from '../../../dotcom-fse/lib/video-celebration-modal/use-should-show-video-celebration-modal';
 import postPublishedImage from './images/illo-share.svg';
 import InlineSocialLogo from './inline-social-logo';
 import InlineSocialLogosSprite from './inline-social-logos-sprite';
 import useSharingModalDismissed from './use-sharing-modal-dismissed';
+
 import './style.scss';
 
 type CoreEditorPlaceholder = {
@@ -31,7 +34,7 @@ type CoreEditorPlaceholder = {
 };
 const FB_APP_ID = '249643311490';
 
-const SharingModal: React.FC = () => {
+const SharingModalInner: React.FC = () => {
 	const isDismissedDefault = window?.sharingModalOptions?.isDismissed || false;
 	const { launchpadScreenOption } = window?.launchpadOptions || {};
 	const { isDismissed, updateIsDismissed } = useSharingModalDismissed( isDismissedDefault );
@@ -290,4 +293,11 @@ const SharingModal: React.FC = () => {
 	);
 };
 
+const SharingModal = () => {
+	const { siteIntent: intent } = useSiteIntent();
+	if ( intent === START_WRITING_FLOW || intent === DESIGN_FIRST_FLOW ) {
+		return null;
+	}
+	return <SharingModalInner />;
+};
 export default SharingModal;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3658

## Proposed Changes

Hide the post-publish modal for Blog onboarding flows.
I also fixed the First Post published modal for all flows because it was showing for all flows instead of only for the write flow.

## Testing Instructions

* You have to sandbox `widgets.wp.com`
* Run `yarn dev --sync` on `apps\editing-toolkit`
* Go to `/setup/start-writing` on an account with 0 existing sites.
* Before `Write a post` you have to sandbox the newly created site.
* Write a post and publish it
* It should redirect to launchpad, and the post-publish modal should not show.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?