### PR TITLE
Stats: Display respective button text for the shared PersonalPurchase component

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -31,6 +31,7 @@ interface PersonalPurchaseProps {
 	adminUrl: string;
 	redirectUri: string;
 	from: string;
+	isStandalone?: boolean;
 }
 
 const PersonalPurchase = ( {
@@ -45,6 +46,7 @@ const PersonalPurchase = ( {
 	adminUrl,
 	redirectUri,
 	from,
+	isStandalone,
 }: PersonalPurchaseProps ) => {
 	const translate = useTranslate();
 	const [ isAdsChecked, setAdsChecked ] = useState( false );
@@ -231,7 +233,7 @@ const PersonalPurchase = ( {
 						} )
 					}
 				>
-					{ translate( 'Get Stats Personal' ) }
+					{ isStandalone ? translate( 'Get Stats Personal' ) : translate( 'Get Jetpack Stats' ) }
 				</ButtonComponent>
 			) }
 		</div>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -244,6 +244,7 @@ const StatsPersonalPurchase = ( {
 				adminUrl={ adminUrl }
 				redirectUri={ redirectUri }
 				from={ from }
+				isStandalone={ true }
 			/>
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81684 

## Proposed Changes

* Introduce the prop `isStandalone` to determine the action button text of `PersonalPurchase` in different purchase flows.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the Calypso Live link.
* Navigate to Stats > `Traffic` page with a site without any Stats purchase: `/stats/day/{site-slug}?flags=stats/paid-wpcom-stats`.
* Click on the `Upgrade my Stats` on the upgrade notice.
* Click on the `Personal site` button on the purchase wizard to show step 2 for the personal product.
* Ensure the action button text of personal purchase displays `Get Jetpack Stats` rather than `Get Stats Personal`.

|Before|After|
|-|-|
|<img width="1243" alt="截圖 2023-09-14 上午12 50 24" src="https://github.com/Automattic/wp-calypso/assets/6869813/97e4f2c1-696e-4744-bcc0-857f682217d9">|<img width="1247" alt="截圖 2023-09-14 上午12 49 50" src="https://github.com/Automattic/wp-calypso/assets/6869813/9d0035e9-03f5-4bc2-be6f-e65d079d50be">|

* Append the feature flag `&productType=personal` to the URL.
* Ensure the action button text of the standalone personal purchase displays `Get Stats Personal` as previously.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?