### PR TITLE
Newsletter categories: Add "settings/newsletter-categories" to staging and horizon configs

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -106,6 +106,7 @@
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
+		"settings/newsletter-categories": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -128,6 +128,7 @@
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
+		"settings/newsletter-categories": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,


### PR DESCRIPTION
## Proposed Changes

Added "settings/newsletter-categories" to both config/stage.json and config/horizon.json. This enables the feature flag for newsletter categories in the staging and horizon environments, making it available for user testing.

## Testing Instructions

Code review should be fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?