### PR TITLE
Domain management: Inline status notice

### DIFF
--- a/packages/data-stores/src/queries/use-site-domains-query.ts
+++ b/packages/data-stores/src/queries/use-site-domains-query.ts
@@ -80,7 +80,13 @@ export interface DomainData {
 	aftermarket_auction_end: string | null;
 	nominet_pending_contact_verification_request: boolean;
 	nominet_domain_suspended: boolean;
-	transfer_status: unknown;
+	transfer_status:
+		| 'pending_owner'
+		| 'pending_registry'
+		| 'cancelled'
+		| 'completed'
+		| 'pending_start'
+		| 'pending_async';
 	last_transfer_error: string;
 	has_private_registration: boolean;
 	is_pending_icann_verification: boolean;

--- a/packages/data-stores/src/queries/use-site-domains-query.ts
+++ b/packages/data-stores/src/queries/use-site-domains-query.ts
@@ -86,7 +86,8 @@ export interface DomainData {
 		| 'cancelled'
 		| 'completed'
 		| 'pending_start'
-		| 'pending_async';
+		| 'pending_async'
+		| null;
 	last_transfer_error: string;
 	has_private_registration: boolean;
 	is_pending_icann_verification: boolean;

--- a/packages/data-stores/src/queries/use-site-domains-query.ts
+++ b/packages/data-stores/src/queries/use-site-domains-query.ts
@@ -29,7 +29,7 @@ export interface DomainData {
 	expiry: string;
 	expiry_soon: boolean;
 	expired: boolean;
-	auto_renewing: 0;
+	auto_renewing: boolean;
 	pending_registration: boolean;
 	pending_registration_time: string;
 	has_registration: boolean;

--- a/packages/domains-table/src/domains-table-header/columns.ts
+++ b/packages/domains-table/src/domains-table-header/columns.ts
@@ -68,6 +68,11 @@ export const allSitesViewColumns = (
 		supportsOrderSwitching: true,
 		sortFunctions: getStatusSortFunctions( translate, domainStatusPurchaseActions ),
 	},
+	{
+		name: 'status_action',
+		label: null,
+		isSortable: false,
+	},
 	{ name: 'action', label: null, className: 'domains-table__action-ellipsis-column-header' },
 ];
 
@@ -113,6 +118,11 @@ export const siteSpecificViewColumns = (
 		initialSortDirection: 'desc',
 		supportsOrderSwitching: true,
 		sortFunctions: getStatusSortFunctions( translate, domainStatusPurchaseActions ),
+	},
+	{
+		name: 'status_action',
+		label: null,
+		isSortable: false,
 	},
 	{ name: 'action', label: null, className: 'domains-table__action-ellipsis-column-header' },
 ];

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -16,7 +16,9 @@ const render = ( el, props ) =>
 	renderWithProvider( el, {
 		wrapper: ( { children } ) => (
 			<DomainsTable { ...props }>
-				<tbody>{ children }</tbody>
+				<table>
+					<tbody>{ children }</tbody>
+				</table>
 			</DomainsTable>
 		),
 	} );

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -854,4 +854,39 @@ describe( 'domain status cell', () => {
 			);
 		} );
 	} );
+
+	describe( 'transfer actions', () => {
+		test( 'when the domain is ready to be transferred, offer the user a way to start it', async () => {
+			renderDomainStatusCell( {
+				domain: 'example.com',
+				blog_id: 123,
+				wpcom_domain: false,
+				type: 'transfer',
+				has_registration: true,
+				points_to_wpcom: false,
+				transfer_status: transferStatus.PENDING_START,
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Complete setup' ) );
+			} );
+
+			const changeAddress = screen.queryByText( 'Start transfer' );
+			expect( changeAddress ).toBeInTheDocument();
+			expect( changeAddress ).toHaveAttribute(
+				'href',
+				'/domains/add/use-my-domain/example.com?initialQuery=example.com&initialMode=start-pending-transfer'
+			);
+
+			fireEvent.mouseOver( screen.getByLabelText( 'More information' ) );
+
+			await waitFor( () => {
+				const tooltip = screen.getByRole( 'tooltip' );
+
+				expect( tooltip ).toHaveTextContent(
+					'You need to start the domain transfer for your domain.'
+				);
+			} );
+		} );
+	} );
 } );

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -753,4 +753,71 @@ describe( 'domain status cell', () => {
 			} );
 		} );
 	} );
