### PR TITLE
Earn: Remove stats from payments screen

### DIFF
--- a/client/my-sites/earn/memberships/index.tsx
+++ b/client/my-sites/earn/memberships/index.tsx
@@ -1,11 +1,9 @@
 import { Card, Button, Dialog, Gridicon } from '@automattic/components';
-import formatCurrency from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useCallback, ReactNode } from 'react';
 import paymentsImage from 'calypso/assets/images/earn/payments-illustration.svg';
 import QueryMembershipProducts from 'calypso/components/data/query-memberships';
-import QueryMembershipsEarnings from 'calypso/components/data/query-memberships-earnings';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Notice from 'calypso/components/notice';
@@ -49,13 +47,9 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 	);
 	const connectUrl: string = useSelector( ( state ) => getConnectUrlForSiteId( state, site?.ID ) );
 
-	const {
-		commission,
-		currency,
-		forecast,
-		last_month: lastMonth,
-		total,
-	} = useSelector( ( state ) => getEarningsWithDefaultsForSiteId( state, site?.ID ) );
+	const { commission } = useSelector( ( state ) =>
+		getEarningsWithDefaultsForSiteId( state, site?.ID )
+	);
 
 	const navigateToLaunchpad = useCallback( () => {
 		const shouldGoToLaunchpad = query?.stripe_connect_success === 'launchpad';
@@ -64,57 +58,6 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 			window.location.assign( `/setup/${ siteIntent }/launchpad?siteSlug=${ site?.slug }` );
 		}
 	}, [ query, site ] );
-
-	function renderEarnings() {
-		if ( ! site ) {
-			return <LoadingEllipsis />;
-		}
-
-		return (
-			<div>
-				<SectionHeader label={ translate( 'Earnings' ) } />
-				<QueryMembershipsEarnings siteId={ site.ID } />
-				<Card>
-					<div className="memberships__module-content module-content">
-						<ul className="memberships__earnings-breakdown-list">
-							<li className="memberships__earnings-breakdown-item">
-								<span className="memberships__earnings-breakdown-label">
-									{ translate( 'Total earnings', { context: 'Sum of earnings' } ) }
-								</span>
-								<span className="memberships__earnings-breakdown-value">
-									{ formatCurrency( total, currency ) }
-								</span>
-							</li>
-							<li className="memberships__earnings-breakdown-item">
-								<span className="memberships__earnings-breakdown-label">
-									{ translate( 'Last 30 days', { context: 'Sum of earnings over last 30 days' } ) }
-								</span>
-								<span className="memberships__earnings-breakdown-value">
-									{ formatCurrency( lastMonth, currency ) }
-								</span>
-							</li>
-							<li className="memberships__earnings-breakdown-item">
-								<span className="memberships__earnings-breakdown-label">
-									{ translate( 'Next month', {
-										context: 'Forecast for the subscriptions due in the next 30 days',
-									} ) }
-								</span>
-								<span className="memberships__earnings-breakdown-value">
-									{ formatCurrency( forecast, currency ) }
-								</span>
-							</li>
-						</ul>
-					</div>
-					<CommissionFees
-						commission={ commission }
-						iconSize={ 12 }
-						siteSlug={ site?.slug }
-						className="memberships__earnings-breakdown-notes"
-					/>
-				</Card>
-			</div>
-		);
-	}
 
 	function onCloseDisconnectStripeAccount( reason: string | undefined ) {
 		if ( reason === 'disconnect' ) {
@@ -220,7 +163,6 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 		return (
 			<div>
 				{ renderNotices() }
-				{ renderEarnings() }
 				{ renderManagePlans() }
 				{ renderSettings() }
 			</div>
@@ -409,7 +351,6 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 
 	return (
 		<div>
-			<QueryMembershipsEarnings siteId={ site.ID } />
 			<QueryMembershipsSettings siteId={ site.ID } source={ source } />
 			{ connectedAccountId && renderStripeConnected() }
 			{ connectUrl && renderConnectStripe() }


### PR DESCRIPTION
## Proposed Changes

* Removes the stats section from the Earn > Payments screen. This is a follow up to https://github.com/Automattic/wp-calypso/pull/81855, which created a new screen to hold stats. 

<img width="986" alt="settings-no-earnings" src="https://github.com/Automattic/wp-calypso/assets/21228350/882a70d5-a2d9-4d09-8044-bf5751b4f868">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Checkout this branch and go to http://calypso.localhost:3000/earn/YOURDOMAIN. 
2) Click the Settings tab and confirm the earning stats no longer show there. Since we've removed code from this screen, also just confirm the screen generally loads and works as expected. 
3) Click the Stats tab to confirm the earns stats do now show there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?