### PR TITLE
Reader post cards - remove tags list from byline

### DIFF
--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
-import TagsList from 'calypso/blocks/reader-post-card/tags-list';
 import ReaderPostEllipsisMenu from 'calypso/blocks/reader-post-options-menu/reader-post-ellipsis-menu';
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
 import TimeSince from 'calypso/components/time-since';
@@ -121,7 +120,6 @@ class PostByline extends Component {
 							</span>
 						) }
 					</div>
-					{ ! compact && <TagsList post={ post } /> }
 				</div>
 				{ ! compact && (
 					<ReaderPostEllipsisMenu


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-1fb-p2

## Proposed Changes

* Removes the tags list from the reader post cards.

Before:

<img width="482" alt="Screenshot 2023-09-13 at 2 00 47 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/398e2e0e-d0d6-4b46-9cca-29ec4da93e10">


After:

<img width="480" alt="Screenshot 2023-09-13 at 2 00 52 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/e319e51c-d6e7-46d4-becd-a87289c8c99f">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the reader streams and verify tags are no longer in the non-compact post cards.
* Verify tags still exist where expected elsewhere.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?