+
+	describe( 'verify domain e-mail actions', () => {
+		test( 'when there domain is pending e-mail verification and the viewer is the owner, display the change email cta', async () => {
+			renderDomainStatusCell( {
+				domain: 'example.com',
+				blog_id: 123,
+				wpcom_domain: false,
+				type: 'registered',
+				has_registration: true,
+				is_pending_icann_verification: true,
+				is_icann_verification_suspended: false,
+				current_user_is_owner: true,
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Verify email' ) );
+			} );
+
+			const changeAddress = screen.queryByText( 'Change address' );
+
+			expect( changeAddress ).toBeInTheDocument();
+			expect( changeAddress ).toHaveAttribute(
+				'href',
+				'/domains/manage/example.com/edit-contact-info/example.com'
+			);
+
+			fireEvent.mouseOver( screen.getByLabelText( 'More information' ) );
+
+			await waitFor( () => {
+				const tooltip = screen.getByRole( 'tooltip' );
+
+				expect( tooltip ).toHaveTextContent(
+					'We sent you an email to verify your contact information. Please complete the verification or your domain will stop working.'
+				);
+			} );
+		} );
+
+		test( 'when there domain is pending e-mail verification and the viewer is not the owner, display a notice', async () => {
+			renderDomainStatusCell( {
+				domain: 'example.com',
+				blog_id: 123,
+				wpcom_domain: false,
+				type: 'registered',
+				has_registration: true,
+				is_pending_icann_verification: true,
+				is_icann_verification_suspended: false,
+				current_user_is_owner: false,
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Verify email' ) );
+			} );
+
+			const changeAddress = screen.queryByText( 'Change address' );
+			expect( changeAddress ).not.toBeInTheDocument();
+
+			fireEvent.mouseOver( screen.getByLabelText( 'More information' ) );
+
+			await waitFor( () => {
+				const tooltip = screen.getByRole( 'tooltip' );
+
+				expect( tooltip ).toHaveTextContent(
+					'We sent an email to the domain owner. Please complete the verification or your domain will stop working.'
+				);
+			} );
+		} );
+	} );
 } );

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -6,6 +6,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import moment from 'moment';
 import React from 'react';
 import { renderWithProvider, testDomain, testPartialDomain } from '../../test-utils';
+import { transferStatus } from '../../utils/constants';
 import { DomainsTable, DomainsTableProps } from '../domains-table';
 import { DomainsTableRow } from '../domains-table-row';
 
@@ -818,6 +819,39 @@ describe( 'domain status cell', () => {
 					'We sent an email to the domain owner. Please complete the verification or your domain will stop working.'
 				);
 			} );
+		} );
+	} );
+
+	test( 'when the domain is transferred but doesnt point to wpcom, display the cta so the user can point it', async () => {
+		renderDomainStatusCell( {
+			domain: 'example.com',
+			blog_id: 123,
+			wpcom_domain: false,
+			type: 'registered',
+			has_registration: true,
+			points_to_wpcom: false,
+			transfer_status: transferStatus.COMPLETED,
+		} );
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Active' ) );
+		} );
+
+		const changeAddress = screen.queryByText( 'Point to WordPress.com' );
+		expect( changeAddress ).toBeInTheDocument();
+		expect( changeAddress ).toHaveAttribute(
+			'href',
+			'/domains/manage/example.com/edit/example.com?nameservers=true'
+		);
+
+		fireEvent.mouseOver( screen.getByLabelText( 'More information' ) );
+
+		await waitFor( () => {
+			const tooltip = screen.getByRole( 'tooltip' );
+
+			expect( tooltip ).toHaveTextContent(
+				'Transfer successful! To make this domain work with your WordPress.com site you need to point it to WordPress.com name servers.'
+			);
 		} );
 	} );
 } );

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -10,6 +10,8 @@ import { transferStatus } from '../../utils/constants';
 import { DomainsTable, DomainsTableProps } from '../domains-table';
 import { DomainsTableRow } from '../domains-table-row';
 
