### PR TITLE
Social Previews | Fix Twitter white background

### DIFF
--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "2.0.1-beta.5",
+	"version": "2.0.1-beta.6",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "2.0.1-beta.6",
+	"version": "2.0.1-beta.7",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/social-previews/src/twitter-preview/style.scss
+++ b/packages/social-previews/src/twitter-preview/style.scss
@@ -66,6 +66,7 @@
 
 	.twitter-preview__main {
 		padding-bottom: 1rem;
+		overflow: hidden;
 	}
 
 	.twitter-preview__header {

--- a/packages/social-previews/src/twitter-preview/style.scss
+++ b/packages/social-previews/src/twitter-preview/style.scss
@@ -10,15 +10,16 @@
 @import "../variables.scss";
 
 .twitter-preview {
-	background-color: #fff;
 	padding: 20px;
 }
 
 .twitter-preview__wrapper {
-	padding: 20px;
 	background-color: #fff;
 	max-width: clamp(200px, 100%, 635px);
 	margin-inline: auto;
+	padding-top: 1rem;
+	border-radius: 4px;
+	padding-inline-end: 1rem;
 }
 
 .twitter-preview__section.social-preview__section {
@@ -29,11 +30,6 @@
 	.social-preview__section-desc {
 		padding-inline-start: 17px;
 	}
-}
-
-// When the preview is in a section of all previews
-.twitter-preview__section .twitter-preview__wrapper {
-	padding: 0;
 }
 
 .twitter-preview__container {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/79355#pullrequestreview-1533669022

## Proposed Changes

* Social Previews | Fix Twitter white background to make it consistent with other networks.

## Testing Instructions

- Checkout fire up this PR or use the Live link below
- Goto `/posts/:site` 
- Click on the 3 dots for any post and Click "Share"
- Click on "Preview"
- Confirm that Twitter background is consistent with other social network previews

| BEFORE | AFTER |
|--------|--------|
| <img width="1457" alt="Screenshot 2023-09-12 at 5 45 21 PM" src="https://github.com/Automattic/wp-calypso/assets/18226415/81466ec9-1acf-427f-97e9-174873ff86df"> | <img width="1450" alt="Screenshot 2023-09-12 at 5 45 33 PM" src="https://github.com/Automattic/wp-calypso/assets/18226415/15fad9e9-75f4-4585-b6b9-9d37711823cb"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?