### PR TITLE
state: refactor away from `_.range`

### DIFF
--- a/client/state/terms/selectors.js
+++ b/client/state/terms/selectors.js
@@ -1,5 +1,5 @@
 import { createSelector } from '@automattic/state-utils';
-import { get, range } from 'lodash';
+import { get } from 'lodash';
 import { getSerializedTermsQuery, getSerializedTermsQueryWithoutPage } from './utils';
 
 import 'calypso/state/terms/init';
@@ -35,7 +35,9 @@ export function isRequestingTermsForQueryIgnoringPage( state, siteId, taxonomy, 
 		return false;
 	}
 
-	return range( 1, lastPage + 1 ).some( ( page ) => {
+	const pages = Array.from( { length: lastPage }, ( _, i ) => i + 1 );
+
+	return pages.some( ( page ) => {
 		const termsQuery = { ...query, page };
 		return isRequestingTermsForQuery( state, siteId, taxonomy, termsQuery );
 	} );


### PR DESCRIPTION
## Proposed Changes

PR refactors away from `_.range` in `client/state`

## Testing Instructions

* Changes are partly covered by unit tests, verify they pass.
* As with a lot of lodash methods it's good practice to ensure we don't accidentally miss guards for whether we operate on the expected data structure (in this case arrays).

As there's only one occurrence you could also smoke test `<TaxonomyManager />` which is used at `/settings/taxonomies/{taxonomy}/{siteSlug}` (go there by clicking _Posts_ > _Tags_ or _Posts_ > _Categories_) and choose a site with lots of entries the chosen taxonomy (ensure loading state works as expected).