### PR TITLE
composite-checkout: Move transaction status state to own provider

### DIFF
--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -63,12 +63,14 @@ export function CheckoutProvider( {
 		children,
 		initiallySelectedPaymentMethodId,
 	};
-	const [ disabledPaymentMethodIds, setDisabledPaymentMethodIds ] = useState< string[] >( [] );
 
+	// Keep track of enabled/disabled payment methods.
+	const [ disabledPaymentMethodIds, setDisabledPaymentMethodIds ] = useState< string[] >( [] );
 	const availablePaymentMethodIds = paymentMethods
 		.filter( ( method ) => ! disabledPaymentMethodIds.includes( method.id ) )
 		.map( ( method ) => method.id );
 
+	// Automatically select first payment method unless explicitly set or disabled.
 	if (
 		selectFirstAvailablePaymentMethod &&
 		! initiallySelectedPaymentMethodId &&
@@ -77,20 +79,26 @@ export function CheckoutProvider( {
 		initiallySelectedPaymentMethodId = availablePaymentMethodIds[ 0 ];
 	}
 
+	// Keep track of selected payment method.
 	const [ paymentMethodId, setPaymentMethodId ] = useState< string | null >(
 		initiallySelectedPaymentMethodId
 	);
 
+	// Reset the selected payment method if the list of payment methods changes.
 	useResetSelectedPaymentMethodWhenListChanges(
 		availablePaymentMethodIds,
 		initiallySelectedPaymentMethodId,
 		setPaymentMethodId
 	);
 
+	// Keep track of form status state (loading, validating, ready, etc).
 	const formStatusManager = useFormStatusManager( Boolean( isLoading ), Boolean( isValidating ) );
+
+	// Keep track of transaction status state (pending, complete, redirecting, etc).
 	const transactionStatusManager = useTransactionStatusManager();
 	const { transactionLastResponse, transactionStatus, transactionError } = transactionStatusManager;
 
+	// When form status or transaction status changes, call the appropriate callbacks.
 	useCallEventCallbacks( {
 		onPaymentComplete,
 		onPaymentRedirect,
@@ -102,6 +110,7 @@ export function CheckoutProvider( {
 		transactionLastResponse,
 	} );
 
+	// Create a big blob of state to store in React Context for use by all this Provider's children.
 	const value: CheckoutContextInterface = useMemo(
 		() => ( {
 			allPaymentMethods: paymentMethods,
@@ -150,6 +159,11 @@ export function CheckoutProvider( {
 	);
 }
 
+/**
+ * Even though CheckoutProvider is TypeScript, it's possible for consumers to
+ * misuse it in ways that are not easy to debug. This helper component throws
+ * errors if the props are not what they should be.
+ */
 function CheckoutProviderPropValidator( {
 	propsToValidate,
 }: {
@@ -170,6 +184,7 @@ function CheckoutProviderPropValidator( {
 	return null;
 }
 
+// When form status or transaction status changes, call the appropriate callbacks.
 function useCallEventCallbacks( {
 	onPaymentComplete,
 	onPaymentRedirect,
@@ -235,6 +250,7 @@ function useCallEventCallbacks( {
 	}, [ transactionStatus, paymentMethodId, transactionLastResponse, transactionError ] );
 }
 
+// Reset the selected payment method if the list of payment methods changes.
 function useResetSelectedPaymentMethodWhenListChanges(
 	availablePaymentMethodIds: string[],
 	initiallySelectedPaymentMethodId: string | null,

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -17,6 +17,7 @@ import { LineItem, CheckoutProviderProps, FormStatus, TransactionStatus } from '
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import { FormStatusProvider } from './form-status-provider';
 import TransactionStatusHandler from './transaction-status-handler';
+import { TransactionStatusProvider } from './transaction-status-provider';
 import type {
 	PaymentEventCallback,
 	PaymentErrorCallback,
@@ -118,7 +119,6 @@ export function CheckoutProvider( {
 			setDisabledPaymentMethodIds,
 			paymentMethodId,
 			setPaymentMethodId,
-			transactionStatusManager,
 			paymentProcessors,
 			onPageLoadError,
 			onPaymentMethodChanged,
@@ -127,7 +127,6 @@ export function CheckoutProvider( {
 			paymentMethodId,
 			paymentMethods,
 			disabledPaymentMethodIds,
-			transactionStatusManager,
 			paymentProcessors,
 			onPageLoadError,
 			onPaymentMethodChanged,
@@ -147,12 +146,14 @@ export function CheckoutProvider( {
 			<CheckoutProviderPropValidator propsToValidate={ propsToValidate } />
 			<ThemeProvider theme={ theme || defaultTheme }>
 				<LineItemsProvider items={ items } total={ total }>
-					<FormStatusProvider formStatusManager={ formStatusManager }>
-						<CheckoutContext.Provider value={ value }>
-							<TransactionStatusHandler redirectToUrl={ redirectToUrl } />
-							{ children }
-						</CheckoutContext.Provider>
-					</FormStatusProvider>
+					<TransactionStatusProvider transactionStatusManager={ transactionStatusManager }>
+						<FormStatusProvider formStatusManager={ formStatusManager }>
+							<CheckoutContext.Provider value={ value }>
+								<TransactionStatusHandler redirectToUrl={ redirectToUrl } />
+								{ children }
+							</CheckoutContext.Provider>
+						</FormStatusProvider>
+					</TransactionStatusProvider>
 				</LineItemsProvider>
 			</ThemeProvider>
 		</CheckoutErrorBoundary>

--- a/packages/composite-checkout/src/components/form-status-provider.tsx
+++ b/packages/composite-checkout/src/components/form-status-provider.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { FormStatusContext } from '../lib/form-status-context';
-import type { FormStatusManager, FormStatusContextInterface } from '../types';
+import type { FormStatusManager } from '../types';
 import type { ReactNode } from 'react';
 
 /**
@@ -33,9 +33,6 @@ export function FormStatusProvider( {
 	formStatusManager: FormStatusManager;
 	children: ReactNode;
 } ) {
-	const value: FormStatusContextInterface = useMemo(
-		() => formStatusManager,
-		[ formStatusManager ]
-	);
+	const value: FormStatusManager = useMemo( () => formStatusManager, [ formStatusManager ] );
 	return <FormStatusContext.Provider value={ value }>{ children }</FormStatusContext.Provider>;
 }

--- a/packages/composite-checkout/src/components/transaction-status-handler.ts
+++ b/packages/composite-checkout/src/components/transaction-status-handler.ts
@@ -7,6 +7,13 @@ import { TransactionStatus } from '../types';
 
 const debug = debugFactory( 'composite-checkout:transaction-status-handler' );
 
+/**
+ * Helper component to take an action when the transaction status changes.
+ *
+ * For example, if the transaction status changes to "pending", this will set
+ * the form status to "submitting"; if the transaction status changes to
+ * "redirecting", this will perform the redirect.
+ */
 export default function TransactionStatusHandler( {
 	redirectToUrl,
 }: {

--- a/packages/composite-checkout/src/components/transaction-status-provider.tsx
+++ b/packages/composite-checkout/src/components/transaction-status-provider.tsx
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { TransactionStatusContext } from '../lib/transaction-status-context';
+import type { TransactionStatusManager } from '../types';
+import type { ReactNode } from 'react';
+
+export function TransactionStatusProvider( {
+	transactionStatusManager,
+	children,
+}: {
+	transactionStatusManager: TransactionStatusManager;
+	children: ReactNode;
+} ) {
+	const value: TransactionStatusManager = useMemo(
+		() => transactionStatusManager,
+		[ transactionStatusManager ]
+	);
+	return (
+		<TransactionStatusContext.Provider value={ value }>
+			{ children }
+		</TransactionStatusContext.Provider>
+	);
+}

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -7,7 +7,6 @@ const defaultCheckoutContext: CheckoutContextInterface = {
 	setDisabledPaymentMethodIds: noop,
 	paymentMethodId: null,
 	setPaymentMethodId: noop,
-	transactionStatusManager: null,
 	paymentProcessors: {},
 };
 

--- a/packages/composite-checkout/src/lib/form-status-context.ts
+++ b/packages/composite-checkout/src/lib/form-status-context.ts
@@ -1,10 +1,10 @@
 import { createContext } from 'react';
-import { FormStatus, FormStatusContextInterface } from '../types';
+import { FormStatus, FormStatusManager } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 function noop(): void {}
 
-const defaultFormStatusContext: FormStatusContextInterface = {
+const defaultFormStatusContext: FormStatusManager = {
 	formStatus: FormStatus.LOADING,
 	setFormStatus: noop,
 };

--- a/packages/composite-checkout/src/lib/transaction-status-context.ts
+++ b/packages/composite-checkout/src/lib/transaction-status-context.ts
@@ -1,0 +1,20 @@
+import { createContext } from 'react';
+import { TransactionStatus, TransactionStatusManager } from '../types';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function noop(): void {}
+
+const defaultTransactionStatusContext: TransactionStatusManager = {
+	transactionStatus: TransactionStatus.NOT_STARTED,
+	previousTransactionStatus: TransactionStatus.NOT_STARTED,
+	transactionLastResponse: null,
+	transactionError: null,
+	transactionRedirectUrl: null,
+	resetTransaction: noop,
+	setTransactionError: noop,
+	setTransactionComplete: noop,
+	setTransactionPending: noop,
+	setTransactionRedirecting: noop,
+};
+
+export const TransactionStatusContext = createContext( defaultTransactionStatusContext );

--- a/packages/composite-checkout/src/lib/transaction-status.ts
+++ b/packages/composite-checkout/src/lib/transaction-status.ts
@@ -1,6 +1,5 @@
 import debugFactory from 'debug';
 import { useCallback, useContext, useMemo, useReducer } from 'react';
-import CheckoutContext from '../lib/checkout-context';
 import {
 	TransactionStatus,
 	TransactionStatusState,
@@ -8,11 +7,12 @@ import {
 	TransactionStatusManager,
 	TransactionStatusPayloads,
 } from '../types';
+import { TransactionStatusContext } from './transaction-status-context';
 
 const debug = debugFactory( 'composite-checkout:transaction-status' );
 
 export function useTransactionStatus(): TransactionStatusManager {
-	const { transactionStatusManager } = useContext( CheckoutContext );
+	const transactionStatusManager = useContext( TransactionStatusContext );
 	if ( ! transactionStatusManager ) {
 		throw new Error( 'useTransactionStatus can only be called inside CheckoutProvider' );
 	}

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -114,7 +114,6 @@ export interface CheckoutContextInterface {
 	setDisabledPaymentMethodIds: ( methods: string[] ) => void;
 	paymentMethodId: string | null;
 	setPaymentMethodId: ( id: string ) => void;
-	transactionStatusManager: TransactionStatusManager | null;
 	paymentProcessors: PaymentProcessorProp;
 	onPageLoadError?: CheckoutPageErrorCallback;
 	onPaymentMethodChanged?: PaymentMethodChangedCallback;

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -103,11 +103,6 @@ export type FormStatusManager = {
 	setFormStatus: FormStatusSetter;
 };
 
-export interface FormStatusContextInterface {
-	formStatus: FormStatus;
-	setFormStatus: ( newStatus: FormStatus ) => void;
-}
-
 export interface CheckoutContextInterface {
 	allPaymentMethods: PaymentMethod[];
 	disabledPaymentMethodIds: string[];


### PR DESCRIPTION
The `@automattic/composite-checkout` package has gone through many variations as calypso's checkout was refactored to use it as a replacement to the original calypso checkout experience. As a result, its `CheckoutProvider` wrapper component is something of a ["god object"](https://en.wikipedia.org/wiki/God_object), containing state for many different parts of the systems that the package makes available. In recent refactors, the primary systems have become more clear: the package contains:

- A form UI which allows for multiple steps and various busy and loading states.
- A transaction processing system with customizable functionality for different payment methods.
- An API for payment method UI elements including validation and customizable submit buttons.
- A number of UI primitives like input fields, buttons, layout helpers, and icons.

There's no real reason why these pieces cannot be used independently. However, the way that the pieces are intertwined and their dependence on the single provider makes it difficult to do.

## Proposed Changes

In this PR we refactor the transaction status state (the state of the form's post-submission process: not started, pending, complete, redirecting, or error) to move it into its own provider, `TransactionStatusProvider`. In order to not change the API of the package too much (yet), this PR leaves the new provider inside the `CheckoutProvider` for now but in the future this change will make it easier to split up the provider into its component parts.

This is similar to https://github.com/Automattic/wp-calypso/pull/80529 which did the same thing for the form status.

## Testing Instructions

Automated tests should cover most things. We can check that the functionality is preserved by viewing calypso checkout and clicking through the steps and submitting the form to make a purchase using a redirect payment method like PayPal. You don't need to actually complete the purchase, just verify that you are redirected to PayPal's site.
