### PR TITLE
Domain Management i1: Don't allow users to select subdomain, redirect, or external domains

### DIFF
--- a/packages/data-stores/src/queries/use-all-domains-query.ts
+++ b/packages/data-stores/src/queries/use-all-domains-query.ts
@@ -20,6 +20,7 @@ export type PartialDomainData = Pick<
 	| 'google_apps_subscription'
 	| 'titan_mail_subscription'
 	| 'email_forwards_count'
+	| 'tld_maintenance_end_time'
 >;
 
 export interface AllDomainsQueryFnData {

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
@@ -6,6 +6,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { PrimaryDomainLabel } from '../primary-domain-label/index';
 import { useDomainRow } from '../use-domain-row';
+import { canBulkUpdate } from '../utils/can-bulk-update';
 import { ResponseDomain } from '../utils/types';
 import { DomainsTableEmailIndicator } from './domains-table-email-indicator';
 import { DomainsTableExpiresRewnewsOnCell } from './domains-table-expires-renew-cell';
@@ -38,7 +39,7 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 		<div className="domains-table-mobile-card" ref={ ref }>
 			<div>
 				<div className="domains-table-mobile-card-header">
-					{ ! domain.wpcom_domain && showBulkActions && (
+					{ canBulkUpdate( domain ) && showBulkActions && (
 						<CheckboxControl
 							__nextHasNoMarginBottom
 							checked={ isSelected }

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -6,6 +6,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { PrimaryDomainLabel } from '../primary-domain-label';
 import { useDomainRow } from '../use-domain-row';
+import { canBulkUpdate } from '../utils/can-bulk-update';
 import { domainInfoContext } from '../utils/constants';
 import { getDomainTypeText } from '../utils/get-domain-type-text';
 import { domainManagementLink } from '../utils/paths';
@@ -82,7 +83,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 	return (
 		<tr key={ domain.domain } ref={ ref }>
 			<td>
-				{ canSelectAnyDomains && ! domain.wpcom_domain && (
+				{ canSelectAnyDomains && canBulkUpdate( domain ) && (
 					<CheckboxControl
 						__nextHasNoMarginBottom
 						checked={ isSelected }

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -83,7 +83,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 	return (
 		<tr key={ domain.domain } ref={ ref }>
 			<td>
-				{ canSelectAnyDomains && canBulkUpdate( domain ) && (
+				{ canSelectAnyDomains && canBulkUpdate( domain, currentDomainData ) && (
 					<CheckboxControl
 						__nextHasNoMarginBottom
 						checked={ isSelected }

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -83,7 +83,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 	return (
 		<tr key={ domain.domain } ref={ ref }>
 			<td>
-				{ canSelectAnyDomains && canBulkUpdate( domain, currentDomainData ) && (
+				{ canSelectAnyDomains && canBulkUpdate( domain ) && (
 					<CheckboxControl
 						__nextHasNoMarginBottom
 						checked={ isSelected }

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -28,6 +28,7 @@ import { DomainsTableColumn } from '../domains-table-header/index';
 import { getDomainId } from '../get-domain-id';
 import { useDomainBulkUpdateStatus } from '../use-domain-bulk-update-status';
 import { shouldHideOwnerColumn } from '../utils';
+import { canBulkUpdate } from '../utils/can-bulk-update';
 import { DomainStatusPurchaseActions } from '../utils/resolve-domain-status';
 import { ResponseDomain } from '../utils/types';
 import { DomainAction } from './domains-table-row-actions';
@@ -268,7 +269,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 	};
 
 	const hasSelectedDomains = selectedDomains.size > 0;
-	const selectableDomains = domains.filter( ( domain ) => ! domain.wpcom_domain );
+	const selectableDomains = domains.filter( canBulkUpdate );
 	const canSelectAnyDomains = selectableDomains.length > 0;
 	const areAllDomainsSelected = selectableDomains.length === selectedDomains.size;
 
@@ -287,9 +288,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 	const changeBulkSelection = () => {
 		if ( filter.query ) {
 			if ( ! hasSelectedDomains ) {
-				setSelectedDomains(
-					new Set( filteredData.filter( ( domain ) => ! domain.wpcom_domain ).map( getDomainId ) )
-				);
+				setSelectedDomains( new Set( filteredData.filter( canBulkUpdate ).map( getDomainId ) ) );
 			} else {
 				setSelectedDomains( new Set() );
 			}
@@ -298,10 +297,8 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		}
 
 		if ( ! hasSelectedDomains || ! areAllDomainsSelected ) {
-			// filter out wpcom domains from bulk selection
-			setSelectedDomains(
-				new Set( domains.filter( ( domain ) => ! domain.wpcom_domain ).map( getDomainId ) )
-			);
+			// filter out unselectable domains from bulk selection
+			setSelectedDomains( new Set( domains.filter( canBulkUpdate ).map( getDomainId ) ) );
 		} else {
 			setSelectedDomains( new Set() );
 		}

--- a/packages/domains-table/src/test-utils.tsx
+++ b/packages/domains-table/src/test-utils.tsx
@@ -53,6 +53,7 @@ export function testDomain(
 			maximum_mailbox_count: 0,
 		},
 		email_forwards_count: 0,
+		tld_maintenance_end_time: 0,
 	};
 
 	const partialOnlyDefaults = Object.entries( defaults ).filter( ( [ key ] ) =>

--- a/packages/domains-table/src/utils/can-bulk-update.ts
+++ b/packages/domains-table/src/utils/can-bulk-update.ts
@@ -13,6 +13,7 @@ export function canBulkUpdate( domain: PartialDomainData ): boolean {
 			domainTypes.SITE_REDIRECT,
 			domainTypes.MAPPED,
 			domainTypes.WPCOM,
+			domainTypes.TRANSFER,
 		] as ( typeof domainTypes )[ keyof typeof domainTypes ][]
 	 ).includes( getDomainType( domain ) );
 }

--- a/packages/domains-table/src/utils/can-bulk-update.ts
+++ b/packages/domains-table/src/utils/can-bulk-update.ts
@@ -1,0 +1,17 @@
+import { PartialDomainData } from '@automattic/data-stores';
+import { type as domainTypes } from './constants';
+import { getDomainType } from './get-domain-type';
+
+export function canBulkUpdate( domain: PartialDomainData ): boolean {
+	if ( domain.wpcom_domain || domain.is_wpcom_staging_domain ) {
+		return false;
+	}
+
+	return ! (
+		[
+			domainTypes.SITE_REDIRECT,
+			domainTypes.MAPPED,
+			domainTypes.WPCOM,
+		] as ( typeof domainTypes )[ keyof typeof domainTypes ][]
+	 ).includes( getDomainType( domain ) );
+}

--- a/packages/domains-table/src/utils/can-bulk-update.ts
+++ b/packages/domains-table/src/utils/can-bulk-update.ts
@@ -1,13 +1,9 @@
 import { PartialDomainData } from '@automattic/data-stores';
 import { type as domainTypes } from './constants';
 import { getDomainType } from './get-domain-type';
-import { ResponseDomain } from './types';
 
-export function canBulkUpdate(
-	domain: PartialDomainData,
-	reponseDomain?: ResponseDomain
-): boolean {
-	const maintenanceDomain = ( reponseDomain?.tldMaintenanceEndTime || 0 ) > 0;
+export function canBulkUpdate( domain: PartialDomainData ): boolean {
+	const maintenanceDomain = domain.tld_maintenance_end_time > 0;
 	if ( domain.wpcom_domain || domain.is_wpcom_staging_domain || maintenanceDomain ) {
 		return false;
 	}

--- a/packages/domains-table/src/utils/can-bulk-update.ts
+++ b/packages/domains-table/src/utils/can-bulk-update.ts
@@ -1,9 +1,14 @@
 import { PartialDomainData } from '@automattic/data-stores';
 import { type as domainTypes } from './constants';
 import { getDomainType } from './get-domain-type';
+import { ResponseDomain } from './types';
 
-export function canBulkUpdate( domain: PartialDomainData ): boolean {
-	if ( domain.wpcom_domain || domain.is_wpcom_staging_domain ) {
+export function canBulkUpdate(
+	domain: PartialDomainData,
+	reponseDomain?: ResponseDomain
+): boolean {
+	const maintenanceDomain = ( reponseDomain?.tldMaintenanceEndTime || 0 ) > 0;
+	if ( domain.wpcom_domain || domain.is_wpcom_staging_domain || maintenanceDomain ) {
 		return false;
 	}
 

--- a/packages/domains-table/src/utils/get-domain-type-text.tsx
+++ b/packages/domains-table/src/utils/get-domain-type-text.tsx
@@ -7,35 +7,43 @@ export function getDomainTypeText(
 	__: typeof __type = ( text: string ) => text,
 	context = domainInfoContext.DOMAIN_ITEM
 ) {
-	switch ( domain.type ) {
-		case domainTypes.MAPPED:
-			if ( context === domainInfoContext.PAGE_TITLE ) {
-				return __( 'Connected Domain', __i18n_text_domain__ );
-			}
+	const underMaintenance = domain?.tldMaintenanceEndTime && domain?.tldMaintenanceEndTime > 0;
+	const domainText = () => {
+		switch ( domain.type ) {
+			case domainTypes.MAPPED:
+				if ( context === domainInfoContext.PAGE_TITLE ) {
+					return __( 'Connected Domain', __i18n_text_domain__ );
+				}
 
-			return __( 'Registered with an external provider', __i18n_text_domain__ );
+				return __( 'Registered with an external provider', __i18n_text_domain__ );
 
-		case domainTypes.REGISTERED:
-			if ( domain?.isPremium ) {
-				return __( 'Premium Domain', __i18n_text_domain__ );
-			}
+			case domainTypes.REGISTERED:
+				if ( domain?.isPremium ) {
+					return __( 'Premium Domain', __i18n_text_domain__ );
+				}
 
-			// Registered domains don't show any type text in the domain row component
-			if ( context === domainInfoContext.DOMAIN_ROW ) {
-				return null;
-			}
-			return __( 'Registered Domain', __i18n_text_domain__ );
+				// Registered domains don't show any type text in the domain row component
+				if ( context === domainInfoContext.DOMAIN_ROW ) {
+					return null;
+				}
+				return __( 'Registered Domain', __i18n_text_domain__ );
 
-		case domainTypes.SITE_REDIRECT:
-			return __( 'Site Redirect', __i18n_text_domain__ );
+			case domainTypes.SITE_REDIRECT:
+				return __( 'Site Redirect', __i18n_text_domain__ );
 
-		case domainTypes.WPCOM:
-			return __( 'Default Site Domain', __i18n_text_domain__ );
+			case domainTypes.WPCOM:
+				return __( 'Default Site Domain', __i18n_text_domain__ );
 
-		case domainTypes.TRANSFER:
-			return __( 'Domain Transfer', __i18n_text_domain__ );
+			case domainTypes.TRANSFER:
+				return __( 'Domain Transfer', __i18n_text_domain__ );
 
-		default:
-			return '';
-	}
+			default:
+				return '';
+		}
+	};
+
+	const text = domainText();
+	return ! text && underMaintenance
+		? __( 'Domain is under maintenance', __i18n_text_domain__ )
+		: text;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3815
Fixes https://github.com/Automattic/dotcom-forge/issues/3555

## Proposed Changes

* Redirect domains can't be selected
* Externally registered domains can't be selected
* Domains being transferred can't be selected
* Domains under maintenance can't be selected
* Centralise logic for deciding whether a domain is selectable


![CleanShot 2023-09-18 at 20 57 01@2x](https://github.com/Automattic/wp-calypso/assets/1500769/3ebf8660-f5b8-42fe-a537-648dc52dc874)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test redirect links
* Test wordpress.com sub domains
* Test domains registered by external provider
* Test the select-all checkbox

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?