### PR TITLE
Storage Add-Ons: Add tracks event

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -5,7 +5,6 @@ import {
 	FEATURE_UPLOAD_THEMES_PLUGINS,
 	isEcommerce,
 	isDomainTransfer,
-	isPlan,
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Site } from '@automattic/data-stores';

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -5,6 +5,7 @@ import {
 	FEATURE_UPLOAD_THEMES_PLUGINS,
 	isEcommerce,
 	isDomainTransfer,
+	isPlan,
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Site } from '@automattic/data-stores';

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -321,6 +321,7 @@ type PlanComparisonGridProps = {
 	selectedFeature?: string;
 	showLegacyStorageFeature?: boolean;
 	showUpgradeableStorage: boolean;
+	onStorageAddOnClick?: () => void;
 };
 
 type PlanComparisonGridHeaderProps = {
@@ -539,6 +540,7 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
 	showUpgradeableStorage: boolean;
 	activeTooltipId: string;
+	onStorageAddOnClick?: () => void;
 } > = ( {
 	feature,
 	visibleGridPlans,
@@ -550,6 +552,7 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	activeTooltipId,
 	showUpgradeableStorage,
 	setActiveTooltipId,
+	onStorageAddOnClick,
 } ) => {
 	const { gridPlansIndex } = usePlansGridContext();
 	const gridPlan = gridPlansIndex[ planSlug ];
@@ -616,6 +619,7 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 						<StorageAddOnDropdown
 							planSlug={ planSlug }
 							storageOptions={ gridPlan.features.storageOptions }
+							onStorageAddOnClick={ onStorageAddOnClick }
 						/>
 					) : (
 						<StorageButton className="plan-features-2023-grid__storage-button" key={ planSlug }>
@@ -696,6 +700,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
 	showUpgradeableStorage: boolean;
 	activeTooltipId: string;
+	onStorageAddOnClick?: () => void;
 } > = ( {
 	feature,
 	isHiddenInMobile,
@@ -710,6 +715,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	activeTooltipId,
 	setActiveTooltipId,
 	showUpgradeableStorage,
+	onStorageAddOnClick,
 } ) => {
 	const translate = useTranslate();
 	const rowClasses = classNames( 'plan-comparison-grid__feature-group-row', {
@@ -776,6 +782,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 					activeTooltipId={ activeTooltipId }
 					setActiveTooltipId={ setActiveTooltipId }
 					showUpgradeableStorage={ showUpgradeableStorage }
+					onStorageAddOnClick={ onStorageAddOnClick }
 				/>
 			) ) }
 		</Row>
