### PR TITLE
Subscriber page: Add number formatting to total subscribers count

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -1,4 +1,4 @@
-import { translate } from 'i18n-calypso';
+import { numberFormat, translate } from 'i18n-calypso';
 import Pagination from 'calypso/components/pagination';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
 import { NoSearchResults } from 'calypso/my-sites/subscribers/components/no-search-results';
@@ -32,7 +32,9 @@ const SubscriberListContainer = ( {
 								context: 'Total number of subscribers',
 							} ) }
 						</span>{ ' ' }
-						<span className="subscriber-list-container__subscriber-count">{ total }</span>
+						<span className="subscriber-list-container__subscriber-count">
+							{ numberFormat( total, 0 ) }
+						</span>
 					</div>
 					<SubscriberListActionsBar />
 


### PR DESCRIPTION
Related to #

## Proposed Changes

The numberFormat function from 'i18n-calypso' has been imported and applied to the total subscribers count in the subscriber-list-container component. This change is made to enhance readability when large numbers of subscribers are displayed.

| Before | After |
|-|-|
|  ![CleanShot 2023-09-18 at 09 35 19@2x](https://github.com/Automattic/wp-calypso/assets/528287/8f4df1a0-fafb-4890-b5a6-1fca5c0f199b) | ![CleanShot 2023-09-18 at 09 41 38@2x](https://github.com/Automattic/wp-calypso/assets/528287/a7b32691-f27a-4cfa-95b4-c5ec7a4d01e5) |

## Testing Instructions

1. Apply this PR
2. Find a site with a lot of subscribers, or cherry pick from or merge @JuanLucha's PR: https://github.com/Automattic/wp-calypso/pull/81775
3. The number of subscribers should be formatted nicely

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?