+const siteSlug = 'site123.com';
+
 const render = ( el, props ) =>
 	renderWithProvider( el, {
 		wrapper: ( { children } ) => (
@@ -80,7 +82,12 @@ test( 'domain name links to management interface', async () => {
 
 	// Test site-specific link
 	rerender(
-		<DomainsTable domains={ [ partialDomain ] } fetchSite={ fetchSite } isAllSitesView={ false }>
+		<DomainsTable
+			siteSlug={ siteSlug }
+			domains={ [ partialDomain ] }
+			fetchSite={ fetchSite }
+			isAllSitesView={ false }
+		>
 			<tbody>
 				<DomainsTableRow domain={ partialDomain } />
 			</tbody>
@@ -137,6 +144,7 @@ test( `redirect links use the site's unmapped URL for the site slug`, async () =
 	// Test site-specific link
 	rerender(
 		<DomainsTable
+			siteSlug={ siteSlug }
 			domains={ [ partialRedirectDomain ] }
 			fetchSiteDomains={ fetchSiteDomains }
 			isAllSitesView={ false }
@@ -190,6 +198,7 @@ test( 'transfer domains link to the transfer management interface', async () => 
 	// Test site-specific link
 	rerender(
 		<DomainsTable
+			siteSlug={ siteSlug }
 			domains={ [ partialDomain ] }
 			fetchSiteDomains={ fetchSiteDomains }
 			isAllSitesView={ false }

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -888,5 +888,38 @@ describe( 'domain status cell', () => {
 				);
 			} );
 		} );
+
+		test( 'when the last attempt to transfer failed, offer the user a way to retry it', async () => {
+			renderDomainStatusCell( {
+				domain: 'example.com',
+				blog_id: 123,
+				wpcom_domain: false,
+				type: 'transfer',
+				has_registration: true,
+				points_to_wpcom: true,
+				last_transfer_error: 'failed',
+			} );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Complete setup' ) );
+			} );
+
+			const changeAddress = screen.queryByText( 'Retry transfer' );
+			expect( changeAddress ).toBeInTheDocument();
+			expect( changeAddress ).toHaveAttribute(
+				'href',
+				'/domains/manage/example.com/transfer/example.com'
+			);
+
+			fireEvent.mouseOver( screen.getByLabelText( 'More information' ) );
+
+			await waitFor( () => {
+				const tooltip = screen.getByRole( 'tooltip' );
+
+				expect( tooltip ).toHaveTextContent(
+					'There was an error when initiating your domain transfer. Please see the details or retry.'
+				);
+			} );
+		} );
 	} );
 } );

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
@@ -7,11 +7,11 @@ import { useI18n } from '@wordpress/react-i18n';
 import { PrimaryDomainLabel } from '../primary-domain-label/index';
 import { useDomainRow } from '../use-domain-row';
 import { canBulkUpdate } from '../utils/can-bulk-update';
-import { ResponseDomain } from '../utils/types';
 import { DomainsTableEmailIndicator } from './domains-table-email-indicator';
 import { DomainsTableExpiresRewnewsOnCell } from './domains-table-expires-renew-cell';
 import { DomainsTableRowActions } from './domains-table-row-actions';
 import { DomainsTableStatusCell } from './domains-table-status-cell';
+import { DomainsTableStatusCTA } from './domains-table-status-cta';
 
 type Props = {
 	domain: PartialDomainData;
@@ -27,7 +27,7 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 		currentDomainData,
 		isSelected,
 		handleSelectDomain,
-		domainStatusPurchaseActions,
+		domainStatus,
 		pendingUpdates,
 		shouldDisplayPrimaryDomainLabel,
 		showBulkActions,
@@ -92,12 +92,15 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 				{ ! currentDomainData || isLoadingSiteDomainsDetails ? (
 					<LoadingPlaceholder style={ { width: '30%' } } />
 				) : (
-					<DomainsTableStatusCell
-						siteSlug={ siteSlug }
-						currentDomainData={ currentDomainData as ResponseDomain }
-						domainStatusPurchaseActions={ domainStatusPurchaseActions }
-						pendingUpdates={ pendingUpdates }
-					/>
+					<div className="domains-table-mobile-card-status">
+						<DomainsTableStatusCell
+							domainStatus={ domainStatus }
+							pendingUpdates={ pendingUpdates }
+						/>
+						{ domainStatus?.callToAction && (
+							<DomainsTableStatusCTA callToAction={ domainStatus.callToAction } />
+						) }
+					</div>
 				) }
 			</div>
 		</div>

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -16,6 +16,7 @@ import { DomainsTableExpiresRewnewsOnCell } from './domains-table-expires-renew-
 import { DomainsTableRowActions } from './domains-table-row-actions';
 import { DomainsTableSiteCell } from './domains-table-site-cell';
 import { DomainsTableStatusCell } from './domains-table-status-cell';
+import { DomainsTableStatusCTA } from './domains-table-status-cta';
 
 interface DomainsTableRowProps {
 	domain: PartialDomainData;
@@ -40,7 +41,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 		handleSelectDomain,
 		isAllSitesView,
 		hideOwnerColumn,
-		domainStatusPurchaseActions,
+		domainStatus,
 		pendingUpdates,
 	} = useDomainRow( domain );
 	const { canSelectAnyDomains, domainsTableColumns } = useDomainsTable();
@@ -144,11 +145,19 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 								<LoadingPlaceholder style={ { width: `${ placeholderWidth }%` } } />
 							) : (
 								<DomainsTableStatusCell
-									siteSlug={ siteSlug }
-									currentDomainData={ currentDomainData }
-									domainStatusPurchaseActions={ domainStatusPurchaseActions }
+									domainStatus={ domainStatus }
 									pendingUpdates={ pendingUpdates }
 								/>
+							) }
+						</td>
+					);
+				}
+
+				if ( column.name === 'status_action' ) {
+					return (
+						<td key={ column.name }>
+							{ ! domainStatus?.callToAction || isLoadingRowDetails ? null : (
+								<DomainsTableStatusCTA callToAction={ domainStatus.callToAction } />
 							) }
 						</td>
 					);

--- a/packages/domains-table/src/domains-table/domains-table-status-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-status-cell.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from '@automattic/components';
+import { Spinner, Button } from '@automattic/components';
 import { DomainUpdateStatus } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import classNames from 'classnames';
@@ -26,7 +26,7 @@ export const DomainsTableStatusCell = ( {
 		return null;
 	}
 	const currentRoute = window.location.pathname;
-	const { status, noticeText, statusClass } = resolveDomainStatus( currentDomainData, {
+	const domainStatus = resolveDomainStatus( currentDomainData, {
 		siteSlug: siteSlug,
 		translate,
 		getMappingErrors: true,
@@ -60,12 +60,12 @@ export const DomainsTableStatusCell = ( {
 
 	return (
 		<div
-			className={ classNames(
-				'domains-table-row__status-cell',
-				`domains-table-row__status-cell__${ statusClass }`
-			) }
+			className={ classNames( 'domains-table-row__status-cell', {
+				[ `domains-table-row__status-cell__${ domainStatus?.statusClass }` ]:
+					!! domainStatus?.statusClass,
+			} ) }
 		>
-			{ status }
+			{ domainStatus?.status ?? translate( 'Unknown status' ) }
 			{ pendingUpdates.length > 0 && (
 				<StatusPopover popoverTargetElement={ <Spinner size={ 16 } /> }>
 					<div className="domains-bulk-update-status-popover">
@@ -87,10 +87,20 @@ export const DomainsTableStatusCell = ( {
 					</div>
 				</StatusPopover>
 			) }
-			{ noticeText && (
-				<StatusPopover className={ `domains-table-row__status-cell__${ statusClass }` }>
-					{ noticeText }
+			{ domainStatus?.noticeText && (
+				<StatusPopover
+					className={ `domains-table-row__status-cell__${ domainStatus.statusClass }` }
+				>
+					{ domainStatus.noticeText }
 				</StatusPopover>
+			) }
+			{ domainStatus?.callToAction && (
+				<Button
+					onClick={ domainStatus.callToAction.onClick }
+					href={ domainStatus.callToAction.href }
+				>
+					{ domainStatus.callToAction.label }
+				</Button>
 			) }
 		</div>
 	);

--- a/packages/domains-table/src/domains-table/domains-table-status-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-status-cell.tsx
@@ -1,41 +1,22 @@
-import { Spinner, Button } from '@automattic/components';
+import { Spinner } from '@automattic/components';
 import { DomainUpdateStatus } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { StatusPopover } from '../status-popover';
-import { DomainStatusPurchaseActions, resolveDomainStatus } from '../utils/resolve-domain-status';
-import { ResponseDomain } from '../utils/types';
+import { ResolveDomainStatusReturn } from '../utils/resolve-domain-status';
 
 interface DomainsTableStatusCellProps {
-	currentDomainData?: ResponseDomain;
-	siteSlug?: string;
-	domainStatusPurchaseActions?: DomainStatusPurchaseActions;
+	domainStatus: ResolveDomainStatusReturn | null;
 	pendingUpdates: DomainUpdateStatus[];
 }
 
 export const DomainsTableStatusCell = ( {
-	currentDomainData,
-	siteSlug,
-	domainStatusPurchaseActions,
+	domainStatus,
 	pendingUpdates,
 }: DomainsTableStatusCellProps ) => {
 	const translate = useTranslate();
 	const locale = useLocale();
-	if ( ! currentDomainData ) {
-		return null;
-	}
-	const currentRoute = window.location.pathname;
-	const domainStatus = resolveDomainStatus( currentDomainData, {
-		siteSlug: siteSlug,
-		translate,
-		getMappingErrors: true,
-		currentRoute,
-		isPurchasedDomain: domainStatusPurchaseActions?.isPurchasedDomain?.( currentDomainData ),
-		isCreditCardExpiring: domainStatusPurchaseActions?.isCreditCardExpiring?.( currentDomainData ),
-		onRenewNowClick: () =>
-			domainStatusPurchaseActions?.onRenewNowClick?.( siteSlug ?? '', currentDomainData ),
-	} );
 
 	const getActionName = ( status: DomainUpdateStatus ) => {
 		if ( 'message' in status ) {
@@ -93,14 +74,6 @@ export const DomainsTableStatusCell = ( {
 				>
 					{ domainStatus.noticeText }
 				</StatusPopover>
-			) }
-			{ domainStatus?.callToAction && (
-				<Button
-					onClick={ domainStatus.callToAction.onClick }
-					href={ domainStatus.callToAction.href }
-				>
-					{ domainStatus.callToAction.label }
-				</Button>
 			) }
 		</div>
 	);

--- a/packages/domains-table/src/domains-table/domains-table-status-cta.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-status-cta.tsx
@@ -1,0 +1,14 @@
+import { Button } from '@automattic/components';
+import { ResolveDomainStatusReturn } from '../utils/resolve-domain-status';
+
+interface DomainsTableStatusCTAProps {
+	callToAction: Exclude< ResolveDomainStatusReturn[ 'callToAction' ], undefined >;
+}
+
+export const DomainsTableStatusCTA = ( { callToAction }: DomainsTableStatusCTAProps ) => {
+	return (
+		<Button compact onClick={ callToAction.onClick } href={ callToAction.href }>
+			{ callToAction.label }
+		</Button>
+	);
+};

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -110,26 +110,23 @@
 			width: 100px;
 		}
 
+		svg {
+			color: currentColor;
+		}
+
 		&__status-success,
-		&__status-verifying,
-		&__status-premium,
-		&__status-alert,
-		&__status-warning,
-		&__status-error {
+		&__status-premium {
 			color: var(--studio-green-50);
-			& svg {
-				color: var(--studio-green-50);
-			}
 		}
 
 		&__status-verifying,
+		&__status-warning {
+			color: var(--studio-orange-50);
+		}
+
 		&__status-alert,
-		&__status-warning,
 		&__status-error {
 			color: var(--studio-red-50);
-			& svg {
-				color: var(--studio-red-50);
-			}
 		}
 	}
 

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -314,6 +314,12 @@
 		font-size: $font-body-small;
 	}
 
+	&-status {
+		display: flex;
+		align-items: center;
+		gap: 16px;
+	}
+
 	&-loading-placeholder {
 		display: flex;
 		flex-direction: column;

--- a/packages/domains-table/src/test-utils.tsx
+++ b/packages/domains-table/src/test-utils.tsx
@@ -85,7 +85,7 @@ export function testDomain(
 		email_forwards_count: 0,
 		expiry_soon: false,
 		expired: false,
-		auto_renewing: 0,
+		auto_renewing: false,
 		pending_registration: false,
 		pending_registration_time: '',
 		has_email_forward_dns_records: null,

--- a/packages/domains-table/src/use-domain-row.ts
+++ b/packages/domains-table/src/use-domain-row.ts
@@ -8,6 +8,8 @@ import { countDomainsRequiringAttention } from './utils';
 import { createSiteDomainObject } from './utils/assembler';
 import { resolveDomainStatus } from './utils/resolve-domain-status';
 
+const notNull = < T >( x: T ): x is Exclude< T, null > => x !== null;
+
 export const useDomainRow = ( domain: PartialDomainData ) => {
 	const {
 		hideOwnerColumn,
@@ -66,8 +68,8 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 		if ( ! currentDomainData || isLoadingRowDetails ) {
 			return null;
 		}
-		return countDomainsRequiringAttention(
-			allSiteDomains?.map( ( domain ) =>
+		const domains = allSiteDomains
+			?.map( ( domain ) =>
 				resolveDomainStatus( domain, {
 					siteSlug: siteSlug,
 					getMappingErrors: true,
@@ -77,7 +79,9 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 						domainStatusPurchaseActions?.isCreditCardExpiring?.( currentDomainData ),
 				} )
 			)
-		);
+			.filter( notNull );
+
+		return countDomainsRequiringAttention( domains ?? [] );
 	}, [
 		allSiteDomains,
 		currentDomainData,

--- a/packages/domains-table/src/use-domain-row.ts
+++ b/packages/domains-table/src/use-domain-row.ts
@@ -125,6 +125,20 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 		return updates;
 	}, [ domain.domain, domainResults, updatingDomain ] );
 
+	const domainStatus = currentDomainData
+		? resolveDomainStatus( currentDomainData, {
+				siteSlug: siteSlug,
+				translate,
+				getMappingErrors: true,
+				currentRoute: window.location.pathname,
+				isPurchasedDomain: domainStatusPurchaseActions?.isPurchasedDomain?.( currentDomainData ),
+				isCreditCardExpiring:
+					domainStatusPurchaseActions?.isCreditCardExpiring?.( currentDomainData ),
+				onRenewNowClick: () =>
+					domainStatusPurchaseActions?.onRenewNowClick?.( siteSlug ?? '', currentDomainData ),
+		  } )
+		: null;
+
 	return {
 		ref,
 		site,
@@ -141,6 +155,7 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 		isSelected,
 		handleSelectDomain,
 		isAllSitesView,
+		domainStatus,
 		domainStatusPurchaseActions,
 		pendingUpdates,
 		currentDomainData,

--- a/packages/domains-table/src/utils.ts
+++ b/packages/domains-table/src/utils.ts
@@ -76,12 +76,13 @@ export const getStatusSortFunctions = (
 		const isPurchased = domainStatusPurchaseActions?.isPurchasedDomain?.( responseDomain );
 		const isCreditCardExpiring =
 			domainStatusPurchaseActions?.isCreditCardExpiring?.( responseDomain );
-		const { listStatusWeight } = resolveDomainStatus( responseDomain, {
-			translate,
-			isPurchasedDomain: isPurchased,
-			isCreditCardExpiring: isCreditCardExpiring,
-			getMappingErrors: true,
-		} );
+		const { listStatusWeight } =
+			resolveDomainStatus( responseDomain, {
+				translate,
+				isPurchasedDomain: isPurchased,
+				isCreditCardExpiring: isCreditCardExpiring,
+				getMappingErrors: true,
+			} ) ?? {};
 		return listStatusWeight ?? 0;
 	};
 

--- a/packages/domains-table/src/utils/constants.ts
+++ b/packages/domains-table/src/utils/constants.ts
@@ -15,12 +15,12 @@ export const useMyDomainInputMode = {
 } as const;
 
 export const transferStatus = {
-	PENDING_OWNER: 'PENDING_OWNER',
-	PENDING_REGISTRY: 'PENDING_REGISTRY',
-	CANCELLED: 'CANCELLED',
-	COMPLETED: 'COMPLETED',
-	PENDING_START: 'PENDING_START',
-	PENDING_ASYNC: 'PENDING_ASYNC',
+	PENDING_OWNER: 'pending_owner',
+	PENDING_REGISTRY: 'pending_registry',
+	CANCELLED: 'cancelled',
+	COMPLETED: 'completed',
+	PENDING_START: 'pending_start',
+	PENDING_ASYNC: 'pending_async',
 };
 
 export const registrar = {

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -160,6 +160,14 @@ export function domainManagementEdit(
 	return domainManagementEditBase( siteName, domainName, 'edit', relativeTo, expandSections );
 }
 
+export function domainManagementTransfer(
+	siteName: string,
+	domainName: string,
+	relativeTo: string | null = null
+) {
+	return domainManagementEditBase( siteName, domainName, 'transfer', relativeTo );
+}
+
 export function isUnderEmailManagementAll( path: string ) {
 	return path?.startsWith( emailManagementAllSitesPrefix + '/' );
 }

--- a/packages/domains-table/src/utils/resolve-domain-status.tsx
+++ b/packages/domains-table/src/utils/resolve-domain-status.tsx
@@ -464,6 +464,10 @@ export function resolveDomainStatus(
 			}
 
 			if ( domain.transferStatus === transferStatus.COMPLETED && ! domain.pointsToWpcom ) {
+				const ctaLink = domainManagementEdit( siteSlug as string, domain.domain, currentRoute, {
+					nameservers: true,
+				} );
+
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-success',
@@ -474,16 +478,14 @@ export function resolveDomainStatus(
 						{
 							components: {
 								strong: <strong />,
-								a: (
-									<a
-										href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute, {
-											nameservers: true,
-										} ) }
-									/>
-								),
+								a: <a href={ ctaLink } />,
 							},
 						}
 					),
+					callToAction: {
+						href: ctaLink,
+						label: translate( 'Point to WordPress.com' ),
+					},
 					listStatusWeight: 600,
 				};
 			}

--- a/packages/domains-table/src/utils/resolve-domain-status.tsx
+++ b/packages/domains-table/src/utils/resolve-domain-status.tsx
@@ -24,22 +24,25 @@ import {
 } from './url-support';
 import type { I18N, TranslateResult } from 'i18n-calypso';
 
-export type ResolveDomainStatusReturn =
-	| {
-			statusText: TranslateResult | TranslateResult[];
-			statusClass:
-				| 'status-error'
-				| 'status-warning'
-				| 'status-alert'
-				| 'status-success'
-				| 'status-neutral'
-				| 'status-premium';
-			status: TranslateResult;
-			icon: 'info' | 'verifying' | 'check_circle' | 'cached' | 'cloud_upload' | 'download_done';
-			listStatusWeight?: number;
-			noticeText?: TranslateResult | Array< TranslateResult > | null;
-	  }
-	| Record< string, never >;
+export type ResolveDomainStatusReturn = {
+	statusText: TranslateResult | TranslateResult[];
+	statusClass:
+		| 'status-error'
+		| 'status-warning'
+		| 'status-alert'
+		| 'status-success'
+		| 'status-neutral'
+		| 'status-premium';
+	status: TranslateResult;
+	icon: 'info' | 'verifying' | 'check_circle' | 'cached' | 'cloud_upload' | 'download_done';
+	listStatusWeight?: number;
+	noticeText?: TranslateResult | Array< TranslateResult > | null;
+	callToAction?: {
+		href?: string;
+		onClick?(): void;
+		label: string;
+	};
+};
 
 export type ResolveDomainStatusOptionsBag = {
 	siteSlug?: string | null;
@@ -47,7 +50,7 @@ export type ResolveDomainStatusOptionsBag = {
 	getMappingErrors?: boolean | null;
 	translate: I18N[ 'translate' ];
 	isPurchasedDomain?: boolean | null;
-	onRenewNowClick?: any;
+	onRenewNowClick?(): void;
 	isCreditCardExpiring?: boolean | null;
 };
 
@@ -65,10 +68,10 @@ export function resolveDomainStatus(
 		currentRoute = null,
 		translate,
 		isPurchasedDomain = false,
-		onRenewNowClick = null,
+		onRenewNowClick,
 		isCreditCardExpiring = false,
 	}: ResolveDomainStatusOptionsBag
-): ResolveDomainStatusReturn {
+): ResolveDomainStatusReturn | null {
 	const transferOptions = {
 		components: {
 			strong: <strong />,
@@ -625,6 +628,6 @@ export function resolveDomainStatus(
 			};
 
 		default:
-			return {};
+			return null;
 	}
 }

--- a/packages/domains-table/src/utils/resolve-domain-status.tsx
+++ b/packages/domains-table/src/utils/resolve-domain-status.tsx
@@ -576,22 +576,15 @@ export function resolveDomainStatus(
 					statusClass: 'status-warning',
 					status: translate( 'Complete setup' ),
 					icon: 'info',
-					noticeText: translate(
-						'You need to {{a}}start the domain transfer{{/a}} for your domain.',
-						{
-							components: {
-								a: (
-									<a
-										href={ domainUseMyDomain(
-											siteSlug as string,
-											domain.name,
-											useMyDomainInputMode.startPendingTransfer
-										) }
-									/>
-								),
-							},
-						}
-					),
+					noticeText: translate( 'You need to start the domain transfer for your domain.' ),
+					callToAction: {
+						label: translate( 'Start transfer' ),
+						href: domainUseMyDomain(
+							siteSlug as string,
+							domain.name,
+							useMyDomainInputMode.startPendingTransfer
+						),
+					},
 					listStatusWeight: 600,
 				};
 			} else if ( domain.transferStatus === transferStatus.CANCELLED ) {

--- a/packages/domains-table/src/utils/resolve-domain-status.tsx
+++ b/packages/domains-table/src/utils/resolve-domain-status.tsx
@@ -88,14 +88,15 @@ export function resolveDomainStatus(
 		},
 	};
 
-	const mappingSetupComponents = {
-		strong: <strong />,
-		a: <a href={ domainMappingSetup( siteSlug as string, domain.domain ) } />,
+	const mappingSetupCallToAction = {
+		href: domainMappingSetup( siteSlug as string, domain.domain ),
+		label: translate( 'Go to setup' ),
 	};
 
 	switch ( domain.type ) {
 		case domainTypes.MAPPED:
 			if ( isExpiringSoon( domain, 30 ) ) {
+				let callToAction;
 				const expiresMessage =
 					null !== domain.bundledPlanSubscriptionId
 						? translate(
@@ -113,10 +114,8 @@ export function resolveDomainStatus(
 				let noticeText = null;
 
 				if ( ! domain.pointsToWpcom ) {
-					noticeText = translate(
-						"We noticed that something wasn't updated correctly. Please try {{a}}this setup{{/a}} again.",
-						{ components: mappingSetupComponents }
-					);
+					noticeText = translate( "We noticed that something wasn't updated correctly." );
+					callToAction = mappingSetupCallToAction;
 				}
 
 				let status = translate( 'Active' );
@@ -133,6 +132,7 @@ export function resolveDomainStatus(
 					icon: 'info',
 					listStatusWeight: isExpiringSoon( domain, 7 ) ? 1000 : 800,
 					noticeText,
+					callToAction,
 				};
 			}
 
@@ -150,10 +150,8 @@ export function resolveDomainStatus(
 						statusClass: 'status-alert',
 						status: translate( 'Error' ),
 						icon: 'info',
-						noticeText: translate(
-							"We noticed that something wasn't updated correctly. Please try {{a}}this setup{{/a}} again.",
-							{ components: mappingSetupComponents }
-						),
+						noticeText: translate( "We noticed that something wasn't updated correctly." ),
+						callToAction: mappingSetupCallToAction,
 						listStatusWeight: 1000,
 					};
 				}

--- a/packages/domains-table/src/utils/resolve-domain-status.tsx
+++ b/packages/domains-table/src/utils/resolve-domain-status.tsx
@@ -237,19 +237,8 @@ export function resolveDomainStatus(
 			if ( domain.isPendingIcannVerification ) {
 				const noticeText = domain.currentUserIsOwner
 					? translate(
-							'We sent you an email to verify your contact information. Please complete the verification or your domain will stop working. You can also {{a}}change your email address{{/a}} if you like.',
+							'We sent you an email to verify your contact information. Please complete the verification or your domain will stop working.',
 							{
-								components: {
-									a: (
-										<a
-											href={ domainManagementEditContactInfo(
-												siteSlug as string,
-												domain.name,
-												currentRoute
-											) }
-										></a>
-									),
-								},
 								args: {
 									domainName: domain.name,
 								},
@@ -264,6 +253,16 @@ export function resolveDomainStatus(
 					statusClass: 'status-error',
 					status: translate( 'Verify email' ),
 					noticeText,
+					callToAction: domain.currentUserIsOwner
+						? {
+								label: translate( 'Change address' ),
+								href: domainManagementEditContactInfo(
+									siteSlug as string,
+									domain.name,
+									currentRoute
+								),
+						  }
+						: undefined,
 					icon: 'info',
 					listStatusWeight: 600,
 				};

--- a/packages/domains-table/src/utils/resolve-domain-status.tsx
+++ b/packages/domains-table/src/utils/resolve-domain-status.tsx
@@ -11,6 +11,7 @@ import { isRecentlyRegistered } from './is-recently-registered';
 import {
 	domainManagementEdit,
 	domainManagementEditContactInfo,
+	domainManagementTransfer,
 	domainMappingSetup,
 	domainUseMyDomain,
 } from './paths';
@@ -549,6 +550,8 @@ export function resolveDomainStatus(
 
 		case domainTypes.TRANSFER:
 			if ( domain.lastTransferError ) {
+				const ctaLink = domainManagementTransfer( siteSlug as string, domain.domain, currentRoute );
+
 				return {
 					statusText: translate( 'Complete setup' ),
 					statusClass: 'status-warning',
@@ -558,14 +561,14 @@ export function resolveDomainStatus(
 						'There was an error when initiating your domain transfer. Please {{a}}see the details or retry{{/a}}.',
 						{
 							components: {
-								a: (
-									<a
-										href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute ) }
-									/>
-								),
+								a: <a href={ ctaLink } />,
 							},
 						}
 					),
+					callToAction: {
+						label: translate( 'Retry transfer' ),
+						href: ctaLink,
+					},
 					listStatusWeight: 600,
 				};
 			}


### PR DESCRIPTION
Related to p58i-fm0-p2#comment-59166.

## Proposed Changes

| Desktop | Mobile |
| --------- | ------ |
| <img width="1099" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/133287f2-e073-4480-b13e-5576e01e8862"> | <img width="478" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/1fead7fe-caa5-4d41-8284-7a82502cee34"> |

## Testing Instructions

Check that the CTAs are showing to the right of the statuses. As a more comprehensive testing method, check the unit tests. They should all pass.