### PR TITLE
Newsletter Settings: Fix the settings being disabled for Simple and Atomic sites

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -6,6 +6,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import { useSelector } from 'calypso/state';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
+import { isJetpackSite as isJetpackSiteSelector } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { NewsletterSettingsSection } from '../reading-newsletter-settings';
 import wrapSettingsForm from '../wrap-settings-form';
@@ -68,6 +69,9 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )(
 		updateFields,
 	}: NewsletterSettingsFormProps ) => {
 		const siteId = useSelector( getSelectedSiteId );
+		const isJetpackSite = useSelector( ( state ) => {
+			return isJetpackSiteSelector( state, siteId, { treatAtomicAsJetpackSite: false } );
+		} );
 
 		const isSubscriptionsModuleActive = useSelector( ( state ) => {
 			if ( ! siteId ) {
@@ -76,7 +80,10 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )(
 			return isJetpackModuleActive( state, siteId, 'subscriptions' );
 		} );
 
-		const disabled = ! isSubscriptionsModuleActive || isRequestingSettings || isSavingSettings;
+		const isSubscriptionModuleInactive =
+			Boolean( isJetpackSite ) && isSubscriptionsModuleActive === false;
+
+		const disabled = isSubscriptionModuleInactive || isRequestingSettings || isSavingSettings;
 		const savedSubscriptionOptions = settings?.subscription_options;
 
 		return (

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -69,19 +69,21 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )(
 		updateFields,
 	}: NewsletterSettingsFormProps ) => {
 		const siteId = useSelector( getSelectedSiteId );
-		const isJetpackSite = useSelector( ( state ) => {
-			return isJetpackSiteSelector( state, siteId, { treatAtomicAsJetpackSite: false } );
-		} );
 
-		const isSubscriptionsModuleActive = useSelector( ( state ) => {
+		const isSubscriptionModuleInactive = useSelector( ( state ) => {
 			if ( ! siteId ) {
 				return null;
 			}
-			return isJetpackModuleActive( state, siteId, 'subscriptions' );
-		} );
 
-		const isSubscriptionModuleInactive =
-			Boolean( isJetpackSite ) && isSubscriptionsModuleActive === false;
+			const isJetpackSite = isJetpackSiteSelector( state, siteId, {
+				treatAtomicAsJetpackSite: false,
+			} );
+
+			return (
+				Boolean( isJetpackSite ) &&
+				isJetpackModuleActive( state, siteId, 'subscriptions' ) === false
+			);
+		} );
 
 		const disabled = isSubscriptionModuleInactive || isRequestingSettings || isSavingSettings;
 		const savedSubscriptionOptions = settings?.subscription_options;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/81840

## Proposed Changes

* Check whether the subscriptions module is inactive only for jetpack connected sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
The Newsletter settings page can be found at: http://calypso.localhost:3000/settings/newsletter/$site-slug
* Test that the form is still disabled for Jetpack connected sites which have the subscriptions module disabled
* Test that the form is enabled for Simple and Atomic sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?