### PR TITLE
state(stats): refactor away from `_.difference`

### DIFF
--- a/client/state/data-layer/wpcom/sites/stats/visits/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/visits/index.js
@@ -1,4 +1,3 @@
-import { difference } from 'lodash';
 import { STATS_CHART_COUNTS_REQUEST } from 'calypso/state/action-types';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
@@ -9,7 +8,8 @@ import fromApi from './from-api';
 export const fetch = ( action ) => {
 	const { chartTab, date, period, quantity, siteId, statFields } = action;
 	const currentTabFields = chartTab === 'views' ? [ 'views', 'visitors' ] : [ chartTab ];
-	const otherTabFields = difference( statFields, currentTabFields );
+	const otherTabFields =
+		statFields?.filter( ( field ) => ! currentTabFields.includes( field ) ) ?? [];
 
 	return [
 		http(


### PR DESCRIPTION
## Proposed Changes

PR refactors away from `_.difference` in `client/state` (only usage is in `stats/visits` data layer handler).

## Testing Instructions

* Change is covered by unit tests, verify they pass
* As with a lot of lodash methods it's good practice to ensure we don't accidentally miss guards for whether we operate on the expected data structure.
* Smoke test `/stats` by choosing `Stats` from the navigation and verify those are shown as expected. Relevant code is executed when using the `(Days | Weeks | Months | Years)` buttons as well as the fields below `(Views | Visitors | Likes | Comments )`. You can observe two requests to `/stats/visits` with a `stat_fields` property which should be disjoint.