### PR TITLE
Jetpack Manage: Update Boost expandable block to support 'Configure Boost' flow.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -41,8 +41,8 @@ export default function BoostSitePerformance( {
 		'Your Overall Score is a summary of your website performance across both mobile and desktop devices.'
 	);
 
-	const OptimizeCSSUrl = `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`;
-	const ConfigureBoostUrl = `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#/add-boost`;
+	const optimizeCSSUrl = `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`;
+	const configureBoostUrl = `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#/add-boost`;
 
 	const handleOnClick = () => {
 		// TODO - should open a modal.
@@ -121,7 +121,7 @@ export default function BoostSitePerformance( {
 				<div className="site-expanded-content__card-footer">
 					{ hasBoost && (
 						<Button
-							href={ OptimizeCSSUrl }
+							href={ optimizeCSSUrl }
 							target="_blank"
 							onClick={ () => trackEvent( 'expandable_block_optimize_css_click' ) }
 							className="site-expanded-content__card-button"
@@ -133,7 +133,7 @@ export default function BoostSitePerformance( {
 
 					{ ! hasBoost && (
 						<Button
-							href={ ConfigureBoostUrl }
+							href={ configureBoostUrl }
 							target="_blank"
 							onClick={ () => trackEvent( 'expandable_block_configure_boost_click' ) }
 							className="site-expanded-content__card-button"

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { Icon, help } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import Tooltip from 'calypso/components/tooltip';
 import { jetpackBoostDesktopIcon, jetpackBoostMobileIcon } from '../../icons';
 import { getBoostRating, getBoostRatingClass } from '../lib/boost';
@@ -41,8 +41,21 @@ export default function BoostSitePerformance( {
 		'Your Overall Score is a summary of your website performance across both mobile and desktop devices.'
 	);
 
-	const optimizeCSSUrl = `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`;
-	const configureBoostUrl = `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#/add-boost`;
+	const buttonProps = useMemo(
+		() =>
+			hasBoost
+				? {
+						label: translate( 'Optimize CSS' ),
+						href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`,
+						onClick: () => trackEvent( 'expandable_block_optimize_css_click' ),
+				  }
+				: {
+						label: translate( 'Configure Boost' ),
+						href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#/add-boost`,
+						onClick: () => trackEvent( 'expandable_block_configure_boost_click' ),
+				  },
+		[ hasBoost, siteUrlWithScheme, trackEvent, translate ]
+	);
 
 	const handleOnClick = () => {
 		// TODO - should open a modal.
@@ -119,29 +132,15 @@ export default function BoostSitePerformance( {
 					</div>
 				</div>
 				<div className="site-expanded-content__card-footer">
-					{ hasBoost && (
-						<Button
-							href={ optimizeCSSUrl }
-							target="_blank"
-							onClick={ () => trackEvent( 'expandable_block_optimize_css_click' ) }
-							className="site-expanded-content__card-button"
-							compact
-						>
-							{ translate( 'Optimize CSS' ) }
-						</Button>
-					) }
-
-					{ ! hasBoost && (
-						<Button
-							href={ configureBoostUrl }
-							target="_blank"
-							onClick={ () => trackEvent( 'expandable_block_configure_boost_click' ) }
-							className="site-expanded-content__card-button"
-							compact
-						>
-							{ translate( 'Configure Boost' ) }
-						</Button>
-					) }
+					<Button
+						href={ buttonProps.href }
+						target="_blank"
+						onClick={ buttonProps.onClick }
+						className="site-expanded-content__card-button"
+						compact
+					>
+						{ buttonProps.label }
+					</Button>
 				</div>
 			</div>
 		</ExpandedCard>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -41,9 +41,11 @@ export default function BoostSitePerformance( {
 		'Your Overall Score is a summary of your website performance across both mobile and desktop devices.'
 	);
 
+	const isEnabled = !! ( hasBoost || overallScore );
+
 	const buttonProps = useMemo(
 		() =>
-			hasBoost
+			hasBoost && overallScore
 				? {
 						label: translate( 'Optimize CSS' ),
 						href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`,
@@ -54,7 +56,7 @@ export default function BoostSitePerformance( {
 						href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#/add-boost`,
 						onClick: () => trackEvent( 'expandable_block_configure_boost_click' ),
 				  },
-		[ hasBoost, siteUrlWithScheme, trackEvent, translate ]
+		[ hasBoost, siteUrlWithScheme, trackEvent, translate, overallScore ]
 	);
 
 	const handleOnClick = () => {
@@ -64,7 +66,7 @@ export default function BoostSitePerformance( {
 	return (
 		<ExpandedCard
 			header={ translate( 'Boost site performance' ) }
-			isEnabled={ !! overallScore }
+			isEnabled={ isEnabled }
 			emptyContent={ translate(
 				'{{strong}}Get Score{{/strong}} to see your site performance scores',
 				{
@@ -73,7 +75,7 @@ export default function BoostSitePerformance( {
 			) }
 			hasError={ hasError }
 			// Allow to click on the card only if Boost is not active
-			onClick={ ! overallScore ? handleOnClick : undefined }
+			onClick={ ! isEnabled ? handleOnClick : undefined }
 		>
 			<div className="site-expanded-content__card-content-container">
 				<div className="site-expanded-content__card-content">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -41,9 +41,8 @@ export default function BoostSitePerformance( {
 		'Your Overall Score is a summary of your website performance across both mobile and desktop devices.'
 	);
 
-	const href = `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`;
-
-	const isEnabled = !! hasBoost;
+	const OptimizeCSSUrl = `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`;
+	const ConfigureBoostUrl = `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#/add-boost`;
 
 	const handleOnClick = () => {
 		// TODO - should open a modal.
@@ -52,7 +51,7 @@ export default function BoostSitePerformance( {
 	return (
 		<ExpandedCard
 			header={ translate( 'Boost site performance' ) }
-			isEnabled={ isEnabled }
+			isEnabled={ !! overallScore }
 			emptyContent={ translate(
 				'{{strong}}Get Score{{/strong}} to see your site performance scores',
 				{
@@ -61,7 +60,7 @@ export default function BoostSitePerformance( {
 			) }
 			hasError={ hasError }
 			// Allow to click on the card only if Boost is not active
-			onClick={ ! isEnabled ? handleOnClick : undefined }
+			onClick={ ! overallScore ? handleOnClick : undefined }
 		>
 			<div className="site-expanded-content__card-content-container">
 				<div className="site-expanded-content__card-content">
@@ -120,15 +119,29 @@ export default function BoostSitePerformance( {
 					</div>
 				</div>
 				<div className="site-expanded-content__card-footer">
-					<Button
-						href={ href }
-						target="_blank"
-						onClick={ () => trackEvent( 'expandable_block_optimize_css_click' ) }
-						className="site-expanded-content__card-button"
-						compact
-					>
-						{ translate( 'Optimize CSS' ) }
-					</Button>
+					{ hasBoost && (
+						<Button
+							href={ OptimizeCSSUrl }
+							target="_blank"
+							onClick={ () => trackEvent( 'expandable_block_optimize_css_click' ) }
+							className="site-expanded-content__card-button"
+							compact
+						>
+							{ translate( 'Optimize CSS' ) }
+						</Button>
+					) }
+
+					{ ! hasBoost && (
+						<Button
+							href={ ConfigureBoostUrl }
+							target="_blank"
+							onClick={ () => trackEvent( 'expandable_block_configure_boost_click' ) }
+							className="site-expanded-content__card-button"
+							compact
+						>
+							{ translate( 'Configure Boost' ) }
+						</Button>
+					) }
 				</div>
 			</div>
 		</ExpandedCard>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
@@ -40,11 +40,11 @@ describe( 'BoostSitePerformance', () => {
 		expect( desktopScore ).toBeInTheDocument();
 	} );
 
-	test( 'renders the empty content when hasBoost is false', () => {
-		const hasBoost = false;
+	test( 'renders the empty content when there is no score', () => {
+		const hasBoost = true;
 		render(
 			<BoostSitePerformance
-				boostData={ boostData }
+				boostData={ { overall: 0, mobile: 0, desktop: 0 } }
 				hasBoost={ hasBoost }
 				siteId={ siteId }
 				siteUrlWithScheme={ siteUrlWithScheme }
@@ -57,6 +57,40 @@ describe( 'BoostSitePerformance', () => {
 		expect( emptyContent ).toBeInTheDocument();
 		const strongTag = screen.getByText( /get score/i );
 		expect( strongTag ).toHaveStyle( 'font-weight: bold' );
+	} );
+
+	test( 'renders the Optimize css button when there is a score and has boost', () => {
+		const hasBoost = true;
+		render(
+			<BoostSitePerformance
+				boostData={ boostData }
+				hasBoost={ hasBoost }
+				siteId={ siteId }
+				siteUrlWithScheme={ siteUrlWithScheme }
+				trackEvent={ trackEventMock }
+				hasError={ false }
+			/>
+		);
+
+		const button = screen.getByRole( 'link', { name: /optimize css/i } );
+		expect( button ).toBeInTheDocument();
+	} );
+
+	test( 'renders the Configure Boost button when there is a score and has no boost', () => {
+		const hasBoost = false;
+		render(
+			<BoostSitePerformance
+				boostData={ boostData }
+				hasBoost={ hasBoost }
+				siteId={ siteId }
+				siteUrlWithScheme={ siteUrlWithScheme }
+				trackEvent={ trackEventMock }
+				hasError={ false }
+			/>
+		);
+
+		const button = screen.getByRole( 'link', { name: /configure boost/i } );
+		expect( button ).toBeInTheDocument();
 	} );
 
 	test( 'calls trackEvent when button is clicked and checks if the button has href', () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
@@ -40,8 +40,8 @@ describe( 'BoostSitePerformance', () => {
 		expect( desktopScore ).toBeInTheDocument();
 	} );
 
-	test( 'renders the empty content when there is no score', () => {
-		const hasBoost = true;
+	test( 'renders the empty content when there is no score and no boost', () => {
+		const hasBoost = false;
 		render(
 			<BoostSitePerformance
 				boostData={ { overall: 0, mobile: 0, desktop: 0 } }
@@ -74,6 +74,13 @@ describe( 'BoostSitePerformance', () => {
 
 		const button = screen.getByRole( 'link', { name: /optimize css/i } );
 		expect( button ).toBeInTheDocument();
+		expect( button ).toHaveAttribute(
+			'href',
+			`${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`
+		);
+
+		fireEvent.click( button );
+		expect( trackEventMock ).toHaveBeenCalledWith( 'expandable_block_optimize_css_click' );
 	} );
 
 	test( 'renders the Configure Boost button when there is a score and has no boost', () => {
@@ -91,30 +98,12 @@ describe( 'BoostSitePerformance', () => {
 
 		const button = screen.getByRole( 'link', { name: /configure boost/i } );
 		expect( button ).toBeInTheDocument();
-	} );
-
-	test( 'calls trackEvent when button is clicked and checks if the button has href', () => {
-		const hasBoost = true;
-
-		render(
-			<BoostSitePerformance
-				boostData={ boostData }
-				hasBoost={ hasBoost }
-				siteId={ siteId }
-				siteUrlWithScheme={ siteUrlWithScheme }
-				trackEvent={ trackEventMock }
-				hasError={ false }
-			/>
-		);
-
-		const button = screen.getByRole( 'link', { name: /optimize css/i } );
-		expect( button ).toBeInTheDocument();
 		expect( button ).toHaveAttribute(
 			'href',
-			`${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`
+			`${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#/add-boost`
 		);
 
 		fireEvent.click( button );
-		expect( trackEventMock ).toHaveBeenCalledWith( 'expandable_block_optimize_css_click' );
+		expect( trackEventMock ).toHaveBeenCalledWith( 'expandable_block_configure_boost_click' );
 	} );
 } );


### PR DESCRIPTION
This PR updates the expandable block to support a 1-time score and render the correct CTA button.

<img width="338" alt="Screen Shot 2023-09-20 at 3 00 27 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ee586f83-1c5f-489e-8ab4-08834ae83f90">
<img width="334" alt="Screen Shot 2023-09-20 at 2 59 02 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7f206498-738f-4511-8e21-da5f419101ae">


Closes https://github.com/Automattic/jetpack-genesis/issues/27

## Proposed Changes

* Update the Jetpack Boost expandable block to render the score regardless of whether the site has an active Jetpack Boost plugin.
* Update the block to display the **'Configure Boost'** button if the site has no active Jetpack boost plugin. The CTA should show the **'Optimize CSS'** button if there is no active plugin.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

### Optimize CSS button
* Spin up a JN site and connect it to the Jetpack cloud. Make sure you install **Jetpack Boost** plugin and generate a score with it.
* Confirm that the Jetpack Boost expandable block displays the score with the **'Optimize CSS'** button.

<img width="334" alt="Screen Shot 2023-09-20 at 2 59 02 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7f206498-738f-4511-8e21-da5f419101ae">

### Configure Boost
* Once you have done the above test, uninstall the Jetpack Boost plugin on the JN Site.
* Confirm the Jetpack Boost expandable block will display the **'Configure Boost'** button.
<img width="338" alt="Screen Shot 2023-09-20 at 3 00 27 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ee586f83-1c5f-489e-8ab4-08834ae83f90">

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
