### PR TITLE
Add test for jetpack products to test the monthly variant

### DIFF
--- a/client/my-sites/checkout/src/test/composite-checkout-variant-picker-dropdown.tsx
+++ b/client/my-sites/checkout/src/test/composite-checkout-variant-picker-dropdown.tsx
@@ -171,10 +171,7 @@ describe( 'CheckoutMain with a variant picker', () => {
 		{ activePlan: 'none', cartPlan: 'two-year', expectedVariant: 'monthly' },
 	] )(
 		'renders the $expectedVariant variant with a discount percentage for a Jetpack $cartPlan plan when the current plan is $activePlan',
-		async ( { activePlan, cartPlan, expectedVariant } ) => {
-			( getPlansBySiteId as jest.Mock ).mockImplementation( () => ( {
-				data: getActivePersonalPlanDataForType( activePlan ),
-			} ) );
+		async ( { cartPlan, expectedVariant } ) => {
 			const user = userEvent.setup();
 			const cartChanges = { products: [ getJetpackPlanForInterval( cartPlan ) ] };
 			render( <MockCheckout initialCart={ initialCart } cartChanges={ cartChanges } /> );

--- a/client/my-sites/checkout/src/test/util/index.ts
+++ b/client/my-sites/checkout/src/test/util/index.ts
@@ -343,6 +343,48 @@ export const planLevel2Biannual: ResponseCartProduct = {
 	months_per_bill_period: 24,
 };
 
+export const jetpackMonthly: ResponseCartProduct = {
+	...getEmptyResponseCartProduct(),
+	product_name: 'Jetpack Scan Monthly',
+	product_slug: 'jetpack_scan_monthly',
+	currency: 'BRL',
+	meta: '',
+	product_id: 2107,
+	volume: 1,
+	item_original_cost_integer: 1495,
+	item_subtotal_integer: 1495,
+	bill_period: '31',
+	months_per_bill_period: 1,
+};
+
+export const jetpackYearly: ResponseCartProduct = {
+	...getEmptyResponseCartProduct(),
+	product_name: 'Jetpack Scan Yearly',
+	product_slug: 'jetpack_scan',
+	currency: 'BRL',
+	meta: '',
+	product_id: 2106,
+	volume: 1,
+	item_original_cost_integer: 19940,
+	item_subtotal_integer: 11940,
+	bill_period: '365',
+	months_per_bill_period: 12,
+};
+
+export const jetpackBiannual: ResponseCartProduct = {
+	...getEmptyResponseCartProduct(),
+	product_name: 'Jetpack Scan Bi-yearly',
+	product_slug: 'jetpack_scan_bi_yearly',
+	currency: 'BRL',
+	meta: '',
+	product_id: 2038,
+	volume: 1,
+	item_original_cost_integer: 23380,
+	item_subtotal_integer: 23380,
+	bill_period: '730',
+	months_per_bill_period: 24,
+};
+
 export const professionalEmailAnnual: ResponseCartProduct = {
 	...getEmptyResponseCartProduct(),
 	product_name: 'Professional Email',
@@ -449,6 +491,15 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				bill_period: 'yearly',
 				currency: 'USD',
 			};
+		case 'jetpack_anti_spam_bi_yearly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2039,
+				product_name: 'Jetpack Akismet Anti-spam',
+				product_slug: productSlug,
+				bill_period: 'bi-yearly',
+				currency: 'USD',
+			};
 		case 'jetpack_backup_t1_monthly':
 			return {
 				...getEmptyResponseCartProduct(),
@@ -512,6 +563,15 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				bill_period: 'yearly',
 				currency: 'USD',
 			};
+		case 'jetpack_boost_bi_yearly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2036,
+				product_name: 'Jetpack Boost',
+				product_slug: productSlug,
+				bill_period: 'bi-yearly',
+				currency: 'USD',
+			};
 		case 'jetpack_complete_monthly':
 			return {
 				...getEmptyResponseCartProduct(),
@@ -530,6 +590,15 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				bill_period: 'yearly',
 				currency: 'USD',
 			};
+		case 'jetpack_complete_bi_yearly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2035,
+				product_name: 'Jetpack Complete',
+				product_slug: productSlug,
+				bill_period: 'bi-yearly',
+				currency: 'USD',
+			};
 		case 'jetpack_scan_monthly':
 			return {
 				...getEmptyResponseCartProduct(),
@@ -543,9 +612,18 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 			return {
 				...getEmptyResponseCartProduct(),
 				product_id: 2106,
-				product_name: 'Jetpack Scan Daily',
+				product_name: 'Jetpack Scan',
 				product_slug: productSlug,
 				bill_period: 'yearly',
+				currency: 'USD',
+			};
+		case 'jetpack_scan_bi_yearly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2038,
+				product_name: 'Jetpack Scan',
+				product_slug: productSlug,
+				bill_period: 'bi-yearly',
 				currency: 'USD',
 			};
 		case 'jetpack_search_monthly':
