### PR TITLE
WIP: The broken step due to cleanup

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -660,6 +660,9 @@ export function generateSteps( {
 				'domainItem',
 				'themeSlugWithRepo',
 			],
+			defaultDependencies: {
+				themeSlugWithRepo: 'pub/twentytwentytwo',
+			},
 		},
 		'site-picker': {
 			stepName: 'site-picker',

--- a/client/signup/config/test/index.js
+++ b/client/signup/config/test/index.js
@@ -57,6 +57,11 @@ describe( 'index', () => {
 		expect( nonExistentModules ).toEqual( [] );
 	} );
 
+	/**
+	 * Before cleaning up a step, make sure to investigate if the step is 'phantom' submitted inside another step.
+	 * Steps can be submitted without a step component or it being included in a flow.
+	 * Eg: https://github.com/Automattic/wp-calypso/pull/81771
+	 */
 	test( 'All step definitions should have a step component mapping', () => {
 		const stepModuleMap = getStepModuleMap();
 		const allStepDefinitions = generateSteps();

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -199,13 +199,9 @@ class SiteOrDomain extends Component {
 	submitDomainOnlyChoice() {
 		const { goToStep } = this.props;
 
-		// we can skip the next two steps in the `domain-first` flow if the
+		// we can skip the next two steps in the `domain` flow if the
 		// user is only purchasing a domain
 		this.props.submitSignupStep( { stepName: 'site-picker', wasSkipped: true } );
-		this.props.submitSignupStep(
-			{ stepName: 'themes', wasSkipped: true },
-			{ themeSlugWithRepo: 'pub/twentysixteen' }
-		);
 		this.props.submitSignupStep(
 			{ stepName: 'plans-site-selected', wasSkipped: true },
 			{ cartItem: null }
@@ -224,10 +220,6 @@ class SiteOrDomain extends Component {
 			goToNextStep();
 		} else {
 			this.props.submitSignupStep( { stepName: 'site-picker', wasSkipped: true } );
-			this.props.submitSignupStep(
-				{ stepName: 'themes', wasSkipped: true },
-				{ themeSlugWithRepo: 'pub/twentysixteen' }
-			);
 			goToStep( 'plans-site-selected' );
 		}
 	};

--- a/client/signup/steps/site-picker/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/site-picker-submit.jsx
@@ -21,11 +21,6 @@ export class SitePickerSubmit extends Component {
 			siteSlug,
 		} );
 
-		this.props.submitSignupStep(
-			{ stepName: 'themes', wasSkipped: true },
-			{ themeSlugWithRepo: 'pub/twentysixteen' }
-		);
-
 		if ( hasPaidPlan ) {
 			this.props.submitSignupStep(
 				{ stepName: 'plans-site-selected', wasSkipped: true },


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/80352

## Proposed Changes

* The cleanup done on #80352, removed a step that was being 'phantomly' being submitted on a step. The step was not used in the relevant flow as well.
https://github.com/Automattic/wp-calypso/blob/d36683bdddb147d2e78c69107a2d8373e172a892/client/signup/steps/site-or-domain/index.jsx#L204-L213
* This PR removes that dead code and also includes some cautionary comments

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
