### PR TITLE
Domain Management i1: Domains table makes fewer requests for `/all-domains` data

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
@@ -25,6 +25,7 @@ import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/
 import DomainHeader from 'calypso/my-sites/domains/domain-management/components/domain-header';
 import { domainManagementList, isUnderDomainManagementAll } from 'calypso/my-sites/domains/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getPreviousPath from 'calypso/state/selectors/get-previous-path';
 import isRequestingWhoisSelector from 'calypso/state/selectors/is-requesting-whois';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { IAppState } from 'calypso/state/types';
@@ -47,7 +48,15 @@ export default function BulkEditContactInfoPage( {
 
 	const selectedDomainsArg = getQueryArg( '?' + context.querystring, 'selected' );
 
-	const { data: partialDomainsData } = useAllDomainsQuery();
+	// If there's no previous path it means we've refreshed since navigating from
+	// the domains table. Previously we relied on the domains data fetched by the table
+	// but since the user refreshed we should fetch the domains again.
+	const hasRefreshedPage = ! useSelector( getPreviousPath );
+
+	const { data: partialDomainsData } = useAllDomainsQuery(
+		{ no_wpcom: true },
+		{ refetchOnMount: hasRefreshedPage }
+	);
 
 	const allSiteIds =
 		Array.isArray( selectedDomainsArg ) && partialDomainsData

--- a/packages/data-stores/src/queries/use-all-domains-query.ts
+++ b/packages/data-stores/src/queries/use-all-domains-query.ts
@@ -1,4 +1,5 @@
 import { UseQueryOptions, useQuery } from '@tanstack/react-query';
+import { addQueryArgs } from '@wordpress/url';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { DomainData } from './use-site-domains-query';
 
@@ -21,11 +22,27 @@ export interface AllDomainsQueryFnData {
 	domains: PartialDomainData[];
 }
 
-export function useAllDomainsQuery( options: UseQueryOptions< AllDomainsQueryFnData > = {} ) {
+export interface AllDomainsQueryArgs {
+	no_wpcom?: boolean;
+}
+
+export function useAllDomainsQuery< TError = unknown, TData = AllDomainsQueryFnData >(
+	queryArgs: AllDomainsQueryArgs = {},
+	options: UseQueryOptions< AllDomainsQueryFnData, TError, TData > = {}
+) {
 	return useQuery( {
-		queryKey: [ 'all-domains' ],
+		queryKey: [ 'all-domains', queryArgs ],
 		queryFn: () =>
-			wpcomRequest< AllDomainsQueryFnData >( { path: '/all-domains', apiVersion: '1.1' } ),
+			wpcomRequest< AllDomainsQueryFnData >( {
+				path: addQueryArgs( '/all-domains', queryArgs ),
+				apiVersion: '1.1',
+			} ),
+
+		// It's reasonable to assume that users won't register a domain in another tab
+		// and then expect the list to update automatically when they switch back.
+		// We expect users to refresh the page after making substantial domain changes.
+		refetchOnWindowFocus: false,
+
 		...options,
 	} );
 }

--- a/packages/domains-table/src/use-domains-table.ts
+++ b/packages/domains-table/src/use-domains-table.ts
@@ -1,30 +1,7 @@
-import { useAllDomainsQuery, AllDomainsQueryFnData } from '@automattic/data-stores';
-import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
-import type { UseQueryOptions } from '@tanstack/react-query';
+import { useAllDomainsQuery } from '@automattic/data-stores';
 
-const EMPTY_STATE = Object.freeze( {} );
+export function useDomainsTable() {
+	const { data, ...queryResult } = useAllDomainsQuery( { no_wpcom: true } );
 
-export function useDomainsTable( queryOptions: UseQueryOptions< AllDomainsQueryFnData > = {} ) {
-	const { capabilities, sites } = useSelector( ( state: any ) => ( {
-		capabilities: state?.currentUser?.capabilities || EMPTY_STATE,
-		sites: state?.sites?.items || EMPTY_STATE,
-	} ) );
-
-	const { data: allDomains, ...queryResult } = useAllDomainsQuery( queryOptions );
-
-	const filteredDomains = useMemo( () => {
-		const sitesUserCanManage = new Set(
-			Object.keys( sites ).filter(
-				( siteId ) => capabilities[ siteId ]?.[ 'manage_options' ] || false
-			)
-		);
-
-		return allDomains?.domains.filter(
-			( domain ) =>
-				domain.type !== 'wpcom' && sitesUserCanManage.has( domain.blog_id.toString( 10 ) )
-		);
-	}, [ allDomains, capabilities, sites ] );
-
-	return { ...queryResult, domains: filteredDomains };
+	return { ...queryResult, domains: data?.domains };
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This diff sets appropriate React Query flags so that we make a more sensible number of requests for `/all-domains` data.

* Doesn't refetch the whole domains list each time the window is focused
* Request non-wpcom domains only (depends on D121545-code)
* The contact form doesn't re-uses the domain data which has already been loaded by the table if it can
* Removed redux code for filtering domains the user can't manage. This is already done by the server fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Snqzva%2Qcyhtvaf%2Sqbznvaf%2Sznantrzrag.cuc%3Se%3Qo1q98707%23100-og

The domains list will still be refetched if the user navigates away and comes back because of the `retryOnMount` flag, which defaults to `true`. If the user comes back within the default 5 minute cache time then the table will be displayed immediately and the request will be made in the background and UI updated silently if there are any changes. If the user comes back after more than 5 minutes then they will see the full placeholder loading sequence.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D121545-code to your sandbox
* Open the browser network tools and filter by `all-domains`
* Confirm that
   * Requests are fired for each page load
   * If the page load happens soon enough (within a 5 minute window) the table skeleton gets shown before the request completes
   * Navigating to the bulk contact info UI doesn't fire another request
   * There are no `.wordpress.com` or `.wpcomstaging.com` domains in the list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?