### PR TITLE
Prepare eslint-plugin-wpcalypso for release

### DIFF
--- a/packages/eslint-plugin-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-plugin-wpcalypso/CHANGELOG.md
@@ -1,6 +1,6 @@
 #### Unreleased
 
-#### v8.0.0 (2023-09-13)
+#### v8.0.0 (2023-09-14)
 
 - Breaking: Updated peer dependency `eslint-plugin-jsdoc` to 46.5.1, which
   may result in more rule violations which were not previously detected.

--- a/packages/eslint-plugin-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-plugin-wpcalypso/CHANGELOG.md
@@ -1,5 +1,15 @@
 #### Unreleased
 
+#### v8.0.0 (2023-09-13)
+
+- Breaking: Updated peer dependency `eslint-plugin-jsdoc` to 46.5.1, which
+  may result in more rule violations which were not previously detected.
+- Breaking: Minimum node version is now 14.21.3 (formerly 14.0.0).
+- Breaking: Minimum eslint version is now 8.48.0 (formerly >=8.6.0).
+- Enhancement: Added rule `wpcalypso/i18n-translate-identifier`.
+- Enhancement: Added rule `wpcalypso/i18n-unlocalized-url`.
+- Fix: Fixed spread operator error.
+
 #### v7.0.0 (2022-01-24)
 
 - Breaking: For JSDoc types like `{object}`, prefer capitalized variants to match

--- a/packages/eslint-plugin-wpcalypso/package.json
+++ b/packages/eslint-plugin-wpcalypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-plugin-wpcalypso",
-	"version": "7.0.0",
+	"version": "8.0.0",
 	"description": "Custom ESLint rules for the WordPress.com Calypso project.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Update changelog and internal version number.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Proofread.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
