### PR TITLE
Stats: remove feature flag `stats/paid-stats`

### DIFF
--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -51,10 +51,9 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 				! isOwnedByTeam51;
 
 			// Show the notice if the site is Jetpack or it is Odyssey Stats.
-			const showUpgradeNoticeOnOdyssey = config.isEnabled( 'stats/paid-stats' ) && isOdysseyStats;
+			const showUpgradeNoticeOnOdyssey = isOdysseyStats;
 
-			const showUpgradeNoticeForJetpackNotAtomic =
-				config.isEnabled( 'stats/paid-stats' ) && isSiteJetpackNotAtomic;
+			const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
 
 			return !! (
 				( showUpgradeNoticeOnOdyssey ||
@@ -90,10 +89,9 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 				! isOwnedByTeam51;
 
 			// Show the notice if the site is Jetpack or it is Odyssey Stats.
-			const showUpgradeNoticeOnOdyssey = config.isEnabled( 'stats/paid-stats' ) && isOdysseyStats;
+			const showUpgradeNoticeOnOdyssey = isOdysseyStats;
 
-			const showUpgradeNoticeForJetpackNotAtomic =
-				config.isEnabled( 'stats/paid-stats' ) && isSiteJetpackNotAtomic;
+			const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
 
 			return !! (
 				( showUpgradeNoticeOnOdyssey ||

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -12,7 +12,7 @@ const getStatsPurchaseURL = (
 	hasFreeStats = false
 ) => {
 	const from = isOdysseyStats ? 'jetpack' : 'calypso';
-	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/paid-stats,stats/paid-wpcom-stats&from=${ from }-stats-upgrade-notice${
+	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/paid-wpcom-stats&from=${ from }-stats-upgrade-notice${
 		hasFreeStats ? '&productType=personal' : ''
 	}`;
 	if ( ! isOdysseyStats ) {

--- a/config/client.json
+++ b/config/client.json
@@ -25,7 +25,6 @@
 	"signup_url",
 	"stats/new-video-summary",
 	"stats/subscribers-chart-section",
-	"stats/paid-stats",
 	"stats/paid-wpcom-stats",
 	"stats/type-detection",
 	"wpcom_concierge_schedule_id",

--- a/config/development.json
+++ b/config/development.json
@@ -185,7 +185,6 @@
 		"ssr/prefetch-timebox": false,
 		"stats/new-video-summary": true,
 		"stats/subscribers-chart-section": false,
-		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -119,7 +119,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
-		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,

--- a/config/production.json
+++ b/config/production.json
@@ -148,7 +148,6 @@
 		"ssr/sample-log-cache-misses": true,
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
-		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -144,7 +144,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
-		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,

--- a/config/test.json
+++ b/config/test.json
@@ -100,7 +100,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
-		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -152,7 +152,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
-		"stats/paid-stats": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,


### PR DESCRIPTION
## Proposed Changes

Paid Stats has been launched for a while now, let's remove the feature flag to cleanup.

## Testing Instructions

* Open Calypso Live for a Jetpack site without any paid Stats subscription
* Ensure you see the upgrade notice
* Open Odyssey Stats for the site
* Ensure you see the upgrade notice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
