### PR TITLE
Onboarding: always call theme-setup endpoint that might Headstart starter blog posts

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -418,6 +418,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			yield* setGlobalStyles( siteSlug, activatedTheme.stylesheet, globalStyles, activatedTheme );
 		}
 
+		// Potentially runs Headstart.
+		// E.g. if the homepage has a Query Loop block, we insert placeholder posts on the new site.
 		yield* runThemeSetupOnSite( siteSlug );
 
 		return activatedTheme;

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,7 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { SiteGoal } from '../onboard';
 import { wpcomRequest } from '../wpcom-request-controls';
-import { THEME_SLUGS_THAT_SHOULD_RUN_THEME_SETUP } from './constants';
 import {
 	SiteLaunchError,
 	AtomicTransferError,
@@ -369,9 +368,6 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		yield wpcomRequest( {
 			path: `/sites/${ encodeURIComponent( siteSlug ) }/theme-setup/?_locale=user`,
 			apiNamespace: 'wpcom/v2',
-			body: {
-				trim_content: true,
-			},
 			method: 'POST',
 		} );
 	}
@@ -385,8 +381,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			selectedDesign.slug ||
 			selectedDesign.recipe?.stylesheet?.split( '/' )[ 1 ] ||
 			selectedDesign.theme;
-		const shouldRunThemeSetup = THEME_SLUGS_THAT_SHOULD_RUN_THEME_SETUP.includes( themeSlug );
-		const { keepHomepage = shouldRunThemeSetup, styleVariation, globalStyles } = options;
+		const { keepHomepage = true, styleVariation, globalStyles } = options;
 		const activatedTheme: ActiveTheme = yield wpcomRequest( {
 			path: `/sites/${ siteSlug }/themes/mine?_locale=user`,
 			apiVersion: '1.1',
@@ -423,9 +418,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			yield* setGlobalStyles( siteSlug, activatedTheme.stylesheet, globalStyles, activatedTheme );
 		}
 
-		if ( shouldRunThemeSetup ) {
-			yield* runThemeSetupOnSite( siteSlug );
-		}
+		yield* runThemeSetupOnSite( siteSlug );
 
 		return activatedTheme;
 	}

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -381,13 +381,12 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			selectedDesign.slug ||
 			selectedDesign.recipe?.stylesheet?.split( '/' )[ 1 ] ||
 			selectedDesign.theme;
-		const { keepHomepage = true, styleVariation, globalStyles } = options;
+		const { styleVariation, globalStyles } = options;
 		const activatedTheme: ActiveTheme = yield wpcomRequest( {
 			path: `/sites/${ siteSlug }/themes/mine?_locale=user`,
 			apiVersion: '1.1',
 			body: {
 				theme: themeSlug,
-				dont_change_homepage: keepHomepage,
 			},
 			method: 'POST',
 		} );

--- a/packages/data-stores/src/site/constants.ts
+++ b/packages/data-stores/src/site/constants.ts
@@ -1,5 +1,3 @@
 export const STORE_KEY = 'automattic/site';
 
 export const PLACEHOLDER_SITE_ID = 220580624; // creatiodemo.wordpress.com
-
-export const THEME_SLUGS_THAT_SHOULD_RUN_THEME_SETUP = [ 'arbutus', 'byrne', 'geologist' ];

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -469,7 +469,6 @@ describe( 'Site Actions', () => {
 			request: {
 				path: `/sites/${ siteSlug }/theme-setup/?_locale=user`,
 				apiNamespace: 'wpcom/v2',
-				body: { trim_content: true },
 				method: 'POST',
 			},
 		} );
@@ -484,7 +483,7 @@ describe( 'Site Actions', () => {
 			expect( generator.next().value ).toEqual(
 				createMockedThemeSwitchApiRequest( {
 					theme: 'zoologist',
-					dont_change_homepage: false,
+					dont_change_homepage: true,
 				} )
 			);
 
@@ -506,7 +505,7 @@ describe( 'Site Actions', () => {
 			);
 		} );
 
-		it( 'should call theme-setup api if the design needs to do that', () => {
+		it( 'should call theme-setup api', () => {
 			const { setDesignOnSite } = createActions( mockedClientCredentials );
 			const generator = setDesignOnSite( siteSlug, {
 				...mockedDesign,
@@ -523,25 +522,6 @@ describe( 'Site Actions', () => {
 
 			// Second iteration: WP_COM_REQUEST to /sites/${ siteSlug }/theme-setup is fired
 			expect( generator.next().value ).toEqual( createMockedThemeSetupApiRequest() );
-
-			// Second iteration: Complete the cycle
-			expect( generator.next().done ).toEqual( true );
-		} );
-
-		it( "should not call theme-setup api if the design doesn't need to do that", () => {
-			const { setDesignOnSite } = createActions( mockedClientCredentials );
-			const generator = setDesignOnSite( siteSlug, {
-				...mockedDesign,
-				slug: 'twentytwentythree',
-			} );
-
-			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
-			expect( generator.next().value ).toEqual(
-				createMockedThemeSwitchApiRequest( {
-					theme: 'twentytwentythree',
-					dont_change_homepage: false,
-				} )
-			);
 
 			// Second iteration: Complete the cycle
 			expect( generator.next().done ).toEqual( true );

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -483,7 +483,6 @@ describe( 'Site Actions', () => {
 			expect( generator.next().value ).toEqual(
 				createMockedThemeSwitchApiRequest( {
 					theme: 'zoologist',
-					dont_change_homepage: true,
 				} )
 			);
 
@@ -516,7 +515,6 @@ describe( 'Site Actions', () => {
 			expect( generator.next().value ).toEqual(
 				createMockedThemeSwitchApiRequest( {
 					theme: 'arbutus',
-					dont_change_homepage: true,
 				} )
 			);
 


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/82009

## Proposed Changes

Always call the theme-setup endpoint after onboarding because we might run Headstart to insert starter blog posts.

## Testing Instructions

See the instructions in D121838-code.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?