### PR TITLE
Site Monitoring: Tweak spelling to 'Web Server Logs'

### DIFF
--- a/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/index.tsx
@@ -11,7 +11,7 @@ import './style.scss';
 export const tabs = [
 	{ name: 'metrics', title: __( 'Metrics' ) },
 	{ name: 'php', title: __( 'PHP Logs' ) },
-	{ name: 'web', title: __( 'Webserver Logs' ) },
+	{ name: 'web', title: __( 'Web Server Logs' ) },
 ];
 
 interface SiteMonitoringTabPanelProps {


### PR DESCRIPTION
## Proposed Changes

'Webserver' isn't a thing, but 'Web Server' is.

<img width="623" alt="CleanShot 2023-09-18 at 16 33 23@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/c0eeca4e-4547-4012-90d1-2f7aa85aa00f">

## Testing Instructions

1. Navigate to `/site-monitoring/<site>`.
2. Verify the label appears as expected.