### PR TITLE
Checkout: add plan features & hide domain term selector for 100-year plan

### DIFF
--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -14,6 +14,7 @@ import {
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useState } from 'react';
+import { has100YearPlan } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/src/hooks/product-variants';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
@@ -168,6 +169,7 @@ function LineItemWrapper( {
 	const isRenewal = isWpComProductRenewal( product );
 	const isWooMobile = isWcMobileApp();
 	let isDeletable = canItemBeRemovedFromCart( product, responseCart ) && ! isWooMobile;
+	const has100YearPlanProduct = has100YearPlan( responseCart );
 
 	const signupFlowName = getSignupCompleteFlowName();
 	if ( isCopySiteFlow( signupFlowName ) && ! product.is_domain_registration ) {
@@ -175,7 +177,12 @@ function LineItemWrapper( {
 	}
 
 	const shouldShowVariantSelector =
-		onChangeSelection && ! isWooMobile && ! isRenewal && ! hasPartnerCoupon;
+		onChangeSelection &&
+		! isWooMobile &&
+		! isRenewal &&
+		! hasPartnerCoupon &&
+		! has100YearPlanProduct;
+
 	const isJetpack = responseCart.products.some( ( product ) =>
 		isJetpackPurchasableItem( product.product_slug )
 	);

--- a/client/my-sites/checkout/src/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/src/lib/get-plan-features.ts
@@ -8,6 +8,7 @@ import {
 	isWpComPersonalPlan,
 	isWpComPremiumPlan,
 	isStarterPlan,
+	is100YearPlan,
 } from '@automattic/calypso-products';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
@@ -93,6 +94,16 @@ export default function getPlanFeatures(
 			String( translate( 'Unlimited products or services for your online store' ) ),
 			String( translate( 'eCommerce marketing tools for emails and social networks' ) ),
 		].filter( isValueTruthy );
+	}
+
+	if ( is100YearPlan( productSlug ) ) {
+		return [
+			String( translate( 'Century-long domain registration' ) ),
+			String( translate( 'Enhanced ownership protocols' ) ),
+			String( translate( 'Top-tier managed WordPress hosting' ) ),
+			String( translate( '24/7 Premier Support' ) ),
+			String( translate( 'Peace of mind' ) ),
+		];
 	}
 
 	return [];

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -710,8 +710,8 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 
 		return (
 			<>
-				{ premiumLabel } <DefaultLineItemSublabel product={ product } />:{ ' ' }
-				{ translate( 'billed annually' ) }
+				{ premiumLabel } <DefaultLineItemSublabel product={ product } />
+				{ ! product.is_included_for_100yearplan && <>: { translate( 'billed annually' ) }</> }
 			</>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#2150
Fixes Automattic/martech#2200

## Proposed Changes

* Adds a list of features to the "Included with your purchase" box on checkout, when the 100-year plan is in the cart.
<img width="1176" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/e803452d-20bb-458e-8f13-be7bb2f3c0b4">

* Hide the variant selector and `billed annually` text for the domain product.

| Before | After |
|--------|--------|
| <img width="728" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/74aacdf7-f83e-47ae-848b-d72cb5c6f1cf"> |<img width="713" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/597e1e9e-e3c6-4635-8a73-5e6a0c6f5542"> |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/hundred-year-plan` and proceed through the steps till you reach the checkout page.
* Confirm that the "Included in your purchase" box matches the screenshot above.
* Confirm that the variant selector is hidden for the domain product.
* Confirm that the `billed annually` text is not shown for the domain product.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?