### PR TITLE
Domain management: add actions to ellipsis menu

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -12,6 +12,7 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { handleRenewNowClick, shouldRenderExpiringCreditCard } from 'calypso/lib/purchases';
 import { Purchase } from 'calypso/lib/purchases/types';
+import { useOdieAssistantContext } from 'calypso/odie/context';
 import { useDispatch } from 'calypso/state';
 import DomainHeader from '../components/domain-header';
 import OptionsDomainButton from './options-domain-button';
@@ -25,6 +26,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 	const { domains } = useDomainsTable();
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const { sendNudge } = useOdieAssistantContext();
 
 	const item = {
 		label: translate( 'All Domains' ),
@@ -91,6 +93,15 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					domains={ domains }
 					isAllSitesView
 					domainStatusPurchaseActions={ purchaseActions }
+					onDomainAction={ ( action, domain ) => {
+						if ( action === 'manage-dns-settings' ) {
+							sendNudge( {
+								nudge: 'dns-settings',
+								initialMessage: `I see you want to change your DNS settings for your domain ${ domain.name }. That's a complex thing, but I can guide you and help you at any moment.`,
+								context: { domain: domain.domain },
+							} );
+						}
+					} }
 				/>
 			</Main>
 			<UsePresalesChat />

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -63,6 +63,10 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 								context: { domain: domain.domain },
 							} );
 						}
+
+						if ( action === 'set-primary' ) {
+							// TODO
+						}
 					} }
 				/>
 			</Main>

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -6,6 +6,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useOdieAssistantContext } from 'calypso/odie/context';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import DomainHeader from '../components/domain-header';
@@ -20,6 +21,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const { data } = useSiteDomainsQuery( siteSlug );
 	const translate = useTranslate();
+	const { sendNudge } = useOdieAssistantContext();
 
 	const item = {
 		label: translate( 'Domains' ),
@@ -43,7 +45,20 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 			<Main className="bulk-domains-main">
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
-				<DomainsTable domains={ data?.domains } isAllSitesView={ false } siteSlug={ siteSlug } />
+				<DomainsTable
+					domains={ data?.domains }
+					isAllSitesView={ false }
+					siteSlug={ siteSlug }
+					onDomainAction={ ( action, domain ) => {
+						if ( action === 'manage-dns-settings' ) {
+							sendNudge( {
+								nudge: 'dns-settings',
+								initialMessage: `I see you want to change your DNS settings for your domain ${ domain.name }. That's a complex thing, but I can guide you and help you at any moment.`,
+								context: { domain: domain.domain },
+							} );
+						}
+					} }
+				/>
 			</Main>
 			<UsePresalesChat />
 		</>

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -8,6 +8,8 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useOdieAssistantContext } from 'calypso/odie/context';
 import { useSelector } from 'calypso/state';
+import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
+import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import DomainHeader from '../components/domain-header';
 import OptionsDomainButton from './options-domain-button';
