### PR TITLE
Add download link to the Jetpack welcome screen, update naming for Jetpack Social

### DIFF
--- a/client/components/jetpack/jetpack-free-welcome/Step1.tsx
+++ b/client/components/jetpack/jetpack-free-welcome/Step1.tsx
@@ -8,15 +8,33 @@ export const Step1 = () => {
 
 	const jetpackInstallInstructionsLink =
 		'https://jetpack.com/support/getting-started-with-jetpack/';
+	const jetpackDownloadLink = 'https://wordpress.org/plugins/jetpack/';
 
 	return (
 		<>
 			<h2>{ translate( 'Install Jetpack' ) }</h2>
 			<p>
 				{ translate(
-					'Download Jetpack or install it directly from your site by following the {{a}}instructions we put together here{{/a}}.',
+					'{{downloadLink}}Download Jetpack{{/downloadLink}} or install it directly from your site by following the {{a}}instructions we put together here{{/a}}.',
 					{
 						components: {
+							downloadLink: (
+								<a
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ () =>
+										dispatch(
+											recordTracksEvent(
+												'calypso_siteless_free_page_download_jetpack_link_clicked',
+												{
+													product_slug: 'jetpack_free',
+												}
+											)
+										)
+									}
+									href={ jetpackDownloadLink }
+								/>
+							),
 							a: (
 								<a
 									target="_blank"

--- a/client/components/jetpack/jetpack-free-welcome/Step2.tsx
+++ b/client/components/jetpack/jetpack-free-welcome/Step2.tsx
@@ -51,7 +51,7 @@ export const Step2 = () => {
 					} ) }
 				</li>
 				<li>
-					{ translate( '{{a}}Grow your brand{{/a}} with our Social Media Tools.', {
+					{ translate( '{{a}}Grow your brand{{/a}} with Jetpack Social.', {
 						components: {
 							a: (
 								<a


### PR DESCRIPTION
## Proposed Changes

* This diff adds a download link to the WordPress plugin repo for Jetpack on the Jetpack Welcome screen

## Testing Instructions

* Use the calypso live link for Jetpack Cloud and navigate to `/pricing/jetpack-free/welcome`
* Confirm that in the first bullet of the first step, "Download Jetpack" is linked to the plugin entry: https://wordpress.org/plugins/jetpack/ 

![Screenshot 2023-09-21 at 12 10 23 PM](https://github.com/Automattic/wp-calypso/assets/18016357/55a8e4ab-4bc2-4c46-8b6e-206f7c28952d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?