### PR TITLE
(2nd try) Stepper: Don't fetch all sites at the beginning

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -144,7 +144,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const { data: allDesigns, isLoading: isLoadingDesigns } = useStarterDesignsQuery(
 		{
-			seed: siteSlugOrId || undefined,
+			seed: siteSlugOrId ? String( siteSlugOrId ) : undefined,
 			_locale: locale,
 		},
 		{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -32,6 +32,7 @@ import {
 import { analyzeUrl } from 'calypso/state/imports/url-analyzer/actions';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import { requestSites } from 'calypso/state/sites/actions';
 import { hasAllSitesList } from 'calypso/state/sites/selectors';
 import { StepProps } from '../../types';
 import { useAtomicTransferQueryParamUpdate } from './hooks/use-atomic-transfer-query-param-update';
@@ -74,6 +75,10 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		/**
 	 	↓ Effects
 		 */
+		useEffect( () => {
+			dispatch( requestSites() );
+		}, [ dispatch ] );
+
 		useEffect( () => {
 			! siteId && site?.ID && setSiteId( site.ID );
 		}, [ siteId, site ] );

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -296,8 +296,8 @@ const pluginBundleFlow: Flow = {
 			};
 		}
 
-		const canManageOptions = useCanUserManageOptions();
-		if ( canManageOptions === 'requesting' ) {
+		const { canManageOptions, isLoading } = useCanUserManageOptions();
+		if ( isLoading ) {
 			result = {
 				state: AssertConditionState.CHECKING,
 			};

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -645,8 +645,8 @@ const siteSetupFlow: Flow = {
 			};
 		}
 
-		const canManageOptions = useCanUserManageOptions();
-		if ( canManageOptions === 'requesting' ) {
+		const { canManageOptions, isLoading } = useCanUserManageOptions();
+		if ( isLoading ) {
 			result = {
 				state: AssertConditionState.CHECKING,
 			};

--- a/client/landing/stepper/hooks/use-site-data.ts
+++ b/client/landing/stepper/hooks/use-site-data.ts
@@ -4,8 +4,8 @@ import { useSiteSlugParam } from './use-site-slug-param';
 
 export const useSiteData = () => {
 	const site = useSite();
-	const siteSlug = useSiteSlugParam();
-	const siteId = useSiteIdParam();
+	const siteSlug = useSiteSlugParam() ?? '';
+	const siteId = Number( useSiteIdParam() ) ?? 0;
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 
 	return {

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -24,7 +24,6 @@ import { getInitialState, getStateFromCache } from 'calypso/state/initial-state'
 import { createQueryClient } from 'calypso/state/query-client';
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
-import { requestSites } from 'calypso/state/sites/actions';
 import { FlowRenderer } from './declarative-flow/internals';
 import 'calypso/components/environment-badge/style.scss';
 import 'calypso/assets/stylesheets/style.scss';
@@ -40,7 +39,6 @@ declare const window: AppWindow;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function initializeCalypsoUserStore( reduxStore: any, user: CurrentUser ) {
 	reduxStore.dispatch( setCurrentUser( user ) );
-	reduxStore.dispatch( requestSites() );
 }
 
 function determineFlow() {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1694560963053709-slack-C02FMH4G8, https://github.com/Automattic/wp-calypso/pull/81498

## Proposed Changes

* Referring to p1694560963053709-slack-C02FMH4G8, the previous one leads to the site-setup flow redirecting the user back to the `/start` flow for the new user since the redux store doesn't have any site information, and the current site won't be fetched either.
* Hence, this PR also proposes to request the current site inside the `useCanUserManageOptions` hook as the hook depends on the current site but it didn't fetch it before...

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Clear the persistent redux store to ensure Calypso didn't fetch any sites
  ![Screenshot 2023-09-13 at 2 11 27 PM](https://github.com/Automattic/wp-calypso/assets/13596067/231957a8-0166-4ea7-a2ff-f8bb98f20544)
* Go to any onboarding flows under the `/setup` directly and ensure it still works well
  * For example, `/setup?siteSlug=<your_site>`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?