### PR TITLE
Sites with lots of subscribers call the right endpoint now

### DIFF
--- a/client/landing/subscriptions/hooks/use-subscribers-filter-options.ts
+++ b/client/landing/subscriptions/hooks/use-subscribers-filter-options.ts
@@ -4,16 +4,16 @@ import { SubscribersFilterBy } from 'calypso/my-sites/subscribers/constants';
 
 const FilterBy = SubscribersFilterBy;
 
-const useSubscribersFilterOptions = () => {
+const useSubscribersFilterOptions = ( skipAllOption: boolean ) => {
 	const translate = useTranslate();
-	return useMemo(
-		() => [
-			{ value: FilterBy.All, label: translate( 'All' ) },
-			{ value: FilterBy.Email, label: translate( 'Via Email' ) },
-			{ value: FilterBy.WPCOM, label: translate( 'Via WordPress.com' ) },
-		],
-		[ translate ]
+
+	const options = skipAllOption ? [] : [ { value: FilterBy.All, label: translate( 'All' ) } ];
+	options.push(
+		{ value: FilterBy.Email, label: translate( 'Via Email' ) },
+		{ value: FilterBy.WPCOM, label: translate( 'Via WordPress.com' ) }
 	);
+
+	return useMemo( () => options, [ translate ] );
 };
 
 export default useSubscribersFilterOptions;

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -1,13 +1,13 @@
 import { useQueries } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
-const querySubscribersTotals = ( siteId: number | null ): Promise< any > => {
+const querySubscribersTotals = ( siteId?: number ): Promise< any > => {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/stats/followers`,
 	} );
 };
 
-const queryMore = ( siteId: number | null ): Promise< any > => {
+const queryMore = ( siteId?: number ): Promise< any > => {
 	return wpcom.req.get( {
 		apiNamespace: 'wpcom/v2',
 		path: `/sites/${ siteId }/subscribers/counts`,
@@ -40,7 +40,7 @@ const selectPaidSubscribers = ( payload: {
 	};
 };
 
-export default function useSubscribersTotalsQueries( siteId: number | null ) {
+export default function useSubscribersTotalsQueries( siteId?: number ) {
 	const queries = useQueries( {
 		queries: [
 			{

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -1,13 +1,13 @@
 import { useQueries } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
-const querySubscribersTotals = ( siteId?: number ): Promise< any > => {
+const querySubscribersTotals = ( siteId: number | null ): Promise< any > => {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/stats/followers`,
 	} );
 };
 
-const queryMore = ( siteId?: number ): Promise< any > => {
+const queryMore = ( siteId: number | null ): Promise< any > => {
 	return wpcom.req.get( {
 		apiNamespace: 'wpcom/v2',
 		path: `/sites/${ siteId }/subscribers/counts`,
@@ -40,7 +40,7 @@ const selectPaidSubscribers = ( payload: {
 	};
 };
 
-export default function useSubscribersTotalsQueries( siteId?: number ) {
+export default function useSubscribersTotalsQueries( siteId: number | null ) {
 	const queries = useQueries( {
 		queries: [
 			{

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -33,8 +33,8 @@ const ListActionsBar = () => {
 	const recordSort = useRecordSort();
 	const { data: subscribersTotals = { total: 0 } } = useSubscribersTotalsQueries( siteId );
 	const totalSubscribers = subscribersTotals?.total ?? 0;
-	const skipAll = totalSubscribers > 30000; // 30000 is the limit of subscribers that can be fetched without breaking the endpoint. This is a temporal solution.
-	const filterOptions = useSubscribersFilterOptions( skipAll );
+	const hasManySubscribers = totalSubscribers > 30000; // 30000 is the limit of subscribers that can be fetched without breaking the endpoint. This is a temporal solution.
+	const filterOptions = useSubscribersFilterOptions( hasManySubscribers );
 	const selectedText = translate( 'Subscribers: %s', {
 		args: getOptionLabel( filterOptions, filterOption ) || '',
 	} );
@@ -60,14 +60,16 @@ const ListActionsBar = () => {
 				initialSelected={ filterOption }
 			/>
 
-			<SortControls
-				options={ sortOptions }
-				value={ sortTerm }
-				onChange={ ( term ) => {
-					setSortTerm( term );
-					recordSort( { sort_field: term } );
-				} }
-			/>
+			{ ! hasManySubscribers && (
+				<SortControls
+					options={ sortOptions }
+					value={ sortTerm }
+					onChange={ ( term ) => {
+						setSortTerm( term );
+						recordSort( { sort_field: term } );
+					} }
+				/>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -6,9 +6,9 @@ import { SearchIcon } from 'calypso/landing/subscriptions/components/icons';
 import { Option, SortControls } from 'calypso/landing/subscriptions/components/sort-controls';
 import { getOptionLabel } from 'calypso/landing/subscriptions/helpers';
 import { useSubscribersFilterOptions } from 'calypso/landing/subscriptions/hooks';
-import useSubscribersTotalsQueries from 'calypso/my-sites/stats/hooks/use-subscribers-totals-query';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
+import useManySubsSite from '../../hooks/use-many-subs-site';
 import './style.scss';
 import { useRecordSort } from '../../tracks';
 
@@ -31,9 +31,7 @@ const ListActionsBar = () => {
 	} = useSubscribersPage();
 	const sortOptions = useMemo( () => getSortOptions( translate ), [ translate ] );
 	const recordSort = useRecordSort();
-	const { data: subscribersTotals = { total: 0 } } = useSubscribersTotalsQueries( siteId );
-	const totalSubscribers = subscribersTotals?.total ?? 0;
-	const hasManySubscribers = totalSubscribers > 30000; // 30000 is the limit of subscribers that can be fetched without breaking the endpoint. This is a temporal solution.
+	const hasManySubscribers = useManySubsSite( siteId );
 	const filterOptions = useSubscribersFilterOptions( hasManySubscribers );
 	const selectedText = translate( 'Subscribers: %s', {
 		args: getOptionLabel( filterOptions, filterOption ) || '',

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -6,6 +6,7 @@ import { SearchIcon } from 'calypso/landing/subscriptions/components/icons';
 import { Option, SortControls } from 'calypso/landing/subscriptions/components/sort-controls';
 import { getOptionLabel } from 'calypso/landing/subscriptions/helpers';
 import { useSubscribersFilterOptions } from 'calypso/landing/subscriptions/hooks';
+import useSubscribersTotalsQueries from 'calypso/my-sites/stats/hooks/use-subscribers-totals-query';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
 import './style.scss';
@@ -26,10 +27,14 @@ const ListActionsBar = () => {
 		setSortTerm,
 		filterOption,
 		setFilterOption,
+		siteId,
 	} = useSubscribersPage();
 	const sortOptions = useMemo( () => getSortOptions( translate ), [ translate ] );
 	const recordSort = useRecordSort();
-	const filterOptions = useSubscribersFilterOptions();
+	const { data: subscribersTotals = { total: 0 } } = useSubscribersTotalsQueries( siteId );
+	const totalSubscribers = subscribersTotals?.total ?? 0;
+	const skipAll = totalSubscribers > 30000; // 30000 is the limit of subscribers that can be fetched without breaking the endpoint. This is a temporal solution.
+	const filterOptions = useSubscribersFilterOptions( skipAll );
 	const selectedText = translate( 'Subscribers: %s', {
 		args: getOptionLabel( filterOptions, filterOption ) || '',
 	} );

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -65,11 +65,11 @@ export const SubscribersPageProvider = ( {
 	const [ debouncedSearchTerm ] = useDebounce( searchTerm, 300 );
 	const hasManySubscribers = useManySubsSite( siteId );
 
-	filterOption =
+	const subscriberType =
 		filterOption === SubscribersFilterBy.All && hasManySubscribers
 			? SubscribersFilterBy.WPCOM
 			: filterOption;
-	const grandTotalQueryResult = useSubscribersQuery( { siteId, filterOption } );
+	const grandTotalQueryResult = useSubscribersQuery( { siteId, filterOption: subscriberType } );
 	const grandTotal = grandTotalQueryResult.data?.total || 0;
 
 	const dispatch = useDispatch();

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -10,7 +10,7 @@ import useManySubsSite from '../../hooks/use-many-subs-site';
 import { useSubscribersQuery } from '../../queries';
 
 type SubscribersPageProviderProps = {
-	siteId: number | undefined;
+	siteId: number | null;
 	filterOption: SubscribersFilterBy;
 	pageNumber: number;
 	searchTerm: string;
@@ -39,7 +39,7 @@ type SubscribersPageContextProps = {
 	showAddSubscribersModal: boolean;
 	setShowAddSubscribersModal: ( show: boolean ) => void;
 	addSubscribersCallback: () => void;
-	siteId?: number;
+	siteId: number | null;
 };
 
 const SubscribersPageContext = createContext< SubscribersPageContextProps | undefined >(

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -2,11 +2,11 @@ import { translate } from 'i18n-calypso';
 import React, { createContext, useState, useContext, useEffect, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { useDebounce } from 'use-debounce';
-import useSubscribersTotalsQueries from 'calypso/my-sites/stats/hooks/use-subscribers-totals-query';
 import { usePagination } from 'calypso/my-sites/subscribers/hooks';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
 import { successNotice } from 'calypso/state/notices/actions';
 import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
+import useManySubsSite from '../../hooks/use-many-subs-site';
 import { useSubscribersQuery } from '../../queries';
 
 type SubscribersPageProviderProps = {
@@ -62,14 +62,11 @@ export const SubscribersPageProvider = ( {
 }: SubscribersPageProviderProps ) => {
 	const [ perPage, setPerPage ] = useState( DEFAULT_PER_PAGE );
 	const [ showAddSubscribersModal, setShowAddSubscribersModal ] = useState( false );
-
 	const [ debouncedSearchTerm ] = useDebounce( searchTerm, 300 );
-	const { data: subscribersTotals = { total: 0 } } = useSubscribersTotalsQueries( siteId || 0 );
-	const totalSubscribers = subscribersTotals?.total ?? 0;
+	const hasManySubscribers = useManySubsSite( siteId );
 
-	// 30000 is the limit of subscribers that can be fetched without breaking the endpoint. This is a temporal solution.
 	filterOption =
-		filterOption === SubscribersFilterBy.All && totalSubscribers > 30000
+		filterOption === SubscribersFilterBy.All && hasManySubscribers
 			? SubscribersFilterBy.WPCOM
 			: filterOption;
 	const grandTotalQueryResult = useSubscribersQuery( { siteId, filterOption } );

--- a/client/my-sites/subscribers/hooks/use-many-subs-site.ts
+++ b/client/my-sites/subscribers/hooks/use-many-subs-site.ts
@@ -1,6 +1,6 @@
 import useSubscribersTotalsQueries from 'calypso/my-sites/stats/hooks/use-subscribers-totals-query';
 
-const useManySubsSite = ( siteId?: number ) => {
+const useManySubsSite = ( siteId: number | null ) => {
 	const { data: subscribersTotals = { total: 0 } } = useSubscribersTotalsQueries( siteId );
 	const totalSubscribers = subscribersTotals?.total ?? 0;
 	const hasManySubscribers = totalSubscribers > 30000; // 30000 is the limit of subscribers that can be fetched without breaking the endpoint. This is a temporal solution.

--- a/client/my-sites/subscribers/hooks/use-many-subs-site.ts
+++ b/client/my-sites/subscribers/hooks/use-many-subs-site.ts
@@ -1,0 +1,11 @@
+import useSubscribersTotalsQueries from 'calypso/my-sites/stats/hooks/use-subscribers-totals-query';
+
+const useManySubsSite = ( siteId?: number ) => {
+	const { data: subscribersTotals = { total: 0 } } = useSubscribersTotalsQueries( siteId );
+	const totalSubscribers = subscribersTotals?.total ?? 0;
+	const hasManySubscribers = totalSubscribers > 30000; // 30000 is the limit of subscribers that can be fetched without breaking the endpoint. This is a temporal solution.
+
+	return hasManySubscribers;
+};
+
+export default useManySubsSite;

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -40,6 +40,8 @@ const SubscribersPage = ( {
 }: SubscribersProps ) => {
 	const selectedSite = useSelector( getSelectedSite );
 
+	const siteId = selectedSite?.ID || null;
+
 	const pageArgs = {
 		currentPage: pageNumber,
 		filterOption,
@@ -83,7 +85,7 @@ const SubscribersPage = ( {
 
 	return (
 		<SubscribersPageProvider
-			siteId={ selectedSite?.ID }
+			siteId={ siteId }
 			filterOption={ filterOption }
 			pageNumber={ pageNumber }
 			searchTerm={ searchTerm }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/81677
Fixes https://github.com/Automattic/wp-calypso/issues/81676
Blocked by D121820-code

## Proposed Changes

The changes in this PR make sites with many subscribers (more than 30k) behave differently in the Subscribers Page:

a) the "all" option will disappear from the filters dropdown. This is because the endpoint with aggregation logic for the two types of subscribers (wpcom and email) cannot handle so many subscribers at the moment.
b) when retrieving only subscribers of one type, the endpoint being called is the new one (the one in the blocking patch). This endpoint can handle sites with many subscribers because it doesn't have the same aggregation logic.

## Testing Instructions

1. You need a site with less than 30k subscribers and a site with more than 30k subscribers to do the proper tests.
2. Apply this PR and start the application.
3. Select the site with more than 30k subscribers and go to `Users`-> `Subscribers`.
4. The list of subscribers should load (note that several seconds can pass for that to happen with such big sites).
5. Check that the Subscribers filter has only two values: `Via Email` and `Via WordPress.com`.
6. Select the other type of subscriber (most likely `Via Email`) and check the correct values are loaded.
7. Use the pagination at the bottom for both subscriber types and check it still works perfectly.
8. Now, select the site with less than 30k subscribers.
9. Repeat steps 4, 6 and 7.
10. For step 5, the dropdown should have the three values: `All`, `Via Email`, and `Via WordPress.com`.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?