### PR TITLE
Revert "Substack importer: add Atomic sites exception"

### DIFF
--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -308,12 +308,10 @@ function getConfig( {
 	return importerConfig;
 }
 
-export function getImporters(
-	args: ImporterConfigArgs = { isAtomic: false, siteSlug: '', siteTitle: '' }
-) {
+export function getImporters( args: ImporterConfigArgs = { siteSlug: '', siteTitle: '' } ) {
 	const importerConfig = getConfig( args );
 
-	if ( ! config.isEnabled( 'importers/substack' ) || args.isAtomic ) {
+	if ( ! config.isEnabled( 'importers/substack' ) ) {
 		delete importerConfig.substack;
 	}
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#80823

Now that original [problem](https://github.com/Automattic/dotcom-forge/issues/3640) with Atomic has been fixed, we can open the importer up for Atomic sites.

Fixes should land on Atomic sites today (Tuesday) at some point with Jetpack deploy.

Fixes were in:

- D120640-code
- https://github.com/Automattic/jetpack/pull/32838