### PR TITLE
Domain management: Translate domain action messages

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -65,7 +65,14 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 						if ( action === 'manage-dns-settings' ) {
 							sendNudge( {
 								nudge: 'dns-settings',
-								initialMessage: `I see you want to change your DNS settings for your domain ${ domain.name }. That's a complex thing, but I can guide you and help you at any moment.`,
+								initialMessage: translate(
+									'I see you want to change your DNS settings for your domain %(domain)s. That’s a complex thing, but I can guide you and help you at any moment.',
+									{
+										args: {
+											domain: domain.name,
+										},
+									}
+								) as string,
 								context: { domain: domain.domain },
 							} );
 						}

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -95,7 +95,14 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 								action: () => {
 									sendNudge( {
 										nudge: 'dns-settings',
-										initialMessage: `I see you want to change your DNS settings for your domain ${ domain.name }. That's a complex thing, but I can guide you and help you at any moment.`,
+										initialMessage: translate(
+											'I see you want to change your DNS settings for your domain %(domain)s. That’s a complex thing, but I can guide you and help you at any moment.',
+											{
+												args: {
+													domain: domain.name,
+												},
+											}
+										) as string,
 										context: { domain: domain.domain },
 									} );
 								},
@@ -104,7 +111,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 
 						if ( action === 'set-primary-address' && site ) {
 							return {
-								message: 'Set domain as the primary site address',
+								message: translate( 'Set domain as the primary site address' ),
 								action: async () => {
 									try {
 										await dispatch( setPrimaryDomain( site.ID, domain.domain ) );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/81818.

## Proposed Changes

The messages passed to the domain table whenever an action is taken were sent literally, without calling the `translate` function. This PR changes that.