### PR TITLE
Domain Management i1: Add sorting functions for the status column

### DIFF
--- a/packages/domains-table/src/domains-table-header/columns.ts
+++ b/packages/domains-table/src/domains-table-header/columns.ts
@@ -1,5 +1,7 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { getSimpleSortFunctionBy, getSiteSortFunctions } from '../utils';
+import { I18N } from 'i18n-calypso';
+import { getSimpleSortFunctionBy, getSiteSortFunctions, getStatusSortFunctions } from '../utils';
+import { DomainStatusPurchaseActions } from '../utils/resolve-domain-status';
 import { DomainsTableColumn } from '.';
 
 const domainLabel = ( count: number, isBulkSelection: boolean ) =>
@@ -20,7 +22,10 @@ const domainLabel = ( count: number, isBulkSelection: boolean ) =>
 				{ count }
 		  );
 
-export const allSitesViewColumns: DomainsTableColumn[] = [
+export const allSitesViewColumns = (
+	translate: I18N[ 'translate' ],
+	domainStatusPurchaseActions?: DomainStatusPurchaseActions
+): DomainsTableColumn[] => [
 	{
 		name: 'domain',
 		label: domainLabel,
@@ -61,12 +66,15 @@ export const allSitesViewColumns: DomainsTableColumn[] = [
 		isSortable: true,
 		initialSortDirection: 'desc',
 		supportsOrderSwitching: true,
-		sortFunctions: [],
+		sortFunctions: getStatusSortFunctions( translate, domainStatusPurchaseActions ),
 	},
 	{ name: 'action', label: null, className: 'domains-table__action-ellipsis-column-header' },
 ];
 
-export const siteSpecificViewColumns: DomainsTableColumn[] = [
+export const siteSpecificViewColumns = (
+	translate: I18N[ 'translate' ],
+	domainStatusPurchaseActions?: DomainStatusPurchaseActions
+): DomainsTableColumn[] => [
 	{
 		name: 'domain',
 		label: domainLabel,
@@ -104,7 +112,7 @@ export const siteSpecificViewColumns: DomainsTableColumn[] = [
 		isSortable: true,
 		initialSortDirection: 'desc',
 		supportsOrderSwitching: true,
-		sortFunctions: [],
+		sortFunctions: getStatusSortFunctions( translate, domainStatusPurchaseActions ),
 	},
 	{ name: 'action', label: null, className: 'domains-table__action-ellipsis-column-header' },
 ];

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -12,6 +12,7 @@ import { useFuzzySearch } from '@automattic/search';
 import { isMobile } from '@automattic/viewport';
 import { useQueries } from '@tanstack/react-query';
 import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import {
 	useCallback,
@@ -190,8 +191,10 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 			return selectedDomainsCopy;
 		} );
 	}, [ domains ] );
-
-	const domainsTableColumns = isAllSitesView ? allSitesViewColumns : siteSpecificViewColumns;
+	const translate = useTranslate();
+	const domainsTableColumns = isAllSitesView
+		? allSitesViewColumns( translate, domainStatusPurchaseActions )
+		: siteSpecificViewColumns( translate, domainStatusPurchaseActions );
 
 	const sortedDomains = useMemo( () => {
 		const selectedColumnDefinition = domainsTableColumns.find(
@@ -263,7 +266,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 			selectedColumn.supportsOrderSwitching &&
 			sortDirection === 'asc'
 				? 'desc'
-				: selectedColumn.initialSortDirection );
+				: 'asc' );
 
 		setSort( {
 			sortKey: selectedColumn.name,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR adds the existing sorting functions to the status column to make it similar to the old table. 
Sorting function uses the `resolveDomainStatus` to calculate weight of each status, as a result we need to pass some extra props to the sorting function that is used by `resolveDomainStatus`, namely the `DomainStatusPurchaseActions`
## Proposed Changes

* Add sorting functions 
* refactor columns to accept props that are used by sorting function.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/domains/manage`
* Verify you are able to sort by status.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?