### PR TITLE
Domain Management i1: Allow updating wpcom email address from bulk update contact form

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
@@ -140,7 +140,6 @@ export default function BulkEditContactInfoPage( {
 	const handleSubmitButtonClick = (
 		newContactDetails: Record< string, string >,
 		transferLock: boolean
-		// updateWpcomEmail: boolean
 	) => {
 		const domainNames = selectedDomains?.map( ( domain ) => domain.domain );
 

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -292,41 +292,7 @@ class EditContactInfoFormCard extends Component {
 			}
 		);
 
-		const { email } = newContactDetails;
-		if ( updateWpcomEmail && email && this.props.currentUser.email !== email ) {
-			wp.me()
-				.settings()
-				.update( { user_email: email } )
-				.then( ( data ) => {
-					if ( data.user_email_change_pending ) {
-						this.props.infoNotice(
-							this.props.translate(
-								'There is a pending change of your WordPress.com email to %(newEmail)s. Please check your inbox for a confirmation link.',
-								{
-									args: { newEmail: data.new_user_email },
-								}
-							),
-							{
-								showDismiss: true,
-								isPersistent: true,
-								duration: null,
-							}
-						);
-					}
-				} )
-				.catch( () => {
-					this.props.errorNotice(
-						this.props.translate(
-							'There was a problem updating your WordPress.com Account email.'
-						),
-						{
-							showDismiss: true,
-							isPersistent: true,
-							duration: null,
-						}
-					);
-				} );
-		}
+		this.updateWpcomEmail( newContactDetails, updateWpcomEmail );
 	};
 
 	onWhoisUpdateSuccess = () => {
@@ -424,6 +390,7 @@ class EditContactInfoFormCard extends Component {
 				this.state.transferLock,
 				this.state.updateWpcomEmail
 			);
+			this.updateWpcomEmail( newContactDetails, this.state.updateWpcomEmail );
 			if ( result === 'cancel' ) {
 				return;
 			}
@@ -461,6 +428,44 @@ class EditContactInfoFormCard extends Component {
 		);
 		return this.state.formSubmitting || includes( unmodifiableFields, snakeCase( name ) );
 	};
+
+	updateWpcomEmail( newContactDetails, updateWpcomEmail ) {
+		const { email } = newContactDetails;
+		if ( updateWpcomEmail && email && this.props.currentUser.email !== email ) {
+			wp.me()
+				.settings()
+				.update( { user_email: email } )
+				.then( ( data ) => {
+					if ( data.user_email_change_pending ) {
+						this.props.infoNotice(
+							this.props.translate(
+								'There is a pending change of your WordPress.com email to %(newEmail)s. Please check your inbox for a confirmation link.',
+								{
+									args: { newEmail: data.new_user_email },
+								}
+							),
+							{
+								showDismiss: true,
+								isPersistent: true,
+								duration: null,
+							}
+						);
+					}
+				} )
+				.catch( () => {
+					this.props.errorNotice(
+						this.props.translate(
+							'There was a problem updating your WordPress.com Account email.'
+						),
+						{
+							showDismiss: true,
+							isPersistent: true,
+							duration: null,
+						}
+					);
+				} );
+		}
+	}
 
 	shouldDisableSubmitButton() {
 		const { haveContactDetailsChanged, formSubmitting } = this.state;

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -25,9 +25,10 @@ import {
 	getWhoisSaveError,
 	getWhoisSaveSuccess,
 } from 'calypso/state/domains/management/selectors';
-import { errorNotice, successNotice, infoNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
+import { createUserEmailPendingUpdate } from 'calypso/state/user-settings/thunks/create-user-email-pending-update';
 import getPreviousPath from '../../../../state/selectors/get-previous-path';
 
 import './style.scss';
@@ -432,38 +433,7 @@ class EditContactInfoFormCard extends Component {
 	updateWpcomEmail( newContactDetails, updateWpcomEmail ) {
 		const { email } = newContactDetails;
 		if ( updateWpcomEmail && email && this.props.currentUser.email !== email ) {
-			wp.me()
-				.settings()
-				.update( { user_email: email } )
-				.then( ( data ) => {
-					if ( data.user_email_change_pending ) {
-						this.props.infoNotice(
-							this.props.translate(
-								'There is a pending change of your WordPress.com email to %(newEmail)s. Please check your inbox for a confirmation link.',
-								{
-									args: { newEmail: data.new_user_email },
-								}
-							),
-							{
-								showDismiss: true,
-								isPersistent: true,
-								duration: null,
-							}
-						);
-					}
-				} )
-				.catch( () => {
-					this.props.errorNotice(
-						this.props.translate(
-							'There was a problem updating your WordPress.com Account email.'
-						),
-						{
-							showDismiss: true,
-							isPersistent: true,
-							duration: null,
-						}
-					);
-				} );
+			this.props.createUserEmailPendingUpdate( email );
 		}
 	}
 
@@ -540,9 +510,9 @@ export default connect(
 	{
 		errorNotice,
 		fetchSiteDomains,
-		infoNotice,
 		requestWhois,
 		saveWhois,
 		successNotice,
+		createUserEmailPendingUpdate,
 	}
 )( localize( EditContactInfoFormCard ) );

--- a/client/state/user-settings/thunks/create-user-email-pending-update.js
+++ b/client/state/user-settings/thunks/create-user-email-pending-update.js
@@ -1,0 +1,46 @@
+import { translate } from 'i18n-calypso';
+import wp from 'calypso/lib/wp';
+import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
+import 'calypso/state/user-settings/init';
+
+/**
+ * Redux thunk which exclusively updates the `email` setting.
+ * @param {string} newEmail The new email address
+ */
+export const createUserEmailPendingUpdate = ( newEmail ) => async ( dispatch ) => {
+	try {
+		const { user_email_change_pending, new_user_email } = await wp
+			.me()
+			.settings()
+			.update( { user_email: newEmail } );
+
+		if ( user_email_change_pending ) {
+			dispatch(
+				infoNotice(
+					translate(
+						'There is a pending change of your WordPress.com email to %(newEmail)s. Please check your inbox for a confirmation link.',
+						{
+							args: { newEmail: new_user_email },
+						}
+					),
+					{
+						showDismiss: true,
+						isPersistent: true,
+					}
+				)
+			);
+		}
+	} catch ( error ) {
+		dispatch(
+			errorNotice(
+				translate( 'There was a problem updating your WordPress.com Account email: %(error)s', {
+					args: { error: error.message },
+				} ),
+				{
+					showDismiss: true,
+					isPersistent: true,
+				}
+			)
+		);
+	}
+};

--- a/client/state/user-settings/thunks/create-user-email-pending-update.js
+++ b/client/state/user-settings/thunks/create-user-email-pending-update.js
@@ -31,16 +31,17 @@ export const createUserEmailPendingUpdate = ( newEmail ) => async ( dispatch ) =
 			);
 		}
 	} catch ( error ) {
+		const errorMessage =
+			error.code === 'invalid_input'
+				? translate( 'There was a problem updating your WordPress.com account email: %(error)s', {
+						args: { error: error.message },
+				  } )
+				: translate( 'There was a problem updating your WordPress.com account email.' );
 		dispatch(
-			errorNotice(
-				translate( 'There was a problem updating your WordPress.com Account email: %(error)s', {
-					args: { error: error.message },
-				} ),
-				{
-					showDismiss: true,
-					isPersistent: true,
-				}
-			)
+			errorNotice( errorMessage, {
+				showDismiss: true,
+				isPersistent: true,
+			} )
 		);
 	}
 };

--- a/client/state/user-settings/thunks/create-user-email-pending-update.js
+++ b/client/state/user-settings/thunks/create-user-email-pending-update.js
@@ -32,7 +32,7 @@ export const createUserEmailPendingUpdate = ( newEmail ) => async ( dispatch ) =
 		}
 	} catch ( error ) {
 		const errorMessage =
-			error.code === 'invalid_input'
+			error.error === 'invalid_input'
 				? translate( 'There was a problem updating your WordPress.com account email: %(error)s', {
 						args: { error: error.message },
 				  } )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR refactors the update wpcom email logic so that it can be executed on both bulk and non-bulk contact information updates if the user chooses the checkbox for that option.
Closes https://github.com/Automattic/dotcom-forge/issues/3652

## Proposed Changes

* Extract email update logic into reusable function.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/domains/manage?flags=domains/bulk-actions-contact-info-editing`
* Select a domain then `edit contact information` button
* change email address and check the Apply` contact update to My Account email.` checkbox
* Verify you receive an email with information about updating your wpcom email address.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?