### PR TITLE
Plans 2023: Bring Oddie AI Assistant logic out of the grid components. Extracts "compare plans" button out too

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -93,12 +93,13 @@ export interface PlanFeatures2023GridProps {
 	showUpgradeableStorage: boolean; // feature flag used to show the storage add-on dropdown
 	stickyRowOffset: number;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
-	showOdie?: () => void;
 	// temporary
 	showPlansComparisonGrid: boolean;
 	// temporary
 	toggleShowPlansComparisonGrid: () => void;
 	planTypeSelectorProps: PlanTypeSelectorProps;
+	// temporary: callback ref to scroll Oddie-AI Assistant into view once "Compare plans" button is clicked
+	observableForOddieRef: ( observableElement: Element | null ) => void;
 }
 
 interface PlanFeatures2023GridType extends PlanFeatures2023GridProps {
@@ -113,29 +114,7 @@ interface PlanFeatures2023GridType extends PlanFeatures2023GridProps {
 }
 
 export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > {
-	observer: IntersectionObserver | null = null;
 	buttonRef: React.RefObject< HTMLButtonElement > = createRef< HTMLButtonElement >();
-
-	componentDidMount() {
-		this.observer = new IntersectionObserver( ( entries ) => {
-			entries.forEach( ( entry ) => {
-				if ( entry.isIntersecting ) {
-					this.props.showOdie?.();
-					this.observer?.disconnect();
-				}
-			} );
-		} );
-
-		if ( this.buttonRef.current ) {
-			this.observer.observe( this.buttonRef.current );
-		}
-	}
-
-	componentWillUnmount() {
-		if ( this.observer ) {
-			this.observer.disconnect();
-		}
-	}
 
 	renderTable( renderedGridPlans: GridPlan[] ) {
 		const { translate, gridPlanForSpotlight, stickyRowOffset, isInSignup } = this.props;
@@ -720,6 +699,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			toggleShowPlansComparisonGrid,
 			showPlansComparisonGrid,
 			showUpgradeableStorage,
+			observableForOddieRef,
 		} = this.props;
 
 		return (
@@ -757,7 +737,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 				</div>
 				{ ! hidePlansFeatureComparison && (
 					<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
-						<Button onClick={ toggleShowPlansComparisonGrid } ref={ this.buttonRef }>
+						<Button onClick={ toggleShowPlansComparisonGrid } ref={ observableForOddieRef }>
 							{ showPlansComparisonGrid
 								? translate( 'Hide comparison' )
 								: translate( 'Compare plans' ) }

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -98,8 +98,8 @@ export interface PlanFeatures2023GridProps {
 	// temporary
 	toggleShowPlansComparisonGrid: () => void;
 	planTypeSelectorProps: PlanTypeSelectorProps;
-	// temporary: callback ref to scroll Oddie-AI Assistant into view once "Compare plans" button is clicked
-	observableForOddieRef: ( observableElement: Element | null ) => void;
+	// temporary: callback ref to scroll Odie AI Assistant into view once "Compare plans" button is clicked
+	observableForOdieRef: ( observableElement: Element | null ) => void;
 }
 
 interface PlanFeatures2023GridType extends PlanFeatures2023GridProps {
@@ -699,7 +699,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			toggleShowPlansComparisonGrid,
 			showPlansComparisonGrid,
 			showUpgradeableStorage,
-			observableForOddieRef,
+			observableForOdieRef,
 		} = this.props;
 
 		return (
@@ -743,7 +743,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 								? translate( 'Hide comparison' )
 								: translate( 'Compare plans' )
 						}
-						ref={ observableForOddieRef }
+						ref={ observableForOdieRef }
 					/>
 				) }
 				{ ! hidePlansFeatureComparison && showPlansComparisonGrid ? (

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -21,7 +21,6 @@ import {
 } from '@automattic/components';
 import { isAnyHostingFlow } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import { Button } from '@wordpress/components';
 import classNames from 'classnames';
 import { LocalizeProps, useTranslate } from 'i18n-calypso';
 import { Component, ForwardedRef, forwardRef, createRef } from 'react';
@@ -34,6 +33,7 @@ import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-p
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
 import CalypsoShoppingCartProvider from '../checkout/calypso-shopping-cart-provider';
+import ComparisonGridToggle from '../plans-features-main/components/comparison-grid-toggle';
 import { getManagePurchaseUrlFor } from '../purchases/paths';
 import PlanFeatures2023GridActions from './components/actions';
 import PlanFeatures2023GridBillingTimeframe from './components/billing-timeframe';
@@ -736,13 +736,15 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 					</PlansGridContextProvider>
 				</div>
 				{ ! hidePlansFeatureComparison && (
-					<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
-						<Button onClick={ toggleShowPlansComparisonGrid } ref={ observableForOddieRef }>
-							{ showPlansComparisonGrid
+					<ComparisonGridToggle
+						onClick={ toggleShowPlansComparisonGrid }
+						label={
+							showPlansComparisonGrid
 								? translate( 'Hide comparison' )
-								: translate( 'Compare plans' ) }
-						</Button>
-					</div>
+								: translate( 'Compare plans' )
+						}
+						ref={ observableForOddieRef }
+					/>
 				) }
 				{ ! hidePlansFeatureComparison && showPlansComparisonGrid ? (
 					<div
@@ -772,11 +774,10 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 								showLegacyStorageFeature={ showLegacyStorageFeature }
 								showUpgradeableStorage={ showUpgradeableStorage }
 							/>
-							<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
-								<Button onClick={ toggleShowPlansComparisonGrid }>
-									{ translate( 'Hide comparison' ) }
-								</Button>
-							</div>
+							<ComparisonGridToggle
+								onClick={ toggleShowPlansComparisonGrid }
+								label={ translate( 'Hide comparison' ) }
+							/>
 						</PlansGridContextProvider>
 					</div>
 				) : null }

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -23,7 +23,7 @@ import { isAnyHostingFlow } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import classNames from 'classnames';
 import { LocalizeProps, useTranslate } from 'i18n-calypso';
-import { Component, ForwardedRef, forwardRef, createRef } from 'react';
+import { Component, ForwardedRef, forwardRef } from 'react';
 import { useSelector } from 'react-redux';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
 import FoldableCard from 'calypso/components/foldable-card';
@@ -114,8 +114,6 @@ interface PlanFeatures2023GridType extends PlanFeatures2023GridProps {
 }
 
 export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > {
-	buttonRef: React.RefObject< HTMLButtonElement > = createRef< HTMLButtonElement >();
-
 	renderTable( renderedGridPlans: GridPlan[] ) {
 		const { translate, gridPlanForSpotlight, stickyRowOffset, isInSignup } = this.props;
 		// Do not render the spotlight plan if it exists

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1100,47 +1100,6 @@ body.is-section-signup.is-white-signup,
 	}
 }
 
-.plan-features-2023-grid__toggle-plan-comparison-button-container {
-	display: flex;
-	justify-content: center;
-	margin-top: 32px;
-	margin-left: 20px;
-	margin-right: 20px;
-
-	@include plans-section-custom-mobile-breakpoint {
-		margin-left: 0;
-		margin-right: 0;
-	}
-
-	button {
-		background: var(--studio-white);
-		border: 1px solid var(--studio-gray-10);
-		border-radius: 4px;
-		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-		color: var(--studio-gray-100);
-		font-size: $font-body-small;
-		font-weight: 500;
-		height: 48px;
-		justify-content: center;
-		line-height: 20px;
-		padding: 0 24px;
-		width: 100%;
-		transition: border-color 0.15s ease-out;
-
-		@include plans-2023-break-small {
-			width: initial;
-			height: 40px;
-		}
-
-		&:not([disabled]):hover,
-		&:not([disabled]):focus {
-			border-color: var(--studio-gray-100);
-			box-shadow: none;
-			color: inherit;
-		}
-	}
-}
-
 /**
  * We auto-scroll to the plan comparison grid when it is shown.
  * However, on the /plans page, due to the presence of the masterbar on top,

--- a/client/my-sites/plans-features-main/components/comparison-grid-toggle.tsx
+++ b/client/my-sites/plans-features-main/components/comparison-grid-toggle.tsx
@@ -1,0 +1,61 @@
+import { Button } from '@automattic/components';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { type TranslateResult } from 'i18n-calypso';
+import { forwardRef } from 'react';
+import { plansBreakSmall } from 'calypso/my-sites/plan-features-2023-grid/media-queries';
+import '../style.scss';
+
+const ComparisonGridToggle = forwardRef<
+	HTMLAnchorElement | HTMLButtonElement,
+	{
+		onClick: () => void;
+		label: TranslateResult;
+	}
+>( ( { onClick, label }, ref ) => {
+	const Container = styled.div`
+		display: flex;
+		justify-content: center;
+		margin-top: 32px;
+		margin-left: 20px;
+		margin-right: 20px;
+
+		button {
+			background: var( --studio-white );
+			border: 1px solid var( --studio-gray-10 );
+			border-radius: 4px;
+			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
+			color: var( --studio-gray-100 );
+			font-size: var( --scss-font-body-small );
+			font-weight: 500;
+			height: 48px;
+			justify-content: center;
+			line-height: 20px;
+			padding: 0 24px;
+			width: 100%;
+			transition: border-color 0.15s ease-out;
+
+			${ plansBreakSmall( css`
+				width: initial;
+				height: 40px;
+			` ) }
+
+			&:not( [disabled] ):hover,
+			&:not( [disabled] ):focus {
+				border-color: var( --studio-gray-100 );
+				box-shadow: none;
+				color: inherit;
+			}
+		}
+	`;
+
+	return (
+		<Container>
+			<Button onClick={ onClick } ref={ ref }>
+				{ label }
+			</Button>
+		</Container>
+	);
+} );
+
+export default ComparisonGridToggle;

--- a/client/my-sites/plans-features-main/hooks/use-observable-for-oddie.ts
+++ b/client/my-sites/plans-features-main/hooks/use-observable-for-oddie.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useOdieAssistantContext } from 'calypso/odie/context';
+
+/**
+ * Returns a callback for setting an observable node to show the Oddie AI assistant
+ * when it's intersected in view
+ */
+const useObservableForOddie = () => {
+	const {
+		isVisible: isOdieVisible,
+		setIsVisible: setIsOdieVisible,
+		trackEvent: trackOdieEvent,
+	} = useOdieAssistantContext();
+
+	const observer = useRef< IntersectionObserver | null >( null );
+
+	useEffect( () => {
+		if ( ! window.IntersectionObserver ) {
+			return;
+		}
+
+		observer.current = new IntersectionObserver( ( entries ) => {
+			entries.forEach( ( entry ) => {
+				if ( entry.isIntersecting ) {
+					if ( ! isOdieVisible ) {
+						trackOdieEvent( 'calypso_odie_chat_toggle_visibility', {
+							visibility: true,
+							trigger: 'scroll',
+						} );
+						setIsOdieVisible( true );
+					}
+
+					observer.current?.disconnect();
+				}
+			} );
+		} );
+
+		return () => {
+			observer.current?.disconnect();
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	return useCallback( ( observableElement: Element | null ) => {
+		if ( null !== observableElement ) {
+			observer?.current?.observe( observableElement );
+		}
+	}, [] );
+};
+
+export default useObservableForOddie;

--- a/client/my-sites/plans-features-main/hooks/use-observable-for-odie.ts
+++ b/client/my-sites/plans-features-main/hooks/use-observable-for-odie.ts
@@ -2,10 +2,10 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useOdieAssistantContext } from 'calypso/odie/context';
 
 /**
- * Returns a callback for setting an observable node to show the Oddie AI assistant
+ * Returns a callback for setting an observable node to show the Odie AI assistant
  * when it's intersected in view
  */
-const useObservableForOddie = () => {
+const useObservableForOdie = () => {
 	const {
 		isVisible: isOdieVisible,
 		setIsVisible: setIsOdieVisible,
@@ -48,4 +48,4 @@ const useObservableForOddie = () => {
 	}, [] );
 };
 
-export default useObservableForOddie;
+export default useObservableForOdie;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -50,7 +50,7 @@ import usePricingMetaForGridPlans from './hooks/data-store/use-pricing-meta-for-
 import useFilterPlansForPlanFeatures from './hooks/use-filter-plans-for-plan-features';
 import useIsCustomDomainAllowedOnFreePlan from './hooks/use-is-custom-domain-allowed-on-free-plan';
 import useIsPlanUpsellEnabledOnFreeDomain from './hooks/use-is-plan-upsell-enabled-on-free-domain';
-import useObservableForOddie from './hooks/use-observable-for-oddie';
+import useObservableForOdie from './hooks/use-observable-for-odie';
 import usePlanBillingPeriod from './hooks/use-plan-billing-period';
 import usePlanFromUpsells from './hooks/use-plan-from-upsells';
 import usePlanIntentFromSiteMeta from './hooks/use-plan-intent-from-site-meta';
@@ -243,7 +243,7 @@ const PlansFeaturesMain = ( {
 	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
 	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
-	const observableForOddieRef = useObservableForOddie();
+	const observableForOdieRef = useObservableForOdie();
 
 	const toggleShowPlansComparisonGrid = () => {
 		setShowPlansComparisonGrid( ! showPlansComparisonGrid );
@@ -690,7 +690,7 @@ const PlansFeaturesMain = ( {
 							toggleShowPlansComparisonGrid={ toggleShowPlansComparisonGrid }
 							planTypeSelectorProps={ planTypeSelectorProps }
 							ref={ plansComparisonGridRef }
-							observableForOddieRef={ observableForOddieRef }
+							observableForOdieRef={ observableForOdieRef }
 						/>
 					</div>
 				</>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -34,7 +34,6 @@ import usePlanFeaturesForGridPlans from 'calypso/my-sites/plan-features-2023-gri
 import useRestructuredPlanFeaturesForComparisonGrid from 'calypso/my-sites/plan-features-2023-grid/hooks/npm-ready/data-store/use-restructured-plan-features-for-comparison-grid';
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
 import PlanTypeSelector from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
-import { useOdieAssistantContext } from 'calypso/odie/context';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
@@ -51,6 +50,7 @@ import usePricingMetaForGridPlans from './hooks/data-store/use-pricing-meta-for-
 import useFilterPlansForPlanFeatures from './hooks/use-filter-plans-for-plan-features';
 import useIsCustomDomainAllowedOnFreePlan from './hooks/use-is-custom-domain-allowed-on-free-plan';
 import useIsPlanUpsellEnabledOnFreeDomain from './hooks/use-is-plan-upsell-enabled-on-free-domain';
+import useObservableForOddie from './hooks/use-observable-for-oddie';
 import usePlanBillingPeriod from './hooks/use-plan-billing-period';
 import usePlanFromUpsells from './hooks/use-plan-from-upsells';
 import usePlanIntentFromSiteMeta from './hooks/use-plan-intent-from-site-meta';
@@ -68,7 +68,6 @@ import type {
 	PlanActionOverrides,
 } from 'calypso/my-sites/plan-features-2023-grid/types';
 import type { IAppState } from 'calypso/state/types';
-
 import './style.scss';
 
 const SPOTLIGHT_ENABLED_INTENTS = [ 'plans-default-wpcom' ];
@@ -244,6 +243,7 @@ const PlansFeaturesMain = ( {
 	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
 	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
+	const observableForOddieRef = useObservableForOddie();
 
 	const toggleShowPlansComparisonGrid = () => {
 		setShowPlansComparisonGrid( ! showPlansComparisonGrid );
@@ -253,7 +253,6 @@ const PlansFeaturesMain = ( {
 		setShowDomainUpsellDialog( true );
 	}, [ setShowDomainUpsellDialog ] );
 
-	const { isVisible, setIsVisible, trackEvent } = useOdieAssistantContext();
 	const currentUserName = useSelector( getCurrentUserName );
 	const { wpcomFreeDomainSuggestion, invalidateDomainSuggestionCache } =
 		useGetFreeSubdomainSuggestion(
@@ -687,19 +686,11 @@ const PlansFeaturesMain = ( {
 							stickyRowOffset={ masterbarHeight }
 							usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 							allFeaturesList={ FEATURES_LIST }
-							showOdie={ () => {
-								if ( ! isVisible ) {
-									trackEvent( 'calypso_odie_chat_toggle_visibility', {
-										visibility: true,
-										trigger: 'scroll',
-									} );
-									setIsVisible( true );
-								}
-							} }
 							showPlansComparisonGrid={ showPlansComparisonGrid }
 							toggleShowPlansComparisonGrid={ toggleShowPlansComparisonGrid }
 							planTypeSelectorProps={ planTypeSelectorProps }
 							ref={ plansComparisonGridRef }
+							observableForOddieRef={ observableForOddieRef }
 						/>
 					</div>
 				</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78266

## Proposed Changes

- Extracts the Odie AI Assistant handler/logic out of the grid components and into a generalised hook
- Extracts the "compare plans" button into a `ComparisonGridToggle` component to forward reference (and temporarily imports into plans grid components for use). **Next up**: use of this toggle will migrate entirely at consuming end (`plans-features-main`)

### Media

https://github.com/Automattic/wp-calypso/assets/1705499/e39efd51-25d3-4e23-9f97-c8f9466e8854


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Confirm Odie AI assistant works like before:
- Visit `/plans/[site]` with `?flags=odie`
- Scroll to the bottom until "Compare Plans" button shows. 
- Oddie widget should slide in from the side and stay present until reload (as per original)
- Clicking on it around the header should hide it back to the side and not scroll it back into view until reload (as per original)

2. Confirm `calypso_odie_chat_toggle_visibility` is tracked when Odie widget slides into view:
- Visit `/plans/[site]` with `?flags=odie`
- Scroll to the bottom until "Compare Plans" button shows and Odie widget slides into view
- Observe Network tab for a `pixel.wp.com/t.gif` request with `_en: calypso_odie_chat_toggle_visibility` in the payload

3. Confirm "compare plans" and "hide comparison" buttons render and work as previously (show/hide comparison)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?