### PR TITLE
Launchpad: Add the skip feature to the Videopress flow

### DIFF
--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { PlansSelect, SiteSelect } from '@automattic/data-stores';
+import { PlansSelect, SiteSelect, updateLaunchpadSettings } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, VIDEOPRESS_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -113,6 +113,8 @@ const videopress: Flow = {
 			setDomain( undefined );
 			setSelectedDesign( undefined );
 		};
+
+		const siteSlug = useSiteSlug();
 
 		const stepValidateUserIsLoggedIn = () => {
 			if ( ! userIsLoggedIn ) {
@@ -287,10 +289,13 @@ const videopress: Flow = {
 			return;
 		};
 
-		const goNext = () => {
+		const goNext = async () => {
 			switch ( _currentStep ) {
 				case 'launchpad':
-					return window.location.replace( `/view/${ siteId ?? _siteSlug }` );
+					if ( siteSlug ) {
+						await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );
+					}
+					return window.location.assign( `/home/${ siteId ?? siteSlug }` );
 
 				default:
 					return navigate( 'intro' );

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -122,6 +122,7 @@ export const setUpActionsForTasks = ( {
 					};
 					break;
 				case 'site_launched':
+				case 'videopress_launched':
 					action = async () => {
 						await wpcomRequest( {
 							path: `/sites/${ siteSlug }/launch`,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* D122233-code
* https://github.com/Automattic/jetpack/pull/33153

## Proposed Changes

* Adds the Skip feature to the Videopress flow. Skipping the fullscreen Launchpad will now redirect users to the Customer Home where the pre-launch Launchpad should be displayed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D122233-code to your sandbox
* Apply the Jetpack PR to your sandbox https://github.com/Automattic/jetpack/pull/33153
* Use the Calypso live below or run Calypso locally
* Navigate to `/setup/videopress/intro`
* Click on the `Showcase your work` card
* Go through the flow until you reach the Fullscreen Launchpad screen
* Click on the `Skip for now` link on the top right corner
* You should land on the Customer Home page and see the pre-launch Launchpad
* Click on the `Upload your first video` task
* You should be redirected to the editor.
* Upload a video and save the page
* Navigate back to the Customer Home
* The `Upload your first video`  should be marked as complete, and the `Launch site` task should be available
* Click on the `Launch site` task, your site should be launched and the task list should disappear from the Customer Home.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?