### PR TITLE
Site profiler: Present WHOIS data inside "Hosting information" block

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -1,8 +1,50 @@
+export interface WhoIs {
+	admin_city: string;
+	admin_country: string;
+	admin_email: string;
+	admin_name: string;
+	admin_organization: string;
+	admin_phone: string;
+	admin_postal_code: string;
+	admin_state: string;
+	admin_street: string;
+	creation_date: string;
+	domain_name: string;
+	name_server: string[];
+	registrant_city: string;
+	registrant_country: string;
+	registrant_email: string;
+	registrant_name: string;
+	registrant_organization: string;
+	registrant_phone: string;
+	registrant_postal_code: string;
+	registrant_state: string;
+	registrant_street: string;
+	registrar: string;
+	registrar_iana_id: string;
+	registrar_url: string;
+	registrar_whois_server: string;
+	registry_domain_id: string;
+	registry_expiry_date: string;
+	reseller: string;
+	status: string;
+	tech_city: string;
+	tech_country: string;
+	tech_email: string;
+	tech_name: string;
+	tech_organization: string;
+	tech_phone: string;
+	tech_postal_code: string;
+	tech_state: string;
+	tech_street: string;
+	updated_date: string;
+}
+
 export interface DomainAnalyzerQueryResponse {
 	domain: string;
 	hosting_provider: {
 		name: string;
 	};
-	whois: any;
+	whois: WhoIs;
 	dns: any;
 }

