### PR TITLE
Hide the 100-year plan notices and buttons that are unrelated

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -777,7 +777,7 @@ export function creditCardExpiresBeforeSubscription( purchase: Purchase ) {
 	return (
 		isPaidWithCreditCard( purchase ) &&
 		hasCreditCardData( purchase ) &&
-		! is100Year( purchase ) &&
+		( ! is100Year( purchase ) || isExpiring( purchase ) ) &&
 		moment( creditCard?.expiryDate, 'MM/YY' ).isBefore( purchase.expiryDate, 'months' )
 	);
 }
@@ -789,7 +789,7 @@ export function creditCardHasAlreadyExpired( purchase: Purchase ) {
 		creditCard &&
 		isPaidWithCreditCard( purchase ) &&
 		hasCreditCardData( purchase ) &&
-		! is100Year( purchase ) &&
+		( ! is100Year( purchase ) || isExpiring( purchase ) ) &&
 		moment( creditCard.expiryDate, 'MM/YY' ).isBefore( moment.now(), 'months' )
 	);
 }

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -22,6 +22,7 @@ import {
 	isJetpackSearchFree,
 	isAkismetProduct,
 	isTieredVolumeSpaceAddon,
+	is100Year,
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import { encodeProductForUrl } from '@automattic/wpcom-checkout';
@@ -776,6 +777,7 @@ export function creditCardExpiresBeforeSubscription( purchase: Purchase ) {
 	return (
 		isPaidWithCreditCard( purchase ) &&
 		hasCreditCardData( purchase ) &&
+		! is100Year( purchase ) &&
 		moment( creditCard?.expiryDate, 'MM/YY' ).isBefore( purchase.expiryDate, 'months' )
 	);
 }
@@ -787,6 +789,7 @@ export function creditCardHasAlreadyExpired( purchase: Purchase ) {
 		creditCard &&
 		isPaidWithCreditCard( purchase ) &&
 		hasCreditCardData( purchase ) &&
+		! is100Year( purchase ) &&
 		moment( creditCard.expiryDate, 'MM/YY' ).isBefore( moment.now(), 'months' )
 	);
 }

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -777,7 +777,7 @@ export function creditCardExpiresBeforeSubscription( purchase: Purchase ) {
 	return (
 		isPaidWithCreditCard( purchase ) &&
 		hasCreditCardData( purchase ) &&
-		( ! is100Year( purchase ) || isExpiring( purchase ) ) &&
+		( ! is100Year( purchase ) || isCloseToExpiration( purchase ) ) &&
 		moment( creditCard?.expiryDate, 'MM/YY' ).isBefore( purchase.expiryDate, 'months' )
 	);
 }
@@ -789,7 +789,7 @@ export function creditCardHasAlreadyExpired( purchase: Purchase ) {
 		creditCard &&
 		isPaidWithCreditCard( purchase ) &&
 		hasCreditCardData( purchase ) &&
-		( ! is100Year( purchase ) || isExpiring( purchase ) ) &&
+		( ! is100Year( purchase ) || isCloseToExpiration( purchase ) ) &&
 		moment( creditCard.expiryDate, 'MM/YY' ).isBefore( moment.now(), 'months' )
 	);
 }

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -83,7 +83,6 @@ import {
 	isPaidWithCredits,
 	canAutoRenewBeTurnedOff,
 	isExpired,
-	isExpiring,
 	isOneTimePurchase,
 	isPartnerPurchase,
 	isRefundable,
@@ -1243,7 +1242,7 @@ class ManagePurchase extends Component<
 		}
 
 		const isActive100YearPurchase =
