### PR TITLE
Odyssey Stats: fix buttons for checkout

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	PRODUCT_JETPACK_STATS_YEARLY,
 	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
@@ -13,7 +14,7 @@ const setUrlParam = ( url: URL, paramName: string, paramValue?: string | null ):
 	}
 };
 
-const getStatsPurchaseURL = (
+export const getStatsPurchaseURL = (
 	siteSlug: string,
 	product: string,
 	redirectUrl: string,
@@ -22,14 +23,14 @@ const getStatsPurchaseURL = (
 	// Get the checkout URL for the product, or the siteless checkout URL if no siteSlug is provided
 	const checkoutProductUrl = new URL(
 		`/checkout/${ siteSlug || 'jetpack' }/${ product }`,
-		window.location.origin
+		'https://wordpress.com'
 	);
 
 	// Add redirect_to parameter
 	setUrlParam( checkoutProductUrl, 'redirect_to', redirectUrl );
 	setUrlParam( checkoutProductUrl, 'checkoutBackUrl', checkoutBackUrl );
 
-	return checkoutProductUrl.pathname + checkoutProductUrl.search;
+	return checkoutProductUrl.toString();
 };
 
 const getYearlyPrice = ( monthlyPrice: number ) => {
@@ -56,9 +57,10 @@ const getCheckoutBackUrl = ( {
 	const isFromWPAdmin = from.startsWith( 'jetpack' );
 	const isFromMyJetpack = from === 'jetpack-my-jetpack';
 	const isFromPlansPage = from === 'calypso-plans';
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	// Use full URL even though redirecting on Calypso.
-	if ( ! isFromWPAdmin ) {
+	if ( ! isFromWPAdmin && ! isOdysseyStats ) {
 		if ( ! siteSlug ) {
 			return 'https://cloud.jetpack.com/pricing/';
 		}
@@ -86,7 +88,8 @@ const getRedirectUrl = ( {
 	redirectUri?: string;
 	siteSlug: string;
 } ) => {
-	const isStartedFromJetpackSite = from.startsWith( 'jetpack' );
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const isStartedFromJetpackSite = from.startsWith( 'jetpack' ) || isOdysseyStats;
 	const statsPurchaseSuccess = type === 'free' ? 'free' : 'paid';
 
 	// If it's a siteless checkout, let it redirect to the thank you page,

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -14,7 +14,7 @@ const setUrlParam = ( url: URL, paramName: string, paramValue?: string | null ):
 	}
 };
 
-export const getStatsPurchaseURL = (
+const getStatsPurchaseURL = (
 	siteSlug: string,
 	product: string,
 	redirectUrl: string,

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -14,7 +14,7 @@ const setUrlParam = ( url: URL, paramName: string, paramValue?: string | null ):
 	}
 };
 
-const getStatsPurchaseURL = (
+const getStatsCheckoutURL = (
 	siteSlug: string,
 	product: string,
 	redirectUrl: string,
@@ -153,7 +153,7 @@ const gotoCheckoutPage = ( {
 	// Allow some time for the event to be recorded before redirecting.
 	setTimeout(
 		() =>
-			( window.location.href = getStatsPurchaseURL(
+			( window.location.href = getStatsCheckoutURL(
 				siteSlug,
 				product,
 				redirectUrl,


### PR DESCRIPTION
## Proposed Changes

The PR proposes to change checkout URL in Odyssey Stats to be WPCOM, as in the current implementation, the checkout URL is of the same origin.

## Testing Instructions

* Build Jetpack if needed `jetpack build plugins/jetpack`
* Build Odyssey Stats `cd apps/odyssey-stats && STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev` <-- Please change the path for jetpack
* Open `/wp-admin/admin.php?page=stats#!/stats/purchase/:siteSlug` in your dev env
* Ensure you can purchase Stats free
* Open `/wp-admin/admin.php?page=stats#!/stats/purchase/:siteSlug?productType=personal` in your dev env
* Ensure you can purchase Stats PWYW
* Open `/wp-admin/admin.php?page=stats#!/stats/purchase/:siteSlug?productType=commercial` in your dev env
* Ensure you can purchase Stats Commercial

<img width="1135" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/29ec3cfc-be94-4e49-aa61-8d17fe9019af">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?