### PR TITLE
Domain management: Remove CTAs from below the table on mobile experience

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable } from '@automattic/domains-table';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { UsePresalesChat } from 'calypso/components/data/domain-management';
@@ -32,6 +33,7 @@ interface BulkSiteDomainsProps {
 }
 
 export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
+	const isMobile = useMobileBreakpoint();
 	const site = useSelector( getSelectedSite );
 	const userCanSetPrimaryDomains = useSelector(
 		( state ) => ! currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
@@ -95,15 +97,19 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 						}
 					} }
 				/>
-				{ ! isLoading && (
-					<EmptyDomainsListCard
-						selectedSite={ site }
-						hasDomainCredit={ !! hasDomainCredit }
-						isCompact={ hasNonWpcomDomains }
-						hasNonWpcomDomains={ hasNonWpcomDomains }
-					/>
+				{ ! isMobile && (
+					<>
+						{ ! isLoading && (
+							<EmptyDomainsListCard
+								selectedSite={ site }
+								hasDomainCredit={ !! hasDomainCredit }
+								isCompact={ hasNonWpcomDomains }
+								hasNonWpcomDomains={ hasNonWpcomDomains }
+							/>
+						) }
+						<ManageAllDomainsCTA shouldDisplaySeparator={ false } />
+					</>
 				) }
-				<ManageAllDomainsCTA shouldDisplaySeparator={ false } />
 			</Main>
 			<UsePresalesChat />
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/81799 and https://github.com/Automattic/wp-calypso/pull/81800.

## Proposed Changes

The related PRs added CTAs after the domains table in the site-specific view, but they are not playing well with the mobile experience (see "Before" below.)

For now I'm just hiding them. But we need to understand how we want to approach this. Do we want to add these CTAs somewhere?

| Before | After |
| -------| ------|
| <img width="431" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/f169f675-58c2-4919-a789-12696140883f"> | <img width="412" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/51aff7af-555d-47e9-8793-d5b69ee31590"> |

## Testing Instructions

Browse the mobile version of `/domains/manage/%s` and check that the CTAs are gone.