### PR TITLE
Domains table: Restore CTAs on mobile view

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -1,7 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable, ResponseDomain } from '@automattic/domains-table';
-import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useMemo, useState } from 'react';
@@ -37,7 +36,6 @@ interface BulkSiteDomainsProps {
 }
 
 export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
-	const isMobile = useMobileBreakpoint();
 	const site = useSelector( getSelectedSite );
 	const userCanSetPrimaryDomains = useSelector(
 		( state ) => ! currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
@@ -129,20 +127,20 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 							setChangeSiteAddressSourceDomain( domain );
 						}
 					} }
+					footer={
+						<>
+							{ ! isLoading && (
+								<EmptyDomainsListCard
+									selectedSite={ site }
+									hasDomainCredit={ !! hasDomainCredit }
+									isCompact={ hasNonWpcomDomains }
+									hasNonWpcomDomains={ hasNonWpcomDomains }
+								/>
+							) }
+							<ManageAllDomainsCTA shouldDisplaySeparator={ false } />
+						</>
+					}
 				/>
-				{ ! isMobile && (
-					<>
-						{ ! isLoading && (
-							<EmptyDomainsListCard
-								selectedSite={ site }
-								hasDomainCredit={ !! hasDomainCredit }
-								isCompact={ hasNonWpcomDomains }
-								hasNonWpcomDomains={ hasNonWpcomDomains }
-							/>
-						) }
-						<ManageAllDomainsCTA shouldDisplaySeparator={ false } />
-					</>
-				) }
 				{ changeSiteAddressSourceDomain && (
 					<SiteAddressChanger
 						currentDomain={ changeSiteAddressSourceDomain }

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -357,4 +357,10 @@
 	main {
 		max-width: 1224px;
 	}
+
+	.empty-domains-list-card {
+		@include breakpoint-deprecated( "<480px" ) {
+			box-shadow: none;
+		}
+	}
 }

--- a/packages/domains-table/src/domains-table-filters/index.tsx
+++ b/packages/domains-table/src/domains-table-filters/index.tsx
@@ -3,7 +3,7 @@ import SearchControl, { SearchIcon } from '@automattic/search';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { DropdownMenu, MenuGroup, MenuItem, ToggleControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { ReactNode, useEffect, useRef } from 'react';
+import { ReactNode } from 'react';
 import { useDomainsTable } from '../domains-table/domains-table';
 import './style.scss';
 
@@ -21,19 +21,6 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 	const { __ } = useI18n();
 
 	const isMobile = useMobileBreakpoint();
-	const filterContainer = useRef< HTMLDivElement >( null );
-
-	useEffect( () => {
-		if ( ! filterContainer.current ) {
-			return;
-		}
-
-		if ( isMobile ) {
-			filterContainer.current.style.top = `${ filterContainer.current.offsetTop }px`;
-		} else {
-			filterContainer.current.style.top = 'unset';
-		}
-	}, [ isMobile ] );
 
 	const {
 		sortKey,
@@ -75,7 +62,7 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 		} );
 
 	return (
-		<div className="domains-table-filter" ref={ filterContainer }>
+		<div className="domains-table-filter">
 			<SearchControl
 				searchIcon={ <SearchIcon /> }
 				className="domains-table-filter__search"

--- a/packages/domains-table/src/domains-table-filters/index.tsx
+++ b/packages/domains-table/src/domains-table-filters/index.tsx
@@ -1,11 +1,10 @@
 import { Gridicon, SelectDropdown } from '@automattic/components';
 import SearchControl, { SearchIcon } from '@automattic/search';
-import { isMobile } from '@automattic/viewport';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { DropdownMenu, MenuGroup, MenuItem, ToggleControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 import { useDomainsTable } from '../domains-table/domains-table';
-
 import './style.scss';
 
 export interface DomainsTableFilter {
@@ -20,6 +19,21 @@ interface DomainsTableFiltersProps {
 
 export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersProps ) => {
 	const { __ } = useI18n();
+
+	const isMobile = useMobileBreakpoint();
+	const filterContainer = useRef< HTMLDivElement >( null );
+
+	useEffect( () => {
+		if ( ! filterContainer.current ) {
+			return;
+		}
+
+		if ( isMobile ) {
+			filterContainer.current.style.top = `${ filterContainer.current.offsetTop }px`;
+		} else {
+			filterContainer.current.style.top = 'unset';
+		}
+	}, [ isMobile ] );
 
 	const {
 		sortKey,
@@ -60,10 +74,8 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 			);
 		} );
 
-	const isMobileDevice = isMobile();
-
 	return (
-		<div className="domains-table-filter">
+		<div className="domains-table-filter" ref={ filterContainer }>
 			<SearchControl
 				searchIcon={ <SearchIcon /> }
 				className="domains-table-filter__search"
@@ -73,7 +85,7 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 				placeholder={ __( 'Search by domain…' ) }
 				disableAutocorrect={ true }
 			/>
-			{ isMobileDevice && (
+			{ isMobile && (
 				<>
 					<div className="domains-table-mobile-cards-controls">
 						<SelectDropdown

--- a/packages/domains-table/src/domains-table-filters/style.scss
+++ b/packages/domains-table/src/domains-table-filters/style.scss
@@ -15,6 +15,7 @@
 .domains-table-filter {
 	display: flex;
 	justify-content: space-between;
+	background: var(--color-surface-backdrop);
 
 	@media ( max-width: 480px ) {
 		flex-direction: column;

--- a/packages/domains-table/src/domains-table-filters/style.scss
+++ b/packages/domains-table/src/domains-table-filters/style.scss
@@ -15,7 +15,6 @@
 .domains-table-filter {
 	display: flex;
 	justify-content: space-between;
-	background: var(--color-surface-backdrop);
 
 	@media ( max-width: 480px ) {
 		flex-direction: column;

--- a/packages/domains-table/src/domains-table/domains-table-toolbar.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-toolbar.tsx
@@ -1,3 +1,5 @@
+import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useEffect, useRef } from 'react';
 import { BulkActionsToolbar } from '../bulk-actions-toolbar/index';
 import { DomainsTableFilters } from '../domains-table-filters/index';
 import { useDomainsTable } from './domains-table';
@@ -14,19 +16,35 @@ export function DomainsTableToolbar() {
 		setFilter,
 	} = useDomainsTable();
 
-	if ( hasSelectedDomains ) {
-		return (
-			<BulkActionsToolbar
-				onAutoRenew={ handleAutoRenew }
-				onUpdateContactInfo={ handleUpdateContactInfo }
-				selectedDomainCount={ selectedDomains.size }
-			/>
-		);
-	}
+	const isMobile = useMobileBreakpoint();
+	const domainsTableToolbar = useRef< HTMLDivElement >( null );
+
+	useEffect( () => {
+		if ( ! domainsTableToolbar.current ) {
+			return;
+		}
+
+		if ( isMobile ) {
+			domainsTableToolbar.current.style.top = `${ domainsTableToolbar.current.offsetTop }px`;
+		} else {
+			domainsTableToolbar.current.style.top = 'unset';
+		}
+	}, [ isMobile ] );
+
 	return (
-		<DomainsTableFilters
-			onSearch={ ( query ) => setFilter( ( filter ) => ( { ...filter, query } ) ) }
-			filter={ filter }
-		/>
+		<div className="domains-table-toolbar" ref={ domainsTableToolbar }>
+			{ hasSelectedDomains ? (
+				<BulkActionsToolbar
+					onAutoRenew={ handleAutoRenew }
+					onUpdateContactInfo={ handleUpdateContactInfo }
+					selectedDomainCount={ selectedDomains.size }
+				/>
+			) : (
+				<DomainsTableFilters
+					onSearch={ ( query ) => setFilter( ( filter ) => ( { ...filter, query } ) ) }
+					filter={ filter }
+				/>
+			) }
+		</div>
 	);
 }

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -1,4 +1,5 @@
 import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { ReactNode } from 'react';
 import { DomainsTable as InternalDomainsTable, DomainsTablePropsNoChildren } from './domains-table';
 import { DomainsTableBody } from './domains-table-body';
 import { DomainsTableBulkUpdateNotice } from './domains-table-bulk-update-notice';
@@ -7,11 +8,12 @@ import { DomainsTableMobileCards } from './domains-table-mobile-cards';
 import { DomainsTableToolbar } from './domains-table-toolbar';
 import './style.scss';
 
-export function DomainsTable( props: DomainsTablePropsNoChildren ) {
+export function DomainsTable( props: DomainsTablePropsNoChildren & { footer?: ReactNode } ) {
 	const isMobile = useMobileBreakpoint();
+	const { footer, ...allProps } = props;
 
 	return (
-		<InternalDomainsTable { ...props }>
+		<InternalDomainsTable { ...allProps }>
 			<DomainsTableBulkUpdateNotice />
 			<DomainsTableToolbar />
 			{ isMobile ? (
@@ -22,6 +24,7 @@ export function DomainsTable( props: DomainsTablePropsNoChildren ) {
 					<DomainsTableBody />
 				</table>
 			) }
+			{ props.footer }
 		</InternalDomainsTable>
 	);
 }

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -2,29 +2,24 @@
 @import "@automattic/onboarding/styles/mixins";
 
 @media ( max-width: 480px ) {
-	.is-bulk-domains-page main {
-		overflow-y: hidden;
+	.navigation-header {
+		position: sticky;
 		/*
 		 * The 47px value comes from https://github.com/Automattic/wp-calypso/blob/d7e2ada/client/my-sites/sidebar/style.scss#L751.
 		 * Using 46px, which is the masterbar height CSS variable, introduces an annoying 1px scroll.
 		 * We're using this magic number elsewhere too, so a clean up would be appreciated.
 		 */
-		height: calc(100vh - 47px);
-		padding-bottom: 0 !important;
-		display: flex;
-		flex-direction: column;
+		top: 47px;
+		z-index: 1;
+	}
 
-		.domains-table {
-			flex: 1;
-			height: 100%;
-			overflow-y: hidden;
+	.domains-table-filter {
+		position: sticky;
+		z-index: 1;
+	}
 
-			border-collapse: collapse;
-
-			@media ( max-width: 480px ) {
-				padding: 13px;
-			}
-		}
+	.domains-table {
+		padding: 0 16px;
 	}
 }
 
@@ -220,10 +215,6 @@
 }
 
 .domains-table-mobile-cards {
-	height: calc(100vh - 280px);
-	overflow-y: auto;
-	padding: 3px;
-
 	.domains-table-mobile-cards-select-all {
 		display: flex;
 		align-items: center;

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -13,7 +13,7 @@
 		z-index: 1;
 	}
 
-	.domains-table-filter {
+	.domains-table-toolbar {
 		position: sticky;
 		z-index: 1;
 	}
@@ -24,7 +24,10 @@
 }
 
 .domains-table {
-	--domains-table-toolbar-height: 40px;
+	.domains-table-toolbar {
+		--domains-table-toolbar-height: 40px;
+		background: var(--color-surface-backdrop);
+	}
 
 	table {
 		margin-top: 14px; /* 30px - 16px of the table heading padding */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/81803.

## Proposed Changes

In the linked PR above, we hid the mobile CTAs (claim free domain, go to all domains) because of the way that the mobile experience was structured: sticky header, scrolling table.

This PR uses a different approach to achieve the same sticking result, but using `position: sticky` instead of messing with overflow and scrolling divs.

![calypso localhost_3000_domains_manage_zaguiini476 wpcomstaging com(iPhone 12 Pro)](https://github.com/Automattic/wp-calypso/assets/26530524/136f2bf6-3cd7-4906-a4de-31d7d033ff08)


## Testing Instructions

Open `/domains/manage/%s` on mobile and verify that once you scroll the table, the page header and domain toolbar are still visible, despite the table scrolling. At the end, you should see the CTAs (like in the screenshot above).