### PR TITLE
Domain management: Implement sticky header

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -50,8 +50,8 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 	return (
 		<>
 			<PageViewTracker path={ props.analyticsPath } title={ props.analyticsTitle } />
-			<Main className="bulk-domains-main">
-				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
+			<Main>
+				<BodySectionCssClass bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page' ] } />
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
 				<DomainsTable
 					isFetchingDomains={ isLoading }

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -72,8 +72,8 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 	return (
 		<>
 			<PageViewTracker path={ props.analyticsPath } title={ props.analyticsTitle } />
-			<Main className="bulk-domains-main">
-				<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
+			<Main>
+				<BodySectionCssClass bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page' ] } />
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
 				<DomainsTable
 					isFetchingDomains={ isLoading }

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -349,6 +349,12 @@
 }
 
 // Custom layout width for the bulk domains pages
-.main.bulk-domains-main {
-	max-width: 1224px;
+.is-bulk-domains-page {
+	.layout__content {
+		overflow: unset;
+	}
+
+	main {
+		max-width: 1224px;
+	}
 }

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -2,7 +2,7 @@
 @import "@automattic/onboarding/styles/mixins";
 
 @media ( max-width: 480px ) {
-	.bulk-domains-main {
+	.is-bulk-domains-page main {
 		overflow-y: hidden;
 		/*
 		 * The 47px value comes from https://github.com/Automattic/wp-calypso/blob/d7e2ada/client/my-sites/sidebar/style.scss#L751.
@@ -32,7 +32,7 @@
 	--domains-table-toolbar-height: 40px;
 
 	table {
-		margin-top: 30px;
+		margin-top: 14px; /* 30px - 16px of the table heading padding */
 		border-collapse: collapse;
 
 		tr {
@@ -40,8 +40,15 @@
 		}
 	}
 
+	thead {
+		position: sticky;
+		top: var(--masterbar-height);
+		background: var(--color-surface-backdrop);
+		z-index: 9999;
+	}
+
 	th {
-		padding-bottom: 16px;
+		padding: 16px 0;
 		color: var(--studio-gray-60);
 		vertical-align: middle;
 		font-size: $font-body-small;


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3742.

## Proposed Changes

Title.

<img width="1031" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/c1bce00a-1312-450f-8518-e8c01f02374b">

## Testing Instructions

Open `/domains/manage` and go loco!