### PR TITLE
BackupBrowser: Add rewindRequestBackup action to default Download buttons

### DIFF
--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -12,6 +12,7 @@ import { SUCCESSFUL_BACKUP_ACTIVITIES } from 'calypso/lib/jetpack/backup-utils';
 import { settingsPath } from 'calypso/lib/jetpack/paths';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import { useDispatch, useSelector } from 'calypso/state';
+import { rewindRequestBackup } from 'calypso/state/activity-log/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
@@ -62,6 +63,8 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 	const isRestoreDisabled =
 		doesRewindNeedCredentials || isRestoreInProgress || ( ! isAtomic && areCredentialsInvalid );
 
+	const onDownloadClick = () => dispatch( rewindRequestBackup( siteId, rewindId ) );
+
 	return (
 		<>
 			<Button
@@ -107,6 +110,7 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 					borderless
 					compact
 					isPrimary={ false }
+					onClick={ onDownloadClick }
 					href={ backupDownloadPath( siteSlug, rewindId ) }
 					className="toolbar__download-button"
 				>

--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import Button from 'calypso/components/forms/form-button';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
+import { rewindRequestBackup } from 'calypso/state/activity-log/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
@@ -16,10 +17,13 @@ const DownloadButton = ( { disabled, rewindId, primary } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteId = useSelector( getSelectedSiteId );
 
 	const href = disabled ? undefined : backupDownloadPath( siteSlug, rewindId );
-	const onDownload = () =>
+	const onDownload = () => {
+		dispatch( rewindRequestBackup( siteId, rewindId ) );
 		dispatch( recordTracksEvent( 'calypso_jetpack_backup_download', { rewind_id: rewindId } ) );
+	};
 
 	return (
 		<Button

--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -238,7 +238,7 @@ export function setRewindBackupDownloadId( siteId, downloadId ) {
  * Request a backup up to a specific Activity.
  *
  * @param  {string|number} siteId Site ID
- * @param  {number}        rewindId Rewind ID
+ * @param  {string|number} rewindId Rewind ID
  * @returns {Object}        action object
  */
 export function rewindRequestBackup( siteId, rewindId ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This adds the rewindRequestBackup to the default download buttons.  This action clears out previous download request information allowing the configuration page to appear.
* The download buttons affects are the ones at the top of the Backup Browser and in the Actions + menu on Activity Cards.  Other buttons didn't seem to be in use, but if you find any others, please let me know.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If using a live branch to test these changes append `?flags=jetpack/backup-granular` to the url to allow the selection of items for granular backups.
* Download a granular backup, then using the UI, click on Activity Log, from a backup activity card expand Actions+ and select Download Backup.
* Ensure the configuration page is displayed for the backup.
* Download another granular backup, then visit a Backup Browser page, deselect any selected items, and click Download Backup at the top of the page.
* Ensure the configuration page is displayed for the backup.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?