### PR TITLE
Domain management: Introduce visual indication when applying action

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -89,24 +89,33 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 					) }
 					domainStatusPurchaseActions={ purchaseActions }
 					userCanSetPrimaryDomains={ userCanSetPrimaryDomains }
-					onDomainAction={ async ( action, domain ) => {
+					onDomainAction={ ( action, domain ) => {
 						if ( action === 'manage-dns-settings' ) {
-							sendNudge( {
-								nudge: 'dns-settings',
-								initialMessage: `I see you want to change your DNS settings for your domain ${ domain.name }. That's a complex thing, but I can guide you and help you at any moment.`,
-								context: { domain: domain.domain },
-							} );
+							return {
+								action: () => {
+									sendNudge( {
+										nudge: 'dns-settings',
+										initialMessage: `I see you want to change your DNS settings for your domain ${ domain.name }. That's a complex thing, but I can guide you and help you at any moment.`,
+										context: { domain: domain.domain },
+									} );
+								},
+							};
 						}
 
-						if ( action === 'set-primary' && site ) {
-							try {
-								await dispatch( setPrimaryDomain( site.ID, domain.domain ) );
-								dispatch( showUpdatePrimaryDomainSuccessNotice( domain.name ) );
-								page.replace( domainManagementList( domain.domain ) );
-								refetch();
-							} catch ( error ) {
-								dispatch( showUpdatePrimaryDomainErrorNotice( ( error as Error ).message ) );
-							}
+						if ( action === 'set-primary-address' && site ) {
+							return {
+								message: 'Set domain as the primary site address',
+								action: async () => {
+									try {
+										await dispatch( setPrimaryDomain( site.ID, domain.domain ) );
+										dispatch( showUpdatePrimaryDomainSuccessNotice( domain.name ) );
+										page.replace( domainManagementList( domain.domain ) );
+										await refetch();
+									} catch ( error ) {
+										dispatch( showUpdatePrimaryDomainErrorNotice( ( error as Error ).message ) );
+									}
+								},
+							};
 						}
 
 						if ( action === 'change-site-address' ) {

--- a/packages/data-stores/src/queries/use-bulk-domain-update-status-query.ts
+++ b/packages/data-stores/src/queries/use-bulk-domain-update-status-query.ts
@@ -26,7 +26,7 @@ export interface JobStatus {
 	complete: boolean;
 }
 
-export interface DomainUpdateStatus {
+interface DomainUpdateRemoteStatus {
 	status: '' | 'success' | 'failed';
 	action: 'set_auto_renew' | 'update_contact_info';
 	created_at: number;
@@ -34,6 +34,14 @@ export interface DomainUpdateStatus {
 	whois?: unknown;
 	transfer_lock?: boolean;
 }
+
+interface DomainUpdateDerivedStatus {
+	status: '';
+	message: string;
+	created_at: number;
+}
+
+export type DomainUpdateStatus = DomainUpdateRemoteStatus | DomainUpdateDerivedStatus;
 
 export const getBulkDomainUpdateStatusQueryKey = () => {
 	return [ 'domains', 'bulk-actions' ];

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -18,7 +18,7 @@ import { shouldUpgradeToMakeDomainPrimary } from '../utils/should-upgrade-to-mak
 import { ResponseDomain } from '../utils/types';
 import { useDomainsTable } from './domains-table';
 
-export type DomainAction = 'change-site-address' | 'manage-dns-settings' | 'set-primary';
+export type DomainAction = 'change-site-address' | 'manage-dns-settings' | 'set-primary-address';
 
 interface MenuItemLinkProps extends Omit< React.ComponentProps< typeof MenuItem >, 'href' > {
 	href?: string;
@@ -95,7 +95,7 @@ export const DomainsTableRowActions = ( {
 			canMakePrimarySiteAddress && (
 				<MenuItemLink
 					onClick={ () => {
-						onDomainAction?.( 'set-primary', domain );
+						onDomainAction?.( 'set-primary-address', domain );
 						onClose?.();
 					} }
 				>

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -43,7 +43,7 @@ export const DomainsTableRowActions = ( {
 	isSiteOnFreePlan,
 	isSimpleSite,
 }: DomainsTableRowActionsProps ) => {
-	const { onDomainAction, userCanSetPrimaryDomains = false } = useDomainsTable();
+	const { onDomainAction, userCanSetPrimaryDomains = false, updatingDomain } = useDomainsTable();
 	const { __ } = useI18n();
 
 	const canViewDetails = domain.type !== domainTypes.WPCOM;
@@ -98,6 +98,7 @@ export const DomainsTableRowActions = ( {
 						onDomainAction?.( 'set-primary-address', domain );
 						onClose?.();
 					} }
+					disabled={ updatingDomain?.action === 'set-primary-address' }
 				>
 					{ __( 'Make primary site address' ) }
 				</MenuItemLink>

--- a/packages/domains-table/src/domains-table/domains-table-status-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-status-cell.tsx
@@ -38,6 +38,10 @@ export const DomainsTableStatusCell = ( {
 	} );
 
 	const getActionName = ( status: DomainUpdateStatus ) => {
+		if ( 'message' in status ) {
+			return status.message;
+		}
+
 		switch ( status.action ) {
 			case 'set_auto_renew':
 				return translate( 'Change auto-renew mode' );
@@ -72,10 +76,12 @@ export const DomainsTableStatusCell = ( {
 									<span className="domains-bulk-update-status-popover-item-indicator__pending" />
 									<span>{ getActionName( update ) }</span>
 								</div>
-								<span className="domains-bulk-update-status-popover-item-date">
-									{ ' ' }
-									{ getTime( update.created_at ) }
-								</span>
+								{ update.created_at && (
+									<span className="domains-bulk-update-status-popover-item-date">
+										{ ' ' }
+										{ getTime( update.created_at ) }
+									</span>
+								) }
 							</div>
 						) ) }
 					</div>

--- a/packages/domains-table/src/use-domain-row.ts
+++ b/packages/domains-table/src/use-domain-row.ts
@@ -20,6 +20,7 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 		handleSelectDomain,
 		domainResults,
 		showBulkActions,
+		updatingDomain,
 	} = useDomainsTable();
 
 	const translate = useTranslate();
@@ -106,6 +107,20 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 
 	const isSelected = selectedDomains.has( getDomainId( domain ) );
 
+	const pendingUpdates = useMemo( () => {
+		const updates = domainResults.get( domain.domain ) ?? [];
+
+		if ( domain.domain === updatingDomain?.domain && updatingDomain.message ) {
+			updates.unshift( {
+				created_at: updatingDomain.created_at,
+				message: updatingDomain.message,
+				status: '',
+			} );
+		}
+
+		return updates;
+	}, [ domain.domain, domainResults, updatingDomain ] );
+
 	return {
 		ref,
 		site,
@@ -123,7 +138,7 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 		handleSelectDomain,
 		isAllSitesView,
 		domainStatusPurchaseActions,
-		pendingUpdates: domainResults.get( domain.domain ) || [],
+		pendingUpdates,
 		currentDomainData,
 		showBulkActions,
 	};


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3813.

## Proposed Changes

This PR adds a visual indicator whenever an action is happening to a domain on the site-specific table.

It also disables the set as primary domain action while it's happening in the domain. The original idea was to disable all actions, like the old table, but that doesn't seem to make a lot of sense to me because this action doesn't impact anything other than being the primary address of the site, which is just a redirect and is not impacted by any other setting on the table.

https://github.com/Automattic/wp-calypso/assets/26530524/b2aff0bf-82a8-4fdb-b256-a20040f3e736

## Testing Instructions

Follow the video. URL:  `/domains/manage%s`.