### PR TITLE
Flaky Jetpack E2E: when using AI Assistant block, validate only whether paragraph block exists.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
@@ -122,7 +122,17 @@ export class AIAssistantFlow implements BlockFlow {
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
 		for ( const keyword of this.validationData.keywords ) {
-			await context.page.getByRole( 'main' ).filter( { hasText: keyword } ).waitFor();
+			try {
+				await context.page.getByRole( 'main' ).filter( { hasText: keyword } ).waitFor();
+			} catch {
+				// Sometimes, the AI block fails to generate anything meaningful and isntead returns
+				// an error text. We can wait on that, but that would be testing implementation details.
+				// Since the AI block ends up creating paragraph blocks which are indistinguishable
+				// from what a user would have typed manually, the fallback is to merely verify that some
+				// form of paragraph block is present.
+				// @see: p1694596605435499-slack-CDLH4C1UZ
+				await context.page.getByRole( 'main' ).getByRole( 'paragraph' ).first().waitFor();
+			}
 		}
 	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80730, https://github.com/Automattic/wp-calypso/pull/81580.

## Proposed Changes

This PR is a follow-up to https://github.com/Automattic/wp-calypso/pull/81580 and updates the expectation in light of a flakeout by ChatGPT noted in p1694596605435499-slack-CDLH4C1UZ.

There will still be an initial attempt to verify the keyword(s) are present in the post, but if that fails, the block flow will fall back to simply verifying whether a paragraph block exists.

Unfortunately, because there is no reliable way to tell _what_ generated the paragraph block in the published post, it is not possible to further narrow the selector.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?