### PR TITLE
Stats: Release Paid Stats to WPCOM sites

### DIFF
--- a/client/assets/images/stats/calypso-purchase-stats-graph.svg
+++ b/client/assets/images/stats/calypso-purchase-stats-graph.svg
@@ -42,7 +42,7 @@
                     <rect
                         width="109.63"
                         height="24.721"
-                        fill="#1689DB"
+                        fill="#CCD9E7"
                         rx="4.299"
                         transform="matrix(0 -1 -1 0 233.464 293.605)"
                     />
@@ -51,7 +51,7 @@
                     <rect
                         width="152.622"
                         height="25.795"
-                        fill="#1689DB"
+                        fill="#CCD9E7"
                         rx="4.299"
                         transform="matrix(0 -1 -1 0 200.146 293.605)"
                     />
@@ -60,7 +60,7 @@
                     <rect
                         width="96.732"
                         height="24.721"
-                        fill="#1689DB"
+                        fill="#CCD9E7"
                         rx="4.299"
                         transform="matrix(0 -1 -1 0 165.752 293.605)"
                     />
@@ -69,7 +69,7 @@
                     <rect
                         width="119.303"
                         height="24.721"
-                        fill="#1689DB"
+                        fill="#CCD9E7"
                         rx="4.299"
                         transform="matrix(0 -1 -1 0 132.433 293.605)"
                     />
@@ -78,7 +78,7 @@
                     <rect
                         width="85.984"
                         height="24.721"
-                        fill="#1689DB"
+                        fill="#CCD9E7"
                         rx="4.299"
                         transform="matrix(0 -1 -1 0 99.114 293.605)"
                     />

