### PR TITLE
Themes: delist shopline wp.org themes

### DIFF
--- a/client/state/themes/actions/receive-themes.js
+++ b/client/state/themes/actions/receive-themes.js
@@ -1,14 +1,13 @@
 import { filter } from 'lodash';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { THEMES_REQUEST_SUCCESS } from 'calypso/state/themes/action-types';
-import { isThemeMatchingQuery } from 'calypso/state/themes/utils';
+import { isDelisted, isThemeMatchingQuery } from 'calypso/state/themes/utils';
 
 import 'calypso/state/themes/init';
 
 /**
  * Returns an action object to be used in signalling that theme objects from
  * a query have been received.
- *
  * @param {Array}  themes Themes received
  * @param {number} siteId ID of site for which themes have been received
  * @param {?Object} query Theme query used in the API request
@@ -26,10 +25,17 @@ export function receiveThemes( themes, siteId, query, foundCount ) {
 			 * because Jetpack theme API does not support search queries
 			 */
 			filteredThemes = filter( themes, ( theme ) => isThemeMatchingQuery( query, theme ) );
-
-			// Jetpack API returns all themes in one response (no paging)
-			found = filteredThemes.length;
 		}
+
+		if ( 'wporg' === siteId ) {
+			/*
+			 * We need to do client-side filtering for wporg results
+			 * because we fetch them directly from the wporg API
+			 */
+			filteredThemes = filter( themes, ( theme ) => ! isDelisted( theme ) );
+		}
+
+		found = filteredThemes.length;
 
 		dispatch( {
 			type: THEMES_REQUEST_SUCCESS,

--- a/client/state/themes/actions/receive-themes.js
+++ b/client/state/themes/actions/receive-themes.js
@@ -25,17 +25,19 @@ export function receiveThemes( themes, siteId, query, foundCount ) {
 			 * because Jetpack theme API does not support search queries
 			 */
 			filteredThemes = filter( themes, ( theme ) => isThemeMatchingQuery( query, theme ) );
+
+			// Jetpack API returns all themes in one response (no paging)
+			found = filteredThemes.length;
 		}
 
 		if ( 'wporg' === siteId ) {
 			/*
 			 * We need to do client-side filtering for wporg results
-			 * because we fetch them directly from the wporg API
+			 * because we fetch them directly from the wporg API.
 			 */
 			filteredThemes = filter( themes, ( theme ) => ! isDelisted( theme ) );
+			found = filteredThemes.length;
 		}
-
-		found = filteredThemes.length;
 
 		dispatch( {
 			type: THEMES_REQUEST_SUCCESS,

--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -9,13 +9,13 @@ import {
 	normalizeJetpackTheme,
 	normalizeWpcomTheme,
 	normalizeWporgTheme,
+	isDelisted,
 } from 'calypso/state/themes/utils';
 
 import 'calypso/state/themes/init';
 
 /**
  * Triggers a network request to fetch themes for the specified site and query.
- *
  * @param  {number|string} siteId        Jetpack site ID or 'wpcom' for any WPCOM site
  * @param  {Object}        query         Theme query
  * @param  {string}        query.search  Search string
@@ -73,7 +73,9 @@ export function requestThemes( siteId, query = {}, locale ) {
 			.then( ( { themes: rawThemes, info: { results } = {}, found = results } ) => {
 				let themes;
 				if ( siteId === 'wporg' ) {
-					themes = map( rawThemes, normalizeWporgTheme );
+					themes = rawThemes
+						.filter( ( theme ) => ! isDelisted( theme ) )
+						.map( rawThemes, normalizeWporgTheme );
 				} else if ( siteId === 'wpcom' ) {
 					themes = map( rawThemes, normalizeWpcomTheme );
 				} else {

--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -9,7 +9,6 @@ import {
 	normalizeJetpackTheme,
 	normalizeWpcomTheme,
 	normalizeWporgTheme,
-	isDelisted,
 } from 'calypso/state/themes/utils';
 
 import 'calypso/state/themes/init';
@@ -73,9 +72,7 @@ export function requestThemes( siteId, query = {}, locale ) {
 			.then( ( { themes: rawThemes, info: { results } = {}, found = results } ) => {
 				let themes;
 				if ( siteId === 'wporg' ) {
-					themes = rawThemes
-						.filter( ( theme ) => ! isDelisted( theme ) )
-						.map( rawThemes, normalizeWporgTheme );
+					themes = map( rawThemes, normalizeWporgTheme );
 				} else if ( siteId === 'wpcom' ) {
 					themes = map( rawThemes, normalizeWpcomTheme );
 				} else {

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -272,5 +272,5 @@ export function filterDelistedTaxonomyTermSlugs( filters ) {
  * @returns {boolean}         True if theme is delisted
  */
 export function isDelisted( theme ) {
-	return DELISTED_WPORG_THEMES.includes( theme.slug );
+	return DELISTED_WPORG_THEMES.includes( theme.id );
 }

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -17,13 +17,16 @@ const SEARCH_TAXONOMIES = [ 'feature' ];
 // Otherwise, they should be delisted in the backend.
 const DELISTED_TAXONOMY_TERM_SLUGS = [ 'auto-loading-homepage' ];
 
+// Used for client-side delisting of wp.org themes. Note that these themes are fethced
+// directly from wp.org, which is why they cannot be removed in the endpoint payload.
+const DELISTED_WPORG_THEMES = [ 'shopline', 'store-shopline' ];
+
 /**
  * Utility
  */
 
 /**
  * Whether a given theme object is premium.
- *
  * @param  {Object} theme Theme object
  * @returns {boolean}      True if the theme is premium
  */
@@ -34,7 +37,6 @@ export function isPremium( theme ) {
 
 /**
  * Normalizes a theme obtained via the WordPress.com REST API from a Jetpack site
- *
  * @param  {Object} theme  Theme object
  * @returns {Object}        Normalized theme object
  */
@@ -54,7 +56,6 @@ export function normalizeJetpackTheme( theme = {} ) {
 
 /**
  * Normalizes a theme obtained from the WordPress.com REST API
- *
  * @param  {Object} theme  Theme object
  * @returns {Object}        Normalized theme object
  */
@@ -76,7 +77,6 @@ export function normalizeWpcomTheme( theme ) {
 
 /**
  * Normalizes a theme obtained from the WordPress.org REST API
- *
  * @param  {Object} theme  Theme object
  * @returns {Object}        Normalized theme object
  */
@@ -120,7 +120,6 @@ export function normalizeWporgTheme( theme ) {
 /**
  * Returns a normalized themes query, excluding any values which match the
  * default theme query.
- *
  * @param  {Object} query Themes query
  * @returns {Object}       Normalized themes query
  */
@@ -130,7 +129,6 @@ export function getNormalizedThemesQuery( query ) {
 
 /**
  * Returns a serialized themes query
- *
  * @param  {Object} query  Themes query
  * @param  {number} siteId Optional site ID
  * @returns {string}        Serialized themes query
@@ -149,7 +147,6 @@ export function getSerializedThemesQuery( query = {}, siteId ) {
 /**
  * Returns an object with details related to the specified serialized query.
  * The object will include siteId and/or query object, if can be parsed.
- *
  * @param  {string} serializedQuery Serialized themes query
  * @returns {Object}                 Deserialized themes query details
  */
@@ -170,7 +167,6 @@ export function getDeserializedThemesQueryDetails( serializedQuery ) {
 
 /**
  * Returns a serialized themes query, excluding any page parameter
- *
  * @param  {Object} query  Themes query
  * @param  {number} siteId Optional site ID
  * @returns {string}        Serialized themes query
@@ -181,7 +177,6 @@ export function getSerializedThemesQueryWithoutPage( query, siteId ) {
 
 /**
  * Returns true if the theme matches the given query, or false otherwise.
- *
  * @param  {Object}  query Query object
  * @param  {Object}  theme Item to consider
  * @returns {boolean}       Whether theme matches query
@@ -235,7 +230,6 @@ export function isThemeMatchingQuery( query, theme ) {
 
 /**
  * Returns the slugs of the theme's given taxonomy.
- *
  * @param  {Object} theme    The theme object.
  * @param  {string} taxonomy The taxonomy items to get.
  * @returns {Array}           An array of theme taxonomy slugs.
@@ -247,7 +241,6 @@ export function getThemeTaxonomySlugs( theme, taxonomy ) {
 
 /**
  * Returns true if a taxonomy term slug is delisted.
- *
  * @param  {string}  slug   The term slug to check for delisting
  * @returns {boolean}       True if term slug is delisted
  */
@@ -257,7 +250,6 @@ export function isDelistedTaxonomyTermSlug( slug ) {
 
 /**
  * Returns the list of available theme filters, excluding the delisted taxonomy terms.
- *
  * @param {Object}  filters A list of filters.
  * @returns {Object}        A nested list of theme filters, keyed by term slug
  */
@@ -272,4 +264,13 @@ export function filterDelistedTaxonomyTermSlugs( filters ) {
 	}
 
 	return result;
+}
+
+/**
+ * Is wp.org theme delisted?
+ * @param  {Object} theme  Theme object
+ * @returns {boolean}         True if theme is delisted
+ */
+export function isDelisted( theme ) {
+	return DELISTED_WPORG_THEMES.includes( theme.slug );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3819

## Proposed Changes

* Adds the ability to blacklist themes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /themes
* Search for `shopline`
* Make sure that themes with slugs `shopline`, `store-shopline` do not appear
* Check for potential regressions

|Before | After|
|-------|------|
|<img width="1081" alt="CleanShot 2023-09-19 at 18 12 50@2x" src="https://github.com/Automattic/wp-calypso/assets/12430020/928bb39f-4094-4f32-a831-68adc00bd918">|<img width="1084" alt="CleanShot 2023-09-19 at 18 13 10@2x" src="https://github.com/Automattic/wp-calypso/assets/12430020/e555fb74-dcd4-440d-952c-f8646a96f135">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?