### PR TITLE
Domain management: Hide site column in site-specific table

### DIFF
--- a/packages/domains-table/src/domains-table-filters/index.tsx
+++ b/packages/domains-table/src/domains-table-filters/index.tsx
@@ -3,8 +3,8 @@ import SearchControl, { SearchIcon } from '@automattic/search';
 import { isMobile } from '@automattic/viewport';
 import { DropdownMenu, MenuGroup, MenuItem, ToggleControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import { ReactNode } from 'react';
 import { useDomainsTable } from '../domains-table/domains-table';
-import { domainsTableColumns } from '../domains-table-header/columns';
 
 import './style.scss';
 
@@ -21,10 +21,16 @@ interface DomainsTableFiltersProps {
 export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersProps ) => {
 	const { __ } = useI18n();
 
-	const { sortKey, sortDirection, onSortChange, setShowBulkActions, showBulkActions } =
-		useDomainsTable();
+	const {
+		sortKey,
+		sortDirection,
+		onSortChange,
+		setShowBulkActions,
+		showBulkActions,
+		domainsTableColumns,
+	} = useDomainsTable();
 
-	const options: any[] = [];
+	const options: ReactNode[] = [];
 	const selected = domainsTableColumns.find( ( column ) => column.name === sortKey );
 	const sortName = selected?.sortLabel || selected?.label;
 	const arrow = sortDirection === 'asc' ? '↓' : '↑';

--- a/packages/domains-table/src/domains-table-header/columns.ts
+++ b/packages/domains-table/src/domains-table-header/columns.ts
@@ -2,7 +2,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { getSimpleSortFunctionBy, getSiteSortFunctions } from '../utils';
 import { DomainsTableColumn } from '.';
 
-export const domainsTableColumns: DomainsTableColumn[] = [
+export const allSitesViewColumns: DomainsTableColumn[] = [
 	{
 		name: 'domain',
 		label: ( count: number ) =>
@@ -44,6 +44,52 @@ export const domainsTableColumns: DomainsTableColumn[] = [
 		supportsOrderSwitching: true,
 		sortFunctions: [ getSimpleSortFunctionBy( 'expiry' ), getSimpleSortFunctionBy( 'domain' ) ],
 		width: '15%',
+	},
+	{
+		name: 'status',
+		label: __( 'Status', __i18n_text_domain__ ),
+		isSortable: true,
+		initialSortDirection: 'desc',
+		supportsOrderSwitching: true,
+		sortFunctions: [],
+		width: '15%',
+	},
+	{ name: 'action', label: null },
+];
+
+export const siteSpecificViewColumns: DomainsTableColumn[] = [
+	{
+		name: 'domain',
+		label: ( count: number ) =>
+			sprintf(
+				/* translators: Heading which displays the number of domains in a table */
+				_n( '%(count)d domain', '%(count)d domains', count, __i18n_text_domain__ ),
+				{ count }
+			),
+		sortLabel: __( 'Domain', __i18n_text_domain__ ),
+		isSortable: true,
+		initialSortDirection: 'asc',
+		supportsOrderSwitching: true,
+		sortFunctions: [ getSimpleSortFunctionBy( 'domain' ) ],
+		width: '35%',
+	},
+	{
+		name: 'owner',
+		label: __( 'Owner', __i18n_text_domain__ ),
+		isSortable: true,
+		initialSortDirection: 'asc',
+		supportsOrderSwitching: true,
+		sortFunctions: [ getSimpleSortFunctionBy( 'domain' ) ],
+		width: '25%',
+	},
+	{
+		name: 'expire_renew',
+		label: __( 'Expires / renews on', __i18n_text_domain__ ),
+		isSortable: true,
+		initialSortDirection: 'asc',
+		supportsOrderSwitching: true,
+		sortFunctions: [ getSimpleSortFunctionBy( 'expiry' ), getSimpleSortFunctionBy( 'domain' ) ],
+		width: '20%',
 	},
 	{
 		name: 'status',

--- a/packages/domains-table/src/domains-table/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/index.tsx
@@ -424,3 +424,70 @@ test( 'search for a domain hides other domains from table', async () => {
 	expect( screen.queryByText( 'dog.com' ) ).toBeInTheDocument();
 	expect( screen.queryByText( 'cat.org' ) ).not.toBeInTheDocument();
 } );
+
+test( 'when isAllSitesView is true, display site column', async () => {
+	const [ primaryPartial, primaryFull ] = testDomain( {
+		domain: 'primary-domain.blog',
+		blog_id: 123,
+		primary_domain: true,
+		owner: 'owner',
+	} );
+
+	const fetchSiteDomains = jest.fn().mockImplementation( () =>
+		Promise.resolve( {
+			domains: [ primaryFull ],
+		} )
+	);
+
+	const fetchSite = jest.fn().mockResolvedValue( { ID: 123, name: 'Primary Domain Blog' } );
+
+	render(
+		<DomainsTable
+			domains={ [ primaryPartial ] }
+			isAllSitesView
+			fetchSiteDomains={ fetchSiteDomains }
+			fetchSite={ fetchSite }
+		/>
+	);
+
+	await waitFor( () => {
+		expect( fetchSite ).toHaveBeenCalled();
+	} );
+
+	expect( screen.queryByText( 'Site' ) ).toBeInTheDocument();
+	expect( screen.queryByText( 'Primary Domain Blog' ) ).toBeInTheDocument();
+} );
+
+test( 'when isAllSitesView is false, do not display site column', async () => {
+	const [ primaryPartial, primaryFull ] = testDomain( {
+		domain: 'primary-domain.blog',
+		blog_id: 123,
+		primary_domain: true,
+		owner: 'owner',
+	} );
+
+	const fetchSiteDomains = jest.fn().mockImplementation( () =>
+		Promise.resolve( {
+			domains: [ primaryFull ],
+		} )
+	);
+
+	const fetchSite = jest.fn().mockResolvedValue( { ID: 123, name: 'Primary Domain Blog' } );
+
+	render(
+		<DomainsTable
+			domains={ [ primaryPartial ] }
+			isAllSitesView={ false }
+			fetchSiteDomains={ fetchSiteDomains }
+			fetchSite={ fetchSite }
+			siteSlug={ primaryPartial.domain }
+		/>
+	);
+
+	await waitFor( () => {
+		expect( fetchSite ).toHaveBeenCalled();
+	} );
+
+	expect( screen.queryByText( 'Site' ) ).not.toBeInTheDocument();
+	expect( screen.queryByText( 'Primary Domain Blog' ) ).not.toBeInTheDocument();
+} );

--- a/packages/domains-table/src/domains-table/domains-table-header.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-header.tsx
@@ -1,17 +1,7 @@
-import { domainsTableColumns as defaultDomainsTableColumns } from '../domains-table-header/columns';
-import {
-	DomainsTableColumn,
-	DomainsTableHeader as InternalDomainsTableHeader,
-} from '../domains-table-header/index';
+import { DomainsTableHeader as InternalDomainsTableHeader } from '../domains-table-header/index';
 import { useDomainsTable } from './domains-table';
 
-type Props = {
-	domainsTableColumns?: DomainsTableColumn[];
-};
-
-export const DomainsTableHeader = ( {
-	domainsTableColumns = defaultDomainsTableColumns,
-}: Props ) => {
+export const DomainsTableHeader = () => {
 	const {
 		sortKey,
 		sortDirection,
@@ -22,11 +12,12 @@ export const DomainsTableHeader = ( {
 		domainsRequiringAttention,
 		canSelectAnyDomains,
 		filteredData,
+		domainsTableColumns,
 	} = useDomainsTable();
 
 	return (
 		<InternalDomainsTableHeader
-			columns={ domainsTableColumns || [] }
+			columns={ domainsTableColumns }
 			activeSortKey={ sortKey }
 			activeSortDirection={ sortDirection }
 			bulkSelectionStatus={ getBulkSelectionStatus() }

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -23,7 +23,7 @@ import {
 	ReactNode,
 } from 'react';
 import { DomainsTableFilter } from '../domains-table-filters/index';
-import { domainsTableColumns } from '../domains-table-header/columns';
+import { allSitesViewColumns, siteSpecificViewColumns } from '../domains-table-header/columns';
 import { DomainsTableColumn } from '../domains-table-header/index';
 import { getDomainId } from '../get-domain-id';
 import { useDomainBulkUpdateStatus } from '../use-domain-bulk-update-status';
@@ -88,6 +88,7 @@ type Value = {
 	onDomainAction: BaseDomainsTableProps[ 'onDomainAction' ];
 	userCanSetPrimaryDomains: BaseDomainsTableProps[ 'userCanSetPrimaryDomains' ];
 	shouldDisplayContactInfoBulkAction: boolean;
+	domainsTableColumns: DomainsTableColumn[];
 };
 
 const Context = createContext< Value | undefined >( undefined );
@@ -166,6 +167,8 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		} );
 	}, [ domains ] );
 
+	const domainsTableColumns = isAllSitesView ? allSitesViewColumns : siteSpecificViewColumns;
+
 	const sortedDomains = useMemo( () => {
 		const selectedColumnDefinition = domainsTableColumns.find(
 			( column ) => column.name === sortKey
@@ -191,7 +194,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 			}
 			return result;
 		} );
-	}, [ fetchedSiteDomains, domains, sortKey, sortDirection ] );
+	}, [ fetchedSiteDomains, domains, sortKey, sortDirection, domainsTableColumns ] );
 
 	const filteredData = useFuzzySearch( {
 		data: sortedDomains ?? [],
@@ -342,6 +345,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		onDomainAction,
 		userCanSetPrimaryDomains,
 		shouldDisplayContactInfoBulkAction,
+		domainsTableColumns,
 	};
 
 	return (

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -5,7 +5,6 @@ import { DomainsTableBulkUpdateNotice } from './domains-table-bulk-update-notice
 import { DomainsTableHeader } from './domains-table-header';
 import { DomainsTableMobileCards } from './domains-table-mobile-cards';
 import { DomainsTableToolbar } from './domains-table-toolbar';
-
 import './style.scss';
 
 export function DomainsTable( props: DomainsTablePropsNoChildren ) {


### PR DESCRIPTION
Related to p1694658540395129-slack-C04H4NY6STW.

## Proposed Changes

Removes the site column when browsing the site-specific table:

<img width="820" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/1641fb8a-3881-4368-9f59-030856cbd77a">

## Testing Instructions

1. Browse `/domains/manage` and check that the site column shows up and with the site's name
2. Browse `/domains/manage/%s` and check that the column is gone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
~- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~