### PR TITLE
Subscribers Page: Add link to subscriber's active blog url.

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list/subscriber-row.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/subscriber-row.tsx
@@ -12,7 +12,7 @@ export type SubscriberRowProps = {
 };
 
 export const SubscriberRow = ( { subscriber, onView, onUnsubscribe }: SubscriberRowProps ) => {
-	const { avatar, display_name, email_address, date_subscribed, open_rate } = subscriber;
+	const { avatar, display_name, email_address, url, date_subscribed, open_rate } = subscriber;
 	const subscriptionPlans = useSubscriptionPlans( subscriber );
 
 	return (
@@ -21,7 +21,12 @@ export const SubscriberRow = ( { subscriber, onView, onUnsubscribe }: Subscriber
 				<FormCheckbox />
 			</div>
 			<span className="subscriber-list__profile-column" role="cell">
-				<SubscriberProfile avatar={ avatar } displayName={ display_name } email={ email_address } />
+				<SubscriberProfile
+					avatar={ avatar }
+					displayName={ display_name }
+					email={ email_address }
+					url={ url }
+				/>
 			</span>
 			<span className="subscriber-list__subscription-type-column" role="cell">
 				{ subscriptionPlans &&

--- a/client/my-sites/subscribers/components/subscriber-profile/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-profile/style.scss
@@ -14,6 +14,18 @@
 				line-height: rem(22px);
 			}
 
+			a.components-external-link.subscriber-profile__name {
+				color: inherit;
+
+				&:hover {
+					text-decoration: underline;
+				}
+
+				> .components-external-link__icon {
+					display: none;
+				}
+			}
+
 			.subscriber-profile__email {
 				font-size: $font-body-extra-small;
 				line-height: rem(24px);

--- a/client/my-sites/subscribers/components/subscriber-profile/subscriber-profile.tsx
+++ b/client/my-sites/subscribers/components/subscriber-profile/subscriber-profile.tsx
@@ -1,10 +1,12 @@
 import './style.scss';
+import { ExternalLink } from '@wordpress/components';
 
 type SubscriberProfileProps = {
 	avatar: string;
 	displayName: string;
 	email: string;
 	compact?: boolean;
+	url?: string;
 };
 
 const SubscriberProfile = ( {
@@ -12,6 +14,7 @@ const SubscriberProfile = ( {
 	displayName,
 	email,
 	compact = true,
+	url,
 }: SubscriberProfileProps ) => {
 	// When adding a click event for this, make sure to also track it
 	// import { useRecordSubscriberClicked } from '../../tracks';
@@ -21,7 +24,13 @@ const SubscriberProfile = ( {
 		<div className={ `subscriber-profile ${ compact ? 'subscriber-profile--compact' : '' }` }>
 			<img src={ avatar } className="subscriber-profile__user-image" alt="Profile pic" />
 			<div className="subscriber-profile__user-details">
-				<span className="subscriber-profile__name">{ displayName }</span>
+				{ url ? (
+					<ExternalLink className="subscriber-profile__name" href={ url }>
+						{ displayName }
+					</ExternalLink>
+				) : (
+					<span className="subscriber-profile__name">{ displayName }</span>
+				) }
 				{ email && email !== displayName && (
 					<span className="subscriber-profile__email">{ email }</span>
 				) }


### PR DESCRIPTION
## Proposed Changes

* Add link to subscriber's active blog url.

## Testing Instructions

* Apply the patch D121771-code (if it hasn't been merged yet) and sandbox `public-api.wordpress.com`.
* Go to `/subscribers`.
* Subscribers who are WPCOM users with active blog should be clickable.

<img width="1162" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/5b9b65ac-6ed0-4e00-b9ae-3e6ab9e51c5d">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?