### PR TITLE
Subscription Management: Update the header title and subtitle to match the new typography

### DIFF
--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -61,6 +61,7 @@ const SiteSubscriptionsManager = () => {
 								: translate( 'Manage your newsletter and blog subscriptions.' )
 						}
 						align="left"
+						brandFont
 					/>
 					<Spacer />
 					<AddSitesButton />

--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -22,17 +22,7 @@
 				margin: 0;
 			}
 
-			&__title {
-				font-size: $font-title-medium;
-				line-height: $font-title-large;
-				color: $studio-gray-100;
-				margin-bottom: rem(4px);
-			}
-
 			&__subtitle {
-				font-size: $font-body-small;
-				line-height: $font-title-small;
-				color: $studio-gray-60;
 				margin-bottom: 0;
 			}
 		}


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/81842

## Proposed Changes

* Update title and subtitle style to use new typography

**Before**
<img width="653" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/cc530621-af4d-481e-a495-c9676b266499">

**After**
<img width="677" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/75b1f4b1-76ab-457d-b534-8c02ee813837">

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/read/subscriptions
* Verify if the header is displayed with the new typography

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?