-			is100Year( purchase ) && ! isExpiring( purchase ) && ! isExpired( purchase );
+			is100Year( purchase ) && ! isCloseToExpiration( purchase ) && ! isExpired( purchase );
 
 		const classes = classNames( 'manage-purchase__info', {
 			'is-expired': purchase && isExpired( purchase ),

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -334,7 +334,8 @@ class ManagePurchase extends Component<
 			isPartnerPurchase( purchase ) ||
 			! isRenewable( purchase ) ||
 			( ! this.props.site && ! isAkismetTemporarySitePurchase( purchase ) ) ||
-			isAkismetFreeProduct( purchase )
+			isAkismetFreeProduct( purchase ) ||
+			( is100Year( purchase ) && ! isCloseToExpiration( purchase ) )
 		) {
 			return null;
 		}
@@ -362,6 +363,7 @@ class ManagePurchase extends Component<
 			! isEcommerce( purchase ) &&
 			! isPro( purchase ) &&
 			! isComplete( purchase ) &&
+			! is100Year( purchase ) &&
 			! isP2Plus( purchase );
 		const isUpgradeableProduct =
 			! isPlan( purchase ) &&

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1241,8 +1241,7 @@ class ManagePurchase extends Component<
 			return this.renderPlaceholder();
 		}
 
