### PR TITLE
fix(eslint): `npmPackageJsonLint.lint` check if no results

### DIFF
--- a/packages/eslint-plugin-package-json/src/rules/npm-package-json-lint-factory.js
+++ b/packages/eslint-plugin-package-json/src/rules/npm-package-json-lint-factory.js
@@ -26,7 +26,7 @@ const buildRules = () => {
 					// I think the second argument is just used for the report, so we can ignore it
 					// (reports will be filtered later by ESlint)
 					const result = rule.lint( json, 'error', options );
-					if ( result !== true ) {
+					if ( result !== null ) {
 						// result.node is the name of the property that failed. We can search for that
 						// property in the AST to get the node. This will help include the location of
 						// the error in ESlint report


### PR DESCRIPTION
## Proposed Changes

* Fix error when running `yarn run lint:js` locally

The `eslint-plugin-package-json` dependency `npm-package-json-lint` was [recently updated ](https://github.com/Automattic/wp-calypso/pull/80783/commits/c51bdde41f1f8180211ef60eee0573e00a146a56)to `v6`. This major version change introduced a change in what `.lint()` returns in case no error was found (it was also refactored to TS afaics). Previously it returned [`true`](https://github.com/tclindner/npm-package-json-lint/pull/584/files#diff-95a5293a998d4be8037fda887e95872e27461ee7b73381b94dcebfbf88281a20) but since `v6` it returns [`null`](https://github.com/tclindner/npm-package-json-lint/pull/584/files#diff-cf4803fc7668f57ee675f808b427aa15e9091a071903d4597673b7f548984a18). This PR accommodates for that.

I found this while looking at https://github.com/Automattic/wp-calypso/pull/81108 and trying to run above command locally on my machine.

<img width="1118" alt="Screenshot showing an error which says 'TypeError: Cannot read properties of null (reading 'node')'" src="https://github.com/Automattic/wp-calypso/assets/9202899/98ddbc1f-6ed3-49e2-8531-be68b82ac55b">

## Testing Instructions

* Try to run `yarn run lint:js` locally and verify linters run well (may take a while) without the error shown in the screenshot above.
