### PR TITLE
Plugin: Add DotOrg download card for free plugins

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -1,3 +1,4 @@
+import { Button, Card, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import classnames from 'classnames';
@@ -304,6 +305,15 @@ function PluginDetails( props ) {
 		);
 	}
 
+	const downloadText = translate(
+		'This plugin is available for download to be used on your {{a}}WordPress self-hosted{{/a}} installation.',
+		{
+			components: {
+				a: <a href="https://wordpress.org" />,
+			},
+		}
+	);
+
 	return (
 		<MainComponent wideLayout>
 			<DocumentHead title={ getPageTitle() } />
@@ -391,10 +401,25 @@ function PluginDetails( props ) {
 					</div>
 
 					<div className="plugin-details__actions">
-						<PluginDetailsCTA plugin={ fullPlugin } isPlaceholder={ showPlaceholder } />
+						<div className="plugin-details__sidebar">
+							<PluginDetailsCTA plugin={ fullPlugin } isPlaceholder={ showPlaceholder } />
 
-						{ ! showPlaceholder && ! requestingPluginsForSites && (
-							<PluginDetailsSidebar plugin={ fullPlugin } />
+							{ ! showPlaceholder && ! requestingPluginsForSites && (
+								<PluginDetailsSidebar plugin={ fullPlugin } />
+							) }
+						</div>
+
+						{ ! showPlaceholder && ! requestingPluginsForSites && isWporgPluginFetched && (
+							<Card className="plugin-details-download-card">
+								<Gridicon icon="cloud-download" size={ 48 } />
+								<p>{ downloadText }</p>
+								<Button
+									href={ `https://downloads.wordpress.org/plugin/${ fullPlugin?.slug || '' }.zip` }
+									rel="nofollow"
+								>
+									{ translate( 'Download' ) }
+								</Button>
+							</Card>
 						) }
 					</div>
 				</div>

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -130,12 +130,20 @@ $calypso-header-height: 31px;
 	.plugin-details__actions {
 		position: relative;
 		grid-area: actions;
-		background-color: var(--studio-gray-0);
-		padding: 40px;
 		height: fit-content;
 
 		@include breakpoint-deprecated( "<1280px" ) {
 			margin-top: 40px;
+		}
+
+
+		.plugin-details__sidebar {
+			background-color: var(--studio-gray-0);
+			padding: 40px;
+		}
+
+		.plugin-details-download-card {
+			margin-top: 50px;
 		}
 	}
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -136,7 +136,6 @@ $calypso-header-height: 31px;
 			margin-top: 40px;
 		}
 
-
 		.plugin-details__sidebar {
 			background-color: var(--studio-gray-0);
 			padding: 40px;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/81685

## Proposed Changes

Add a card with a download button for DotOrg plugins.

| Desktop  | Mobile |
| ------------- | ------------- |
|![CleanShot 2023-09-18 at 17 37 50@2x](https://github.com/Automattic/wp-calypso/assets/5039531/ca053e8e-00f2-4631-b43f-f50a6e5f4ba1)|![CleanShot 2023-09-18 at 17 38 51@2x](https://github.com/Automattic/wp-calypso/assets/5039531/1539485a-0a37-4b9a-9f98-2daf84eff8b5)|

## Testing Instructions

* Go to a DotOrg plugin page `/plugin/:plugin_slug.` Ex: `/plugins/woocommerce/`
* You should see a card with a download button for the plugin
* Click on the button and the plugin zip file should be downloaded
* Go to a paid plugin page. Ex: `/plugins/woocommerce-subscriptions/`
* You should NOT see the card

PS: Check if the mobile design works well
PS2: Check in incognito mode and the card should behave similarly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
