### PR TITLE
Earn: Add navigation tabs

### DIFF
--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -44,6 +44,17 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		'refer-a-friend': translate( 'Refer-a-Friend Program' ),
 	};
 
+	const getEarnTabs = () => {
+		const pathSuffix = site?.slug ? '/' + site?.slug : '';
+		return [
+			{
+				title: translate( 'Tools' ),
+				path: '/earn' + pathSuffix,
+				id: 'earn',
+			},
+		];
+	};
+
 	const getAdTabs = () => {
 		const pathSuffix = site?.slug ? '/' + site?.slug : '';
 		const tabs = [];
@@ -67,6 +78,15 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		}
 
 		return tabs;
+	};
+
+	const getEarnSelectedText = () => {
+		const selected = find( getEarnTabs(), { path: path } );
+		if ( selected ) {
+			return selected.title;
+		}
+
+		return '';
 	};
 
 	const getAdSelectedText = () => {
@@ -161,6 +181,30 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		);
 	};
 
+	const getEarnSectionNav = () => {
+		const currentPath = getCurrentPath();
+
+		return (
+			<div id="earn-navigation">
+				<SectionNav selectedText={ getEarnSelectedText() }>
+					<NavTabs>
+						{ getEarnTabs().map( ( tabItem ) => {
+							return (
+								<NavItem
+									key={ tabItem.id }
+									path={ tabItem.path }
+									selected={ tabItem.path === currentPath }
+								>
+									{ tabItem.title }
+								</NavItem>
+							);
+						} ) }
+					</NavTabs>
+				</SectionNav>
+			</div>
+		);
+	};
+
 	const getAdSectionNav = () => {
 		const currentPath = getCurrentPath();
 
@@ -204,6 +248,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				) }
 				align="left"
 			/>
+			{ getEarnSectionNav() }
 			{ getHeaderCake() }
 			{ isAdSection( section ) && getAdSectionNav() }
 			{ getComponent( section ) }

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -1,6 +1,5 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-@import "@wordpress/base-styles/variables";
 
 .earn .promo-section__promos img {
 	width: 48px;

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -51,11 +51,3 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 		font-weight: 600;
 	}
 }
-
-// Override some SectionNav styles on Earn page
-#earn-navigation {
-	margin-top: -10px;
-	.section-nav {
-		margin: 0 0 24px;
-	}
-}

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .earn .promo-section__promos img {
 	width: 48px;
@@ -48,5 +49,26 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 	font-style: italic;
 	em {
 		font-weight: 600;
+	}
+}
+
+// Override some SectionNav styles on Earn page
+#earn-navigation {
+	margin-top: -10px;
+	.section-nav {
+		box-shadow: inset 0 -1px 0 #0000000d;
+		background: transparent;
+		margin: 0 0 24px;
+	}
+	.section-nav-tab__link {
+		color: var(--color-neutral-60);
+		&:hover,
+		&:focus {
+			color: var(--color-primary-90);
+			background-color: transparent;
+		}
+		.is-selected & {
+			color: var(--color-primary-90);
+		}
 	}
 }

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -60,6 +60,9 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 		background: transparent;
 		margin: 0 0 24px;
 	}
+}
+
+@media (min-width: 481px) {
 	.section-nav-tab__link {
 		color: var(--color-neutral-60);
 		&:hover,

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -56,22 +56,6 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 #earn-navigation {
 	margin-top: -10px;
 	.section-nav {
-		box-shadow: inset 0 -1px 0 #0000000d;
-		background: transparent;
 		margin: 0 0 24px;
-	}
-}
-
-@media (min-width: 481px) {
-	.section-nav-tab__link {
-		color: var(--color-neutral-60);
-		&:hover,
-		&:focus {
-			color: var(--color-primary-90);
-			background-color: transparent;
-		}
-		.is-selected & {
-			color: var(--color-primary-90);
-		}
 	}
 }


### PR DESCRIPTION
**Should be merged after https://github.com/Automattic/wp-calypso/pull/81697**

## Proposed Changes

- Adds the ability to add navigation tabs
- Puts all current content under the Tools tab
- Prepares the way to start adding other tabs per figma designs

**Before:**
<img width="1067" alt="no-tabs" src="https://github.com/Automattic/wp-calypso/assets/21228350/9134b89a-3fde-4bd7-873e-9626f5e30d04">

**After:**
<img width="1061" alt="earn-tabs" src="https://github.com/Automattic/wp-calypso/assets/21228350/f37d2188-cb5a-44c7-984d-a4874ef65c59">

**From Figma designs - what we're building toward**
<img width="694" alt="earn-design" src="https://github.com/Automattic/wp-calypso/assets/21228350/9e50e285-d4e0-4801-8674-e94c660aa1a7">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Checkout this branch and go to http://calypso.localhost:3000/earn/YOURDOMAIN
2) Confirm Tools tab shows as in screenshot above.
3) Navigate to some other Earn page (payments, ads, etc), click Tools tab, and confirm you are brought back to Earn home.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
