### PR TITLE
Add missing invalidateQueries call in domainTransferRequestUpdate

### DIFF
--- a/client/data/domains/transfers/use-domain-transfer-request-update.ts
+++ b/client/data/domains/transfers/use-domain-transfer-request-update.ts
@@ -1,7 +1,8 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { DomainsApiError } from 'calypso/lib/domains/types';
 import wp from 'calypso/lib/wp';
+import { domainTransferRequestQueryKey } from './domain-transfer-request-query-key';
 
 export default function useDomainTransferRequestUpdate(
 	siteSlug: string,
@@ -11,6 +12,7 @@ export default function useDomainTransferRequestUpdate(
 		onError?: ( error: DomainsApiError ) => void;
 	}
 ) {
+	const queryClient = useQueryClient();
 	const mutation = useMutation( {
 		mutationFn: ( email: string ) =>
 			wp.req.post( `/sites/${ siteSlug }/domains/${ domainName }/transfer-to-any-user`, {
@@ -18,6 +20,7 @@ export default function useDomainTransferRequestUpdate(
 			} ),
 		...queryOptions,
 		onSuccess() {
+			queryClient.invalidateQueries( domainTransferRequestQueryKey( siteSlug, domainName ) );
 			queryOptions.onSuccess?.();
 		},
 	} );


### PR DESCRIPTION
Follow up from https://github.com/Automattic/wp-calypso/pull/81613

Related to https://github.com/Automattic/dotcom-forge/issues/3685

## Proposed Changes

* Adds a missing query invalidation call, this will be a noop for what we have in dev but is required for https://github.com/Automattic/dotcom-forge/issues/3685

## Testing Instructions

* Visit domain transfer screen with the flag enabled: http://calypso.localhost:3000/domains/manage/all/test345678.blog/transfer/test345678.blog?flags=domains/transfer-to-any-user
* The transfer request should still send and save the backend option.
