### PR TITLE
Notices: Update docs for client/state/notices for functional components

### DIFF
--- a/client/state/notices/README.md
+++ b/client/state/notices/README.md
@@ -1,7 +1,7 @@
 # Notices
 
 A subtree of state that manages global notices.
-Supported types of notices are `error`, `success`.
+Supported types of notices are `error`, `success`, `info`, and `warning`.
 
 ## How to use?
 
@@ -9,7 +9,7 @@ Supported types of notices are `error`, `success`.
 
 ```js
 import { useDispatch } from 'react-redux';
-import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 
 function Component() {
 	const reduxDispatch = useDispatch();

--- a/client/state/notices/README.md
+++ b/client/state/notices/README.md
@@ -5,25 +5,37 @@ Supported types of notices are `error`, `success`.
 
 ## How to use?
 
-### Connect to Redux
+### Functional components
 
-First, the component that wants to send notices must be connected to Redux.
+```js
+import { useDispatch } from 'react-redux';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+
+function Component() {
+	const reduxDispatch = useDispatch();
+	useEffect(() => {
+		reduxDispatch(errorNotice('Something went wrong'));
+	}, []);
+}
+```
+
+### Class components
+
+The component that wants to send notices must be connected to Redux.
 
 ```javascript
 import { connect } from 'react-redux';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 
+class Component {
+	componentDidMount() {
+		this.props.successNotice( 'Settings saved successfully!', {
+			duration: 4000,
+		} );
+	}
+}
+
 export default connect( null, { successNotice, errorNotice } )( Component );
-```
-
-### Uses
-
-Now you can use notices like so:
-
-```javascript
-this.props.successNotice( 'Settings saved successfully!', {
-	duration: 4000,
-} );
 ```
 
 ### The available methods are


### PR DESCRIPTION
## Proposed Changes

The README for `client/state/notices` was only for class-based components. This PR updates it to also mention functional components.

## Testing Instructions

None