### PR TITLE
Fix: Remove top spacing on the checkout page for mobile app

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -13,6 +13,7 @@ body.is-mobile-app-view {
 	.masterbar {
 		display: none;
 	}
+	/* We are ignoring these lines because without the px value the calc function does not work as expected */
 	/* stylelint-disable-next-line length-zero-no-unit */
 	--masterbar-checkout-height: 0px;
 	/* stylelint-disable-next-line length-zero-no-unit */

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -15,6 +15,8 @@ body.is-mobile-app-view {
 	}
 	/* stylelint-disable-next-line length-zero-no-unit */
 	--masterbar-checkout-height: 0px;
+	/* stylelint-disable-next-line length-zero-no-unit */
+	--masterbar-height: 0px;
 }
 
 // The WordPress.com Masterbar

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -9,10 +9,12 @@ $masterbar-color-secondary: #101517;
 @import "calypso/assets/stylesheets/shared/animation";
 
 // Hide the masterbar on WP Mobile App views.
-.is-mobile-app-view {
+body.is-mobile-app-view {
 	.masterbar {
 		display: none;
 	}
+	/* stylelint-disable-next-line length-zero-no-unit */
+	--masterbar-checkout-height: 0px;
 }
 
 // The WordPress.com Masterbar


### PR DESCRIPTION
This PR fixes the top spacing on the checkout page in the mobile app checkout view when displayed as a webview

Related to pcdRpT-3PI-p2

## Proposed Changes

Before:
<img width="430" alt="Screenshot 2023-09-15 at 1 46 37 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/a519d28e-4827-4c41-9fcf-ff217c6c238d">

After:
<img width="442" alt="Screenshot 2023-09-15 at 1 46 58 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/0cb3aa12-a0a7-4555-bdcb-222329d9dd97">

## Testing Instructions

Make a web request with a user agent such as
`Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 wp-iphone`

Navigate to the checkout menu. (such as purchasing a domain or a plan)
Notice that the space at the very top is not there any more.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?