### PR TITLE
Staging Sites: Remove redirects for backup pages when on staging sites

### DIFF
--- a/client/my-sites/backup/index.js
+++ b/client/my-sites/backup/index.js
@@ -17,12 +17,7 @@ import {
 	showUnavailableForMultisites,
 } from 'calypso/my-sites/backup/controller';
 import WPCOMUpsellPage from 'calypso/my-sites/backup/wpcom-backup-upsell';
-import {
-	navigation,
-	siteSelection,
-	sites,
-	stagingSiteNotSupportedRedirect,
-} from 'calypso/my-sites/controller';
+import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import isJetpackSectionEnabledForSite from 'calypso/state/selectors/is-jetpack-section-enabled-for-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
@@ -51,7 +46,6 @@ export default function () {
 	page(
 		backupDownloadPath( ':site', ':rewindId' ),
 		siteSelection,
-		stagingSiteNotSupportedRedirect,
 		navigation,
 		backupDownload,
 		wrapInSiteOffsetProvider,
@@ -69,7 +63,6 @@ export default function () {
 	page(
 		backupRestorePath( ':site', ':rewindId' ),
 		siteSelection,
-		stagingSiteNotSupportedRedirect,
 		navigation,
 		backupRestore,
 		wrapInSiteOffsetProvider,
@@ -87,7 +80,6 @@ export default function () {
 	page(
 		backupClonePath( ':site' ),
 		siteSelection,
-		stagingSiteNotSupportedRedirect,
 		navigation,
 		backupClone,
 		wrapInSiteOffsetProvider,
@@ -105,7 +97,6 @@ export default function () {
 	page(
 		backupMainPath( ':site' ),
 		siteSelection,
-		stagingSiteNotSupportedRedirect,
 		navigation,
 		backups,
 		wrapInSiteOffsetProvider,
@@ -124,7 +115,6 @@ export default function () {
 	page(
 		backupContentsPath( ':site', ':rewindId' ),
 		siteSelection,
-		stagingSiteNotSupportedRedirect,
 		navigation,
 		backupContents,
 		wrapInSiteOffsetProvider,
@@ -142,7 +132,6 @@ export default function () {
 	page(
 		backupGranularRestorePath( ':site', ':rewindId' ),
 		siteSelection,
-		stagingSiteNotSupportedRedirect,
 		navigation,
 		backupGranularRestore,
 		wrapInSiteOffsetProvider,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3693

When the active site is a staging site, the backup pages redirect to the homepage because the backup feature was not available for staging sites. This has now changed, staging sites now have the backup feature enabled.

## Proposed Changes

* No longer redirect to the homepage when trying to access a backup-related page when the currently active site is a staging site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a staging site
2. Navigate to `/backup/<your-site>`

You should be able to see the backup page and see when the next backup is scheduled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?