### PR TITLE
Domain management: Display selected domain count when applicable

### DIFF
--- a/packages/domains-table/src/domains-table-header/columns.ts
+++ b/packages/domains-table/src/domains-table-header/columns.ts
@@ -2,15 +2,28 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { getSimpleSortFunctionBy, getSiteSortFunctions } from '../utils';
 import { DomainsTableColumn } from '.';
 
-export const allSitesViewColumns: DomainsTableColumn[] = [
-	{
-		name: 'domain',
-		label: ( count: number ) =>
-			sprintf(
+const domainLabel = ( count: number, isBulkSelection: boolean ) =>
+	isBulkSelection
+		? sprintf(
+				/* translators: Heading which displays the number of selected domains in a table */
+				_n(
+					'%(count)d domain selected',
+					'%(count)d domains selected',
+					count,
+					__i18n_text_domain__
+				),
+				{ count }
+		  )
+		: sprintf(
 				/* translators: Heading which displays the number of domains in a table */
 				_n( '%(count)d domain', '%(count)d domains', count, __i18n_text_domain__ ),
 				{ count }
-			),
+		  );
+
+export const allSitesViewColumns: DomainsTableColumn[] = [
+	{
+		name: 'domain',
+		label: domainLabel,
 		sortLabel: __( 'Domain', __i18n_text_domain__ ),
 		isSortable: true,
 		initialSortDirection: 'asc',
@@ -56,12 +69,7 @@ export const allSitesViewColumns: DomainsTableColumn[] = [
 export const siteSpecificViewColumns: DomainsTableColumn[] = [
 	{
 		name: 'domain',
-		label: ( count: number ) =>
-			sprintf(
-				/* translators: Heading which displays the number of domains in a table */
-				_n( '%(count)d domain', '%(count)d domains', count, __i18n_text_domain__ ),
-				{ count }
-			),
+		label: domainLabel,
 		sortLabel: __( 'Domain', __i18n_text_domain__ ),
 		isSortable: true,
 		initialSortDirection: 'asc',

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -12,7 +12,7 @@ export type DomainsTableBulkSelectionStatus = 'no-domains' | 'some-domains' | 'a
 
 interface BaseDomainsTableColumn {
 	name: string;
-	label: string | ( ( count: number ) => string ) | null;
+	label: string | ( ( count: number, isBulkSelection: boolean ) => string ) | null;
 	sortFunctions?: Array<
 		( first: DomainData, second: DomainData, sortOrder: number, sites?: SiteDetails[] ) => number
 	>;
@@ -44,6 +44,7 @@ type DomainsTableHeaderProps = {
 	bulkSelectionStatus: DomainsTableBulkSelectionStatus;
 	onBulkSelectionChange(): void;
 	domainCount: number;
+	selectedDomainsCount: number;
 	headerClasses?: string;
 	hideOwnerColumn?: boolean;
 	domainsRequiringAttention?: number;
@@ -58,6 +59,7 @@ export const DomainsTableHeader = ( {
 	onBulkSelectionChange,
 	onChangeSortOrder,
 	domainCount,
+	selectedDomainsCount,
 	headerClasses,
 	hideOwnerColumn = false,
 	domainsRequiringAttention,
@@ -80,6 +82,8 @@ export const DomainsTableHeader = ( {
 
 		return <Icon icon={ columnSortOrder === 'asc' ? chevronDown : chevronUp } size={ 16 } />;
 	};
+
+	const isBulkSelection = bulkSelectionStatus !== 'no-domains';
 
 	return (
 		<thead className={ listHeaderClasses }>
@@ -120,7 +124,10 @@ export const DomainsTableHeader = ( {
 							>
 								{ column?.headerComponent ||
 									( typeof column?.label === 'function'
-										? column.label( domainCount )
+										? column.label(
+												isBulkSelection ? selectedDomainsCount : domainCount,
+												isBulkSelection
+										  )
 										: column?.label ) }
 								{ column?.name === 'status' && domainsRequiringAttention && (
 									<span className="list-status-cell__bubble">{ domainsRequiringAttention }</span>

--- a/packages/domains-table/src/domains-table/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/index.tsx
@@ -521,3 +521,30 @@ test( 'when isAllSitesView is false, hide wordpress.com domain if there is a wpc
 	expect( screen.queryByText( 'primary-domain.wpcomstaging.com' ) ).toBeInTheDocument();
 	expect( screen.queryByText( 'primary-domain.wordpress.com' ) ).not.toBeInTheDocument();
 } );
+
+test( 'when selecting a domain, display the selected count instead of the total count', () => {
+	const [ primaryPartial ] = testDomain( {
+		domain: 'primary-domain.blog',
+		blog_id: 123,
+		primary_domain: true,
+		owner: 'owner',
+	} );
+
+	const [ notPrimaryPartial ] = testDomain( {
+		domain: 'not-primary-domain.blog',
+		blog_id: 124,
+		primary_domain: true,
+		owner: 'owner',
+	} );
+
+	render( <DomainsTable domains={ [ primaryPartial, notPrimaryPartial ] } isAllSitesView /> );
+
+	expect( screen.queryByText( '2 domains' ) ).toBeInTheDocument();
+
+	const firstDomainsCheckbox = getDomainCheckbox( 'primary-domain.blog' );
+
+	fireEvent.click( firstDomainsCheckbox );
+
+	expect( screen.queryByText( '2 domains' ) ).not.toBeInTheDocument();
+	expect( screen.queryByText( '1 domain selected' ) ).toBeInTheDocument();
+} );

--- a/packages/domains-table/src/domains-table/domains-table-header.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-header.tsx
@@ -13,6 +13,7 @@ export const DomainsTableHeader = () => {
 		canSelectAnyDomains,
 		filteredData,
 		domainsTableColumns,
+		selectedDomains,
 	} = useDomainsTable();
 
 	return (
@@ -27,6 +28,7 @@ export const DomainsTableHeader = () => {
 			domainsRequiringAttention={ domainsRequiringAttention }
 			canSelectAnyDomains={ canSelectAnyDomains }
 			domainCount={ filteredData.length }
+			selectedDomainsCount={ selectedDomains.size }
 		/>
 	);
 };


### PR DESCRIPTION
Related to p58i-fm0-p2#comment-59187.

## Proposed Changes

Let's add a different label to indicate that there is a bulk selection in place.

https://github.com/Automattic/wp-calypso/assets/26530524/b719c50e-d56c-4810-a237-f4029b7b2dd4

## Testing Instructions

Open the domains table and select any selectionable domain. Check that the top label updates and says "X domains selected." The label is reversed once no domains are selected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
~- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~