### PR TITLE
Earn: Remove header cake

### DIFF
--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -2,7 +2,6 @@ import { useTranslate } from 'i18n-calypso';
 import { capitalize, find } from 'lodash';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
-import HeaderCake from 'calypso/components/header-cake';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import SectionNav from 'calypso/components/section-nav';
@@ -171,35 +170,6 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		return currentPath;
 	};
 
-	/**
-	 * Check the current path and returns an appropriate title.
-	 */
-	const getHeaderText = (): string => {
-		switch ( section ) {
-			case 'payments':
-				return translate( 'Payments' );
-			case 'ads-earnings':
-			case 'ads-payments':
-			case 'ads-settings':
-				return translate( 'Ads' );
-
-			case 'refer-a-friend':
-				return translate( 'Refer-a-Friend Program' );
-
-			default:
-				return '';
-		}
-	};
-
-	const getHeaderCake = () => {
-		const headerText = getHeaderText();
-		return (
-			headerText && (
-				<HeaderCake backHref={ `/earn/${ site?.slug ?? '' }` }>{ headerText }</HeaderCake>
-			)
-		);
-	};
-
 	const getEarnSectionNav = () => {
 		const currentPath = getCurrentPath();
 
@@ -268,7 +238,6 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				align="left"
 			/>
 			{ getEarnSectionNav() }
-			{ getHeaderCake() }
 			{ isAdSection( section ) && getAdSectionNav() }
 			{ getComponent( section ) }
 		</Main>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

- Removes the 'HeaderCake' from most Earn pages. It is for navigation, and is no longer needed now that we have tabs.
- The only page that still has it is Settings > Plans. The header cake is added to this screen directly rather than as part of the Earn layout, and it still plays a useful role for user how want to return from Plans (a nested page) back to Settings. 

<img width="1012" alt="header-cake" src="https://github.com/Automattic/wp-calypso/assets/21228350/2fb1e127-be43-411b-95d4-0fb53001a3cd">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Checkout this branch, go to http://calypso.localhost:3000/earn/YOURDOMAIN, click around, and confirm that the header cake is removed from most pages (Settings, Ads), and is only visible on Settings > Plans. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?