### PR TITLE
Earn: Add customer tab and screen

### DIFF
--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -1,0 +1,344 @@
+import { Card, Button, Dialog, Gridicon } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { saveAs } from 'browser-filesaver';
+import { useTranslate } from 'i18n-calypso';
+import { orderBy } from 'lodash';
+import { useState, useEffect, useCallback, MouseEvent } from 'react';
+import { shallowEqual } from 'react-redux';
+import QueryMembershipsEarnings from 'calypso/components/data/query-memberships-earnings';
+import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import Gravatar from 'calypso/components/gravatar';
+import InfiniteScroll from 'calypso/components/infinite-scroll';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import Notice from 'calypso/components/notice';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import SectionHeader from 'calypso/components/section-header';
+import { decodeEntities } from 'calypso/lib/formatting';
+import { useDispatch, useSelector } from 'calypso/state';
+import {
+	requestSubscribers,
+	requestSubscriptionStop,
+} from 'calypso/state/memberships/subscribers/actions';
+import {
+	getTotalSubscribersForSiteId,
+	getOwnershipsForSiteId,
+} from 'calypso/state/memberships/subscribers/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+type Subscriber = {
+	id: string;
+	status: string;
+	start_date: string;
+	end_date: string;
+	// appears as both subscriber.user_email & subscriber.user.user_email in this file
+	user_email: string;
+	user: {
+		ID: string;
+		name: string;
+		user_email: string;
+	};
+	plan: {
+		connected_account_product_id: string;
+		title: string;
+		renewal_price: number;
+		currency: string;
+		renew_interval: string;
+	};
+	renew_interval: string;
+	all_time_total: number;
+};
+
+function CustomerSection() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const moment = useLocalizedMoment();
+	const [ cancelledSubscriber, setCancelledSubscriber ] = useState< Subscriber | null >( null );
+
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+
+	const subscribers = useSelector(
+		( state ) => getOwnershipsForSiteId( state, site?.ID ),
+		shallowEqual
+	);
+
+	const totalSubscribers = useSelector( ( state ) =>
+		getTotalSubscribersForSiteId( state, site?.ID )
+	);
+
+	const fetchNextSubscriberPage = useCallback(
+		( force: boolean ) => {
+			const fetched = Object.keys( subscribers ).length;
+			if ( fetched < totalSubscribers || force ) {
+				dispatch( requestSubscribers( site?.ID, fetched ) );
+			}
+		},
+		[ dispatch, site, subscribers, totalSubscribers ]
+	);
+
+	function onCloseCancelSubscription( reason: string | undefined ) {
+		if ( reason === 'cancel' ) {
+			dispatch(
+				requestSubscriptionStop(
+					site?.ID,
+					cancelledSubscriber,
+					getIntervalDependantWording( cancelledSubscriber ).success
+				)
+			);
+		}
+		setCancelledSubscriber( null );
+	}
+
+	function downloadSubscriberList( event: MouseEvent< HTMLButtonElement > ) {
+		event.preventDefault();
+		const fileName = [ site?.slug, 'memberships', 'subscribers' ].join( '_' ) + '.csv';
+
+		const csvData = [
+			[
+				'ID',
+				'status',
+				'start_date',
+				'end_date',
+				'user_name',
+				'user_email',
+				'plan_id',
+				'plan_title',
+				'renewal_price',
+				'currency',
+				'renew_interval',
+				'All time total',
+			]
+				.map( ( field ) => '"' + field + '"' )
+				.join( ',' ),
+		]
+			.concat(
+				Object.values( subscribers ).map( ( row ) =>
+					[
+						row.id,
+						row.status,
+						row.start_date,
+						row.end_date,
+						row.user.name,
+						row.user.user_email,
+						row.plan.connected_account_product_id,
+						row.plan.title,
+						row.plan.renewal_price,
+						row.plan.currency,
+						row.renew_interval,
+						row.all_time_total,
+					]
+						.map( ( field ) => ( field ? '"' + field + '"' : '""' ) )
+						.join( ',' )
+				)
+			)
+			.join( '\n' );
+
+		const blob = new window.Blob( [ csvData ], { type: 'text/csv;charset=utf-8' } );
+
+		saveAs( blob, fileName );
+	}
+
+	function renderSubscriberList() {
+		const wording = getIntervalDependantWording( cancelledSubscriber );
+		return (
+			<div>
+				<SectionHeader label={ translate( 'Customers and Subscribers' ) } />
+				{ Object.values( subscribers ).length === 0 && (
+					<Card>
+						{ translate( "You haven't added any customers. {{a}}Learn more{{/a}} about payments.", {
+							components: {
+								a: (
+									<a
+										href={ localizeUrl(
+											'https://wordpress.com/support/wordpress-editor/blocks/payments/'
+										) }
+										target="_blank"
+										rel="noreferrer noopener"
+									/>
+								),
+							},
+						} ) }
+					</Card>
+				) }
+				{ Object.values( subscribers ).length > 0 && (
+					<Card>
+						<div className="memberships__module-content module-content">
+							<div>
+								{ orderBy( Object.values( subscribers ), [ 'id' ], [ 'desc' ] ).map( ( sub ) =>
+									renderSubscriber( sub )
+								) }
+							</div>
+							<InfiniteScroll nextPageMethod={ () => fetchNextSubscriberPage( false ) } />
+						</div>
+						<Dialog
+							isVisible={ !! cancelledSubscriber }
+							buttons={ [
+								{
+									label: translate( 'Back' ),
+									action: 'back',
+								},
+								{
+									label: wording.button,
+									isPrimary: true,
+									action: 'cancel',
+								},
+							] }
+							onClose={ onCloseCancelSubscription }
+						>
+							<h1>{ translate( 'Confirmation' ) }</h1>
+							<p>{ wording.confirmation_subheading }</p>
+							<Notice text={ wording.confirmation_info } showDismiss={ false } />
+						</Dialog>
+						<div className="memberships__module-footer">
+							<Button onClick={ downloadSubscriberList }>
+								{ translate( 'Download list as CSV' ) }
+							</Button>
+						</div>
+					</Card>
+				) }
+			</div>
+		);
+	}
+
+	function getIntervalDependantWording( subscriber: Subscriber | null ) {
+		const subscriber_email = subscriber?.user.user_email ?? '';
+		const plan_name = subscriber?.plan.title ?? '';
+
+		if ( subscriber?.plan?.renew_interval === 'one-time' ) {
+			return {
+				button: translate( 'Remove payment' ),
+				confirmation_subheading: translate( 'Do you want to remove this payment?' ),
+				confirmation_info: translate(
+					'Removing this payment means that the user %(subscriber_email)s will no longer have access to any service granted by the %(plan_name)s plan. The payment will not be refunded.',
+					{ args: { subscriber_email, plan_name } }
+				),
+				success: translate( 'Payment removed for %(subscriber_email)s.', {
+					args: { subscriber_email },
+				} ),
+			};
+		}
+		return {
+			button: translate( 'Cancel payment' ),
+			confirmation_subheading: translate( 'Do you want to cancel this payment?' ),
+			confirmation_info: translate(
+				'Cancelling this payment means that the user %(subscriber_email)s will no longer have access to any service granted by the %(plan_name)s plan. Payments already made will not be refunded but any scheduled future payments will not be made.',
+				{ args: { subscriber_email, plan_name } }
+			),
+			success: translate( 'Payment cancelled for %(subscriber_email)s.', {
+				args: { subscriber_email },
+			} ),
+		};
+	}
+
+	function renderSubscriberSubscriptionSummary( subscriber: Subscriber ) {
+		const title = subscriber.plan.title ? ` (${ subscriber.plan.title }) ` : ' ';
+		if ( subscriber.plan.renew_interval === 'one-time' ) {
+			/* translators: Information about a one-time payment made by a subscriber to a site owner.
+				%(amount)s - the amount paid,
+				%(formattedDate) - the date it was paid
+				%(title) - description of the payment plan, or a blank space if no description available. */
+			return translate( 'Paid %(amount)s once on %(formattedDate)s%(title)s', {
+				args: {
+					amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
+					formattedDate: moment( subscriber.start_date ).format( 'll' ),
+					title,
+				},
+			} );
+		} else if ( subscriber.plan.renew_interval === '1 year' ) {
+			/* translators: Information about a recurring yearly payment made by a subscriber to a site owner.
+				%(amount)s - the amount paid,
+				%(formattedDate)s - the date it was first paid
+				%(title)s - description of the payment plan, or a blank space if no description available
+				%(total)s - the total amount subscriber has paid thus far */
+			return translate(
+				'Paying %(amount)s/year%(title)ssince %(formattedDate)s. Total of %(total)s.',
+				{
+					args: {
+						amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
+						formattedDate: moment( subscriber.start_date ).format( 'll' ),
+						total: formatCurrency( subscriber.all_time_total, subscriber.plan.currency ),
+						title,
+					},
+				}
+			);
+		} else if ( subscriber.plan.renew_interval === '1 month' ) {
+			/* translators: Information about a recurring monthly payment made by a subscriber to a site owner.
+				%(amount)s - the amount paid,
+				%(formattedDate)s - the date it was first paid
+				%(title)s - description of the payment plan, or a blank space if no description available
+				%(total)s - the total amount subscriber has paid thus far */
+			return translate(
+				'Paying %(amount)s/month%(title)ssince %(formattedDate)s. Total of %(total)s.',
+				{
+					args: {
+						amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
+						formattedDate: moment( subscriber.start_date ).format( 'll' ),
+						total: formatCurrency( subscriber.all_time_total, subscriber.plan.currency ),
+						title,
+					},
+				}
+			);
+		}
+	}
+
+	function renderSubscriberActions( subscriber: Subscriber ) {
+		return (
+			<EllipsisMenu position="bottom left" className="memberships__subscriber-actions">
+				<PopoverMenuItem
+					target="_blank"
+					rel="noopener norefferer"
+					href={ `https://dashboard.stripe.com/search?query=metadata%3A${ subscriber.user.ID }` }
+				>
+					<Gridicon size={ 18 } icon="external" />
+					{ translate( 'See transactions in Stripe Dashboard' ) }
+				</PopoverMenuItem>
+				<PopoverMenuItem onClick={ () => setCancelledSubscriber( subscriber ) }>
+					<Gridicon size={ 18 } icon="cross" />
+					{ getIntervalDependantWording( subscriber ).button }
+				</PopoverMenuItem>
+			</EllipsisMenu>
+		);
+	}
+
+	function renderSubscriber( subscriber: Subscriber ) {
+		return (
+			<Card className="memberships__subscriber-profile is-compact" key={ subscriber.id }>
+				{ renderSubscriberActions( subscriber ) }
+				<div className="memberships__subscriber-gravatar">
+					<Gravatar user={ subscriber.user } size={ 72 } />
+				</div>
+				<div className="memberships__subscriber-detail">
+					<div className="memberships__subscriber-username">
+						{ decodeEntities( subscriber.user.name ) }
+					</div>
+					<div className="memberships__subscriber-email" data-e2e-login={ subscriber.user_email }>
+						<span>{ subscriber.user.user_email }</span>
+					</div>
+					<div className="memberships__subscriber-subscribed">
+						{ renderSubscriberSubscriptionSummary( subscriber ) }
+					</div>
+				</div>
+			</Card>
+		);
+	}
+
+	useEffect( () => {
+		fetchNextSubscriberPage( true );
+	}, [ fetchNextSubscriberPage ] );
+
+	if ( ! site ) {
+		return <LoadingEllipsis />;
+	}
+
+	return (
+		<div>
+			<QueryMembershipsEarnings siteId={ site.ID } />
+			<QueryMembershipsSettings siteId={ site.ID } />
+			<div>{ renderSubscriberList() }</div>
+		</div>
+	);
+}
+
+export default CustomerSection;

