### PR TITLE
Domain Transfer: Update copy when domain is not pointing to WPCOM

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, englishLocales } from '@automattic/i18n-utils';
+import i18n, { getLocaleSlug } from 'i18n-calypso';
 import moment from 'moment';
 import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import { isExpiringSoon } from 'calypso/lib/domains/utils/is-expiring-soon';
@@ -468,28 +469,51 @@ export function resolveDomainStatus(
 					icon: 'check_circle',
 				};
 			}
+			// domain.transferStatus === transferStatus.COMPLETED &&
+			if ( ! domain.pointsToWpcom ) {
+				const hasTranslation =
+					englishLocales.includes( String( getLocaleSlug() ) ) ||
+					i18n.hasTranslation(
+						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com.{{/a}}'
+					);
 
-			if ( domain.transferStatus === transferStatus.COMPLETED && ! domain.pointsToWpcom ) {
+				const oldCopy = translate(
+					'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com name servers.{{/a}}',
+					{
+						components: {
+							strong: <strong />,
+							a: (
+								<a
+									href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute, {
+										nameservers: true,
+									} ) }
+								/>
+							),
+						},
+					}
+				);
+
+				const newCopy = translate(
+					'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com.{{/a}}',
+					{
+						components: {
+							strong: <strong />,
+							a: (
+								<a
+									href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute, {
+										nameservers: true,
+									} ) }
+								/>
+							),
+						},
+					}
+				);
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-success',
 					status: translate( 'Active' ),
 					icon: 'info',
-					noticeText: translate(
-						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com.{{/a}}',
-						{
-							components: {
-								strong: <strong />,
-								a: (
-									<a
-										href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute, {
-											nameservers: true,
-										} ) }
-									/>
-								),
-							},
-						}
-					),
+					noticeText: hasTranslation ? newCopy : oldCopy,
 					listStatusWeight: 600,
 				};
 			}

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -476,7 +476,7 @@ export function resolveDomainStatus(
 					status: translate( 'Active' ),
 					icon: 'info',
 					noticeText: translate(
-						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com name servers.{{/a}}',
+						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com.{{/a}}',
 						{
 							components: {
 								strong: <strong />,

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -469,8 +469,8 @@ export function resolveDomainStatus(
 					icon: 'check_circle',
 				};
 			}
-			// domain.transferStatus === transferStatus.COMPLETED &&
-			if ( ! domain.pointsToWpcom ) {
+
+			if ( domain.transferStatus === transferStatus.COMPLETED && ! domain.pointsToWpcom ) {
 				const hasTranslation =
 					englishLocales.includes( String( getLocaleSlug() ) ) ||
 					i18n.hasTranslation(


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3550

## Proposed Changes

Update the copy when a Domain Transfer is completed, and the domain is not pointing to WPCOM, removing the `name servers` because we don't check the name servers.

| Before | After |
| --- | --- |
| <img width="1065" alt="image" src="https://github.com/Automattic/wp-calypso/assets/402286/82c56d2d-4763-419d-b6de-89cbc0dea1bb"> | <img width="1065" alt="image" src="https://github.com/Automattic/wp-calypso/assets/402286/3795c527-cc2b-44e3-bbaa-ec0d8e1049c9"> | 


## Testing Instructions

* Go to `/domains/manage/all`
* On `client/lib/domains/resolve-domain-status.tsx`, remove `domain.transferStatus === transferStatus.COMPLETED && ` from line 472.
* If you have a domain transfer and not pointing to WPCOM, you should see the message
* If not, try changing the DNS (on WPCOM or external) and point elsewhere.
* Wait 5 minutes for the cache and try again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?