### PR TITLE
Plugin Management: Show the plugin version range on the plugin details page

### DIFF
--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -19,7 +19,7 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder, isJetpackCloud } ) => {
 
 	const selectedSite = useSelector( getSelectedSite );
 
-	const { currentVersionsRange } = usePluginVersionInfo( plugin, selectedSite );
+	const { currentVersionsRange } = usePluginVersionInfo( plugin, selectedSite?.ID );
 
 	if ( isPlaceholder ) {
 		return <PluginDetailsHeaderPlaceholder />;

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -8,6 +8,8 @@ import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import usePluginVersionInfo from '../plugin-management-v2/hooks/use-plugin-version-info';
+
 import './style.scss';
 
 const PluginDetailsHeader = ( { plugin, isPlaceholder, isJetpackCloud } ) => {
@@ -16,6 +18,8 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder, isJetpackCloud } ) => {
 	const { localizePath } = useLocalizedPlugins();
 
 	const selectedSite = useSelector( getSelectedSite );
+
+	const { currentVersionsRange } = usePluginVersionInfo( plugin, selectedSite );
 
 	if ( isPlaceholder ) {
 		return <PluginDetailsHeaderPlaceholder />;
@@ -74,7 +78,10 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder, isJetpackCloud } ) => {
 				</div>
 				<div className="plugin-details-header__info">
 					<div className="plugin-details-header__info-title">{ translate( 'Version' ) }</div>
-					<div className="plugin-details-header__info-value">{ plugin.version }</div>
+					<div className="plugin-details-header__info-value">
+						{ currentVersionsRange?.min }
+						{ currentVersionsRange?.max && ` - ${ currentVersionsRange.max }` }
+					</div>
 				</div>
 				{ Boolean( plugin.active_installs ) && (
 					<div className="plugin-details-header__info">

--- a/client/my-sites/plugins/plugin-details-header/test/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/test/index.jsx
@@ -2,11 +2,26 @@
  * @jest-environment jsdom
  */
 import config from '@automattic/calypso-config';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
 import PluginDetailsHeader from 'calypso/my-sites/plugins/plugin-details-header';
+
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useSelector: jest.fn(),
+} ) );
+
+jest.mock( '../../plugin-management-v2/hooks/use-plugin-version-info', () => {
+	return jest.fn().mockImplementation( () => {
+		return {
+			currentVersionsRange: {
+				min: '1.0.0',
+				max: null,
+			},
+			updatedVersions: [ '1.0.0' ],
+			hasUpdate: true,
+		};
+	} );
+} );
 
 jest.mock( '@automattic/calypso-config', () => {
 	const fn = ( key ) => {
@@ -49,38 +64,11 @@ describe( 'PluginDetailsHeader', () => {
 		plugin,
 	};
 
-	const initialState = {
-		currentUser: {
-			capabilities: {},
-		},
-		plugins: {
-			installed: {
-				isRequesting: {},
-				plugins: {},
-				status: {},
-			},
-		},
-		sites: {},
-		ui: { selectedSiteId: 1234 },
-	};
-
-	const mockStore = configureStore();
-	const store = mockStore( initialState );
-	const queryClient = new QueryClient();
-
-	const Wrapper = ( { children } ) => (
-		<Provider store={ store }>
-			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
-		</Provider>
-	);
-
 	test.each( [ { configEnabled: true }, { configEnabled: false } ] )(
 		'should render the correct author url (configEnabled: $configEnabled)',
 		( { configEnabled } ) => {
 			config.isEnabled.mockImplementation( () => configEnabled );
-			render( <PluginDetailsHeader { ...mockedProps } />, {
-				wrapper: Wrapper,
-			} );
+			render( <PluginDetailsHeader { ...mockedProps } /> );
 			const want = /\/plugins\/.*\?s=developer:.*/;
 			const have = screen.getByText( plugin.author_name ).getAttribute( 'href' );
 			expect( have ).toMatch( want );

--- a/client/my-sites/plugins/plugin-management-v2/hooks/test/use-plugin-version-info.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/hooks/test/use-plugin-version-info.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { plugin as plugin1, site as site1 } from '../../test/utils/constants';
+import usePluginVersionInfo from '../use-plugin-version-info';
+import type { PluginComponentProps } from '../../types';
+
+describe( 'usePluginVersionInfo', () => {
+	const plugin2 = {
+		...plugin1,
+		version: '12.7',
+	};
+
+	const site2 = {
+		...site1,
+		ID: 123456,
+	};
+
+	const initialState = {
+		sites: { items: { [ site1.ID ]: site1, [ site2.ID ]: site2 } },
+		currentUser: {
+			capabilities: {},
+		},
+		plugins: {
+			installed: {
+				isRequesting: {},
+				isRequestingAll: false,
+				plugins: {
+					[ `${ site1.ID }` ]: [ plugin1 ],
+					[ `${ site2.ID }` ]: [ plugin2 ],
+				},
+			},
+		},
+	};
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'should return the correct versions range and updated versions when the plugin is installed on many sites', () => {
+		// We don't need all the properties of the plugin, just the ones we use in the hook
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		const pluginWithSites = {
+			...plugin1,
+			sites: {
+				[ site1.ID ]: {
+					active: true,
+					autoupdate: true,
+					version: '1.23',
+				},
+				[ site2.ID ]: {
+					active: true,
+					autoupdate: true,
+					version: '1.23',
+				},
+			},
+		} as PluginComponentProps;
+
+		const { result } = renderHook( () => usePluginVersionInfo( pluginWithSites ), {
+			wrapper,
+		} );
+
+		expect( result.current.currentVersionsRange ).toEqual( {
+			min: '11.3',
+			max: '12.7',
+		} );
+		expect( result.current.updatedVersions ).toEqual( [ '11.5', '11.5' ] );
+		expect( result.current.hasUpdate ).toEqual( true );
+	} );
+
+	it( 'should return the correct versions range and updated versions when the plugin is installed on one site', () => {
+		// We don't need all the properties of the plugin, just the ones we use in the hook
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		const { result } = renderHook( () => usePluginVersionInfo( plugin2 ), {
+			wrapper,
+		} );
+
+		expect( result.current.currentVersionsRange ).toEqual( {
+			min: '11.3',
+			max: null,
+		} );
+		expect( result.current.updatedVersions ).toEqual( [ '11.5' ] );
+		expect( result.current.hasUpdate ).toEqual( true );
+	} );
+} );

--- a/client/my-sites/plugins/plugin-management-v2/hooks/use-plugin-version-info.ts
+++ b/client/my-sites/plugins/plugin-management-v2/hooks/use-plugin-version-info.ts
@@ -8,7 +8,7 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 export default function usePluginVersionInfo(
 	plugin: PluginComponentProps,
-	selectedSite?: SiteDetails
+	selectedSiteId?: number
 ): {
 	currentVersionsRange: { min: string; max: string };
 	updatedVersions: string[];
@@ -27,11 +27,13 @@ export default function usePluginVersionInfo(
 		: [];
 
 	const siteIds = siteObjectsToSiteIds( sites );
-	const state = useSelector( ( state ) => state );
-	const pluginsOnSites: any = getPluginOnSites( state, siteIds, plugin?.slug );
+
+	const pluginsOnSites: any = useSelector( ( state ) =>
+		getPluginOnSites( state, siteIds, plugin?.slug )
+	);
 
 	const getSitePlugin = ( site: SiteDetails ) => {
-		const siteId = selectedSite ? selectedSite.ID : site.ID;
+		const siteId = selectedSiteId || site.ID;
 		return pluginsOnSites?.sites[ siteId ];
 	};
 

--- a/client/my-sites/plugins/plugin-management-v2/hooks/use-plugin-version-info.ts
+++ b/client/my-sites/plugins/plugin-management-v2/hooks/use-plugin-version-info.ts
@@ -1,0 +1,76 @@
+import { useMemo } from 'react';
+import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import { useSelector } from 'calypso/state';
+import { getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
+import getSites from 'calypso/state/selectors/get-sites';
+import type { PluginComponentProps } from '../types';
+import type { SiteDetails } from '@automattic/data-stores';
+
+export default function usePluginVersionInfo(
+	plugin: PluginComponentProps,
+	selectedSite?: SiteDetails
+) {
+	const allSites = useSelector( getSites );
+
+	const sites = plugin?.sites
+		? Object.keys( plugin.sites ).map( ( siteId ) => {
+				const site = allSites.find( ( s ) => s?.ID === parseInt( siteId ) );
+				return {
+					...site,
+					...plugin.sites[ siteId ],
+				} as any; // This must be cast as any until this file is updated to work with the selectors in state/plugins/installed/selectors
+		  } )
+		: [];
+
+	const siteIds = siteObjectsToSiteIds( sites );
+	const state = useSelector( ( state ) => state );
+	const pluginsOnSites: any = getPluginOnSites( state, siteIds, plugin?.slug );
+
+	const hasUpdate = sites.some( ( site ) => {
+		const siteId = selectedSite ? selectedSite.ID : site.ID;
+		const sitePlugin = pluginsOnSites?.sites[ siteId ];
+		return sitePlugin?.update?.new_version && site.canUpdateFiles;
+	} );
+
+	const updatedVersions = sites
+		.map( ( site ) => {
+			const siteId = selectedSite ? selectedSite.ID : site.ID;
+			const sitePlugin = pluginsOnSites?.sites[ siteId ];
+			return sitePlugin?.update?.new_version;
+		} )
+		.filter( ( version ) => version );
+
+	const currentVersions = sites
+		.map( ( site ) => {
+			const siteId = selectedSite ? selectedSite.ID : site.ID;
+			const sitePlugin = pluginsOnSites?.sites[ siteId ];
+			return sitePlugin?.version;
+		} )
+		.filter( ( version ) => version );
+
+	return useMemo( () => {
+		const versions = [
+			// We want to remove the duplicated versions in the array, because if multiple sites have
+			// the same plugin version, we don't want to display the range.
+			...new Set(
+				// Sort the plugin versions, respecting semantic version convention.
+				currentVersions.sort( ( a: string, b: string ): number =>
+					a.localeCompare( b, undefined, {
+						numeric: true,
+						sensitivity: 'case',
+						caseFirst: 'upper',
+					} )
+				)
+			),
+		];
+
+		return {
+			currentVersionsRange: {
+				min: versions[ 0 ],
+				max: versions.length > 1 ? versions[ versions.length - 1 ] : null,
+			},
+			updatedVersions,
+			hasUpdate,
+		};
+	}, [ currentVersions, hasUpdate, updatedVersions ] );
+}

--- a/client/my-sites/plugins/plugin-management-v2/hooks/use-plugin-version-info.ts
+++ b/client/my-sites/plugins/plugin-management-v2/hooks/use-plugin-version-info.ts
@@ -9,7 +9,11 @@ import type { SiteDetails } from '@automattic/data-stores';
 export default function usePluginVersionInfo(
 	plugin: PluginComponentProps,
 	selectedSite?: SiteDetails
-) {
+): {
+	currentVersionsRange: { min: string; max: string };
+	updatedVersions: string[];
+	hasUpdate: boolean;
+} {
 	const allSites = useSelector( getSites );
 
 	const sites = plugin?.sites
@@ -26,24 +30,26 @@ export default function usePluginVersionInfo(
 	const state = useSelector( ( state ) => state );
 	const pluginsOnSites: any = getPluginOnSites( state, siteIds, plugin?.slug );
 
-	const hasUpdate = sites.some( ( site ) => {
+	const getSitePlugin = ( site: SiteDetails ) => {
 		const siteId = selectedSite ? selectedSite.ID : site.ID;
-		const sitePlugin = pluginsOnSites?.sites[ siteId ];
+		return pluginsOnSites?.sites[ siteId ];
+	};
+
+	const hasUpdate = sites.some( ( site ) => {
+		const sitePlugin = getSitePlugin( site );
 		return sitePlugin?.update?.new_version && site.canUpdateFiles;
 	} );
 
 	const updatedVersions = sites
 		.map( ( site ) => {
-			const siteId = selectedSite ? selectedSite.ID : site.ID;
-			const sitePlugin = pluginsOnSites?.sites[ siteId ];
+			const sitePlugin = getSitePlugin( site );
 			return sitePlugin?.update?.new_version;
 		} )
 		.filter( ( version ) => version );
 
 	const currentVersions = sites
 		.map( ( site ) => {
-			const siteId = selectedSite ? selectedSite.ID : site.ID;
-			const sitePlugin = pluginsOnSites?.sites[ siteId ];
+			const sitePlugin = getSitePlugin( site );
 			return sitePlugin?.version;
 		} )
 		.filter( ( version ) => version );

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -26,7 +26,7 @@ export default function UpdatePlugin( { plugin, selectedSite, className, updateP
 
 	const { currentVersionsRange, updatedVersions, hasUpdate } = usePluginVersionInfo(
 		plugin,
-		selectedSite
+		selectedSite?.ID
 	);
 
 	const allowedActions = getAllowedPluginActions( plugin, state, selectedSite );

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -2,12 +2,9 @@ import { Button } from '@automattic/components';
 import { Icon, arrowRight } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
 import { UPDATE_PLUGIN } from 'calypso/lib/plugins/constants';
-import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { useSelector } from 'calypso/state';
-import { getPluginOnSites } from 'calypso/state/plugins/installed/selectors';
-import getSites from 'calypso/state/selectors/get-sites';
+import usePluginVersionInfo from '../hooks/use-plugin-version-info';
 import PluginActionStatus from '../plugin-action-status';
 import { getAllowedPluginActions } from '../utils/get-allowed-plugin-actions';
 import { getPluginActionStatuses } from '../utils/get-plugin-action-statuses';
@@ -25,66 +22,12 @@ interface Props {
 
 export default function UpdatePlugin( { plugin, selectedSite, className, updatePlugin }: Props ) {
 	const translate = useTranslate();
-	const allSites = useSelector( getSites );
 	const state = useSelector( ( state ) => state );
 
-	const getPluginSites = ( plugin: PluginComponentProps ) => {
-		return Object.keys( plugin.sites ).map( ( siteId ) => {
-			const site = allSites.find( ( s ) => s?.ID === parseInt( siteId ) );
-			return {
-				...site,
-				...plugin.sites[ siteId ],
-			} as any; // This must be cast as any until this file is updated to work with the selectors in state/plugins/installed/selectors
-		} );
-	};
-
-	const sites = getPluginSites( plugin );
-	const siteIds = siteObjectsToSiteIds( sites );
-	const pluginsOnSites: any = getPluginOnSites( state, siteIds, plugin?.slug );
-
-	const currentVersions = sites
-		.map( ( site ) => {
-			const siteId = selectedSite ? selectedSite.ID : site.ID;
-			const sitePlugin = pluginsOnSites?.sites[ siteId ];
-			return sitePlugin?.version;
-		} )
-		.filter( ( version ) => version );
-
-	const updatedVersions = sites
-		.map( ( site ) => {
-			const siteId = selectedSite ? selectedSite.ID : site.ID;
-			const sitePlugin = pluginsOnSites?.sites[ siteId ];
-			return sitePlugin?.update?.new_version;
-		} )
-		.filter( ( version ) => version );
-
-	const currentVersionsRange = useMemo( () => {
-		const versions = [
-			// We want to remove the duplicated versions in the array, because if multiple sites have
-			// the same plugin version, we don't want to display the range.
-			...new Set(
-				// Sort the plugin versions, respecting semantic version convention.
-				currentVersions.sort( ( a: string, b: string ): number =>
-					a.localeCompare( b, undefined, {
-						numeric: true,
-						sensitivity: 'case',
-						caseFirst: 'upper',
-					} )
-				)
-			),
-		];
-
-		return {
-			min: versions[ 0 ],
-			max: versions.length > 1 ? versions[ versions.length - 1 ] : null,
-		};
-	}, [ currentVersions ] );
-
-	const hasUpdate = sites.some( ( site ) => {
-		const siteId = selectedSite ? selectedSite.ID : site.ID;
-		const sitePlugin = pluginsOnSites?.sites[ siteId ];
-		return sitePlugin?.update?.new_version && site.canUpdateFiles;
-	} );
+	const { currentVersionsRange, updatedVersions, hasUpdate } = usePluginVersionInfo(
+		plugin,
+		selectedSite
+	);
 
 	const allowedActions = getAllowedPluginActions( plugin, state, selectedSite );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-genesis/issues/14

## Proposed Changes

This PR updates the version column on the plugin details page to show the version range if multiple versions of the plugin are installed on different sites.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud live link
2. We need to install different versions of the same plugin on different sites > Visit https://wordpress.org/plugins/woocommerce/advanced/ > Scroll to the button > Download any old version of the plugin

<img width="730" alt="Screenshot 2023-09-14 at 11 02 13 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/066e3129-fda3-4838-82c8-859cad9953fb">

3. Visit the link by updating the site slug: https://wordpress.com/plugins/upload/{site-slug} > Upload the downloaded .zip file and install the plugin

<img width="795" alt="Screenshot 2023-09-14 at 11 05 29 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/28affbd5-e71c-4d6f-9b01-5bb7c9d7547c">

4. Now visit the plugins page(/plugins/manage) and verify the installed version is shown as expected(example below)

<img width="1531" alt="Screenshot 2023-09-14 at 11 07 09 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/db8dd765-1515-42b2-a988-ebca8b06ceb2">

5. Now click on the plugin name(WooCommerce) and verify that the version is shown as below

<img width="1546" alt="Screenshot 2023-09-14 at 11 09 55 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3701451b-d91d-403e-8450-ac4cb09cf573">

6. Repeat steps 2 & 3 on a different site > Repeat step 4 and verify the version range is shown

<img width="1523" alt="Screenshot 2023-09-14 at 11 22 53 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/fd795d9f-a7f3-4e76-9e4b-68eb25c07396">

7. Repeat step 5 and verify the version range is shown

<img width="1551" alt="Screenshot 2023-09-14 at 10 24 52 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/a53252cf-b85a-4b67-9969-634f5c2a25c3">
<img width="1530" alt="Screenshot 2023-09-14 at 10 25 10 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/580da274-a8ec-4319-b3ea-f9906abb15a3">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?