### PR TITLE
Domain management: Ensure empty site cell on domain only rows

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -101,7 +101,7 @@ class DomainRow extends PureComponent {
 	renderSite() {
 		const { domain } = this.props;
 		if ( domain.isDomainOnlySite ) {
-			return null;
+			return <div className="domain-row__site-cell"></div>;
 		}
 
 		return (


### PR DESCRIPTION
## Proposed Changes

* Ensures an empty div cell is rendered even when there is no content for that cell in domain only views.


## Testing Instructions

* View domain manage with domain only sites. Confirm table lines up again

Before
![Screenshot 2023-09-13 at 13-31-14 Domains — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/6d25fbf7-90a5-45de-b287-752763b2d682)

After
![Screenshot 2023-09-13 at 13-31-03 Domains — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/c822ce9a-d8a6-476a-b26b-38d004c1a718)

props: @p-jackson 