### PR TITLE
Site profiler: Prepare basic layout and component placeholders

### DIFF
--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -1,17 +1,24 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { FormEvent, useState } from 'react';
+import { FormEvent } from 'react';
 import './styles.scss';
 
-export default function DomainAnalyzer() {
+interface Props {
+	onFormSubmit: ( domain: string ) => void;
+	isBusy?: boolean;
+}
+
+export default function DomainAnalyzer( props: Props ) {
 	const translate = useTranslate();
-	const [ , setDomain ] = useState( '' );
+	const { isBusy, onFormSubmit } = props;
 
 	const onSubmit = ( e: FormEvent< HTMLFormElement > ) => {
 		e.preventDefault();
 
 		const domainEl = e.currentTarget.elements.namedItem( 'domain' ) as HTMLInputElement;
-		setDomain( domainEl.value );
+		const domain = domainEl.value;
+
+		domain && onFormSubmit( domain );
 	};
 
 	return (
@@ -29,7 +36,9 @@ export default function DomainAnalyzer() {
 						<input type="text" name="domain" placeholder={ translate( 'mysite.com' ) } />
 					</div>
 					<div className="col-2">
-						<Button type="submit">{ translate( 'Check site' ) }</Button>
+						<Button isBusy={ isBusy } type="submit">
+							{ translate( 'Check site' ) }
+						</Button>
 					</div>
 				</div>
 			</form>

--- a/client/site-profiler/components/domain-analyzer/styles.scss
+++ b/client/site-profiler/components/domain-analyzer/styles.scss
@@ -1,19 +1,3 @@
-.domain-analyzer {
-	& > h1 {
-		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-		/* stylelint-disable-next-line */
-		font-size: 4.375rem;
-		color: var(--studio-gray-100);
-	}
-
-	& > p {
-		font-family: "Noto Sans", Helvetica, Arial, sans-serif;
-		/* stylelint-disable-next-line */
-		font-size: 1.125rem;
-		color: var(--studio-gray-80);
-	}
-}
-
 .domain-analyzer--form-container {
 	background: #fff;
 	border: solid 1px #ccc;
@@ -60,6 +44,10 @@
 
 		&:hover {
 			color: #fff !important;
+		}
+
+		&.is-busy {
+			background-image: linear-gradient(-45deg, var(--wp-admin-theme-color) 33%, var(--wp-admin-theme-color-darker-20) 33%, var(--wp-admin-theme-color-darker-20) 70%, var(--wp-admin-theme-color) 70%);
 		}
 	}
 }

--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -1,0 +1,7 @@
+export default function DomainInformation() {
+	return (
+		<>
+			<h3>Domain information</h3>
+		</>
+	);
+}

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -1,0 +1,7 @@
+export default function HeadingInformation() {
+	return (
+		<>
+			<h3>Heading information</h3>
+		</>
+	);
+}

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -1,0 +1,7 @@
+export default function HostingInformation() {
+	return (
+		<>
+			<h3>Hosting information</h3>
+		</>
+	);
+}

--- a/client/site-profiler/components/hosting-into/index.tsx
+++ b/client/site-profiler/components/hosting-into/index.tsx
@@ -1,0 +1,12 @@
+export default function HostingInto() {
+	return (
+		<>
+			<h2>The best WordPress Hosting on the planet</h2>
+			<p>
+				Whatever you’re building, WordPress.com has everything you need: unmetered bandwidth,
+				unmatched speed, unstoppable security, and intuitive multi-site management.
+			</p>
+			<p>Bring your WordPress site to WordPress.com and get it all.</p>
+		</>
+	);
+}

--- a/client/site-profiler/components/layout/index.tsx
+++ b/client/site-profiler/components/layout/index.tsx
@@ -5,12 +5,17 @@ import './styles.scss';
 interface Props {
 	children: React.ReactNode;
 	className?: string;
+	isMonoBg?: boolean;
 }
 
 export function LayoutBlock( props: Props ) {
-	const { children, className } = props;
+	const { children, className, isMonoBg } = props;
 
-	return <div className={ classnames( 'l-block', className ) }>{ children }</div>;
+	return (
+		<div className={ classnames( 'l-block', className, { 'is-mono-bg': isMonoBg } ) }>
+			<div className="l-block-content">{ children }</div>
+		</div>
+	);
 }
 
 export function LayoutBlockSection( props: Props ) {

--- a/client/site-profiler/components/layout/index.tsx
+++ b/client/site-profiler/components/layout/index.tsx
@@ -1,0 +1,20 @@
+import classnames from 'classnames';
+import React from 'react';
+import './styles.scss';
+
+interface Props {
+	children: React.ReactNode;
+	className?: string;
+}
+
+export function LayoutBlock( props: Props ) {
+	const { children, className } = props;
+
+	return <div className={ classnames( 'l-block', className ) }>{ children }</div>;
+}
+
+export function LayoutBlockSection( props: Props ) {
+	const { children, className } = props;
+
+	return <div className={ classnames( 'l-block-section', className ) }>{ children }</div>;
+}

--- a/client/site-profiler/components/layout/styles.scss
+++ b/client/site-profiler/components/layout/styles.scss
@@ -1,0 +1,9 @@
+.l-block {
+	border: solid 1px;
+	padding: 2rem 0;
+}
+
+.l-block-section {
+	border: dashed 1px;
+	padding: 2rem 0;
+}

--- a/client/site-profiler/components/layout/styles.scss
+++ b/client/site-profiler/components/layout/styles.scss
@@ -1,9 +1,16 @@
 .l-block {
-	border: solid 1px;
-	padding: 2rem 0;
+	padding: 5rem 0;
+
+	&.is-mono-bg {
+		background-color: #e9eff5;
+	}
+}
+
+.l-block-content {
+	max-width: 1224px;
+	margin: 0 auto;
 }
 
 .l-block-section {
-	border: dashed 1px;
-	padding: 2rem 0;
+	padding: 1.5rem 0;
 }

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -1,5 +1,44 @@
+import { useState } from 'react';
+import { useDomainAnalyzerQuery } from 'calypso/data/site-profiler/use-domain-analyzer-query';
+import HostingInto from 'calypso/site-profiler/components/hosting-into';
+import { LayoutBlock, LayoutBlockSection } from 'calypso/site-profiler/components/layout';
 import DomainAnalyzer from './domain-analyzer';
+import DomainInformation from './domain-information';
+import HeadingInformation from './heading-information';
+import HostingInformation from './hosting-information';
+import './styles.scss';
 
 export default function SiteProfiler() {
-	return <DomainAnalyzer />;
+	const [ domain, setDomain ] = useState( '' );
+	const { data, isFetching } = useDomainAnalyzerQuery( domain );
+
+	const onFormSubmit = ( domain: string ) => {
+		setDomain( domain );
+	};
+
+	return (
+		<>
+			{ ! data && (
+				<LayoutBlock>
+					<DomainAnalyzer onFormSubmit={ onFormSubmit } isBusy={ isFetching } />
+				</LayoutBlock>
+			) }
+
+			<LayoutBlock>
+				<LayoutBlockSection>
+					<HeadingInformation />
+				</LayoutBlockSection>
+				<LayoutBlockSection>
+					<HostingInformation />
+				</LayoutBlockSection>
+				<LayoutBlockSection>
+					<DomainInformation />
+				</LayoutBlockSection>
+			</LayoutBlock>
+
+			<LayoutBlock isMonoBg>
+				<HostingInto />
+			</LayoutBlock>
+		</>
+	);
 }

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -1,0 +1,26 @@
+.is-section-site-profiler {
+	h1 {
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		/* stylelint-disable-next-line */
+		font-size: 4.375rem;
+		color: var(--studio-gray-100);
+	}
+
+	h2 {
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		/* stylelint-disable-next-line */
+		font-size: 2.5rem;
+	}
+
+	h3 {
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		font-size: 1.75rem;
+	}
+
+	p {
+		font-family: "Noto Sans", Helvetica, Arial, sans-serif;
+		/* stylelint-disable-next-line */
+		font-size: 1.125rem;
+		color: var(--studio-gray-80);
+	}
+}

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -1,4 +1,8 @@
 .is-section-site-profiler {
+	.layout__content {
+		padding: 0;
+	}
+
 	h1 {
 		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
 		/* stylelint-disable-next-line */

--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -10,7 +10,7 @@ export function siteProfilerContext( context: PageJS.Context, next: () => void )
 	}
 
 	context.primary = (
-		<Main wideLayout>
+		<Main fullWidthLayout>
 			<SiteProfiler />
 		</Main>
 	);


### PR DESCRIPTION
Closes #81742

## Proposed Changes

* Created layout component
* Created placeholder components

The idea is to have a SiteProfiler component for fetching and preparing data for the presentation. The data will be provided to the presentational components such as `HostingInformation`, `DomainInformation`, etc.

## Testing Instructions

Since this is a basic setup for to future development, it doesn't need to be specifically tested.

* From the development env, go to `/site-profiler`
* Check if there is the page layout rendered

<img width="1194" alt="Screenshot 2023-09-15 at 11 33 40" src="https://github.com/Automattic/wp-calypso/assets/1241413/88ae351b-0298-4331-9834-855ce0d0b815">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?