### PR TITLE
Use launchpad/navigator feature flag to protect masterbar item

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -502,7 +502,11 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderLaunchpadNavigator() {
-		return <AsyncLoad require="./masterbar-launchpad-navigator" />;
+		if ( config.isEnabled( 'launchpad/navigator' ) ) {
+			return <AsyncLoad require="./masterbar-launchpad-navigator" />;
+		}
+
+		return null;
 	}
 
 	render() {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81651

## Proposed Changes

* This PR ensures that the Launchpad Navigator feature we are working on in the `try/add-launchpad-navigator-to-masterbar` branch is protected by the `launchpad/navigator` feature flag added in #81651

## Testing Instructions

* Use Calypso.live or a local Calypso to navigate to the My Home for a site
* Verify that you don't see a task icon in the masterbar
* Add the following to the URL`?flags=launchpad/navigator`
* Verify that the task icon appears in the masterbar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?