### PR TITLE
Link Update: Upgrade Credit Banner link

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -148,7 +148,7 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 								a: (
 									<a
 										href={ localizeUrl(
-											'https://wordpress.com/support/manage-purchases/#upgrade-credit'
+											'https://wordpress.com/support/manage-purchases/upgrade-your-plan/#upgrade-credit'
 										) }
 										className="get-apps__desktop-link"
 									/>


### PR DESCRIPTION
Simple url update for upgrade credit banner link.

Related to #81501 

## Testing Instructions

See steps in original issue https://github.com/Automattic/wp-calypso/issues/81500