### PR TITLE
Domain table row: check if site options have been loaded before trying to access them

### DIFF
--- a/packages/domains-table/src/use-domain-row.ts
+++ b/packages/domains-table/src/use-domain-row.ts
@@ -52,7 +52,7 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 			return domain.blog_id.toString( 10 );
 		}
 
-		if ( site.options.is_redirect && site.options.unmapped_url ) {
+		if ( site.options?.is_redirect && site.options?.unmapped_url ) {
 			return new URL( site.options.unmapped_url ).host;
 		}
 


### PR DESCRIPTION
Related to p1694808405800609-slack-C04H4NY6STW.

## Proposed Changes

Let's safely access the `site.options` object when using the `useSiteQuery` hook. [For some reason, the `SiteDetails` type does not mark `options` as potentially undefined.](https://github.com/Automattic/wp-calypso/blob/trunk/packages/data-stores/src/site/types.ts#L124) @Automattic/team-calypso do you have any insights on why is that? It feels we're lying to TypeScript and it's starting to show. 

## Testing Instructions

I am not sure how to reproduce that. @lupus2k reported this problem in the message above, so let's wait his testing to understand what are the conditions to reproduce it.