@@ -564,6 +642,15 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_name: 'Jetpack Search',
 				product_slug: productSlug,
 				bill_period: 'yearly',
+				currency: 'USD',
+			};
+		case 'jetpack_search_bi_yearly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2131,
+				product_name: 'Jetpack Search',
+				product_slug: productSlug,
+				bill_period: 'bi-yearly',
 				currency: 'USD',
 			};
 		case 'jetpack_security_t1_monthly':
@@ -629,6 +716,15 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				bill_period: 'yearly',
 				currency: 'USD',
 			};
+		case 'jetpack_social_basic_bi_yearly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2037,
+				product_name: 'Jetpack Social Basic',
+				product_slug: productSlug,
+				bill_period: 'bi-yearly',
+				currency: 'USD',
+			};
 		case 'jetpack_social_advanced_monthly':
 			return {
 				...getEmptyResponseCartProduct(),
@@ -647,6 +743,15 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				bill_period: 'yearly',
 				currency: 'USD',
 			};
+		case 'jetpack_social_advanced_bi_yearly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2604,
+				product_name: 'Jetpack Social Advanced',
+				product_slug: productSlug,
+				bill_period: 'bi-yearly',
+				currency: 'USD',
+			};
 		case 'jetpack_videopress_monthly':
 			return {
 				...getEmptyResponseCartProduct(),
@@ -663,6 +768,15 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_name: 'Jetpack VideoPress',
 				product_slug: productSlug,
 				bill_period: 'yearly',
+				currency: 'USD',
+			};
+		case 'jetpack_videopress_bi_yearly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2119,
+				product_name: 'Jetpack VideoPress',
+				product_slug: productSlug,
+				bill_period: 'bi-yearly',
 				currency: 'USD',
 			};
 		case 'ak_free_yearly':
@@ -1057,6 +1171,57 @@ function convertRequestProductToResponseProduct(
 						isAkismetSitelessCheckout: true,
 					},
 				};
+			case jetpackMonthly.product_slug:
+				return {
+					...getEmptyResponseCartProduct(),
+					product_id: jetpackMonthly.product_id,
+					product_name: jetpackMonthly.product_name,
+					product_slug: jetpackMonthly.product_slug,
+					currency: currency,
+					is_domain_registration: false,
+					item_original_cost_integer: jetpackMonthly.item_original_cost_integer,
+					item_subtotal_integer: jetpackMonthly.item_subtotal_integer,
+					bill_period: jetpackMonthly.bill_period,
+					months_per_bill_period: jetpackMonthly.months_per_bill_period,
+					item_tax: 0,
+					meta: product.meta,
+					volume: 1,
+					extra: {},
+				};
+			case jetpackYearly.product_slug:
+				return {
+					...getEmptyResponseCartProduct(),
+					product_id: jetpackYearly.product_id,
+					product_name: jetpackYearly.product_name,
+					product_slug: jetpackYearly.product_slug,
+					currency: currency,
+					is_domain_registration: false,
+					item_original_cost_integer: jetpackYearly.item_original_cost_integer,
+					item_subtotal_integer: jetpackYearly.item_subtotal_integer,
+					bill_period: jetpackYearly.bill_period,
+					months_per_bill_period: jetpackYearly.months_per_bill_period,
+					item_tax: 0,
+					meta: product.meta,
+					volume: 1,
+					extra: {},
+				};
+			case jetpackBiannual.product_slug:
+				return {
+					...getEmptyResponseCartProduct(),
+					product_id: jetpackBiannual.product_id,
+					product_name: jetpackBiannual.product_name,
+					product_slug: jetpackBiannual.product_slug,
+					currency: currency,
+					is_domain_registration: false,
+					item_original_cost_integer: jetpackBiannual.item_original_cost_integer,
+					item_subtotal_integer: jetpackBiannual.item_subtotal_integer,
+					bill_period: jetpackBiannual.bill_period,
+					months_per_bill_period: jetpackBiannual.months_per_bill_period,
+					item_tax: 0,
+					meta: product.meta,
+					volume: 1,
+					extra: {},
+				};
 			case planLevel2.product_slug:
 				return {
 					...getEmptyResponseCartProduct(),
@@ -1249,6 +1414,17 @@ export function getBusinessPlanForInterval( type: string ) {
 	}
 }
 
