### PR TITLE
Update: remove sidebar from horizontal mobile app webview layout

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -130,7 +130,16 @@ body.is-focus-sites {
 		padding-bottom: 0;
 	}
 }
-
+body.is-mobile-app-view {
+	/* We are ignoring these lines because without the px value the calc function does not work as expected */
+	/* stylelint-disable */
+	--sidebar-width-max: 0px;
+	--sidebar-width-min: 0px;
+	/* stylelint-enable */
+	.layout__secondary {
+		display: none;
+	}
+}
 // Setup the secondary element, which contains the sidebar and
 // the site-selector elements.
 .layout__secondary {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -135,7 +135,7 @@ body.is-mobile-app-view {
 	/* stylelint-disable length-zero-no-unit */
 	--sidebar-width-max: 0px;
 	--sidebar-width-min: 0px;
-	/* stylelint-enable */
+	/* stylelint-enable length-zero-no-unit */
 	.layout__secondary {
 		display: none;
 	}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -132,7 +132,7 @@ body.is-focus-sites {
 }
 body.is-mobile-app-view {
 	/* We are ignoring these lines because without the px value the calc function does not work as expected */
-	/* stylelint-disable */
+	/* stylelint-disable length-zero-no-unit */
 	--sidebar-width-max: 0px;
 	--sidebar-width-min: 0px;
 	/* stylelint-enable */


### PR DESCRIPTION
This PR removes the sidebar from the mobile app webview. 

Related to pcdRpT-3PI-p2 

## Proposed Changes

* My making 
### Domains:
Before:
<img width="855" alt="Screenshot 2023-09-15 at 12 58 45 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/a8daddda-ef3a-4dcf-ad4d-99fc0c81ef8f">

After:
<img width="872" alt="Screenshot 2023-09-15 at 12 58 40 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/19fa80fe-4f26-44b6-8ec2-cbe613f5acd1">

### People:
before:
<img width="853" alt="Screenshot 2023-09-15 at 12 54 30 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/b9f2ea7d-454b-437a-be0d-5e84ddeb0369">

after:
<img width="865" alt="Screenshot 2023-09-15 at 12 54 34 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/2f63b57a-49cd-49d8-90d4-25e9efeb6267">



## Testing Instructions
* Make a web request with a user agent such as
Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 wp-iphone

Flip the device so that the width is set to ` 812px` and the height is `375px`. Notice that you don't see the sidebar any more.

Notice that this is not the case when visiting from a regular device. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?