### PR TITLE
Add empty cell to prevent broken alignement

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -101,7 +101,7 @@ class DomainRow extends PureComponent {
 	renderSite() {
 		const { domain } = this.props;
 		if ( domain.isDomainOnlySite ) {
-			return <div className="domain-row__site-cell"></div>;
+			return <div className="domain-row__site-cell" />;
 		}
 
 		return (


### PR DESCRIPTION
## Proposed Changes

This PR fixes a a rendering issue in the _Manage all domains_ page, where the row layout is broken for domain-only sites ( due to the missing "site" cell).

![domain only broken](https://github.com/Automattic/wp-calypso/assets/2797601/b3a13dd9-409c-466e-861e-f593b768b4df)

![domain-only-ok](https://github.com/Automattic/wp-calypso/assets/2797601/5c6324e2-e1b5-4c22-b854-56f9cb9f7a7a)

## Testing Instructions

Visit _Manage all domains_ page (`domains/manage`) and check that the row are rendered properly for domain only sites entries.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?