### PR TITLE
state: refactor away from `_.uniqBy`

### DIFF
--- a/client/state/reader/feed-searches/reducer.js
+++ b/client/state/reader/feed-searches/reducer.js
@@ -1,4 +1,4 @@
-import { uniqBy } from 'lodash';
+import { uniqueBy } from '@automattic/js-utils';
 import { READER_FEED_SEARCH_RECEIVE } from 'calypso/state/reader/action-types';
 import { combineReducers, keyedReducer } from 'calypso/state/utils';
 
@@ -22,7 +22,10 @@ import { combineReducers, keyedReducer } from 'calypso/state/utils';
 export const items = keyedReducer( 'queryKey', ( state = null, action ) => {
 	switch ( action.type ) {
 		case READER_FEED_SEARCH_RECEIVE:
-			return uniqBy( ( state || [] ).concat( action.payload.feeds ), 'feed_URL' );
+			return uniqueBy(
+				( state ?? [] ).concat( action.payload.feeds ),
+				( a, b ) => a.feed_URL === b.feed_URL
+			);
 	}
 
 	return state;

--- a/client/state/reader/recommended-sites/reducer.ts
+++ b/client/state/reader/recommended-sites/reducer.ts
@@ -1,4 +1,4 @@
-import { uniqBy } from 'lodash';
+import { uniqueBy } from '@automattic/js-utils';
 import {
 	READER_RECOMMENDED_SITE_DISMISSED,
 	READER_RECOMMENDED_SITE_FOLLOWED,
@@ -19,9 +19,9 @@ import { RecommendedSite } from './types';
 export const items = keyedReducer< RecommendedSite[] >( 'seed', ( state = [], action ) => {
 	switch ( action.type ) {
 		case READER_RECOMMENDED_SITES_RECEIVE:
-			return uniqBy(
+			return uniqueBy(
 				state.concat( ( action as ReturnType< typeof receiveRecommendedSites > ).payload.sites ),
-				'feedId'
+				( a, b ) => a.feedId === b.feedId
 			);
 		case READER_RECOMMENDED_SITE_FOLLOWED:
 		case READER_RECOMMENDED_SITE_DISMISSED:


### PR DESCRIPTION
## Proposed Changes

Refactor away from `_.uniqBy` in `client/state`. In this case we replace it with a method from our own `js-utils` package.

## Testing Instructions

* Changes are covered by unit tests, make sure they still pass
* As with a lot of lodash methods it's good practice to ensure we don't accidentally miss guards for whether we operate on the expected data structure.
