### PR TITLE
Fix: Update name of plan from eCommerce to Commerce in Calypso

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -131,7 +131,7 @@ const Home = () => {
 	const getPremiumPlanNames = () => {
 		const nonAtomicJetpackText = eligibleForProPlan
 			? translate( 'Available only with a Pro plan.' )
-			: translate( 'Available only with a Premium, Business, or eCommerce plan.' );
+			: translate( 'Available only with a Premium, Business, or Commerce plan.' );
 
 		// Space isn't included in the translatable string to prevent it being easily missed.
 		return isNonAtomicJetpack ? getAnyPlanNames() : ' ' + nonAtomicJetpackText;

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -125,7 +125,7 @@ export const MarketingTools: FunctionComponent = () => {
 					<MarketingToolsFeature
 						title={ translate( 'Want to connect with your audience on Facebook and Instagram?' ) }
 						description={ translate(
-							'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on Business and eCommerce plans{{/em}}.',
+							'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on Business and Commerce plans{{/em}}.',
 							{
 								components: {
 									em: <em />,


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/81462

## Proposed Changes

This PR changes the spelling of the `eCommerce` plan to `Commerce` plan in Calypso since `eCommerce` plan was renamed. It affects the spelling on:

* `Tools > Marketing > Want to connect with your audience on Facebook and Instagram?`  card
* `Tools > Earn > Collect PayPal payments` card
* `Tools > Earn > Earn and revenue` card

<img width="995" alt="Screenshot 2023-09-13 at 12 00 02 PM" src="https://github.com/Automattic/wp-calypso/assets/25575134/cbf579f6-86a9-4c56-aa9f-f84c60762eba">

## Testing Instructions

* Make sure you have a WP.com site with a Free plan
* Navigate to `Tools > Marketing`
* Check `Want to connect with your audience on Facebook and Instagram?` card and confirm that the spelling is changed to `Commerce plan`
* Navigate to `Tools > Earn`
* Check `Collect PayPal payments` and `Earn and revenue` cards 
* Confirm that the spelling is changed to `Commerce plan`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?