### PR TITLE
Plans 2023: Woo  promotional pricing - fix price regression

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/header-price.tsx
@@ -156,7 +156,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 								rawPrice={ introOffer.rawPrice }
 								displayPerMonthNotation={ false }
 								isLargeCurrency={ isLargeCurrency }
-								isSmallestUnit={ true }
+								isSmallestUnit={ false }
 								priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
 							/>
 						</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Fixes a regression with the promo offer price display. Recent changes in https://github.com/Automattic/wp-calypso/pull/81537 forced the header price logic to treat the intro offer price as a smallest unit (cents instead of float), like done for the other/regular prices. This should fix it.

It might make sense to send smallest unit from endpoint instead, so to unify with the rest. down the line, maybe 🤔 

### Media

**Before:**

<img width="700" alt="Screenshot 2023-09-18 at 2 31 14 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/bb05bdf3-2f4c-4241-ad32-51de424844c9">


**After:**

<img width="700" alt="Screenshot 2023-09-18 at 2 31 23 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/bf4bba58-3247-47a8-a9ba-ca80a915934e">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox public-api and disable store sandbox (more about this in phab diff D119416-code ) 
    * Go to `/setup/wooexpress` and create a Woo Express site
    * Go to `/plans/[woo-trial]` and confirm pricing renders correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?