### PR TITLE
Stats: Restore purchaseScreenLabel for commercial product

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-wizard.jsx
@@ -70,6 +70,7 @@ const ProductCard = ( {
 	const personalLabel = translate( 'Personal site' );
 	const commercialLabel = translate( 'Commercial site' );
 	const personalProductTitle = translate( 'What is Jetpack Stats worth to you?' );
+	const commercialProductTitle = translate( 'Upgrade your Jetpack Stats' );
 
 	// Default titles for no site type selected.
 	const typeSelectionScreenLabel = translate( 'Select your site type', {
@@ -77,7 +78,15 @@ const ProductCard = ( {
 			site: siteSlug,
 		},
 	} );
-	const purchaseScreenLabel = personalProductTitle;
+	let purchaseScreenLabel = personalProductTitle;
+
+	if ( siteType === TYPE_PERSONAL ) {
+		purchaseScreenLabel = personalProductTitle;
+	}
+
+	if ( siteType === TYPE_COMMERCIAL ) {
+		purchaseScreenLabel = commercialProductTitle;
+	}
 
 	const showCelebration =
 		siteType &&


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81684 

## Proposed Changes

* Restore the label `Upgrade your Jetpack Stats` for the `commercial` purchase on the wizard step 2 from https://github.com/Automattic/wp-calypso/pull/81602.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the Calypso Live link.
* Navigate to Stats > `Traffic` page with a site without any Stats purchase: `/stats/day/{site-slug}?flags=stats/paid-wpcom-stats`.
* Click on the `Upgrade my Stats` on the upgrade notice.
* Click on the `Commercial site` button on the purchase wizard to show step 2 for the commercial product.
* Ensure the step 2 label of commercial purchase is `Upgrade your Jetpack Stats` rather than `What is Jetpack Stats worth to you?`.

|Before|After|
|-|-|
|<img width="1246" alt="截圖 2023-09-14 上午12 40 40" src="https://github.com/Automattic/wp-calypso/assets/6869813/15f78b06-98f7-47d1-aac4-09a305f5b37e">|<img width="1259" alt="截圖 2023-09-14 上午12 40 21" src="https://github.com/Automattic/wp-calypso/assets/6869813/4bb2941a-c701-4118-9b12-39e7d2a4c8de">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?