### PR TITLE
Site profiler: Create/hydrate "Hosting Information" block

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -1,3 +1,19 @@
+export interface DNS {
+	host: string;
+	class: string;
+	ttl: number;
+	type: string;
+	ip?: string;
+	target?: string;
+	mname?: string;
+	rname?: string;
+	serial?: number;
+	refresh?: number;
+	retry?: number;
+	expire?: number;
+	'minimum-ttl'?: number;
+}
+
 export interface WhoIs {
 	admin_city: string;
 	admin_country: string;
@@ -40,16 +56,27 @@ export interface WhoIs {
 	updated_date: string;
 }
 
+export interface HostingProvider {
+	slug: string;
+	name: string;
+	is_cdn: boolean;
+}
+
 export interface DomainAnalyzerQueryResponse {
 	domain: string;
 	hosting_provider: {
 		name: string;
 	};
 	whois: WhoIs;
-	dns: any;
+	dns: DNS[];
 }
 
 export interface DomainAnalyzerWhoisRawDataQueryResponse {
 	domain: string;
 	whois: string[];
+}
+
+export interface HostingProviderQueryResponse {
+	domain: string;
+	hosting_provider: HostingProvider;
 }

--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -64,11 +64,9 @@ export interface HostingProvider {
 
 export interface DomainAnalyzerQueryResponse {
 	domain: string;
-	hosting_provider: {
-		name: string;
-	};
 	whois: WhoIs;
 	dns: DNS[];
+	is_domain_available: boolean;
 }
 
 export interface DomainAnalyzerWhoisRawDataQueryResponse {

--- a/client/data/site-profiler/use-hosting-provider-query.ts
+++ b/client/data/site-profiler/use-hosting-provider-query.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { HostingProviderQueryResponse } from 'calypso/data/site-profiler/types';
+import wp from 'calypso/lib/wp';
+
+export const useHostingProviderQuery = ( domain: string ) => {
+	return useQuery( {
+		queryKey: [ 'hosting-provider-', domain ],
+		queryFn: (): Promise< HostingProviderQueryResponse > =>
+			wp.req.get( {
+				path: '/site-profiler/hosting-provider/' + encodeURIComponent( domain ),
+				apiNamespace: 'wpcom/v2',
+			} ),
+		meta: {
+			persist: false,
+		},
+		enabled: !! domain,
+		retry: false,
+		refetchOnWindowFocus: false,
+	} );
+};

--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -26,7 +26,7 @@ export default function DomainInformation( props: Props ) {
 		<div className="domain-information">
 			<h3>Domain information</h3>
 
-			<ul className="domain-information-details">
+			<ul className="domain-information-details result-list">
 				{ whois.registrar_url && (
 					<li>
 						<div className="name">Registrar</div>

--- a/client/site-profiler/components/domain-information/styles.scss
+++ b/client/site-profiler/components/domain-information/styles.scss
@@ -1,32 +1,4 @@
 .domain-information-details {
-	margin: 0;
-	list-style: none;
-
-	ul {
-		margin: 0;
-		list-style: none;
-	}
-
-	& > li {
-		display: flex;
-		padding: 1rem 0;
-		border-top: solid 1px var(--studio-gray-5);
-		gap: 2rem;
-
-		&:first-child {
-			border: none;
-		}
-
-		.name {
-			min-width: 200px;
-			text-transform: uppercase;
-		}
-	}
-
-	.col {
-		max-width: 300px;
-	}
-
 	.whois-raw-data {
 		button {
 			margin-bottom: 0.5rem;

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -1,7 +1,37 @@
-export default function HostingInformation() {
+import { DNS, HostingProvider } from 'calypso/data/site-profiler/types';
+
+interface Props {
+	dns: DNS[];
+	hostingProvider?: HostingProvider;
+}
+
+export default function HostingInformation( props: Props ) {
+	const { dns = [], hostingProvider } = props;
+	const aRecordIps = dns.filter( ( x ) => x.type === 'A' && x.ip );
+
 	return (
-		<>
+		<div className="hosting-information">
 			<h3>Hosting information</h3>
-		</>
+			<ul className="hosting-information-details result-list">
+				<li>
+					<div className="name">Provider</div>
+					<div>{ hostingProvider?.name }</div>
+				</li>
+				<li>
+					<div className="name">Support</div>
+					<div>Contact support</div>
+				</li>
+				<li>
+					<div className="name">A Records</div>
+					<div>
+						<ul>
+							{ aRecordIps.map( ( x, i ) => (
+								<li key={ i }>{ x.ip }</li>
+							) ) }
+						</ul>
+					</div>
+				</li>
+			</ul>
+		</div>
 	);
 }

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -16,7 +16,16 @@ export default function HostingInformation( props: Props ) {
 			<ul className="hosting-information-details result-list">
 				<li>
 					<div className="name">Provider</div>
-					<div>{ hostingProvider?.name }</div>
+					<div>
+						{ hostingProvider?.slug !== 'automattic' && <>{ hostingProvider?.name }</> }
+						{ hostingProvider?.slug === 'automattic' && (
+							<>
+								<a href={ localizeUrl( 'https://automattic.com' ) }>{ hostingProvider?.name }</a>
+								&nbsp;&nbsp;
+								<a href={ localizeUrl( 'https://automattic.com/login' ) }>(login)</a>
+							</>
+						) }
+					</div>
 				</li>
 				{ hostingProvider?.slug === 'automattic' && (
 					<li>

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { DNS, HostingProvider } from 'calypso/data/site-profiler/types';
 
 interface Props {
@@ -17,10 +18,14 @@ export default function HostingInformation( props: Props ) {
 					<div className="name">Provider</div>
 					<div>{ hostingProvider?.name }</div>
 				</li>
-				<li>
-					<div className="name">Support</div>
-					<div>Contact support</div>
-				</li>
+				{ hostingProvider?.slug === 'automattic' && (
+					<li>
+						<div className="name">Support</div>
+						<div>
+							<a href={ localizeUrl( 'https://wordpress.com/help/contact' ) }>Contact support</a>
+						</div>
+					</li>
+				) }
 				<li>
 					<div className="name">A Records</div>
 					<div>

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useDomainAnalyzerQuery } from 'calypso/data/site-profiler/use-domain-analyzer-query';
+import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
 import HostingInto from 'calypso/site-profiler/components/hosting-into';
 import { LayoutBlock, LayoutBlockSection } from 'calypso/site-profiler/components/layout';
 import DomainAnalyzer from './domain-analyzer';
@@ -11,6 +12,7 @@ import './styles.scss';
 export default function SiteProfiler() {
 	const [ domain, setDomain ] = useState( '' );
 	const { data, isFetching } = useDomainAnalyzerQuery( domain );
+	const { data: hostingProviderData } = useHostingProviderQuery( domain );
 
 	const onFormSubmit = ( domain: string ) => {
 		setDomain( domain );
@@ -31,7 +33,10 @@ export default function SiteProfiler() {
 					) }
 					{ data && (
 						<LayoutBlockSection>
-							<HostingInformation />
+							<HostingInformation
+								dns={ data.dns }
+								hostingProvider={ hostingProviderData?.hosting_provider }
+							/>
 						</LayoutBlockSection>
 					) }
 					{ data?.whois && (

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -41,4 +41,34 @@
 			color: var(--wp-admin-theme-color-darker-20);
 		}
 	}
+
+	.result-list {
+		margin: 0;
+		list-style: none;
+
+		ul {
+			margin: 0;
+			list-style: none;
+		}
+
+		& > li {
+			display: flex;
+			padding: 1rem 0;
+			border-top: solid 1px var(--studio-gray-5);
+			gap: 2rem;
+
+			&:first-child {
+				border: none;
+			}
+
+			.name {
+				min-width: 200px;
+				text-transform: uppercase;
+			}
+		}
+
+		.col {
+			max-width: 300px;
+		}
+	}
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/81726

## Proposed Changes

* Created `useHostingProviderQuery` for fetching hosting provider data
* Created Hosting information block

## Testing Instructions

* Go to `/site-profiler`
* Entry domain
* Check if there is "Hosting information" block

**Note:**
- In case, if there is an Automattic provider, show the **login** and **customer support** links

<img width="694" alt="Screenshot 2023-09-18 at 15 39 47" src="https://github.com/Automattic/wp-calypso/assets/1241413/ba9a080e-c97e-4d9d-a20d-f95a5fdff931">
<img width="590" alt="Screenshot 2023-09-18 at 15 39 57" src="https://github.com/Automattic/wp-calypso/assets/1241413/26c788b0-f615-4b50-82a7-24edf81f1bc0">
<img width="679" alt="Screenshot 2023-09-18 at 15 40 09" src="https://github.com/Automattic/wp-calypso/assets/1241413/9cc209b3-2848-4a3d-add5-10f56407810d">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?