### PR TITLE
Stats: Remove ToS on the purchase pages

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
@@ -1,5 +1,4 @@
 import { Button as CalypsoButton } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -64,31 +63,6 @@ const CommercialPurchase = ( {
 					<li>{ translate( 'Priority support' ) }</li>
 				</ul>
 			</div>
-
-			<p className={ `${ COMPONENT_CLASS_NAME }__commercial-tos` }>
-				{ translate(
-					`By clicking the button below, you agree to our {{a}}Terms of Service{{/a}} and to {{b}}share details{{/b}} with WordPress.com.`,
-					{
-						components: {
-							a: (
-								<Button
-									variant="link"
-									target="_blank"
-									href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-								/>
-							),
-							b: (
-								<Button
-									variant="link"
-									target="_blank"
-									rel="noopener noreferrer"
-									href={ localizeUrl( 'https://jetpack.com/support/what-data-does-jetpack-sync/' ) }
-								/>
-							),
-						},
-					}
-				) }
-			</p>
 
 			<ButtonComponent
 				variant="primary"

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -4,7 +4,6 @@ import {
 	Button as CalypsoButton,
 } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { Button, CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
@@ -188,24 +187,6 @@ const PersonalPurchase = ( {
 					</ul>
 				</div>
 			) }
-
-			<p className={ `${ COMPONENT_CLASS_NAME }__personal-tos` }>
-				{ translate(
-					`By clicking the button below, you agree to our {{a}}Terms of Service{{/a}} and to {{b}}share details{{/b}} with WordPress.com.`,
-					{
-						components: {
-							a: (
-								<Button
-									variant="link"
-									target="_blank"
-									href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-								/>
-							),
-							b: <Button variant="link" href="#" />,
-						},
-					}
-				) }
-			</p>
 
 			{ subscriptionValue === 0 ? (
 				<ButtonComponent

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -92,21 +92,6 @@
 			}
 		}
 
-		.stats-purchase-wizard__card-panel {
-			.stats-purchase-wizard__personal-tos,
-			.stats-purchase-wizard__commercial-tos {
-				display: block;
-
-				.is-link {
-					color: var(--color-primary);
-				}
-			}
-		}
-
-		.stats-purchase-wizard__personal-tos {
-			display: none;
-		}
-
 		.stats-purchase-wizard__card-grid {
 			color: var(--studio-black);
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1694708450136749/1694703727.916069-slack-C0438NHCLSY and pdtkmj-1LR-p2#comment-3283

## Proposed Changes

* Remove the Terms of Service agreement section from all Stats purchase pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the change with the Calypso Live link.
* Navigate to Stats > `Traffic` page for a site without any Stats purchase or plan: `/stats/day/{site-slug}?flags=stats/paid-wpcom-stats`.
* Click on the `Upgrade my Stats` button.
* Ensure the `Terms of Service` relevant text is removed from the purchase wizard.
* Append `&productType=personal` to the purchase page URL.
* Ensure the `Terms of Service` relevant text is removed from the standalone personal purchase page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?