### PR TITLE
Subscribers Page: Make acquisition source clickable in Subscribers Details page.

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import TimeSince from 'calypso/components/time-since';
@@ -132,7 +133,9 @@ const SubscriberDetails = ( {
 							<div className="subscriber-details__content-label">
 								{ translate( 'Acquisition source' ) }
 							</div>
-							<div className="subscriber-details__content-value">{ url }</div>
+							<div className="subscriber-details__content-value">
+								<ExternalLink href={ url }>{ url }</ExternalLink>
+							</div>
 						</div>
 					) }
 				</div>


### PR DESCRIPTION
## Proposed Changes

* Make the acquisition source clickable in Subscribers Details page.

## Testing Instructions

* Go to `/subscribers`.
* View the details page of any WPCOM subscriber.
* The url on the acquisition source should be clickable.

<img width="1154" alt="2023-09-14_14-38-01" src="https://github.com/Automattic/wp-calypso/assets/1287077/b0bc438d-a732-4ae3-beb5-4504f753285b">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?