### PR TITLE
Earn: Convert jsdoc to TypeScript types

### DIFF
--- a/client/components/promo-section/index.tsx
+++ b/client/components/promo-section/index.tsx
@@ -5,7 +5,7 @@ import type { Props as PromoCardCtaProps } from './promo-card/cta';
 import type { TranslateResult } from 'i18n-calypso';
 import type { FunctionComponent } from 'react';
 
-interface PromoSectionCardProps extends PromoCardProps {
+export interface PromoSectionCardProps extends PromoCardProps {
 	body: string | TranslateResult;
 	actions?: PromoCardCtaProps;
 }

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -47,11 +47,6 @@ type DefaultNames = {
  * Return the minimum transaction amount for a currency.
  * If the defaultCurrency is not the same as the current currency, return the double, in order to prevent issues with Stripe minimum amounts
  * See https://wp.me/p81Rsd-1hN
- *
- * @param {StripeMinimumCurrencyAmounts} currency_min - Minimum transaction amount for each currency.
- * @param {string} currency - Currency.
- * @param {string} connectedAccountDefaultCurrency - Default currency of the current account
- * @returns {number} Minimum transaction amount for given currency.
  */
 function minimumCurrencyTransactionAmount(
 	currency_min: StripeMinimumCurrencyAmounts,

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -16,7 +16,10 @@ import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import QueryMembershipsEarnings from 'calypso/components/data/query-memberships-earnings';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
 import EmptyContent from 'calypso/components/empty-content';
-import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
+import PromoSection, {
+	Props as PromoSectionProps,
+	PromoSectionCardProps,
+} from 'calypso/components/promo-section';
 import { CtaButton } from 'calypso/components/promo-section/promo-card/cta';
 import wp from 'calypso/lib/wp';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
@@ -139,10 +142,8 @@ const Home = () => {
 
 	/**
 	 * Return the content to display in the Simple Payments card based on the current plan.
-	 *
-	 * @returns {Object} Object with props to render a PromoCard.
 	 */
-	const getSimplePaymentsCard = () => {
+	const getSimplePaymentsCard = (): PromoSectionCardProps => {
 		const supportLink = localizeUrl(
 			'https://wordpress.com/support/wordpress-editor/blocks/pay-with-paypal/'
 		);
@@ -192,10 +193,8 @@ const Home = () => {
 
 	/**
 	 * Return the content to display in the Recurring Payments card based on the current plan.
-	 *
-	 * @returns {Object} Object with props to render a PromoCard.
 	 */
-	const getRecurringPaymentsCard = () => {
+	const getRecurringPaymentsCard = (): PromoSectionCardProps => {
 		const hasConnectionCtaTitle = translate( 'Manage Payment Button' );
 		const noConnectionCtaTitle = translate( 'Enable Payment Button' );
 		const ctaTitle = hasConnectedAccount ? hasConnectionCtaTitle : noConnectionCtaTitle;
@@ -245,10 +244,8 @@ const Home = () => {
 
 	/**
 	 * Return the content to display in the Donations card based on the current plan.
-	 *
-	 * @returns {Object} Object with props to render a PromoCard.
 	 */
-	const getDonationsCard = () => {
+	const getDonationsCard = (): PromoSectionCardProps => {
 		const hasConnectionCtaTitle = translate( 'Manage Donations Form' );
 		const noConnectionCtaTitle = translate( 'Enable Donations Form' );
 		const ctaTitle = hasConnectedAccount ? hasConnectionCtaTitle : noConnectionCtaTitle;
@@ -298,10 +295,8 @@ const Home = () => {
 
 	/**
 	 * Return the content to display in the Premium Content Block card based on the current plan.
-	 *
-	 * @returns {Object | undefined} Object with props to render a PromoCard.
 	 */
-	const getPremiumContentCard = () => {
+	const getPremiumContentCard = (): PromoSectionCardProps | undefined => {
 		const hasConnectionCtaTitle = translate( 'Manage Premium Content' );
 		const noConnectionCtaTitle = translate( 'Enable Premium Content' );
 		const ctaTitle = hasConnectedAccount ? hasConnectionCtaTitle : noConnectionCtaTitle;
@@ -328,7 +323,7 @@ const Home = () => {
 				'https://wordpress.com/support/wordpress-editor/blocks/premium-content-block/'
 			),
 			onClick: () => trackLearnLink( 'premium-content' ),
-			label: hasConnectedAccount ? translate( 'Support documentation' ) : null,
+			label: hasConnectedAccount ? translate( 'Support documentation' ) : undefined,
 		};
 
 		return {
@@ -344,10 +339,8 @@ const Home = () => {
 
 	/**
 	 * Return the content to display in the Paid Newsletter card based on the current plan.
-	 *
-	 * @returns {Object | undefined} Object with props to render a PromoCard.
 	 */
-	const getPaidNewsletterCard = () => {
+	const getPaidNewsletterCard = (): PromoSectionCardProps | undefined => {
 		if ( isNonAtomicJetpack ) {
 			return;
 		}
@@ -377,10 +370,8 @@ const Home = () => {
 
 	/**
 	 * Return the content to display in the Peer Referrals card.
-	 *
-	 * @returns {Object | undefined} Object with props to render a PromoCard.
 	 */
-	const getPeerReferralsCard = () => {
+	const getPeerReferralsCard = (): PromoSectionCardProps | undefined => {
 		if ( isNonAtomicJetpack ) {
 			return;
 		}
@@ -426,15 +417,8 @@ const Home = () => {
 
 	/**
 	 * Return the content to display in the Ads card based on the current plan.
-	 *
-	 * @returns {Object} Object with props to render a PromoCard.
 	 */
-	/**
-	 * Return the content to display in the Ads card based on the current plan.
-	 *
-	 * @returns {Object} Object with props to render a PromoCard.
-	 */
-	const getAdsCard = () => {
+	const getAdsCard = (): PromoSectionCardProps => {
 		const cta =
 			hasWordAdsFeature || hasSetupAds
 				? {

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -161,10 +161,8 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 	/**
 	 * Remove any query parameters from the path before using it to
 	 * identify which screen the user is seeing.
-	 *
-	 * @returns {string} Path to current screen.
 	 */
-	const getCurrentPath = () => {
+	const getCurrentPath = (): string => {
 		let currentPath = path;
 		const queryStartPosition = currentPath.indexOf( '?' );
 		if ( queryStartPosition > -1 ) {
@@ -175,10 +173,8 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 
 	/**
 	 * Check the current path and returns an appropriate title.
-	 *
-	 * @returns {string} Header text for current screen.
 	 */
-	const getHeaderText = () => {
+	const getHeaderText = (): string => {
 		switch ( section ) {
 			case 'payments':
 				return translate( 'Payments' );


### PR DESCRIPTION
## Proposed Changes

Converts jsdoc types to TypeScript types/syntax. This resolves some minor, non-blocking eslint notices about the jsdocs types. It also allows us to tighten up some types - in Earn > Main, we had been returning 'object' types. I've updated that to be the more precise PromoSectionCardProps types. 

All of this represents a small follow up after refactoring all the Earn code to TypeScript over the last month. 

## Testing Instructions

1) Checkout this branch, go to http://calypso.localhost:3000/earn/YOURDOMAIN, and click around to confirm everything works as expected. 

2) In your code editor, review the earn code (especially the changed files) and confirm there are no TypeScript errors. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?