### PR TITLE
state: refactor away from `_.compact`

### DIFF
--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -1,6 +1,6 @@
 import { extendAction } from '@automattic/state-utils';
 import debugModule from 'debug';
-import { compact, get } from 'lodash';
+import { get } from 'lodash';
 import wpcom, { wpcomJetpackLicensing } from 'calypso/lib/wp';
 import { WPCOM_HTTP_REQUEST } from 'calypso/state/action-types';
 import {
@@ -73,7 +73,7 @@ export const queueRequest =
 			method,
 			fetcher
 		)(
-			...compact( [
+			...[
 				{ path, formData, onStreamRecord, responseType },
 				{ ...query }, // wpcom mutates the query so hand it a copy
 				method === 'POST' && body,
@@ -95,7 +95,7 @@ export const queueRequest =
 								dispatch( extendAction( handler, successMeta( nextData, nextHeaders ) ) )
 						  );
 				},
-			] )
+			].filter( Boolean )
 		);
 
 		if ( 'POST' === method && onProgress ) {

--- a/client/state/data-layer/wpcom-http/pipeline/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/index.js
@@ -1,4 +1,4 @@
-import { compact, pick } from 'lodash';
+import { pick } from 'lodash';
 import { applyDuplicatesHandlers, removeDuplicateGets } from './remove-duplicate-gets';
 import { retryOnFailure } from './retry-on-failure';
 
@@ -60,8 +60,8 @@ export const processInboundChain =
 				nextData: originalData,
 				nextError: originalError,
 				nextHeaders: originalHeaders,
-				failures: compact( [ originalRequest.onFailure ] ),
-				successes: compact( [ originalRequest.onSuccess ] ),
+				failures: [ originalRequest.onFailure ].filter( Boolean ),
+				successes: [ originalRequest.onSuccess ].filter( Boolean ),
 			} ),
 			[ 'failures', 'nextData', 'nextError', 'nextHeaders', 'successes', 'shouldAbort' ]
 		);

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
@@ -1,5 +1,5 @@
 import debugFactory from 'debug';
-import { compact, get, isEqual, sortBy } from 'lodash';
+import { get, isEqual, sortBy } from 'lodash';
 const debug = debugFactory( 'calypso:data-layer:remove-duplicate-gets' );
 
 /**
@@ -75,8 +75,8 @@ export const buildKey = ( { path, apiNamespace, apiVersion, query = {} } ) =>
  * @returns {Object<string, Object[]>} union of existing list and new item
  */
 export const addResponder = ( list, item ) => ( {
-	failures: unionWith( list.failures, compact( [ item.onFailure ] ) ),
-	successes: unionWith( list.successes, compact( [ item.onSuccess ] ) ),
+	failures: unionWith( list.failures, [ item.onFailure ].filter( Boolean ) ),
+	successes: unionWith( list.successes, [ item.onSuccess ].filter( Boolean ) ),
 } );
 
 /**

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -1,6 +1,5 @@
 import debugModule from 'debug';
 import i18n from 'i18n-calypso';
-import { compact } from 'lodash';
 import page from 'page';
 import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
 import {
@@ -77,7 +76,7 @@ export const request = ( action ) => {
 };
 
 export const success = ( action, { rewind_state } ) =>
-	compact( [
+	[
 		{
 			type: JETPACK_CREDENTIALS_UPDATE_SUCCESS,
 			siteId: action.siteId,
@@ -114,7 +113,7 @@ export const success = ( action, { rewind_state } ) =>
 		// The idea is to mark the credentials test as valid so
 		// it doesn't need to be tested again.
 		markCredentialsAsValid( action.siteId, action.credentials.role ),
-	] );
+	].filter( Boolean );
 
 export const failure = ( action, error ) => ( dispatch, getState ) => {
 	const getHelp = () => navigateTo( contactSupportUrl( getSelectedSiteSlug( getState() ) ) );

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
-import { compact, get, startsWith, pickBy, map } from 'lodash';
+import { get, startsWith, pickBy, map } from 'lodash';
 import { decodeEntities } from 'calypso/lib/formatting';
 import {
 	COMMENTS_REQUEST,
@@ -155,7 +155,7 @@ export const deleteComment = ( action ) => ( dispatch, getState ) => {
 export const handleDeleteSuccess = ( { options, refreshCommentListQuery } ) => {
 	const showSuccessNotice = get( options, 'showSuccessNotice', false );
 
-	return compact( [
+	return [
 		showSuccessNotice &&
 			successNotice( translate( 'Comment deleted permanently.' ), {
 				duration: 5000,
@@ -163,7 +163,7 @@ export const handleDeleteSuccess = ( { options, refreshCommentListQuery } ) => {
 				isPersistent: true,
 			} ),
 		!! refreshCommentListQuery && requestCommentsList( refreshCommentListQuery ),
-	] );
+	].filter( Boolean );
 };
 
 export const announceDeleteFailure = ( action ) => {

--- a/client/state/document-head/selectors/get-document-head-formatted-title.js
+++ b/client/state/document-head/selectors/get-document-head-formatted-title.js
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { createSelector } from '@automattic/state-utils';
-import { compact } from 'lodash';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { getDocumentHeadCappedUnreadCount } from 'calypso/state/document-head/selectors/get-document-head-capped-unread-count';
 import { getDocumentHeadTitle } from 'calypso/state/document-head/selectors/get-document-head-title';
@@ -26,10 +25,12 @@ export const getDocumentHeadFormattedTitle = createSelector(
 			title += `(${ unreadCount }) `;
 		}
 
-		title += compact( [
+		title += [
 			getDocumentHeadTitle( state ),
 			isSiteSection( state ) && getSiteTitle( state, getSelectedSiteId( state ) ),
-		] ).join( ' ‹ ' );
+		]
+			.filter( Boolean )
+			.join( ' ‹ ' );
 
 		if ( title ) {
 			title = decodeEntities( title ) + ' — ';

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -1,5 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
-import { filter, forEach, compact, partition, get } from 'lodash';
+import { filter, forEach, partition, get } from 'lodash';
 import { v4 as uuid } from 'uuid';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { bumpStat } from 'calypso/lib/analytics/mc';
@@ -89,7 +89,7 @@ export const receivePosts = ( posts ) => ( dispatch ) => {
 	const [ toReload, toProcess ] = partition( posts, '_should_reload' );
 	toReload.forEach( ( post ) => dispatch( reloadPost( post ) ) );
 
-	const normalizedPosts = compact( toProcess ).map( runFastRules );
+	const normalizedPosts = toProcess.filter( Boolean ).map( runFastRules );
 
 	// dispatch post like additions before the posts. Cuts down on rerenders a bit.
 	forEach( normalizedPosts, ( post ) => {
@@ -114,7 +114,7 @@ export const receivePosts = ( posts ) => ( dispatch ) => {
 		( processedPosts ) =>
 			dispatch( {
 				type: READER_POSTS_RECEIVE,
-				posts: compact( processedPosts ), // prune out the "null" rejections
+				posts: processedPosts.filter( Boolean ), // prune out the "null" rejections
 			} )
 	);
 


### PR DESCRIPTION
## Proposed Changes

PR refactors away from [`_.compact`](https://devdocs.io/lodash~4/index#compact) in `client/state`.

## Testing Instructions

* Changes are partly covered by unit tests, make sure they still pass
* As with a lot of lodash methods it's good practice to ensure we don't accidentally miss guards for whether we operate on the expected data structure. In this case we're operating almost every time on arrays we construct ourselves so the changes are pretty safe.