### PR TITLE
Reader streams - show inline comments on all streams except conversations.

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -648,7 +648,8 @@ class PostCommentList extends Component {
 			this.props.showConversationFollowButton &&
 			shouldShowConversationFollowButton( this.props.post );
 
-		const showManageCommentsButton = this.props.canUserModerateComments && commentCount > 0;
+		const showManageCommentsButton =
+			! expandableView && this.props.canUserModerateComments && commentCount > 0;
 
 		return (
 			<div

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -1,5 +1,5 @@
 import { Card } from '@automattic/components';
-import { localeRegexString, removeLocaleFromPathLocaleInFront } from '@automattic/i18n-utils';
+import { localeRegexString } from '@automattic/i18n-utils';
 import classnames from 'classnames';
 import closest from 'component-closest';
 import { truncate } from 'lodash';
@@ -157,17 +157,7 @@ class ReaderPostCard extends Component {
 			currentRoute
 		);
 
-		const isReaderA8CPage = currentRoute.startsWith( '/read/a8c' );
-		const isReaderListPage = currentRoute.startsWith( '/read/list/' );
-		const isDiscoverPage =
-			removeLocaleFromPathLocaleInFront( currentRoute ).startsWith( '/discover' );
-		const isTagPage = removeLocaleFromPathLocaleInFront( currentRoute ).startsWith( '/tag/' );
-
-		const shouldShowPostCardComments =
-			! isConversations &&
-			! isReaderA8CPage &&
-			! isReaderListPage &&
-			( ! compact || isDiscoverPage || isTagPage );
+		const shouldShowPostCardComments = ! isConversations;
 
 		const classes = classnames( 'reader-post-card', {
 			'has-thumbnail': !! post.canonical_media,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #  https://github.com/Automattic/wp-calypso/pull/80980 / https://github.com/Automattic/wp-calypso/pull/80977

## Proposed Changes

* The above noted PRs were shipped to hide inline comments from these areas while we looked to make them less intrusive and more usable. We are now looking to re-release inline comments to these areas.
* Enables inline comments in lists pages, read/a8c, and individual site feeds.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify inline comments are now available on lists, read/a8c, and individual site (and individual p2) feeds.
* Smoke test reader streams and ensure these comments show up where and work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
