### PR TITLE
Add mailboxes route and copy /inbox path elements to /mailboxes

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
@@ -5,7 +5,7 @@ import domainRegistrationThankYouProps from 'calypso/my-sites/checkout/checkout-
 import domainTransferProps from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-transfer';
 import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import {
-	emailManagementInbox,
+	emailManagementMailboxes,
 	emailManagementPurchaseNewEmailAccount,
 } from 'calypso/my-sites/email/paths';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
@@ -35,7 +35,7 @@ const StepCTA = ( { email, primary, siteName }: StepCTAProps ) => {
 
 	const redirectUrl = `${ window.location.protocol }//${
 		window.location.host
-	}${ emailManagementInbox( siteName ) }`;
+	}${ emailManagementMailboxes( siteName ) }`;
 
 	return (
 		<FullWidthButton
@@ -49,13 +49,13 @@ const StepCTA = ( { email, primary, siteName }: StepCTAProps ) => {
 				} );
 			} }
 		>
-			{ translate( 'Go to Inbox' ) }
+			{ translate( 'Your Mailboxes' ) }
 		</FullWidthButton>
 	);
 };
 
 /**
- * Helper function to reuse Get Inbox/Access your inbox components
+ * Helper function to reuse Get mailboxes/Access your mailboxes components
  */
 export function buildDomainStepForProfessionalEmail(
 	{
@@ -103,7 +103,7 @@ export function buildDomainStepForProfessionalEmail(
 
 	return {
 		stepKey: `domain_${ domainType }_whats_next_email_setup_view_inbox`,
-		stepTitle: translate( 'Access your inbox' ),
+		stepTitle: translate( 'Access your mailboxes' ),
 		stepDescription: translate( 'Access your email from anywhere with our webmail.' ),
 		stepCta: <StepCTA siteName={ selectedSiteSlug } email={ email } primary={ primary } />,
 	};

--- a/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
+++ b/client/my-sites/email/inbox/mailbox-selection-list/index.jsx
@@ -137,7 +137,7 @@ const MailboxItems = ( { mailboxes } ) => {
 				align="center"
 				brandFont
 				className="mailbox-selection-list__header"
-				headerText={ translate( 'Welcome to Inbox!' ) }
+				headerText={ translate( 'My Mailboxes!' ) }
 				subHeaderText={ translate( 'Choose the mailbox you’d like to open.' ) }
 			/>
 

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -17,9 +17,9 @@ function registerMultiPage( { paths: givenPaths, handlers } ) {
 
 const commonHandlers = [ siteSelection, navigation, stagingSiteNotSupportedRedirect ];
 
-const emailInboxSiteSelectionHeader = ( context, next ) => {
+const emailMailboxesSiteSelectionHeader = ( context, next ) => {
 	context.getSiteSelectionHeaderText = () => {
-		return translate( 'Select a site to open {{strong}}My Inbox{{/strong}}', {
+		return translate( 'Select a site to open {{strong}}My Mailboxes{{/strong}}', {
 			components: {
 				strong: <strong />,
 			},
@@ -35,7 +35,7 @@ export default function () {
 	page(
 		paths.emailManagementInbox(),
 		siteSelection,
-		emailInboxSiteSelectionHeader,
+		emailMailboxesSiteSelectionHeader,
 		sites,
 		makeLayout,
 		clientRender
@@ -43,6 +43,23 @@ export default function () {
 
 	page(
 		paths.emailManagementInbox( ':site' ),
+		...commonHandlers,
+		controller.emailManagementInbox,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		paths.emailManagementMailboxes(),
+		siteSelection,
+		emailMailboxesSiteSelectionHeader,
+		sites,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		paths.emailManagementMailboxes( ':site' ),
 		...commonHandlers,
 		controller.emailManagementInbox,
 		makeLayout,

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -17,6 +17,18 @@ function registerMultiPage( { paths: givenPaths, handlers } ) {
 
 const commonHandlers = [ siteSelection, navigation, stagingSiteNotSupportedRedirect ];
 
+const emailInboxSiteSelectionHeader = ( context, next ) => {
+	context.getSiteSelectionHeaderText = () => {
+		return translate( 'Select a site to open {{strong}}My Inbox{{/strong}}', {
+			components: {
+				strong: <strong />,
+			},
+		} );
+	};
+
+	next();
+};
+
 const emailMailboxesSiteSelectionHeader = ( context, next ) => {
 	context.getSiteSelectionHeaderText = () => {
 		return translate( 'Select a site to open {{strong}}My Mailboxes{{/strong}}', {
@@ -35,7 +47,7 @@ export default function () {
 	page(
 		paths.emailManagementInbox(),
 		siteSelection,
-		emailMailboxesSiteSelectionHeader,
+		emailInboxSiteSelectionHeader,
 		sites,
 		makeLayout,
 		clientRender

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -295,6 +295,21 @@ export function emailManagementInbox( siteName = null ) {
 	return `/inbox`;
 }
 
+/**
+ * Retrieves the url of the Mailboxes page:
+ *
+ *   https://wordpress.com/mailboxes/:siteName
+ *
+ * @param {string|null|undefined} siteName - slug of the current site
+ * @returns {string} the corresponding url
+ */
+export function emailManagementMailboxes( siteName = null ) {
+	if ( siteName ) {
+		return `/mailboxes/${ siteName }`;
+	}
+	return `/mailboxes`;
+}
+
 export function isUnderEmailManagementAll( path ) {
 	return path?.startsWith( emailManagementAllSitesPrefix + '/' );
 }

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -10,7 +10,7 @@ import { addQueryArgs } from 'calypso/lib/url';
 import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import {
 	emailManagement,
-	emailManagementInbox,
+	emailManagementMailboxes,
 	emailManagementTitanControlPanelRedirect,
 	emailManagementTitanSetUpMailbox,
 } from 'calypso/my-sites/email/paths';
@@ -50,7 +50,7 @@ const TitanSetUpThankYou = ( {
 	const translate = useTranslate();
 
 	const emailManagementPath = emailManagement( selectedSiteSlug, domainName, currentRoute );
-	const inboxPath = emailManagementInbox( selectedSiteSlug );
+	const mailboxesPath = emailManagementMailboxes( selectedSiteSlug );
 
 	const thankYouImage = {
 		alt: translate( 'Thank you' ),
@@ -69,7 +69,7 @@ const TitanSetUpThankYou = ( {
 	let nextSteps = [
 		{
 			stepKey: 'titan_whats_next_view_inbox',
-			stepTitle: translate( 'Access your inbox' ),
+			stepTitle: translate( 'Access your mailboxes' ),
 			stepDescription: translate( 'Access your email from anywhere with our webmail.' ),
 			stepCta: (
 				<FullWidthButton
@@ -77,7 +77,7 @@ const TitanSetUpThankYou = ( {
 						titanAppsUrlPrefix,
 						emailAddress,
 						false,
-						`${ window.location.protocol }//${ window.location.host }${ inboxPath }`
+						`${ window.location.protocol }//${ window.location.host }${ mailboxesPath }`
 					) }
 					primary
 					onClick={ () => {
@@ -88,7 +88,7 @@ const TitanSetUpThankYou = ( {
 						} );
 					} }
 				>
