### PR TITLE
Mobile domains table: restore sticky header and content scroll

### DIFF
--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -4,6 +4,11 @@
 @media ( max-width: 480px ) {
 	.bulk-domains-main {
 		overflow-y: hidden;
+		/*
+		 * The 47px value comes from https://github.com/Automattic/wp-calypso/blob/d7e2ada/client/my-sites/sidebar/style.scss#L751.
+		 * Using 46px, which is the masterbar height CSS variable, introduces an annoying 1px scroll.
+		 * We're using this magic number elsewhere too, so a clean up would be appreciated.
+		 */
 		height: calc(100vh - 47px);
 		padding-bottom: 0 !important;
 		display: flex;

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -1,6 +1,19 @@
 @import "@automattic/typography/styles/variables";
 @import "@automattic/onboarding/styles/mixins";
 
+@media ( max-width: 480px ) {
+	.bulk-domains-main {
+		overflow-y: hidden;
+		height: calc(100vh - 47px);
+		padding-bottom: 0 !important;
+		display: flex;
+		flex-direction: column;
+
+		.domains-table {
+			flex: 1;
+		}
+	}
+}
 
 .domains-table {
 	--domains-table-toolbar-height: 40px;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/81792.

## Proposed Changes

The CSS code introduced was applying changes globally. This PR fixes this problem while maintaining behavior.

The expected behavior is to have a sticky header with scrolling domain cards.

## Testing Instructions

On mobile, open `/domains/manage`. Check that the header is sticky and the content scrolls. Browse elsewhere and verify that you can scroll the page normally.