### PR TITLE
Link to an article on the differences between .org and .com

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -309,7 +309,7 @@ function PluginDetails( props ) {
 		'This plugin is available for download to be used on your {{a}}WordPress self-hosted{{/a}} installation.',
 		{
 			components: {
-				a: <a href="https://wordpress.org/documentation/article/wordpress-org-and-wordpress-com/" />,
+				a: <a href="https://wordpress.com/go/website-building/wordpress-com-vs-wordpress-org/" />,
 			},
 		}
 	);

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -309,7 +309,7 @@ function PluginDetails( props ) {
 		'This plugin is available for download to be used on your {{a}}WordPress self-hosted{{/a}} installation.',
 		{
 			components: {
-				a: <a href="https://wordpress.org" />,
+				a: <a href="https://wordpress.org/documentation/article/wordpress-org-and-wordpress-com/" />,
 			},
 		}
 	);


### PR DESCRIPTION
## Proposed Changes
(just a quick suggestion!)
* Update the link for the phrase "[WordPress self-hosted](https://wordpress.org/)" from `wordpress.org` to a support article on `wordpress.org` that explains the difference between self-hosted WordPress and WordPress.com. Alternatively, you could also link to the WordPress.com explanation: [https://wordpress.org/documentation/article/wordpress-org-and-wordpress-com/.](https://wordpress.com/go/website-building/wordpress-com-vs-wordpress-org/)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
