### PR TITLE
Stats: Adjust Stats notice icon alignment

### DIFF
--- a/client/my-sites/stats/stats-notices/style.scss
+++ b/client/my-sites/stats/stats-notices/style.scss
@@ -33,6 +33,7 @@
 
 		.notice-banner__action-link > span {
 			border-bottom: 0;
+			vertical-align: middle;
 		}
 	}
 }

--- a/packages/components/src/notice-banner/style.scss
+++ b/packages/components/src/notice-banner/style.scss
@@ -1,5 +1,7 @@
 @import "@automattic/components/src/styles/typography";
 
+$banner-title-height: 30px;
+
 :root {
 	--font-title-small: 20px;
 	--font-body: 16px;
@@ -27,9 +29,11 @@
 }
 
 .notice-banner__icon-wrapper {
-	margin-right: 20px;
 	width: calc(var(--spacing-base) * 3);
 	height: calc(var(--spacing-base) * 3);
+	margin-right: 20px;
+	// Align the icon vertically in the middle compared to the title.
+	margin-top: calc(($banner-title-height - var(--spacing-base) * 3) / 2);
 }
 
 .notice-banner__close-button {
@@ -72,7 +76,7 @@
 	font-family: $font-sf-pro-display;
 	font-weight: 500;
 	font-size: var(--font-title-small);
-	line-height: 30px;
+	line-height: $banner-title-height;
 	margin-bottom: 8px;
 }
 
@@ -118,6 +122,7 @@
 		fill: var(--jp-black);
 	}
 
+	// TODO: Move out these two classes to StatsNotices since they are defined and passed there.
 	.notice-banner__action-button,
 	.notice-banner__action-link {
 		font-family: inherit;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81684 

## Proposed Changes

* Align notice icons vertically.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the Calypso Live link.
* Navigate to Stats > `Traffic` page with a site without any Stats purchase: `/stats/day/{site-slug}?flags=stats/paid-wpcom-stats`.
* Ensure the notice icons align vertically.

|Before|After|
|-|-|
|<img width="683" alt="截圖 2023-09-14 上午1 11 35" src="https://github.com/Automattic/wp-calypso/assets/6869813/75f5d0de-8100-45cc-9f90-f48137f8b11c">|<img width="678" alt="截圖 2023-09-14 上午1 10 38" src="https://github.com/Automattic/wp-calypso/assets/6869813/f3c93941-b155-49ba-b408-84cac8e55338">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?