### PR TITLE
composite-checkout: Move form and transaction management to own provider

### DIFF
--- a/packages/composite-checkout/src/components/form-and-transaction-event-handler.ts
+++ b/packages/composite-checkout/src/components/form-and-transaction-event-handler.ts
@@ -18,9 +18,10 @@ const debug = debugFactory( 'composite-checkout:transaction-status-handler' );
  *
  * For example, if the transaction status changes to "pending", this will set
  * the form status to "submitting"; if the transaction status changes to
- * "redirecting", this will perform the redirect.
+ * "redirecting", this will perform the redirect. If there is an error, the
+ * `onPaymentError` callback will be called.
  */
-export default function TransactionStatusHandler( {
+export default function FormAndTransactionEventHandler( {
 	onPaymentComplete,
 	onPaymentRedirect,
 	onPaymentError,

--- a/packages/composite-checkout/src/components/form-and-transaction-provider.tsx
+++ b/packages/composite-checkout/src/components/form-and-transaction-provider.tsx
@@ -1,8 +1,8 @@
 import { ReactNode } from 'react';
 import { useFormStatusManager } from '../lib/form-status';
 import { useTransactionStatusManager } from '../lib/transaction-status';
+import FormAndTransactionEventHandler from './form-and-transaction-event-handler';
 import { FormStatusProvider } from './form-status-provider';
-import TransactionStatusHandler from './transaction-status-handler';
 import { TransactionStatusProvider } from './transaction-status-provider';
 import type { PaymentEventCallback, PaymentErrorCallback } from '../types';
 
@@ -32,7 +32,7 @@ export function FormAndTransactionProvider( {
 	return (
 		<TransactionStatusProvider transactionStatusManager={ transactionStatusManager }>
 			<FormStatusProvider formStatusManager={ formStatusManager }>
-				<TransactionStatusHandler
+				<FormAndTransactionEventHandler
 					onPaymentComplete={ onPaymentComplete }
 					onPaymentRedirect={ onPaymentRedirect }
 					onPaymentError={ onPaymentError }

--- a/packages/composite-checkout/src/components/form-and-transaction-provider.tsx
+++ b/packages/composite-checkout/src/components/form-and-transaction-provider.tsx
@@ -1,0 +1,130 @@
+import debugFactory from 'debug';
+import { ReactNode, useEffect, useRef } from 'react';
+import { useFormStatusManager } from '../lib/form-status';
+import { useTransactionStatusManager } from '../lib/transaction-status';
+import { usePaymentMethodId } from '../public-api';
+import { FormStatus, TransactionStatus } from '../types';
+import { FormStatusProvider } from './form-status-provider';
+import TransactionStatusHandler from './transaction-status-handler';
+import { TransactionStatusProvider } from './transaction-status-provider';
+import type {
+	PaymentEventCallback,
+	PaymentErrorCallback,
+	PaymentProcessorResponseData,
+} from '../types';
+
+const debug = debugFactory( 'composite-checkout:form-and-transaction-status-provider' );
+
+export function FormAndTransactionProvider( {
+	onPaymentComplete,
+	onPaymentRedirect,
+	onPaymentError,
+	isLoading,
+	isValidating,
+	redirectToUrl,
+	children,
+}: {
+	onPaymentComplete?: PaymentEventCallback;
+	onPaymentRedirect?: PaymentEventCallback;
+	onPaymentError?: PaymentErrorCallback;
+	isLoading?: boolean;
+	isValidating?: boolean;
+	redirectToUrl?: ( url: string ) => void;
+	children?: ReactNode;
+} ) {
+	const [ paymentMethodId ] = usePaymentMethodId();
+
+	// Keep track of form status state (loading, validating, ready, etc).
+	const formStatusManager = useFormStatusManager( Boolean( isLoading ), Boolean( isValidating ) );
+
+	// Keep track of transaction status state (pending, complete, redirecting, etc).
+	const transactionStatusManager = useTransactionStatusManager();
+	const { transactionLastResponse, transactionStatus, transactionError } = transactionStatusManager;
+
+	// When form status or transaction status changes, call the appropriate callbacks.
+	useCallEventCallbacks( {
+		onPaymentComplete,
+		onPaymentRedirect,
+		onPaymentError,
+		formStatus: formStatusManager.formStatus,
+		transactionError,
+		transactionStatus,
+		paymentMethodId,
+		transactionLastResponse,
+	} );
+
+	return (
+		<TransactionStatusProvider transactionStatusManager={ transactionStatusManager }>
+			<FormStatusProvider formStatusManager={ formStatusManager }>
+				<TransactionStatusHandler redirectToUrl={ redirectToUrl } />
+				{ children }
+			</FormStatusProvider>
+		</TransactionStatusProvider>
+	);
+}
+
+// When form status or transaction status changes, call the appropriate callbacks.
+function useCallEventCallbacks( {
+	onPaymentComplete,
+	onPaymentRedirect,
+	onPaymentError,
+	formStatus,
+	transactionError,
+	transactionStatus,
+	paymentMethodId,
+	transactionLastResponse,
+}: {
+	onPaymentComplete?: PaymentEventCallback;
+	onPaymentRedirect?: PaymentEventCallback;
+	onPaymentError?: PaymentErrorCallback;
+	formStatus: FormStatus;
+	transactionError: string | null;
+	transactionStatus: TransactionStatus;
+	paymentMethodId: string | null;
+	transactionLastResponse: PaymentProcessorResponseData;
+} ): void {
+	// Store the callbacks as refs so we do not call them more than once if they
+	// are anonymous functions. This way they are only called when the
+	// transactionStatus/formStatus changes, which is what we really want.
+	const paymentCompleteRef = useRef( onPaymentComplete );
+	paymentCompleteRef.current = onPaymentComplete;
+	const paymentRedirectRef = useRef( onPaymentRedirect );
+	paymentRedirectRef.current = onPaymentRedirect;
+	const paymentErrorRef = useRef( onPaymentError );
+	paymentErrorRef.current = onPaymentError;
+
+	const prevFormStatus = useRef< FormStatus >();
+	const prevTransactionStatus = useRef< TransactionStatus >();
+
+	useEffect( () => {
+		if (
+			paymentCompleteRef.current &&
+			formStatus === FormStatus.COMPLETE &&
+			formStatus !== prevFormStatus.current
+		) {
+			debug( "form status changed to complete so I'm calling onPaymentComplete" );
+			paymentCompleteRef.current( { paymentMethodId, transactionLastResponse } );
+		}
+		prevFormStatus.current = formStatus;
+	}, [ formStatus, transactionLastResponse, paymentMethodId ] );
+
+	useEffect( () => {
+		if (
+			paymentRedirectRef.current &&
+			transactionStatus === TransactionStatus.REDIRECTING &&
+			transactionStatus !== prevTransactionStatus.current
+		) {
+			debug( "transaction status changed to redirecting so I'm calling onPaymentRedirect" );
+			paymentRedirectRef.current( { paymentMethodId, transactionLastResponse } );
+		}
+		if (
+			paymentErrorRef.current &&
+			transactionStatus === TransactionStatus.ERROR &&
+			transactionStatus !== prevTransactionStatus.current
+		) {
+			debug( "transaction status changed to error so I'm calling onPaymentError" );
+			paymentErrorRef.current( { paymentMethodId, transactionError } );
+		}
+		prevTransactionStatus.current = transactionStatus;
+	}, [ transactionStatus, paymentMethodId, transactionLastResponse, transactionError ] );
+}

--- a/packages/composite-checkout/src/components/form-and-transaction-provider.tsx
+++ b/packages/composite-checkout/src/components/form-and-transaction-provider.tsx
@@ -1,19 +1,10 @@
-import debugFactory from 'debug';
-import { ReactNode, useEffect, useRef } from 'react';
+import { ReactNode } from 'react';
 import { useFormStatusManager } from '../lib/form-status';
 import { useTransactionStatusManager } from '../lib/transaction-status';
-import { usePaymentMethodId } from '../public-api';
-import { FormStatus, TransactionStatus } from '../types';
 import { FormStatusProvider } from './form-status-provider';
 import TransactionStatusHandler from './transaction-status-handler';
 import { TransactionStatusProvider } from './transaction-status-provider';
-import type {
-	PaymentEventCallback,
-	PaymentErrorCallback,
-	PaymentProcessorResponseData,
-} from '../types';
-
-const debug = debugFactory( 'composite-checkout:form-and-transaction-status-provider' );
+import type { PaymentEventCallback, PaymentErrorCallback } from '../types';
 
 export function FormAndTransactionProvider( {
 	onPaymentComplete,
@@ -32,99 +23,23 @@ export function FormAndTransactionProvider( {
 	redirectToUrl?: ( url: string ) => void;
 	children?: ReactNode;
 } ) {
-	const [ paymentMethodId ] = usePaymentMethodId();
-
 	// Keep track of form status state (loading, validating, ready, etc).
 	const formStatusManager = useFormStatusManager( Boolean( isLoading ), Boolean( isValidating ) );
 
 	// Keep track of transaction status state (pending, complete, redirecting, etc).
 	const transactionStatusManager = useTransactionStatusManager();
-	const { transactionLastResponse, transactionStatus, transactionError } = transactionStatusManager;
-
-	// When form status or transaction status changes, call the appropriate callbacks.
-	useCallEventCallbacks( {
-		onPaymentComplete,
-		onPaymentRedirect,
-		onPaymentError,
-		formStatus: formStatusManager.formStatus,
-		transactionError,
-		transactionStatus,
-		paymentMethodId,
-		transactionLastResponse,
-	} );
 
 	return (
 		<TransactionStatusProvider transactionStatusManager={ transactionStatusManager }>
 			<FormStatusProvider formStatusManager={ formStatusManager }>
-				<TransactionStatusHandler redirectToUrl={ redirectToUrl } />
+				<TransactionStatusHandler
+					onPaymentComplete={ onPaymentComplete }
+					onPaymentRedirect={ onPaymentRedirect }
+					onPaymentError={ onPaymentError }
+					redirectToUrl={ redirectToUrl }
+				/>
 				{ children }
 			</FormStatusProvider>
 		</TransactionStatusProvider>
 	);
-}
-
-// When form status or transaction status changes, call the appropriate callbacks.
-function useCallEventCallbacks( {
-	onPaymentComplete,
-	onPaymentRedirect,
-	onPaymentError,
-	formStatus,
-	transactionError,
-	transactionStatus,
-	paymentMethodId,
-	transactionLastResponse,
-}: {
-	onPaymentComplete?: PaymentEventCallback;
-	onPaymentRedirect?: PaymentEventCallback;
-	onPaymentError?: PaymentErrorCallback;
-	formStatus: FormStatus;
-	transactionError: string | null;
-	transactionStatus: TransactionStatus;
-	paymentMethodId: string | null;
-	transactionLastResponse: PaymentProcessorResponseData;
-} ): void {
-	// Store the callbacks as refs so we do not call them more than once if they
-	// are anonymous functions. This way they are only called when the
-	// transactionStatus/formStatus changes, which is what we really want.
-	const paymentCompleteRef = useRef( onPaymentComplete );
-	paymentCompleteRef.current = onPaymentComplete;
-	const paymentRedirectRef = useRef( onPaymentRedirect );
-	paymentRedirectRef.current = onPaymentRedirect;
-	const paymentErrorRef = useRef( onPaymentError );
-	paymentErrorRef.current = onPaymentError;
-
-	const prevFormStatus = useRef< FormStatus >();
-	const prevTransactionStatus = useRef< TransactionStatus >();
-
-	useEffect( () => {
-		if (
-			paymentCompleteRef.current &&
-			formStatus === FormStatus.COMPLETE &&
-			formStatus !== prevFormStatus.current
-		) {
-			debug( "form status changed to complete so I'm calling onPaymentComplete" );
-			paymentCompleteRef.current( { paymentMethodId, transactionLastResponse } );
-		}
-		prevFormStatus.current = formStatus;
-	}, [ formStatus, transactionLastResponse, paymentMethodId ] );
-
-	useEffect( () => {
-		if (
-			paymentRedirectRef.current &&
-			transactionStatus === TransactionStatus.REDIRECTING &&
-			transactionStatus !== prevTransactionStatus.current
-		) {
-			debug( "transaction status changed to redirecting so I'm calling onPaymentRedirect" );
-			paymentRedirectRef.current( { paymentMethodId, transactionLastResponse } );
-		}
-		if (
-			paymentErrorRef.current &&
-			transactionStatus === TransactionStatus.ERROR &&
-			transactionStatus !== prevTransactionStatus.current
-		) {
-			debug( "transaction status changed to error so I'm calling onPaymentError" );
-			paymentErrorRef.current( { paymentMethodId, transactionError } );
-		}
-		prevTransactionStatus.current = transactionStatus;
-	}, [ transactionStatus, paymentMethodId, transactionLastResponse, transactionError ] );
 }

--- a/packages/composite-checkout/src/components/transaction-status-handler.ts
+++ b/packages/composite-checkout/src/components/transaction-status-handler.ts
@@ -1,41 +1,84 @@
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { useCallback, useEffect } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { useFormStatus } from '../lib/form-status';
 import { useTransactionStatus } from '../lib/transaction-status';
-import { TransactionStatus } from '../types';
+import { usePaymentMethodId } from '../public-api';
+import { FormStatus, TransactionStatus } from '../types';
+import type {
+	PaymentEventCallback,
+	PaymentErrorCallback,
+	PaymentProcessorResponseData,
+} from '../types';
 
 const debug = debugFactory( 'composite-checkout:transaction-status-handler' );
 
 /**
- * Helper component to take an action when the transaction status changes.
+ * Helper component to take an action when the form or transaction status changes.
  *
  * For example, if the transaction status changes to "pending", this will set
  * the form status to "submitting"; if the transaction status changes to
  * "redirecting", this will perform the redirect.
  */
 export default function TransactionStatusHandler( {
+	onPaymentComplete,
+	onPaymentRedirect,
+	onPaymentError,
 	redirectToUrl,
 }: {
+	onPaymentComplete?: PaymentEventCallback;
+	onPaymentRedirect?: PaymentEventCallback;
+	onPaymentError?: PaymentErrorCallback;
 	redirectToUrl?: ( url: string ) => void;
 } ): null {
-	// @ts-expect-error window.location can accept a string, but the types don't like it.
-	const defaultRedirect = useCallback( ( url: string ) => ( window.location = url ), [] );
-	useTransactionStatusHandler( redirectToUrl || defaultRedirect );
+	useTransactionStatusHandler( {
+		onPaymentComplete,
+		onPaymentRedirect,
+		onPaymentError,
+		redirectToUrl,
+	} );
 	return null;
 }
 
-function useTransactionStatusHandler( redirectToUrl: ( url: string ) => void ): void {
+export function useTransactionStatusHandler( {
+	onPaymentComplete,
+	onPaymentRedirect,
+	onPaymentError,
+	redirectToUrl,
+}: {
+	onPaymentComplete?: PaymentEventCallback;
+	onPaymentRedirect?: PaymentEventCallback;
+	onPaymentError?: PaymentErrorCallback;
+	redirectToUrl?: ( url: string ) => void;
+} ): void {
+	// @ts-expect-error window.location can accept a string, but the types don't like it.
+	const defaultRedirect = useCallback( ( url: string ) => ( window.location = url ), [] );
+	const performRedirect = redirectToUrl ?? defaultRedirect;
+
 	const { __ } = useI18n();
-	const { setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
+	const [ paymentMethodId ] = usePaymentMethodId();
+	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
 	const {
 		previousTransactionStatus,
+		transactionLastResponse,
 		transactionStatus,
 		transactionRedirectUrl,
 		transactionError,
 		resetTransaction,
 		setTransactionError,
 	} = useTransactionStatus();
+
+	// When form status or transaction status changes, call the appropriate callbacks.
+	useCallStatusChangeCallbacks( {
+		onPaymentComplete,
+		onPaymentRedirect,
+		onPaymentError,
+		formStatus,
+		transactionError,
+		transactionStatus,
+		paymentMethodId,
+		transactionLastResponse,
+	} );
 
 	const redirectErrormessage = __(
 		'An error occurred while redirecting to the payment partner. Please try again or contact support.'
@@ -64,11 +107,77 @@ function useTransactionStatusHandler( redirectToUrl: ( url: string ) => void ): 
 				return;
 			}
 			debug( 'redirecting to', transactionRedirectUrl );
-			redirectToUrl( transactionRedirectUrl );
+			performRedirect( transactionRedirectUrl );
 		}
 		if ( transactionStatus === TransactionStatus.NOT_STARTED ) {
 			debug( 'transaction status has been reset; enabling form' );
 			setFormReady();
 		}
 	}, [ transactionStatus ] ); // eslint-disable-line react-hooks/exhaustive-deps
+}
+
+// When form status or transaction status changes, call the appropriate callbacks.
+function useCallStatusChangeCallbacks( {
+	onPaymentComplete,
+	onPaymentRedirect,
+	onPaymentError,
+	formStatus,
+	transactionError,
+	transactionStatus,
+	paymentMethodId,
+	transactionLastResponse,
+}: {
+	onPaymentComplete?: PaymentEventCallback;
+	onPaymentRedirect?: PaymentEventCallback;
+	onPaymentError?: PaymentErrorCallback;
+	formStatus: FormStatus;
+	transactionError: string | null;
+	transactionStatus: TransactionStatus;
+	paymentMethodId: string | null;
+	transactionLastResponse: PaymentProcessorResponseData;
+} ): void {
+	// Store the callbacks as refs so we do not call them more than once if they
+	// are anonymous functions. This way they are only called when the
+	// transactionStatus/formStatus changes, which is what we really want.
+	const paymentCompleteRef = useRef( onPaymentComplete );
+	paymentCompleteRef.current = onPaymentComplete;
+	const paymentRedirectRef = useRef( onPaymentRedirect );
+	paymentRedirectRef.current = onPaymentRedirect;
+	const paymentErrorRef = useRef( onPaymentError );
+	paymentErrorRef.current = onPaymentError;
+
+	const prevFormStatus = useRef< FormStatus >();
+	const prevTransactionStatus = useRef< TransactionStatus >();
+
+	useEffect( () => {
+		if (
+			paymentCompleteRef.current &&
+			formStatus === FormStatus.COMPLETE &&
+			formStatus !== prevFormStatus.current
+		) {
+			debug( "form status changed to complete so I'm calling onPaymentComplete" );
+			paymentCompleteRef.current( { paymentMethodId, transactionLastResponse } );
+		}
+		prevFormStatus.current = formStatus;
+	}, [ formStatus, transactionLastResponse, paymentMethodId ] );
+
+	useEffect( () => {
+		if (
+			paymentRedirectRef.current &&
+			transactionStatus === TransactionStatus.REDIRECTING &&
+			transactionStatus !== prevTransactionStatus.current
+		) {
+			debug( "transaction status changed to redirecting so I'm calling onPaymentRedirect" );
+			paymentRedirectRef.current( { paymentMethodId, transactionLastResponse } );
+		}
+		if (
+			paymentErrorRef.current &&
+			transactionStatus === TransactionStatus.ERROR &&
+			transactionStatus !== prevTransactionStatus.current
+		) {
+			debug( "transaction status changed to error so I'm calling onPaymentError" );
+			paymentErrorRef.current( { paymentMethodId, transactionError } );
+		}
+		prevTransactionStatus.current = transactionStatus;
+	}, [ transactionStatus, paymentMethodId, transactionLastResponse, transactionError ] );
 }


### PR DESCRIPTION
The `@automattic/composite-checkout` package has gone through many variations as calypso's checkout was refactored to use it as a replacement to the original calypso checkout experience. As a result, its `CheckoutProvider` wrapper component is something of a ["god object"](https://en.wikipedia.org/wiki/God_object), containing state for many different parts of the systems that the package makes available. In recent refactors, the primary systems have become more clear: the package contains:

- A form UI which allows for multiple steps and various busy and loading states.
- A transaction processing system with customizable functionality for different payment methods.
- An API for payment method UI elements including validation and customizable submit buttons.
- A number of UI primitives like input fields, buttons, layout helpers, and icons.

There's no real reason why these pieces cannot be used independently. However, the way that the pieces are intertwined and their dependence on the single provider makes it difficult to do.

## Proposed Changes

Form status and transaction status are intertwined because whenever the transaction status changes, it is likely to trigger a change in the form status too (eg: when a transaction begins, the form is set to a busy state). 

In this PR we move the initialization and management of both these states into a new provider, `FormAndTransactionProvider`. In order to not change the API of the package too much (yet), this PR leaves the new provider inside the `CheckoutProvider` for now but in the future this change will make it easier to split up the provider into its component parts.

Depends on https://github.com/Automattic/wp-calypso/pull/81793

## Testing Instructions

Automated tests should cover most things. We can check that the functionality is preserved by viewing calypso checkout and clicking through the steps and submitting the form to make a purchase using a redirect payment method like PayPal. You don't need to actually complete the purchase, just verify that you are redirected to PayPal's site.
