### PR TITLE
Domain management: Update table visually after changing primary domain

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -41,7 +41,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 		( state ) => ! currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
 	);
 	const hasDomainCredit = useSelector( ( state ) => hasDomainCreditSelector( state, site?.ID ) );
-	const { data, isLoading } = useSiteDomainsQuery( site?.slug );
+	const { data, isLoading, refetch } = useSiteDomainsQuery( site?.ID );
 	const translate = useTranslate();
 	const { sendNudge } = useOdieAssistantContext();
 	const dispatch = useDispatch();
@@ -94,6 +94,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 								await dispatch( setPrimaryDomain( site.ID, domain.domain ) );
 								dispatch( showUpdatePrimaryDomainSuccessNotice( domain.name ) );
 								page.redirect( domainManagementList( domain.domain ) );
+								refetch();
 							} catch ( error ) {
 								dispatch( showUpdatePrimaryDomainErrorNotice( ( error as Error ).message ) );
 							}

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -93,7 +93,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 							try {
 								await dispatch( setPrimaryDomain( site.ID, domain.domain ) );
 								dispatch( showUpdatePrimaryDomainSuccessNotice( domain.name ) );
-								page.redirect( domainManagementList( domain.domain ) );
+								page.replace( domainManagementList( domain.domain ) );
 								refetch();
 							} catch ( error ) {
 								dispatch( showUpdatePrimaryDomainErrorNotice( ( error as Error ).message ) );

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -3,6 +3,7 @@ import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable } from '@automattic/domains-table';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useMemo } from 'react';
 import { UsePresalesChat } from 'calypso/components/data/domain-management';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -20,6 +21,7 @@ import {
 import { setPrimaryDomain } from 'calypso/state/sites/domains/actions';
 import { hasDomainCredit as hasDomainCreditSelector } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { domainManagementList } from '../../paths';
 import DomainHeader from '../components/domain-header';
 import EmptyDomainsListCard from './empty-domains-list-card';
 import { filterDomainsByOwner } from './helpers';
@@ -91,6 +93,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 							try {
 								await dispatch( setPrimaryDomain( site.ID, domain.domain ) );
 								dispatch( showUpdatePrimaryDomainSuccessNotice( domain.name ) );
+								page.redirect( domainManagementList( domain.domain ) );
 							} catch ( error ) {
 								dispatch( showUpdatePrimaryDomainErrorNotice( ( error as Error ).message ) );
 							}

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -133,14 +133,14 @@
 }
 
 .domains-table-row__actions-group {
-	.components-menu-item__button:hover {
-		background-color: var(--color-primary);
-		border: 0;
-		box-shadow: none;
-		color: var(--color-text-inverted);
-	}
-	a:visited {
-		color: var(--color-neutral-70);
+	.components-button {
+		&:visited {
+			color: var(--color-text);
+		}
+
+		&:hover:not(:disabled) {
+			color: var(--color-primary);
+		}
 	}
 }
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3813.

## Proposed Changes

After switching the primary domain of a site, let's update the table to reflect the choice:

https://github.com/Automattic/wp-calypso/assets/26530524/8e54d546-1eef-4126-9f63-c1518c50dfda

## Testing Instructions

Open a site with multiple domains and switch the primary site address. Check that after the notice has been displayed at the top-right corner, the new primary domain label moved to your domain of choice.