### PR TITLE
i18n: Make the date format in RelativeTime component translatable

### DIFF
--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { InfiniteData } from '@tanstack/react-query';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import moment from 'moment';
 import {
 	BlazablePost,
@@ -115,8 +115,10 @@ export const getCampaignDurationFormatted = ( start_date?: string, end_date?: st
 	if ( campaignDays === 0 ) {
 		durationFormatted = '-';
 	} else {
-		const dateStartFormatted = moment.utc( start_date ).format( 'MMM D' );
-		const dateEndFormatted = moment.utc( end_date ).format( 'MMM D' );
+		// translators: Moment.js date format, `MMM` refers to short month name (e.g. `Sep`), `D`` refers to day of month (e.g. `5`). Wrap text [] to be displayed as is, for example `D [de] MMM` will be formatted as `5 de sep.`.
+		const format = _x( 'MMM D', 'shorter date format' );
+		const dateStartFormatted = moment.utc( start_date ).format( format );
+		const dateEndFormatted = moment.utc( end_date ).format( format );
 		durationFormatted = `${ dateStartFormatted } - ${ dateEndFormatted }`;
 	}
 
@@ -243,9 +245,13 @@ export const getShortDateString = ( date: string ) => {
 		return timestamp.fromNow();
 	}
 
-	return timestamp.isSame( now, 'year' )
-		? moment( date ).format( 'MMM DD' )
-		: moment( date ).format( 'MMM DD, YYYY' );
+	const format = timestamp.isSame( now, 'year' )
+		? // translators: Moment.js date format, `MMM` refers to short month name (e.g. `Sep`), `DD`` refers to 2-digit day of month (e.g. `05`). Wrap text [] to be displayed as is, for example `DD [de] MMM` will be formatted as `05 de sep.`.
+		  _x( 'MMM DD', 'short date format' )
+		: // translators: Moment.js date format, `MMM` refers to short month name (e.g. `Sep`), `DD`` refers to 2-digit day of month (e.g. `05`), `YYYY` refers to the full year format (e.g. `2023`). Wrap text [] to be displayed as is, for example `DD [de] MMM [de] YYYY` will be formatted as `05 de sep. de 2023`.
+		  _x( 'MMM DD, YYYY', 'short date with year format' );
+
+	return moment( date ).format( format );
 };
 
 export const getLongDateString = ( date: string ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 672-gh-Automattic/i18n-issues

## Proposed Changes

* Wrap moment.js formats used in RelativeTime component (from `promote-post-i2/utils/index.ts`) in translate functions.

![CleanShot 2023-09-12 at 16 43 26](https://github.com/Automattic/wp-calypso/assets/2722412/3aba7694-d690-46c4-b43e-7e0883466f1e)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Confirm `/advertising/[site]` works the same as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
