### PR TITLE
Earn: Add tab for Ads

### DIFF
--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -215,7 +215,8 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 				plan={ PLAN_PREMIUM }
 				title={ translate( 'Upgrade to the Premium plan and start earning' ) }
 				description={ translate(
-					"By upgrading to the Premium plan, you'll be able to monetize your site through the WordAds program."
+					"By upgrading to the Premium plan, you'll be able to monetize your site through the <a href='%(url)s'>WordAds program</>.",
+					{ args: { url: 'https://wordads.co/' } }
 				) }
 				feature={ WPCOM_FEATURES_WORDADS }
 				href={ bannerURL }

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -62,6 +62,11 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				path: '/earn/payments' + pathSuffix,
 				id: 'payments',
 			},
+			{
+				title: translate( 'Ads' ),
+				path: '/earn/ads-earnings' + pathSuffix,
+				id: 'ads-earnings',
+			},
 		];
 	};
 

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -28,6 +28,12 @@ type EarningsMainProps = {
 	path: string;
 };
 
+type Tab = {
+	title: string;
+	path: string;
+	id: string;
+};
+
 const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 	const translate = useTranslate();
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
@@ -164,9 +170,17 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		return currentPath;
 	};
 
-	const getEarnSectionNav = () => {
+	const isEarnTabSelected = ( tabItem: Tab ) => {
 		const currentPath = getCurrentPath();
 
+		if ( 'ads-earnings' === tabItem.id ) {
+			return isAdSection( section );
+		}
+
+		return tabItem.path === currentPath;
+	};
+
+	const getEarnSectionNav = () => {
 		return (
 			<div id="earn-navigation">
 				<SectionNav selectedText={ getEarnSelectedText() }>
@@ -176,7 +190,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 								<NavItem
 									key={ tabItem.id }
 									path={ tabItem.path }
-									selected={ tabItem.path === currentPath }
+									selected={ isEarnTabSelected( tabItem ) }
 								>
 									{ tabItem.title }
 								</NavItem>

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -106,16 +106,35 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 	}
 }
 
-// Override heading/SectionNav styles for Ads Dashboard
+h3.highlight-cards-heading,
+h3.ads__table-header-title {
+	font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+}
+
 .earn__ads-header {
 	margin: 20px 0;
 
 	h2.formatted-header__title {
-		margin: 0 0 20px;
+		margin: 0 0 12px;
+		font-size: $font-size-header-small;
 	}
-}
 
-h3.highlight-cards-heading,
-h3.ads__table-header-title {
-	font-size: 1.25rem;
+	.section-nav {
+		box-shadow: none;
+	}
+
+	.section-nav-tab {
+		&:hover:not(.is-selected) {
+			border-bottom-color: transparent;
+		}
+		&.is-selected {
+			border-bottom: none;
+		}
+		.section-nav-tab__link {
+			padding: 0 20px 10px 0;
+			&:hover {
+				background-color: transparent;
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Proposed Changes

This PR is for feedback. It adds an 'Ads' tab to Earn page. As is, this tab is only accessible via a card at the bottom. Since we're moving everything else to tab navigation, I wonder if we should move this to a tab as well? This is what it would look like. 

**Without Premium Plan**
<img width="1069" alt="ad-earnings-1" src="https://github.com/Automattic/wp-calypso/assets/21228350/f0020245-dd0e-4d6e-9078-511e499de32d">


**With Premium Plan, but Without Signup**
<img width="1063" alt="ad-earnings-2" src="https://github.com/Automattic/wp-calypso/assets/21228350/4bda25cc-224a-4903-90c7-9184a3059aa1">

**With Premium Plan and Signup**
<img width="1059" alt="ad-earnings-3" src="https://github.com/Automattic/wp-calypso/assets/21228350/9c7f7756-f8ed-4471-9658-ef3b64d494fd">

## Testing Instructions

1) Checkout this branch and go to http://calypso.localhost:3000/earn/YOURDOMAIN. Confirm you see the new Ads tab at the top. 
2) Test the ads tab in all the three states above (not a premium plan, premium plan but not applied, premium plan + applied and accepted) an confirm the screen looks like screenshots above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?