### PR TITLE
Link to an article on the differences between .org and .com

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -309,7 +309,7 @@ function PluginDetails( props ) {
 		'This plugin is available for download to be used on your {{a}}WordPress self-hosted{{/a}} installation.',
 		{
 			components: {
-				a: <a href="https://wordpress.org/documentation/article/wordpress-org-and-wordpress-com/" />,
+				a: <a href="https://wordpress.com/go/website-building/wordpress-com-vs-wordpress-org/" />,
 			},
 		}
 	);

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -309,7 +309,13 @@ function PluginDetails( props ) {
 		'This plugin is available for download to be used on your {{a}}WordPress self-hosted{{/a}} installation.',
 		{
 			components: {
-				a: <a href="https://wordpress.com/go/website-building/wordpress-com-vs-wordpress-org/" />,
+				a: (
+					<a
+						href={ localizeUrl(
+							'https://wordpress.com/go/website-building/wordpress-com-vs-wordpress-org/'
+						) }
+					/>
+				),
 			},
 		}
 	);

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -309,7 +309,7 @@ function PluginDetails( props ) {
 		'This plugin is available for download to be used on your {{a}}WordPress self-hosted{{/a}} installation.',
 		{
 			components: {
-				a: <a href="https://wordpress.org" />,
+				a: <a href="https://wordpress.org/documentation/article/wordpress-org-and-wordpress-com/" />,
 			},
 		}
 	);


### PR DESCRIPTION
From https://github.com/Automattic/wp-calypso/pull/81861

## Proposed Changes

Switches the wordpress.org link to a wordpress.com/go link.

## Testing Instructions

N/A