### PR TITLE
Assembler: Update copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
@@ -8,40 +8,89 @@ export type UseScreenOptions = {
 	shouldUnlockGlobalStyles?: boolean;
 };
 
-const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ) => {
+export type Screen = {
+	name: string;
+	title: string;
+	description: string;
+	continueLabel: string;
+	/** The label for going back from the next screen */
+	backLabel?: string;
+	initialPath: string;
+	previousScreen?: Screen | null;
+	nextScreen?: Screen | null;
+};
+
+const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ): Screen => {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
-	const screens = {
+	const screens: Record< ScreenName, Screen > = {
 		main: {
 			name: 'main',
-			title: translate( 'Design your own' ),
+			title: hasEnTranslation( 'Select your patterns' )
+				? translate( 'Select your patterns' )
+				: translate( 'Design your own' ),
+			description: translate( 'Create your homepage from our library of patterns.' )
+				? translate( 'Create your homepage from our library of patterns.' )
+				: translate(
+						'Create your homepage by first adding patterns and then choosing a color palette and font style.'
+				  ),
+			continueLabel: hasEnTranslation( 'Pick your styles' )
+				? translate( 'Pick your styles' )
+				: translate( 'Pick your style' ),
+			backLabel: hasEnTranslation( 'patterns' ) ? translate( 'patterns' ) : undefined,
 			initialPath: NAVIGATOR_PATHS.MAIN_HEADER,
 		},
 		sections: {
 			name: 'sections',
 			title: translate( 'Sections' ),
+			description: hasEnTranslation(
+				'Find the right patterns for you by exploring the list of categories below.'
+			)
+				? translate( 'Find the right patterns for you by exploring the list of categories below.' )
+				: translate(
+						'Find the section patterns for your homepage by exploring the categories below.'
+				  ),
+			continueLabel: translate( 'Save and continue' ),
 			initialPath: `${ NAVIGATOR_PATHS.SECTIONS }/${ INITIAL_CATEGORY }`,
 		},
 		styles: {
 			name: 'styles',
-			title: hasEnTranslation( 'Pick your style' )
-				? translate( 'Pick your style' )
-				: translate( 'Styles' ),
+			title: hasEnTranslation( 'Pick your styles' )
+				? translate( 'Pick your styles' )
+				: translate( 'Pick your style' ),
+			description: hasEnTranslation(
+				'Add style to your page with our expertly curated color palettes and font parings.'
+			)
+				? translate(
+						'Add style to your page with our expertly curated color palettes and font parings.'
+				  )
+				: translate(
+						'Create your homepage by first adding patterns and then choosing a color palette and font style.'
+				  ),
+			continueLabel: translate( 'Save and continue' ),
+			backLabel: hasEnTranslation( 'styles' ) ? translate( 'styles' ) : undefined,
 			initialPath: NAVIGATOR_PATHS.STYLES_COLORS,
 		},
 		upsell: {
 			name: 'upsell',
 			title: translate( 'Custom styles' ),
+			description: translate( "You've chosen a custom style and action is required." ),
+			continueLabel: translate( 'Continue' ),
+			backLabel: hasEnTranslation( 'custom styles' ) ? translate( 'custom styles' ) : undefined,
 			initialPath: NAVIGATOR_PATHS.UPSELL,
 		},
 		activation: {
 			name: 'activation',
 			title: translate( 'Activate this theme' ),
+			description: translate( 'Activating this theme will result in the following changes.' ),
+			continueLabel: translate( 'Activate' ),
 			initialPath: NAVIGATOR_PATHS.ACTIVATION,
 		},
 		confirmation: {
 			name: 'confirmation',
 			title: translate( 'Great job!' ),
+			description: translate( 'Time to add some content and bring your site to life!' ),
+			continueLabel: translate( 'Start adding content' ),
 			initialPath: NAVIGATOR_PATHS.CONFIRMATION,
 		},
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
@@ -59,10 +59,10 @@ const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ): Sc
 				? translate( 'Pick your styles' )
 				: translate( 'Pick your style' ),
 			description: hasEnTranslation(
-				'Add style to your page with our expertly curated color palettes and font parings.'
+				'Add style to your page with our expertly curated color palettes and font pairings.'
 			)
 				? translate(
-						'Add style to your page with our expertly curated color palettes and font parings.'
+						'Add style to your page with our expertly curated color palettes and font pairings.'
 				  )
 				: translate(
 						'Create your homepage by first adding patterns and then choosing a color palette and font style.'

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -426,11 +426,9 @@ const PatternAssembler = ( {
 			return undefined;
 		}
 
-		// Commit the following string for the translation
-		// translate( 'Back to %(pageTitle)s' );
-		return translate( 'Back to %(clientTitle)s', {
+		return translate( 'Back to %(pageTitle)s', {
 			args: {
-				clientTitle: currentScreen.previousScreen.title,
+				pageTitle: currentScreen.previousScreen.backLabel || currentScreen.previousScreen.title,
 			},
 		} );
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-activation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-activation.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 const ScreenActivation = ( { onActivate }: Props ) => {
 	const translate = useTranslate();
-	const { title } = useScreen( 'activation' );
+	const { title, description, continueLabel } = useScreen( 'activation' );
 	const [ isConfirmed, setIsConfirmed ] = useState( false );
 	const toggleConfirm = () => setIsConfirmed( ( value ) => ! value );
 
@@ -22,7 +22,7 @@ const ScreenActivation = ( { onActivate }: Props ) => {
 		<>
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ title } /> }
-				description={ translate( 'Activating this theme will result in the following changes.' ) }
+				description={ description }
 				hideBack
 			/>
 			<div className="screen-container__body">
@@ -60,7 +60,7 @@ const ScreenActivation = ( { onActivate }: Props ) => {
 					aria-disabled={ ! isConfirmed }
 					onClick={ onActivate }
 				>
-					{ translate( 'Activate' ) }
+					{ continueLabel }
 				</Button>
 			</div>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@automattic/components';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { NavigatorHeader } from '@automattic/onboarding';
 import {
 	__experimentalVStack as VStack,
@@ -18,31 +17,22 @@ interface Props {
 const ScreenConfirmation = ( { onConfirm }: Props ) => {
 	const translate = useTranslate();
 	const { title, description, continueLabel } = useScreen( 'confirmation' );
-	const hasEnTranslation = useHasEnTranslation();
 
 	const list = [
 		{
 			icon: image,
 			title: translate( 'Upload images' ),
-			description: hasEnTranslation( 'Showcase your photos in their best light.' )
-				? translate( 'Showcase your photos in their best light.' )
-				: null,
+			description: translate( 'Showcase your photos in their best light.' ),
 		},
 		{
 			icon: verse,
 			title: translate( 'Start writing' ),
-			description: hasEnTranslation( 'Get things going and share your insights.' )
-				? translate( 'Get things going and share your insights.' )
-				: null,
+			description: translate( 'Get things going and share your insights.' ),
 		},
 		{
 			icon: layout,
-			title: hasEnTranslation( 'Customize every detail' )
-				? translate( 'Customize every detail' )
-				: translate( 'Customize in editor' ),
-			description: hasEnTranslation( 'Make your site even more unique.' )
-				? translate( 'Make your site even more unique.' )
-				: null,
+			title: translate( 'Customize every detail' ),
+			description: translate( 'Make your site even more unique.' ),
 		},
 	];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/components';
 import { Icon, image, verse, layout } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useScreen } from './hooks';
 import NavigatorTitle from './navigator-title';
 import './screen-confirmation.scss';
 
@@ -16,6 +17,7 @@ interface Props {
 
 const ScreenConfirmation = ( { onConfirm }: Props ) => {
 	const translate = useTranslate();
+	const { title, description, continueLabel } = useScreen( 'confirmation' );
 	const hasEnTranslation = useHasEnTranslation();
 
 	const list = [
@@ -47,12 +49,8 @@ const ScreenConfirmation = ( { onConfirm }: Props ) => {
 	return (
 		<>
 			<NavigatorHeader
-				title={ <NavigatorTitle title={ translate( 'Great job!' ) } /> }
-				description={
-					hasEnTranslation( 'Time to add some content and bring your site to life!' )
-						? translate( 'Time to add some content and bring your site to life!' )
-						: translate( 'Bring your site to life with some content.' )
-				}
+				title={ <NavigatorTitle title={ title } /> }
+				description={ description }
 				hideBack
 			/>
 			<div className="screen-container__body">
@@ -72,9 +70,7 @@ const ScreenConfirmation = ( { onConfirm }: Props ) => {
 			</div>
 			<div className="screen-container__footer">
 				<Button className="pattern-assembler__button" primary onClick={ onConfirm }>
-					{ hasEnTranslation( 'Start adding content' )
-						? translate( 'Start adding content' )
-						: translate( 'Continue' ) }
+					{ continueLabel }
 				</Button>
 			</div>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -1,4 +1,3 @@
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { NavigatorHeader, NavigatorItem, NavigatorItemGroup } from '@automattic/onboarding';
 import {
 	Button,
@@ -6,7 +5,7 @@ import {
 	__experimentalUseNavigator as useNavigator,
 } from '@wordpress/components';
 import { header, footer, layout } from '@wordpress/icons';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { NAVIGATOR_PATHS, INITIAL_CATEGORY } from './constants';
 import { useScreen } from './hooks';
 import NavigatorTitle from './navigator-title';
@@ -33,15 +32,10 @@ const ScreenMain = ( {
 	onContinueClick,
 }: Props ) => {
 	const translate = useTranslate();
-	const { title } = useScreen( 'main' );
-	const isEnglishLocale = useIsEnglishLocale();
+	const { title, description, continueLabel } = useScreen( 'main' );
 	const { location, params, goTo } = useNavigator();
 	const selectedCategory = params.categorySlug as string;
 	const isButtonDisabled = ! hasSections && ! hasHeader && ! hasFooter;
-	const buttonText =
-		isEnglishLocale || i18n.hasTranslation( 'Pick your style' )
-			? translate( 'Pick your style' )
-			: translate( 'Save and continue' );
 
 	const handleNavigatorItemSelect = ( type: PatternType, path: string, category: string ) => {
 		const nextPath = category !== selectedCategory ? `${ path }/${ category }` : path;
@@ -53,9 +47,7 @@ const ScreenMain = ( {
 		<>
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ title } /> }
-				description={ translate(
-					'Create your homepage by first adding patterns and then choosing a color palette and font style.'
-				) }
+				description={ description }
 				hideBack
 			/>
 			<div className="screen-container__body">
@@ -105,10 +97,10 @@ const ScreenMain = ( {
 					showTooltip={ isButtonDisabled }
 					onClick={ onContinueClick }
 					label={
-						isButtonDisabled ? translate( 'Add your first pattern to get started.' ) : buttonText
+						isButtonDisabled ? translate( 'Add your first pattern to get started.' ) : continueLabel
 					}
 					variant="primary"
-					text={ buttonText }
+					text={ continueLabel }
 					__experimentalIsFocusable
 				/>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-sections.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-sections.tsx
@@ -1,11 +1,9 @@
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { NavigatorHeader } from '@automattic/onboarding';
 import {
 	Button,
 	__experimentalVStack as VStack,
 	__experimentalUseNavigator as useNavigator,
 } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
 import { NAVIGATOR_PATHS } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import { useScreen } from './hooks';
@@ -26,11 +24,9 @@ const ScreenSections = ( {
 	onContinueClick,
 	recordTracksEvent,
 }: Props ) => {
-	const translate = useTranslate();
-	const { title } = useScreen( 'sections' );
+	const { title, description, continueLabel } = useScreen( 'sections' );
 	const { params, goTo } = useNavigator();
 	const selectedCategory = params.categorySlug as string;
-	const hasEnTranslation = useHasEnTranslation();
 
 	const onSelectSectionCategory = ( category: string ) => {
 		const nextPath =
@@ -48,17 +44,7 @@ const ScreenSections = ( {
 		<>
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ title } /> }
-				description={
-					hasEnTranslation(
-						'Find the right patterns for you by exploring the list of categories below.'
-					)
-						? translate(
-								'Find the right patterns for you by exploring the list of categories below.'
-						  )
-						: translate(
-								'Find the section patterns for your homepage by exploring the categories below.'
-						  )
-				}
+				description={ description }
 				hideBack
 			/>
 			<div className="screen-container__body">
@@ -73,7 +59,7 @@ const ScreenSections = ( {
 			</div>
 			<div className="screen-container__footer">
 				<Button className="pattern-assembler__button" variant="primary" onClick={ onContinueClick }>
-					{ translate( 'Save and continue' ) }
+					{ continueLabel }
 				</Button>
 			</div>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-styles.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-styles.tsx
@@ -30,7 +30,7 @@ const ScreenStyles = ( {
 	const translate = useTranslate();
 	const [ disabled, setDisabled ] = useState( true );
 	const { location, goTo } = useNavigator();
-	const { title } = useScreen( 'styles' );
+	const { title, description, continueLabel } = useScreen( 'styles' );
 
 	const handleNavigatorItemSelect = ( type: string, path: string ) => {
 		const nextPath = path !== location.path ? path : NAVIGATOR_PATHS.STYLES;
@@ -64,9 +64,7 @@ const ScreenStyles = ( {
 		<>
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ title } /> }
-				description={ translate(
-					'Create your homepage by first adding patterns and then choosing a color palette and font style.'
-				) }
+				description={ description }
 				hideBack
 			/>
 			<div className="screen-container__body">
@@ -108,7 +106,7 @@ const ScreenStyles = ( {
 					onMouseDown={ handleMouseDown }
 					onClick={ () => handleContinueClick() }
 				>
-					{ translate( 'Save and continue' ) }
+					{ continueLabel }
 				</Button>
 			</div>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -25,14 +25,14 @@ const ScreenUpsell = ( {
 	onContinue,
 }: Props ) => {
 	const translate = useTranslate();
-	const { title } = useScreen( 'upsell' );
+	const { title, description, continueLabel } = useScreen( 'upsell' );
 	const translations = useGlobalStylesUpgradeTranslations( { numOfSelectedGlobalStyles } );
 
 	return (
 		<>
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ title } /> }
-				description={ translate( "You've chosen a custom style and action is required." ) }
+				description={ description }
 				hideBack
 			/>
 			<div className="screen-container__body">
@@ -73,7 +73,7 @@ const ScreenUpsell = ( {
 					primary
 					onClick={ ! resetCustomStyles ? onCheckout : onContinue }
 				>
-					{ ! resetCustomStyles ? translations.upgradeWithPlan : translate( 'Continue' ) }
+					{ ! resetCustomStyles ? translations.upgradeWithPlan : continueLabel }
 				</Button>
 			</div>
 		</>

--- a/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
@@ -22,7 +22,7 @@ export class SiteAssemblerFlow {
 	 * @param {string} text User-visible text on the button.
 	 */
 	async clickButton( text: string ): Promise< void > {
-		await this.page.getByRole( 'button', { name: text } ).click();
+		await this.page.getByRole( 'button', { name: new RegExp( text ) } ).click();
 	}
 
 	/**

--- a/test/e2e/specs/onboarding/ftme__site-assembler.ts
+++ b/test/e2e/specs/onboarding/ftme__site-assembler.ts
@@ -113,7 +113,7 @@ describe( 'Site Assembler', () => {
 		} );
 
 		it( 'Pick default style', async function () {
-			await siteAssemblerFlow.clickButton( 'Pick your styles' );
+			await siteAssemblerFlow.clickButton( 'Pick your style' );
 			await siteAssemblerFlow.pickStyle( 'Color: Free style' );
 			await siteAssemblerFlow.clickButton( 'Save and continue' );
 		} );

--- a/test/e2e/specs/onboarding/ftme__site-assembler.ts
+++ b/test/e2e/specs/onboarding/ftme__site-assembler.ts
@@ -113,7 +113,7 @@ describe( 'Site Assembler', () => {
 		} );
 
 		it( 'Pick default style', async function () {
-			await siteAssemblerFlow.clickButton( 'Pick your style' );
+			await siteAssemblerFlow.clickButton( 'Pick your styles' );
 			await siteAssemblerFlow.pickStyle( 'Color: Free style' );
 			await siteAssemblerFlow.clickButton( 'Save and continue' );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/81307

## Proposed Changes

* Update the copy on the patterns & styles screen

| Patterns | Styles | Activation |
| - | - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/e8ef83aa-6dd1-4c90-93dc-0ddf6974c406) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/5767f792-5138-4d2e-9c73-d1ad9c02f837) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/e1c877ba-cb6d-4a9a-bd14-485a23dcfafe) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase
* Scroll down to select Assembler CTA
* On the Assembler screen, ensure the following copy is updated on patterns & styles screen
  * title
  * description
  * back button 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?