### PR TITLE
Launchpad: Adds the list of launchpad to the Navigator

### DIFF
--- a/packages/launchpad-navigator/src/floating-navigator/index.tsx
+++ b/packages/launchpad-navigator/src/floating-navigator/index.tsx
@@ -83,16 +83,14 @@ const FloatingNavigator = ( { siteSlug }: FloatingNavigatorProps ) => {
 	const {
 		data: { available_checklists },
 	} = useLaunchpadNavigator( siteSlug, activeChecklistSlug );
+	const checklists = Object.values( available_checklists );
 
 	const [ currentView, setCurrentView ] = useState< string | null >( null );
 
 	return (
 		<Card className="launchpad-navigator__floating-navigator">
 			{ ! currentView ? (
-				<NavigatorLaunchpadList
-					checklists={ available_checklists }
-					setCurrentView={ setCurrentView }
-				/>
+				<NavigatorLaunchpadList checklists={ checklists } setCurrentView={ setCurrentView } />
 			) : (
 				<NavigatorLaunchpadView
 					siteSlug={ siteSlug }

--- a/packages/launchpad-navigator/src/floating-navigator/index.tsx
+++ b/packages/launchpad-navigator/src/floating-navigator/index.tsx
@@ -79,7 +79,7 @@ const NavigatorLaunchpadList = ( { checklists, setCurrentView }: NavigatorLaunch
 };
 
 const FloatingNavigator = ( { siteSlug }: FloatingNavigatorProps ) => {
-	const activeChecklistSlug = select( LaunchpadNavigator.register() ).getActiveChecklistSlug();
+	const activeChecklistSlug = select( LaunchpadNavigator.store ).getActiveChecklistSlug() || null;
 	const {
 		data: { available_checklists },
 	} = useLaunchpadNavigator( siteSlug, activeChecklistSlug );

--- a/packages/launchpad-navigator/src/floating-navigator/index.tsx
+++ b/packages/launchpad-navigator/src/floating-navigator/index.tsx
@@ -1,16 +1,105 @@
 import { Card } from '@automattic/components';
+import { LaunchpadNavigator } from '@automattic/data-stores';
 import { Launchpad } from '@automattic/launchpad';
+import { select } from '@wordpress/data';
+import { useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
+import { useLaunchpadNavigator } from 'calypso/data/launchpad-navigator/use-launchpad-navigator';
+import type { Dispatch } from 'react';
 
 import './style.scss';
 
 export type FloatingNavigatorProps = {
-	siteSlug: string | null;
+	siteSlug: string;
+};
+
+export type LaunchpadNavigatorChecklist = {
+	slug: string;
+	title: string;
+};
+
+interface NavigatorLaunchpadCellProps {
+	checklist: LaunchpadNavigatorChecklist;
+}
+const NavigatorLaunchpadCell = ( { checklist }: NavigatorLaunchpadCellProps ) => {
+	return <div className="launchpad-navigator__navigator-launchpad-cell">{ checklist.title }</div>;
+};
+
+interface NavigatorLaunchpadViewHeaderProps {
+	setCurrentView: Dispatch< string | null >;
+}
+
+const NavigatorLaunchpadViewHeader = ( { setCurrentView }: NavigatorLaunchpadViewHeaderProps ) => {
+	return (
+		<button
+			onClick={ () => setCurrentView( null ) }
+			className="launchpad-navigator__navigator-launchpad-view-header"
+		>
+			Back
+		</button>
+	);
+};
+
+interface LaunchpadNavigatorViewProps {
+	siteSlug: string;
+	checklist_slug: string;
+	setCurrentView: Dispatch< string | null >;
+}
+const NavigatorLaunchpadView = ( {
+	siteSlug,
+	checklist_slug,
+	setCurrentView,
+}: LaunchpadNavigatorViewProps ) => {
+	return (
+		<div className="launchpad-navigator__navigator-launchpad-view">
+			<NavigatorLaunchpadViewHeader setCurrentView={ setCurrentView } />
+			<Launchpad siteSlug={ siteSlug } checklistSlug={ checklist_slug } />;
+		</div>
+	);
+};
+
+interface NavigatorLaunchpadListProps {
+	checklists: LaunchpadNavigatorChecklist[];
+	setCurrentView: Dispatch< string | null >;
+}
+
+const NavigatorLaunchpadList = ( { checklists, setCurrentView }: NavigatorLaunchpadListProps ) => {
+	return (
+		<div className="launchpad-navigator__navigator-launchpad-list">
+			{ checklists &&
+				checklists.map( ( checklist ) => (
+					<div>
+						<button onClick={ () => setCurrentView( checklist.slug ) }>
+							<NavigatorLaunchpadCell key={ checklist.slug } checklist={ checklist } />
+						</button>
+					</div>
+				) ) }
+		</div>
+	);
 };
 
 const FloatingNavigator = ( { siteSlug }: FloatingNavigatorProps ) => {
+	const activeChecklistSlug = select( LaunchpadNavigator.register() ).getActiveChecklistSlug();
+	const {
+		data: { available_checklists },
+	} = useLaunchpadNavigator( siteSlug, activeChecklistSlug );
+
+	const [ currentView, setCurrentView ] = useState< string | null >( null );
+
 	return (
 		<Card className="launchpad-navigator__floating-navigator">
-			<Launchpad siteSlug={ siteSlug } checklistSlug="intent-build" />
+			{ ! currentView ? (
+				<NavigatorLaunchpadList
+					checklists={ available_checklists }
+					setCurrentView={ setCurrentView }
+				/>
+			) : (
+				<NavigatorLaunchpadView
+					siteSlug={ siteSlug }
+					checklist_slug={ currentView }
+					setCurrentView={ setCurrentView }
+				/>
+			) }
 		</Card>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
