### PR TITLE
Domain management: Hide connect to site action when browsing site-specific view

### DIFF
--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -44,7 +44,8 @@ export const DomainsTableRowActions = ( {
 	const { onDomainAction, userCanSetPrimaryDomains = false } = useDomainsTable();
 	const { __ } = useI18n();
 
-	const canConnectDomainToASite = domain.currentUserCanCreateSiteFromDomainOnly;
+	const canViewDetails = domain.type !== domainTypes.WPCOM;
+	const canConnectDomainToASite = isAllSitesView && domain.currentUserCanCreateSiteFromDomainOnly;
 	const canManageDNS =
 		domain.canManageDnsRecords &&
 		domain.transferStatus !== transferStatus.PENDING_ASYNC &&
@@ -68,6 +69,55 @@ export const DomainsTableRowActions = ( {
 	const canTransferToWPCOM =
 		domain.type === domainTypes.MAPPED && domain.isEligibleForInboundTransfer;
 
+	const getActions = ( onClose?: () => void ) => {
+		return [
+			canViewDetails && (
+				<MenuItemLink href={ domainManagementLink( domain, siteSlug, isAllSitesView ) }>
+					{ domain.type === domainTypes.TRANSFER ? __( 'View transfer' ) : __( 'View settings' ) }
+				</MenuItemLink>
+			),
+			canManageDNS && (
+				<MenuItemLink
+					onClick={ () => onDomainAction?.( 'manage-dns-settings', domain ) }
+					href={ domainMagementDNS( siteSlug, domain.name ) }
+				>
+					{ __( 'Manage DNS' ) }
+				</MenuItemLink>
+			),
+			canManageContactInfo && (
+				<MenuItemLink href={ domainManagementEditContactInfo( siteSlug, domain.name ) }>
+					{ __( 'Manage contact information' ) }
+				</MenuItemLink>
+			),
+			canMakePrimarySiteAddress && (
+				<MenuItemLink
+					onClick={ () => {
+						onDomainAction?.( 'set-primary', domain );
+						onClose?.();
+					} }
+				>
+					{ __( 'Make primary site address' ) }
+				</MenuItemLink>
+			),
+			canTransferToWPCOM && (
+				<MenuItemLink
+					href={ domainUseMyDomain( siteSlug, domain.name, useMyDomainInputMode.transferDomain ) }
+				>
+					{ __( 'Transfer to WordPress.com' ) }
+				</MenuItemLink>
+			),
+			canConnectDomainToASite && (
+				<MenuItemLink href={ domainManagementTransferToOtherSiteLink( siteSlug, domain.domain ) }>
+					{ __( 'Connect to an existing site' ) }
+				</MenuItemLink>
+			),
+		];
+	};
+
+	if ( getActions().filter( Boolean ).length === 0 ) {
+		return null;
+	}
+
 	return (
 		<DropdownMenu
 			className="domains-table-row__actions"
@@ -76,50 +126,7 @@ export const DomainsTableRowActions = ( {
 		>
 			{ ( { onClose } ) => (
 				<MenuGroup className="domains-table-row__actions-group">
-					<MenuItemLink href={ domainManagementLink( domain, siteSlug, isAllSitesView ) }>
-						{ domain.type === domainTypes.TRANSFER ? __( 'View transfer' ) : __( 'View settings' ) }
-					</MenuItemLink>
-					{ canManageDNS && (
-						<MenuItemLink
-							onClick={ () => onDomainAction?.( 'manage-dns-settings', domain ) }
-							href={ domainMagementDNS( siteSlug, domain.name ) }
-						>
-							{ __( 'Manage DNS' ) }
-						</MenuItemLink>
-					) }
-					{ canManageContactInfo && (
-						<MenuItemLink href={ domainManagementEditContactInfo( siteSlug, domain.name ) }>
-							{ __( 'Manage contact information' ) }
-						</MenuItemLink>
-					) }
-					{ canMakePrimarySiteAddress && (
-						<MenuItemLink
-							onClick={ () => {
-								onDomainAction?.( 'set-primary', domain );
-								onClose();
-							} }
-						>
-							{ __( 'Make primary site address' ) }
-						</MenuItemLink>
-					) }
-					{ canTransferToWPCOM && (
-						<MenuItemLink
-							href={ domainUseMyDomain(
-								siteSlug,
-								domain.name,
-								useMyDomainInputMode.transferDomain
-							) }
-						>
-							{ __( 'Transfer to WordPress.com' ) }
-						</MenuItemLink>
-					) }
-					{ canConnectDomainToASite && (
-						<MenuItemLink
-							href={ domainManagementTransferToOtherSiteLink( siteSlug, domain.domain ) }
-						>
-							{ __( 'Connect to an existing site' ) }
-						</MenuItemLink>
-					) }
+					{ getActions( onClose ) }
 				</MenuGroup>
 			) }
 		</DropdownMenu>


### PR DESCRIPTION
Related to p1694658540395129-slack-C04H4NY6STW.

## Proposed Changes

Title. I also:
- removed the "view settings" action when browsing a WPCOM domain.
- removed the ellipsis menu when no items are displayed.

Sorry for breaking the single responsibility principle, but it's faster to ship smaller changes in a single PR. I can break it down if strong feelings against.

## Testing Instructions

1. Check that the "view settings" action is gone for WPCOM domains in `/domains/manage/%s`
2. Check that WPCOM domains have no ellipsis menu in `/domains/manage/%s`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
~- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~