### PR TITLE
Allow subdomain forwarding for primary domain

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -306,6 +306,23 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 			return;
 		}
 
+		const newNoticeText =
+			"This domain is your site's main address. You can forward subdomains or {{a}}set a new primary site address{{/a}} to forward the root domain.";
+
+		let noticeText;
+		if ( hasTranslation( newNoticeText ) || isEnglishLocale ) {
+			noticeText = translate(
+				"This domain is your site's main address. You can forward subdomains or {{a}}set a new primary site address{{/a}} to forward the root domain.",
+				{
+					components: {
+						a: <a href={ `/domains/manage/${ domain.domain }` } />,
+					},
+				}
+			);
+		} else {
+			return;
+		}
+
 		return (
 			<div className="domain-forwarding-card-notice">
 				<Icon
@@ -314,17 +331,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 					className="domain-forwarding-card-notice__icon gridicon"
 					viewBox="2 2 20 20"
 				/>
-				<div className="domain-forwarding-card-notice__message">
-					{ translate(
-						'Domains set as the {{strong}}primary site address{{/strong}} can not be forwarded. To forward this domain, please {{a}}set a new primary site address{{/a}}.',
-						{
-							components: {
-								strong: <strong />,
-								a: <a href={ `/domains/manage/${ domain.domain }` } />,
-							},
-						}
-					) }
-				</div>
+				<div className="domain-forwarding-card-notice__message">{ noticeText }</div>
 			</div>
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -55,6 +55,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 	const pointsToWpcom = domain.pointsToWpcom;
 	const isDomainOnly = useSelector( ( state ) => isDomainOnlySite( state, domain.blogId ) );
+	const isPrimaryDomain = domain?.isPrimary && ! isDomainOnly;
 	const protocol = 'https';
 
 	// Display success notices when the forwarding is updated
@@ -131,7 +132,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 		// By default, the interface already opens with domain forwarding addition
 		if ( data?.length === 0 ) {
 			setEditingId( -1 );
-			setSourceType( 'domain' );
+			setSourceType( isPrimaryDomain ? 'subdomain' : 'domain' );
 		}
 	}, [ isLoading, data ] );
 
@@ -356,10 +357,8 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 		return false;
 	};
 
-	const isDomainForwardDisabled = ( domain?.isPrimary && ! isDomainOnly ) || ! pointsToWpcom;
-
 	const FormViewRow = ( { child: child }: { child: DomainForwardingObject } ) => (
-		<FormFieldset disabled={ isDomainForwardDisabled } className="domain-forwarding-card__fields">
+		<FormFieldset disabled={ ! pointsToWpcom } className="domain-forwarding-card__fields">
 			<div className="domain-forwarding-card__fields-row">
 				<div className="domain-forwarding-card__fields-column">
 					<Badge type={ child.subdomain === '' ? 'warning' : 'info' }>
@@ -403,7 +402,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 		<>
 			<FormFieldset
 				key={ child.domain_redirect_id }
-				disabled={ isDomainForwardDisabled }
+				disabled={ ! pointsToWpcom }
 				className="domain-forwarding-card__fields"
 			>
 				<FormLabel>{ translate( 'Source URL' ) }</FormLabel>
@@ -428,7 +427,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 									name="redirect_type"
 									value={ sourceType }
 									onChange={ handleDomainSubdomainChange }
-									disabled={ isLoading }
+									disabled={ isLoading || isPrimaryDomain }
 								>
 									<option value="domain">{ translate( 'Domain' ) }</option>
 									<option value="subdomain">{ translate( 'Subdomain' ) }</option>
@@ -450,7 +449,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 						maxLength={ 1000 }
 						suffix={
 							child.target_host + child.target_path !== '' &&
-							! isDomainForwardDisabled && (
+							pointsToWpcom && (
 								<Button className="forwarding__clear" onClick={ cleanForwardingInput }>
 									<Gridicon icon="cross" />
 								</Button>
@@ -459,10 +458,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 					/>
 					<Button
 						className={ classNames( 'forwarding__checkmark', {
-							visible:
-								! isDomainForwardDisabled &&
-								isValidUrl &&
-								child.target_host + child.target_path !== '',
+							visible: pointsToWpcom && isValidUrl && child.target_host + child.target_path !== '',
 						} ) }
 					>
 						<Gridicon icon="checkmark" />
@@ -560,7 +556,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 				<div>
 					<FormButton
 						disabled={
-							isDomainForwardDisabled ||
+							! pointsToWpcom ||
 							! isValidUrl ||
 							isLoading ||
 							( forwarding && ! redirectHasChanged( child ) ) ||


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3787

## Proposed Changes

* We do not allow domain forwarding when a domain is the primary site address. However, we can allow subdomain forwarding on the site's primary domain. This PR allows for subdomain forwarding on the domain forwarding UI.
* This PR also adds a new notice on primary domains if the translation exists. If the translation doesn't exist yet, it shows no warning at all. This is because the old warning seems confusing since subdomains are now allowed.

New warning.
<img width="698" alt="Screenshot 2023-09-18 at 5 28 42 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/c17e834a-0151-46dd-9e15-73a29bce34d9">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D122270-code to your sandbox API
* Load this PR
* On a test site with a primary domain, try adding a subdomain forwarding rule.
* Ensure it works.
* Test non-primary domains to ensure there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?