### PR TITLE
Email stats: Add user-content-links to email stats

### DIFF
--- a/client/state/stats/emails/actions.js
+++ b/client/state/stats/emails/actions.js
@@ -71,7 +71,7 @@ function emailStatsAlltimeTransform( stats ) {
 		countries: parseEmailCountriesData( stats.countries?.data, stats[ 'countries-info' ] ),
 		devices: parseEmailListData( stats.devices?.data ),
 		clients: parseEmailListData( stats.clients?.data ),
-		links: parseEmailLinksData( stats.links?.data ),
+		links: parseEmailLinksData( stats.links?.data, stats[ 'user-content-links' ]?.data ),
 		rate: {
 			opens_rate: stats.opens_rate,
 			total_opens: stats.total_opens,

--- a/client/state/stats/emails/utils.js
+++ b/client/state/stats/emails/utils.js
@@ -222,10 +222,9 @@ export function parseEmailListData( list ) {
  * @param {Array} userContentLinks - the array of user content links for the given data
  * @returns {Array|null} - Array of data objects
  */
-export function parseEmailLinksData( internalLinks, userContentLinks ) {
-	if ( ! Array.isArray( internalLinks ) || ! Array.isArray( userContentLinks ) ) {
-		return [];
-	}
+export function parseEmailLinksData( internalLinks = [], userContentLinks = [] ) {
+	const validatedInternalLinks = Array.isArray( internalLinks ) ? internalLinks : [];
+	const validatedUserContentLinks = Array.isArray( userContentLinks ) ? userContentLinks : [];
 
 	const stringMap = {
 		'post-url': translate( 'Post URL', { context: 'Email link type' } ),
@@ -235,11 +234,10 @@ export function parseEmailLinksData( internalLinks, userContentLinks ) {
 	};
 
 	// filter out links that are not in the stringMap
-	const filteredInternalLinks = internalLinks
-		.filter( ( link ) => stringMap[ link[ 0 ] ] )
-		.sort( ( a, b ) => b[ 1 ] - a[ 1 ] );
+	const filteredInternalLinks = validatedInternalLinks.filter( ( link ) => stringMap[ link[ 0 ] ] );
+
 	// Get count of all links where the first element is not a key of stringMap
-	const otherInternalLinksCount = internalLinks.reduce( ( count, link ) => {
+	const otherInternalLinksCount = validatedInternalLinks.reduce( ( count, link ) => {
 		if ( ! stringMap[ link[ 0 ] ] ) {
 			count += parseInt( link[ 1 ], 10 );
 		}
@@ -261,7 +259,7 @@ export function parseEmailLinksData( internalLinks, userContentLinks ) {
 	}
 
 	// add user content links
-	userContentLinks.forEach( ( link ) => {
+	validatedUserContentLinks.forEach( ( link ) => {
 		mappedLinks.push( {
 			label: link[ 0 ],
 			link: link[ 0 ],

--- a/client/state/stats/emails/utils.js
+++ b/client/state/stats/emails/utils.js
@@ -218,12 +218,13 @@ export function parseEmailListData( list ) {
  * Return link data in a format used by lists for email stats. The fields array is matched to
  * the data in a single object.
  *
- * @param {Array} links - the array of links for the given data
+ * @param {Array} internalLinks - the array of links for the given data
+ * @param {Array} userContentLinks - the array of user content links for the given data
  * @returns {Array|null} - Array of data objects
  */
-export function parseEmailLinksData( links ) {
-	if ( ! links ) {
-		return null;
+export function parseEmailLinksData( internalLinks, userContentLinks ) {
+	if ( ! Array.isArray( internalLinks ) || ! Array.isArray( userContentLinks ) ) {
+		return [];
 	}
 
 	const stringMap = {
@@ -234,30 +235,40 @@ export function parseEmailLinksData( links ) {
 	};
 
 	// filter out links that are not in the stringMap
-	const filteredLinks = links
+	const filteredInternalLinks = internalLinks
 		.filter( ( link ) => stringMap[ link[ 0 ] ] )
 		.sort( ( a, b ) => b[ 1 ] - a[ 1 ] );
 	// Get count of all links where the first element is not a key of stringMap
-	const otherCount = links.reduce( ( count, link ) => {
+	const otherInternalLinksCount = internalLinks.reduce( ( count, link ) => {
 		if ( ! stringMap[ link[ 0 ] ] ) {
 			count += parseInt( link[ 1 ], 10 );
 		}
 		return count;
 	}, 0 );
 
-	const mappedLinks = filteredLinks.map( ( link ) => {
+	const mappedLinks = filteredInternalLinks.map( ( link ) => {
 		return {
 			label: stringMap[ link[ 0 ] ],
 			value: parseInt( link[ 1 ], 10 ),
 		};
 	} );
 
-	if ( otherCount ) {
+	if ( otherInternalLinksCount ) {
 		mappedLinks.push( {
 			label: translate( 'Other', { context: 'Email link type' } ),
-			value: otherCount,
+			value: otherInternalLinksCount,
 		} );
 	}
 
-	return mappedLinks;
+	// add user content links
+	userContentLinks.forEach( ( link ) => {
+		mappedLinks.push( {
+			label: link[ 0 ],
+			link: link[ 0 ],
+			value: parseInt( link[ 1 ], 10 ),
+		} );
+	} );
+
+	// sort by value
+	return mappedLinks.sort( ( a, b ) => b.value - a.value );
 }

--- a/packages/wpcom.js/src/lib/site.js
+++ b/packages/wpcom.js/src/lib/site.js
@@ -422,6 +422,7 @@ class Site {
 		const statFields = [ 'client', 'device', 'country', 'rate' ];
 		if ( statType === 'clicks' ) {
 			statFields.push( 'link' );
+			statFields.push( 'user-content-link' );
 		}
 		return Promise.all(
 			statFields.map( ( field ) => this.wpcom.req.get( `${ basePath }/${ field }`, fn ) )


### PR DESCRIPTION
Closes #81881 

## Proposed Changes

In the previous implementation, we only tracked internal links for email statistics. However, there is also a need to include and track user-content-links.

This PR adds user content links to the links overview in Calypso:

![CleanShot 2023-09-19 at 10 46 01@2x](https://github.com/Automattic/wp-calypso/assets/528287/ffabc3b3-2951-45aa-8dce-a2d4139d864d)


## Testing Instructions

Since the user content link tracking isn't live yet, the easiest way to test this is to modify the endpoint on wpcom to provide mock data: fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Sjcpbz%2Qwfba%2Qraqcbvagf%2Spynff.jcpbz%2Qwfba%2Qncv%2Qfgngf%2Qrznvy%2Qpyvpxf%2Qol%2Qhfre%2Qpbagrag%2Qyvax%2Qi1%2Q1%2Qraqcbvag.cuc%2322%2Q22-og 

Add this on line 10:

```php

		return array( 'user-content-links' => array('data' => array(
			['https://google.com', 10],
			['https://youtube.com', 200]
		), 'fields' => array( 'url', 'clicks_count' ) ) );
```

Then:
1. Apply this PR
2. Go to Stats & click an email inside the `Emails ` box
3. Click `Email clicks` in the navigation & you should see the user content links inside the Links box
4. Clicking a link will open a new tab with that link./

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?