### PR TITLE
Migration trial: Add tracking to show and hide confirm modal

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -248,7 +248,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 					<ConfirmModal
 						sourceSiteSlug={ sourceSiteSlug }
 						targetSiteSlug={ targetSite.slug }
-						onClose={ () => setShowConfirmModal( false ) }
+						onClose={ hideConfirmModal }
 						onConfirm={ () => {
 							// reset migration confirmation to initial state
 							setMigrationConfirmed( false );
@@ -272,7 +272,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 								onClick={ () => {
 									migrationConfirmed
 										? startImport( { type: 'without-credentials', ...migrationTrackingProps } )
-										: setShowConfirmModal( true );
+										: displayConfirmModal();
 								} }
 							>
 								{ translate( 'Start migration' ) }
@@ -282,6 +282,22 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 				</div>
 			</>
 		);
+	}
+
+	function displayConfirmModal() {
+		dispatch(
+			recordTracksEvent( 'calypso_site_migration_confirm_modal_display', migrationTrackingProps )
+		);
+
+		setShowConfirmModal( true );
+	}
+
+	function hideConfirmModal() {
+		dispatch(
+			recordTracksEvent( 'calypso_site_migration_confirm_modal_hide', migrationTrackingProps )
+		);
+
+		setShowConfirmModal( false );
 	}
 
 	function renderUpdatePluginInfo() {


### PR DESCRIPTION
Related to discussions here: p1694501774240579-slack-C01A60HCGUA

## Proposed Changes

Adds tracking to show and hide confirm modal at the last step of the migration flow.

## Testing Instructions

* Go to the last step of the migration flow by entering any source and destination site. 
![CleanShot 2023-09-12 at 16 17 56](https://github.com/Automattic/wp-calypso/assets/533/ce01b5ea-5ade-4ddd-908d-0a99afe70dec)
* In the console, type in `localStorage.setItem( 'debug', 'calypso:analytics*' );`
* Click the Start migration button and make sure that you see an event recorded:
![CleanShot 2023-09-12 at 16 19 00](https://github.com/Automattic/wp-calypso/assets/533/caa0a9df-0690-4045-9dee-c3036d78cb28)
* Hide the dialog and make sure another event is recorded:
![CleanShot 2023-09-12 at 16 19 28](https://github.com/Automattic/wp-calypso/assets/533/b833e6d7-3ce6-474a-8338-9940cdc709f2)
* Make sure migration works after you hit continue.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?