### PR TITLE
Domain Management I1: Add supplemental domain text in domain row based on type

### DIFF
--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -156,8 +156,7 @@ export function DomainsTableRow( {
 	};
 
 	const domainTypeText =
-		currentDomainData &&
-		getDomainTypeText( currentDomainData, translate, domainInfoContext.DOMAIN_ROW );
+		currentDomainData && getDomainTypeText( currentDomainData, __, domainInfoContext.DOMAIN_ROW );
 
 	return (
 		<tr key={ domain.domain } ref={ ref }>

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -16,6 +16,8 @@ import { useInView } from 'react-intersection-observer';
 import { PrimaryDomainLabel } from '../primary-domain-label';
 import { countDomainsRequiringAttention } from '../utils';
 import { createSiteDomainObject } from '../utils/assembler';
+import { domainInfoContext } from '../utils/constants';
+import { getDomainTypeText } from '../utils/get-domain-type-text';
 import { domainManagementLink } from '../utils/paths';
 import { DomainStatusPurchaseActions, resolveDomainStatus } from '../utils/resolve-domain-status';
 import { DomainsTableRegisteredUntilCell } from './domains-table-registered-until-cell';
@@ -153,6 +155,10 @@ export function DomainsTableRow( {
 		return null;
 	};
 
+	const domainTypeText =
+		currentDomainData &&
+		getDomainTypeText( currentDomainData, translate, domainInfoContext.DOMAIN_ROW );
+
 	return (
 		<tr key={ domain.domain } ref={ ref }>
 			<td>
@@ -179,6 +185,9 @@ export function DomainsTableRow( {
 					</a>
 				) : (
 					<span className="domains-table__domain-name">{ domain.domain }</span>
+				) }
+				{ domainTypeText && (
+					<span className="domains-table-row__domain-type-text">{ domainTypeText }</span>
 				) }
 			</td>
 			{ ! hideOwnerColumn && (

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -1,4 +1,6 @@
 @import "@automattic/typography/styles/variables";
+@import "@automattic/onboarding/styles/mixins";
+
 
 .domains-table {
 	--domains-table-toolbar-height: 40px;
@@ -138,5 +140,17 @@
 	p {
 		line-height: 1.2;
 		font-size: smaller;
+	}
+}
+
+.domains-table-row__domain-type-text {
+	display: none;
+	font-size: $font-body-extra-small;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 20px;
+
+	@include break-large {
+		display: block;
 	}
 }

--- a/packages/domains-table/src/utils/get-domain-type-text.tsx
+++ b/packages/domains-table/src/utils/get-domain-type-text.tsx
@@ -1,38 +1,39 @@
 import { type as domainTypes, domainInfoContext } from './constants';
 import { ResponseDomain } from './types';
+import type { __ as __type } from '@wordpress/i18n';
 
 export function getDomainTypeText(
 	domain: ResponseDomain,
-	__ = ( text: string ) => text,
+	__: typeof __type = ( text: string ) => text,
 	context = domainInfoContext.DOMAIN_ITEM
 ) {
 	switch ( domain.type ) {
 		case domainTypes.MAPPED:
 			if ( context === domainInfoContext.PAGE_TITLE ) {
-				return __( 'Connected Domain' );
+				return __( 'Connected Domain', __i18n_text_domain__ );
 			}
 
-			return 'Registered with an external provider';
+			return __( 'Registered with an external provider', __i18n_text_domain__ );
 
 		case domainTypes.REGISTERED:
 			if ( domain?.isPremium ) {
-				return __( 'Premium Domain' );
+				return __( 'Premium Domain', __i18n_text_domain__ );
 			}
 
 			// Registered domains don't show any type text in the domain row component
 			if ( context === domainInfoContext.DOMAIN_ROW ) {
 				return null;
 			}
-			return __( 'Registered Domain' );
+			return __( 'Registered Domain', __i18n_text_domain__ );
 
 		case domainTypes.SITE_REDIRECT:
-			return __( 'Site Redirect' );
+			return __( 'Site Redirect', __i18n_text_domain__ );
 
 		case domainTypes.WPCOM:
-			return __( 'Default Site Domain' );
+			return __( 'Default Site Domain', __i18n_text_domain__ );
 
 		case domainTypes.TRANSFER:
-			return __( 'Domain Transfer' );
+			return __( 'Domain Transfer', __i18n_text_domain__ );
 
 		default:
 			return '';

--- a/packages/domains-table/src/utils/get-domain-type-text.tsx
+++ b/packages/domains-table/src/utils/get-domain-type-text.tsx
@@ -1,0 +1,40 @@
+import { type as domainTypes, domainInfoContext } from './constants';
+import { ResponseDomain } from './types';
+
+export function getDomainTypeText(
+	domain: ResponseDomain,
+	__ = ( text: string ) => text,
+	context = domainInfoContext.DOMAIN_ITEM
+) {
+	switch ( domain.type ) {
+		case domainTypes.MAPPED:
+			if ( context === domainInfoContext.PAGE_TITLE ) {
+				return __( 'Connected Domain' );
+			}
+
+			return 'Registered with an external provider';
+
+		case domainTypes.REGISTERED:
+			if ( domain?.isPremium ) {
+				return __( 'Premium Domain' );
+			}
+
+			// Registered domains don't show any type text in the domain row component
+			if ( context === domainInfoContext.DOMAIN_ROW ) {
+				return null;
+			}
+			return __( 'Registered Domain' );
+
+		case domainTypes.SITE_REDIRECT:
+			return __( 'Site Redirect' );
+
+		case domainTypes.WPCOM:
+			return __( 'Default Site Domain' );
+
+		case domainTypes.TRANSFER:
+			return __( 'Domain Transfer' );
+
+		default:
+			return '';
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

closes https://github.com/Automattic/dotcom-forge/issues/3743
## Proposed Changes

* Add util function in domains table package to generate supplemental text based on domain type

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* browse `/domains/manage?flags=domains/management`
* Verify text "Registered with external provider"  in domains table row

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?