### PR TITLE
Earn: Update ads wrapper to functional component

### DIFF
--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -71,7 +71,7 @@ const AdsWrapper = ( { section, children } ) => {
 		site?.options?.wordads && ! hasWordAdsFeature && wordAdsStatus === WordAdsStatus.ineligible;
 
 	const requestAdsApproval = () =>
-		requestingWordAdsApproval ? dispatch( requestWordAdsApproval( siteId ) ) : null;
+		! requestingWordAdsApproval ? dispatch( requestWordAdsApproval( siteId ) ) : null;
 
 	const handleDismissWordAdsError = () => {
 		dispatch( dismissWordAdsError( siteId ) );

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -127,7 +127,7 @@ const AdsWrapper = ( { section, children } ) => {
 							'Your site is marked as private. It needs to be public so that visitors can see the ads.'
 						) }
 					>
-						<NoticeAction href={ '/settings/general/' + this.props.siteSlug }>
+						<NoticeAction href={ '/settings/general/' + siteSlug }>
 							{ translate( 'Change privacy settings' ) }
 						</NoticeAction>
 					</Notice>
@@ -147,8 +147,8 @@ const AdsWrapper = ( { section, children } ) => {
 						<div className="ads__activate-header-toggle">
 							<FormButton
 								disabled={
-									this.props.site.options.wordads ||
-									( this.props.requestingWordAdsApproval && this.props.wordAdsError === null ) ||
+									site?.options?.wordads ||
+									( requestingWordAdsApproval && wordAdsError === null ) ||
 									isUnsafe !== false
 								}
 								onClick={ requestAdsApproval }
@@ -191,7 +191,7 @@ const AdsWrapper = ( { section, children } ) => {
 		return (
 			<EmptyContent
 				illustration="/calypso/images/illustrations/illustration-404.svg"
-				title={ this.props.translate( 'You are not authorized to view this page' ) }
+				title={ translate( 'You are not authorized to view this page' ) }
 			/>
 		);
 	};
@@ -201,7 +201,7 @@ const AdsWrapper = ( { section, children } ) => {
 			<EmptyContent
 				illustration="/calypso/images/illustrations/wordAds.svg"
 				illustrationWidth={ 400 }
-				title={ this.props.translate( 'Only site owners are eligible to activate WordAds.' ) }
+				title={ translate( 'Only site owners are eligible to activate WordAds.' ) }
 			/>
 		);
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Updates the Earn > Ads > AdsWrapper component from class component to functional component with hooks.

## Testing Instructions

1) Checkout this branch and go to `http://calypso.localhost:3000/earn/YOURDOMAIN`
2) Test Ads pages to confirm they look and behave the same as before: 
   - If you haven't yet, find the Ads card and enable Ads. 
   - Click around on the ads dashboard and confirm everything loads as expect. 
3) Bonus: I don't have a personal site with ad revenue to check earning stats. I tested this by using the Switch to User functionality. I went to an active WordPress.com site with ads and confirmed totals still show. 