--- a/client/my-sites/earn/index.ts
+++ b/client/my-sites/earn/index.ts
@@ -6,6 +6,7 @@ import earnController from './controller';
 export default function () {
 	page( '/earn', siteSelection, sites, makeLayout, clientRender );
 	page( '/earn/stats', siteSelection, sites, makeLayout, clientRender );
+	page( '/earn/customers', siteSelection, sites, makeLayout, clientRender );
 	page( '/earn/payments', siteSelection, sites, makeLayout, clientRender );
 	// This is legacy, we are leaving it here because it may have been public
 	page(

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -17,6 +17,7 @@ import { useSelector } from 'calypso/state';
 import { canAccessWordAds, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import AdsWrapper from './ads/wrapper';
+import CustomerSection from './customers';
 import Home from './home';
 import MembershipsSection from './memberships';
 import MembershipsProductsSection from './memberships/products';
@@ -52,6 +53,11 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				title: translate( 'Tools' ),
 				path: '/earn' + pathSuffix,
 				id: 'earn',
+			},
+			{
+				title: translate( 'Customers' ),
+				path: '/earn/customers' + pathSuffix,
+				id: 'customers',
 			},
 			{
 				title: translate( 'Stats' ),
@@ -140,6 +146,9 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 
 			case 'stats':
 				return <StatsSection />;
+
+			case 'customers':
+				return <CustomerSection />;
 
 			case 'refer-a-friend':
 				return <ReferAFriendSection />;

--- a/client/my-sites/earn/memberships/index.tsx
+++ b/client/my-sites/earn/memberships/index.tsx
@@ -1,25 +1,17 @@
 import { Card, Button, Dialog, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { saveAs } from 'browser-filesaver';
 import { useTranslate } from 'i18n-calypso';
-import { orderBy } from 'lodash';
-import { useState, useEffect, useCallback, MouseEvent, ReactNode } from 'react';
-import { shallowEqual } from 'react-redux';
+import { useState, useEffect, useCallback, ReactNode } from 'react';
 import paymentsImage from 'calypso/assets/images/earn/payments-illustration.svg';
 import QueryMembershipProducts from 'calypso/components/data/query-memberships';
 import QueryMembershipsEarnings from 'calypso/components/data/query-memberships-earnings';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
-import EllipsisMenu from 'calypso/components/ellipsis-menu';
-import Gravatar from 'calypso/components/gravatar';
-import InfiniteScroll from 'calypso/components/infinite-scroll';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SectionHeader from 'calypso/components/section-header';
-import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
+import { preventWidows } from 'calypso/lib/formatting';
 import { userCan } from 'calypso/lib/site/utils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -30,14 +22,6 @@ import {
 	getConnectedAccountDescriptionForSiteId,
 	getConnectUrlForSiteId,
 } from 'calypso/state/memberships/settings/selectors';
-import {
-	requestSubscribers,
-	requestSubscriptionStop,
-} from 'calypso/state/memberships/subscribers/actions';
-import {
-	getTotalSubscribersForSiteId,
-	getOwnershipsForSiteId,
-} from 'calypso/state/memberships/subscribers/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import CommissionFees from '../components/commission-fees';
 import { Query } from '../types';
@@ -49,47 +33,13 @@ type MembershipsSectionProps = {
 	query?: Query;
 };
 
-type Subscriber = {
-	id: string;
-	status: string;
-	start_date: string;
-	end_date: string;
-	// appears as both subscriber.user_email & subscriber.user.user_email in this file
-	user_email: string;
-	user: {
-		ID: string;
-		name: string;
-		user_email: string;
-	};
-	plan: {
-		connected_account_product_id: string;
-		title: string;
-		renewal_price: number;
-		currency: string;
-		renew_interval: string;
-	};
-	renew_interval: string;
-	all_time_total: number;
-};
-
 function MembershipsSection( { query }: MembershipsSectionProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const moment = useLocalizedMoment();
 	const source = getSource();
-	const [ cancelledSubscriber, setCancelledSubscriber ] = useState< Subscriber | null >( null );
 	const [ disconnectedConnectedAccountId, setDisconnectedConnectedAccountId ] = useState( null );
 
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
-
-	const subscribers = useSelector(
-		( state ) => getOwnershipsForSiteId( state, site?.ID ),
-		shallowEqual
-	);
-
-	const totalSubscribers = useSelector( ( state ) =>
-		getTotalSubscribersForSiteId( state, site?.ID )
-	);
 
 	const connectedAccountId = useSelector( ( state ) =>
 		getConnectedAccountIdForSiteId( state, site?.ID )
@@ -166,16 +116,6 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 		);
 	}
 
-	const fetchNextSubscriberPage = useCallback(
-		( force: boolean ) => {
-			const fetched = Object.keys( subscribers ).length;
-			if ( fetched < totalSubscribers || force ) {
-				dispatch( requestSubscribers( site?.ID, fetched ) );
-			}
-		},
-		[ dispatch, site, subscribers, totalSubscribers ]
-	);
-
 	function onCloseDisconnectStripeAccount( reason: string | undefined ) {
 		if ( reason === 'disconnect' ) {
 			dispatch(
@@ -188,160 +128,6 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 			);
 		}
 		setDisconnectedConnectedAccountId( null );
-	}
-
-	function onCloseCancelSubscription( reason: string | undefined ) {
-		if ( reason === 'cancel' ) {
-			dispatch(
-				requestSubscriptionStop(
-					site?.ID,
-					cancelledSubscriber,
-					getIntervalDependantWording( cancelledSubscriber ).success
-				)
-			);
-		}
-		setCancelledSubscriber( null );
-	}
-
-	function downloadSubscriberList( event: MouseEvent< HTMLButtonElement > ) {
-		event.preventDefault();
-		const fileName = [ site?.slug, 'memberships', 'subscribers' ].join( '_' ) + '.csv';
-
-		const csvData = [
-			[
-				'ID',
-				'status',
-				'start_date',
-				'end_date',
-				'user_name',
-				'user_email',
-				'plan_id',
-				'plan_title',
-				'renewal_price',
-				'currency',
-				'renew_interval',
-				'All time total',
-			]
-				.map( ( field ) => '"' + field + '"' )
-				.join( ',' ),
-		]
-			.concat(
-				Object.values( subscribers ).map( ( row ) =>
-					[
-						row.id,
-						row.status,
-						row.start_date,
-						row.end_date,
-						row.user.name,
-						row.user.user_email,
-						row.plan.connected_account_product_id,
-						row.plan.title,
-						row.plan.renewal_price,
-						row.plan.currency,
-						row.renew_interval,
-						row.all_time_total,
-					]
-						.map( ( field ) => ( field ? '"' + field + '"' : '""' ) )
-						.join( ',' )
-				)
-			)
-			.join( '\n' );
-
-		const blob = new window.Blob( [ csvData ], { type: 'text/csv;charset=utf-8' } );
-
-		saveAs( blob, fileName );
-	}
-
-	function renderSubscriberList() {
-		const wording = getIntervalDependantWording( cancelledSubscriber );
-		return (
-			<div>
-				<SectionHeader label={ translate( 'Customers and Subscribers' ) } />
-				{ Object.values( subscribers ).length === 0 && (
-					<Card>
-						{ translate( "You haven't added any customers. {{a}}Learn more{{/a}} about payments.", {
-							components: {
-								a: (
-									<a
-										href={ localizeUrl(
-											'https://wordpress.com/support/wordpress-editor/blocks/payments/'
-										) }
-										target="_blank"
-										rel="noreferrer noopener"
-									/>
-								),
-							},
-						} ) }
-					</Card>
-				) }
-				{ Object.values( subscribers ).length > 0 && (
-					<Card>
-						<div className="memberships__module-content module-content">
-							<div>
-								{ orderBy( Object.values( subscribers ), [ 'id' ], [ 'desc' ] ).map( ( sub ) =>
-									renderSubscriber( sub )
-								) }
-							</div>
-							<InfiniteScroll nextPageMethod={ () => fetchNextSubscriberPage( false ) } />
-						</div>
-						<Dialog
-							isVisible={ !! cancelledSubscriber }
-							buttons={ [
-								{
-									label: translate( 'Back' ),
-									action: 'back',
-								},
-								{
-									label: wording.button,
-									isPrimary: true,
-									action: 'cancel',
-								},
-							] }
-							onClose={ onCloseCancelSubscription }
-						>
-							<h1>{ translate( 'Confirmation' ) }</h1>
-							<p>{ wording.confirmation_subheading }</p>
-							<Notice text={ wording.confirmation_info } showDismiss={ false } />
-						</Dialog>
-						<div className="memberships__module-footer">
-							<Button onClick={ downloadSubscriberList }>
-								{ translate( 'Download list as CSV' ) }
-							</Button>
-						</div>
-					</Card>
-				) }
-			</div>
-		);
-	}
-
-	function getIntervalDependantWording( subscriber: Subscriber | null ) {
-		const subscriber_email = subscriber?.user.user_email ?? '';
-		const plan_name = subscriber?.plan.title ?? '';
-
-		if ( subscriber?.plan?.renew_interval === 'one-time' ) {
-			return {
-				button: translate( 'Remove payment' ),
-				confirmation_subheading: translate( 'Do you want to remove this payment?' ),
-				confirmation_info: translate(
-					'Removing this payment means that the user %(subscriber_email)s will no longer have access to any service granted by the %(plan_name)s plan. The payment will not be refunded.',
-					{ args: { subscriber_email, plan_name } }
-				),
-				success: translate( 'Payment removed for %(subscriber_email)s.', {
-					args: { subscriber_email },
-				} ),
-			};
-		}
-		return {
-			button: translate( 'Cancel payment' ),
-			confirmation_subheading: translate( 'Do you want to cancel this payment?' ),
-			confirmation_info: translate(
-				'Cancelling this payment means that the user %(subscriber_email)s will no longer have access to any service granted by the %(plan_name)s plan. Payments already made will not be refunded but any scheduled future payments will not be made.',
-				{ args: { subscriber_email, plan_name } }
-			),
-			success: translate( 'Payment cancelled for %(subscriber_email)s.', {
-				args: { subscriber_email },
-			} ),
-		};
 	}
 
 	function renderManagePlans() {
@@ -430,104 +216,11 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 		);
 	}
 
-	function renderSubscriberSubscriptionSummary( subscriber: Subscriber ) {
-		const title = subscriber.plan.title ? ` (${ subscriber.plan.title }) ` : ' ';
-		if ( subscriber.plan.renew_interval === 'one-time' ) {
-			/* translators: Information about a one-time payment made by a subscriber to a site owner.
-				%(amount)s - the amount paid,
-				%(formattedDate) - the date it was paid
-				%(title) - description of the payment plan, or a blank space if no description available. */
-			return translate( 'Paid %(amount)s once on %(formattedDate)s%(title)s', {
-				args: {
-					amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
-					formattedDate: moment( subscriber.start_date ).format( 'll' ),
-					title,
-				},
-			} );
-		} else if ( subscriber.plan.renew_interval === '1 year' ) {
-			/* translators: Information about a recurring yearly payment made by a subscriber to a site owner.
-				%(amount)s - the amount paid,
-				%(formattedDate)s - the date it was first paid
-				%(title)s - description of the payment plan, or a blank space if no description available
-				%(total)s - the total amount subscriber has paid thus far */
-			return translate(
-				'Paying %(amount)s/year%(title)ssince %(formattedDate)s. Total of %(total)s.',
-				{
-					args: {
-						amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
-						formattedDate: moment( subscriber.start_date ).format( 'll' ),
-						total: formatCurrency( subscriber.all_time_total, subscriber.plan.currency ),
-						title,
-					},
-				}
-			);
-		} else if ( subscriber.plan.renew_interval === '1 month' ) {
-			/* translators: Information about a recurring monthly payment made by a subscriber to a site owner.
-				%(amount)s - the amount paid,
-				%(formattedDate)s - the date it was first paid
-				%(title)s - description of the payment plan, or a blank space if no description available
-				%(total)s - the total amount subscriber has paid thus far */
-			return translate(
-				'Paying %(amount)s/month%(title)ssince %(formattedDate)s. Total of %(total)s.',
-				{
-					args: {
-						amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
-						formattedDate: moment( subscriber.start_date ).format( 'll' ),
-						total: formatCurrency( subscriber.all_time_total, subscriber.plan.currency ),
-						title,
-					},
-				}
-			);
-		}
-	}
-
-	function renderSubscriberActions( subscriber: Subscriber ) {
-		return (
-			<EllipsisMenu position="bottom left" className="memberships__subscriber-actions">
-				<PopoverMenuItem
-					target="_blank"
-					rel="noopener norefferer"
-					href={ `https://dashboard.stripe.com/search?query=metadata%3A${ subscriber.user.ID }` }
-				>
-					<Gridicon size={ 18 } icon="external" />
-					{ translate( 'See transactions in Stripe Dashboard' ) }
-				</PopoverMenuItem>
-				<PopoverMenuItem onClick={ () => setCancelledSubscriber( subscriber ) }>
-					<Gridicon size={ 18 } icon="cross" />
-					{ getIntervalDependantWording( subscriber ).button }
-				</PopoverMenuItem>
-			</EllipsisMenu>
-		);
-	}
-
-	function renderSubscriber( subscriber: Subscriber ) {
-		return (
-			<Card className="memberships__subscriber-profile is-compact" key={ subscriber.id }>
-				{ renderSubscriberActions( subscriber ) }
-				<div className="memberships__subscriber-gravatar">
-					<Gravatar user={ subscriber.user } size={ 72 } />
-				</div>
-				<div className="memberships__subscriber-detail">
-					<div className="memberships__subscriber-username">
-						{ decodeEntities( subscriber.user.name ) }
-					</div>
-					<div className="memberships__subscriber-email" data-e2e-login={ subscriber.user_email }>
-						<span>{ subscriber.user.user_email }</span>
-					</div>
-					<div className="memberships__subscriber-subscribed">
-						{ renderSubscriberSubscriptionSummary( subscriber ) }
-					</div>
-				</div>
-			</Card>
-		);
-	}
-
 	function renderStripeConnected() {
 		return (
 			<div>
 				{ renderNotices() }
 				{ renderEarnings() }
-				{ renderSubscriberList() }
 				{ renderManagePlans() }
 				{ renderSettings() }
 			</div>
@@ -698,8 +391,7 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 
 	useEffect( () => {
 		navigateToLaunchpad();
-		fetchNextSubscriberPage( true );
-	}, [ fetchNextSubscriberPage, navigateToLaunchpad ] );
+	}, [ navigateToLaunchpad ] );
 
 	if ( ! userCan( 'manage_options', site ) ) {
 		return renderOnboarding(


### PR DESCRIPTION
## Proposed Changes

* Adds a new Customers tab and screen to the Earn area
* Moves all the code related to rendering customer/subscriber lists to this screen from membership/index, and deletes that code from the membership/index page. 
* This section should render exactly as it would have on the membership/index tab before. We're just moving it.

**Customers Screen: Without Customers**
<img width="1087" alt="earn-no-customers" src="https://github.com/Automattic/wp-calypso/assets/21228350/cdae6463-6981-490c-ab8a-3cd641e92fad">

**Customers Screen: With Customers**
<img width="1074" alt="earn-customers" src="https://github.com/Automattic/wp-calypso/assets/21228350/687ec413-f848-4021-9553-4d61a9726eae">

**Settings Screen: No Longer Has Customers Section**
<img width="1020" alt="earn-settings" src="https://github.com/Automattic/wp-calypso/assets/21228350/a46dda26-d66b-439a-8846-331894158547">


## Testing Instructions

1) Checkout this branch and go to http://calypso.localhost:3000/earn/YOURDOMAIN. Confirm you see the new Customers tab at the top. 
2) Click the customer tab and confirm it renders the customer list correctly as in screenshots above. It's worth being sure to test this on a site that has at least one active customer to confirm that loads as expected. 
3) Since a lot of code was moved from membership/index, also click around and test the payments/settings tab to confirm that works as before (except that customer list is no longer there). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?