### PR TITLE
BackupBrowser: Skip confirmation page on backup granular downloads

### DIFF
--- a/client/my-sites/backup/rewind-flow/download.tsx
+++ b/client/my-sites/backup/rewind-flow/download.tsx
@@ -8,6 +8,7 @@ import { getRewindBackupProgress, rewindBackup } from 'calypso/state/activity-lo
 import getBackupProgress from 'calypso/state/selectors/get-backup-progress';
 import getRequest from 'calypso/state/selectors/get-request';
 import getRequestedBackup from 'calypso/state/selectors/get-requested-backup';
+import isGranularBackupDownloadRequested from 'calypso/state/selectors/is-granular-backup-download-requested';
 import Error from './error';
 import Loading from './loading';
 import ProgressBar from './progress-bar';
@@ -63,6 +64,10 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 	const downloadRewindId = backupProgress?.rewindId;
 	const downloadInfoRequest = useSelector( ( state ) =>
 		getRequest( state, getRewindBackupProgress( siteId ) )
+	);
+
+	const isGranularRestore = useSelector( ( state ) =>
+		isGranularBackupDownloadRequested( state, siteId )
 	);
 
 	const requestDownload = useCallback(
@@ -247,7 +252,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 		if ( ! isDownloadInfoRequestComplete ) {
 			return <Loading />;
 		} else if (
-			isOtherDownloadInfo ||
+			( isOtherDownloadInfo && ! isGranularRestore ) ||
 			( downloadProgress === undefined && isDownloadURLNotReady )
 		) {
 			return renderConfirm();

--- a/client/state/activity-log/backup/reducer.js
+++ b/client/state/activity-log/backup/reducer.js
@@ -30,6 +30,23 @@ export const backupRequest = keyedReducer( 'siteId', ( state = undefined, action
 	}
 } );
 
+/**
+ * Whether a backup granular download has been requested
+ */
+export const granularBackupDownloadRequested = keyedReducer(
+	'siteId',
+	( state = false, action ) => {
+		switch ( action.type ) {
+			case REWIND_GRANULAR_BACKUP_REQUEST:
+				return true;
+			case REWIND_BACKUP:
+				return false;
+		}
+
+		return state;
+	}
+);
+
 export const backupProgress = keyedReducer( 'siteId', ( state = undefined, action ) => {
 	switch ( action.type ) {
 		case REWIND_BACKUP:

--- a/client/state/activity-log/reducer.js
+++ b/client/state/activity-log/reducer.js
@@ -2,7 +2,7 @@ import { withStorageKey } from '@automattic/state-utils';
 import { ACTIVITY_LOG_FILTER_SET, ACTIVITY_LOG_FILTER_UPDATE } from 'calypso/state/action-types';
 import { combineReducers, keyedReducer } from 'calypso/state/utils';
 import { activationRequesting } from './activation/reducer';
-import { backupRequest, backupProgress } from './backup/reducer';
+import { backupRequest, backupProgress, granularBackupDownloadRequested } from './backup/reducer';
 import { restoreProgress, restoreRequest } from './restore/reducer';
 
 export const emptyFilter = {
@@ -29,6 +29,7 @@ const combinedReducer = combineReducers( {
 	restoreRequest,
 	backupProgress,
 	backupRequest,
+	granularBackupDownloadRequested,
 } );
 
 export default withStorageKey( 'activityLog', combinedReducer );

--- a/client/state/selectors/is-granular-backup-download-requested.ts
+++ b/client/state/selectors/is-granular-backup-download-requested.ts
@@ -1,0 +1,16 @@
+import { AppState } from 'calypso/types';
+import 'calypso/state/activity-log/init';
+
+/**
+ * Returns whether a granular backup download has been requested
+ * for a given site.
+ *
+ * @param {Object} state Global state tree
+ * @param {number} siteId The site ID
+ * @returns {boolean} Whether a granular backup download has been requested
+ */
+const isGranularBackupDownloadRequested = ( state: AppState, siteId: number ): boolean => {
+	return state.activityLog.granularBackupDownloadRequested?.[ siteId ] ?? false;
+};
+
+export default isGranularBackupDownloadRequested;


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack-backup-team/issues/164

## Proposed Changes

* Add a new reducer and selector to fetch if the download request is granular or not. This is because we want to skip the confirmation page and go directly to the download progress view.
* Skip confirmation page for granular downloads

## Testing Instructions
* Spin up a Calypso or Jetpack Cloud live branch
* Select a site with a Jetpack VaultPress Backup plan
* Pick a backup and click on `View files` inside the `Actions (+)` menu
* Try to execute a regular download, but do not confirm the download
* Go back (through the browser history)
* Pick some files and then click on `Download selected files` on top.
* Ensure you see directly the progress bar instead of the confirm download view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
