### PR TITLE
Remove: Back button from the domain details page

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/main-placeholder.scss
+++ b/client/my-sites/domains/domain-management/components/domain/main-placeholder.scss
@@ -19,3 +19,7 @@
 		}
 	}
 }
+
+.is-mobile-app-view .domain__main-placeholder .breadcrumbs-back {
+	display: none;
+}

--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -184,3 +184,7 @@ body.edit__body-white.theme-default.color-scheme {
 		}
 	}
 }
+
+.is-mobile-app-view .domain-settings-page .breadcrumbs-back {
+	display: none;
+}


### PR DESCRIPTION
This PR addresses the change requested in pcdRpT-3PI-p2 to hide the back button in the mobile app.

## Proposed Changes

* Use CSS to remove the back button from the app when on the Domain details screen and the placeholder loading screen. 

Before:
<img width="400" alt="Screenshot 2023-09-18 at 4 45 57 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/4f769268-3852-4898-a725-d60b46f0c53b">


After:
Placeholder (no back button)
<img width="400" alt="Screenshot 2023-09-18 at 4 09 00 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/6b567ae0-5bf8-4cdb-98d7-d4b88261d5b6">
Loaded view (notice no back button)
<img width="400" alt="Screenshot 2023-09-18 at 4 09 27 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/ed58783d-bab8-48c6-94e3-b9fad29c5a42">

## Testing Instructions

Visit the domain details screen (**/domains/manage/example.ca/edit/example.ca**) by going using the user agent such as:
Make a web request with a user agent such as (which is similar to the iOS app) 
`Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 wp-iphone`


Notice that you don't see the domain details screen. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?