### PR TITLE
i18n: Remove Deliverable Mode from Community Translator

### DIFF
--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -1,17 +1,14 @@
 import config from '@automattic/calypso-config';
-import { Button, Dialog, Gridicon } from '@automattic/components';
-import { addQueryArgs } from '@wordpress/url';
+import { Dialog, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import i18n, { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { createRef, Component, Fragment } from 'react';
-import ReactDOM from 'react-dom';
+import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import localStorageHelper from 'store';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
-import FormTextInput from 'calypso/components/forms/form-text-input';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import {
 	getLanguageEmpathyModeActive,
@@ -20,10 +17,8 @@ import {
 import { TranslationScanner } from 'calypso/lib/i18n-utils/translation-scanner';
 import translator, { trackTranslatorStatus } from 'calypso/lib/translator-jumpstart';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getOriginalUserSetting from 'calypso/state/selectors/get-original-user-setting';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
-import { setLocale } from 'calypso/state/ui/language/actions';
 import './style.scss';
 
 class TranslatorLauncher extends Component {
@@ -50,53 +45,15 @@ class TranslatorLauncher extends Component {
 		firstActivation: true,
 		isActive: translator.isActivated(),
 		isEnabled: translator.isEnabled(),
-		isDeliverableHighlightEnabled: false,
-		deliverableTarget: null,
-		selectedDeliverableTarget: null,
-		deliverableTitle: '',
-		scrollTop: 0,
 	};
-
-	highlightRef = createRef();
 
 	componentDidMount() {
 		i18n.on( 'change', this.onI18nChange );
-		window.addEventListener( 'keydown', this.handleKeyDown );
 	}
 
 	componentWillUnmount() {
 		i18n.off( 'change', this.onI18nChange );
-		window.removeEventListener( 'keydown', this.handleKeyDown );
 	}
-
-	getOriginalIds = () => {
-		const { selectedDeliverableTarget } = this.state;
-
-		return [ selectedDeliverableTarget ]
-			.concat(
-				Array.from( selectedDeliverableTarget.querySelectorAll( '[class*=translator-original-]' ) )
-			)
-			.reduce( ( ids, node ) => {
-				const [ , originalId ] =
-					( node.className && node.className.match( /translator-original-(\d+)/ ) ) || [];
-
-				if ( originalId && ids.indexOf( originalId ) === -1 ) {
-					ids.push( originalId );
-				}
-
-				return ids;
-			}, [] );
-	};
-
-	getCreateDeliverableUrl = () => {
-		const DELIVERABLES_ENDPOINT = 'https://translate.wordpress.com/deliverables/create';
-		const { deliverableTitle } = this.state;
-
-		return addQueryArgs( DELIVERABLES_ENDPOINT, {
-			original_ids: this.getOriginalIds().join( ',' ),
-			title: deliverableTitle,
-		} );
-	};
 
 	onI18nChange = () => {
 		if ( ! this.state.isActive && translator.isActivated() ) {
@@ -115,72 +72,6 @@ class TranslatorLauncher extends Component {
 			// Deactivating
 			this.setState( { isActive: false } );
 		}
-	};
-
-	handleKeyDown = ( event ) => {
-		const { isActive, selectedDeliverableTarget } = this.state;
-
-		if ( ! isActive || ! event.getModifierState( 'Control' ) || event.key.toLowerCase() !== 'd' ) {
-			return;
-		}
-
-		if ( selectedDeliverableTarget ) {
-			this.toggleSelectedDeliverableTarget();
-		}
-
-		this.toggleDeliverableHighlight();
-	};
-
-	handleWindowScroll = () => {
-		this.setState( { scrollTop: window.scrollY } );
-	};
-
-	handleHighlightMouseMove = ( event ) => {
-		const { deliverableTarget } = this.state;
-
-		if ( deliverableTarget !== event.target ) {
-			this.setState( { deliverableTarget: event.target } );
-		}
-	};
-
-	handleHighlightMouseDown = ( event ) => {
-		event.preventDefault();
-		event.stopPropagation();
-
-		if ( this.highlightRef.current ) {
-			this.highlightRef.current.style.pointerEvents = 'all';
-		}
-	};
-
-	handleHighlightClick = ( event ) => {
-		event.preventDefault();
-		event.stopPropagation();
-
-		if ( this.highlightRef.current ) {
-			this.highlightRef.current.style.pointerEvents = '';
-		}
-
-		this.toggleSelectedDeliverableTarget();
-		this.toggleDeliverableHighlight();
-	};
-
-	handleDeliverableTitleChange = ( event ) => {
-		this.setState( { deliverableTitle: event.target.value } );
-	};
-
-	handleDeliverableLinkClick = () => {
-		this.toggleSelectedDeliverableTarget();
-	};
-
-	handleDeliverableCancelClick = () => {
-		this.toggleSelectedDeliverableTarget();
-	};
-
-	handleDeliverableSubmit = ( event ) => {
-		event.preventDefault();
-
-		window.open( this.getCreateDeliverableUrl(), '_blank' );
-		this.toggleSelectedDeliverableTarget();
 	};
 
 	toggleInfoCheckbox = ( event ) => {
@@ -209,123 +100,6 @@ class TranslatorLauncher extends Component {
 		bumpStat( 'calypso_translator_toggle', nextIsActive ? 'on' : 'off' );
 		this.setState( { isActive: nextIsActive } );
 	};
-
-	toggleDeliverableHighlight = () => {
-		const isDeliverableHighlightEnabled = ! this.state.isDeliverableHighlightEnabled;
-
-		this.setState( { isDeliverableHighlightEnabled, deliverableTarget: null } );
-
-		if ( isDeliverableHighlightEnabled ) {
-			window.addEventListener( 'scroll', this.handleWindowScroll );
-			window.addEventListener( 'mousemove', this.handleHighlightMouseMove );
-			window.addEventListener( 'mousedown', this.handleHighlightMouseDown );
-			window.addEventListener( 'click', this.handleHighlightClick );
-		} else {
-			window.removeEventListener( 'mousemove', this.handleHighlightMouseMove );
-			window.removeEventListener( 'mousedown', this.handleHighlightMouseDown );
-			window.removeEventListener( 'click', this.handleHighlightClick );
-		}
-	};
-
-	toggleSelectedDeliverableTarget = () => {
-		this.setState(
-			( { deliverableTarget, selectedDeliverableTarget } ) => ( {
-				selectedDeliverableTarget: selectedDeliverableTarget ? null : deliverableTarget,
-				deliverableTitle: '',
-			} ),
-			() => {
-				const hasSelectedDeliverableTarget = !! this.state.selectedDeliverableTarget;
-
-				document.body.classList.toggle(
-					'has-deliverable-highlighted',
-					hasSelectedDeliverableTarget
-				);
-
-				if ( hasSelectedDeliverableTarget ) {
-					window.addEventListener( 'scroll', this.handleWindowScroll );
-
-					this.selectedLanguageSlug = this.props.selectedLanguageSlug;
-
-					const DEFAULT_LANGUAGE = 'en';
-					setLocale( DEFAULT_LANGUAGE );
-				} else {
-					window.removeEventListener( 'scroll', this.handleWindowScroll );
-
-					this.selectedLanguageSlug && this.props.setLocale( this.selectedLanguageSlug );
-				}
-			}
-		);
-	};
-
-	renderDeliverableForm() {
-		const { selectedDeliverableTarget, deliverableTitle } = this.state;
-		const { translate } = this.props;
-
-		if ( ! selectedDeliverableTarget ) {
-			return;
-		}
-
-		const stringIdsCount = this.getOriginalIds().length;
-
-		return (
-			<div className="masterbar community-translator__bar">
-				<form className="community-translator__bar-form" onSubmit={ this.handleDeliverableSubmit }>
-					<div className="community-translator__bar-label">
-						{ translate( '%d string found.', '%d strings found.', {
-							count: stringIdsCount,
-							args: [ stringIdsCount ],
-						} ) }{ ' ' }
-						{ translate( 'Enter a title:' ) }
-					</div>
-
-					<FormTextInput
-						autoFocus // eslint-disable-line jsx-a11y/no-autofocus
-						value={ deliverableTitle }
-						onChange={ this.handleDeliverableTitleChange }
-					/>
-
-					<Button
-						href={ this.getCreateDeliverableUrl() }
-						target="_blank"
-						onClick={ this.handleDeliverableLinkClick }
-						primary
-					>
-						{ translate( 'Create Deliverable' ) }
-					</Button>
-					<Button onClick={ this.handleDeliverableCancelClick }>{ translate( 'Cancel' ) }</Button>
-				</form>
-			</div>
-		);
-	}
-
-	renderDeliverableHighlight() {
-		const { deliverableTarget, selectedDeliverableTarget, scrollTop } = this.state;
-		const target = deliverableTarget || selectedDeliverableTarget;
-
-		if ( ! target ) {
-			return null;
-		}
-
-		const { left, top, width, height } = target.getBoundingClientRect();
-		const style = {
-			transform: `translate(${ left }px, ${ top + scrollTop }px)`,
-			width: `${ width }px`,
-			height: `${ height }px`,
-		};
-
-		return ReactDOM.createPortal(
-			<Fragment>
-				<div
-					ref={ this.highlightRef }
-					className="community-translator__highlight"
-					style={ style }
-				/>
-
-				{ this.renderDeliverableForm() }
-			</Fragment>,
-			document.body
-		);
-	}
 
 	renderConfirmationModal() {
 		const { translate } = this.props;
@@ -392,21 +166,15 @@ class TranslatorLauncher extends Component {
 						{ infoDialogVisible && this.renderConfirmationModal() }
 					</Fragment>
 				) }
-				{ this.renderDeliverableHighlight() }
 			</Fragment>
 		);
 	}
 }
 
-export default connect(
-	( state ) => ( {
-		currentUser: getCurrentUser( state ),
-		isUserSettingsReady: !! getUserSettings( state ),
-		isTranslatorEnabled: getOriginalUserSetting( state, 'enable_translator' ),
-		isEmpathyModeEnabled:
-			config.isEnabled( 'i18n/empathy-mode' ) &&
-			getOriginalUserSetting( state, 'i18n_empathy_mode' ),
-		selectedLanguageSlug: getCurrentLocaleSlug( state ),
-	} ),
-	{ setLocale }
-)( localize( TranslatorLauncher ) );
+export default connect( ( state ) => ( {
+	currentUser: getCurrentUser( state ),
+	isUserSettingsReady: !! getUserSettings( state ),
+	isTranslatorEnabled: getOriginalUserSetting( state, 'enable_translator' ),
+	isEmpathyModeEnabled:
+		config.isEnabled( 'i18n/empathy-mode' ) && getOriginalUserSetting( state, 'i18n_empathy_mode' ),
+} ) )( localize( TranslatorLauncher ) );

--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -163,16 +163,3 @@ body {
 		margin-right: 8px;
 	}
 }
-
-.has-deliverable-highlighted {
-	// Disable translatable strings highlight when deliverable is highlighted
-	.translator-translatable {
-		text-shadow: none !important;
-	}
-
-	#notices,
-	.environment-badge,
-	.community-translator {
-		display: none !important;
-	}
-}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Deliverable Mode has not been working correctly for quite some time, but so far we haven't received any reports about it, which means that it not really being used.

* Remove Deliverable Mode from Community Translator component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch UI to a Mag-16 language and enable Community Translator.
* Confirm Community Translator works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