@@ -798,6 +805,7 @@ export const PlanComparisonGrid = ( {
 	selectedPlan,
 	selectedFeature,
 	showUpgradeableStorage,
+	onStorageAddOnClick,
 }: PlanComparisonGridProps ) => {
 	const translate = useTranslate();
 	const { gridPlans, allFeaturesList } = usePlansGridContext();
@@ -1018,6 +1026,7 @@ export const PlanComparisonGrid = ( {
 									activeTooltipId={ activeTooltipId }
 									setActiveTooltipId={ setActiveTooltipId }
 									showUpgradeableStorage={ showUpgradeableStorage }
+									onStorageAddOnClick={ onStorageAddOnClick }
 								/>
 							) ) }
 							{ featureGroup.slug === FEATURE_GROUP_ESSENTIAL_FEATURES ? (
@@ -1035,6 +1044,7 @@ export const PlanComparisonGrid = ( {
 									activeTooltipId={ activeTooltipId }
 									setActiveTooltipId={ setActiveTooltipId }
 									showUpgradeableStorage={ showUpgradeableStorage }
+									onStorageAddOnClick={ onStorageAddOnClick }
 								/>
 							) : null }
 						</div>

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -40,7 +40,13 @@ import type {
 	TransformedFeatureObject,
 } from '../hooks/npm-ready/data-store/use-grid-plans';
 import type { PlanActionOverrides } from '../types';
-import type { FeatureObject, Feature, FeatureGroup, PlanSlug } from '@automattic/calypso-products';
+import type {
+	FeatureObject,
+	Feature,
+	FeatureGroup,
+	PlanSlug,
+	WPComStorageAddOnSlug,
+} from '@automattic/calypso-products';
 import type { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 
 function DropdownIcon() {
@@ -321,7 +327,7 @@ type PlanComparisonGridProps = {
 	selectedFeature?: string;
 	showLegacyStorageFeature?: boolean;
 	showUpgradeableStorage: boolean;
-	onStorageAddOnClick?: () => void;
+	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
 };
 
 type PlanComparisonGridHeaderProps = {
@@ -540,7 +546,7 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
 	showUpgradeableStorage: boolean;
 	activeTooltipId: string;
-	onStorageAddOnClick?: () => void;
+	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
 } > = ( {
 	feature,
 	visibleGridPlans,
@@ -700,7 +706,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
 	showUpgradeableStorage: boolean;
 	activeTooltipId: string;
-	onStorageAddOnClick?: () => void;
+	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
 } > = ( {
 	feature,
 	isHiddenInMobile,

--- a/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
@@ -12,7 +12,7 @@ type StorageAddOnDropdownProps = {
 	planSlug: PlanSlug;
 	storageOptions: StorageOption[];
 	showPrice?: boolean;
-	onStorageAddOnClick?: () => void;
+	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
 };
 
 type StorageAddOnOptionProps = {
@@ -95,9 +95,12 @@ export const StorageAddOnDropdown = ( {
 			options={ selectControlOptions }
 			value={ selectedOption }
 			onChange={ ( { selectedItem }: { selectedItem: { key: WPComStorageAddOnSlug } } ) => {
-				onStorageAddOnClick && onStorageAddOnClick();
-				selectedItem?.key &&
-					setSelectedStorageOptionForPlan( { addOnSlug: selectedItem.key, planSlug } );
+				const addOnSlug = selectedItem?.key;
+
+				if ( addOnSlug ) {
+					onStorageAddOnClick && onStorageAddOnClick( addOnSlug );
+					setSelectedStorageOptionForPlan( { addOnSlug, planSlug } );
+				}
 			} }
 		/>
 	);

--- a/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
@@ -96,7 +96,8 @@ export const StorageAddOnDropdown = ( {
 			value={ selectedOption }
 			onChange={ ( { selectedItem }: { selectedItem: { key: WPComStorageAddOnSlug } } ) => {
 				onStorageAddOnClick && onStorageAddOnClick();
-				setSelectedStorageOptionForPlan( { addOnSlug: selectedItem?.key || '', planSlug } );
+				selectedItem?.key &&
+					setSelectedStorageOptionForPlan( { addOnSlug: selectedItem.key, planSlug } );
 			} }
 		/>
 	);

--- a/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/storage-add-on-dropdown.tsx
@@ -12,6 +12,7 @@ type StorageAddOnDropdownProps = {
 	planSlug: PlanSlug;
 	storageOptions: StorageOption[];
 	showPrice?: boolean;
+	onStorageAddOnClick?: () => void;
 };
 
 type StorageAddOnOptionProps = {
@@ -52,6 +53,7 @@ export const StorageAddOnDropdown = ( {
 	planSlug,
 	storageOptions,
 	showPrice = false,
+	onStorageAddOnClick,
 }: StorageAddOnDropdownProps ) => {
 	const { gridPlansIndex } = usePlansGridContext();
 	const { storageAddOnsForPlan } = gridPlansIndex[ planSlug ];
@@ -92,9 +94,10 @@ export const StorageAddOnDropdown = ( {
 			label={ label }
 			options={ selectControlOptions }
 			value={ selectedOption }
-			onChange={ ( { selectedItem }: { selectedItem: { key: WPComStorageAddOnSlug } } ) =>
-				setSelectedStorageOptionForPlan( { addOnSlug: selectedItem?.key || '', planSlug } )
-			}
+			onChange={ ( { selectedItem }: { selectedItem: { key: WPComStorageAddOnSlug } } ) => {
+				onStorageAddOnClick && onStorageAddOnClick();
+				setSelectedStorageOptionForPlan( { addOnSlug: selectedItem?.key || '', planSlug } );
+			} }
 		/>
 	);
 };

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -8,6 +8,7 @@ import {
 	PlanSlug,
 	isWooExpressPlusPlan,
 	FeatureList,
+	WPComStorageAddOnSlug,
 } from '@automattic/calypso-products';
 import {
 	BloombergLogo,
@@ -77,7 +78,7 @@ export interface PlanFeatures2023GridProps {
 	isLaunchPage?: boolean | null;
 	isReskinned?: boolean;
 	onUpgradeClick?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
-	onStorageAddOnClick?: () => void;
+	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
 	flowName?: string | null;
 	paidDomainName?: string;
 	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >; // used to show a wpcom free domain in the Free plan column when a paid domain is picked.
@@ -440,6 +441,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			product_slug: storageAddOn.productSlug,
 			quantity: storageAddOn.quantity,
 			volume: 1,
+			extra: { feature_slug: selectedStorageOption },
 		};
 
 		// TODO clk: Revisit. Could this suffice: `ownPropsOnUpgradeClick?.( cartItemForPlan )`

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -77,6 +77,7 @@ export interface PlanFeatures2023GridProps {
 	isLaunchPage?: boolean | null;
 	isReskinned?: boolean;
 	onUpgradeClick?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
+	onStorageAddOnClick?: () => void;
 	flowName?: string | null;
 	paidDomainName?: string;
 	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >; // used to show a wpcom free domain in the Free plan column when a paid domain is picked.
@@ -636,7 +637,14 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 	}
 
 	renderPlanStorageOptions( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const { translate, intervalType, isInSignup, flowName, showUpgradeableStorage } = this.props;
+		const {
+			translate,
+			intervalType,
+			isInSignup,
+			flowName,
+			onStorageAddOnClick,
+			showUpgradeableStorage,
+		} = this.props;
 
 		return renderedGridPlans.map( ( { planSlug, features: { storageOptions } } ) => {
 			if ( ! options?.isTableCell && isWpcomEnterpriseGridPlan( planSlug ) ) {
@@ -662,6 +670,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 				<StorageAddOnDropdown
 					label={ translate( 'Storage' ) }
 					planSlug={ planSlug }
+					onStorageAddOnClick={ onStorageAddOnClick }
 					storageOptions={ storageOptions }
 					showPrice
 				/>
@@ -719,6 +728,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			showPlansComparisonGrid,
 			showUpgradeableStorage,
 			observableForOdieRef,
+			onStorageAddOnClick,
 		} = this.props;
 
 		return (
@@ -792,6 +802,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 								selectedFeature={ selectedFeature }
 								showLegacyStorageFeature={ showLegacyStorageFeature }
 								showUpgradeableStorage={ showUpgradeableStorage }
+								onStorageAddOnClick={ onStorageAddOnClick }
 							/>
 							<ComparisonGridToggle
 								onClick={ toggleShowPlansComparisonGrid }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -710,9 +710,11 @@ const PlansFeaturesMain = ( {
 							planTypeSelectorProps={ planTypeSelectorProps }
 							ref={ plansComparisonGridRef }
 							observableForOdieRef={ observableForOdieRef }
-							onStorageAddOnClick={ () => {
-								recordTracksEvent( 'calypso_plans_page_storage_add_on_click' );
-							} }
+							onStorageAddOnClick={ ( addOnSlug ) =>
+								recordTracksEvent( 'calypso_signup_storage_add_on_dropdown_option_click', {
+									add_on_slug: addOnSlug,
+								} )
+							}
 						/>
 					</div>
 				</>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -301,6 +301,9 @@ const PlansFeaturesMain = ( {
 
 	const handleUpgradeClick = ( cartItems?: MinimalRequestCartProduct[] | null ) => {
 		const cartItemForPlan = getPlanCartItem( cartItems );
+		const cartItemForStorageAddOn = cartItems?.find(
+			( items ) => items.product_slug === PRODUCT_1GB_SPACE
+		);
 
 		// `cartItemForPlan` is empty if Free plan is selected. Show `FreePlanPaidDomainDialog`
 		// in that case and exit. `FreePlanPaidDomainDialog` takes over from there.
@@ -316,6 +319,12 @@ const PlansFeaturesMain = ( {
 				setIsFreePlanFreeDomainDialogOpen( true );
 				return;
 			}
+		}
+
+		if ( cartItemForStorageAddOn?.extra ) {
+			recordTracksEvent( 'calypso_signup_storage_add_on_upgrade_click', {
+				add_on_slug: cartItemForStorageAddOn.extra.feature_slug,
+			} );
 		}
 
 		if ( onUpgradeClick ) {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -710,6 +710,9 @@ const PlansFeaturesMain = ( {
 							planTypeSelectorProps={ planTypeSelectorProps }
 							ref={ plansComparisonGridRef }
 							observableForOdieRef={ observableForOdieRef }
+							onStorageAddOnClick={ () => {
+								recordTracksEvent( 'calypso_plans_page_storage_add_on_click' );
+							} }
 						/>
 					</div>
 				</>

--- a/client/state/sites/hooks/use-billing-history.ts
+++ b/client/state/sites/hooks/use-billing-history.ts
@@ -23,7 +23,7 @@ export const usePastBillingTransactions = ( disabled: boolean ) => {
 
 	return {
 		billingTransactions: data?.billing_history || null,
-		isLoading,
+		isLoading: disabled ? false : isLoading,
 		error: error?.message || null,
 		enabled: ! disabled,
 	};

--- a/client/state/sites/hooks/use-billing-history.ts
+++ b/client/state/sites/hooks/use-billing-history.ts
@@ -13,7 +13,7 @@ const fetchPastBillingTransactions = () =>
 		apiVersion: '1.3',
 	} );
 
-export const usePastBillingTransactions = ( isInSignup: boolean ) => {
+export const usePastBillingTransactions = ( disabled: boolean ) => {
 	const queryKey = [ billingTransactionsQueryKey ];
 
 	const { data, isLoading, error } = useQuery< BillingHistory, Error >( {
@@ -25,6 +25,6 @@ export const usePastBillingTransactions = ( isInSignup: boolean ) => {
 		billingTransactions: data?.billing_history || null,
 		isLoading,
 		error: error?.message || null,
-		enabled: ! isInSignup,
+		enabled: ! disabled,
 	};
 };

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -614,6 +614,7 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	import_dns_records?: boolean;
 	signup?: boolean;
 	headstart_theme?: string;
+	feature_slug?: string;
 }
 
 export interface GSuiteProductUser {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Related to https://github.com/Automattic/martech/issues/2027
Tracking Issue https://github.com/Automattic/martech/issues/2023

## Proposed Changes

* Adds user interaction tracks event to the storage add-on dropdown
* Passes tracks event callback through plans features main component to avoid creating a dependency to the Calypso environment for the [2023 plan features component](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/plan-features-2023-grid/index.tsx)

## Note
I will formally register this tracks event once this PR is approved

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR or use Calypso Live
* Smoke test the onboarding signup flow with business or ecommerce plans `/start?flags=plans%2Fupgradeable-storage`
* Verify that, when interacting with the dropdown, a tracks event is dispatched using either the tracks vigilante chrome dev tool or or searching for `.gif storage` in the dev tools network tab

<img width="844" alt="Screenshot 2023-09-17 at 3 44 13 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/eae6591a-1a47-4084-a4dd-b3e6b03c8538">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?