### PR TITLE
state: refactor away from `_.xor` (and some _.map)

### DIFF
--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -18,7 +18,7 @@ import {
 
 describe( 'utils', () => {
 	describe( 'isTermsEqual', () => {
-		test( 'should return false if term edits are the same as saved terms', () => {
+		test( 'should return true if term edits are the same as saved terms', () => {
 			const isEqual = isTermsEqual(
 				{
 					post_tag: [ 'ribs', 'chicken' ],

--- a/client/state/posts/utils/is-terms-equal.js
+++ b/client/state/posts/utils/is-terms-equal.js
@@ -1,5 +1,3 @@
-import { map, xor } from 'lodash';
-
 /**
  * Returns truthy if local terms object is the same as the API response
  * @param  {Object}  localTermEdits local state of term edits
@@ -10,9 +8,17 @@ export function isTermsEqual( localTermEdits, savedTerms ) {
 	return Object.entries( localTermEdits ).every( ( [ taxonomy, terms ] ) => {
 		const termsArray = Object.values( terms );
 		const isHierarchical = typeof termsArray[ 0 ] === 'object' && termsArray[ 0 ] !== null;
-		const normalizedEditedTerms = isHierarchical ? map( termsArray, 'ID' ) : termsArray;
+		const normalizedEditedTerms = isHierarchical
+			? termsArray.map( ( term ) => term.ID )
+			: termsArray;
 		const normalizedKey = isHierarchical ? 'ID' : 'name';
-		const normalizedSavedTerms = map( savedTerms[ taxonomy ], normalizedKey );
-		return ! xor( normalizedEditedTerms, normalizedSavedTerms ).length;
+		const normalizedSavedTerms = Object.values( savedTerms[ taxonomy ] ?? {} ).map(
+			( value ) => value[ normalizedKey ]
+		);
+
+		return ! [
+			...normalizedEditedTerms.filter( ( x ) => ! normalizedSavedTerms.includes( x ) ),
+			...normalizedSavedTerms.filter( ( x ) => ! normalizedEditedTerms.includes( x ) ),
+		].length;
 	} );
 }

--- a/client/state/posts/utils/is-terms-equal.js
+++ b/client/state/posts/utils/is-terms-equal.js
@@ -8,17 +8,24 @@ export function isTermsEqual( localTermEdits, savedTerms ) {
 	return Object.entries( localTermEdits ).every( ( [ taxonomy, terms ] ) => {
 		const termsArray = Object.values( terms );
 		const isHierarchical = typeof termsArray[ 0 ] === 'object' && termsArray[ 0 ] !== null;
-		const normalizedEditedTerms = isHierarchical
-			? termsArray.map( ( term ) => term.ID )
-			: termsArray;
+		const normalizedEditedTerms = new Set(
+			isHierarchical ? termsArray.map( ( term ) => term.ID ) : termsArray
+		);
 		const normalizedKey = isHierarchical ? 'ID' : 'name';
-		const normalizedSavedTerms = Object.values( savedTerms[ taxonomy ] ?? {} ).map(
-			( value ) => value[ normalizedKey ]
+		const normalizedSavedTerms = new Set(
+			Object.values( savedTerms[ taxonomy ] ?? {} ).map( ( value ) => value[ normalizedKey ] )
 		);
 
-		return ! [
-			...normalizedEditedTerms.filter( ( x ) => ! normalizedSavedTerms.includes( x ) ),
-			...normalizedSavedTerms.filter( ( x ) => ! normalizedEditedTerms.includes( x ) ),
-		].length;
+		if ( normalizedEditedTerms.size !== normalizedSavedTerms.size ) {
+			return false;
+		}
+
+		for ( const term of normalizedEditedTerms ) {
+			if ( ! normalizedSavedTerms.has( term ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	} );
 }

--- a/client/state/posts/utils/is-terms-equal.js
+++ b/client/state/posts/utils/is-terms-equal.js
@@ -12,8 +12,11 @@ export function isTermsEqual( localTermEdits, savedTerms ) {
 			isHierarchical ? termsArray.map( ( term ) => term.ID ) : termsArray
 		);
 		const normalizedKey = isHierarchical ? 'ID' : 'name';
+		const savedTermsValues = savedTerms[ taxonomy ] ? Object.values( savedTerms[ taxonomy ] ) : [];
 		const normalizedSavedTerms = new Set(
-			Object.values( savedTerms[ taxonomy ] ?? {} ).map( ( value ) => value[ normalizedKey ] )
+			savedTermsValues.length > 0
+				? savedTermsValues.map( ( value ) => value[ normalizedKey ] )
+				: savedTermsValues
 		);
 
 		if ( normalizedEditedTerms.size !== normalizedSavedTerms.size ) {

--- a/client/state/reader-ui/sidebar/reducer.js
+++ b/client/state/reader-ui/sidebar/reducer.js
@@ -1,4 +1,3 @@
-import { xor } from 'lodash';
 import {
 	READER_SIDEBAR_LISTS_TOGGLE,
 	READER_SIDEBAR_TAGS_TOGGLE,
@@ -37,7 +36,8 @@ export const isFollowingOpen = withPersistence( ( state = false, action ) => {
 export const openOrganizations = withPersistence( ( state = [], action ) => {
 	switch ( action.type ) {
 		case READER_SIDEBAR_ORGANIZATIONS_TOGGLE: {
-			return xor( state, [ action.organizationId ] );
+			const orgId = action.organizationId;
+			return state.includes( orgId ) ? state.filter( ( id ) => id !== orgId ) : [ ...state, orgId ];
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

PR refactors away from `_.xor` in `client/state`.

## Testing Instructions

* Changes are covered by unit tests, verify they still pass
* As with a lot of lodash methods it's good practice to ensure we don't accidentally miss guards for whether we operate on the expected data structure.