-					{ translate( 'Go to Inbox' ) }
+					{ translate( 'Your Mailboxes' ) }
 				</FullWidthButton>
 			),
 		},

--- a/client/my-sites/sidebar/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/fallback-menu.js
@@ -28,7 +28,7 @@ const WOOCOMMERCE_ICON = `data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3
 
 export default function buildFallbackResponse( {
 	siteDomain = '',
-	shouldShowInbox = false,
+	shouldShowMailboxes = false,
 	shouldShowLinks = false,
 	shouldShowTestimonials = false,
 	shouldShowPortfolio = false,
@@ -41,15 +41,15 @@ export default function buildFallbackResponse( {
 	shouldShowAddOns = false,
 	showSiteMonitoring = false,
 } = {} ) {
-	let inbox = [];
-	if ( shouldShowInbox ) {
-		inbox = [
+	let mailboxes = [];
+	if ( shouldShowMailboxes ) {
+		mailboxes = [
 			{
 				icon: 'dashicons-email',
-				slug: 'Inbox',
-				title: translate( 'Inbox' ),
+				slug: 'mailboxes',
+				title: translate( 'My Mailboxes' ),
 				type: 'menu-item',
-				url: `/inbox/${ siteDomain }`,
+				url: `/mailboxes/${ siteDomain }`,
 			},
 		];
 	}
@@ -117,7 +117,7 @@ export default function buildFallbackResponse( {
 				},
 			],
 		},
-		...inbox,
+		...mailboxes,
 		{
 			icon: 'dashicons-admin-post',
 			slug: 'edit-php',

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -54,7 +54,7 @@ const useSiteMenuItems = () => {
 	const isP2 = useSelector( ( state ) => !! isSiteWPForTeams( state, selectedSiteId ) );
 	const isDomainOnly = useSelector( ( state ) => isDomainOnlySite( state, selectedSiteId ) );
 
-	const shouldShowInbox = ! isP2;
+	const shouldShowMailboxes = ! isP2;
 
 	const shouldShowAddOnsInFallbackMenu = isEnabled( 'my-sites/add-ons' ) && ! isAtomic;
 
@@ -92,7 +92,7 @@ const useSiteMenuItems = () => {
 		siteDomain,
 		shouldShowWooCommerce,
 		shouldShowThemes,
-		shouldShowInbox,
+		shouldShowMailboxes,
 		shouldShowAddOns: shouldShowAddOnsInFallbackMenu,
 		showSiteMonitoring: isAtomic,
 	};

--- a/client/sections.js
+++ b/client/sections.js
@@ -267,6 +267,12 @@ const sections = [
 		group: 'sites',
 	},
 	{
+		name: 'mailboxes',
+		paths: [ '/mailboxes' ],
+		module: 'calypso/my-sites/email',
+		group: 'sites',
+	},
+	{
 		name: 'inbox',
 		paths: [ '/inbox' ],
 		module: 'calypso/my-sites/email',


### PR DESCRIPTION
See: p7fD6U-bs2-p2#comment-25280 for details about the proposal to switch `/inbox` to `/mailboxes`

Some path elements that make `/inbox` work are copied to `/mailboxes` to allow for a redirect to ensure we do not have broken links on WPCOM landing pages and probably existing documentation.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to  pMz3w-ilk-p2  and https://github.com/Automattic/jetpack/pull/32992

## Proposed Changes

* Adds the `/mailboxes` route locally in Calypso. This is different from the Systems request
* Duplicate some `/inbox` path elements to `/mailboxes` to make a redirect work
* Change static fallback "Inbox" menu items to "My Mailboxes"
* Switches the site launcher introduction to refer to "My Mailboxes"

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Using either your local Calypso build, or [Calypso live](https://github.com/Automattic/wp-calypso/pull/81666#issuecomment-1716983359):

#### Test the static fallback menu 

<br />
<img width="1000" alt="Screenshot 2023-09-14 at 5 13 30 AM" src="https://github.com/Automattic/wp-calypso/assets/277661/19d7a68e-86fa-4aaa-ad5d-b4ae754ac64c">

<br />  

- Block requests containing the word `/admin-menu` from the **Network** of your Developer Console. [Introduction](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/request_list/index.html#blocking-specific-urls) to blocking requests for Firefox
- Clear your browser's caches
- Confirm that you see the `My Mailboxes` menu item 


#### Test the routes

* Confirm that the `/inbox` route is still working
* Confirm that the new `/mailboxes` route works
* Confirm that the site switcher now refers to "My Mailboxes" rather than "My Inbox" when a bare `/mailboxes` is navigated without a site.

<br />

<img width="1100" alt="Screenshot 2023-09-14 at 6 26 12 AM" src="https://github.com/Automattic/wp-calypso/assets/277661/56908fdd-5091-4bae-a841-a13adaa4adcd">


<br />