### PR TITLE
Jetpack E2E: update `Editor: Basic Post Flow` to also test Jetpack SEO & Social Previews.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -91,15 +91,17 @@ export class EditorSettingsSidebarComponent {
 	//#endregion
 
 	/**
-	 * Closes the sidebar only for Mobile viewport.
+	 * Closes the sidebar for mobile viewport.
+	 *
+	 * This method can close both the post/page settings as well as the Jetpack
+	 * sidebar.
 	 */
 	async closeSidebarForMobile(): Promise< void > {
 		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
 			return;
 		}
 		const editorParent = await this.editor.parent();
-		const closeButton = editorParent.getByRole( 'button', { name: 'Close Settings' } );
-		await closeButton.click();
+		await editorParent.getByRole( 'button', { name: /Close Settings|Close plugin/ } ).click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -1,12 +1,7 @@
 import { Page } from 'playwright';
 import envVariables from '../../env-variables';
 import { EditorComponent } from './editor-component';
-import type {
-	ArticlePublishSchedule,
-	EditorSidebarTab,
-	ArticleSections,
-	ArticlePrivacyOptions,
-} from './types';
+import type { ArticlePublishSchedule, EditorSidebarTab, ArticlePrivacyOptions } from './types';
 
 const panel = '[aria-label="Editor settings"]';
 
@@ -17,7 +12,7 @@ const selectors = {
 		`${ panel } button.is-active:has-text("${ tabName }")`,
 
 	// General section-related
-	section: ( name: ArticleSections ) =>
+	section: ( name: string ) =>
 		`${ panel } .components-panel__body-title button:has-text("${ name }")`,
 	showRevisionButton: '.edit-post-last-revision__panel', // Revision is a link, not a panel.
 
@@ -60,6 +55,41 @@ export class EditorSettingsSidebarComponent {
 		this.editor = editor;
 	}
 
+	//#region Generic methods
+
+	/**
+	 * Clicks a button matching the accessible name.
+	 *
+	 * @param {string} name Accessible name of the button.
+	 */
+	async clickButton( name: string ): Promise< void > {
+		const editorParent = await this.editor.parent();
+
+		await editorParent.getByRole( 'button', { name: name } ).click();
+	}
+
+	/**
+	 * Enters the specified text to an input field, specified by a label.
+	 *
+	 * In the future, this method may support other methods of locating a
+	 * text box.
+	 *
+	 * @param {string} text Text to enter.
+	 * @param param1 Keyed object parametr.
+	 * @param {string} param1.label Locate text field by label.
+	 */
+	async enterText( text: string, { label }: { label: string } ): Promise< void > {
+		const editorParent = await this.editor.parent();
+
+		if ( label ) {
+			return await editorParent.getByLabel( label ).fill( text );
+		}
+
+		throw new Error( `Must specify a method to locate the text field.` );
+	}
+
+	//#endregion
+
 	/**
 	 * Closes the sidebar only for Mobile viewport.
 	 */
@@ -94,20 +124,16 @@ export class EditorSettingsSidebarComponent {
 	 *
 	 * If the section is already open, this method will pass.
 	 *
-	 * @param {ArticleSections} name Name of section to be expanded.
-	 * @returns {Promise<void>} No return value.
+	 * @param {string} name Name of section to be expanded.
 	 */
-	async expandSection( name: ArticleSections ): Promise< void > {
+	async expandSection( name: string ): Promise< void > {
 		if ( await this.targetIsOpen( selectors.section( name ) ) ) {
 			return;
 		}
 
-		// Avoid the wpcalypso/staging banner.
-		await this.scrollToBottomOfSidebar();
-
 		const editorParent = await this.editor.parent();
 		const sectionLocator = editorParent.locator( selectors.section( name ) );
-		await sectionLocator.click();
+		await sectionLocator.click( { position: { x: 5, y: 5 } } );
 
 		const expandedLocator = editorParent.locator(
 			`${ selectors.section( name ) }[aria-expanded="true"]`
@@ -353,16 +379,5 @@ export class EditorSettingsSidebarComponent {
 		await editorParent.getByRole( 'button', { name: /Change URL:/ } ).click();
 		await editorParent.getByLabel( 'Permalink' ).fill( slug );
 		await editorParent.getByRole( 'button', { name: 'Close', exact: true } ).click();
-	}
-
-	/**
-	 * Scroll to the bottom of the sidebar.
-	 *
-	 * Useful to work around the wpcalypso/staging banner (for proxied users).
-	 */
-	private async scrollToBottomOfSidebar(): Promise< void > {
-		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selectors.section( 'Discussion' ) );
-		await locator.scrollIntoViewIfNeeded();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -1,8 +1,8 @@
-import { Page } from 'playwright';
+import { Locator, Page } from 'playwright';
 import envVariables from '../../env-variables';
 import { translateFromPage } from '../utils';
 import { EditorComponent } from './editor-component';
-import type { EditorPreviewOptions } from './types';
+import type { EditorPreviewOptions, EditorToolbarSettingsButton } from './types';
 
 const panel = '.interface-navigable-region[class*="header"]';
 const settingsButtonLabel = 'Settings';
@@ -253,7 +253,7 @@ export class EditorToolbarComponent {
 		await Promise.race( [
 			( async () => {
 				// Works with Gutenberg >=v15.8.0
-				await this.openSettings();
+				await this.openSettings( 'Settings' );
 				await editorParent.getByRole( 'button', { name: 'Switch to draft' } ).click();
 			} )(),
 			( async () => {
@@ -268,15 +268,23 @@ export class EditorToolbarComponent {
 	/**
 	 * Opens the editor settings.
 	 */
-	async openSettings(): Promise< void > {
-		const label = await this.translateFromPage( settingsButtonLabel );
-		const selector = selectors.settingsButton( label );
-
-		if ( await this.targetIsOpen( selector ) ) {
-			return;
-		}
+	async openSettings( target: EditorToolbarSettingsButton ): Promise< void > {
 		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selector );
+
+		let locator: Locator;
+		if ( target === 'Settings' ) {
+			const label = await this.translateFromPage( settingsButtonLabel );
+			const selector = selectors.settingsButton( label );
+
+			if ( await this.targetIsOpen( selector ) ) {
+				return;
+			}
+
+			locator = editorParent.locator( selector );
+		} else {
+			locator = editorParent.getByRole( 'button', { name: 'Jetpack', exact: true } );
+		}
+
 		await locator.click();
 	}
 

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -5,7 +5,6 @@ import { EditorComponent } from './editor-component';
 import type { EditorPreviewOptions, EditorToolbarSettingsButton } from './types';
 
 const panel = '.interface-navigable-region[class*="header"]';
-const settingsButtonLabel = 'Settings';
 const moreOptionsLabel = 'Options';
 const selectors = {
 	// Block Inserter
@@ -37,10 +36,6 @@ const selectors = {
 	documentActionsDropdown: `${ panel } button[aria-label="Show template details"]`,
 	documentActionsDropdownItem: ( itemSelector: string ) => `.popover-slot ${ itemSelector }`,
 	documentActionsDropdownShowAll: `.popover-slot .edit-site-template-details__show-all-button`,
-
-	// Editor settings
-	settingsButton: ( label = settingsButtonLabel ) =>
-		`${ panel } .edit-post-header__settings .interface-pinned-items button[aria-label="${ label }"]`,
 
 	// Undo/Redo
 	undoButton: 'button[aria-disabled=false][aria-label="Undo"]',
@@ -86,20 +81,18 @@ export class EditorToolbarComponent {
 	/* General helper */
 
 	/**
-	 * Given a selector, determines whether the target button/toggle is
+	 * Given a Locator, determines whether the target button/toggle is
 	 * in an expanded state.
 	 *
 	 * If the toggle is in the on state or otherwise in an expanded
 	 * state, this method will return true. Otherwise, false.
 	 *
-	 * @param {string} selector Target selector.
+	 * @param {Locator} target Target button.
 	 * @returns {Promise<boolean>} True if target is in an expanded state. False otherwise.
 	 */
-	private async targetIsOpen( selector: string ): Promise< boolean > {
-		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selector );
-		const pressed = await locator.getAttribute( 'aria-pressed' );
-		const expanded = await locator.getAttribute( 'aria-expanded' );
+	private async targetIsOpen( target: Locator ): Promise< boolean > {
+		const pressed = await target.getAttribute( 'aria-pressed' );
+		const expanded = await target.getAttribute( 'aria-expanded' );
 		return pressed === 'true' || expanded === 'true';
 	}
 
@@ -109,7 +102,15 @@ export class EditorToolbarComponent {
 	 * Opens the block inserter.
 	 */
 	async openBlockInserter(): Promise< void > {
-		if ( ! ( await this.targetIsOpen( selectors.blockInserterButton ) ) ) {
+		const editorParent = await this.editor.parent();
+
+		const translatedButtonName = await this.translateFromPage( 'Toggle block inserter' );
+		const blockInserterButton = editorParent.getByRole( 'button', {
+			name: translatedButtonName,
+			exact: true,
+		} );
+
+		if ( ! ( await this.targetIsOpen( blockInserterButton ) ) ) {
 			const editorParent = await this.editor.parent();
 			const locator = editorParent.locator( selectors.blockInserterButton );
 			await locator.click();
@@ -120,7 +121,15 @@ export class EditorToolbarComponent {
 	 * Closes the block inserter.
 	 */
 	async closeBlockInserter(): Promise< void > {
-		if ( await this.targetIsOpen( selectors.blockInserterButton ) ) {
+		const editorParent = await this.editor.parent();
+
+		const translatedButtonName = await this.translateFromPage( 'Toggle block inserter' );
+		const blockInserterButton = editorParent.getByRole( 'button', {
+			name: translatedButtonName,
+			exact: true,
+		} );
+
+		if ( await this.targetIsOpen( blockInserterButton ) ) {
 			// We click on the panel instead of on the block inserter button as a workaround for an issue
 			// that disables the block inserter button after inserting a block using the block API V2.
 			// See https://github.com/WordPress/gutenberg/issues/43090.
@@ -197,7 +206,15 @@ export class EditorToolbarComponent {
 	 * Opens the Preview menu for Desktop viewport.
 	 */
 	async openDesktopPreviewMenu(): Promise< void > {
-		if ( ! ( await this.targetIsOpen( selectors.previewButton ) ) ) {
+		const editorParent = await this.editor.parent();
+
+		const translatedButtonName = await this.translateFromPage( 'Preview' );
+		const previewButton = editorParent.getByRole( 'button', {
+			name: translatedButtonName,
+			exact: true,
+		} );
+
+		if ( ! ( await this.targetIsOpen( previewButton ) ) ) {
 			const editorParent = await this.editor.parent();
 			const desktopPreviewButtonLocator = editorParent.locator( selectors.previewButton );
 			await desktopPreviewButtonLocator.click();
@@ -208,7 +225,15 @@ export class EditorToolbarComponent {
 	 * Closes the Preview menu for the Desktop viewport.
 	 */
 	async closeDesktopPreviewMenu(): Promise< void > {
-		if ( await this.targetIsOpen( selectors.previewButton ) ) {
+		const editorParent = await this.editor.parent();
+
+		const translatedButtonName = await this.translateFromPage( 'Preview' );
+		const previewButton = editorParent.getByRole( 'button', {
+			name: translatedButtonName,
+			exact: true,
+		} );
+
+		if ( await this.targetIsOpen( previewButton ) ) {
 			const editorParent = await this.editor.parent();
 			const desktopPreviewButtonLocator = editorParent.locator( selectors.previewButton );
 			await desktopPreviewButtonLocator.click();
@@ -271,36 +296,40 @@ export class EditorToolbarComponent {
 	async openSettings( target: EditorToolbarSettingsButton ): Promise< void > {
 		const editorParent = await this.editor.parent();
 
-		let locator: Locator;
-		if ( target === 'Settings' ) {
-			const label = await this.translateFromPage( settingsButtonLabel );
-			const selector = selectors.settingsButton( label );
+		// To support i18n tests.
+		const translatedTargetName = await this.translateFromPage( target );
+		const button = editorParent.getByRole( 'button', { name: translatedTargetName, exact: true } );
 
-			if ( await this.targetIsOpen( selector ) ) {
-				return;
-			}
-
-			locator = editorParent.locator( selector );
-		} else {
-			locator = editorParent.getByRole( 'button', { name: 'Jetpack', exact: true } );
+		if ( await this.targetIsOpen( button ) ) {
+			return;
 		}
 
-		await locator.click();
+		await button.click();
 	}
 
 	/**
 	 * Closes the editor settings.
 	 */
 	async closeSettings(): Promise< void > {
-		const label = await this.translateFromPage( settingsButtonLabel );
-		const selector = selectors.settingsButton( label );
+		const editorParent = await this.editor.parent();
 
-		if ( ! ( await this.targetIsOpen( selector ) ) ) {
+		// Post/Page settings and Jetpack settings close buttons have slightly
+		// different names. When building the accessible selector, a RegExp
+		// must be used in order to support multiple accessible names.
+		const translatedCloseSettingsName = await this.translateFromPage( 'Close Settings' );
+		const translatedCloseJetpackSettingsName = await this.translateFromPage( 'Close plugin' );
+
+		const button = editorParent.getByRole( 'button', {
+			name: new RegExp(
+				`${ translatedCloseJetpackSettingsName }|${ translatedCloseSettingsName }`
+			),
+		} );
+
+		if ( ! ( await this.targetIsOpen( button ) ) ) {
 			return;
 		}
-		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selector );
-		await locator.click();
+
+		await button.click();
 	}
 
 	/* Navigation sidebar */
@@ -309,26 +338,33 @@ export class EditorToolbarComponent {
 	 * Opens the nav sidebar.
 	 */
 	async openNavSidebar(): Promise< void > {
-		if ( await this.targetIsOpen( selectors.navSidebarButton ) ) {
+		const editorParent = await this.editor.parent();
+
+		const target = editorParent.getByRole( 'button', {
+			name: 'Block editor sidebar',
+		} );
+		if ( await this.targetIsOpen( target ) ) {
 			return;
 		}
 
-		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selectors.navSidebarButton );
-		await locator.click();
+		await target.click();
 	}
 
 	/**
 	 * Closes the nav sidebar.
 	 */
 	async closeNavSidebar(): Promise< void > {
-		if ( ! ( await this.targetIsOpen( selectors.navSidebarButton ) ) ) {
+		const editorParent = await this.editor.parent();
+
+		const target = editorParent.getByRole( 'button', {
+			name: 'Block editor sidebar',
+		} );
+
+		if ( ! ( await this.targetIsOpen( target ) ) ) {
 			return;
 		}
 
-		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selectors.navSidebarButton );
-		await locator.click();
+		await target.click();
 	}
 
 	/* List view */
@@ -342,13 +378,17 @@ export class EditorToolbarComponent {
 			return;
 		}
 
-		if ( await this.targetIsOpen( selectors.documentOverviewButton ) ) {
+		const editorParent = await this.editor.parent();
+
+		const target = editorParent.getByRole( 'button', {
+			name: 'Document Overview',
+		} );
+
+		if ( await this.targetIsOpen( target ) ) {
 			return;
 		}
 
-		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selectors.documentOverviewButton );
-		await locator.click();
+		await target.click();
 	}
 
 	/**
@@ -360,13 +400,17 @@ export class EditorToolbarComponent {
 			return;
 		}
 
-		if ( ! ( await this.targetIsOpen( selectors.documentOverviewButton ) ) ) {
+		const editorParent = await this.editor.parent();
+
+		const target = editorParent.getByRole( 'button', {
+			name: 'Document Overview',
+		} );
+
+		if ( ! ( await this.targetIsOpen( target ) ) ) {
 			return;
 		}
 
-		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selectors.documentOverviewButton );
-		await locator.click();
+		await target.click();
 	}
 
 	/**
@@ -395,14 +439,23 @@ export class EditorToolbarComponent {
 	 * Opens the more options menu (three dots).
 	 */
 	async openMoreOptionsMenu(): Promise< void > {
-		const label = await this.translateFromPage( moreOptionsLabel );
-		const selector = selectors.moreOptionsButton( label );
+		// const label = await this.translateFromPage( moreOptionsLabel );
+		// const selector = selectors.moreOptionsButton( label );
 
-		if ( ! ( await this.targetIsOpen( selector ) ) ) {
-			const editorParent = await this.editor.parent();
-			const locator = editorParent.locator( selector );
-			await locator.click();
+		const editorParent = await this.editor.parent();
+
+		// To support i18n tests.
+		const translatedTargetName = await this.translateFromPage( 'Options' );
+		const button = editorParent.getByRole( 'button', {
+			name: translatedTargetName,
+			exact: true,
+		} );
+
+		if ( await this.targetIsOpen( button ) ) {
+			return;
 		}
+
+		await button.click();
 	}
 
 	/** FSE unique buttons */

--- a/packages/calypso-e2e/src/lib/components/types.ts
+++ b/packages/calypso-e2e/src/lib/components/types.ts
@@ -15,17 +15,6 @@ export type EditorPreviewOptions = 'Desktop' | 'Mobile' | 'Tablet';
 export type EditorSidebarTab = 'Post' | 'Block' | 'Page';
 
 /**
- * The different foldable sections on the sidebar.
- */
-export type ArticleSections =
-	| 'Summary'
-	| 'Revisions'
-	| 'Permalink'
-	| 'Categories'
-	| 'Tags'
-	| 'Discussion';
-
-/**
  * Post/Page privacy options.
  */
 export type ArticlePrivacyOptions = 'Public' | 'Private' | 'Password';
@@ -41,3 +30,8 @@ export interface ArticlePublishSchedule {
 	minutes: number;
 	meridian: 'am' | 'pm';
 }
+
+/**
+ * Settings button on the Editor Toolbar.
+ */
+export type EditorToolbarSettingsButton = 'Settings' | 'Jetpack';

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -20,6 +20,7 @@ import {
 	TemplateCategory,
 	BlockToolbarButtonIdentifier,
 	CookieBannerComponent,
+	EditorToolbarSettingsButton,
 } from '../components';
 import { BlockInserter, OpenInlineInserter } from './shared-types';
 import type {
@@ -485,8 +486,8 @@ export class EditorPage {
 	/**
 	 * Opens the Settings sidebar.
 	 */
-	async openSettings(): Promise< void > {
-		await this.editorToolbarComponent.openSettings();
+	async openSettings( target: EditorToolbarSettingsButton = 'Settings' ): Promise< void > {
+		await this.editorToolbarComponent.openSettings( target );
 	}
 
 	/**
@@ -499,6 +500,24 @@ export class EditorPage {
 		} else {
 			await this.editorToolbarComponent.closeSettings();
 		}
+	}
+
+	/**
+	 * General method to expand the named section in the settings sidebar.
+	 *
+	 * @param {string} name Name of the section to expand.
+	 */
+	async expandSection( name: string ): Promise< void > {
+		await this.editorSettingsSidebarComponent.expandSection( name );
+	}
+
+	/**
+	 * Clicks on a button with matching accessible name in the Editor sidebar.
+	 *
+	 * @param {string} name Accessible name of the button.
+	 */
+	async clickSidebarButton( name: string ): Promise< void > {
+		await this.editorSettingsSidebarComponent.clickButton( name );
 	}
 
 	/**
@@ -585,6 +604,20 @@ export class EditorPage {
 		] );
 		await this.editorSettingsSidebarComponent.expandSection( 'Summary' );
 		await this.editorSettingsSidebarComponent.enterUrlSlug( slug );
+	}
+
+	/**
+	 * Enters SEO details on the Editor sidebar.
+	 *
+	 * @param param0 Keyed object parameter.
+	 * @param {string} param0.title SEO title.
+	 * @param {string} param0.description SEO description.
+	 */
+	async enterSEODetails( { title, description }: { title: string; description: string } ) {
+		await this.editorSettingsSidebarComponent.enterText( title, { label: 'SEO TITLE' } );
+		await this.editorSettingsSidebarComponent.enterText( description, {
+			label: 'SEO DESCRIPTION',
+		} );
 	}
 
 	//#endregion

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -20,6 +20,8 @@ const quote =
 const title = DataHelper.getRandomPhrase();
 const category = 'Uncategorized';
 const tag = 'test-tag';
+const seoTitle = 'SEO example title';
+const seoDescription = 'SEO example description';
 
 declare const browser: Browser;
 
@@ -91,8 +93,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			'Enter SEO title and preview',
 			async function () {
 				await editorPage.enterSEODetails( {
-					title: 'SEO example title',
-					description: 'SEO example description',
+					title: seoTitle,
+					description: seoDescription,
 				} );
 			}
 		);
@@ -109,6 +111,14 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 			await dialog.getByRole( 'tab', { name: 'Tumblr' } ).click();
 			await dialog.getByRole( 'tabpanel', { name: 'Tumblr' } ).waitFor();
+			await dialog
+				.filter( {
+					// Look for either the SEO title, or the post title,
+					// depending on whether the platform had SEO options
+					// two steps previously.
+					hasText: new RegExp( `${ seoTitle }|${ title }` ),
+				} )
+				.waitFor();
 		} );
 
 		it( 'Dismiss social preview', async function () {

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -64,8 +64,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	describe( 'Categories and Tags', function () {
-		it( 'Open settings', async function () {
-			await editorPage.openSettings();
+		it( 'Open post settings', async function () {
+			await editorPage.openSettings( 'Settings' );
 		} );
 
 		it( 'Add post category', async function () {
@@ -75,14 +75,15 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		it( 'Add post tag', async function () {
 			await editorPage.addTag( tag );
 		} );
+
+		afterAll( async function () {
+			// For mobile, but doesn't hurt to do this for Desktop either.
+			await editorPage.closeSettings();
+		} );
 	} );
 
 	describe( 'Jetpack features', function () {
-		beforeAll( async function () {
-			await editorPage.openSettings();
-		} );
-
-		it( 'Open Jetpack post settings', async function () {
+		it( 'Open Jetpack settings', async function () {
 			await editorPage.openSettings( 'Jetpack' );
 		} );
 
@@ -113,15 +114,15 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		it( 'Dismiss social preview', async function () {
 			await page.keyboard.press( 'Escape' );
 		} );
+
+		afterAll( async function () {
+			// For mobile, but doesn't hurt to do this for Desktop either.
+			await editorPage.closeSettings();
+		} );
 	} );
 
 	describe( 'Preview', function () {
 		let previewPage: Page;
-
-		// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional.
-		it( 'Close settings sidebar', async function () {
-			await editorPage.closeSettings();
-		} );
 
 		it( 'Launch preview', async function () {
 			if ( envVariables.VIEWPORT_NAME === 'mobile' ) {

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -77,6 +77,44 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		} );
 	} );
 
+	describe( 'Jetpack features', function () {
+		beforeAll( async function () {
+			await editorPage.openSettings();
+		} );
+
+		it( 'Open Jetpack post settings', async function () {
+			await editorPage.openSettings( 'Jetpack' );
+		} );
+
+		skipItIf( envVariables.TEST_ON_ATOMIC !== true )(
+			'Enter SEO title and preview',
+			async function () {
+				await editorPage.enterSEODetails( {
+					title: 'SEO example title',
+					description: 'SEO example description',
+				} );
+			}
+		);
+
+		it( 'Open social preview', async function () {
+			await editorPage.expandSection( 'Social Previews' );
+			await editorPage.clickSidebarButton( 'Open Social Previews' );
+		} );
+
+		it( 'Show social preview for Tumblr', async function () {
+			// Action implemented as "raw" calls for now (2023-09).
+			const editorParent = await editorPage.getEditorParent();
+			const dialog = editorParent.getByRole( 'dialog' );
+
+			await dialog.getByRole( 'tab', { name: 'Tumblr' } ).click();
+			await dialog.getByRole( 'tabpanel', { name: 'Tumblr' } ).waitFor();
+		} );
+
+		it( 'Dismiss social preview', async function () {
+			await page.keyboard.press( 'Escape' );
+		} );
+	} );
+
 	describe( 'Preview', function () {
 		let previewPage: Page;
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80730.

## Proposed Changes

This PR updates the flow mentioned in the title to also test the Jetpack specific features of SEO and Social Previews.

The SEO step is gated behind an environment variable check, but the social preview step is available for both Simple and AT environments.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?