### PR TITLE
reader: Fix posts with oddly sized images

### DIFF
--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -4,10 +4,10 @@ import DotPager from 'calypso/components/dot-pager';
 import cssSafeUrl from 'calypso/lib/css-safe-url';
 import resizeImageUrl from 'calypso/lib/resize-image-url';
 import { getImagesFromPostToDisplay } from 'calypso/state/reader/posts/normalization-rules';
-import { READER_CONTENT_WIDTH } from 'calypso/state/reader/posts/sizes';
+import { GALLERY_MAX_IMAGES, READER_CONTENT_WIDTH } from 'calypso/state/reader/posts/sizes';
 
 function PostGallery( { post, children } ) {
-	const imagesToDisplay = getImagesFromPostToDisplay( post, 10 );
+	const imagesToDisplay = getImagesFromPostToDisplay( post, GALLERY_MAX_IMAGES );
 
 	function handleClick( event ) {
 		event.preventDefault();

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -1,4 +1,4 @@
-import { filter, flow } from 'lodash';
+import { flow } from 'lodash';
 import addImageWrapperElement from 'calypso/lib/post-normalizer/rule-add-image-wrapper-element';
 import detectMedia from 'calypso/lib/post-normalizer/rule-content-detect-media';
 import detectPolls from 'calypso/lib/post-normalizer/rule-content-detect-polls';
@@ -78,7 +78,7 @@ const hasShortContent = ( post ) => getCharacterCount( post ) <= PHOTO_ONLY_MAX_
  * @returns {Object}            The classified post
  */
 export function classifyPost( post ) {
-	const imagesForGallery = filter( post.content_images, imageIsBigEnoughForGallery );
+	const imagesForGallery = getImagesFromPostToDisplay( post, GALLERY_MIN_IMAGES + 1 );
 	let displayType = DISPLAY_TYPES.UNCLASSIFIED;
 
 	if ( imagesForGallery.length >= GALLERY_MIN_IMAGES ) {

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -32,6 +32,7 @@ import {
 	PHOTO_ONLY_MIN_WIDTH,
 	PHOTO_ONLY_MAX_CHARACTER_COUNT,
 	GALLERY_MIN_IMAGES,
+	GALLERY_MAX_IMAGES,
 	GALLERY_MIN_IMAGE_WIDTH,
 	MIN_IMAGE_WIDTH,
 	MIN_IMAGE_HEIGHT,
@@ -78,7 +79,7 @@ const hasShortContent = ( post ) => getCharacterCount( post ) <= PHOTO_ONLY_MAX_
  * @returns {Object}            The classified post
  */
 export function classifyPost( post ) {
-	const imagesForGallery = getImagesFromPostToDisplay( post, GALLERY_MIN_IMAGES + 1 );
+	const imagesForGallery = getImagesFromPostToDisplay( post, GALLERY_MAX_IMAGES );
 	let displayType = DISPLAY_TYPES.UNCLASSIFIED;
 
 	if ( imagesForGallery.length >= GALLERY_MIN_IMAGES ) {

--- a/client/state/reader/posts/sizes.js
+++ b/client/state/reader/posts/sizes.js
@@ -9,6 +9,7 @@ export const READER_RELATED_IMAGE_WIDTH = 348;
 export const PHOTO_ONLY_MIN_WIDTH = 440;
 export const PHOTO_ONLY_MAX_CHARACTER_COUNT = 85;
 export const GALLERY_MIN_IMAGES = 5;
+export const GALLERY_MAX_IMAGES = 10;
 export const GALLERY_MIN_IMAGE_WIDTH = 300;
 export const MIN_IMAGE_WIDTH = 144;
 export const MIN_IMAGE_HEIGHT = 72;


### PR DESCRIPTION
Part of p1694888378538879-slack-C03NLNTPZ2T.

When checking which display type to use for a post, we count the number of images, previously we were only checking the image size is sufficient.

But when rendering the gallery, we perform another check in and return null if we have less than two images that meet a range of other criteria https://github.com/Automattic/wp-calypso/blob/trunk/client/blocks/reader-post-card/gallery.jsx#L16

This change makes sure that we are using the same criteria in both places.


### Testing instructions

Like the post mentioned in p1694888378538879-slack-C03NLNTPZ2T (it's an a8c p2 post)
Go to `/activities/likes`
You should see the post displayed with a single image