### PR TITLE
Update: Hide the presales chat from within mobile app webviews.

### DIFF
--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -6,6 +6,7 @@ import {
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import type { ZendeskConfigName } from '@automattic/help-center/src/hooks/use-zendesk-messaging';
 
@@ -51,8 +52,11 @@ function getGroupName( keyType: KeyType ) {
 
 export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabilityCheck = false ) {
 	const isEnglishLocale = useIsEnglishLocale();
+	const isWpMobileAppUser = isWpMobileApp();
+
 	const { canConnectToZendesk } = useChatStatus();
-	const isEligibleForPresalesChat = enabled && isEnglishLocale && canConnectToZendesk;
+	const isEligibleForPresalesChat =
+		enabled && isEnglishLocale && canConnectToZendesk && ! isWpMobileAppUser;
 
 	const group = getGroupName( keyType );
 


### PR DESCRIPTION
This PR hides the presales chat bot from all jetpack mobile app web views by using the user agent to check if the presales bot should be shown.

Related to pcdRpT-3PI-p2 and pcdRpT-3wj-p2#comment-6146


## Proposed Changes

*Use the useragent that the mobile apps use 

before

<img width="400" alt="Screenshot 2023-09-15 at 11 45 02 AM" src="https://github.com/Automattic/wp-calypso/assets/115071/2830f6cf-c9e3-4278-ae04-85ecfdf35354">

after:

<img width="400" alt="Screenshot 2023-09-15 at 11 45 14 AM" src="https://github.com/Automattic/wp-calypso/assets/115071/3423f769-5f15-4002-82dd-a73dd14ab66c">

## Testing Instructions

* Make a web request with a user agent such as 
`Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 wp-iphone` 

This can be done by updating the user-agent string the developer tools. 

Notice that you don't see the presales bot any more.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?