### PR TITLE
Domains table: Lower z-index priority of the sticky header

### DIFF
--- a/packages/domains-table/src/domains-table-header/style.scss
+++ b/packages/domains-table/src/domains-table-header/style.scss
@@ -9,6 +9,22 @@
 	font-weight: 500;
 	color: var(--color-neutral-60);
 	border-bottom: 1px solid #f0f0f0;
+
+	position: sticky;
+	top: var(--masterbar-height);
+	background: var(--color-surface-backdrop);
+	z-index: 1;
+
+	th {
+		padding: 16px 0;
+		color: var(--studio-gray-60);
+		vertical-align: middle;
+		font-size: $font-body-small;
+		font-style: normal;
+		font-weight: 500;
+		line-height: 20px;
+	}
+
 	.button-plain {
 		text-align: left;
 		line-height: 20px;

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -40,23 +40,6 @@
 		}
 	}
 
-	thead {
-		position: sticky;
-		top: var(--masterbar-height);
-		background: var(--color-surface-backdrop);
-		z-index: 9999;
-	}
-
-	th {
-		padding: 16px 0;
-		color: var(--studio-gray-60);
-		vertical-align: middle;
-		font-size: $font-body-small;
-		font-style: normal;
-		font-weight: 500;
-		line-height: 20px;
-	}
-
 	.domains-table__bulk-action-container {
 		width: 0;
 		min-width: fit-content;


### PR DESCRIPTION

Related to https://github.com/Automattic/wp-calypso/pull/81866.

## Proposed Changes

Setting `z-index: 9999` means that the sticky header will take precedence over everything on the page, including the popover, and that's not the desired behavior!

This PR changes the sticky table to the lowest possible z-index so that the table header still sticks but doesn't interfere with higher-priority elements on the page.

| Before | After |
| ------- | ----- |
| <img width="990" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/0735c4f5-3a78-4463-ad50-93173b2a3a2f"> | <img width="984" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/b5716e49-fe96-452e-ab53-7a607dea3214"> | 

I also moved the styles from the main SCSS file to the `domains-table-header` so it's better organized, code-wise.