### PR TITLE
Lazy Loading Images: Update description toggle to discourage enabling it

### DIFF
--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -1,4 +1,5 @@
 import { Card, CompactCard } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -69,7 +70,9 @@ class SpeedUpSiteSettings extends Component {
 							) }
 							link={
 								siteIsAtomic
-									? 'https://wordpress.com/support/settings/performance-settings/#enable-site-accelerator'
+									? localizeUrl(
+											'https://wordpress.com/support/settings/performance-settings/#enable-site-accelerator'
+									  )
 									: 'https://jetpack.com/support/site-accelerator/'
 							}
 							privacyLink={ ! siteIsAtomic }
@@ -110,7 +113,9 @@ class SpeedUpSiteSettings extends Component {
 								) }
 								link={
 									siteIsAtomic
-										? 'https://wordpress.com/support/settings/performance-settings/#lazy-load-images'
+										? localizeUrl(
+												'https://wordpress.com/support/settings/performance-settings/#lazy-load-images'
+										  )
 										: 'https://jetpack.com/support/lazy-images/'
 								}
 								privacyLink={ ! siteIsAtomic }
@@ -120,9 +125,9 @@ class SpeedUpSiteSettings extends Component {
 								moduleSlug="lazy-images"
 								label={ translate( 'Lazy load images' ) }
 								description={ translate(
-									"Improve your site's speed by only loading images visible on the screen. New images will " +
-										'load just before they scroll into view. This prevents viewers from having to download ' +
-										"all the images on a page all at once, even ones they can't see."
+									'Most modern browsers already support lazy loading. ' +
+										'With over 90% of current browsers offering native support, ' +
+										'enabling this feature may be unnecessary.'
 								) }
 								disabled={ isRequestingOrSaving }
 							/>


### PR DESCRIPTION
This pull request aims to discourage the activation of the JavaScript-based image lazy loading feature from the Performance settings panel. Given that over 90% of modern browsers now support native lazy loading, this feature is no longer a necessary optimization.

The new description will be

_Most modern browsers already support lazy loading. With over 90% of current browsers offering native support, enabling this feature may be unnecessary._

This feature is interfering with the work being done on the Interactivity API

See https://github.com/WordPress/gutenberg/issues/54396

Related: https://github.com/Automattic/jetpack/pull/33030

#### After
<img width="743" alt="image" src="https://github.com/Automattic/wp-calypso/assets/746152/cb56955d-0a93-4bda-b850-58540053a4e9">



#### Before 
<img width="745" alt="image" src="https://github.com/Automattic/wp-calypso/assets/746152/36199a5d-d7e9-4258-b93d-73ff894fb559">


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Updates description text for the _Lazy load images_ setting
* Adds some localizeUrl wrapper demanded by the linter

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch
* Visit Settings -> Performance for a site with a Business plan
* Confirm the new text is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?