### PR TITLE
Earn: Add subtitle to Ads Dashboard screen

### DIFF
--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -194,7 +194,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		);
 	};
 
-	const getAdSectionNav = () => {
+	const getAdsHeader = () => {
 		const currentPath = getCurrentPath();
 
 		return (
@@ -242,7 +242,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				align="left"
 			/>
 			{ getEarnSectionNav() }
-			{ isAdSection( section ) && getAdSectionNav() }
+			{ isAdSection( section ) && getAdsHeader() }
 			{ getComponent( section ) }
 		</Main>
 	);

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -198,21 +198,25 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		const currentPath = getCurrentPath();
 
 		return (
-			<SectionNav selectedText={ getAdSelectedText() }>
-				<NavTabs>
-					{ getAdTabs().map( ( filterItem ) => {
-						return (
-							<NavItem
-								key={ filterItem.id }
-								path={ filterItem.path }
-								selected={ filterItem.path === currentPath }
-							>
-								{ filterItem.title }
-							</NavItem>
-						);
-					} ) }
-				</NavTabs>
-			</SectionNav>
+			<div className="earn__ads-header">
+				<h2 className="formatted-header__title wp-brand-font">{ translate( 'Ads Dashboard' ) }</h2>
+
+				<SectionNav selectedText={ getAdSelectedText() }>
+					<NavTabs>
+						{ getAdTabs().map( ( filterItem ) => {
+							return (
+								<NavItem
+									key={ filterItem.id }
+									path={ filterItem.path }
+									selected={ filterItem.path === currentPath }
+								>
+									{ filterItem.title }
+								</NavItem>
+							);
+						} ) }
+					</NavTabs>
+				</SectionNav>
+			</div>
 		);
 	};
 

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -50,3 +50,36 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 		font-weight: 600;
 	}
 }
+
+// Override heading/SectionNav styles for Ads Dashboard
+.earn__ads-header {
+	display: flex;
+	margin: 20px 0;
+	flex-direction: column;
+
+	@include break-mobile {
+		align-items: center;
+		flex-direction: row;
+	}
+
+	h2.formatted-header__title {
+		margin: 0 0 20px;
+		@include break-mobile {
+			margin: 0;
+			min-width: 200px;
+		}
+	}
+
+	.section-nav {
+		@include break-mobile {
+			background: transparent;
+			box-shadow: none;
+			margin-bottom: 10px;
+		}
+	}
+}
+
+h3.highlight-cards-heading,
+h3.ads__table-header-title {
+	font-size: 1.25rem;
+}

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -53,29 +53,10 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 
 // Override heading/SectionNav styles for Ads Dashboard
 .earn__ads-header {
-	display: flex;
 	margin: 20px 0;
-	flex-direction: column;
-
-	@include break-mobile {
-		align-items: center;
-		flex-direction: row;
-	}
 
 	h2.formatted-header__title {
 		margin: 0 0 20px;
-		@include break-mobile {
-			margin: 0;
-			min-width: 200px;
-		}
-	}
-
-	.section-nav {
-		@include break-mobile {
-			background: transparent;
-			box-shadow: none;
-			margin-bottom: 10px;
-		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds a new 'Ads Dashboard' sub title to the Earn > Ads Dashboard page. This is intended to add clarity for the user about where they are, especially given there are now two sets of nav tabs on this page. 

<img width="1113" alt="ads-heading" src="https://github.com/Automattic/wp-calypso/assets/21228350/51e4de0e-6df8-4200-a08d-da2372d77084">

## Testing Instructions

1) Checkout this branch and go to http://calypso.localhost:3000/earn/YOURDOMAIN. If you haven't yet, find the Ads card and enable Ads.
2) Confirm it looks like the screenshot above. Click around to confirm that all navigation and screens look good and work as before. 
3) Test on mobiel and confirm it looks presentable and that both sets of nav tabs are usable. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?