### PR TITLE
Assembler: Update the order of categories

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -18,7 +18,6 @@ export const NAVIGATOR_PATHS = {
 };
 
 export const INITIAL_PATH = NAVIGATOR_PATHS.MAIN_HEADER;
-export const INITIAL_CATEGORY = 'posts';
 
 export const INITIAL_SCREEN = 'main';
 
@@ -56,3 +55,17 @@ export const PATTERN_CATEGORIES = [
 	//'testimonials', -- Not exist
 	// 'text', -- Hidden
 ];
+
+export const ORDERED_PATTERN_CATEGORIES = [
+	'call-to-action',
+	'about',
+	'services',
+	'store',
+	'quotes',
+	'posts',
+	'newsletter',
+	'gallery',
+	'contact',
+];
+
+export const INITIAL_CATEGORY = ORDERED_PATTERN_CATEGORIES[ 0 ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-categories-order.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-categories-order.ts
@@ -1,32 +1,21 @@
 import { useMemo } from 'react';
+import { ORDERED_PATTERN_CATEGORIES } from '../constants';
 import type { Category } from '../types';
-
-const patternCategoriesOrder = [
-	'call-to-action',
-	'about',
-	'services',
-	'store',
-	'quotes',
-	'posts',
-	'newsletter',
-	'gallery',
-	'contact',
-];
 
 const useCategoriesOrder = ( categories: Category[] ) => {
 	return useMemo(
 		() =>
 			categories.sort( ( { name: aName }, { name: bName } ) => {
 				if ( aName && bName ) {
-					// Sort categories according to `patternCategoriesOrder`.
-					let aIndex = patternCategoriesOrder.indexOf( aName );
-					let bIndex = patternCategoriesOrder.indexOf( bName );
+					// Sort categories according to `ORDERED_PATTERN_CATEGORIES`.
+					let aIndex = ORDERED_PATTERN_CATEGORIES.indexOf( aName );
+					let bIndex = ORDERED_PATTERN_CATEGORIES.indexOf( bName );
 					// All other categories should come after that.
 					if ( aIndex < 0 ) {
-						aIndex = patternCategoriesOrder.length;
+						aIndex = ORDERED_PATTERN_CATEGORIES.length;
 					}
 					if ( bIndex < 0 ) {
-						bIndex = patternCategoriesOrder.length;
+						bIndex = ORDERED_PATTERN_CATEGORIES.length;
 					}
 					return aIndex - bIndex;
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-categories-order.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-categories-order.ts
@@ -1,7 +1,17 @@
 import { useMemo } from 'react';
 import type { Category } from '../types';
 
-const patternCategoriesOrder = [ 'posts', 'gallery', 'call-to-action' ];
+const patternCategoriesOrder = [
+	'call-to-action',
+	'about',
+	'services',
+	'store',
+	'quotes',
+	'posts',
+	'newsletter',
+	'gallery',
+	'contact',
+];
 
 const useCategoriesOrder = ( categories: Category[] ) => {
 	return useMemo(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1694574489370359-slack-CRWCHQGUB

## Proposed Changes

* Reorder the categories of section patterns in the Assembler

![image](https://github.com/Automattic/wp-calypso/assets/13596067/5aa926aa-7180-4a46-9721-b6716526216e)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase
* Scroll down to select Assembler CTA
* On the Assembler screen, select ”Sections“
* Ensure the order is updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?