### PR TITLE
Fix the Sell flow in Onboarding is broken during the Atomic transfer step

### DIFF
--- a/client/landing/stepper/declarative-flow/plugin-bundle-data.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-data.ts
@@ -1,5 +1,6 @@
 import BusinessInfo from './internals/steps-repository/business-info';
 import CheckForWoo from './internals/steps-repository/check-for-woo';
+import ErrorStep from './internals/steps-repository/error-step';
 import ProcessingStep from './internals/steps-repository/processing-step';
 import StoreAddress from './internals/steps-repository/store-address';
 import WooConfirm from './internals/steps-repository/woo-confirm';
@@ -16,6 +17,7 @@ const pluginBundleSteps: Record< string, StepperStep[] > = {
 		{ slug: 'wooTransfer', component: WooTransfer },
 		{ slug: 'wooInstallPlugins', component: WooInstallPlugins },
 		{ slug: 'processing', component: ProcessingStep },
+		{ slug: 'error', component: ErrorStep },
 	],
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1693911664654279-slack-C02FMH4G8, https://github.com/Automattic/wp-calypso/pull/81711

## Proposed Changes

* Add the retry mechanism to the status of the software install as the site might not become an atomic site right away after the transfer is completed. See p1694664847170059/1693911664.654279-slack-C02FMH4G8 for more context.
* Add the error step to the plugin-bundle flow to display the error instead of the white screen

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new site on a Free plan.
2. In the Design Picker, choose a WooCommerce theme such as Tsubaki (you can find them in the Store tab).
3. Upgrade plan to Business.
4. Activate the theme.
5. Fill out the store details forms.
6. Confirm the domain change warning to trigger the Atomic transfer.
7. Ensure everything works well and you won't see the WSOD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?