### PR TITLE
Sell Flow: Fix the thank you page got stuck after the atomic transfer

### DIFF
--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Onboard } from '@automattic/data-stores';
+import { Onboard, getThemeIdFromStylesheet } from '@automattic/data-stores';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useDispatch as reduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -151,10 +151,11 @@ const pluginBundleFlow: Flow = {
 
 			let defaultExitDest = `/home/${ siteSlug }`;
 			if ( siteDetails?.options?.theme_slug ) {
+				const themeId = getThemeIdFromStylesheet( siteDetails?.options?.theme_slug );
 				if ( isEnabled( 'themes/display-thank-you-page-for-woo' ) ) {
-					defaultExitDest = `/marketplace/thank-you/${ siteSlug }?themes=${ siteDetails?.options?.theme_slug }`;
+					defaultExitDest = `/marketplace/thank-you/${ siteSlug }?themes=${ themeId }`;
 				} else {
-					defaultExitDest = `/theme/${ siteDetails?.options.theme_slug }/${ siteSlug }`;
+					defaultExitDest = `/theme/${ themeId }/${ siteSlug }`;
 				}
 			}
 			switch ( currentStep ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/81710, https://github.com/Automattic/wp-calypso/pull/81711, p1694709443318829-slack-C048CUFRGFQ

## Proposed Changes

* Referring to https://github.com/Automattic/wp-calypso/pull/81710#pullrequestreview-1625875419, the Activating screen on the thank you page got stuck after the atomic transfer. The reason is we use the stylesheet instead of the theme id to request themes after redirecting people to the thank you page
* Hence, this PR is proposing to ensure the themes query parameter is the id without the prefix (e.g.: pub, premium, etc)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new site on a Free plan.
2. In the Design Picker, choose a WooCommerce theme such as Tsubaki (you can find them in the Store tab).
3. Upgrade plan to Business.
4. Activate the theme.
5. Fill out the store details forms.
6. Confirm the domain change warning to trigger the Atomic transfer.
7. After the Atomic transfer, you're able to see the Thank you page successfully

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?