### PR TITLE
Update auth footer copy for Jetpack AI and Jetpack Boost A/B test

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -867,6 +867,34 @@ export class JetpackAuthorize extends Component {
 	renderContent() {
 		const { translate, user, authQuery } = this.props;
 		if ( this.isWooCoreProfiler() ) {
+			let col1Features = [];
+			let col2Features = [];
+			if ( authQuery.plugin_name === 'jetpack-boost' ) {
+				col1Features = [
+					translate( 'Speed up your store' ),
+					translate( 'Optimize CSS loading' ),
+					translate( 'Defer non-essential Javascript' ),
+				];
+				col2Features = [
+					translate( 'Lazy image loading' ),
+					translate( 'Site performance scores' ),
+					translate( 'Improve SEO' ),
+				];
+			} else {
+				col1Features = [
+					translate( 'Speed up content creation' ),
+					translate( 'Prompt based AI assistant' ),
+					translate( 'Adaptive tone adjustment' ),
+					translate( 'Generate text, tables, and lists' ),
+				];
+				col2Features = [
+					translate( 'Quota of 20 requests' ),
+					translate( 'Title and summary generation' ),
+					translate( 'Translate content to multiple languages' ),
+					translate( 'Spelling and grammar correction' ),
+				];
+			}
+
 			return (
 				<Fragment>
 					<div className="jetpack-connect__logged-in-content">
@@ -888,7 +916,7 @@ export class JetpackAuthorize extends Component {
 						</Card>
 						<div className="jetpack-connect__logged-in-bottom">
 							{ this.renderStateAction() }
-							<JetpackFeatures />
+							<JetpackFeatures col1Features={ col1Features } col2Features={ col2Features } />
 							<Disclaimer siteName={ decodeEntities( authQuery.blogname ) } />
 							<div className="jetpack-connect__jetpack-logo-wrapper">
 								<JetpackLogo monochrome size={ 18 } />{ ' ' }

--- a/client/jetpack-connect/features.tsx
+++ b/client/jetpack-connect/features.tsx
@@ -8,8 +8,8 @@ export const JetpackFeatures = ( {
 	col2Features,
 }: {
 	className?: string;
-	col1Features?: string[];
-	col2Features?: string[];
+	col1Features: string[];
+	col2Features: string[];
 } ) => {
 	const translate = useTranslate();
 

--- a/client/jetpack-connect/features.tsx
+++ b/client/jetpack-connect/features.tsx
@@ -1,6 +1,5 @@
 import { Icon, check } from '@wordpress/icons';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
 
 export const JetpackFeatures = ( {
 	className,
@@ -11,22 +10,6 @@ export const JetpackFeatures = ( {
 	col1Features: string[];
 	col2Features: string[];
 } ) => {
-	const translate = useTranslate();
-
-	col1Features = col1Features || [
-		translate( 'Speed up images and photos' ),
-		translate( 'Prevent brute force attacks' ),
-		translate( 'Secure user authentication' ),
-		translate( 'Enhanced site stats and insights' ),
-	];
-
-	col2Features = col2Features || [
-		translate( 'Daily or real-time backups' ),
-		translate( 'Keep plugins auto-updated' ),
-		translate( 'Immediate downtime alerts' ),
-		translate( 'Bulk site management from one dashboard' ),
-	];
-
 	return (
 		<div className={ classNames( 'jetpack-connect__features_wrapper', className ) }>
 			<ul className="jetpack-connect__features">

--- a/client/jetpack-connect/features.tsx
+++ b/client/jetpack-connect/features.tsx
@@ -2,17 +2,25 @@ import { Icon, check } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 
-export const JetpackFeatures = ( { className }: { className?: string } ) => {
+export const JetpackFeatures = ( {
+	className,
+	col1Features,
+	col2Features,
+}: {
+	className?: string;
+	col1Features?: string[];
+	col2Features?: string[];
+} ) => {
 	const translate = useTranslate();
 
-	const col1Features = [
+	col1Features = col1Features || [
 		translate( 'Speed up images and photos' ),
 		translate( 'Prevent brute force attacks' ),
 		translate( 'Secure user authentication' ),
 		translate( 'Enhanced site stats and insights' ),
 	];
 
-	const col2Features = [
+	col2Features = col2Features || [
 		translate( 'Daily or real-time backups' ),
 		translate( 'Keep plugins auto-updated' ),
 		translate( 'Immediate downtime alerts' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/woocommerce/woocommerce/issues/39629

## Proposed Changes

* Updated Auth Form Footer copies for Jetpack AI and Jetpack Boost A/B test

## Testing Instructions

1. Create a new JN site with WooCommerce
2. Start the core profiler and proceed to the plugins page.
3. Make sure to choose Jetpack
4. Click the continue button to install
5. You should be redirected to Jetpack connect page.
6. Copy the URL
7. Checkout this branch and open your local wp-calypso
8. Replace the copied URL and replace the host to your local wp-calypso
9. You should see Jetpack connect page
10. Append `plugin_name=jetpack-ai` query param and refresh the page
11. The feature list should contain lists from screenshot #1
12. Change the param to `plugin_name=jetpack-boost` and refresh the page
13. The feature list should contain lists from screenshot #2

Screenshot 1
![Screen Shot 2023-09-18 at 7 06 00 PM](https://github.com/Automattic/wp-calypso/assets/4723145/4d0ae1c4-abf8-4a7e-86ef-4df1304ec489)

Screenshot 2
![Screen Shot 2023-09-18 at 7 05 54 PM](https://github.com/Automattic/wp-calypso/assets/4723145/3ce174f8-2754-435c-a349-9113d6337936)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?