### PR TITLE
Domain management: Hide wordpress.com domain on Atomic sites domains table

### DIFF
--- a/packages/domains-table/src/domains-table/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/index.tsx
@@ -491,3 +491,33 @@ test( 'when isAllSitesView is false, do not display site column', async () => {
 	expect( screen.queryByText( 'Site' ) ).not.toBeInTheDocument();
 	expect( screen.queryByText( 'Primary Domain Blog' ) ).not.toBeInTheDocument();
 } );
+
+test( 'when isAllSitesView is false, hide wordpress.com domain if there is a wpcom staging domain', () => {
+	const [ wpcomDomain ] = testDomain( {
+		domain: 'primary-domain.wordpress.com',
+		blog_id: 123,
+		primary_domain: true,
+		owner: 'owner',
+		wpcom_domain: true,
+	} );
+
+	const [ wpcomStagingDomain ] = testDomain( {
+		domain: 'primary-domain.wpcomstaging.com',
+		blog_id: 123,
+		primary_domain: true,
+		owner: 'owner',
+		wpcom_domain: true,
+		is_wpcom_staging_domain: true,
+	} );
+
+	render(
+		<DomainsTable
+			domains={ [ wpcomDomain, wpcomStagingDomain ] }
+			isAllSitesView={ false }
+			siteSlug={ wpcomStagingDomain.domain }
+		/>
+	);
+
+	expect( screen.queryByText( 'primary-domain.wpcomstaging.com' ) ).toBeInTheDocument();
+	expect( screen.queryByText( 'primary-domain.wordpress.com' ) ).not.toBeInTheDocument();
+} );

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -97,7 +97,7 @@ export const useDomainsTable = () => useContext( Context ) as Value;
 
 export const DomainsTable = ( props: DomainsTableProps ) => {
 	const {
-		domains,
+		domains: allDomains,
 		fetchSiteDomains,
 		fetchSite,
 		isAllSitesView,
@@ -122,6 +122,26 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 	const [ domainsRequiringAttention, setDomainsRequiringAttention ] = useState<
 		number | undefined
 	>( undefined );
+
+	const domains = useMemo( () => {
+		if ( isAllSitesView || ! allDomains ) {
+			return allDomains;
+		}
+
+		const hasWpcomStagingDomain = allDomains.find( ( domain ) => domain.is_wpcom_staging_domain );
+
+		if ( ! hasWpcomStagingDomain ) {
+			return allDomains;
+		}
+
+		return allDomains.filter( ( domain ) => {
+			if ( domain.wpcom_domain ) {
+				return domain.is_wpcom_staging_domain;
+			}
+
+			return true;
+		} );
+	}, [ allDomains, isAllSitesView ] );
 
 	const allSiteIds = [ ...new Set( domains?.map( ( { blog_id } ) => blog_id ) || [] ) ];
 	const allSiteDomains = useQueries( {


### PR DESCRIPTION
Related to p1694658540395129-slack-C04H4NY6STW.

## Proposed Changes

When there is a `.wpcomstaging.com` site, it means that the site is Atomic. Once the site is Atomic, you can't set their primary domain to be `.wordpress.com`, thus we should remove that entry from the site-specific table.

If the site does not have a `.wpcomstaging.com` domain, we should return the `.wordpress.com` domain because it could be a simple site mapped to a domain.

## Testing Instructions

In `trunk`, verify that `/domains/manage/%s` for an Atomic site displays both `.wordpress.com` and `.wpcomstaging.com` site. Verify that the `.wordpress.com` entry is gone in this branch.

| `trunk` | This PR |
| ------- | -------- |
| <img width="580" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/40df3a44-254b-44b7-89cc-14c99ca9d55f"> | <img width="549" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/44a5a09c-a400-4c99-bc2b-bd1e74597e39"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
~- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~