### PR TITLE
Add Settings tab

### DIFF
--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -52,6 +52,11 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				path: '/earn' + pathSuffix,
 				id: 'earn',
 			},
+			{
+				title: translate( 'Settings' ),
+				path: '/earn/payments' + pathSuffix,
+				id: 'payments',
+			},
 		];
 	};
 


### PR DESCRIPTION
## Proposed Changes

Adds 'Settings' tab to Earn page following figma designs here: DqXCQr1dEWpF3P2dIEwiwd-fi-636_37983. This tab contains everything from the existing payments tab. It will be updated subsequent PRs to eventually match figma designs here: DqXCQr1dEWpF3P2dIEwiwd-fi-335_45103

**Without Stripe Connected**
<img width="1086" alt="earn-payments-tab" src="https://github.com/Automattic/wp-calypso/assets/21228350/457d4e34-48a2-4850-b519-5cbc8bc55550">

**With Stripe Connected**
<img width="1066" alt="earn-payments-tab-2" src="https://github.com/Automattic/wp-calypso/assets/21228350/16de6f4b-61de-4d00-94dd-6387feec00a4">

## Testing Instructions

1) Checkout this branch and go to http://calypso.localhost:3000/earn/YOURDOMAIN. Confirm you see the new Settings tab at the top. 
2) Test without Stripe connection: Click the settings tab, and confirm the page looks like the first screenshot above. 
3) Test with Stripe connection: Click the settings tab, and confirm the page looks like the second screenshot above. 
4) Generally click around and confirm all navigation still works. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?