--- a/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
@@ -58,7 +58,6 @@ const CommercialPurchase = ( {
 			<StatsCommercialPriceDisplay planValue={ planValue } currencyCode={ currencyCode } />
 
 			<div className={ `${ COMPONENT_CLASS_NAME }__benefits` }>
-				<p>{ translate( 'Benefits:' ) }</p>
 				<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--included` }>
 					<li>{ translate( 'Instant access to upcoming features' ) }</li>
 					<li>{ translate( 'Priority support' ) }</li>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -96,29 +96,6 @@ const PersonalPurchase = ( {
 
 	return (
 		<div>
-			<div className={ `${ COMPONENT_CLASS_NAME }__benefits` }>
-				<ul>
-					{ subscriptionValue > 0 ? (
-						<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
-							{ translate( 'Instant access to upcoming features' ) }
-						</li>
-					) : (
-						<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
-							{ translate( 'No access to upcoming features' ) }
-						</li>
-					) }
-					{ subscriptionValue >= defaultStartingValue ? (
-						<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
-							{ translate( 'Priority support' ) }
-						</li>
-					) : (
-						<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
-							{ translate( 'No priority support' ) }
-						</li>
-					) }
-				</ul>
-			</div>
-
 			<div className={ `${ COMPONENT_CLASS_NAME }__notice` }>
 				{ translate(
 					'This plan is for personal sites only. If your site is used for a commercial activity, {{Button}}you will need to choose a commercial plan{{/Button}}.',
@@ -146,6 +123,29 @@ const PersonalPurchase = ( {
 					},
 				} ) }
 			</p>
+
+			<div className={ `${ COMPONENT_CLASS_NAME }__benefits` }>
+				<ul>
+					{ subscriptionValue > 0 ? (
+						<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
+							{ translate( 'Instant access to upcoming features' ) }
+						</li>
+					) : (
+						<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
+							{ translate( 'No access to upcoming features' ) }
+						</li>
+					) }
+					{ subscriptionValue >= defaultStartingValue ? (
+						<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
+							{ translate( 'Priority support' ) }
+						</li>
+					) : (
+						<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
+							{ translate( 'No priority support' ) }
+						</li>
+					) }
+				</ul>
+			</div>
 
 			{ subscriptionValue === 0 && (
 				<div className={ `${ COMPONENT_CLASS_NAME }__persnal-checklist` }>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -82,7 +82,7 @@ const PersonalPurchase = ( {
 					},
 					comment: 'Price per month selected by the user via the pricing slider',
 				} ) }
-				{ subscriptionValue > 0 && emoji }
+				{ ` ${ subscriptionValue > 0 ? emoji : '' }` }
 			</div>
 		);
 	} ) as RenderThumbFunction;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -28,9 +28,8 @@ const StatsCommercialPriceDisplay = ( {
 					</div>
 				) }
 				<div className={ `${ COMPONENT_CLASS_NAME }__pricing-amount` }>
-					{ planPriceObject.hasNonZeroFraction
-						? `${ planPriceObject.integer }${ planPriceObject.fraction }`
-						: `${ planPriceObject.integer }` }
+					{ `${ planPriceObject.integer }` }
+					{ planPriceObject.hasNonZeroFraction && <sup>{ `${ planPriceObject.fraction }` }</sup> }
 				</div>
 				{ planPriceObject.symbolPosition === 'after' && (
 					<div className={ `${ COMPONENT_CLASS_NAME }__pricing-currency` }>

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -1,6 +1,8 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/components/src/styles/typography.scss";
 
+$button-padding: 8px 32px;
+
 .stats-purchase-page {
 	--font-body: 16px;
 	--jp-black: #000;
@@ -15,8 +17,6 @@
 // Adjust purchase page styling for WPCOM.
 .stats-purchase-page--is-wpcom {
 	.stats-purchase-wizard {
-		font-family: $font-sf-pro-text;
-
 		.components-button {
 			&.is-primary {
 				background-color: var(--color-accent);
@@ -35,11 +35,7 @@
 		.stats-purchase-wizard__card {
 			color: var(--studio-gray-80);
 
-			.components-panel__header { //todo: re-assess if this element should be h1 not h2
-
-				font-family: $font-recoleta;
-			}
-
+			// Page heading styles.
 			h1,
 			.components-panel__header h2 {
 				font-family: $font-recoleta;
@@ -56,11 +52,6 @@
 				color: var(--studio-gray-80);
 			}
 
-			.stats-purchase-wizard__pricing-value {
-				font-family: $font-sf-pro-display;
-				color: var(--studio-gray-100);
-			}
-
 			.stats-purchase-wizard__pricing-cadency {
 				font-size: $font-body-small;
 			}
@@ -68,7 +59,7 @@
 			.button {
 				font-family: $font-sf-pro-text;
 				font-size: $font-body;
-				padding: 8px 32px;
+				padding: $button-padding;
 			}
 		}
 
@@ -135,6 +126,8 @@
 }
 
 .stats-purchase-wizard {
+	// Basic font family for all the text regardless of the site type.
+	font-family: $font-sf-pro-text;
 	display: flex;
 	justify-content: center;
 
@@ -191,15 +184,13 @@
 
 	.stats-purchase-wizard__average-price {
 		font-size: $font-body-small;
-		margin-bottom: 3em;
+		margin-bottom: 32px;
 		color: var(--studio-gray-80);
 		text-align: center;
 	}
 
 	.stats-purchase-wizard__benefits {
-		ul {
-			margin: 0 0 40px;
-		}
+		margin-bottom: 32px;
 
 		li {
 			margin-bottom: 8px;
@@ -255,29 +246,41 @@
 	}
 
 	.stats-purchase-wizard__pricing {
-		margin-bottom: 1.5rem;
+		margin: 32px 0;
 
 		.stats-purchase-wizard__pricing-value {
 			display: flex;
 			align-items: flex-start;
 			gap: 2px;
-			margin-bottom: -1em;
+			font-family: $font-sf-pro-display;
+			color: var(--studio-gray-100);
 		}
 
 		.stats-purchase-wizard__pricing-currency {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-			font-size: 24px;
+			font-size: $font-title-medium;
 			line-height: 60px;
+			line-height: 24px;
 		}
 
 		.stats-purchase-wizard__pricing-amount {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-			font-size: 54px;
+			font-size: $font-headline-large;
 			font-weight: 700;
+			line-height: 40px;
 		}
 
 		.stats-purchase-wizard__pricing-cadency {
+			font-size: $font-body-small;
 			color: var(--studio-gray-40);
+			margin-top: 12px;
+		}
+
+		sup {
+			color: var(--studio-black);
+			vertical-align: super;
+			font-size: $font-title-small;
+			font-style: normal;
+			font-weight: 700;
+			line-height: 20px;
 		}
 	}
 
@@ -285,6 +288,14 @@
 		display: grid;
 		grid-template-columns: repeat(2, 1fr);
 		grid-gap: 16px 32px;
+
+		p {
+			margin-bottom: 0;
+		}
+
+		button {
+			margin-top: 8px;
+		}
 	}
 
 	.stats-purchase-wizard__card-panel {
@@ -292,12 +303,6 @@
 
 		> div {
 			border: 0;
-		}
-
-		h2 {
-			font-weight: 700;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-			font-size: 36px;
 		}
 
 		.components-panel__body-title {
@@ -374,7 +379,7 @@
 			transition: all 0.25s ease-out;
 			font-size: var(--font-body);
 			line-height: 24px;
-			padding: 8px 12px;
+			padding: $button-padding;
 			height: auto;
 
 			&:hover,
@@ -395,7 +400,7 @@
 			border-radius: 4px;
 			font-size: var(--font-body);
 			line-height: 24px;
-			padding: 8px 12px;
+			padding: $button-padding;
 			height: auto;
 		}
 
@@ -413,14 +418,25 @@
 		}
 
 		&.is-opened {
+			padding: 0 16px;
+
 			& > .components-panel__body-title {
-				margin-bottom: 8px;
+				margin-top: 0;
+				margin-bottom: 12px;
 			}
 		}
 	}
 
+	.components-panel__header {
+		margin-bottom: 28px;
+	}
+
+	.components-panel__row {
+		padding-left: 35px;
+	}
+
 	.components-panel__body-toggle.components-button {
-		padding: 16px;
+		padding: 12px 16px;
 	}
 
 	.components-panel__arrow {
@@ -464,8 +480,8 @@
 
 .stats-purchase-wizard--single {
 	h1 {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		font-size: 36px;
+		font-family: $font-sf-pro-display;
+		font-size: $font-headline-small;
 		font-weight: 700;
 		line-height: 40px;
 		margin-bottom: 24px;

--- a/config/development.json
+++ b/config/development.json
@@ -185,7 +185,7 @@
 		"stats/new-video-summary": true,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": true,
-		"stats/paid-wpcom-stats": false,
+		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -121,7 +121,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": true,
-		"stats/paid-wpcom-stats": false,
+		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/production.json
+++ b/config/production.json
@@ -149,7 +149,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": true,
-		"stats/paid-wpcom-stats": false,
+		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -144,7 +144,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": true,
-		"stats/paid-wpcom-stats": false,
+		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/test.json
+++ b/config/test.json
@@ -100,7 +100,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": true,
-		"stats/paid-wpcom-stats": false,
+		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -153,7 +153,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-stats": true,
-		"stats/paid-wpcom-stats": false,
+		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80258 
## Proposed Changes

* Enable the feature flag `stats/paid-wpcom-stats` on all environments to release Paid Stats for all WPCOM sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the change with the Calypso Live link.
* Prepare a WPCOM site without any Stats purchases or WordPress.com plans.

#### Upgrade from Stats dashboard
* Navigate to Stats > `Traffic` page: `/stats/day/{site-slug}`.
* Ensure the upgrade notice shows on top of the page.

<img width="1322" alt="截圖 2023-09-14 下午10 29 05" src="https://github.com/Automattic/wp-calypso/assets/6869813/f6918c1b-43a4-4e65-9326-079a7f1e5eb4">

* Click on the `Upgrade my Stats` button.
* Ensure the page is redirected to the purchase wizard or standalone purchase page according to the `is_commercial` classifier.
* Ensure the page is in line with the design for WPCOM sites.
* Ensure the purchase action can be done and the page is redirected to the checkout page.

#### Upgrade from Add-Ons page
* Navigate to the `Add-Ons` page: `/add-ons/{site-slug}`.
* Ensure the Stats product cards show on the page.

<img width="1166" alt="截圖 2023-09-14 下午10 34 00" src="https://github.com/Automattic/wp-calypso/assets/6869813/74478979-c220-41ad-a875-df37f3818ef4">

* Click on the `Upgrade Stats` button of Stats product cards.
* Ensure the page is redirected to the respective standalone purchase page.
* Ensure the page is in line with the design for WPCOM sites.
* Ensure the purchase action can be done and the page is redirected to the checkout page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?