@@ -19,6 +21,9 @@ interface BulkSiteDomainsProps {
 
 export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const userCanSetPrimaryDomains = useSelector(
+		( state ) => ! currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
+	);
 	const { data } = useSiteDomainsQuery( siteSlug );
 	const translate = useTranslate();
 	const { sendNudge } = useOdieAssistantContext();
@@ -49,6 +54,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 					domains={ data?.domains }
 					isAllSitesView={ false }
 					siteSlug={ siteSlug }
+					userCanSetPrimaryDomains={ userCanSetPrimaryDomains }
 					onDomainAction={ ( action, domain ) => {
 						if ( action === 'manage-dns-settings' ) {
 							sendNudge( {

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -1,14 +1,13 @@
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable } from '@automattic/domains-table';
 import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'react-redux';
 import { UsePresalesChat } from 'calypso/components/data/domain-management';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useOdieAssistantContext } from 'calypso/odie/context';
-import { useSelector } from 'calypso/state';
+import { useSelector, useDispatch } from 'calypso/state';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import {
@@ -16,7 +15,7 @@ import {
 	showUpdatePrimaryDomainSuccessNotice,
 } from 'calypso/state/domains/management/actions';
 import { setPrimaryDomain } from 'calypso/state/sites/domains/actions';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import DomainHeader from '../components/domain-header';
 import OptionsDomainButton from './options-domain-button';
 
@@ -26,6 +25,7 @@ interface BulkSiteDomainsProps {
 }
 
 export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
+	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const userCanSetPrimaryDomains = useSelector(
 		( state ) => ! currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
@@ -73,7 +73,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 
 						if ( action === 'set-primary' ) {
 							try {
-								await dispatch( setPrimaryDomain( siteSlug, domain.domain ) );
+								await dispatch( setPrimaryDomain( siteId, domain.domain ) );
 								dispatch( showUpdatePrimaryDomainSuccessNotice( domain.name ) );
 							} catch ( error ) {
 								dispatch( showUpdatePrimaryDomainErrorNotice( ( error as Error ).message ) );

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -73,7 +73,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 
 						if ( action === 'set-primary' ) {
 							try {
-								await dispatch( setPrimaryDomain( siteId, domain.domain ) );
+								await dispatch( setPrimaryDomain( siteId as number, domain.domain ) );
 								dispatch( showUpdatePrimaryDomainSuccessNotice( domain.name ) );
 							} catch ( error ) {
 								dispatch( showUpdatePrimaryDomainErrorNotice( ( error as Error ).message ) );

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
@@ -82,7 +82,7 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 
 			<div>
 				<span className="domains-table-mobile-card-label"> { __( 'Status' ) } </span>
-				{ isLoadingSiteDomainsDetails ? (
+				{ ! currentDomainData || isLoadingSiteDomainsDetails ? (
 					<LoadingPlaceholder style={ { width: '50%' } } />
 				) : (
 					<DomainsTableStatusCell

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
@@ -57,15 +57,17 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 				</div>
 
 				<div>
-					<DomainsTableRowActions
-						siteSlug={ siteSlug }
-						domain={ currentDomainData }
-						isAllSitesView={ isAllSitesView }
-						canSetPrimaryDomainForSite={
-							site?.plan?.features.active.includes( FEATURE_SET_PRIMARY_CUSTOM_DOMAIN ) ?? false
-						}
-						isSiteOnFreePlan={ site?.plan?.is_free ?? true }
-					/>
+					{ currentDomainData && (
+						<DomainsTableRowActions
+							siteSlug={ siteSlug }
+							domain={ currentDomainData }
+							isAllSitesView={ isAllSitesView }
+							canSetPrimaryDomainForSite={
+								site?.plan?.features.active.includes( FEATURE_SET_PRIMARY_CUSTOM_DOMAIN ) ?? false
+							}
+							isSiteOnFreePlan={ site?.plan?.is_free ?? true }
+						/>
+					) }
 				</div>
 			</div>
 

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
@@ -1,3 +1,4 @@
+import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
 import { LoadingPlaceholder } from '@automattic/components';
 import { PartialDomainData } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
@@ -19,9 +20,9 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 
 	const {
 		ref,
+		site,
 		siteSlug,
 		currentDomainData,
-		userCanAddSiteToDomain,
 		isSelected,
 		handleSelectDomain,
 		domainStatusPurchaseActions,
@@ -29,6 +30,7 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 		shouldDisplayPrimaryDomainLabel,
 		showBulkActions,
 		isLoadingSiteDomainsDetails,
+		isAllSitesView,
 	} = useDomainRow( domain );
 
 	return (
@@ -55,9 +57,13 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 
 				<div>
 					<DomainsTableRowActions
-						canConnectDomainToASite={ userCanAddSiteToDomain }
 						siteSlug={ siteSlug }
-						domainName={ domain.domain }
+						domain={ currentDomainData }
+						isAllSitesView={ isAllSitesView }
+						canSetPrimaryDomainForSite={
+							site?.plan?.features.active.includes( FEATURE_SET_PRIMARY_CUSTOM_DOMAIN ) ?? false
+						}
+						isSiteOnFreePlan={ site?.plan?.is_free ?? true }
 					/>
 				</div>
 			</div>

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
@@ -6,6 +6,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { PrimaryDomainLabel } from '../primary-domain-label/index';
 import { useDomainRow } from '../use-domain-row';
+import { ResponseDomain } from '../utils/types';
 import { DomainsTableEmailIndicator } from './domains-table-email-indicator';
 import { DomainsTableRegisteredUntilCell } from './domains-table-registered-until-cell';
 import { DomainsTableRowActions } from './domains-table-row-actions';
@@ -87,7 +88,7 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 				) : (
 					<DomainsTableStatusCell
 						siteSlug={ siteSlug }
-						currentDomainData={ currentDomainData }
+						currentDomainData={ currentDomainData as ResponseDomain }
 						domainStatusPurchaseActions={ domainStatusPurchaseActions }
 						pendingUpdates={ pendingUpdates }
 					/>

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -2,8 +2,8 @@ import { Gridicon } from '@automattic/components';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { ComponentType } from 'react';
-import { type as domainTypes } from '../utils/constants';
-import { domainManagementLink } from '../utils/paths';
+import { type as domainTypes, transferStatus } from '../utils/constants';
+import { domainMagementDNS, domainManagementLink } from '../utils/paths';
 import { ResponseDomain } from '../utils/types';
 
 interface MenuItemLinkProps extends Omit< React.ComponentProps< typeof MenuItem >, 'href' > {
@@ -26,6 +26,10 @@ export const DomainsTableRowActions = ( {
 	const { __ } = useI18n();
 
 	const canConnectDomainToASite = domain.currentUserCanCreateSiteFromDomainOnly;
+	const canManageDNS =
+		domain.canManageDnsRecords &&
+		domain.transferStatus !== transferStatus.PENDING_ASYNC &&
+		domain.type !== domainTypes.SITE_REDIRECT;
 
 	return (
 		<DropdownMenu
@@ -38,6 +42,11 @@ export const DomainsTableRowActions = ( {
 					<MenuItemLink href={ domainManagementLink( domain, siteSlug, isAllSitesView ) }>
 						{ domain.type === domainTypes.TRANSFER ? __( 'View transfer' ) : __( 'View settings' ) }
 					</MenuItemLink>
+					{ canManageDNS && (
+						<MenuItemLink href={ domainMagementDNS( siteSlug, domain.name ) }>
+							{ __( 'Manage DNS' ) }
+						</MenuItemLink>
+					) }
 					{ canConnectDomainToASite && (
 						<MenuItemLink
 							href={ domainManagementTransferToOtherSiteLink( siteSlug, domain.domain ) }

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -9,6 +9,7 @@ import {
 	domainMagementDNS,
 	domainManagementEditContactInfo,
 	domainManagementLink,
+	domainManagementTransferToOtherSiteLink,
 } from '../utils/paths';
 import { ResponseDomain } from '../utils/types';
 
@@ -73,7 +74,3 @@ export const DomainsTableRowActions = ( {
 		</DropdownMenu>
 	);
 };
-
-export function domainManagementTransferToOtherSiteLink( siteSlug: string, domainName: string ) {
-	return `/domains/manage/all/${ domainName }/transfer/other-site/${ siteSlug }`;
-}

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -12,6 +12,9 @@ import {
 	domainManagementTransferToOtherSiteLink,
 } from '../utils/paths';
 import { ResponseDomain } from '../utils/types';
+import { useDomainsTable } from './domains-table';
+
+export type DomainAction = 'manage-dns-settings';
 
 interface MenuItemLinkProps extends Omit< React.ComponentProps< typeof MenuItem >, 'href' > {
 	href?: string;
@@ -30,6 +33,7 @@ export const DomainsTableRowActions = ( {
 	siteSlug,
 	isAllSitesView,
 }: DomainsTableRowActionsProps ) => {
+	const { onDomainAction } = useDomainsTable();
 	const { __ } = useI18n();
 
 	const canConnectDomainToASite = domain.currentUserCanCreateSiteFromDomainOnly;
@@ -53,7 +57,10 @@ export const DomainsTableRowActions = ( {
 						{ domain.type === domainTypes.TRANSFER ? __( 'View transfer' ) : __( 'View settings' ) }
 					</MenuItemLink>
 					{ canManageDNS && (
-						<MenuItemLink href={ domainMagementDNS( siteSlug, domain.name ) }>
+						<MenuItemLink
+							onClick={ () => onDomainAction?.( 'manage-dns-settings', domain ) }
+							href={ domainMagementDNS( siteSlug, domain.name ) }
+						>
 							{ __( 'Manage DNS' ) }
 						</MenuItemLink>
 					) }

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -3,7 +3,13 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { ComponentType } from 'react';
 import { type as domainTypes, transferStatus } from '../utils/constants';
-import { domainMagementDNS, domainManagementLink } from '../utils/paths';
+import { isDomainInGracePeriod } from '../utils/is-in-grace-period';
+import { isDomainUpdateable } from '../utils/is-updateable';
+import {
+	domainMagementDNS,
+	domainManagementEditContactInfo,
+	domainManagementLink,
+} from '../utils/paths';
 import { ResponseDomain } from '../utils/types';
 
 interface MenuItemLinkProps extends Omit< React.ComponentProps< typeof MenuItem >, 'href' > {
@@ -30,6 +36,9 @@ export const DomainsTableRowActions = ( {
 		domain.canManageDnsRecords &&
 		domain.transferStatus !== transferStatus.PENDING_ASYNC &&
 		domain.type !== domainTypes.SITE_REDIRECT;
+	const canManageContactInfo =
+		domain.type === domainTypes.REGISTERED &&
+		( isDomainUpdateable( domain ) || isDomainInGracePeriod( domain ) );
 
 	return (
 		<DropdownMenu
@@ -45,6 +54,11 @@ export const DomainsTableRowActions = ( {
 					{ canManageDNS && (
 						<MenuItemLink href={ domainMagementDNS( siteSlug, domain.name ) }>
 							{ __( 'Manage DNS' ) }
+						</MenuItemLink>
+					) }
+					{ canManageContactInfo && (
+						<MenuItemLink href={ domainManagementEditContactInfo( siteSlug, domain.name ) }>
+							{ __( 'Manage contact information' ) }
 						</MenuItemLink>
 					) }
 					{ canConnectDomainToASite && (

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -2,6 +2,8 @@ import { Gridicon } from '@automattic/components';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { ComponentType } from 'react';
+import { type as domainTypes } from '../utils/constants';
+import { domainManagementLink } from '../utils/paths';
 import { ResponseDomain } from '../utils/types';
 
 interface MenuItemLinkProps extends Omit< React.ComponentProps< typeof MenuItem >, 'href' > {
@@ -13,9 +15,14 @@ const MenuItemLink = MenuItem as ComponentType< MenuItemLinkProps >;
 interface DomainsTableRowActionsProps {
 	siteSlug: string;
 	domain: ResponseDomain;
+	isAllSitesView: boolean;
 }
 
-export const DomainsTableRowActions = ( { domain, siteSlug }: DomainsTableRowActionsProps ) => {
+export const DomainsTableRowActions = ( {
+	domain,
+	siteSlug,
+	isAllSitesView,
+}: DomainsTableRowActionsProps ) => {
 	const { __ } = useI18n();
 
 	const canConnectDomainToASite = domain.currentUserCanCreateSiteFromDomainOnly;
@@ -28,6 +35,9 @@ export const DomainsTableRowActions = ( { domain, siteSlug }: DomainsTableRowAct
 		>
 			{ () => (
 				<MenuGroup>
+					<MenuItemLink href={ domainManagementLink( domain, siteSlug, isAllSitesView ) }>
+						{ domain.type === domainTypes.TRANSFER ? __( 'View transfer' ) : __( 'View settings' ) }
+					</MenuItemLink>
 					{ canConnectDomainToASite && (
 						<MenuItemLink
 							href={ domainManagementTransferToOtherSiteLink( siteSlug, domain.domain ) }

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -2,6 +2,7 @@ import { Gridicon } from '@automattic/components';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { ComponentType } from 'react';
+import { ResponseDomain } from '../utils/types';
 
 interface MenuItemLinkProps extends Omit< React.ComponentProps< typeof MenuItem >, 'href' > {
 	href?: string;
@@ -10,21 +11,14 @@ interface MenuItemLinkProps extends Omit< React.ComponentProps< typeof MenuItem 
 const MenuItemLink = MenuItem as ComponentType< MenuItemLinkProps >;
 
 interface DomainsTableRowActionsProps {
-	canConnectDomainToASite: boolean;
 	siteSlug: string;
-	domainName: string;
+	domain: ResponseDomain;
 }
 
-export const DomainsTableRowActions = ( {
-	canConnectDomainToASite,
-	siteSlug,
-	domainName,
-}: DomainsTableRowActionsProps ) => {
+export const DomainsTableRowActions = ( { domain, siteSlug }: DomainsTableRowActionsProps ) => {
 	const { __ } = useI18n();
 
-	if ( ! canConnectDomainToASite ) {
-		return null;
-	}
+	const canConnectDomainToASite = domain.currentUserCanCreateSiteFromDomainOnly;
 
 	return (
 		<DropdownMenu
@@ -35,7 +29,9 @@ export const DomainsTableRowActions = ( {
 			{ () => (
 				<MenuGroup>
 					{ canConnectDomainToASite && (
-						<MenuItemLink href={ domainManagementTransferToOtherSiteLink( siteSlug, domainName ) }>
+						<MenuItemLink
+							href={ domainManagementTransferToOtherSiteLink( siteSlug, domain.domain ) }
+						>
 							{ __( 'Connect to an existing site' ) }
 						</MenuItemLink>
 					) }

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -18,7 +18,7 @@ import { shouldUpgradeToMakeDomainPrimary } from '../utils/should-upgrade-to-mak
 import { ResponseDomain } from '../utils/types';
 import { useDomainsTable } from './domains-table';
 
-export type DomainAction = 'manage-dns-settings';
+export type DomainAction = 'manage-dns-settings' | 'set-primary';
 
 interface MenuItemLinkProps extends Omit< React.ComponentProps< typeof MenuItem >, 'href' > {
 	href?: string;
@@ -63,8 +63,8 @@ export const DomainsTableRowActions = ( {
 				isSiteOnFreePlan,
 			} )
 		) &&
-		isRecentlyRegistered( domain.registrationDate ) &&
-		! domain.pointsToWpcom;
+		! isRecentlyRegistered( domain.registrationDate ) &&
+		domain.pointsToWpcom;
 	const canTransferToWPCOM =
 		domain.type === domainTypes.MAPPED && domain.isEligibleForInboundTransfer;
 
@@ -93,7 +93,7 @@ export const DomainsTableRowActions = ( {
 						</MenuItemLink>
 					) }
 					{ canMakePrimarySiteAddress && (
-						<MenuItemLink href={ domainManagementEditContactInfo( siteSlug, domain.name ) }>
+						<MenuItemLink onClick={ () => onDomainAction?.( 'set-primary', domain ) }>
 							{ __( 'Make primary site address' ) }
 						</MenuItemLink>
 					) }

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -75,7 +75,7 @@ export const DomainsTableRowActions = ( {
 			label={ __( 'Domain actions' ) }
 		>
 			{ () => (
-				<MenuGroup>
+				<MenuGroup className="domains-table-row__actions-group">
 					<MenuItemLink href={ domainManagementLink( domain, siteSlug, isAllSitesView ) }>
 						{ domain.type === domainTypes.TRANSFER ? __( 'View transfer' ) : __( 'View settings' ) }
 					</MenuItemLink>

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -3,7 +3,7 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { ComponentType } from 'react';
 import { canSetAsPrimary } from '../utils/can-set-as-primary';
-import { type as domainTypes, transferStatus } from '../utils/constants';
+import { type as domainTypes, transferStatus, useMyDomainInputMode } from '../utils/constants';
 import { isDomainInGracePeriod } from '../utils/is-in-grace-period';
 import { isRecentlyRegistered } from '../utils/is-recently-registered';
 import { isDomainUpdateable } from '../utils/is-updateable';
@@ -12,6 +12,7 @@ import {
 	domainManagementEditContactInfo,
 	domainManagementLink,
 	domainManagementTransferToOtherSiteLink,
+	domainUseMyDomain,
 } from '../utils/paths';
 import { shouldUpgradeToMakeDomainPrimary } from '../utils/should-upgrade-to-make-domain-primary';
 import { ResponseDomain } from '../utils/types';
@@ -64,6 +65,8 @@ export const DomainsTableRowActions = ( {
 		) &&
 		isRecentlyRegistered( domain.registrationDate ) &&
 		! domain.pointsToWpcom;
+	const canTransferToWPCOM =
+		domain.type === domainTypes.MAPPED && domain.isEligibleForInboundTransfer;
 
 	return (
 		<DropdownMenu
@@ -92,6 +95,17 @@ export const DomainsTableRowActions = ( {
 					{ canMakePrimarySiteAddress && (
 						<MenuItemLink href={ domainManagementEditContactInfo( siteSlug, domain.name ) }>
 							{ __( 'Make primary site address' ) }
+						</MenuItemLink>
+					) }
+					{ canTransferToWPCOM && (
+						<MenuItemLink
+							href={ domainUseMyDomain(
+								siteSlug,
+								domain.name,
+								useMyDomainInputMode.transferDomain
+							) }
+						>
+							{ __( 'Transfer to WordPress.com' ) }
 						</MenuItemLink>
 					) }
 					{ canConnectDomainToASite && (

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -74,7 +74,7 @@ export const DomainsTableRowActions = ( {
 			icon={ <Gridicon icon="ellipsis" /> }
 			label={ __( 'Domain actions' ) }
 		>
-			{ () => (
+			{ ( { onClose } ) => (
 				<MenuGroup className="domains-table-row__actions-group">
 					<MenuItemLink href={ domainManagementLink( domain, siteSlug, isAllSitesView ) }>
 						{ domain.type === domainTypes.TRANSFER ? __( 'View transfer' ) : __( 'View settings' ) }
@@ -93,7 +93,12 @@ export const DomainsTableRowActions = ( {
 						</MenuItemLink>
 					) }
 					{ canMakePrimarySiteAddress && (
-						<MenuItemLink onClick={ () => onDomainAction?.( 'set-primary', domain ) }>
+						<MenuItemLink
+							onClick={ () => {
+								onDomainAction?.( 'set-primary', domain );
+								onClose();
+							} }
+						>
 							{ __( 'Make primary site address' ) }
 						</MenuItemLink>
 					) }

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -125,11 +125,17 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 			</td>
 			<td></td>
 			<td className="domains-table-row__actions">
-				<DomainsTableRowActions
-					canConnectDomainToASite={ userCanAddSiteToDomain }
-					siteSlug={ siteSlug }
-					domainName={ domain.domain }
-				/>
+				{ currentDomainData && (
+					<DomainsTableRowActions
+						siteSlug={ siteSlug }
+						domain={ currentDomainData }
+						isAllSitesView={ isAllSitesView }
+						canSetPrimaryDomainForSite={
+							site?.plan?.features.active.includes( FEATURE_SET_PRIMARY_CUSTOM_DOMAIN ) ?? false
+						}
+						isSiteOnFreePlan={ site?.plan?.is_free ?? true }
+					/>
+				) }
 			</td>
 		</tr>
 	);

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,3 +1,4 @@
+import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
 import { LoadingPlaceholder } from '@automattic/components';
 import { PartialDomainData } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -44,6 +44,7 @@ interface BaseDomainsTableProps {
 	) => Promise< SiteDomainsQueryFnData >;
 	fetchSite?: ( siteIdOrSlug: number | string | null | undefined ) => Promise< SiteDetails >;
 	onDomainAction?( action: DomainAction, domain: ResponseDomain ): void;
+	userCanSetPrimaryDomains?: boolean;
 }
 
 export type DomainsTablePropsNoChildren =
@@ -84,6 +85,7 @@ type Value = {
 	showBulkActions: boolean;
 	setShowBulkActions: ( showBulkActions: boolean ) => void;
 	onDomainAction: BaseDomainsTableProps[ 'onDomainAction' ];
+	userCanSetPrimaryDomains: BaseDomainsTableProps[ 'userCanSetPrimaryDomains' ];
 };
 
 const Context = createContext< Value | undefined >( undefined );
@@ -99,6 +101,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		domainStatusPurchaseActions,
 		children,
 		onDomainAction,
+		userCanSetPrimaryDomains,
 	} = props;
 
 	const [ { sortKey, sortDirection }, setSort ] = useState< {
@@ -334,6 +337,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		showBulkActions,
 		setShowBulkActions,
 		onDomainAction,
+		userCanSetPrimaryDomains,
 	};
 
 	return (

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -29,6 +29,8 @@ import { getDomainId } from '../get-domain-id';
 import { useDomainBulkUpdateStatus } from '../use-domain-bulk-update-status';
 import { shouldHideOwnerColumn } from '../utils';
 import { DomainStatusPurchaseActions } from '../utils/resolve-domain-status';
+import { ResponseDomain } from '../utils/types';
+import { DomainAction } from './domains-table-row-actions';
 
 interface BaseDomainsTableProps {
 	domains: PartialDomainData[] | undefined;
@@ -41,6 +43,7 @@ interface BaseDomainsTableProps {
 		siteIdOrSlug: number | string | null | undefined
 	) => Promise< SiteDomainsQueryFnData >;
 	fetchSite?: ( siteIdOrSlug: number | string | null | undefined ) => Promise< SiteDetails >;
+	onDomainAction?( action: DomainAction, domain: ResponseDomain ): void;
 }
 
 export type DomainsTablePropsNoChildren =
@@ -80,6 +83,7 @@ type Value = {
 	handleRestartDomainStatusPolling: () => void;
 	showBulkActions: boolean;
 	setShowBulkActions: ( showBulkActions: boolean ) => void;
+	onDomainAction: BaseDomainsTableProps[ 'onDomainAction' ];
 };
 
 const Context = createContext< Value | undefined >( undefined );
@@ -94,6 +98,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		isAllSitesView,
 		domainStatusPurchaseActions,
 		children,
+		onDomainAction,
 	} = props;
 
 	const [ { sortKey, sortDirection }, setSort ] = useState< {
@@ -328,6 +333,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		handleRestartDomainStatusPolling,
 		showBulkActions,
 		setShowBulkActions,
+		onDomainAction,
 	};
 
 	return (

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -119,6 +119,19 @@
 
 	.domains-table-row__actions {
 		text-align: right;
+
+	}
+}
+
+.domains-table-row__actions-group {
+	.components-menu-item__button:hover {
+		background-color: var(--color-primary);
+		border: 0;
+		box-shadow: none;
+		color: var(--color-text-inverted);
+	}
+	a:visited {
+		color: var(--color-neutral-70);
 	}
 }
 

--- a/packages/domains-table/src/utils/can-set-as-primary.ts
+++ b/packages/domains-table/src/utils/can-set-as-primary.ts
@@ -1,0 +1,14 @@
+import { ResponseDomain } from './types';
+
+export function canSetAsPrimary(
+	domain: ResponseDomain,
+	shouldUpgradeToMakePrimary: boolean
+): boolean {
+	return (
+		domain &&
+		domain.canSetAsPrimary &&
+		! domain.isPrimary &&
+		! shouldUpgradeToMakePrimary &&
+		! domain.aftermarketAuction
+	);
+}

--- a/packages/domains-table/src/utils/constants.ts
+++ b/packages/domains-table/src/utils/constants.ts
@@ -4,7 +4,7 @@ export const type = {
 	SITE_REDIRECT: 'redirect',
 	WPCOM: 'wpcom',
 	TRANSFER: 'transfer',
-};
+} as const;
 
 export const useMyDomainInputMode = {
 	domainInput: 'domain-input',

--- a/packages/domains-table/src/utils/get-domain-type.ts
+++ b/packages/domains-table/src/utils/get-domain-type.ts
@@ -1,7 +1,9 @@
 import { DomainData } from '@automattic/data-stores';
 import { type as domainTypes } from './constants';
 
-export function getDomainType( domainFromApi: DomainData ) {
+export function getDomainType(
+	domainFromApi: Pick< DomainData, 'type' | 'wpcom_domain' | 'has_registration' >
+) {
 	if ( domainFromApi.type === 'redirect' ) {
 		return domainTypes.SITE_REDIRECT;
 	}

--- a/packages/domains-table/src/utils/is-in-grace-period.ts
+++ b/packages/domains-table/src/utils/is-in-grace-period.ts
@@ -1,0 +1,6 @@
+import moment from 'moment';
+import { ResponseDomain } from './types';
+
+export function isDomainInGracePeriod( domain: Pick< ResponseDomain, 'expiry' > ) {
+	return moment().subtract( 18, 'days' ) <= moment( domain.expiry );
+}

--- a/packages/domains-table/src/utils/is-updateable.ts
+++ b/packages/domains-table/src/utils/is-updateable.ts
@@ -1,0 +1,7 @@
+import { ResponseDomain } from './types';
+
+export function isDomainUpdateable(
+	domain: Pick< ResponseDomain, 'pendingTransfer' | 'expired' >
+) {
+	return ! domain.pendingTransfer && ! domain.expired;
+}

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -163,3 +163,7 @@ export function domainManagementEdit(
 export function isUnderEmailManagementAll( path: string ) {
 	return path?.startsWith( emailManagementAllSitesPrefix + '/' );
 }
+
+export function domainMagementDNS( siteName: string, domainName: string ) {
+	return domainManagementEditBase( siteName, domainName, 'dns' );
+}

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -1,11 +1,11 @@
 import { addQueryArgs } from '@wordpress/url';
 import { stringify } from 'qs';
-import type { PartialDomainData } from '@automattic/data-stores';
+import { ResponseDomain } from './types';
 
 export const emailManagementAllSitesPrefix = '/email/all';
 
 export function domainManagementLink(
-	{ domain, type }: PartialDomainData,
+	{ domain, type }: Pick< ResponseDomain, 'domain' | 'type' >,
 	siteSlug: string,
 	isAllSitesView: boolean
 ) {
@@ -29,7 +29,7 @@ export function domainManagementTransferToOtherSiteLink( siteSlug: string, domai
 	return `${ domainManagementAllRoot() }/${ domainName }/transfer/other-site/${ siteSlug }`;
 }
 
-function domainManagementViewSlug( type: PartialDomainData[ 'type' ] ) {
+function domainManagementViewSlug( type: ResponseDomain[ 'type' ] ) {
 	switch ( type ) {
 		case 'transfer':
 			return 'transfer/in';

--- a/packages/domains-table/src/utils/should-upgrade-to-make-domain-primary.ts
+++ b/packages/domains-table/src/utils/should-upgrade-to-make-domain-primary.ts
@@ -1,0 +1,30 @@
+import { type as domainTypes } from './constants';
+import { ResponseDomain } from './types';
+
+interface Attributes {
+	isDomainOnly: boolean;
+	canSetPrimaryDomainForSite: boolean;
+	userCanSetPrimaryDomains: boolean;
+	isSiteOnFreePlan: boolean;
+}
+
+export const shouldUpgradeToMakeDomainPrimary = (
+	domain: ResponseDomain,
+	{
+		isDomainOnly,
+		isSiteOnFreePlan,
+		userCanSetPrimaryDomains,
+		canSetPrimaryDomainForSite,
+	}: Attributes
+) => {
+	return (
+		! userCanSetPrimaryDomains &&
+		isSiteOnFreePlan &&
+		( domain.type === domainTypes.REGISTERED || domain.type === domainTypes.MAPPED ) &&
+		! isDomainOnly &&
+		! domain.isPrimary &&
+		! domain.isWPCOMDomain &&
+		! domain.isWpcomStagingDomain &&
+		! canSetPrimaryDomainForSite
+	);
+};

--- a/packages/domains-table/src/utils/types.ts
+++ b/packages/domains-table/src/utils/types.ts
@@ -5,7 +5,7 @@ export type CannotAddEmailReason = {
 	message: string;
 };
 
-export type DomainType = keyof typeof domainType;
+export type DomainType = ( typeof domainType )[ keyof typeof domainType ];
 
 interface EmailSubscription {
 	expiryDate?: string;


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3740.

## Proposed Changes

Achieves feature-parity with the old domains table.

<img width="256" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/27b48400-eab0-4967-8c88-a37007d4dc20">

### TODO

- Handle primary domain address switches
- Change color of menu items
- Add tests to ensure that items only appear under the right conditions
- Add testing instructions

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?