### PR TITLE
state: refactor away from `_.trim`

### DIFF
--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -1,4 +1,4 @@
-import { includes, keyBy, omit, omitBy, trim } from 'lodash';
+import { includes, keyBy, omit, omitBy } from 'lodash';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { withoutHttp } from 'calypso/lib/url';
 import {
@@ -36,7 +36,8 @@ function adaptSite( attributes ) {
 		attributes.domain = withoutHttp( attributes.URL );
 		attributes.slug = attributes.domain.replace( /\//g, '::' );
 	}
-	attributes.title = trim( attributes.name ) || attributes.domain;
+	attributes.title =
+		( typeof attributes.name === 'string' && attributes.name.trim() ) || attributes.domain;
 
 	if ( attributes.description ) {
 		attributes.description = decodeEntities( attributes.description );

--- a/client/state/reader/tags/items/actions.js
+++ b/client/state/reader/tags/items/actions.js
@@ -1,4 +1,3 @@
-import { trim } from 'lodash';
 import {
 	READER_TAGS_REQUEST,
 	READER_TAGS_RECEIVE,
@@ -19,7 +18,9 @@ import 'calypso/state/reader/init';
  * @returns {string}      Tag slug
  */
 export const slugify = ( tag ) =>
-	encodeURIComponent( trim( tag ).toLowerCase().replace( /\s+/g, '-' ).replace( /-{2,}/g, '-' ) );
+	typeof tag === 'string'
+		? encodeURIComponent( tag.trim().toLowerCase().replace( /\s+/g, '-' ).replace( /-{2,}/g, '-' ) )
+		: '';
 
 export const requestTags = ( tag, locale = null ) => {
 	const slug = tag ? slugify( tag ) : null;


### PR DESCRIPTION
## Proposed Changes

PR refactors away from `_.trim` in `client/state`.

## Testing Instructions

* Changes are well covered by unit tests, verify they pass.
* As with a lot of lodash methods it's good practice to ensure we don't accidentally miss guards for whether we operate on the expected data structure.
