### PR TITLE
Domain Management i1: Show bulk update contact form on site specific domain table

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -5,6 +5,7 @@ import { isFreeUrlDomainName } from 'calypso/lib/domains/utils';
 import { decodeURIComponentIfValid } from 'calypso/lib/url';
 import {
 	domainManagementAllEditSelectedContactInfo,
+	domainManagementEditSelectedContactInfo,
 	domainManagementContactsPrivacy,
 	domainManagementDns,
 	domainManagementDnsAddRecord,
@@ -185,6 +186,19 @@ export default {
 		pageContext.primary = (
 			<DomainManagementData
 				analyticsPath={ domainManagementAllEditSelectedContactInfo() }
+				analyticsTitle="Domain Management > Edit Selected Contact Info"
+				component={ DomainManagement.BulkEditContactInfoPage }
+				context={ pageContext }
+				needsDomains
+			/>
+		);
+		next();
+	},
+
+	domainManagementEditSelectedContactInfo( pageContext, next ) {
+		pageContext.primary = (
+			<DomainManagementData
+				analyticsPath={ domainManagementEditSelectedContactInfo( ':site' ) }
 				analyticsTitle="Domain Management > Edit Selected Contact Info"
 				component={ DomainManagement.BulkEditContactInfoPage }
 				context={ pageContext }

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
@@ -161,9 +161,19 @@ export default function BulkEditContactInfoPage( {
 		);
 
 		if ( firstDomainUserCanNotManage ) {
+			// domains passed to NonOwnerCard expects name to be on the domain to properly show the message
+			// otherwise nothing is rendered.
+			const nonOwnerDomains = allSiteDomains?.map( ( domain ) => {
+				return {
+					name: domain.domain,
+					type: domain.type,
+					owner: domain.owner,
+				};
+			} );
+
 			return (
 				<NonOwnerCard
-					domains={ partialDomainsData }
+					domains={ nonOwnerDomains }
 					selectedDomainName={ firstDomainUserCanNotManage.domain }
 				/>
 			);

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -170,6 +170,14 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+	page(
+		paths.domainManagementEditSelectedContactInfo( ':site' ),
+		noSite,
+		...getCommonHandlers( { noSitePath: false, noSiteSelection: true } ),
+		domainManagementController.domainManagementEditSelectedContactInfo,
+		makeLayout,
+		clientRender
+	);
 
 	registerStandardDomainManagementPages(
 		paths.domainManagementEdit,

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -145,6 +145,13 @@ export function domainManagementAllEditSelectedContactInfo() {
 
 /**
  * @param {string} siteName
+ */
+export function domainManagementEditSelectedContactInfo( siteName ) {
+	return domainManagementRoot() + '/edit-selected-contact-info/' + siteName;
+}
+
+/**
+ * @param {string} siteName
  * @param {string} domainName
  * @param {string?} relativeTo
  */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR allows bulk contact update on site specific domain table

Closes https://github.com/Automattic/dotcom-forge/issues/3651

## Proposed Changes

* Allow accessing bulk update form from site specific domain table
* Pass the correct parameters when rendering `NonOwnerCard` to show message when user cannot edit contact form.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* browser `/domains/manage/:siteSlug?flags=domains/bulk-actions-contact-info-editing`
* Select domain using checkbox and click `Edit contact information` button
* Verify the bulk contact information is shown and works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?