### PR TITLE
Checkout: Confirm 3DS challenges using card-specific stripe account

### DIFF
--- a/client/my-sites/checkout/src/test/existing-card-processor.ts
+++ b/client/my-sites/checkout/src/test/existing-card-processor.ts
@@ -50,7 +50,7 @@ describe( 'existingCardProcessor', () => {
 			name: 'test name',
 			payment_key: 'stripe-token',
 			payment_method: 'WPCOM_Billing_MoneyPress_Stored',
-			payment_partner: 'IE',
+			payment_partner: 'stripe_ie',
 			postal_code: '10001',
 			stored_details_id: 'stored-details-id',
 			zip: '10001',
@@ -104,7 +104,7 @@ describe( 'existingCardProcessor', () => {
 			storedDetailsId: 'stored-details-id',
 			name: 'test name',
 			paymentMethodToken: 'stripe-token',
-			paymentPartnerProcessorId: 'IE',
+			paymentPartnerProcessorId: 'stripe_ie',
 		};
 		const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 		await expect(
@@ -124,7 +124,7 @@ describe( 'existingCardProcessor', () => {
 		const submitData = {
 			storedDetailsId: 'stored-details-id',
 			paymentMethodToken: 'stripe-token',
-			paymentPartnerProcessorId: 'IE',
+			paymentPartnerProcessorId: 'stripe_ie',
 		};
 		const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 		await expect(
@@ -157,7 +157,7 @@ describe( 'existingCardProcessor', () => {
 			storedDetailsId: 'stored-details-id',
 			name: 'test name',
 			paymentMethodToken: 'stripe-token',
-			paymentPartnerProcessorId: 'IE',
+			paymentPartnerProcessorId: 'stripe_ie',
 		};
 		const expected = { payload: 'test error', type: 'ERROR' };
 		await expect(
@@ -177,7 +177,7 @@ describe( 'existingCardProcessor', () => {
 			storedDetailsId: 'stored-details-id',
 			name: 'test name',
 			paymentMethodToken: 'stripe-token',
-			paymentPartnerProcessorId: 'IE',
+			paymentPartnerProcessorId: 'stripe_ie',
 		};
 		const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 		await expect(
@@ -208,7 +208,7 @@ describe( 'existingCardProcessor', () => {
 			storedDetailsId: 'stored-details-id',
 			name: 'test name',
 			paymentMethodToken: 'stripe-token',
-			paymentPartnerProcessorId: 'IE',
+			paymentPartnerProcessorId: 'stripe_ie',
 		};
 		const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 		await expect(
@@ -250,7 +250,7 @@ describe( 'existingCardProcessor', () => {
 			storedDetailsId: 'stored-details-id',
 			name: 'test name',
 			paymentMethodToken: 'stripe-token',
-			paymentPartnerProcessorId: 'IE',
+			paymentPartnerProcessorId: 'stripe_ie',
 		};
 		const expected = { payload: { success: 'true' }, type: 'SUCCESS' };
 		await expect(

--- a/packages/calypso-stripe/README.md
+++ b/packages/calypso-stripe/README.md
@@ -45,3 +45,13 @@ A function that can be used to create a Stripe setup intent with a setup intent 
 ## withStripeProps
 
 A higher-order-component function for use when using `useStripe` is not possible. Provides the same data as returned by `useStripe` as props to a component.
+
+## loadStripeLibrary
+
+Loads the Stripe.js library directly.
+
+Unlike `StripeHookProvider` and `useStripe`, this does not keep any state, so try not to call it too often.
+
+This can be useful when you need a different stripe object (eg: for a different country) than the one in `StripeHookProvider`, or if you cannot easily use the provider.
+
+If `country` is provided, it will be used to determine which Stripe account to load. If `paymentPartner` is provided, it will be used instead. If neither is provided, the geolocation will be used.

--- a/packages/calypso-stripe/README.md
+++ b/packages/calypso-stripe/README.md
@@ -10,8 +10,8 @@ You'll need to wrap this context provider around any component that wishes to us
 
 - `children: React.ReactNode`
 - `fetchStripeConfiguration: GetStripeConfiguration` A function to fetch the stripe configuration from the WP.com HTTP API.
-- `configurationArgs?: null | GetStripeConfigurationArgs` Options to pass to the fetchStripeConfiguration function, specifically `country`.
 - `locale?: string` An optional locale string used to localize error messages for the Stripe elements fields.
+- `country?: string` An optional country string used to determine which Stripe account to use. If not provided, the country will be detected based on Geo IP.
 
 ## StripeSetupIntentIdProvider
 

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -509,13 +509,16 @@ export function StripeSetupIntentIdProvider( {
 export function StripeHookProvider( {
 	children,
 	fetchStripeConfiguration,
-	configurationArgs = null,
-	locale = undefined,
+	locale,
+	country,
 }: PropsWithChildren< {
 	fetchStripeConfiguration: GetStripeConfiguration;
-	configurationArgs?: undefined | null | GetStripeConfigurationArgs;
-	locale?: undefined | string;
+	locale?: string;
+	country?: string;
 } > ) {
+	const configurationArgs = {
+		country,
+	};
 	const { stripeConfiguration, stripeConfigurationError } = useStripeConfiguration(
 		fetchStripeConfiguration,
 		configurationArgs

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -108,7 +108,6 @@ export interface StripePaymentRequestHandlerEvent {
  *
  * This object also includes a `messagesByField` property which can be used to
  * find which error was for which input field.
- *
  * @param {string} code - The error code
  * @param {Object} messagesByField - An object whose keys are input field names and whose values are arrays of error strings for that field
  */
@@ -141,7 +140,6 @@ export class StripeConfigurationError extends Error {}
  * before being used again.
  *
  * The object will include the original stripe error in the stripeError prop.
- *
  * @param {Object} stripeError - The original Stripe error object
  */
 export class StripeSetupIntentError extends Error {
@@ -158,7 +156,6 @@ export class StripeSetupIntentError extends Error {
  * An error related to a Stripe PaymentMethod
  *
  * The object will include the original stripe error in the stripeError prop.
- *
  * @param {Object} stripeError - The original Stripe error object
  */
 export class StripePaymentMethodError extends Error {
@@ -186,7 +183,6 @@ export class StripePaymentMethodError extends Error {
  * depending on the type. For example, validation errors should be type
  * `validation_error` and have a `code` property which might be something like
  * `incomplete_cvc`.
- *
  * @param {Object} stripe The stripe object with payment data included
  * @param {Object} element The StripeCardNumberElement or StripeCardElement
  * @param {Object} paymentDetails The `billing_details` field of the `createPaymentMethod()` request
@@ -280,7 +276,6 @@ export async function confirmStripePaymentIntent(
  * Extract validation errors from a Stripe error
  *
  * Returns null if validation errors cannot be found.
- *
  * @param {Object} error An error returned by a Stripe function like createPaymentMethod
  * @returns {Object | null} An object keyed by input field name whose values are arrays of error strings for that field
  */
@@ -316,7 +311,6 @@ function getValidationErrorsFromStripeError(
  * This is internal. You probably actually want the useStripe hook.
  *
  * Its parameter is the value returned by useStripeConfiguration
- *
  * @param {Object} stripeConfiguration An object containing { public_key, js_url }
  * @param {Error|undefined} [stripeConfigurationError] Any error that occured trying to load the configuration
  * @param {string} [locale] The locale, like 'en-us'. Stripe will auto-detect if not set.
@@ -556,7 +550,6 @@ export function StripeHookProvider( {
  * - stripeConfiguration: the object containing the data returned by the wpcom stripe configuration endpoint
  * - isStripeLoading: a boolean that is true if stripe is currently being loaded
  * - stripeLoadingError: an optional object that will be set if there is an error loading stripe
- *
  * @returns {StripeData} See above
  */
 export function useStripe(): StripeData {
@@ -602,7 +595,6 @@ export function withStripeProps< P >( WrappedComponent: ComponentType< P > ) {
  * Transforms a locale like en-us to a Stripe supported locale
  *
  * See https://stripe.com/docs/js/appendix/supported_locales
- *
  * @param {string} locale A locale string like 'en-us'
  * @returns {string} A stripe-supported locale string like 'en'
  */

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -78,7 +78,7 @@ export interface UseStripeJs {
 	stripeLoadingError: StripeLoadingError;
 }
 
-export type GetStripeConfigurationArgs = { country?: string };
+export type GetStripeConfigurationArgs = { country?: string; payment_partner?: string };
 export type GetStripeSetupIntentId = () => Promise< {
 	setup_intent_id: StripeSetupIntentId | undefined;
 } >;
@@ -639,6 +639,57 @@ function getStripeLocaleForLocale( locale: string | null | undefined ): string {
 		return 'auto';
 	}
 	return stripeLocale;
+}
+
+/**
+ * Loads the Stripe JS library directly.
+ *
+ * Unlike `StripeHookProvider` and `useStripe`, this does not keep any state,
+ * so try not to call it too often.
+ *
+ * This can be useful when you need a different stripe object (eg: for a
+ * different country) than the one in the provider, or if you cannot easily use
+ * the provider.
+ *
+ * If `country` is provided, it will be used to determine which Stripe account
+ * to load. If `paymentPartner` is provided, it will be used instead. If
+ * neither is provided, the geolocation will be used.
+ */
+export async function loadStripeLibrary( {
+	country,
+	paymentPartner,
+	locale,
+	fetchStripeConfiguration,
+}: {
+	country?: string;
+	paymentPartner?: string;
+	locale?: string;
+	fetchStripeConfiguration: GetStripeConfiguration;
+} ): Promise< Stripe > {
+	const stripeConfiguration = await fetchStripeConfiguration( {
+		country,
+		payment_partner: paymentPartner,
+	} );
+	if (
+		! stripeConfiguration.js_url ||
+		! stripeConfiguration.public_key ||
+		! stripeConfiguration.processor_id
+	) {
+		throw new StripeConfigurationError(
+			'Error loading payment method configuration. Received invalid data from the server.'
+		);
+	}
+
+	const stripeLocale = getStripeLocaleForLocale( locale );
+	const stripe = await loadStripe( stripeConfiguration.public_key, {
+		locale: stripeLocale as StripeElementLocale,
+	} );
+
+	if ( ! stripe ) {
+		throw new StripeConfigurationError( 'Error loading payment method processing library.' );
+	}
+
+	return stripe;
 }
 
 // See https://usehooks.com/useMemoCompare/


### PR DESCRIPTION
When checkout loads, it uses the `StripeHookProvider` component to load a Stripe configuration, using that to create the stripe.js object necessary to render the new credit card form. When that happens, the configuration uses the user's geolocation to determine a country code that it then maps to a Stripe account. So if the user is geolocated in the UK, any credit card they add will be sent to the Stripe Ireland account. Only this geolocation matters in determining the account; self-reported tax location and currency are not factored in.

But the stripe.js object is used for other things, too. Notably, it is used to confirm the 3DS challenge from cards that require it. In order to for that to work, the confirmation must be sent to the Stripe account where the card is saved.

If a saved card's Stripe account differs from the one created when checkout loads (eg: if the card was added when the user was in a different geolocation), then the confirmation will fail with the cryptic error `No such payment_intent`.

## Proposed Changes

In this PR we make a new stripe.js object when confirming the 3DS challenge of an existing card to guarantee that we use the Stripe account matching that card.

Requires D121710-code

Fixes https://github.com/Automattic/payments-shilling/issues/2020

Before:

<img width="871" alt="Screenshot 2023-09-13 at 7 50 07 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/504ad9d6-df8c-4234-899e-c628db708f2b">

After:

<img width="446" alt="Screenshot 2023-09-13 at 7 50 35 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/3831455a-852e-44b9-aa2f-94d1e0c00edc">

## Testing Instructions

- First, apply D121710-code and point public-api to your sandbox.
- Visit `/me/purchases/add-payment-method` and add a new [3DS test credit card](https://stripe.com/docs/testing#regulatory-cards) like `4000000000003220`. This card will be saved on a Stripe account based on your current geolocation. You can verify this using Payments Admin. `stripe` is Stripe US, `stripe_ie` is Stripe IE, `stripe_ca` is Stripe CA, etc.
- Set your geolocated country code to a different country. You can do this with a VPN or by changing the Stripe configuration endpoint on your sandbox. See D121710-code for instructions.
- Add a product to your cart and visit checkout. Make sure that you've changed your geolocation before this step!
- Select the card you saved above as the payment method and submit the purchase.
- Verify that you see the test 3DS confirmation dialog and not an error. You do not need to confirm the payment and can safely press "Fail" at this point.