### PR TITLE
Earn: Add stats tab and screen

### DIFF
--- a/client/my-sites/earn/index.ts
+++ b/client/my-sites/earn/index.ts
@@ -5,6 +5,7 @@ import earnController from './controller';
 
 export default function () {
 	page( '/earn', siteSelection, sites, makeLayout, clientRender );
+	page( '/earn/stats', siteSelection, sites, makeLayout, clientRender );
 	page( '/earn/payments', siteSelection, sites, makeLayout, clientRender );
 	// This is legacy, we are leaving it here because it may have been public
 	page(

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -21,6 +21,7 @@ import Home from './home';
 import MembershipsSection from './memberships';
 import MembershipsProductsSection from './memberships/products';
 import ReferAFriendSection from './refer-a-friend';
+import StatsSection from './stats';
 import { Query } from './types';
 
 type EarningsMainProps = {
@@ -51,6 +52,11 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				title: translate( 'Tools' ),
 				path: '/earn' + pathSuffix,
 				id: 'earn',
+			},
+			{
+				title: translate( 'Stats' ),
+				path: '/earn/stats' + pathSuffix,
+				id: 'stats',
 			},
 			{
 				title: translate( 'Settings' ),
@@ -131,6 +137,9 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				return <MembershipsSection query={ query } />;
 			case 'payments-plans':
 				return <MembershipsProductsSection />;
+
+			case 'stats':
+				return <StatsSection />;
 
 			case 'refer-a-friend':
 				return <ReferAFriendSection />;

--- a/client/my-sites/earn/stats/index.tsx
+++ b/client/my-sites/earn/stats/index.tsx
@@ -1,0 +1,88 @@
+import { Card } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import QueryMembershipsEarnings from 'calypso/components/data/query-memberships-earnings';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import SectionHeader from 'calypso/components/section-header';
+import { useSelector } from 'calypso/state';
+import { getEarningsWithDefaultsForSiteId } from 'calypso/state/memberships/earnings/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import CommissionFees from '../components/commission-fees';
+
+function StatsSection() {
+	const translate = useTranslate();
+
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+
+	const {
+		commission,
+		currency,
+		forecast,
+		last_month: lastMonth,
+		total,
+	} = useSelector( ( state ) => getEarningsWithDefaultsForSiteId( state, site?.ID ) );
+
+	function renderEarnings() {
+		if ( ! site ) {
+			return <LoadingEllipsis />;
+		}
+
+		return (
+			<div>
+				<SectionHeader label={ translate( 'Earnings' ) } />
+				<QueryMembershipsEarnings siteId={ site.ID } />
+				<Card>
+					<div className="memberships__module-content module-content">
+						<ul className="memberships__earnings-breakdown-list">
+							<li className="memberships__earnings-breakdown-item">
+								<span className="memberships__earnings-breakdown-label">
+									{ translate( 'Total earnings', { context: 'Sum of earnings' } ) }
+								</span>
+								<span className="memberships__earnings-breakdown-value">
+									{ formatCurrency( total, currency ) }
+								</span>
+							</li>
+							<li className="memberships__earnings-breakdown-item">
+								<span className="memberships__earnings-breakdown-label">
+									{ translate( 'Last 30 days', { context: 'Sum of earnings over last 30 days' } ) }
+								</span>
+								<span className="memberships__earnings-breakdown-value">
+									{ formatCurrency( lastMonth, currency ) }
+								</span>
+							</li>
+							<li className="memberships__earnings-breakdown-item">
+								<span className="memberships__earnings-breakdown-label">
+									{ translate( 'Next month', {
+										context: 'Forecast for the subscriptions due in the next 30 days',
+									} ) }
+								</span>
+								<span className="memberships__earnings-breakdown-value">
+									{ formatCurrency( forecast, currency ) }
+								</span>
+							</li>
+						</ul>
+					</div>
+					<CommissionFees
+						commission={ commission }
+						iconSize={ 12 }
+						siteSlug={ site?.slug }
+						className="memberships__earnings-breakdown-notes"
+					/>
+				</Card>
+			</div>
+		);
+	}
+
+	if ( ! site ) {
+		return <LoadingEllipsis />;
+	}
+
+	return (
+		<div>
+			<QueryMembershipsEarnings siteId={ site.ID } />
+			<div>{ renderEarnings() }</div>
+		</div>
+	);
+}
+
+export default StatsSection;


### PR DESCRIPTION
## Proposed Changes

* Add 'Stats' tab and screen to earn page. 
* Moves all stats-related code from membership-index to the new file.
* Screen renders the same whether stripe is connected or not (just shows $0 earnings if stripe not connected).
* A follow up PR will remove the stats section from the Settings screen (memberships/index). I don't want to do it yet to avoid extensive merge conflicts with https://github.com/Automattic/wp-calypso/pull/81853, which adds Customers tab and already removes a lot of code from memberships/index.

**Stats Section**
<img width="1080" alt="stats" src="https://github.com/Automattic/wp-calypso/assets/21228350/2c75c985-0de2-4e05-9ee0-d91c92506411">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Checkout this branch and go to http://calypso.localhost:3000/earn/YOURDOMAIN. Confirm you see the new Stats tab at the top. 
2) Click the stats tab and confirm it renders the stats section correctly as in screenshots above. It would be good to check this on a site that actually has some stats (ie, earnings) to show to confirm it fetches and renders totals correctly.
3) Since a lot of code was moved from membership/index, also click around and test the payments/settings tab to confirm that works as before (except that customer list is no longer there). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?