### PR TITLE
Earn: Update WordAd method names

### DIFF
--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -79,7 +79,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 	};
 
 	const isAdSection = ( currentSection: string | undefined ) =>
-		currentSection && currentSection.includes( 'ads' );
+		currentSection && currentSection.startsWith( 'ads' );
 
 	const getComponent = ( currentSection: string | undefined ) => {
 		switch ( currentSection ) {

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -24,7 +24,7 @@ import ReferAFriendSection from './refer-a-friend';
 import { Query } from './types';
 
 type EarningsMainProps = {
-	section: string;
+	section?: string;
 	query: Query;
 	path: string;
 };
@@ -44,7 +44,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		'refer-a-friend': translate( 'Refer-a-Friend Program' ),
 	};
 
-	const getFilters = () => {
+	const getAdTabs = () => {
 		const pathSuffix = site?.slug ? '/' + site?.slug : '';
 		const tabs = [];
 
@@ -69,8 +69,8 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		return tabs;
 	};
 
-	const getSelectedText = () => {
-		const selected = find( getFilters(), { path: path } );
+	const getAdSelectedText = () => {
+		const selected = find( getAdTabs(), { path: path } );
 		if ( selected ) {
 			return selected.title;
 		}
@@ -78,7 +78,10 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		return '';
 	};
 
-	const getComponent = ( currentSection: string ) => {
+	const isAdSection = ( currentSection: string | undefined ) =>
+		currentSection && currentSection.includes( 'ads' );
+
+	const getComponent = ( currentSection: string | undefined ) => {
 		switch ( currentSection ) {
 			case 'ads-earnings':
 				return (
@@ -158,28 +161,25 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		);
 	};
 
-	const getSectionNav = ( currentSection: string ) => {
+	const getAdSectionNav = () => {
 		const currentPath = getCurrentPath();
 
 		return (
-			! currentSection.startsWith( 'payments' ) &&
-			! currentSection.startsWith( 'refer-a-friend' ) && (
-				<SectionNav selectedText={ getSelectedText() }>
-					<NavTabs>
-						{ getFilters().map( ( filterItem ) => {
-							return (
-								<NavItem
-									key={ filterItem.id }
-									path={ filterItem.path }
-									selected={ filterItem.path === currentPath }
-								>
-									{ filterItem.title }
-								</NavItem>
-							);
-						} ) }
-					</NavTabs>
-				</SectionNav>
-			)
+			<SectionNav selectedText={ getAdSelectedText() }>
+				<NavTabs>
+					{ getAdTabs().map( ( filterItem ) => {
+						return (
+							<NavItem
+								key={ filterItem.id }
+								path={ filterItem.path }
+								selected={ filterItem.path === currentPath }
+							>
+								{ filterItem.title }
+							</NavItem>
+						);
+					} ) }
+				</NavTabs>
+			</SectionNav>
 		);
 	};
 
@@ -205,7 +205,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				align="left"
 			/>
 			{ getHeaderCake() }
-			{ section && getSectionNav( section ) }
+			{ isAdSection( section ) && getAdSectionNav() }
 			{ getComponent( section ) }
 		</Main>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Earn > Home has many methods that are designed to handle tab navigation specifically for the WordAds page/section. I'll be adding generic tab navigation for Earn as a whole. Before I do, this PR updates WordAd-specific method names for clarity. In a future PR, I may move these to a separate file.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check out this branch, go to http://calypso.localhost:3000/earn/YOURDOMAIN, and click around various Earn pages, and especially on Ads pages to confirm everything behaves the same as before. If you haven't already, you may need to enable Ads, which is quick to do. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
