### PR TITLE
Domains Management i1: Show transfer lock opt-out in bulk contact update form

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
@@ -78,6 +78,16 @@ export default function BulkEditContactInfoPage( {
 		: null;
 	const firstSelectedDomain = selectedDomains?.[ 0 ];
 
+	// If all domains have the same registration agreement then we can link directly to it. Otherwise we
+	// use `''` and the form will fall back to a support page which links to all the different agreements.
+	const allDomainsShareAgreementUrl = selectedDomains?.every(
+		( domain ) =>
+			domain.domain_registration_agreement_url ===
+			firstSelectedDomain?.domain_registration_agreement_url
+	);
+	const domainRegistrationAgreementUrl =
+		( allDomainsShareAgreementUrl && firstSelectedDomain?.domain_registration_agreement_url ) || '';
+
 	const [ showAllSelectedDomains, setShowAllSelectedDomains ] = useState( false );
 	const domainListElementId = useId();
 
@@ -217,7 +227,7 @@ export default function BulkEditContactInfoPage( {
 
 		return (
 			<EditContactInfoFormCard
-				domainRegistrationAgreementUrl={ firstSelectedDomain.domain_registration_agreement_url }
+				domainRegistrationAgreementUrl={ domainRegistrationAgreementUrl }
 				selectedDomain={ getSelectedDomain( {
 					domains: reduxDomains,
 					selectedDomainName: firstSelectedDomain.domain,

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
@@ -9,6 +9,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { useQueries } from '@tanstack/react-query';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import moment from 'moment';
 import page from 'page';
 import { useId, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -87,6 +88,18 @@ export default function BulkEditContactInfoPage( {
 	);
 	const domainRegistrationAgreementUrl =
 		( allDomainsShareAgreementUrl && firstSelectedDomain?.domain_registration_agreement_url ) || '';
+
+	const anyDomainSupportsTransferLockOptOut =
+		selectedDomains?.some( ( domain ) => {
+			if ( ! domain.transfer_lock_on_whois_update_optional ) {
+				return false;
+			}
+
+			const registrationDatePlus60Days = moment.utc( domain.registration_date ).add( 60, 'days' );
+			const isLocked = moment.utc().isSameOrBefore( registrationDatePlus60Days );
+
+			return ! isLocked;
+		} ) ?? false;
 
 	const [ showAllSelectedDomains, setShowAllSelectedDomains ] = useState( false );
 	const domainListElementId = useId();
@@ -227,6 +240,7 @@ export default function BulkEditContactInfoPage( {
 
 		return (
 			<EditContactInfoFormCard
+				forceShowTransferLockOptOut={ anyDomainSupportsTransferLockOptOut }
 				domainRegistrationAgreementUrl={ domainRegistrationAgreementUrl }
 				selectedDomain={ getSelectedDomain( {
 					domains: reduxDomains,

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -47,6 +47,7 @@ class EditContactInfoFormCard extends Component {
 		backUrl: PropTypes.string.isRequired,
 		onSubmitButtonClick: PropTypes.func, // Callback can return "cancel" to cancel the default form handling
 		bulkEdit: PropTypes.bool,
+		forceShowTransferLockOptOut: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -148,13 +149,13 @@ class EditContactInfoFormCard extends Component {
 	handleFormSubmittingComplete = () => this.setState( { formSubmitting: false } );
 
 	renderTransferLockOptOut() {
-		const { domainRegistrationAgreementUrl, translate } = this.props;
+		const { domainRegistrationAgreementUrl, translate, forceShowTransferLockOptOut } = this.props;
 		const registrationDatePlus60Days = moment
 			.utc( this.props.selectedDomain.registrationDate )
 			.add( 60, 'days' );
 		const isLocked = moment.utc().isSameOrBefore( registrationDatePlus60Days );
 
-		if ( ! isLocked ) {
+		if ( forceShowTransferLockOptOut || ! isLocked ) {
 			return (
 				<>
 					<TransferLockOptOutForm
@@ -473,7 +474,8 @@ class EditContactInfoFormCard extends Component {
 	}
 
 	render() {
-		const { selectedDomain, showContactInfoNote, translate } = this.props;
+		const { selectedDomain, showContactInfoNote, translate, forceShowTransferLockOptOut } =
+			this.props;
 		const canUseDesignatedAgent = selectedDomain.transferLockOnWhoisUpdateOptional;
 		const whoisRegistrantData = this.getContactFormFieldValues();
 
@@ -508,7 +510,8 @@ class EditContactInfoFormCard extends Component {
 						updateWpcomEmailCheckboxDisabled={ updateWpcomEmailCheckboxDisabled }
 						onUpdateWpcomEmailCheckboxChange={ this.handleUpdateWpcomEmailCheckboxChange }
 					>
-						{ canUseDesignatedAgent && this.renderTransferLockOptOut() }
+						{ ( forceShowTransferLockOptOut || canUseDesignatedAgent ) &&
+							this.renderTransferLockOptOut() }
 					</ContactDetailsFormFields>
 				</form>
 				{ this.renderDialog() }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3649
Fixes https://github.com/Automattic/dotcom-forge/issues/3650

## Proposed Changes

* Show the transfer lock opt-out toggle whenever one of the selected domains supports opt-out
* Link to [a generic registration agreement page](https://wordpress.com/support/domains/domain-registration-agreements/) when the domains don't all share the same agreement

![image](https://github.com/Automattic/wp-calypso/assets/1500769/dc6397c4-a0fb-40f2-a670-801248b2b2ab)

The presence of the opt-out controls shown above used to depend on the "first selected domain". This isn't the correct logic. We now show the opt-out if _any_ of the domains are able to opt out. We can ensure on the backend that we don't attempt to opt-out when a domain doesn't support it. WIP here D121939-code

With regards to the registration agreement, each registrar has it's own agreement and the domain object has a property linking to the correct one. If all the selected domains share the same agreement link then it's no problem. If they don't then we fall back to a generic agreement page on the support site. This is already the fallback we use if the domain doesn't happen to have it's own agreement URL.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Select and bulk update a domain where transfer lock opt-out **isn't** supported
   * The bulk update contact form **shouldn't** show the opt-out UI
* Select and bulk update a domain where transfer lock opt-out **is** supported
   * The bulk update contact form **should** show the opt-out UI
* Select and bulk update both domains
   * The bulk update contact form **should** show
   * Choose to opt-out of transfer lock
   * Observer that the `/update-contact-info` network request's payload includes `transfer_lock: false`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?