### PR TITLE
 Paid Stats: Add event tracking to the new single item purchase pages

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
@@ -2,6 +2,7 @@ import { Button as CalypsoButton } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
@@ -16,6 +17,7 @@ interface CommercialPurchaseProps {
 	adminUrl: string;
 	redirectUri: string;
 	from: string;
+	type: string;
 }
 
 const CommercialPurchase = ( {
@@ -26,6 +28,7 @@ const CommercialPurchase = ( {
 	adminUrl,
 	redirectUri,
 	from,
+	type,
 }: CommercialPurchaseProps ) => {
 	const translate = useTranslate();
 
@@ -66,9 +69,10 @@ const CommercialPurchase = ( {
 			<ButtonComponent
 				variant="primary"
 				primary={ isWPCOMSite ? true : undefined }
-				onClick={ () =>
-					gotoCheckoutPage( { from, type: 'commercial', siteSlug, adminUrl, redirectUri } )
-				}
+				onClick={ () => {
+					recordTracksEvent( `${ type }_stats_purchase_commercial_plan_selected` );
+					gotoCheckoutPage( { from, type: 'commercial', siteSlug, adminUrl, redirectUri } );
+				} }
 			>
 				{ translate( 'Get Jetpack Stats' ) }
 			</ButtonComponent>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -7,6 +7,7 @@ import formatCurrency from '@automattic/format-currency';
 import { Button, CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
@@ -31,6 +32,7 @@ interface PersonalPurchaseProps {
 	redirectUri: string;
 	from: string;
 	isStandalone?: boolean;
+	type: string;
 }
 
 const PersonalPurchase = ( {
@@ -45,7 +47,11 @@ const PersonalPurchase = ( {
 	adminUrl,
 	redirectUri,
 	from,
+<<<<<<< HEAD
 	isStandalone,
+=======
+	type,
+>>>>>>> 2fbdeb2c8d (add type & tracks events to personal purchase)
 }: PersonalPurchaseProps ) => {
 	const translate = useTranslate();
 	const [ isAdsChecked, setAdsChecked ] = useState( false );
@@ -193,9 +199,10 @@ const PersonalPurchase = ( {
 					variant="primary"
 					primary={ isWPCOMSite ? true : undefined }
 					disabled={ ! isAdsChecked || ! isSellingChecked || ! isBusinessChecked }
-					onClick={ () =>
-						gotoCheckoutPage( { from, type: 'free', siteSlug, adminUrl, redirectUri } )
-					}
+					onClick={ () => {
+						recordTracksEvent( `${ type }_stats_free_plan_selected` );
+						gotoCheckoutPage( { from, type: 'free', siteSlug, adminUrl, redirectUri } );
+					} }
 				>
 					{ translate( 'Continue with Jetpack Stats for free' ) }
 				</ButtonComponent>
@@ -203,7 +210,8 @@ const PersonalPurchase = ( {
 				<ButtonComponent
 					variant="primary"
 					primary={ isWPCOMSite ? true : undefined }
-					onClick={ () =>
+					onClick={ () => {
+						recordTracksEvent( 'jetpack_stats_personal_plan_selected' );
 						gotoCheckoutPage( {
 							from,
 							type: 'pwyw',
@@ -211,8 +219,8 @@ const PersonalPurchase = ( {
 							adminUrl,
 							redirectUri,
 							price: subscriptionValue / MIN_STEP_SPLITS,
-						} )
-					}
+						} );
+					} }
 				>
 					{ isStandalone ? translate( 'Get Stats Personal' ) : translate( 'Get Jetpack Stats' ) }
 				</ButtonComponent>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -195,6 +195,7 @@ const PersonalPurchase = ( {
 				<ButtonComponent
 					variant="primary"
 					primary={ isWPCOMSite ? true : undefined }
+					disabled={ ! isAdsChecked || ! isSellingChecked || ! isBusinessChecked }
 					onClick={ () => {
 						recordTracksEvent( `${ type }_stats_free_plan_selected` );
 						gotoCheckoutPage( { from, type: 'free', siteSlug, adminUrl, redirectUri } );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -47,11 +47,8 @@ const PersonalPurchase = ( {
 	adminUrl,
 	redirectUri,
 	from,
-<<<<<<< HEAD
 	isStandalone,
-=======
 	type,
->>>>>>> 2fbdeb2c8d (add type & tracks events to personal purchase)
 }: PersonalPurchaseProps ) => {
 	const translate = useTranslate();
 	const [ isAdsChecked, setAdsChecked ] = useState( false );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -195,7 +195,6 @@ const PersonalPurchase = ( {
 				<ButtonComponent
 					variant="primary"
 					primary={ isWPCOMSite ? true : undefined }
-					disabled={ ! isAdsChecked || ! isSellingChecked || ! isBusinessChecked }
 					onClick={ () => {
 						recordTracksEvent( `${ type }_stats_free_plan_selected` );
 						gotoCheckoutPage( { from, type: 'free', siteSlug, adminUrl, redirectUri } );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -211,7 +211,7 @@ const PersonalPurchase = ( {
 					variant="primary"
 					primary={ isWPCOMSite ? true : undefined }
 					onClick={ () => {
-						recordTracksEvent( 'jetpack_stats_personal_plan_selected' );
+						recordTracksEvent( `${ type }_stats_personal_plan_selected` );
 						gotoCheckoutPage( {
 							from,
 							type: 'pwyw',

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -91,9 +91,7 @@ const StatsCommercialPurchase = ( {
 	const [ isSellingChecked, setSellingChecked ] = useState( false );
 	const [ isBusinessChecked, setBusinessChecked ] = useState( false );
 
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-
-	const handleClick = ( event: React.MouseEvent, isOdysseyStats: boolean ) => {
+	const handleClick = ( event: React.MouseEvent ) => {
 		const emailSubject = translate( 'Jetpack Stats Commercial Classification Dispute' );
 		const emailBody = `Hi Jetpack Team,\n
 I'm writing to dispute the classification of my site '${ siteSlug }' as commercial.\n
@@ -108,8 +106,6 @@ Thanks\n\n`;
 		) }&body=${ encodeURIComponent( emailBody ) }`;
 
 		event.preventDefault();
-
-		const type = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 
 		recordTracksEvent( `${ type }_stats_purchase_commercial_update_classification_clicked` );
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -72,6 +72,9 @@ interface StatsPersonalPurchaseProps {
 
 const COMPONENT_CLASS_NAME = 'stats-purchase-single';
 
+const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+const type = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
+
 const StatsCommercialPurchase = ( {
 	siteId,
 	siteSlug,
@@ -241,6 +244,7 @@ const StatsPersonalPurchase = ( {
 				redirectUri={ redirectUri }
 				from={ from }
 				isStandalone={ true }
+				type={ type }
 			/>
 		</>
 	);

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -178,7 +178,7 @@ Thanks\n\n`;
 									<Button
 										variant="secondary"
 										disabled={ ! isAdsChecked || ! isSellingChecked || ! isBusinessChecked }
-										onClick={ ( e: React.MouseEvent ) => handleClick( e, isOdysseyStats ) }
+										onClick={ ( e: React.MouseEvent ) => handleClick( e ) }
 									>
 										{ translate( 'Request update' ) }
 									</Button>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -31,6 +31,7 @@ interface StatsCommercialPurchaseProps {
 	redirectUri: string;
 	from: string;
 	showClassificationDispute?: boolean;
+	type: string;
 }
 
 interface StatsSingleItemPagePurchaseProps {
@@ -299,6 +300,7 @@ const StatsSingleItemPagePurchase = ( {
 				redirectUri={ redirectUri }
 				from={ from }
 				showClassificationDispute={ !! isCommercial }
+				type={ type }
 			/>
 		</StatsSingleItemPagePurchaseFrame>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

fixes #81700 

## Proposed Changes

* Add tracks event tracking to the new single-item purchase pages (personal and commercial) in three locations:
	- `${ type }_stats_purchase_commercial_plan_selected`
	- `${ type }_stats_free_plan_selected`
	- `${ type }_stats_personal_plan_selected`
	
* _note: `${type}` can be `jetpack_odyssey` | `calypso`_

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This PR is only adding event tracking and one tiny change to where a variable is declared. So mostly check that the code looks good and check the naming conventions of the tracks events. 
* Tracks events can be tested by taking the following steps:
	- add `localStorage.setItem( 'debug', 'calypso:analytics*' );` in the console & hit enter. You will see `undefined`
	- enable all items in the filters by clicking on “All levels” and making sure all of the items are checked.
	- refresh the page
	- Click the funnel icon in the top menu and filter for events with the word “recording.” This removes unnecessary noise.
	- Take the action (eg go to a single purchase page and click the `Get Stats Personal` button or the `Get Stats Commercial` button. 
	- Confirm that the expected tracks event fires
	
![image](https://github.com/Automattic/wp-calypso/assets/30754158/4d612f1f-06a6-418e-b1f8-5fce5e051ebf)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?