### PR TITLE
state(reader/streams): refactor away from `lodash`

### DIFF
--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -1,4 +1,3 @@
-import { findIndex, last, filter } from 'lodash';
 import moment from 'moment';
 import { keysAreEqual } from 'calypso/reader/post-key';
 import {
@@ -46,7 +45,7 @@ export const items = ( state = [], action ) => {
 				const afterGap = takeRightWhile( state, ( postKey ) => ! keysAreEqual( postKey, gap ) );
 
 				// after query param is inclusive, so we need to drop duplicate post
-				if ( keysAreEqual( last( streamItems ), afterGap[ 0 ] ) ) {
+				if ( keysAreEqual( streamItems?.at( -1 ), afterGap[ 0 ] ) ) {
 					streamItems.pop();
 				}
 
@@ -58,7 +57,7 @@ export const items = ( state = [], action ) => {
 				// create a new gap if we still need one
 				let nextGap = [];
 				const from = gap.from;
-				const to = moment( last( streamItems ).date );
+				const to = moment( streamItems?.at( -1 )?.date );
 				if ( ! from.isSame( to ) ) {
 					nextGap = [ { isGap: true, from, to } ];
 				}
@@ -73,7 +72,7 @@ export const items = ( state = [], action ) => {
 			}, state );
 
 			// Find any x-posts
-			newXPosts = filter( streamItems, ( postKey ) => postKey.xPostMetadata );
+			newXPosts = streamItems.filter( ( postKey ) => postKey.xPostMetadata );
 
 			if ( ! newXPosts ) {
 				return newState;
@@ -86,7 +85,7 @@ export const items = ( state = [], action ) => {
 			return combineXPosts( [ ...action.payload.items, ...state ] );
 		case READER_DISMISS_POST: {
 			const postKey = action.payload.postKey;
-			const indexToRemove = findIndex( state, ( item ) => keysAreEqual( item, postKey ) );
+			const indexToRemove = state.findIndex( ( item ) => keysAreEqual( item, postKey ) );
 
 			if ( indexToRemove === -1 ) {
 				return state;
@@ -133,7 +132,7 @@ export const pendingItems = ( state = PENDING_ITEMS_DEFAULT, action ) => {
 			}
 
 			maxDate = moment( streamItems[ 0 ].date );
-			minDate = moment( last( streamItems ).date );
+			minDate = moment( streamItems?.at( -1 )?.date );
 
 			// only retain posts that are newer than ones we already have
 			if ( state.lastUpdated ) {
@@ -149,7 +148,7 @@ export const pendingItems = ( state = PENDING_ITEMS_DEFAULT, action ) => {
 			newItems = [ ...streamItems ];
 
 			// Find any x-posts and filter out duplicates
-			newXPosts = filter( newItems, ( postKey ) => postKey.xPostMetadata );
+			newXPosts = newItems.filter( ( postKey ) => postKey.xPostMetadata );
 
 			if ( newXPosts ) {
 				newItems = combineXPosts( newItems );
@@ -176,16 +175,18 @@ export const pendingItems = ( state = PENDING_ITEMS_DEFAULT, action ) => {
  * This is relevant for keyboard navigation
  */
 export const selected = ( state = null, action ) => {
-	let idx;
 	switch ( action.type ) {
-		case READER_STREAMS_SELECT_ITEM:
+		case READER_STREAMS_SELECT_ITEM: {
 			return action.payload.postKey;
-		case READER_STREAMS_SELECT_NEXT_ITEM:
-			idx = findIndex( action.payload.items, ( item ) => keysAreEqual( item, state ) );
+		}
+		case READER_STREAMS_SELECT_NEXT_ITEM: {
+			const idx = action.payload.items?.findIndex( ( item ) => keysAreEqual( item, state ) ) ?? -1;
 			return idx === action.payload.items.length - 1 ? state : action.payload.items[ idx + 1 ];
-		case READER_STREAMS_SELECT_PREV_ITEM:
-			idx = findIndex( action.payload.items, ( item ) => keysAreEqual( item, state ) );
+		}
+		case READER_STREAMS_SELECT_PREV_ITEM: {
+			const idx = action.payload.items?.findIndex( ( item ) => keysAreEqual( item, state ) ) ?? -1;
 			return idx === 0 ? state : action.payload.items[ idx - 1 ];
+		}
 	}
 	return state;
 };

--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -40,12 +40,16 @@ export const items = ( state = [], action ) => {
 			gap = action.payload.gap;
 			streamItems = action.payload.streamItems;
 
+			if ( ! Array.isArray( streamItems ) ) {
+				return state;
+			}
+
 			if ( gap ) {
 				const beforeGap = takeWhile( state, ( postKey ) => ! keysAreEqual( postKey, gap ) );
 				const afterGap = takeRightWhile( state, ( postKey ) => ! keysAreEqual( postKey, gap ) );
 
 				// after query param is inclusive, so we need to drop duplicate post
-				if ( keysAreEqual( streamItems?.at( -1 ), afterGap[ 0 ] ) ) {
+				if ( keysAreEqual( streamItems[ streamItems.length - 1 ], afterGap[ 0 ] ) ) {
 					streamItems.pop();
 				}
 
@@ -57,7 +61,7 @@ export const items = ( state = [], action ) => {
 				// create a new gap if we still need one
 				let nextGap = [];
 				const from = gap.from;
-				const to = moment( streamItems?.at( -1 )?.date );
+				const to = moment( streamItems[ streamItems.length - 1 ]?.date );
 				if ( ! from.isSame( to ) ) {
 					nextGap = [ { isGap: true, from, to } ];
 				}
@@ -132,7 +136,7 @@ export const pendingItems = ( state = PENDING_ITEMS_DEFAULT, action ) => {
 			}
 
 			maxDate = moment( streamItems[ 0 ].date );
-			minDate = moment( streamItems?.at( -1 )?.date );
+			minDate = moment( streamItems[ streamItems.length - 1 ].date );
 
 			// only retain posts that are newer than ones we already have
 			if ( state.lastUpdated ) {

--- a/client/state/reader/streams/selectors/get-reader-stream-offset-item.js
+++ b/client/state/reader/streams/selectors/get-reader-stream-offset-item.js
@@ -1,4 +1,3 @@
-import { findIndex } from 'lodash';
 import { keysAreEqual } from 'calypso/reader/post-key';
 import getCurrentStream from 'calypso/state/selectors/get-reader-current-stream';
 
@@ -21,11 +20,12 @@ function getOffsetItem( state, currentItem, offset ) {
 	}
 
 	const stream = state.reader.streams[ streamKey ];
-	let index = findIndex( stream.items, ( item ) => keysAreEqual( item, currentItem ) );
+	let index = stream.items?.findIndex( ( item ) => keysAreEqual( item, currentItem ) ) ?? -1;
 
 	// If we didn't find a match, check x-posts too
 	if ( index < 0 ) {
-		index = findIndex( stream.items, ( item ) => keysAreEqual( item.xPostMetadata, currentItem ) );
+		index =
+			stream.items?.findIndex( ( item ) => keysAreEqual( item.xPostMetadata, currentItem ) ) ?? -1;
 	}
 
 	if ( index < 0 ) {

--- a/client/state/reader/streams/utils.js
+++ b/client/state/reader/streams/utils.js
@@ -1,4 +1,3 @@
-import { last } from 'lodash';
 import { sameXPost } from 'calypso/reader/stream/utils';
 
 /**
@@ -26,7 +25,7 @@ export const addDuplicateXPostToPostKey = ( postKey1, postKey2 ) => {
  */
 export const combineXPosts = ( postKeys ) =>
 	postKeys.reduce( ( accumulator, postKey ) => {
-		const lastPostKey = last( accumulator );
+		const lastPostKey = accumulator[ accumulator.length - 1 ];
 		if ( sameXPost( lastPostKey, postKey ) ) {
 			accumulator[ accumulator.length - 1 ] = addDuplicateXPostToPostKey( lastPostKey, postKey );
 		} else {


### PR DESCRIPTION
## Proposed Changes

* Refactor away from lodash methods in `client/state/reader/streams`

## Testing Instructions

* Changes are partially covered by unit tests, verify they pass.
* As with a lot of lodash methods it's good practice to ensure we don't accidentally miss guards for whether we operate on the expected data structure.
* Smoke test `/read`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
