### PR TITLE
Sites with lots of subscribers shows data now

### DIFF
--- a/client/landing/subscriptions/helpers/index.ts
+++ b/client/landing/subscriptions/helpers/index.ts
@@ -2,8 +2,14 @@ import { getQueryArgs } from '@wordpress/url';
 import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
 import type { Option } from 'calypso/landing/subscriptions/components/sort-controls';
 
-export const getOptionLabel = < T >( options: Option< T >[], value: T ) =>
-	options.find( ( option ) => option.value === value )?.label;
+export const getOptionLabel = < T >( options: Option< T >[], value: T ) => {
+	const foundOption = options.find( ( option ) => option.value === value )?.label;
+	if ( ! foundOption ) {
+		return options[ 0 ].label;
+	}
+
+	return foundOption;
+};
 
 export const getUrlQuerySearchTerm = () => {
 	const { s: urlQuerySearchTerm } = getQueryArgs( window.location.href );

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -2,10 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { DEFAULT_PER_PAGE, SubscribersFilterBy, SubscribersSortBy } from '../constants';
 import { getSubscribersCacheKey } from '../helpers';
+import useManySubsSite from '../hooks/use-many-subs-site';
 import type { SubscriberEndpointResponse } from '../types';
 
 type SubscriberQueryParams = {
-	siteId: number | undefined | null;
+	siteId: number | null;
 	page?: number;
 	perPage?: number;
 	search?: string;
@@ -21,21 +22,24 @@ const useSubscribersQuery = ( {
 	sortTerm = SubscribersSortBy.DateSubscribed,
 	filterOption = SubscribersFilterBy.All,
 }: SubscriberQueryParams ) => {
+	const hasManySubscribers = useManySubsSite( siteId );
+
 	return useQuery< SubscriberEndpointResponse >( {
 		queryKey: getSubscribersCacheKey( siteId, page, perPage, search, sortTerm, filterOption ),
 		queryFn: () => {
-			// When user_type is set to 'all', we use the 'subscribers' endpoint, which has aggregation.
 			// This is a temporary solution until we have a better way to handle this.
-			const pathRoute =
-				filterOption === SubscribersFilterBy.All ? 'subscribers' : 'subscribers_by_user_type';
-			const userTypeField = filterOption === SubscribersFilterBy.All ? 'filter' : 'user_type';
+			const pathRoute = hasManySubscribers ? 'subscribers_by_user_type' : 'subscribers';
+			const userTypeField = hasManySubscribers ? 'user_type' : 'filter';
+
+			const validatedFilterOption =
+				hasManySubscribers && filterOption === SubscribersFilterBy.All
+					? SubscribersFilterBy.WPCOM
+					: filterOption;
 
 			return wpcom.req.get( {
 				path: `/sites/${ siteId }/${ pathRoute }?per_page=${ perPage }&page=${ page }${
 					search ? `&search=${ encodeURIComponent( search ) }` : ''
-				}${ sortTerm ? `&sort=${ sortTerm }` : '' }${
-					filterOption ? `&${ userTypeField }=${ filterOption }` : ''
-				}`,
+				}${ sortTerm ? `&sort=${ sortTerm }` : '' }&${ userTypeField }=${ validatedFilterOption }`,
 				apiNamespace: 'wpcom/v2',
 			} );
 		},


### PR DESCRIPTION
## Proposed Changes

This PR fixes a problem where the admin of sites with many subscribers couldn't see the list of subscribers at all.

## Testing Instructions

1. You need a site with less than 30k subscribers and a site with more than 30k subscribers to do the proper tests.
2. Apply this PR and start the application.
3. Select the site with more than 30k subscribers and go to `Users`-> `Subscribers`.
4. The list of subscribers should load (note that several seconds can pass for that to happen with such big sites).
5. Check that the Subscribers filter has only two values: `Via Email` and `Via WordPress.com`.
6. Select the other type of subscriber (most likely `Via Email`) and check the correct values are loaded.
7. Use the pagination at the bottom for both subscriber types and check it still works perfectly.
8. Now, select the site with less than 30k subscribers.
9. Repeat steps 4, 6 and 7.
10. For step 5, the dropdown should have the three values: `All`, `Via Email`, and `Via WordPress.com`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?