### PR TITLE
Domain Management i1: Add domain count to DomainsTable header

### DIFF
--- a/packages/domains-table/src/domains-table-header/columns.ts
+++ b/packages/domains-table/src/domains-table-header/columns.ts
@@ -1,11 +1,16 @@
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { getSimpleSortFunctionBy, getSiteSortFunctions } from '../utils';
 import { DomainsTableColumn } from '.';
 
 export const domainsTableColumns: DomainsTableColumn[] = [
 	{
 		name: 'domain',
-		label: __( 'Domain', __i18n_text_domain__ ),
+		label: ( count: number ) =>
+			sprintf(
+				/* translators: Heading which displays the number of domains in a table */
+				_n( '%(count)d domain', '%(count)d domains', count, __i18n_text_domain__ ),
+				{ count }
+			),
 		isSortable: true,
 		initialSortDirection: 'asc',
 		supportsOrderSwitching: true,

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -13,7 +13,7 @@ export type DomainsTableBulkSelectionStatus = 'no-domains' | 'some-domains' | 'a
 export type DomainsTableColumn =
 	| {
 			name: string;
-			label: string | null;
+			label: string | ( ( count: number ) => string ) | null;
 			isSortable: true;
 			initialSortDirection: 'asc' | 'desc';
 			supportsOrderSwitching?: boolean;
@@ -30,7 +30,7 @@ export type DomainsTableColumn =
 	  }
 	| {
 			name: string;
-			label: string | null;
+			label: string | ( ( count: number ) => string ) | null;
 			isSortable?: false;
 			initialSortDirection?: never;
 			supportsOrderSwitching?: never;
@@ -53,6 +53,7 @@ type DomainsTableHeaderProps = {
 	onChangeSortOrder: ( selectedColumn: DomainsTableColumn ) => void;
 	bulkSelectionStatus: DomainsTableBulkSelectionStatus;
 	onBulkSelectionChange(): void;
+	domainCount: number;
 	headerClasses?: string;
 	hideOwnerColumn?: boolean;
 	domainsRequiringAttention?: number;
@@ -66,6 +67,7 @@ export const DomainsTableHeader = ( {
 	bulkSelectionStatus,
 	onBulkSelectionChange,
 	onChangeSortOrder,
+	domainCount,
 	headerClasses,
 	hideOwnerColumn = false,
 	domainsRequiringAttention,
@@ -122,7 +124,10 @@ export const DomainsTableHeader = ( {
 								} ) }
 								tabIndex={ column?.isSortable ? 0 : -1 }
 							>
-								{ column?.headerComponent || column?.label }
+								{ column?.headerComponent ||
+									( typeof column?.label === 'function'
+										? column.label( domainCount )
+										: column?.label ) }
 								{ column?.name === 'status' && domainsRequiringAttention && (
 									<span className="list-status-cell__bubble">{ domainsRequiringAttention }</span>
 								) }

--- a/packages/domains-table/src/domains-table/domains-table-header.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-header.tsx
@@ -21,6 +21,7 @@ export const DomainsTableHeader = ( {
 		hideOwnerColumn,
 		domainsRequiringAttention,
 		canSelectAnyDomains,
+		filteredData,
 	} = useDomainsTable();
 
 	return (
@@ -34,6 +35,7 @@ export const DomainsTableHeader = ( {
 			hideOwnerColumn={ hideOwnerColumn }
 			domainsRequiringAttention={ domainsRequiringAttention }
 			canSelectAnyDomains={ canSelectAnyDomains }
+			domainCount={ filteredData.length }
 		/>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3737

## Proposed Changes

* Add ability for column header labels to be computed values
* Add domain count to domain column header (matching mockup p9Jlb4-8DU-p2)

![CleanShot 2023-09-13 at 20 42 51@2x](https://github.com/Automattic/wp-calypso/assets/1500769/9a5352eb-6b4d-43f7-88bf-ef41098b484e)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test table at `/domains/manage?flags=domains/management`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?