### PR TITLE
Ensure that vendor id is a string.

### DIFF
--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -84,5 +84,5 @@ export const GA_PRODUCT_BRAND_AKISMET = 'Akismet';
 /**
  * Vendor Id's from refer.wordpress.com
  */
-export const WOOEXPRESS_AFFILIATE_VENDOR_ID = 67386441;
-export const WPCOM_AFFILIATE_VENDOR_ID = 67402;
+export const WOOEXPRESS_AFFILIATE_VENDOR_ID = '67386441';
+export const WPCOM_AFFILIATE_VENDOR_ID = '67402';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
We need to ensure 
WOOEXPRESS_AFFILIATE_VENDOR_ID and WOOEXPRESS_AFFILIATE_VENDOR_ID are always treated as strings instead
of integers.
- One because they won't be used in calculations. They are constant IDs from the referral system.
- Two, because we always use them as parts of a string.
- Most importantly because as integers, they introduce a bug [here](https://github.com/Automattic/wp-calypso/blob/fix/cast-vendor-id-to-string/client/lib/analytics/refer.js#L20) where we pick vid from the URL as a string and compare it to WOOEXPRESS_AFFILIATE_VENDOR_ID which is currently an integer., 
*

## Testing Instructions
- To verify this bug is fixed.
- Switch to this branch in calypso.
- Put a breakpoint. ... debugger; [on line 24](https://github.com/Automattic/wp-calypso/blob/fix/cast-vendor-id-to-string/client/lib/analytics/refer.js#L24)
- Run this URL http://calypso.localhost:3000/?aff=86844&vid=67386441 with the console open.
- Ensure the value of the variables vid and vendorId are the same at the breakpoint above.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?