### PR TITLE
Domain Management i1: Remove username from domains table

### DIFF
--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -248,6 +248,62 @@ test( 'when a site is associated with a domain, display its name', async () => {
 	await waitFor( () => expect( screen.queryByText( 'Primary Domain Blog' ) ).toBeInTheDocument() );
 } );
 
+test( 'Parenthetical username is removed from owner column', async () => {
+	const [ primaryPartial, primaryFull ] = testDomain( {
+		domain: 'primary-domain.blog',
+		blog_id: 123,
+		primary_domain: true,
+		owner: 'Joe Blogs (joeblogs)',
+	} );
+
+	const fetchSiteDomains = jest.fn().mockResolvedValue( {
+		domains: [ primaryFull ],
+	} );
+
+	const fetchSite = jest.fn().mockResolvedValue( { ID: 123, name: 'Primary Domain Blog' } );
+
+	render(
+		<DomainsTableRow
+			domain={ primaryPartial }
+			fetchSiteDomains={ fetchSiteDomains }
+			fetchSite={ fetchSite }
+			isAllSitesView
+			isSelected={ false }
+			onSelect={ noop }
+		/>
+	);
+
+	await waitFor( () => expect( screen.queryByText( 'Joe Blogs' ) ).toBeInTheDocument() );
+} );
+
+test( `Doesn't strip parentheses used in the name portion of the owner field`, async () => {
+	const [ primaryPartial, primaryFull ] = testDomain( {
+		domain: 'primary-domain.blog',
+		blog_id: 123,
+		primary_domain: true,
+		owner: 'Joe (Danger) Blogs (joeblogs)',
+	} );
+
+	const fetchSiteDomains = jest.fn().mockResolvedValue( {
+		domains: [ primaryFull ],
+	} );
+
+	const fetchSite = jest.fn().mockResolvedValue( { ID: 123, name: 'Primary Domain Blog' } );
+
+	render(
+		<DomainsTableRow
+			domain={ primaryPartial }
+			fetchSiteDomains={ fetchSiteDomains }
+			fetchSite={ fetchSite }
+			isAllSitesView
+			isSelected={ false }
+			onSelect={ noop }
+		/>
+	);
+
+	await waitFor( () => expect( screen.queryByText( 'Joe (Danger) Blogs' ) ).toBeInTheDocument() );
+} );
+
 describe( 'site linking ctas', () => {
 	beforeAll( () => {
 		global.ResizeObserver = require( 'resize-observer-polyfill' );

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -158,6 +158,20 @@ export function DomainsTableRow( {
 	const domainTypeText =
 		currentDomainData && getDomainTypeText( currentDomainData, __, domainInfoContext.DOMAIN_ROW );
 
+	const renderOwnerCell = () => {
+		if ( isLoadingSiteDetails || isLoadingSiteDomainsDetails ) {
+			return <LoadingPlaceholder style={ { width: `${ placeholderWidth }%` } } />;
+		}
+
+		if ( ! currentDomainData?.owner ) {
+			return '-';
+		}
+
+		// Removes the username that appears in parentheses after the owner's name.
+		// Uses $ and the negative lookahead assertion (?!.*\() to ensure we only match the very last parenthetical.
+		return currentDomainData.owner.replace( / \((?!.*\().+\)$/, '' );
+	};
+
 	return (
 		<tr key={ domain.domain } ref={ ref }>
 			<td>
@@ -189,15 +203,7 @@ export function DomainsTableRow( {
 					<span className="domains-table-row__domain-type-text">{ domainTypeText }</span>
 				) }
 			</td>
-			{ ! hideOwnerColumn && (
-				<td>
-					{ isLoadingSiteDetails || isLoadingSiteDomainsDetails ? (
-						<LoadingPlaceholder style={ { width: `${ placeholderWidth }%` } } />
-					) : (
-						currentDomainData?.owner ?? '-'
-					) }
-				</td>
-			) }
+			{ ! hideOwnerColumn && <td>{ renderOwnerCell() }</td> }
 			<td>{ renderSiteCell() }</td>
 			<td>
 				{ isLoadingRowDetails ? (

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -37,7 +37,7 @@ interface DomainsTableRowProps {
 		siteIdOrSlug: number | string | null | undefined
 	) => Promise< SiteDomainsQueryFnData >;
 	fetchSite?: ( siteIdOrSlug: number | string | null | undefined ) => Promise< SiteDetails >;
-	pendingUpdates: DomainUpdateStatus[];
+	pendingUpdates?: DomainUpdateStatus[];
 }
 
 export function DomainsTableRow( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The backend returns the user's name and username concatenated into one string. The logic is here fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Snqzva%2Qcyhtvaf%2Sqbznvaf%2Sqbznva%2Qznantrzrag%2Qqbznva.cuc%3Se%3Qo1q98707%23584-og

Our mockups only show name. But we should also fall back to username if the user hasn't set a name.

Rather than risk changing the backend logic (another client might be depending on it) I'm using a regex to remove the parenthetical username if it happens to be there.

**Before**
![CleanShot 2023-09-12 at 22 17 29@2x](https://github.com/Automattic/wp-calypso/assets/1500769/edfc7571-eac6-440a-8c13-adb751b55156)

**After**
<img width="1117" alt="CleanShot 2023-09-12 at 22 16 45@2x" src="https://github.com/Automattic/wp-calypso/assets/1500769/8fe5f304-ebdf-41d6-8a65-c96a1f0dfa33">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Take a look at the table at `/domains/manage?flags=domains/management`
* Manually run the regex through some test cases to confirm it's working.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~