### PR TITLE
Domain management: Add claim domain CTA to the site-specific table

### DIFF
--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card-styles.scss
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card-styles.scss
@@ -1,0 +1,87 @@
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+@import "@automattic/typography/styles/fonts";
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/colors";
+
+.empty-domains-list-card:not(.has-non-wpcom-domains) {
+	box-shadow: none;
+}
+
+.empty-domains-list-card__wrapper {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	margin-top: 32px;
+	margin-bottom: 32px;
+
+	h2 {
+		@extend .wp-brand-font;
+		color: var(--color-neutral-70);
+		font-size: $font-title-large;
+		margin-top: 24px;
+	}
+
+	h3 {
+		color: var(--color-neutral-50);
+		font-size: $font-body;
+	}
+
+	.empty-domains-list-card__text {
+		text-align: center;
+		margin-bottom: 10px;
+	}
+
+	.empty-domains-list-card__content {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
+
+	.empty-domains-list-card__actions {
+		display: inline-flex;
+		justify-content: center;
+		flex-wrap: wrap;
+		& > .button {
+			margin: 16px 8px 0;
+		}
+		@include break-small {
+			justify-content: flex-start;
+			& > .button:first-child {
+				margin-left: 0;
+			}
+		}
+	}
+
+	@include break-small {
+		&.is-compact {
+			flex-direction: row-reverse;
+			margin-top: 0;
+			margin-bottom: 0;
+
+			h2 {
+				font-size: $font-title-medium;
+				margin-top: 0;
+			}
+
+			> .empty-domains-list-card__illustration {
+				margin-left: 40px;
+				margin-right: 24px;
+			}
+
+			.empty-domains-list-card__text {
+				margin-bottom: 10px;
+				text-align: initial;
+			}
+
+			.empty-domains-list-card__actions {
+				text-align: initial;
+			}
+
+			.empty-domains-list-card__content {
+				align-items: normal;
+				width: 100%;
+			}
+		}
+	}
+}

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { domainAddNew, domainUseMyDomain } from 'calypso/my-sites/domains/paths';
 import { EmptyDomainsListCardSkeleton } from './empty-domains-list-card-skeleton';
 
-import './style.scss';
+import './empty-domains-list-card-styles.scss';
 
 function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNonWpcomDomains } ) {
 	const translate = useTranslate();

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -83,10 +83,6 @@
 	}
 }
 
-.empty-domains-list-card:not(.has-non-wpcom-domains) {
-	box-shadow: none;
-}
-
 .domain-management-list__items.has-no-wpcom-domain {
 	margin-top: 24px;
 }
@@ -117,84 +113,6 @@
 
 		@include break-large {
 			display: none;
-		}
-	}
-}
-
-.empty-domains-list-card__wrapper {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	margin-top: 32px;
-	margin-bottom: 32px;
-
-	h2 {
-		@extend .wp-brand-font;
-		color: var(--color-neutral-70);
-		font-size: $font-title-large;
-		margin-top: 24px;
-	}
-
-	h3 {
-		color: var(--color-neutral-50);
-		font-size: $font-body;
-	}
-
-	.empty-domains-list-card__text {
-		text-align: center;
-		margin-bottom: 10px;
-	}
-
-	.empty-domains-list-card__content {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-	}
-
-	.empty-domains-list-card__actions {
-		display: inline-flex;
-		justify-content: center;
-		flex-wrap: wrap;
-		& > .button {
-			margin: 16px 8px 0;
-		}
-		@include break-small {
-			justify-content: flex-start;
-			& > .button:first-child {
-				margin-left: 0;
-			}
-		}
-	}
-
-	@include break-small {
-		&.is-compact {
-			flex-direction: row-reverse;
-			margin-top: 0;
-			margin-bottom: 0;
-
-			h2 {
-				font-size: $font-title-medium;
-				margin-top: 0;
-			}
-
-			> .empty-domains-list-card__illustration {
-				margin-left: 40px;
-				margin-right: 24px;
-			}
-
-			.empty-domains-list-card__text {
-				margin-bottom: 10px;
-				text-align: initial;
-			}
-
-			.empty-domains-list-card__actions {
-				text-align: initial;
-			}
-
-			.empty-domains-list-card__content {
-				align-items: normal;
-				width: 100%;
-			}
 		}
 	}
 }


### PR DESCRIPTION
Related to p58i-fm0-p2#comment-59173.

## Proposed Changes

<img width="1104" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/ee5514f7-e15c-4d29-8122-24753462922c">

## Testing Instructions

Browse `/domains/manage/%s` on a site that can claim a free domain for a year, and you should see the banner.
