### PR TITLE
Flaky Jetpack E2E: fix locators used for Maps to take into account differences between Apple and mapbox.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/map.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/map.ts
@@ -35,8 +35,6 @@ export class MapFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		await context.page.pause();
-
 		await context.addedBlockLocator.scrollIntoViewIfNeeded();
 		await context.addedBlockLocator.getByRole( 'button', { name: 'Add marker' } ).waitFor();
 

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/map.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/map.ts
@@ -1,7 +1,12 @@
 import { BlockFlow, EditorContext, PublishedPostContext } from '.';
 
 interface ConfigurationData {
-	address: string;
+	address?: string;
+	// Often, the list of locations returned by the Map block is not formatted exactly
+	// like the initial input address. We could do fuzzy matching with a third party lib,
+	// but that seems excessive - so instead, the caller is expected to supply the expected
+	// target text.
+	select?: string;
 }
 
 const blockParentSelector = '[aria-label="Block: Map"]';
@@ -25,23 +30,36 @@ export class MapFlow implements BlockFlow {
 	blockEditorSelector = blockParentSelector;
 
 	/**
-	 * Configure the block in the editor with the configuration data from the constructor
+	 * Configure the block in the editor with the configuration data from the constructor.
 	 *
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		const editorCanvas = await context.editorPage.getEditorCanvas();
-		const block = editorCanvas.getByRole( 'document', { name: 'Block: Map' } );
+		await context.page.pause();
 
-		// Enter the supplied address.
-		const editorParent = await context.editorPage.getEditorParent();
-		await editorParent.getByPlaceholder( 'Add a marker' ).fill( this.configurationData.address );
+		await context.addedBlockLocator.scrollIntoViewIfNeeded();
+		await context.addedBlockLocator.getByRole( 'button', { name: 'Add marker' } ).waitFor();
 
-		// Wait for the popover.
-		await editorParent.locator( '.components-popover' ).getByRole( 'listbox' ).waitFor();
-		await context.page.keyboard.press( 'Enter' );
+		if ( this.configurationData.address && this.configurationData.select ) {
+			// Note: there are at least two providers of Maps data on macOS:
+			// mapbox and Apple Maps.
+			// The locators differ between the two, but the data entry portion
+			// should work the same between the two services.
 
-		await block.locator( '.wp-block-jetpack-map-marker' ).waitFor();
+			// Enter the supplied address.
+			const editorParent = await context.editorPage.getEditorParent();
+			await editorParent
+				.getByRole( 'textbox', { name: 'Add a marker' } )
+				.type( this.configurationData.address, { delay: 5 } );
+
+			// Wait for the popover and click on the first matching item.
+			await editorParent
+				.locator( '.components-popover' )
+				.getByRole( 'listbox' )
+				.filter( { hasText: this.configurationData.select } )
+				.first()
+				.click();
+		}
 	}
 
 	/**

--- a/test/e2e/specs/blocks/blocks__jetpack-other.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-other.ts
@@ -19,7 +19,9 @@ const blockFlows: BlockFlow[] = [
 // Private sites change behaivor of the Map block.
 // @see: https://github.com/Automattic/jetpack/issues/32991
 if ( envVariables.ATOMIC_VARIATION !== 'private' ) {
-	blockFlows.push( new MapFlow( { address: '1455 Quebec St, Vancouver, BC V6A 3Z7' } ) );
+	blockFlows.push(
+		new MapFlow( { address: '1455 Quebec Street, Vancouver', select: '1455 Quebec St' } )
+	);
 }
 
 createBlockTests( 'Blocks: Other Jetpack Blocks', blockFlows );


### PR DESCRIPTION
Related to: https://github.com/Automattic/wp-calypso/issues/80730.

## Proposed Changes

This PR updates the locators for the Maps block flow to make it work with both Apple Maps and Mapbox services.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [ ] Jetpack E2E Simple (mobile)
  - [ ] Jetpack E2E Simple (desktop)
  - [ ] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?