### PR TITLE
Bootstrap Site profiler

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -1,0 +1,8 @@
+export interface DomainAnalyzerQueryResponse {
+	domain: string;
+	hosting_provider: {
+		name: string;
+	};
+	whois: any;
+	dns: any;
+}

--- a/client/data/site-profiler/use-domain-analyzer-query.ts
+++ b/client/data/site-profiler/use-domain-analyzer-query.ts
@@ -1,5 +1,5 @@
-import { SourceSiteMigrationDetails } from '@automattic/data-stores/src/site';
 import { useQuery } from '@tanstack/react-query';
+import { DomainAnalyzerQueryResponse } from 'calypso/data/site-profiler/types';
 import wp from 'calypso/lib/wp';
 
 export interface MigrationStatusError {
@@ -10,7 +10,7 @@ export interface MigrationStatusError {
 export const useDomainAnalyzerQuery = ( domain: string ) => {
 	return useQuery( {
 		queryKey: [ 'domain-', domain ],
-		queryFn: (): Promise< SourceSiteMigrationDetails > =>
+		queryFn: (): Promise< DomainAnalyzerQueryResponse > =>
 			wp.req.get( {
 				path: '/site-profiler/' + encodeURIComponent( domain ),
 				apiNamespace: 'wpcom/v2',

--- a/client/data/site-profiler/use-domain-analyzer-query.ts
+++ b/client/data/site-profiler/use-domain-analyzer-query.ts
@@ -1,0 +1,25 @@
+import { SourceSiteMigrationDetails } from '@automattic/data-stores/src/site';
+import { useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+
+export interface MigrationStatusError {
+	status: number;
+	message: string;
+}
+
+export const useDomainAnalyzerQuery = ( domain: string ) => {
+	return useQuery( {
+		queryKey: [ 'domain-', domain ],
+		queryFn: (): Promise< SourceSiteMigrationDetails > =>
+			wp.req.get( {
+				path: '/site-profiler/' + encodeURIComponent( domain ),
+				apiNamespace: 'wpcom/v2',
+			} ),
+		meta: {
+			persist: false,
+		},
+		enabled: !! domain,
+		retry: false,
+		refetchOnWindowFocus: false,
+	} );
+};

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -135,7 +135,9 @@ const LayoutLoggedOut = ( {
 	} else if ( config.isEnabled( 'jetpack-cloud' ) || isWpMobileApp() || isJetpackThankYou ) {
 		masterbar = null;
 	} else if (
-		[ 'plugins', 'themes', 'theme', 'reader', 'subscriptions' ].includes( sectionName ) &&
+		[ 'plugins', 'themes', 'theme', 'reader', 'subscriptions', 'site-profiler' ].includes(
+			sectionName
+		) &&
 		! isReaderTagPage &&
 		! isReaderSearchPage &&
 		! isReaderDiscoverPage
@@ -191,7 +193,7 @@ const LayoutLoggedOut = ( {
 				<CookieBannerContainerSSR serverShow={ showGdprBanner } />
 			) }
 
-			{ sectionName === 'plugins' && (
+			{ [ 'plugins', 'site-profiler' ].includes( sectionName ) && (
 				<>
 					<UniversalNavbarFooter
 						currentRoute={ currentRoute }

--- a/client/sections.js
+++ b/client/sections.js
@@ -249,6 +249,16 @@ const sections = [
 		trackLoadPerformance: true,
 	},
 	{
+		name: 'site-profiler',
+		paths: [ '/site-profiler' ],
+		module: 'calypso/site-profiler',
+		enableLoggedOut: true,
+		group: 'site-profiler',
+		isomorphic: true,
+		title: 'Site Profiler',
+		trackLoadPerformance: true,
+	},
+	{
 		name: 'domains',
 		paths: [ '/domains' ],
 		module: 'calypso/my-sites/domains',

--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -1,9 +1,18 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { FormEvent, useState } from 'react';
 import './styles.scss';
 
 export default function DomainAnalyzer() {
 	const translate = useTranslate();
+	const [ , setDomain ] = useState( '' );
+
+	const onSubmit = ( e: FormEvent< HTMLFormElement > ) => {
+		e.preventDefault();
+
+		const domainEl = e.currentTarget.elements.namedItem( 'domain' ) as HTMLInputElement;
+		setDomain( domainEl.value );
+	};
 
 	return (
 		<div className="domain-analyzer">
@@ -14,13 +23,13 @@ export default function DomainAnalyzer() {
 				) }
 			</p>
 
-			<form className="domain-analyzer--form">
+			<form className="domain-analyzer--form" onSubmit={ onSubmit }>
 				<div className="domain-analyzer--form-container">
 					<div className="col-1">
 						<input type="text" name="domain" placeholder={ translate( 'mysite.com' ) } />
 					</div>
 					<div className="col-2">
-						<Button>{ translate( 'Check site' ) }</Button>
+						<Button type="submit">{ translate( 'Check site' ) }</Button>
 					</div>
 				</div>
 			</form>

--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -1,0 +1,29 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import './styles.scss';
+
+export default function DomainAnalyzer() {
+	const translate = useTranslate();
+
+	return (
+		<div className="domain-analyzer">
+			<h1>{ translate( 'Who Hosts This Site?' ) }</h1>
+			<p>
+				{ translate(
+					'Access essential information about a site, such as hosting provider, domain details, and contact information.'
+				) }
+			</p>
+
+			<form className="domain-analyzer--form">
+				<div className="domain-analyzer--form-container">
+					<div className="col-1">
+						<input type="text" name="domain" placeholder={ translate( 'mysite.com' ) } />
+					</div>
+					<div className="col-2">
+						<Button>{ translate( 'Check site' ) }</Button>
+					</div>
+				</div>
+			</form>
+		</div>
+	);
+}

--- a/client/site-profiler/components/domain-analyzer/styles.scss
+++ b/client/site-profiler/components/domain-analyzer/styles.scss
@@ -1,0 +1,65 @@
+.domain-analyzer {
+	& > h1 {
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		/* stylelint-disable-next-line */
+		font-size: 4.375rem;
+		color: var(--studio-gray-100);
+	}
+
+	& > p {
+		font-family: "Noto Sans", Helvetica, Arial, sans-serif;
+		/* stylelint-disable-next-line */
+		font-size: 1.125rem;
+		color: var(--studio-gray-80);
+	}
+}
+
+.domain-analyzer--form-container {
+	background: #fff;
+	border: solid 1px #ccc;
+	/* stylelint-disable-next-line */
+	border-radius: 8px;
+	padding: 0.625rem 1.5rem;
+	display: flex;
+	gap: 1rem;
+
+	.col-1 {
+		flex: 1;
+	}
+
+	.col-2 {
+		display: flex;
+		align-items: center;
+		width: fit-content;
+	}
+
+	input {
+		width: 100%;
+		border: none;
+		padding: 0;
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		font-size: 2.75rem;
+		color: var(--studio-gray-100);
+
+		&::placeholder {
+			color: var(--studio-gray-40);
+		}
+
+		&:focus {
+			outline: none;
+		}
+	}
+
+	button {
+		color: #fff;
+		background: var(--wp-admin-theme-color);
+		border-radius: 4px;
+		font-size: 1rem;
+		font-weight: 500;
+		padding: 1.5rem;
+
+		&:hover {
+			color: #fff !important;
+		}
+	}
+}

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -1,0 +1,5 @@
+import DomainAnalyzer from './domain-analyzer';
+
+export default function SiteProfiler() {
+	return <DomainAnalyzer />;
+}

--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -1,5 +1,12 @@
+import Main from 'calypso/components/main';
+import SiteProfiler from 'calypso/site-profiler/components/site-profiler';
+
 export function siteProfilerContext( context: PageJS.Context, next: () => void ): void {
-	context.primary = <div>Primary content goes here</div>;
+	context.primary = (
+		<Main wideLayout>
+			<SiteProfiler />
+		</Main>
+	);
 
 	next();
 }

--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -6,6 +6,7 @@ import SiteProfiler from 'calypso/site-profiler/components/site-profiler';
 export function siteProfilerContext( context: PageJS.Context, next: () => void ): void {
 	if ( ! config.isEnabled( 'site-profiler' ) ) {
 		page.redirect( '/' );
+		return;
 	}
 
 	context.primary = (

--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -1,7 +1,13 @@
+import config from '@automattic/calypso-config';
+import page from 'page';
 import Main from 'calypso/components/main';
 import SiteProfiler from 'calypso/site-profiler/components/site-profiler';
 
 export function siteProfilerContext( context: PageJS.Context, next: () => void ): void {
+	if ( ! config.isEnabled( 'site-profiler' ) ) {
+		page.redirect( '/' );
+	}
+
 	context.primary = (
 		<Main wideLayout>
 			<SiteProfiler />

--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -1,0 +1,5 @@
+export function siteProfilerContext( context: PageJS.Context, next: () => void ): void {
+	context.primary = <div>Primary content goes here</div>;
+
+	next();
+}

--- a/client/site-profiler/index.node.ts
+++ b/client/site-profiler/index.node.ts
@@ -1,0 +1,19 @@
+import { getLanguageRouteParam } from '@automattic/i18n-utils';
+import { makeLayout, setLocaleMiddleware } from 'calypso/controller';
+import { serverRouter } from 'calypso/server/isomorphic-routing';
+
+/**
+ * Using the server routing for this section has the sole purpose of defining
+ * a named route parameter for the language, that is used to set `context.lang`
+ * via the `setLocaleMiddleware()`.
+ *
+ * The `context.lang` value is then used in the server renderer to properly
+ * attach the translation files to the page.
+ *
+ * @see https://github.com/Automattic/wp-calypso/blob/trunk/client/server/render/index.js#L171.
+ */
+export default ( router: ReturnType< typeof serverRouter > ) => {
+	const lang = getLanguageRouteParam();
+
+	router( [ `/${ lang }/site-profiler(/*)?` ], setLocaleMiddleware(), makeLayout );
+};

--- a/client/site-profiler/index.web.ts
+++ b/client/site-profiler/index.web.ts
@@ -1,0 +1,7 @@
+import page from 'page';
+import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
+import { siteProfilerContext } from 'calypso/site-profiler/controller';
+
+export default function () {
+	page( '/site-profiler', siteProfilerContext, makeLayout, clientRender );
+}

--- a/client/site-profiler/package.json
+++ b/client/site-profiler/package.json
@@ -1,0 +1,4 @@
+{
+	"main": "index.node.ts",
+	"browser": "index.web.ts"
+}

--- a/config/development.json
+++ b/config/development.json
@@ -181,6 +181,7 @@
 		"signup/social": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"site-profiler": true,
 		"ssr/prefetch-timebox": false,
 		"stats/new-video-summary": true,
 		"stats/subscribers-chart-section": false,

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -35,7 +35,8 @@ $studio-blue-30: #0675c4;
 
 .is-section-themes,
 .is-section-theme,
-.is-section-reader {
+.is-section-reader,
+.is-section-site-profiler {
 	&.has-no-sidebar {
 		.masterbar-menu {
 			.masterbar {


### PR DESCRIPTION
Closes #81473

## Proposed Changes

* Introduce `site-profiler` feature flag (development env for now)
* Bootstrap a `SiteProfiler` mini app accessible on the `/site-profiler` route

## Testing Instructions

* Go to `/site-profiler` (for non-development env, it will redirect to the root `/`)
* Check if there is a "DomainAnalyzer" block rendered there

* NOTE: the form doesn't have any logic so far; in the next iteration, the focus will be the concrete flow

**Non-logged in user**
<img width="1046" alt="Screenshot 2023-09-14 at 14 12 13" src="https://github.com/Automattic/wp-calypso/assets/1241413/5206ad16-0dac-49f3-a583-5ca38ba097be">

**Logged in user**
<img width="949" alt="Screenshot 2023-09-14 at 14 11 51" src="https://github.com/Automattic/wp-calypso/assets/1241413/1ce63abc-b84b-46bd-9bab-63d55b1111a1">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?