### PR TITLE
Domain management: enable new table internally and gate bulk contact info editing behind a feature flag

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -31,7 +31,7 @@ import DomainManagement from '.';
 
 export default {
 	domainManagementList( pageContext, next ) {
-		if ( isEnabled( 'domains/management' ) ) {
+		if ( isEnabled( 'domains/bulk-actions-table' ) ) {
 			pageContext.primary = (
 				<DomainManagement.BulkSiteDomains
 					analyticsPath={ domainManagementRoot( ':site' ) }
@@ -56,7 +56,7 @@ export default {
 	},
 
 	domainManagementListAllSites( pageContext, next ) {
-		if ( isEnabled( 'domains/management' ) ) {
+		if ( isEnabled( 'domains/bulk-actions-table' ) ) {
 			pageContext.primary = (
 				<>
 					<DomainManagement.BulkAllDomains

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	DomainsTable,
 	useDomainsTable,
@@ -92,6 +93,9 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				<DomainsTable
 					domains={ domains }
 					isAllSitesView
+					shouldDisplayContactInfoBulkAction={ isEnabled(
+						'domains/bulk-actions-contact-info-editing'
+					) }
 					domainStatusPurchaseActions={ purchaseActions }
 					onDomainAction={ ( action, domain ) => {
 						if ( action === 'manage-dns-settings' ) {

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable } from '@automattic/domains-table';
 import { useTranslate } from 'i18n-calypso';
@@ -61,6 +62,9 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 					domains={ data?.domains }
 					isAllSitesView={ false }
 					siteSlug={ siteSlug }
+					shouldDisplayContactInfoBulkAction={ isEnabled(
+						'domains/bulk-actions-contact-info-editing'
+					) }
 					userCanSetPrimaryDomains={ userCanSetPrimaryDomains }
 					onDomainAction={ async ( action, domain ) => {
 						if ( action === 'manage-dns-settings' ) {

--- a/config/development.json
+++ b/config/development.json
@@ -57,7 +57,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/max-characters-filter": false,
 		"domains/kracken-ui/pagination": true,
-		"domains/management": false,
+		"domains/bulk-actions-table": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"domains/transfer-to-any-user": true,

--- a/config/development.json
+++ b/config/development.json
@@ -58,6 +58,7 @@
 		"domains/kracken-ui/max-characters-filter": false,
 		"domains/kracken-ui/pagination": true,
 		"domains/bulk-actions-table": true,
+		"domains/bulk-actions-contact-info-editing": false,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"domains/transfer-to-any-user": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -27,7 +27,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"domains/management": false,
+		"domains/bulk-actions-table": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,

--- a/config/production.json
+++ b/config/production.json
@@ -38,7 +38,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"domains/management": false,
+		"domains/bulk-actions-table": false,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,

--- a/config/production.json
+++ b/config/production.json
@@ -39,6 +39,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/bulk-actions-table": false,
+		"domains/bulk-actions-contact-info-editing": false,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -37,6 +37,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/bulk-actions-table": true,
+		"domains/bulk-actions-contact-info-editing": false,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -36,7 +36,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"domains/management": false,
+		"domains/bulk-actions-table": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,

--- a/config/test.json
+++ b/config/test.json
@@ -39,6 +39,7 @@
 		"devdocs/redirect-loggedout-homepage": true,
 		"difm/allow-extra-pages": false,
 		"domains/bulk-actions-table": true,
+		"domains/bulk-actions-contact-info-editing": false,
 		"cookie-banner": false,
 		"google-my-business": false,
 		"help": true,

--- a/config/test.json
+++ b/config/test.json
@@ -38,7 +38,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"difm/allow-extra-pages": false,
-		"domains/management": false,
+		"domains/bulk-actions-table": true,
 		"cookie-banner": false,
 		"google-my-business": false,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -41,7 +41,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"domains/management": false,
+		"domains/bulk-actions-table": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -42,6 +42,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/bulk-actions-table": true,
+		"domains/bulk-actions-contact-info-editing": false,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,

--- a/packages/domains-table/src/bulk-actions-toolbar/index.tsx
+++ b/packages/domains-table/src/bulk-actions-toolbar/index.tsx
@@ -3,6 +3,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
+import { useDomainsTable } from '../domains-table/domains-table';
 import contactIcon from './contact.svg';
 import transformIcon from './transform.svg';
 import './style.scss';
@@ -18,6 +19,7 @@ export function BulkActionsToolbar( {
 	onUpdateContactInfo,
 	selectedDomainCount,
 }: BulkActionsToolbarProps ) {
+	const { shouldDisplayContactInfoBulkAction } = useDomainsTable();
 	const { __, _n } = useI18n();
 	const [ controlKey, setControlKey ] = useState( 1 );
 
@@ -64,16 +66,18 @@ export function BulkActionsToolbar( {
 
 	return (
 		<div className="domains-table-bulk-actions-toolbar">
-			<Button onClick={ onUpdateContactInfo }>
-				<img
-					className="domains-table-bulk-actions-toolbar__icon"
-					src={ contactIcon }
-					width={ 18 }
-					height={ 18 }
-					alt=""
-				/>{ ' ' }
-				{ __( 'Edit contact information', __i18n_text_domain__ ) }
-			</Button>
+			{ shouldDisplayContactInfoBulkAction && (
+				<Button onClick={ onUpdateContactInfo }>
+					<img
+						className="domains-table-bulk-actions-toolbar__icon"
+						src={ contactIcon }
+						width={ 18 }
+						height={ 18 }
+						alt=""
+					/>{ ' ' }
+					{ __( 'Edit contact information', __i18n_text_domain__ ) }
+				</Button>
+			) }
 			<SelectDropdown
 				key={ controlKey }
 				className="domains-table-bulk-actions-toolbar__select"

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -45,6 +45,7 @@ interface BaseDomainsTableProps {
 	fetchSite?: ( siteIdOrSlug: number | string | null | undefined ) => Promise< SiteDetails >;
 	onDomainAction?( action: DomainAction, domain: ResponseDomain ): void;
 	userCanSetPrimaryDomains?: boolean;
+	shouldDisplayContactInfoBulkAction?: boolean;
 }
 
 export type DomainsTablePropsNoChildren =
@@ -86,6 +87,7 @@ type Value = {
 	setShowBulkActions: ( showBulkActions: boolean ) => void;
 	onDomainAction: BaseDomainsTableProps[ 'onDomainAction' ];
 	userCanSetPrimaryDomains: BaseDomainsTableProps[ 'userCanSetPrimaryDomains' ];
+	shouldDisplayContactInfoBulkAction: boolean;
 };
 
 const Context = createContext< Value | undefined >( undefined );
@@ -102,6 +104,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		children,
 		onDomainAction,
 		userCanSetPrimaryDomains,
+		shouldDisplayContactInfoBulkAction = false,
 	} = props;
 
 	const [ { sortKey, sortDirection }, setSort ] = useState< {
@@ -338,6 +341,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		setShowBulkActions,
 		onDomainAction,
 		userCanSetPrimaryDomains,
+		shouldDisplayContactInfoBulkAction,
 	};
 
 	return (


### PR DESCRIPTION
## Proposed Changes

Title.

## Testing Instructions

1. Verify that the new table shows up everywhere but production
2. Verify that only the auto-renew bulk action shows up by default
3. Enable the `domains/bulk-actions-contact-info-editing` flag and check that the contact info editing bulk action shows in the bulk actions toolbar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
~- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~