### PR TITLE
Domain management: Hook purchases in bulk tables

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -1,22 +1,15 @@
 import { isEnabled } from '@automattic/calypso-config';
-import {
-	DomainsTable,
-	useDomainsTable,
-	DomainStatusPurchaseActions,
-	ResponseDomain,
-} from '@automattic/domains-table';
+import { DomainsTable, useDomainsTable } from '@automattic/domains-table';
 import { useTranslate } from 'i18n-calypso';
 import { UsePresalesChat } from 'calypso/components/data/domain-management';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { handleRenewNowClick, shouldRenderExpiringCreditCard } from 'calypso/lib/purchases';
-import { Purchase } from 'calypso/lib/purchases/types';
 import { useOdieAssistantContext } from 'calypso/odie/context';
-import { useDispatch } from 'calypso/state';
 import DomainHeader from '../components/domain-header';
 import OptionsDomainButton from './options-domain-button';
+import { usePurchaseActions } from './use-purchase-actions';
 
 interface BulkAllDomainsProps {
 	analyticsPath: string;
@@ -25,7 +18,6 @@ interface BulkAllDomainsProps {
 
 export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 	const { domains, isLoading } = useDomainsTable();
-	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { sendNudge } = useOdieAssistantContext();
 
@@ -53,36 +45,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 		<OptionsDomainButton key="breadcrumb_button_1" specificSiteActions allDomainsList />,
 	];
 
-	const isCreditCardExpiring = ( purchases: Purchase[] ) => ( domain: ResponseDomain ) => {
-		const purchase = purchases?.find(
-			( p ) => p.id === parseInt( domain.subscriptionId ?? '', 10 )
-		);
-
-		return ( purchase && dispatch( shouldRenderExpiringCreditCard( purchase ) ) ) ?? false;
-	};
-
-	const isPurchasedDomain = ( purchases: Purchase[] ) => ( domain: ResponseDomain ) => {
-		const purchase = purchases?.find(
-			( p ) => p.id === parseInt( domain.subscriptionId ?? '', 10 )
-		);
-		return !! purchase;
-	};
-
-	const onRenewNowClick =
-		( purchases: Purchase[] ) => ( siteSlug: string, domain: ResponseDomain ) => {
-			const purchase = purchases?.find(
-				( p ) => p.id === parseInt( domain.subscriptionId ?? '', 10 )
-			);
-			if ( purchase ) {
-				dispatch( handleRenewNowClick( purchase, siteSlug ) );
-			}
-		};
-
-	const purchaseActions: DomainStatusPurchaseActions = {
-		isCreditCardExpiring: isCreditCardExpiring( [] ),
-		isPurchasedDomain: isPurchasedDomain( [] ),
-		onRenewNowClick: onRenewNowClick( [] ),
-	};
+	const purchaseActions = usePurchaseActions();
 
 	return (
 		<>

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -27,6 +27,7 @@ import EmptyDomainsListCard from './empty-domains-list-card';
 import { filterDomainsByOwner } from './helpers';
 import { ManageAllDomainsCTA } from './manage-domains-cta';
 import OptionsDomainButton from './options-domain-button';
+import { usePurchaseActions } from './use-purchase-actions';
 import { filterOutWpcomDomains } from './utils';
 
 interface BulkSiteDomainsProps {
@@ -64,6 +65,8 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 		),
 	};
 
+	const purchaseActions = usePurchaseActions();
+
 	const buttons = [ <OptionsDomainButton key="breadcrumb_button_1" specificSiteActions /> ];
 
 	return (
@@ -80,6 +83,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 					shouldDisplayContactInfoBulkAction={ isEnabled(
 						'domains/bulk-actions-contact-info-editing'
 					) }
+					domainStatusPurchaseActions={ purchaseActions }
 					userCanSetPrimaryDomains={ userCanSetPrimaryDomains }
 					onDomainAction={ async ( action, domain ) => {
 						if ( action === 'manage-dns-settings' ) {

--- a/client/my-sites/domains/domain-management/list/use-purchase-actions.ts
+++ b/client/my-sites/domains/domain-management/list/use-purchase-actions.ts
@@ -1,0 +1,41 @@
+import { DomainStatusPurchaseActions, ResponseDomain } from '@automattic/domains-table';
+import { handleRenewNowClick, shouldRenderExpiringCreditCard } from 'calypso/lib/purchases';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getUserPurchases } from 'calypso/state/purchases/selectors';
+
+export const usePurchaseActions = () => {
+	const dispatch = useDispatch();
+	const purchases = useSelector( getUserPurchases );
+
+	const isCreditCardExpiring = ( domain: ResponseDomain ) => {
+		const purchase = purchases?.find(
+			( p ) => p.id === parseInt( domain.subscriptionId ?? '', 10 )
+		);
+
+		return purchase ? shouldRenderExpiringCreditCard( purchase ) : false;
+	};
+
+	const isPurchasedDomain = ( domain: ResponseDomain ) => {
+		const purchase = purchases?.find(
+			( p ) => p.id === parseInt( domain.subscriptionId ?? '', 10 )
+		);
+		return !! purchase;
+	};
+
+	const onRenewNowClick = ( siteSlug: string, domain: ResponseDomain ) => {
+		const purchase = purchases?.find(
+			( p ) => p.id === parseInt( domain.subscriptionId ?? '', 10 )
+		);
+		if ( purchase ) {
+			dispatch( handleRenewNowClick( purchase, siteSlug ) );
+		}
+	};
+
+	const purchaseActions: DomainStatusPurchaseActions = {
+		isCreditCardExpiring,
+		isPurchasedDomain,
+		onRenewNowClick,
+	};
+
+	return purchaseActions;
+};

--- a/client/my-sites/domains/domain-management/list/use-purchase-actions.ts
+++ b/client/my-sites/domains/domain-management/list/use-purchase-actions.ts
@@ -1,9 +1,12 @@
 import { DomainStatusPurchaseActions, ResponseDomain } from '@automattic/domains-table';
+import { useQueryUserPurchases } from 'calypso/components/data/query-user-purchases';
 import { handleRenewNowClick, shouldRenderExpiringCreditCard } from 'calypso/lib/purchases';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
 
 export const usePurchaseActions = () => {
+	useQueryUserPurchases();
+
 	const dispatch = useDispatch();
 	const purchases = useSelector( getUserPurchases );
 


### PR DESCRIPTION
## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/80993/files#r1307680350, we set the purchases array to empty. Now it's time to glue things together and make sure that the purchases are taken into account when rendering the domain status. This PR does exactly that, for both the all sites and the site-specific table.

## Testing Instructions

In a row that has a purchased domain (`domain.isRenewable`) , toggle `domain.expired` and verify that the "Renew now" action shows up in the status popover.