### PR TITLE
100 year plan flow: small design fixes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -232,8 +232,6 @@ export function DomainFormControl( {
 				// filter before counting length
 				initialState.loadingResults =
 					getDomainSuggestionSearch( getFixedDomainSearch( initialQuery ) ).length >= 2;
-				// when it's provided via the query arg, follow the convention of /start/domains to show it
-				initialState.hideInitialQuery = ! initialQuery;
 			}
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -233,7 +233,7 @@ export function DomainFormControl( {
 				initialState.loadingResults =
 					getDomainSuggestionSearch( getFixedDomainSearch( initialQuery ) ).length >= 2;
 				// when it's provided via the query arg, follow the convention of /start/domains to show it
-				initialState.hideInitialQuery = ! domainSearchInQuery;
+				initialState.hideInitialQuery = ! initialQuery;
 			}
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/hundred-year-plan-logo.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/hundred-year-plan-logo.tsx
@@ -1,6 +1,12 @@
-export default function () {
+export default function ( { width }: { width?: number } ) {
 	return (
-		<svg xmlns="http://www.w3.org/2000/svg" width="61" height="88" viewBox="0 0 61 88" fill="none">
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width={ width || 61 }
+			height={ ( ( width || 61 ) * 88 ) / 61 }
+			viewBox="0 0 61 88"
+			fill="none"
+		>
 			<g clipPath="url(#clip0_1031_13381)">
 				<path
 					d="M5.61961 0.25H55.3804C58.2078 0.25 60.5 2.573 60.5 5.43137V56.885C60.5 73.6438 47.056 87.2469 30.5 87.2469C13.944 87.25 0.5 73.6438 0.5 56.8881V5.43137C0.5 2.573 2.79532 0.25 5.61961 0.25Z"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -151,6 +151,8 @@ const StyledFoldableCard = styled( FoldableCard )`
 			}
 			.gridicons-chevron-down {
 				fill: var( --studio-gray-0 );
+				height: 16px;
+				width: 16px;
 			}
 			.foldable-card__action.foldable-card__expand {
 				.screen-reader-text {
@@ -211,7 +213,7 @@ function InfoColumn( { isMobile, openModal }: { isMobile: boolean; openModal: ()
 					<WordPressLogo size={ 24 } />
 				</WordPressLogoWrapper>
 
-				<HundredYearPlanLogo />
+				<HundredYearPlanLogo width={ isMobile ? 40 : undefined } />
 				<Info isMobile={ isMobile }>
 					<Title>{ planTitle }</Title>
 					<Description isMobile={ isMobile }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#2199

## Proposed Changes

* Reduces the size of the 100-year logo to 40px on mobile.
* Reduces the size of the chevron icon to 16px.
* Populate the search box on the domains step with the site title entered on the setup step.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/hundred-year-plan` on a mobile screen.
* Confirm that the size of the chevron icon is 16px.
<img width="475" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/e6182b22-a2a4-498a-862f-41ad6fb18a89">

* Confirm that the logo is 40px wide. 
<img width="400" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/ca0a2f08-eb46-4948-8310-65ccc471a973">

* This step can be done on desktop/mobile. Enter a site title and proceed to the domains step. The search text box should be populated with the site title.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?