### PR TITLE
Fix: Redirect for new post comment

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -319,11 +319,12 @@ export function redirectToPermalinkIfLoggedOut( context, next ) {
 	if ( ! siteFragment || ! context.path ) {
 		return next();
 	}
-	// Check if the path is in this format.
-	// - /page/{site}/{id}
-	// - /post/{site}/{id}
-	// - /edit/jetpack-portfolio/{site}/{id}
-	// - /edit/jetpack-testimonial/{site}/{id}
+	// "single view" pages are parsed from URLs like these:
+	// (posts, pages, custom post types, etc…)
+	//  - /page/{site}/{post_id}
+	//  - /post/{site}/{post_id}
+	//  - /edit/jetpack-portfolio/{site}/{post_id}
+	//  - /edit/jetpack-testimonial/{site}/{post_id}
 	const postId = parseInt( context.params.post, 10 );
 	const linksToSingleView = postId > 0;
 	if ( linksToSingleView ) {


### PR DESCRIPTION
This PR fixes the comment so that it is more readable.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the inked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/81573

## Proposed Changes

* comment fixes.

## Testing Instructions

* Does it still work as expected. No code changes are shipped in this.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?