### PR TITLE
Domain management: Introduce 'Change your site address' action

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -58,7 +58,7 @@ export class SiteAddressChanger extends Component {
 		this.props.clearValidationError( this.props.siteId );
 	}
 
-	onConfirm = () => {
+	onConfirm = async () => {
 		const { domainFieldValue, newDomainSuffix } = this.state;
 		const { currentDomain, currentDomainSuffix, siteId } = this.props;
 		const oldDomain = get( currentDomain, 'name', null );
@@ -67,13 +67,15 @@ export class SiteAddressChanger extends Component {
 				? freeSiteAddressType.BLOG
 				: freeSiteAddressType.MANAGED;
 
-		this.props.requestSiteAddressChange(
+		await this.props.requestSiteAddressChange(
 			siteId,
 			domainFieldValue,
 			newDomainSuffix.substr( 1 ),
 			oldDomain,
 			type
 		);
+
+		this.props.onSiteAddressChanged?.();
 	};
 
 	setValidationState = () => {

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -36,6 +36,7 @@ export class SiteAddressChanger extends Component {
 		currentDomainSuffix: PropTypes.string.isRequired,
 		currentDomain: PropTypes.object.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
+		onSiteAddressChanged: PropTypes.func,
 
 		// `connect`ed
 		isSiteAddressChangeRequesting: PropTypes.bool,

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -1,10 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
-import { DomainsTable } from '@automattic/domains-table';
+import { DomainsTable, ResponseDomain } from '@automattic/domains-table';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
+import SiteAddressChanger from 'calypso/blocks/site-address-changer';
 import { UsePresalesChat } from 'calypso/components/data/domain-management';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
@@ -69,6 +70,9 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 
 	const buttons = [ <OptionsDomainButton key="breadcrumb_button_1" specificSiteActions /> ];
 
+	const [ changeSiteAddressSourceDomain, setChangeSiteAddressSourceDomain ] =
+		useState< ResponseDomain | null >( null );
+
 	return (
 		<>
 			<PageViewTracker path={ props.analyticsPath } title={ props.analyticsTitle } />
@@ -104,6 +108,10 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 								dispatch( showUpdatePrimaryDomainErrorNotice( ( error as Error ).message ) );
 							}
 						}
+
+						if ( action === 'change-site-address' ) {
+							setChangeSiteAddressSourceDomain( domain );
+						}
 					} }
 				/>
 				{ ! isMobile && (
@@ -118,6 +126,15 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 						) }
 						<ManageAllDomainsCTA shouldDisplaySeparator={ false } />
 					</>
+				) }
+				{ changeSiteAddressSourceDomain && (
+					<SiteAddressChanger
+						currentDomain={ changeSiteAddressSourceDomain }
+						currentDomainSuffix={ changeSiteAddressSourceDomain.name.match( /\.\w+\.\w+$/ )?.[ 0 ] }
+						isDialogVisible
+						onClose={ () => setChangeSiteAddressSourceDomain( null ) }
+						onSiteAddressChanged={ () => refetch() }
+					/>
 				) }
 			</Main>
 			<UsePresalesChat />

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
@@ -67,6 +67,7 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 								site?.plan?.features.active.includes( FEATURE_SET_PRIMARY_CUSTOM_DOMAIN ) ?? false
 							}
 							isSiteOnFreePlan={ site?.plan?.is_free ?? true }
+							isSimpleSite={ ! site?.is_wpcom_atomic }
 						/>
 					) }
 				</div>

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -18,7 +18,7 @@ import { shouldUpgradeToMakeDomainPrimary } from '../utils/should-upgrade-to-mak
 import { ResponseDomain } from '../utils/types';
 import { useDomainsTable } from './domains-table';
 
-export type DomainAction = 'manage-dns-settings' | 'set-primary';
+export type DomainAction = 'change-site-address' | 'manage-dns-settings' | 'set-primary';
 
 interface MenuItemLinkProps extends Omit< React.ComponentProps< typeof MenuItem >, 'href' > {
 	href?: string;
@@ -32,6 +32,7 @@ interface DomainsTableRowActionsProps {
 	isAllSitesView: boolean;
 	canSetPrimaryDomainForSite: boolean;
 	isSiteOnFreePlan: boolean;
+	isSimpleSite: boolean;
 }
 
 export const DomainsTableRowActions = ( {
@@ -40,6 +41,7 @@ export const DomainsTableRowActions = ( {
 	isAllSitesView,
 	canSetPrimaryDomainForSite,
 	isSiteOnFreePlan,
+	isSimpleSite,
 }: DomainsTableRowActionsProps ) => {
 	const { onDomainAction, userCanSetPrimaryDomains = false } = useDomainsTable();
 	const { __ } = useI18n();
@@ -68,6 +70,7 @@ export const DomainsTableRowActions = ( {
 		domain.pointsToWpcom;
 	const canTransferToWPCOM =
 		domain.type === domainTypes.MAPPED && domain.isEligibleForInboundTransfer;
+	const canChangeSiteAddress = ! isAllSitesView && isSimpleSite;
 
 	const getActions = ( onClose?: () => void ) => {
 		return [
@@ -109,6 +112,16 @@ export const DomainsTableRowActions = ( {
 			canConnectDomainToASite && (
 				<MenuItemLink href={ domainManagementTransferToOtherSiteLink( siteSlug, domain.domain ) }>
 					{ __( 'Connect to an existing site' ) }
+				</MenuItemLink>
+			),
+			canChangeSiteAddress && (
+				<MenuItemLink
+					onClick={ () => {
+						onDomainAction?.( 'change-site-address', domain );
+						onClose?.();
+					} }
+				>
+					{ __( 'Change site address' ) }
 				</MenuItemLink>
 			),
 		];

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -175,6 +175,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 										false
 									}
 									isSiteOnFreePlan={ site?.plan?.is_free ?? true }
+									isSimpleSite={ ! site?.is_wpcom_atomic }
 								/>
 							) }
 						</td>


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3814.

## Proposed Changes

Adds the "Change your site address" to the kebab menu when the user is browsing the site-specific table of a simple site.

https://github.com/Automattic/wp-calypso/assets/26530524/7bd538ee-b8f8-42c7-aaaf-b6ae46ea9917

## Testing Instructions

1. Open `/domains/manage/%s` in a simple site and verify that it's possible to change the site address
2. Change it and check that the site URL changes, along with the site address in the table and the URL
3. Verify that the option to change the site address does not show up in Atomic sites (i.e., `.wpcomstaging.com` URLs)