### PR TITLE
Adds premium domain transfers in both bulk and single domain transfers flows

### DIFF
--- a/client/components/domains/use-my-domain/utilities/get-option-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-option-info.js
@@ -109,9 +109,8 @@ export function getOptionInfo( {
 			if ( availability?.is_price_limit_exceeded === true ) {
 				transferContent = {
 					...optionInfo.transferNotSupported,
-					/* translators: %s - the domain the user wanted to transfer */
 					topText: __(
-						"We're sorry but we can't transfer your domain as it is a higher tier premium name that we don't support yet."
+						"We're sorry but we can't transfer your domain as it is a high tier premium name that we don't support."
 					),
 				};
 			} else {

--- a/client/components/domains/use-my-domain/utilities/get-option-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-option-info.js
@@ -4,6 +4,7 @@ import page from 'page';
 import { getTld } from 'calypso/lib/domains';
 import { domainAvailability } from 'calypso/lib/domains/constants';
 import { getAvailabilityNotice } from 'calypso/lib/domains/registration/availability-messages';
+import { getTransferCostText } from './get-transfer-cost-text';
 import {
 	getMappingFreeText,
 	getTransferFreeText,
@@ -70,6 +71,15 @@ export function getOptionInfo( {
 		domain,
 		isSignupStep,
 		siteIsOnPaidPlan,
+		availability,
+	} );
+
+	const transferCostText = getTransferCostText( {
+		cart,
+		currencyCode,
+		domain,
+		productsList,
+		availability,
 	} );
 
 	const transferSalePriceText = getTransferSalePriceText( {
@@ -77,10 +87,12 @@ export function getOptionInfo( {
 		currencyCode,
 		domain,
 		productsList,
+		availability,
 	} );
 
 	const transferPricing = {
-		isFree: isFreeTransfer( { cart, domain } ),
+		isFree: isFreeTransfer( { cart, domain, availability } ),
+		cost: transferCostText,
 		sale: transferSalePriceText,
 		text: transferFreeText,
 	};
@@ -93,12 +105,23 @@ export function getOptionInfo( {
 	switch ( availability.status ) {
 		case domainAvailability.TRANSFERRABLE:
 		case domainAvailability.MAPPED_SAME_SITE_TRANSFERRABLE:
-			transferContent = {
-				...optionInfo.transferSupported,
-				pricing: transferPricing,
-				onSelect: onTransfer,
-				primary: true,
-			};
+		case domainAvailability.TRANSFERRABLE_PREMIUM:
+			if ( availability?.is_price_limit_exceeded === true ) {
+				transferContent = {
+					...optionInfo.transferNotSupported,
+					/* translators: %s - the domain the user wanted to transfer */
+					topText: __(
+						"We're sorry but we can't transfer your domain as it is a higher tier premium name that we don't support yet."
+					),
+				};
+			} else {
+				transferContent = {
+					...optionInfo.transferSupported,
+					pricing: transferPricing,
+					onSelect: onTransfer,
+					primary: true,
+				};
+			}
 			break;
 		case domainAvailability.TLD_NOT_SUPPORTED:
 			transferContent = {

--- a/client/components/domains/use-my-domain/utilities/get-transfer-cost-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-transfer-cost-text.js
@@ -2,27 +2,17 @@ import formatCurrency from '@automattic/format-currency';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { isDomainBundledWithPlan, isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
-import { getDomainProductSlug, getDomainTransferSalePrice } from 'calypso/lib/domains';
 import { domainAvailability } from 'calypso/lib/domains/constants';
 
-export function getTransferSalePriceText( {
-	cart,
-	currencyCode,
-	domain,
-	productsList,
-	availability,
-} ) {
+export function getTransferCostText( { cart, domain, availability } ) {
 	let domainProductSalePrice = null;
 
 	if (
 		availability?.status === domainAvailability.TRANSFERRABLE_PREMIUM &&
 		availability?.is_price_limit_exceeded !== true &&
-		availability?.sale_cost
+		availability?.raw_price
 	) {
-		domainProductSalePrice = formatCurrency( availability?.sale_cost, availability?.currency_code );
-	} else {
-		const productSlug = getDomainProductSlug( domain );
-		domainProductSalePrice = getDomainTransferSalePrice( productSlug, productsList, currencyCode );
+		domainProductSalePrice = formatCurrency( availability?.raw_price, availability?.currency_code );
 	}
 
 	if (
@@ -34,8 +24,11 @@ export function getTransferSalePriceText( {
 	}
 
 	return createInterpolateElement(
-		/* translators: %s is the cost of the domain transfer formatted in the user's currency. */
-		sprintf( __( '%s <small>for the first year</small>' ), domainProductSalePrice ),
+		sprintf(
+			/* translators: %s is the cost of the domain transfer formatted in the user's currency. */
+			__( '%s <small>will renew the domain for additional year</small>' ),
+			domainProductSalePrice
+		),
 		{ small: createElement( 'small' ) }
 	);
 }

--- a/client/components/domains/use-my-domain/utilities/get-transfer-cost-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-transfer-cost-text.js
@@ -26,7 +26,7 @@ export function getTransferCostText( { cart, domain, availability } ) {
 	return createInterpolateElement(
 		sprintf(
 			/* translators: %s is the cost of the domain transfer formatted in the user's currency. */
-			__( '%s <small>will renew the domain for additional year</small>' ),
+			__( '%s <small>will renew the domain for an additional year</small>' ),
 			domainProductSalePrice
 		),
 		{ small: createElement( 'small' ) }

--- a/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
+++ b/client/components/domains/use-my-domain/utilities/get-transfer-free-text.js
@@ -1,7 +1,17 @@
 import { __ } from '@wordpress/i18n';
 import { isDomainBundledWithPlan, isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
+import { domainAvailability } from 'calypso/lib/domains/constants';
 
-export function getTransferFreeText( { cart, domain, isSignupStep, siteIsOnPaidPlan } ) {
+export function getTransferFreeText( {
+	cart,
+	domain,
+	isSignupStep,
+	siteIsOnPaidPlan,
+	availability,
+} ) {
+	if ( availability?.status === domainAvailability.TRANSFERRABLE_PREMIUM ) {
+		return null;
+	}
 	const siteHasNoPaidPlan = ! siteIsOnPaidPlan || isSignupStep;
 
 	let domainProductFreeText = null;

--- a/client/components/domains/use-my-domain/utilities/is-free-transfer.js
+++ b/client/components/domains/use-my-domain/utilities/is-free-transfer.js
@@ -1,5 +1,9 @@
 import { isDomainBundledWithPlan, isNextDomainFree } from 'calypso/lib/cart-values/cart-items';
+import { domainAvailability } from 'calypso/lib/domains/constants';
 
-export function isFreeTransfer( { cart, domain } ) {
-	return isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, domain );
+export function isFreeTransfer( { cart, domain, availability } ) {
+	return (
+		( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, domain ) ) &&
+		availability.status !== domainAvailability.TRANSFERRABLE_PREMIUM
+	);
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -83,6 +83,12 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 			saleCost: validationResult.sale_cost,
 			currencyCode: validationResult.currency_code,
 		};
+	} else if ( validationResult?.is_price_limit_exceeded === true ) {
+		return {
+			valid: false,
+			loading: false,
+			message: __( "Sorry, we still don't support some higher tier premium domain transfers." ),
+		};
 	} else if ( validationResult?.auth_code_valid === false ) {
 		// the auth check API has a bug and returns error 400 for incorrect auth codes,
 		// in which case, the `useIsDomainCodeValid` hook returns `false`.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -87,7 +87,7 @@ export function useValidationMessage( domain: string, auth: string, hasDuplicate
 		return {
 			valid: false,
 			loading: false,
-			message: __( "Sorry, we still don't support some higher tier premium domain transfers." ),
+			message: __( "Sorry, we don't support some higher tier premium domain transfers." ),
 		};
 	} else if ( validationResult?.auth_code_valid === false ) {
 		// the auth check API has a bug and returns error 400 for incorrect auth codes,

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -434,6 +434,7 @@ function getAvailabilityNotice(
 			);
 			break;
 
+		case domainAvailability.TRANSFERRABLE_PREMIUM:
 		case domainAvailability.TRANSFERRABLE:
 			if ( availabilityPreCheck ) {
 				message = translate(
@@ -483,37 +484,6 @@ function getAvailabilityNotice(
 					},
 				}
 			);
-			break;
-
-		case domainAvailability.TRANSFERRABLE_PREMIUM:
-			if ( site ) {
-				message = translate(
-					"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support transfers of premium domains on WordPress.com, but if you are the owner of this domain, you can {{a}}map it to your site{{/a}}.",
-					{
-						args: { domain },
-						components: {
-							strong: <strong />,
-							a: (
-								<a
-									target={ linksTarget }
-									rel="noopener noreferrer"
-									href={ domainMapping( site, domain ) }
-								/>
-							),
-						},
-					}
-				);
-			} else {
-				message = translate(
-					"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support transfers of premium domains on WordPress.com.",
-					{
-						args: { domain },
-						components: {
-							strong: <strong />,
-						},
-					}
-				);
-			}
 			break;
 
 		case domainAvailability.RECENT_REGISTRATION_LOCK_NOT_TRANSFERRABLE:


### PR DESCRIPTION
We want to allow premium domain transfers on WordPress.com. In order to do that I have to modify both the bulk transfers and the single domain transfer flows.

Depends on D121111-code ( and D120328-code but not for testing this PR )

## Proposed Changes

* Allow premium domains transfers
* Use the price returned from the availability check for premium transfers
* Don't allow transfers for preimum domains that exceed the price limit

## Testing Instructions

* Follow the instructions in D121111-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?