### PR TITLE
Jetpack E2E: miscellaneous block flows from the important tasks.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -28,6 +28,7 @@ export * from './form-ai';
 export * from './image-compare';
 export * from './map';
 export * from './gif';
+export * from './markdown';
 
 /* Types */
 export * from './types';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/index.ts
@@ -29,6 +29,7 @@ export * from './image-compare';
 export * from './map';
 export * from './gif';
 export * from './markdown';
+export * from './related-posts';
 
 /* Types */
 export * from './types';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/markdown.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/markdown.ts
@@ -10,7 +10,7 @@ interface ValidationData {
 }
 
 /**
- * Represents the flow of using the AI Assistant block.
+ * Represents the flow of using the Markdown block.
  */
 export class MarkdownFlow implements BlockFlow {
 	private configurationData: ConfigurationData;

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/markdown.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/markdown.ts
@@ -37,12 +37,7 @@ export class MarkdownFlow implements BlockFlow {
 	 * test execution.
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		const editorCanvas = await context.editorPage.getEditorCanvas();
-		const block = editorCanvas.getByRole( 'document', {
-			name: `Block: ${ this.blockSidebarName }`,
-		} );
-
-		const textarea = block.getByRole( 'textbox', { name: 'Markdown' } );
+		const textarea = context.addedBlockLocator.getByRole( 'textbox', { name: 'Markdown' } );
 
 		await textarea.fill( this.configurationData.text );
 

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/markdown.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/markdown.ts
@@ -1,0 +1,66 @@
+import { BlockFlow, EditorContext, PublishedPostContext } from '.';
+
+interface ConfigurationData {
+	text: string;
+}
+interface ValidationData {
+	expectedText: string;
+	// Has to be one of the aria roles supported by the locator.getByRole call.
+	expectedRole: 'heading' | 'paragraph';
+}
+
+/**
+ * Represents the flow of using the AI Assistant block.
+ */
+export class MarkdownFlow implements BlockFlow {
+	private configurationData: ConfigurationData;
+	private validationData: ValidationData;
+
+	/**
+	 * Constructs an instance of this block flow with data to be used when
+	 * configuring and validating the block.
+	 *
+	 * @param {ConfigurationData} configurationData Configuration data for the block.
+	 */
+	constructor( configurationData: ConfigurationData, validationData: ValidationData ) {
+		this.configurationData = configurationData;
+		this.validationData = validationData;
+	}
+
+	blockSidebarName = 'Markdown';
+	blockEditorSelector = 'div[aria-label="Block: Markdown"]';
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of
+	 * test execution.
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		const block = editorCanvas.getByRole( 'document', {
+			name: `Block: ${ this.blockSidebarName }`,
+		} );
+
+		const textarea = block.getByRole( 'textbox', { name: 'Markdown' } );
+
+		await textarea.fill( this.configurationData.text );
+
+		await context.editorPage.clickBlockToolbarButton( { name: 'Preview' } );
+		await textarea.waitFor( { state: 'hidden' } );
+	}
+
+	/**
+	 * Validate the block in the published post
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at
+	 * the point of test execution.
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		await context.page
+			.getByRole( this.validationData.expectedRole, {
+				name: this.validationData.expectedText,
+			} )
+			.waitFor();
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/related-posts.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/related-posts.ts
@@ -5,7 +5,9 @@ interface ConfigurationData {
 }
 
 /**
- * Represents the flow of using the AI Assistant block.
+ * Represents the flow of using the Related Posts block.
+ *
+ * Note, this block must be turned on from Jetpack Settings > Traffic for AT sites.
  */
 export class RelatedPostsFlow implements BlockFlow {
 	blockSidebarName = 'Related Posts';

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/related-posts.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/related-posts.ts
@@ -1,0 +1,57 @@
+import { BlockFlow, EditorContext, PublishedPostContext } from '.';
+
+/**
+ * Represents the flow of using the AI Assistant block.
+ */
+export class RelatedPostsFlow implements BlockFlow {
+	blockSidebarName = 'Related Posts';
+	blockEditorSelector = 'div[aria-label="Block: Related Posts"]';
+
+	private noRelatedPosts = false;
+
+	/**
+	 * Configure the block in the editor with the configuration data from the constructor
+	 *
+	 * @param {EditorContext} context The current context for the editor at the point of
+	 * test execution.
+	 */
+	async configure( context: EditorContext ): Promise< void > {
+		const editorCanvas = await context.editorPage.getEditorCanvas();
+		const block = editorCanvas.getByRole( 'document', {
+			name: `Block: ${ this.blockSidebarName }`,
+		} );
+
+		await block.waitFor();
+
+		// This section requires understanding the implementation detail for this block a little.
+		// In short, even on sites with many posts, this block renders a notice stating that preview
+		// is unavailable.
+		// When no related posts are actually available, the published page will not render the block.
+		// If the number of "Preview unavailable" message corresponds to the number of available "slots",
+		// the site really has no related posts thus the published page will not render this block.
+		const noRelatedPostsNotice = await block.getByText( /Preview unavailable/ ).count();
+		const postSlotCount = await block.getByRole( 'menuitem' ).count();
+
+		if ( noRelatedPostsNotice === postSlotCount ) {
+			this.noRelatedPosts = true;
+		}
+	}
+
+	/**
+	 * Validate the block in the published post.
+	 *
+	 * @param {PublishedPostContext} context The current context for the published post at
+	 * the point of test execution.
+	 */
+	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
+		const publishedBlock = context.page.locator( '.wp-block-jetpack-related-posts' );
+
+		if ( this.noRelatedPosts ) {
+			// For sites with no related posts at all, the block will not render.
+			await publishedBlock.waitFor( { state: 'detached' } );
+		} else {
+			// For sites with related posts, the block will render.
+			await publishedBlock.waitFor();
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/related-posts.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/related-posts.ts
@@ -61,6 +61,9 @@ export class RelatedPostsFlow implements BlockFlow {
 		if ( noRelatedPostsNotice === postSlotCount ) {
 			this.noRelatedPosts = true;
 		}
+
+		// For mobile viewports, this block automatically opens the Block Settings sidebar.
+		await context.editorPage.closeSettings();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/related-posts.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/related-posts.ts
@@ -32,12 +32,7 @@ export class RelatedPostsFlow implements BlockFlow {
 	 * test execution.
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		const editorCanvas = await context.editorPage.getEditorCanvas();
-		const block = editorCanvas.getByRole( 'document', {
-			name: `Block: ${ this.blockSidebarName }`,
-		} );
-
-		await block.waitFor();
+		await context.addedBlockLocator.waitFor();
 
 		if ( this.configurationData.headline ) {
 			await context.editorPage.openSettings();
@@ -58,8 +53,10 @@ export class RelatedPostsFlow implements BlockFlow {
 		// When no related posts are actually available, the published page will not render the block.
 		// If the number of "Preview unavailable" message corresponds to the number of available "slots",
 		// the site really has no related posts thus the published page will not render this block.
-		const noRelatedPostsNotice = await block.getByText( /Preview unavailable/ ).count();
-		const postSlotCount = await block.getByRole( 'menuitem' ).count();
+		const noRelatedPostsNotice = await context.addedBlockLocator
+			.getByText( /Preview unavailable/ )
+			.count();
+		const postSlotCount = await context.addedBlockLocator.getByRole( 'menuitem' ).count();
 
 		if ( noRelatedPostsNotice === postSlotCount ) {
 			this.noRelatedPosts = true;

--- a/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
@@ -58,10 +58,9 @@ export class EditorBlockToolbarComponent {
 		if ( identifier.name ) {
 			// Accessible names don't need to have the selector built, but needs to be narrowed
 			// to the toolbar.
-			await editorParent
+			locator = editorParent
 				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: identifier.name } )
-				.click();
+				.getByRole( 'button', { name: identifier.name } );
 		} else {
 			// Other identifers need to have the selector built.
 			locator = editorParent.locator( selectors.button( identifier ) );

--- a/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
@@ -56,8 +56,12 @@ export class EditorBlockToolbarComponent {
 
 		let locator: Locator;
 		if ( identifier.name ) {
-			// Accessible names don't need to have the selector built.
-			locator = editorParent.getByRole( 'button', { name: identifier.name } );
+			// Accessible names don't need to have the selector built, but needs to be narrowed
+			// to the toolbar.
+			await editorParent
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: identifier.name } )
+				.click();
 		} else {
 			// Other identifers need to have the selector built.
 			locator = editorParent.locator( selectors.button( identifier ) );

--- a/test/e2e/specs/blocks/blocks__jetpack-other.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-other.ts
@@ -8,7 +8,6 @@ import {
 	MapFlow,
 	GifFlow,
 	envVariables,
-	RelatedPostsFlow,
 } from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared/block-smoke-testing';
 
@@ -22,20 +21,6 @@ const blockFlows: BlockFlow[] = [
 if ( envVariables.ATOMIC_VARIATION !== 'private' ) {
 	blockFlows.push(
 		new MapFlow( { address: '1455 Quebec Street, Vancouver', select: '1455 Quebec St' } )
-	);
-}
-
-// Related posts block do not show up on private sites, as one would expect.
-// However, it also does not appear on eCommerce plan sites.
-// @see: https://github.com/Automattic/jetpack/issues/33062
-if (
-	envVariables.ATOMIC_VARIATION !== 'private' &&
-	envVariables.ATOMIC_VARIATION !== 'ecomm-plan'
-) {
-	blockFlows.push(
-		new RelatedPostsFlow( {
-			headline: `Related Posts from this user`,
-		} )
 	);
 }
 

--- a/test/e2e/specs/blocks/blocks__jetpack-other.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-other.ts
@@ -8,12 +8,14 @@ import {
 	MapFlow,
 	GifFlow,
 	envVariables,
+	RelatedPostsFlow,
 } from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
 	new StarRatingBlock( { rating: 3.5 } ),
 	new GifFlow( { query: 'https://giphy.com/embed/MDJ9IbxxvDUQM' } ),
+	new RelatedPostsFlow(),
 ];
 
 // Private sites change behaivor of the Map block.

--- a/test/e2e/specs/blocks/blocks__jetpack-other.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-other.ts
@@ -15,7 +15,6 @@ import { createBlockTests } from './shared/block-smoke-testing';
 const blockFlows: BlockFlow[] = [
 	new StarRatingBlock( { rating: 3.5 } ),
 	new GifFlow( { query: 'https://giphy.com/embed/MDJ9IbxxvDUQM' } ),
-	new RelatedPostsFlow(),
 ];
 
 // Private sites change behaivor of the Map block.
@@ -23,6 +22,20 @@ const blockFlows: BlockFlow[] = [
 if ( envVariables.ATOMIC_VARIATION !== 'private' ) {
 	blockFlows.push(
 		new MapFlow( { address: '1455 Quebec Street, Vancouver', select: '1455 Quebec St' } )
+	);
+}
+
+// Related posts block do not show up on private sites, as one would expect.
+// However, it also does not appear on eCommerce plan sites.
+// @see: https://github.com/Automattic/jetpack/issues/33062
+if (
+	envVariables.ATOMIC_VARIATION !== 'private' &&
+	envVariables.ATOMIC_VARIATION !== 'ecomm-plan'
+) {
+	blockFlows.push(
+		new RelatedPostsFlow( {
+			headline: `Related Posts from this user`,
+		} )
 	);
 }
 

--- a/test/e2e/specs/blocks/blocks__jetpack-other.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-other.ts
@@ -8,6 +8,7 @@ import {
 	MapFlow,
 	GifFlow,
 	envVariables,
+	RelatedPostsFlow,
 } from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared/block-smoke-testing';
 
@@ -18,9 +19,15 @@ const blockFlows: BlockFlow[] = [
 
 // Private sites change behaivor of the Map block.
 // @see: https://github.com/Automattic/jetpack/issues/32991
+// Related posts block do not show up on private sites, as one would expect.
 if ( envVariables.ATOMIC_VARIATION !== 'private' ) {
 	blockFlows.push(
 		new MapFlow( { address: '1455 Quebec Street, Vancouver', select: '1455 Quebec St' } )
+	);
+	blockFlows.push(
+		new RelatedPostsFlow( {
+			headline: `Related Posts from this user`,
+		} )
 	);
 }
 

--- a/test/e2e/specs/blocks/blocks__jetpack-writing.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-writing.ts
@@ -2,7 +2,7 @@
  * @group gutenberg
  * @group jetpack-wpcom-integration
  */
-import { BlockFlow, AIAssistantFlow } from '@automattic/calypso-e2e';
+import { BlockFlow, AIAssistantFlow, MarkdownFlow } from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared/block-smoke-testing';
 
 const blockFlows: BlockFlow[] = [
@@ -14,6 +14,16 @@ const blockFlows: BlockFlow[] = [
 		},
 		{ keywords: [ 'Vancouver' ] }
 	),
+	new MarkdownFlow(
+		{
+			text: '### Test',
+		},
+		{
+			expectedText: 'Test',
+			expectedRole: 'heading',
+		}
+	),
 ];
 
 createBlockTests( 'Blocks: Jetpack Writing', blockFlows );
+8;

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -48,6 +48,10 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 			await editorPage.visit( 'post' );
 		} );
 
+		it( 'Enter post title', async () => {
+			await editorPage.enterTitle( `${ specName } - ${ DataHelper.getDateString( 'ISO-8601' ) }` );
+		} );
+
 		describe( 'Add and configure blocks in the editor', function () {
 			for ( const blockFlow of blockFlows ) {
 				it( `${ blockFlow.blockSidebarName }: Add the block from the sidebar`, async function () {


### PR DESCRIPTION
Related to: https://github.com/Automattic/wp-calypso/issues/80730.

## Proposed Changes

This PR adds two new specs under the miscellaneous blocks:
- related posts
- markdown

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?