### PR TITLE
Domains Management i1: Fix repeated requests for `/sites/%s/domains` when navigating domains table

### DIFF
--- a/packages/data-stores/src/queries/use-site-domains-query.ts
+++ b/packages/data-stores/src/queries/use-site-domains-query.ts
@@ -123,7 +123,9 @@ export function getSiteDomainsQueryObject< TError = unknown, TData = SiteDomains
 				path: `/sites/${ siteIdOrSlug }/domains`,
 				apiVersion: '1.2',
 			} ),
+		staleTime: 1000 * 60 * 5, // 5 minutes
 		...options,
+		meta: { persist: false, ...options.meta },
 		enabled: Boolean( siteIdOrSlug ) && options.enabled,
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

1. Instruct React Query that "site domains" data doesn't become stale immediately
2. Don't persist "site domains" requests to local storage

The first change vastly reduces the number of requests made to `/sites/%s/domains` for data. [It requests the data once when rendering `<DomainsTable>`](https://github.com/Automattic/wp-calypso/blob/5dbb420c3277d41bc0c89fb7faafaf47296cf356/packages/domains-table/src/domains-table/domains-table.tsx#L123) (because at least for now the full domain data is needed to render the table, hopefully in the future we can use partial domain data). [It then requests it again for each row](https://github.com/Automattic/wp-calypso/blob/5dbb420c3277d41bc0c89fb7faafaf47296cf356/packages/domains-table/src/use-domain-row.ts#L28). This will be good when we eventually lazy load row data. We _want_ to request it when it's needed to render a row. But then it also requests it _again_ if there's a 2nd domain that happens to belong to the same site.

All 3 requests use the same query key so we'd like to be able to use the React Query hooks without it actually making 3 network requests. The reason it makes the request each time is because React Query immediately treats the data as "stale". Adding a non-zero stale time means the data gets pulled from cache. I feel like setting the `refetchOnMount` option to `false` would be a better option, but this didn't seem to work the way I expected.

The second change (not persisting the request to local storage) is there because if the user refreshes the page I still want them to see the latest data. Because the data is now counted as not stale I was worried refreshing the browser wouldn't re-request the data. Setting our meta flag prevents it from being saved between browser refreshes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Clear indexdb in your browser, otherwise the change to the persist flag will have no impact
* Filter network tool for `domains`
* Reload domains table
* `/sites/%s/domains` requests should now only fire when `<DomainsTable>` renders. Row renders no longer produce extra requests.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~