### PR TITLE
Jetpack Manage: Add support for the 'Get score' and 'Configure Boost' buttons in the Boost column.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { getUrlParts } from '@automattic/calypso-url';
 import { Button, Gridicon, ShortenedNumber, WordPressLogo } from '@automattic/components';
 import { Icon, arrowUp, arrowDown } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
@@ -295,10 +296,15 @@ export default function SiteStatusContent( {
 			}
 
 			if ( hasBoost ) {
+				const { origin, pathname } = getUrlParts( adminUrl ?? '' );
 				return (
 					<a
 						className="sites-overview__column-action-button"
-						href={ `${ adminUrl }?page=my-jetpack#/add-boost` }
+						href={
+							adminUrl
+								? `${ origin }${ pathname }?page=my-jetpack#/add-boost`
+								: `https://${ siteUrl }/wp-admin/admin.php?page=jetpack`
+						}
 						target="_blank"
 						rel="noreferrer"
 					>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -277,25 +277,24 @@ export default function SiteStatusContent( {
 
 		if ( type === 'boost' ) {
 			const overallScore = rows.site.value.jetpack_boost_scores.overall;
-			if ( hasBoost ) {
-				if ( overallScore ) {
-					return (
-						<div
-							className={ classNames(
-								'sites-overview__boost-score',
-								getBoostRatingClass( overallScore )
-							) }
-						>
-							{ translate( '%(rating)s Score', {
-								args: { rating: getBoostRating( overallScore ) },
-								comment:
-									'%rating will be replaced by boost rating, e.g. "A", "B", "C", "D", or "F"',
-							} ) }
-						</div>
-					);
-				}
 
-				// If we do not have score, we will need to redirect user to WP-admin to configure boost.
+			if ( overallScore ) {
+				return (
+					<div
+						className={ classNames(
+							'sites-overview__boost-score',
+							getBoostRatingClass( overallScore )
+						) }
+					>
+						{ translate( '%(rating)s Score', {
+							args: { rating: getBoostRating( overallScore ) },
+							comment: '%rating will be replaced by boost rating, e.g. "A", "B", "C", "D", or "F"',
+						} ) }
+					</div>
+				);
+			}
+
+			if ( hasBoost ) {
 				return (
 					<a
 						className="sites-overview__column-action-button"

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -298,7 +298,7 @@ export default function SiteStatusContent( {
 				return (
 					<a
 						className="sites-overview__column-action-button"
-						href={ adminUrl }
+						href={ `${ adminUrl }?page=my-jetpack#/add-boost` }
 						target="_blank"
 						rel="noreferrer"
 					>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -13,6 +13,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectLicense, unselectLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { hasSelectedLicensesOfType } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
+import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
 import ToggleActivateMonitoring from '../../downtime-monitoring/toggle-activate-monitoring';
 import SitesOverviewContext from '../context';
 import { getBoostRating, getBoostRatingClass } from '../lib/boost';
@@ -108,11 +109,17 @@ export default function SiteStatusContent( {
 		return page( issueLicenseRedirectUrl );
 	};
 
+	const handleGetBoostScoreAction = () => {
+		// TODO - should open a modal.
+	};
+
 	const handleDeselectLicenseAction = () => {
 		dispatch( unselectLicense( siteId, type ) );
 	};
 
 	const hasBoost = rows.site.value.has_boost;
+
+	const adminUrl = useSelector( ( state ) => getJetpackAdminUrl( state, siteId ) );
 
 	function getTrendIcon( viewsTrend: 'up' | 'down' ) {
 		if ( viewsTrend === 'up' ) {
@@ -271,21 +278,44 @@ export default function SiteStatusContent( {
 		if ( type === 'boost' ) {
 			const overallScore = rows.site.value.jetpack_boost_scores.overall;
 			if ( hasBoost ) {
+				if ( overallScore ) {
+					return (
+						<div
+							className={ classNames(
+								'sites-overview__boost-score',
+								getBoostRatingClass( overallScore )
+							) }
+						>
+							{ translate( '%(rating)s Score', {
+								args: { rating: getBoostRating( overallScore ) },
+								comment:
+									'%rating will be replaced by boost rating, e.g. "A", "B", "C", "D", or "F"',
+							} ) }
+						</div>
+					);
+				}
+
+				// If we do not have score, we will need to redirect user to WP-admin to configure boost.
 				return (
-					<div
-						className={ classNames(
-							'sites-overview__boost-score',
-							getBoostRatingClass( overallScore )
-						) }
+					<a
+						className="sites-overview__column-action-button"
+						href={ adminUrl }
+						target="_blank"
+						rel="noreferrer"
 					>
-						{ translate( '%(rating)s Score', {
-							args: { rating: getBoostRating( overallScore ) },
-							comment: '%rating will be replaced by boost rating, e.g. "A", "B", "C", "D", or "F"',
-						} ) }
-					</div>
+						{ translate( 'Configure Boost' ) }
+					</a>
 				);
 			}
-			return <div></div>;
+
+			return (
+				<button
+					className="sites-overview__column-action-button"
+					onClick={ handleGetBoostScoreAction }
+				>
+					{ translate( 'Get Score' ) }
+				</button>
+			);
 		}
 
 		switch ( status ) {
@@ -318,18 +348,20 @@ export default function SiteStatusContent( {
 			}
 			case 'inactive': {
 				content = ! isLicenseSelected ? (
-					<button onClick={ handleSelectLicenseAction }>
-						<span className="sites-overview__status-select-license">
-							<Gridicon icon="plus-small" size={ 16 } />
-							<span>{ translate( 'Add' ) }</span>
-						</span>
+					<button
+						className="sites-overview__column-action-button"
+						onClick={ handleSelectLicenseAction }
+					>
+						<Gridicon icon="plus-small" size={ 16 } />
+						<span>{ translate( 'Add' ) }</span>
 					</button>
 				) : (
-					<button onClick={ handleDeselectLicenseAction }>
-						<span className="sites-overview__status-unselect-license">
-							<Gridicon icon="checkmark" size={ 16 } />
-							<span>{ translate( 'Selected' ) }</span>
-						</span>
+					<button
+						className="sites-overview__column-action-button is-selected"
+						onClick={ handleDeselectLicenseAction }
+					>
+						<Gridicon icon="checkmark" size={ 16 } />
+						<span>{ translate( 'Selected' ) }</span>
 					</button>
 				);
 				break;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -135,8 +135,8 @@
 		text-underline-offset: 3px;
 	}
 }
-.sites-overview__status-select-license,
-.sites-overview__status-unselect-license {
+
+.sites-overview__column-action-button {
 	max-width: 100%;
 	display: inline-flex;
 	flex-direction: row;
@@ -154,6 +154,7 @@
 	border: 1px solid var(--studio-gray-5);
 	padding: 2px 11px;
 	cursor: pointer;
+
 	span {
 		margin: 0 0.2em;
 	}
@@ -164,12 +165,14 @@
 		background: var(--studio-gray-80);
 		color: var(--studio-white);
 	}
+
+	&.is-selected {
+		background: var(--studio-jetpack-green-50);
+		color: var(--studio-white);
+		border: none;
+	}
 }
-.sites-overview__status-unselect-license {
-	background: var(--studio-jetpack-green-50);
-	color: var(--studio-white);
-	border: none;
-}
+
 .sites-overview__grey-icon {
 	vertical-align: middle;
 	color: var(--studio-gray-40);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -166,6 +166,10 @@
 		color: var(--studio-white);
 	}
 
+	&:visited:not(:hover) {
+		color: var(--studio-gray-80);
+	}
+
 	&.is-selected {
 		background: var(--studio-jetpack-green-50);
 		color: var(--studio-white);


### PR DESCRIPTION
This PR updates the Boost column to support the **'Get score'** and **'Configure Boost'** action buttons.

<img width="777" alt="Screen Shot 2023-09-18 at 8 00 34 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/3f9d53ef-4385-4eaf-9c35-421d64cf3cac">


Related to https://github.com/orgs/Automattic/projects/757/views/1?pane=issue&itemId=38829030

## Proposed Changes

* Update **'Boost'** column render logic to display the **'Get score'** button when the current site does not have a Boost score and has no active Jetpack Boost plugin and license. If the user has a plugin or license installed, the **'Configure Boost'** button will be displayed instead.
* Clicking the **'Configure Boost'** button will open a new tab redirecting the user to the WP-Admin.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

### 'Get Score' button
* Spin up a new JN site and connect it to the Jetpack cloud. Make sure you are installing only the **Jetpack Backup** plugin.
* Use the live link below and go to `/dashboard?flags=jetpack/pro-dashboard-jetpack-boost.`
* Confirm that the **'Get score'** button is visible in the **'Boost'** column. _Note that clicking the button will not work at the moment. A separate task will handle the button event._

### 'Configure Boost' button
* install **Jetpack boost** plugin or purchase a Boost license on your JN site.
* Go back to `/dashboard?flags=jetpack/pro-dashboard-jetpack-boost`
* Confirm that the **'Configure Boost'** button is visible. Clicking this button will redirect the user to the **WP admin**.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