--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -33,7 +33,12 @@ export default function DomainAnalyzer( props: Props ) {
 			<form className="domain-analyzer--form" onSubmit={ onSubmit }>
 				<div className="domain-analyzer--form-container">
 					<div className="col-1">
-						<input type="text" name="domain" placeholder={ translate( 'mysite.com' ) } />
+						<input
+							type="text"
+							name="domain"
+							autoComplete="off"
+							placeholder={ translate( 'mysite.com' ) }
+						/>
 					</div>
 					<div className="col-2">
 						<Button isBusy={ isBusy } type="submit">

--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -1,7 +1,226 @@
-export default function DomainInformation() {
+import { Button } from '@wordpress/components';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import type { WhoIs } from 'calypso/data/site-profiler/types';
+import './styles.scss';
+
+interface Props {
+	whois: WhoIs;
+}
+
+export default function DomainInformation( props: Props ) {
+	const { whois } = props;
+	const moment = useLocalizedMoment();
+	const momentFormat = 'YYYY-MM-DD HH:mm:ss UTC';
+
 	return (
-		<>
+		<div className="domain-information">
 			<h3>Domain information</h3>
-		</>
+
+			<ul className="domain-information-details">
+				{ whois.registrar_url && (
+					<li>
+						<div className="name">Registrar</div>
+						<div>
+							<a href={ whois.registrar_url }>{ whois.registrar_url }</a>
+						</div>
+					</li>
+				) }
+				{ whois.creation_date && (
+					<li>
+						<div className="name">Registered on</div>
+						<div>{ moment.utc( whois.creation_date ).format( momentFormat ) }</div>
+					</li>
+				) }
+				{ whois.registry_expiry_date && (
+					<li>
+						<div className="name">Expires on</div>
+						<div>{ moment.utc( whois.registry_expiry_date ).format( momentFormat ) }</div>
+					</li>
+				) }
+				{ whois.updated_date && (
+					<li>
+						<div className="name">Updated on</div>
+						<div>{ moment.utc( whois.updated_date ).format( momentFormat ) }</div>
+					</li>
+				) }
+				{ whois.name_server && (
+					<li>
+						<div className="name">Name servers</div>
+						<div>
+							<ul>
+								{ whois.name_server.map( ( x, i ) => (
+									<li key={ i }>{ x }</li>
+								) ) }
+							</ul>
+						</div>
+					</li>
+				) }
+				<li>
+					<div className="name">Contact</div>
+					<div className="col">
+						<h4>
+							<strong>Registrant contact</strong>
+						</h4>
+						<ul>
+							{ whois.registrant_name && (
+								<li>
+									<strong>Name:</strong> { whois.registrant_name }
+								</li>
+							) }
+							{ whois.registrant_organization && (
+								<li>
+									<strong>Organization:</strong> { whois.registrant_organization }
+								</li>
+							) }
+							{ whois.registrant_street && (
+								<li>
+									<strong>Street:</strong> { whois.registrant_street }
+								</li>
+							) }
+							{ whois.registrant_city && (
+								<li>
+									<strong>City:</strong> { whois.registrant_city }
+								</li>
+							) }
+							{ whois.registrant_state && (
+								<li>
+									<strong>State:</strong> { whois.registrant_state }
+								</li>
+							) }
+							{ whois.registrant_postal_code && (
+								<li>
+									<strong>Postal Code:</strong> { whois.registrant_postal_code }
+								</li>
+							) }
+							{ whois.registrant_country && (
+								<li>
+									<strong>Country:</strong> { whois.registrant_country }
+								</li>
+							) }
+							{ whois.registrant_phone && (
+								<li>
+									<strong>Phone:</strong> { whois.registrant_phone }
+								</li>
+							) }
+							{ whois.registrant_email && (
+								<li>
+									<a href={ `mailto:${ whois.registrant_email }` }>Email</a>
+								</li>
+							) }
+						</ul>
+					</div>
+					<div className="col">
+						<h4>
+							<strong>Administrative contact</strong>
+						</h4>
+						<ul>
+							{ whois.admin_name && (
+								<li>
+									<strong>Name:</strong> { whois.admin_name }
+								</li>
+							) }
+							{ whois.admin_organization && (
+								<li>
+									<strong>Organization:</strong> { whois.admin_organization }
+								</li>
+							) }
+							{ whois.admin_street && (
+								<li>
+									<strong>Street:</strong> { whois.admin_street }
+								</li>
+							) }
+							{ whois.admin_city && (
+								<li>
+									<strong>City:</strong> { whois.admin_city }
+								</li>
+							) }
+							{ whois.admin_state && (
+								<li>
+									<strong>State:</strong> { whois.admin_state }
+								</li>
+							) }
+							{ whois.admin_postal_code && (
+								<li>
+									<strong>Postal Code:</strong> { whois.admin_postal_code }
+								</li>
+							) }
+							{ whois.admin_country && (
+								<li>
+									<strong>Country:</strong> { whois.admin_country }
+								</li>
+							) }
+							{ whois.admin_phone && (
+								<li>
+									<strong>Phone:</strong> { whois.admin_phone }
+								</li>
+							) }
+							{ whois.admin_email && (
+								<li>
+									<a href={ `mailto:${ whois.admin_email }` }>Email</a>
+								</li>
+							) }
+						</ul>
+					</div>
+					<div className="col">
+						<h4>
+							<strong>Technical contact</strong>
+						</h4>
+						<ul>
+							{ whois.tech_name && (
+								<li>
+									<strong>Name:</strong> { whois.tech_name }
+								</li>
+							) }
+							{ whois.tech_organization && (
+								<li>
+									<strong>Organization:</strong> { whois.tech_organization }
+								</li>
+							) }
+							{ whois.tech_street && (
+								<li>
+									<strong>Street:</strong> { whois.tech_street }
+								</li>
+							) }
+							{ whois.tech_city && (
+								<li>
+									<strong>City:</strong> { whois.tech_city }
+								</li>
+							) }
+							{ whois.tech_state && (
+								<li>
+									<strong>State:</strong> { whois.tech_state }
+								</li>
+							) }
+							{ whois.tech_postal_code && (
+								<li>
+									<strong>Postal Code:</strong> { whois.tech_postal_code }
+								</li>
+							) }
+							{ whois.tech_country && (
+								<li>
+									<strong>Country:</strong> { whois.tech_country }
+								</li>
+							) }
+							{ whois.tech_phone && (
+								<li>
+									<strong>Phone:</strong> { whois.tech_phone }
+								</li>
+							) }
+							{ whois.tech_email && (
+								<li>
+									<a href={ `mailto:${ whois.tech_email }` }>Email</a>
+								</li>
+							) }
+						</ul>
+					</div>
+				</li>
+				<li>
+					<div className="name">WhoIs</div>
+					<div>
+						<Button variant="link">Display raw WHOIS output</Button>
+					</div>
+				</li>
+			</ul>
+		</div>
 	);
 }

--- a/client/site-profiler/components/domain-information/styles.scss
+++ b/client/site-profiler/components/domain-information/styles.scss
@@ -1,0 +1,29 @@
+.domain-information-details {
+	margin: 0;
+	list-style: none;
+
+	ul {
+		margin: 0;
+		list-style: none;
+	}
+
+	& > li {
+		display: flex;
+		padding: 1rem 0;
+		border-top: solid 1px var(--studio-gray-5);
+		gap: 2rem;
+
+		&:first-child {
+			border: none;
+		}
+
+		.name {
+			width: 200px;
+			text-transform: uppercase;
+		}
+	}
+
+	.col {
+		max-width: 300px;
+	}
+}

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -18,23 +18,29 @@ export default function SiteProfiler() {
 
 	return (
 		<>
-			{ ! data && (
+			<LayoutBlock>
+				<DomainAnalyzer onFormSubmit={ onFormSubmit } isBusy={ isFetching } />
+			</LayoutBlock>
+
+			{ data && (
 				<LayoutBlock>
-					<DomainAnalyzer onFormSubmit={ onFormSubmit } isBusy={ isFetching } />
+					{ data && (
+						<LayoutBlockSection>
+							<HeadingInformation />
+						</LayoutBlockSection>
+					) }
+					{ data && (
+						<LayoutBlockSection>
+							<HostingInformation />
+						</LayoutBlockSection>
+					) }
+					{ data?.whois && (
+						<LayoutBlockSection>
+							<DomainInformation whois={ data.whois } />
+						</LayoutBlockSection>
+					) }
 				</LayoutBlock>
 			) }
-
-			<LayoutBlock>
-				<LayoutBlockSection>
-					<HeadingInformation />
-				</LayoutBlockSection>
-				<LayoutBlockSection>
-					<HostingInformation />
-				</LayoutBlockSection>
-				<LayoutBlockSection>
-					<DomainInformation />
-				</LayoutBlockSection>
-			</LayoutBlock>
 
 			<LayoutBlock isMonoBg>
 				<HostingInto />

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -1,7 +1,5 @@
-.is-section-site-profiler {
-	.layout__content {
-		padding: 0;
-	}
+.is-section-site-profiler .layout__content {
+	padding: 0;
 
 	h1 {
 		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
@@ -19,6 +17,11 @@
 	h3 {
 		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
 		font-size: 1.75rem;
+		margin-bottom: 1.25rem;
+	}
+
+	h4 {
+		margin-bottom: 1rem;
 	}
 
 	p {
@@ -26,5 +29,27 @@
 		/* stylelint-disable-next-line */
 		font-size: 1.125rem;
 		color: var(--studio-gray-80);
+	}
+
+	button {
+		color: #fff;
+		background: var(--wp-admin-theme-color);
+		border-radius: 4px;
+		font-size: 1rem;
+		font-weight: 500;
+		padding: 1.5rem;
+
+		&:hover {
+			color: #fff !important;
+		}
+
+		&.is-busy {
+			background-image: linear-gradient(-45deg, var(--wp-admin-theme-color) 33%, var(--wp-admin-theme-color-darker-20) 33%, var(--wp-admin-theme-color-darker-20) 70%, var(--wp-admin-theme-color) 70%);
+		}
+	}
+
+	a {
+		color: var(--wp-admin-theme-color);
+		text-decoration: underline;
 	}
 }

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -31,25 +31,14 @@
 		color: var(--studio-gray-80);
 	}
 
-	button {
-		color: #fff;
-		background: var(--wp-admin-theme-color);
-		border-radius: 4px;
-		font-size: 1rem;
-		font-weight: 500;
-		padding: 1.5rem;
-
-		&:hover {
-			color: #fff !important;
-		}
-
-		&.is-busy {
-			background-image: linear-gradient(-45deg, var(--wp-admin-theme-color) 33%, var(--wp-admin-theme-color-darker-20) 33%, var(--wp-admin-theme-color-darker-20) 70%, var(--wp-admin-theme-color) 70%);
-		}
-	}
-
-	a {
+	a,
+	button.is-link {
 		color: var(--wp-admin-theme-color);
 		text-decoration: underline;
+		font-size: 1rem;
+
+		&:hover {
+			color: var(--wp-admin-theme-color-darker-20);
+		}
 	}
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/81725

## Proposed Changes

* Create a "Hosting information" block HTML structure with proper CSS matching design
* Adjust init Site profiler component
* Adjust Site profiler page CSS

## Testing Instructions

* Go to `/site-profiler`
* Enter any domain
* Check if there is a Hosting information block populated with WHOIS data

**NOTE:**
- Localisation is not covered since the design is still in progress
- Domain analyzer form missing validation
- Missing "Display raw WHOIS output" logic
- Missing "login" link next to the REGISTRAR value
- ...will be handled in the next iterations


<img width="1278" alt="Screenshot 2023-09-17 at 19 02 04" src="https://github.com/Automattic/wp-calypso/assets/1241413/3940a930-e8ac-4523-94ae-36457c7e3a44">

<img width="1264" alt="Screenshot 2023-09-17 at 19 02 26" src="https://github.com/Automattic/wp-calypso/assets/1241413/ff1bb591-6638-42fc-bded-ff71bce44cc5">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?