### PR TITLE
Fix wrong external dns notice for mapped domains

### DIFF
--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -319,7 +319,9 @@ const Settings = ( {
 				! i18n.hasTranslation(
 					"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers. {{a}}Update your name servers now{{/a}}."
 				) ) ||
-			areAllWpcomNameServers()
+			areAllWpcomNameServers() ||
+			! nameservers ||
+			! nameservers.length
 		) {
 			return null;
 		}


### PR DESCRIPTION
Related to #80867 

## Proposed Changes

After deploying #80867, @wynwin noticed that for mapped domain, the message is showed even if the domain is using WordPress.com name servers.

Checking the code I notice that there is a missing check in the condition. This quick PR fixes the issue.

## Testing Instructions

Apply the patch and visit the management page for a mapped domain (that is using WordPress.com name servers).
Expand the DNS card and verify that the message `"Your domain is using external name servers so the DNS records [...]"` is not showed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?