### PR TITLE
Domain management: Add all-sites table CTA to the site-specific table

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -18,6 +18,7 @@ import {
 import { setPrimaryDomain } from 'calypso/state/sites/domains/actions';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import DomainHeader from '../components/domain-header';
+import { ManageAllDomainsCTA } from './manage-domains-cta';
 import OptionsDomainButton from './options-domain-button';
 
 interface BulkSiteDomainsProps {
@@ -83,6 +84,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 						}
 					} }
 				/>
+				<ManageAllDomainsCTA shouldDisplaySeparator={ false } />
 			</Main>
 			<UsePresalesChat />
 		</>

--- a/client/my-sites/domains/domain-management/list/manage-domains-cta.tsx
+++ b/client/my-sites/domains/domain-management/list/manage-domains-cta.tsx
@@ -1,0 +1,31 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button } from '@automattic/components';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
+
+export const ManageAllDomainsCTA = ( { shouldDisplaySeparator = true } ) => {
+	const translate = useTranslate();
+
+	return (
+		<div
+			className={ classNames( 'domain-management__all-domains-section', {
+				separator: shouldDisplaySeparator,
+			} ) }
+		>
+			<p css={ { marginBottom: '1rem', textAlign: 'center' } }>
+				{ translate( 'Manage all the domains you own on WordPress.com' ) }
+			</p>
+			<Button
+				className="domain-management__all-domains-link"
+				href={ domainManagementRoot() }
+				key="breadcrumb_see_all_domains_link"
+				onClick={ () => {
+					recordTracksEvent( 'calypso_domain_management_see_all_domains_link_click' );
+				} }
+			>
+				{ translate( 'Manage all domains' ) }
+			</Button>
+		</div>
+	);
+};

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
-import { Button } from '@automattic/components';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -49,6 +48,7 @@ import DomainsTable from './domains-table';
 import DomainsTableFilterButton from './domains-table-filter-button';
 import GoogleDomainOwnerBanner from './google-domain-owner-banner';
 import { filterDomainsByOwner } from './helpers';
+import { ManageAllDomainsCTA } from './manage-domains-cta';
 import {
 	countDomainsInOrangeStatus,
 	filterOutWpcomDomains,
@@ -56,7 +56,6 @@ import {
 	getSimpleSortFunctionBy,
 	getReverseSimpleSortFunctionBy,
 } from './utils';
-
 import './style.scss';
 import 'calypso/my-sites/domains/style.scss';
 
@@ -235,7 +234,9 @@ export class SiteDomains extends Component {
 					/>
 				) }
 
-				{ ! this.isLoading() && this.renderManageDomainsSection( nonWpcomDomains ) }
+				{ ! this.isLoading() && (
+					<ManageAllDomainsCTA shouldDisplaySeparator={ nonWpcomDomains.length === 0 } />
+				) }
 
 				<DomainToPlanNudge />
 			</>
@@ -319,34 +320,6 @@ export class SiteDomains extends Component {
 				buttons={ buttons }
 				mobileButtons={ mobileButtons }
 			/>
-		);
-	}
-
-	renderManageDomainsSection( nonWpcomDomains ) {
-		const { dispatch, translate } = this.props;
-
-		const handleClick = () => {
-			dispatch( recordTracksEvent( 'calypso_domain_management_see_all_domains_link_click' ) );
-		};
-
-		return (
-			<div
-				className={ classnames( 'domain-management__all-domains-section', {
-					separator: nonWpcomDomains.length === 0,
-				} ) }
-			>
-				<p css={ { marginBottom: '1rem', textAlign: 'center' } }>
-					{ translate( 'Manage all the domains you own on WordPress.com' ) }
-				</p>
-				<Button
-					className="domain-management__all-domains-link"
-					href={ domainManagementRoot() }
-					key="breadcrumb_see_all_domains_link"
-					onClick={ handleClick }
-				>
-					{ translate( 'Manage all domains' ) }
-				</Button>
-			</div>
 		);
 	}
 


### PR DESCRIPTION
Related to p58i-fm0-p2#comment-59173.

## Proposed Changes

Reuses the component from the old view in the new view:

<img width="1081" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/851e7cef-5215-4480-a30e-5fc3be52fa6b">

## Testing Instructions

Check that the site-specific table has an all-sites table CTA and it takes you to /domains/manage. It also dispatches the `calypso_domain_management_see_all_domains_link_click` Tracks event.