+export function getJetpackPlanForInterval( type: string ) {
+	switch ( type ) {
+		case 'monthly':
+			return addVariantsToCartItem( jetpackMonthly );
+		case 'yearly':
+			return addVariantsToCartItem( jetpackYearly );
+		case 'two-year':
+			return addVariantsToCartItem( jetpackBiannual );
+	}
+}
+
 export function getVariantItemTextForInterval( type: string ) {
 	switch ( type ) {
 		case 'monthly':
@@ -1343,6 +1519,39 @@ export function getPlansItemsState(): PricedAPIPlan[] {
 			raw_price: 499,
 			raw_price_integer: 49900,
 		},
+		{
+			product_id: jetpackMonthly.product_id,
+			product_slug: jetpackMonthly.product_slug as StorePlanSlug,
+			product_name: jetpackMonthly.product_name,
+			product_name_short: jetpackMonthly.product_name,
+			currency_code: 'USD',
+			bill_period: 31,
+			product_type: 'product',
+			raw_price: 14.95,
+			raw_price_integer: 1495,
+		},
+		{
+			product_id: jetpackYearly.product_id,
+			product_slug: jetpackYearly.product_slug as StorePlanSlug,
+			product_name: jetpackYearly.product_name,
+			product_name_short: jetpackYearly.product_name,
+			currency_code: 'USD',
+			bill_period: 365,
+			product_type: 'product',
+			raw_price: 119.4,
+			raw_price_integer: 11940,
+		},
+		{
+			product_id: jetpackBiannual.product_id,
+			product_slug: jetpackBiannual.product_slug as StorePlanSlug,
+			product_name: jetpackBiannual.product_name,
+			product_name_short: jetpackBiannual.product_name,
+			currency_code: 'USD',
+			bill_period: 730,
+			product_type: 'product',
+			raw_price: 238.8,
+			raw_price_integer: 23880,
+		},
 	];
 }
 
@@ -1405,6 +1614,30 @@ export function createTestReduxStore() {
 						available: true,
 						is_domain_registration: false,
 						currency_code: planLevel2Biannual.currency,
+					},
+					[ jetpackMonthly.product_slug ]: {
+						product_id: jetpackMonthly.product_id,
+						product_slug: jetpackMonthly.product_slug,
+						product_type: 'product',
+						available: true,
+						is_domain_registration: false,
+						currency_code: jetpackMonthly.currency,
+					},
+					[ jetpackYearly.product_slug ]: {
+						product_id: jetpackYearly.product_id,
+						product_slug: jetpackYearly.product_slug,
+						product_type: 'product',
+						available: true,
+						is_domain_registration: false,
+						currency_code: jetpackYearly.currency,
+					},
+					[ jetpackBiannual.product_slug ]: {
+						product_id: jetpackBiannual.product_id,
+						product_slug: jetpackBiannual.product_slug,
+						product_type: 'product',
+						available: true,
+						is_domain_registration: false,
+						currency_code: jetpackBiannual.currency,
 					},
 					domain_map: {
 						product_id: 5,
@@ -1767,6 +2000,14 @@ function buildVariantsForCartItem( data: ResponseCartProduct ): ResponseCartProd
 				buildVariant( planWithoutDomain ),
 				buildVariant( planWithoutDomainBiannual ),
 			];
+		case jetpackMonthly.product_slug:
+		case jetpackYearly.product_slug:
+		case jetpackBiannual.product_slug:
+			return [
+				buildVariant( jetpackMonthly ),
+				buildVariant( jetpackYearly ),
+				buildVariant( jetpackBiannual ),
+			];
 	}
 	return [];
 }
@@ -1783,6 +2024,36 @@ function getVariantPrice( data: ResponseCartProduct ): number {
 
 function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 	switch ( data.product_slug ) {
+		case jetpackMonthly.product_slug:
+			return {
+				product_id: jetpackMonthly.product_id,
+				bill_period_in_months: jetpackMonthly.months_per_bill_period as number,
+				product_slug: data.product_slug,
+				currency: jetpackMonthly.currency,
+				price_integer: getVariantPrice( jetpackMonthly ),
+				price_before_discounts_integer: getVariantPrice( jetpackMonthly ),
+				introductory_offer_terms: {},
+			};
+		case jetpackYearly.product_slug:
+			return {
+				product_id: jetpackYearly.product_id,
+				bill_period_in_months: jetpackYearly.months_per_bill_period as number,
+				product_slug: data.product_slug,
+				currency: jetpackYearly.currency,
+				price_integer: getVariantPrice( jetpackYearly ),
+				price_before_discounts_integer: getVariantPrice( jetpackYearly ),
+				introductory_offer_terms: {},
+			};
+		case jetpackBiannual.product_slug:
+			return {
+				product_id: jetpackBiannual.product_id,
+				bill_period_in_months: jetpackBiannual.months_per_bill_period as number,
+				product_slug: data.product_slug,
+				currency: jetpackBiannual.currency,
+				price_integer: getVariantPrice( jetpackBiannual ),
+				price_before_discounts_integer: getVariantPrice( jetpackBiannual ),
+				introductory_offer_terms: {},
+			};
 		case planLevel2Monthly.product_slug:
 			return {
 				product_id: planLevel2Monthly.product_id,


### PR DESCRIPTION
## Proposed Changes

* Add tests for jetpack products variant picker since it handles products a bit differently for jetpack products compared to wordpress.com products

## Testing Instructions

1. Make sure all tests pass
2. Make sure the tests makes sense

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?