### PR TITLE
BackupBrowser: Fix files selected count

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -83,7 +83,12 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 						siteId,
 						path,
 						backupFiles.filter( shouldAddChildNode ).map( ( childItem: FileBrowserItem ) => {
-							return { id: childItem.id ?? '', path: childItem.name, type: childItem.type };
+							return {
+								id: childItem.id ?? '',
+								path: childItem.name,
+								type: childItem.type,
+								totalItems: childItem.totalItems,
+							};
 						} )
 					)
 				);

--- a/client/my-sites/backup/backup-contents-page/file-browser/test/util.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/test/util.ts
@@ -186,6 +186,7 @@ describe( 'parseBackupContentsData', () => {
 				hasChildren: false,
 				period: '1690411648',
 				id: 'ZjY6L2luZGV4LnBocA==',
+				totalItems: 1,
 			},
 		];
 

--- a/client/my-sites/backup/backup-contents-page/file-browser/util.ts
+++ b/client/my-sites/backup/backup-contents-page/file-browser/util.ts
@@ -92,7 +92,7 @@ export const parseBackupContentsData = ( payload: BackupLsResponse ): FileBrowse
 			...( item.extension_version && { extensionVersion: item.extension_version } ),
 			...( item.manifest_path && { manifestPath: item.manifest_path } ),
 			...( item.id && { id: item.id } ),
-			...( item.total_items && { totalItems: item.total_items } ),
+			...( item.type !== 'wordpress' && { totalItems: item.total_items ?? 1 } ),
 		};
 	} );
 

--- a/client/state/rewind/browser/reducer.ts
+++ b/client/state/rewind/browser/reducer.ts
@@ -210,6 +210,7 @@ export default ( state = initialState, { type, payload }: AnyAction ) => {
 					checkState: parentNode.checkState === 'checked' ? 'checked' : 'unchecked',
 					childrenLoaded: false,
 					children: [],
+					totalItems: childPath.totalItems,
 				} );
 			}
 

--- a/client/state/rewind/browser/reducer.ts
+++ b/client/state/rewind/browser/reducer.ts
@@ -13,6 +13,7 @@ const initialState: AppState = {
 		checkState: 'unchecked',
 		childrenLoaded: false,
 		children: [],
+		totalItems: 0,
 	},
 };
 

--- a/client/state/rewind/browser/types.ts
+++ b/client/state/rewind/browser/types.ts
@@ -8,6 +8,7 @@ export type BackupBrowserItem = {
 	checkState: 'checked' | 'unchecked' | 'mixed';
 	childrenLoaded: boolean;
 	children: BackupBrowserItem[];
+	totalItems: number;
 };
 
 export type BackupBrowserCheckListInfo = {

--- a/client/state/rewind/selectors/get-backup-browser-check-list.ts
+++ b/client/state/rewind/selectors/get-backup-browser-check-list.ts
@@ -25,6 +25,15 @@ const addChildrenToList = (
 			id: currentNode.id,
 			path: getNodeFullPath( currentNode ),
 		} );
+
+		if ( currentNode.path === '/' ) {
+			currentNode.children.forEach( ( node: BackupBrowserItem ) => {
+				if ( node.checkState === 'checked' ) {
+					currentList.totalItems += node.totalItems;
+				}
+			} );
+		}
+
 		return currentList;
 	}
 

--- a/client/state/rewind/selectors/get-backup-browser-check-list.ts
+++ b/client/state/rewind/selectors/get-backup-browser-check-list.ts
@@ -26,6 +26,8 @@ const addChildrenToList = (
 			path: getNodeFullPath( currentNode ),
 		} );
 
+		// If the current node is the root, let's go through direct children and
+		// sum the `totalItems` of each of them.
 		if ( currentNode.path === '/' ) {
 			currentNode.children.forEach( ( node: BackupBrowserItem ) => {
 				if ( node.checkState === 'checked' ) {

--- a/client/state/rewind/selectors/get-backup-browser-check-list.ts
+++ b/client/state/rewind/selectors/get-backup-browser-check-list.ts
@@ -25,7 +25,6 @@ const addChildrenToList = (
 			id: currentNode.id,
 			path: getNodeFullPath( currentNode ),
 		} );
-		currentList.totalItems++;
 		return currentList;
 	}
 
@@ -43,7 +42,6 @@ const addChildrenToList = (
 			id: currentNode.id,
 			path: getNodeFullPath( currentNode ),
 		} );
-		currentList.totalItems++;
 		return currentList;
 	}
 
@@ -62,10 +60,11 @@ const addChildrenToList = (
 			path: getNodeFullPath( currentNode ),
 		} );
 
-		// Lets sum only the selected children
-		currentList.totalItems = currentList.totalItems + selectedChildren;
-
 		currentNode.children.forEach( ( node: BackupBrowserItem ) => {
+			if ( node.checkState === 'checked' ) {
+				currentList.totalItems += node.totalItems;
+			}
+
 			if ( node.checkState === 'unchecked' ) {
 				currentList.excludeList.push( {
 					id: node.id,
@@ -81,7 +80,7 @@ const addChildrenToList = (
 	currentNode.children.forEach( ( node: BackupBrowserItem ) => {
 		if ( 'checked' === node.checkState ) {
 			currentList.includeList.push( { id: node.id, path: getNodeFullPath( node ) } );
-			currentList.totalItems++;
+			currentList.totalItems += node.totalItems;
 		}
 		if ( 'mixed' === node.checkState ) {
 			currentList = addChildrenToList( node, currentList );


### PR DESCRIPTION
Currently the count of files selected is just considering directories and files as 1. The idea is to use the `totalItems` field retrieved by `backup/ls` API to display a real selected files count. For example, if you check in `sql`, it should display the number of database tables as files selected instead of just 1.

![CleanShot 2023-09-14 at 22 49 51@2x](https://github.com/Automattic/wp-calypso/assets/1488641/7316a901-1b81-4720-8122-fe96adec8129)

## Proposed Changes
* Default totalItems to 1 and undefined for WordPress version.
* Map `totalItems` in child nodes redux state
* Count selected files based on totalItems in the get backup browser checklist selector.
* Count direct children `totalItems` when the current node is the root.

## Demo
https://github.com/Automattic/wp-calypso/assets/1488641/ac5303f9-8595-4071-83f2-cce1e4b45f8a

## Known issues
* We have some issues with `totalItems` in production, where VP is returning the wrong number for `wp-content` in some cases. This is getting fixed in a VP PR.

https://github.com/Automattic/wp-calypso/assets/1488641/c6503b7f-c5aa-41fb-b7d0-26d93e16e051

## Testing Instructions
* Spin up a Calypso or Jetpack Cloud live branch
* Select a site with a Jetpack VaultPress Backup plan
* Pick a backup and click on `View files` inside the `Actions (+)` menu. This option is only available on full/daily backups
* Try to select some files and ensure the files selected count on top is right.
  * Try selecting all files
  * Try selecting some random files
  * Try selecting a full directory and then deselect one file inside that directory

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?