-		const isActive100YearPurchase =
-			is100Year( purchase ) && ! isCloseToExpiration( purchase ) && ! isExpired( purchase );
+		const isActive100YearPurchase = is100Year( purchase ) && ! isCloseToExpiration( purchase );
 
 		const classes = classNames( 'manage-purchase__info', {
 			'is-expired': purchase && isExpired( purchase ),

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -36,6 +36,7 @@ import {
 	isJetpackStarterPlan,
 	AKISMET_UPGRADES_PRODUCTS_MAP,
 	JETPACK_STARTER_UPGRADE_MAP,
+	is100Year,
 } from '@automattic/calypso-products';
 import {
 	Badge,
@@ -82,6 +83,7 @@ import {
 	isPaidWithCredits,
 	canAutoRenewBeTurnedOff,
 	isExpired,
+	isExpiring,
 	isOneTimePurchase,
 	isPartnerPurchase,
 	isRefundable,
@@ -517,7 +519,8 @@ class ManagePurchase extends Component<
 			! isEcommerce( purchase ) &&
 			! isPro( purchase ) &&
 			! isComplete( purchase ) &&
-			! isP2Plus( purchase );
+			! isP2Plus( purchase ) &&
+			! is100Year( purchase );
 
 		const isUpgradeableBackupProduct = (
 			JETPACK_BACKUP_T1_PRODUCTS as ReadonlyArray< string >
@@ -1239,6 +1242,8 @@ class ManagePurchase extends Component<
 			return this.renderPlaceholder();
 		}
 
+		const isActive100YearPurchase = is100Year( purchase ) && ! isExpiring( purchase );
+
 		const classes = classNames( 'manage-purchase__info', {
 			'is-expired': purchase && isExpired( purchase ),
 			'is-personal': purchase && isPersonal( purchase ),
@@ -1310,7 +1315,10 @@ class ManagePurchase extends Component<
 				{ isProductOwner && ! purchase.isLocked && (
 					<>
 						{ preventRenewal && this.renderSelectNewNavItem() }
-						{ ! preventRenewal && ! renderMonthlyRenewalOption && this.renderRenewNowNavItem() }
+						{ ! preventRenewal &&
+							! renderMonthlyRenewalOption &&
+							! isActive100YearPurchase &&
+							this.renderRenewNowNavItem() }
 						{ ! preventRenewal && renderMonthlyRenewalOption && this.renderRenewAnnuallyNavItem() }
 						{ ! preventRenewal && renderMonthlyRenewalOption && this.renderRenewMonthlyNavItem() }
 						{ /* We don't want to show the Renew/Upgrade nav item for "Jetpack" temporary sites, but we DO

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1242,7 +1242,8 @@ class ManagePurchase extends Component<
 			return this.renderPlaceholder();
 		}
 
-		const isActive100YearPurchase = is100Year( purchase ) && ! isExpiring( purchase );
+		const isActive100YearPurchase =
+			is100Year( purchase ) && ! isExpiring( purchase ) && ! isExpired( purchase );
 
 		const classes = classNames( 'manage-purchase__info', {
 			'is-expired': purchase && isExpired( purchase ),

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -9,6 +9,7 @@ import {
 	PLAN_BUSINESS,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_MIGRATION_TRIAL_MONTHLY,
+	is100Year,
 } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { isEmpty, merge, minBy } from 'lodash';
@@ -96,7 +97,7 @@ class PurchaseNotice extends Component<
 		const { translate, moment, selectedSite } = this.props;
 		const expiry = moment( purchase.expiryDate );
 
-		if ( selectedSite && purchase.expiryStatus === 'manualRenew' ) {
+		if ( selectedSite && purchase.expiryStatus === 'manualRenew' && ! is100Year( purchase ) ) {
 			return this.getExpiringLaterText( purchase );
 		}
 
@@ -339,6 +340,9 @@ class PurchaseNotice extends Component<
 			return null;
 		}
 
+		if ( is100Year( purchase ) && ! isCloseToExpiration( purchase ) ) {
+			return null;
+		}
 		let noticeStatus = 'is-info';
 
 		if ( isCloseToExpiration( currentPurchase ) && ! isRecentMonthlyPurchase( currentPurchase ) ) {
@@ -795,7 +799,8 @@ class PurchaseNotice extends Component<
 		if (
 			! currentPurchaseNeedsToRenewSoon &&
 			! currentPurchaseIsExpiring &&
-			! anotherPurchaseIsExpiring
+			! anotherPurchaseIsExpiring &&
+			! is100Year( purchase )
 		) {
 			if ( ! currentPurchaseCreditCardExpiresBeforeSubscription ) {
 				noticeStatus = 'is-success';

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -1,4 +1,5 @@
-import { isDomainTransfer } from '@automattic/calypso-products';
+// eslint-disable-next-line import/named
+import { isDomainTransfer, is100Year } from '@automattic/calypso-products';
 import {
 	isExpired,
 	isIncludedWithPlan,
@@ -16,7 +17,8 @@ function canEditPaymentDetails( purchase ) {
 		! isExpired( purchase ) &&
 		! isOneTimePurchase( purchase ) &&
 		! isIncludedWithPlan( purchase ) &&
-		! isDomainTransfer( purchase )
+		! isDomainTransfer( purchase ) &&
+		! is100Year( purchase )
 	);
 }
 

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -1,5 +1,6 @@
 import { isDomainTransfer, is100Year } from '@automattic/calypso-products';
 import {
+	isExpiring,
 	isExpired,
 	isIncludedWithPlan,
 	isOneTimePurchase,
@@ -17,7 +18,7 @@ function canEditPaymentDetails( purchase ) {
 		! isOneTimePurchase( purchase ) &&
 		! isIncludedWithPlan( purchase ) &&
 		! isDomainTransfer( purchase ) &&
-		! is100Year( purchase )
+		( ! is100Year( purchase ) || isExpiring( purchase ) )
 	);
 }
 

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/named
 import { isDomainTransfer, is100Year } from '@automattic/calypso-products';
 import {
 	isExpired,

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -1,6 +1,6 @@
 import { isDomainTransfer, is100Year } from '@automattic/calypso-products';
 import {
-	isExpiring,
+	isCloseToExpiration,
 	isExpired,
 	isIncludedWithPlan,
 	isOneTimePurchase,
@@ -18,7 +18,7 @@ function canEditPaymentDetails( purchase ) {
 		! isOneTimePurchase( purchase ) &&
 		! isIncludedWithPlan( purchase ) &&
 		! isDomainTransfer( purchase ) &&
-		( ! is100Year( purchase ) || isExpiring( purchase ) )
+		( ! is100Year( purchase ) || isCloseToExpiration( purchase ) )
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See https://github.com/Automattic/martech/issues/2186

## Proposed Changes

Hide buttons and notices that are unrelated to the 100-year plan. The auto-renew is probably also good to be removed but is out of scope for the change.

## Testing Instructions

Buy a 100-year plan with the Store Sandbox - /checkout/wp_com_hundred_year_bundle_centennially
* Go to /me/purchases - it should say that the product will be renewed in 2123 and not that the card expires before renewal
* Click the purchase details
* No error notices should be visible
* The only action available should be to cancel

Change the plan to expiring (90-0 days to expiration) with Store Admin
* There should be more action buttons showing up - updating payment information, renew
* The purchase notices should now be visible

Expire the plan
* There should be a purchase notice stating that the plan expired
* Renew should be available

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
