### PR TITLE
Site profiler: Implement Heading block

### DIFF
--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -41,7 +41,7 @@ export default function DomainAnalyzer( props: Props ) {
 						/>
 					</div>
 					<div className="col-2">
-						<Button isBusy={ isBusy } type="submit">
+						<Button isBusy={ isBusy } type="submit" className="button-action">
 							{ translate( 'Check site' ) }
 						</Button>
 					</div>

--- a/client/site-profiler/components/domain-analyzer/styles.scss
+++ b/client/site-profiler/components/domain-analyzer/styles.scss
@@ -33,21 +33,4 @@
 			outline: none;
 		}
 	}
-
-	button {
-		color: #fff;
-		background: var(--wp-admin-theme-color);
-		border-radius: 4px;
-		font-size: 1rem;
-		font-weight: 500;
-		padding: 1.5rem;
-
-		&:hover {
-			color: #fff !important;
-		}
-
-		&.is-busy {
-			background-image: linear-gradient(-45deg, var(--wp-admin-theme-color) 33%, var(--wp-admin-theme-color-darker-20) 33%, var(--wp-admin-theme-color-darker-20) 70%, var(--wp-admin-theme-color) 70%);
-		}
-	}
 }

--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -27,11 +27,16 @@ export default function DomainInformation( props: Props ) {
 			<h3>Domain information</h3>
 
 			<ul className="domain-information-details result-list">
-				{ whois.registrar_url && (
+				{ whois.registrar && (
 					<li>
 						<div className="name">Registrar</div>
 						<div>
-							<a href={ whois.registrar_url }>{ whois.registrar_url }</a>
+							{ whois.registrar_url && (
+								<a href={ whois.registrar_url } target="_blank" rel="noopener noreferrer">
+									{ whois.registrar }
+								</a>
+							) }
+							{ ! whois.registrar_url && <span>{ whois.registrar }</span> }
 						</div>
 					</li>
 				) }

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -1,7 +1,24 @@
-export default function HeadingInformation() {
+import { Button } from '@wordpress/components';
+import './styles.scss';
+
+interface Props {
+	domain: string;
+}
+
+export default function HeadingInformation( props: Props ) {
+	const { domain } = props;
+
 	return (
-		<>
-			<h3>Heading information</h3>
-		</>
+		<div className="heading-information">
+			<summary>
+				<h5>Who Hosts This Site?</h5>
+				<div className="domain">{ domain }</div>
+				<p>Nice! This site and its domain are fully hosted on WordPress.com!</p>
+			</summary>
+			<footer>
+				<Button className="button-action">Transfer domain</Button>
+				<Button variant="link">Check another site</Button>
+			</footer>
+		</div>
 	);
 }

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import './styles.scss';
 
@@ -13,16 +14,35 @@ export default function HeadingInformation( props: Props ) {
 		<div className="heading-information">
 			<summary>
 				<h5>Who Hosts This Site?</h5>
-				<div className="domain">{ domain }</div>
+				<div className="domain">
+					<span className="status-icon green">
+						<Gridicon icon="checkmark" size={ 18 } />
+					</span>
+					<span className="status-icon blue">
+						<Gridicon icon="checkmark" size={ 18 } />
+					</span>
+					<span className="status-icon red">
+						<Gridicon icon="cross" size={ 18 } />
+					</span>
+					{ domain }
+				</div>
 				<p>Nice! This site and its domain are fully hosted on WordPress.com!</p>
 			</summary>
 			<footer>
-				<Button className="button-action">Transfer domain</Button>
-				{ onCheckAnotherSite && (
-					<Button variant="link" onClick={ onCheckAnotherSite }>
-						Check another site
-					</Button>
-				) }
+				<p>
+					If you own this site, host it with <strong>WordPress.com</strong> and benefit from one of
+					the best hosting platforms in the world.
+				</p>
+				<div className="cta-wrapper">
+					<Button className="button-action">Migrate site</Button>
+					<Button className="button-action">Transfer domain</Button>
+					<Button className="button-action">Transfer domain for free</Button>
+					{ onCheckAnotherSite && (
+						<Button variant="link" onClick={ onCheckAnotherSite }>
+							Check another site
+						</Button>
+					) }
+				</div>
 			</footer>
 		</div>
 	);

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -1,42 +1,43 @@
-import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
+import StatusCtaInfo from '../heading-information/status-cta-info';
+import StatusIcon from '../heading-information/status-icon';
+import StatusInfo from '../heading-information/status-info';
+import type { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
 import './styles.scss';
 
 interface Props {
 	domain: string;
+	conversionAction?: CONVERSION_ACTION;
 	onCheckAnotherSite?: () => void;
 }
 
 export default function HeadingInformation( props: Props ) {
-	const { domain, onCheckAnotherSite } = props;
+	const { domain, conversionAction, onCheckAnotherSite } = props;
 
 	return (
 		<div className="heading-information">
 			<summary>
 				<h5>Who Hosts This Site?</h5>
 				<div className="domain">
-					<span className="status-icon green">
-						<Gridicon icon="checkmark" size={ 18 } />
-					</span>
-					<span className="status-icon blue">
-						<Gridicon icon="checkmark" size={ 18 } />
-					</span>
-					<span className="status-icon red">
-						<Gridicon icon="cross" size={ 18 } />
-					</span>
+					<StatusIcon conversionAction={ conversionAction } />
 					{ domain }
 				</div>
-				<p>Nice! This site and its domain are fully hosted on WordPress.com!</p>
+				<StatusInfo conversionAction={ conversionAction } />
 			</summary>
 			<footer>
-				<p>
-					If you own this site, host it with <strong>WordPress.com</strong> and benefit from one of
-					the best hosting platforms in the world.
-				</p>
+				<StatusCtaInfo conversionAction={ conversionAction } />
 				<div className="cta-wrapper">
-					<Button className="button-action">Migrate site</Button>
-					<Button className="button-action">Transfer domain</Button>
-					<Button className="button-action">Transfer domain for free</Button>
+					{ conversionAction === 'register-domain' && (
+						<Button className="button-action">Register domain</Button>
+					) }
+					{ ( conversionAction === 'transfer-domain' ||
+						conversionAction === 'transfer-domain-hosting' ) && (
+						<Button className="button-action">Transfer domain</Button>
+					) }
+					{ conversionAction === 'transfer-hosting' && (
+						<Button className="button-action">Migrate site</Button>
+					) }
+
 					{ onCheckAnotherSite && (
 						<Button variant="link" onClick={ onCheckAnotherSite }>
 							Check another site

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -3,10 +3,11 @@ import './styles.scss';
 
 interface Props {
 	domain: string;
+	onCheckAnotherSite?: () => void;
 }
 
 export default function HeadingInformation( props: Props ) {
-	const { domain } = props;
+	const { domain, onCheckAnotherSite } = props;
 
 	return (
 		<div className="heading-information">
@@ -17,7 +18,11 @@ export default function HeadingInformation( props: Props ) {
 			</summary>
 			<footer>
 				<Button className="button-action">Transfer domain</Button>
-				<Button variant="link">Check another site</Button>
+				{ onCheckAnotherSite && (
+					<Button variant="link" onClick={ onCheckAnotherSite }>
+						Check another site
+					</Button>
+				) }
 			</footer>
 		</div>
 	);

--- a/client/site-profiler/components/heading-information/status-cta-info.tsx
+++ b/client/site-profiler/components/heading-information/status-cta-info.tsx
@@ -1,0 +1,41 @@
+import { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
+
+interface Props {
+	conversionAction?: CONVERSION_ACTION;
+}
+export default function StatusCtaInfo( props: Props ) {
+	const { conversionAction } = props;
+
+	switch ( conversionAction ) {
+		case 'register-domain':
+			return (
+				<p>
+					Register your domain with <strong>WordPress.com</strong> and benefit from one of the best
+					hosting platforms in the world.
+				</p>
+			);
+		case 'transfer-domain':
+			return (
+				<p>
+					If you own this domain, transfer it to <strong>WordPress.com</strong> and benefit from the
+					best-performing, most reliable registrar in the business.
+				</p>
+			);
+		case 'transfer-hosting':
+			return (
+				<p>
+					If you own this site, host it with <strong>WordPress.com</strong> and benefit from one of
+					the best hosting platforms in the world.
+				</p>
+			);
+		case 'transfer-domain-hosting':
+			return (
+				<p>
+					If you are the owner, bring your site and domain to <strong>WordPress.com</strong> and
+					benefit from one of the best hosting platforms in the world.{ ' ' }
+				</p>
+			);
+		default:
+			return null;
+	}
+}

--- a/client/site-profiler/components/heading-information/status-icon.tsx
+++ b/client/site-profiler/components/heading-information/status-icon.tsx
@@ -1,0 +1,42 @@
+import { Gridicon } from '@automattic/components';
+import { useState, useEffect } from 'react';
+import type { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
+
+interface Props {
+	conversionAction?: CONVERSION_ACTION;
+}
+export default function StatusIcon( props: Props ) {
+	const { conversionAction } = props;
+	const [ statusIcon, setStatusIcon ] = useState( '' );
+	const [ statusColor, setStatusColor ] = useState( '' );
+
+	useEffect( () => {
+		switch ( conversionAction ) {
+			case 'register-domain':
+				setStatusIcon( 'checkmark' );
+				setStatusColor( 'green' );
+				break;
+			case 'transfer-domain':
+			case 'transfer-hosting':
+			case 'transfer-domain-hosting':
+				setStatusIcon( 'cross' );
+				setStatusColor( 'red' );
+				break;
+			case 'idle':
+			default:
+				setStatusIcon( 'checkmark' );
+				setStatusColor( 'blue' );
+				break;
+		}
+	}, [ conversionAction ] );
+
+	if ( ! conversionAction ) {
+		return null;
+	}
+
+	return (
+		<span className={ `status-icon ${ statusColor }` }>
+			<Gridicon icon={ statusIcon } size={ 18 } />
+		</span>
+	);
+}

--- a/client/site-profiler/components/heading-information/status-info.tsx
+++ b/client/site-profiler/components/heading-information/status-info.tsx
@@ -1,0 +1,42 @@
+import { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
+
+interface Props {
+	conversionAction?: CONVERSION_ACTION;
+}
+export default function StatusInfo( props: Props ) {
+	const { conversionAction } = props;
+
+	switch ( conversionAction ) {
+		case 'register-domain':
+			return <p>Nice! This site and its domain are fully hosted on WordPress.com!</p>;
+		case 'transfer-domain':
+			return (
+				<p>
+					This site is hosted on <strong>WordPress.com</strong> but the domain is registered
+					elsewhere.
+				</p>
+			);
+		case 'transfer-hosting':
+			return (
+				<p>
+					This site is using <strong>WordPress.com</strong> to manage the domain, but the site is
+					hosted elsewhere.
+				</p>
+			);
+		case 'transfer-domain-hosting':
+			return (
+				<p>
+					The hosting and domain of this site are not on <strong>WordPress.com</strong>, but they
+					could be!
+				</p>
+			);
+		case 'idle':
+			return (
+				<p>
+					Nice! This site and its domain are fully hosted on <strong>WordPress.com</strong>!
+				</p>
+			);
+		default:
+			return null;
+	}
+}

--- a/client/site-profiler/components/heading-information/styles.scss
+++ b/client/site-profiler/components/heading-information/styles.scss
@@ -1,0 +1,33 @@
+.heading-information {
+	border: 1px solid var(--studio-gray-5);
+	/* stylelint-disable-next-line */
+	border-radius: 3px;
+	box-shadow: 0 4px 10px 0 #0000000d;
+
+	p {
+		font-size: 1rem !important;
+		margin: 0;
+	}
+
+	h5 {
+		font-size: 0.875rem;
+		color: var(--studio-gray-50);
+	}
+
+	.domain {
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		font-size: 3rem;
+		color: var(--studio-gray-100);
+	}
+
+	summary {
+		padding: 1.5rem;
+	}
+
+	footer {
+		background: var(--studio-gray-0);
+		padding: 1rem 1.5rem;
+		display: flex;
+		gap: 1rem;
+	}
+}

--- a/client/site-profiler/components/heading-information/styles.scss
+++ b/client/site-profiler/components/heading-information/styles.scss
@@ -27,6 +27,13 @@
 	footer {
 		background: var(--studio-gray-0);
 		padding: 1rem 1.5rem;
+
+		p {
+			margin-bottom: 1rem;
+		}
+	}
+
+	.cta-wrapper {
 		display: flex;
 		gap: 1rem;
 	}

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -21,15 +21,17 @@ export default function SiteProfiler() {
 
 	return (
 		<>
-			<LayoutBlock>
-				<DomainAnalyzer onFormSubmit={ onFormSubmit } isBusy={ isFetching } />
-			</LayoutBlock>
+			{ ! data && (
+				<LayoutBlock>
+					<DomainAnalyzer onFormSubmit={ onFormSubmit } isBusy={ isFetching } />
+				</LayoutBlock>
+			) }
 
 			{ data && (
 				<LayoutBlock>
 					{ data && (
 						<LayoutBlockSection>
-							<HeadingInformation domain={ domain } />
+							<HeadingInformation domain={ domain } onCheckAnotherSite={ () => setDomain( '' ) } />
 						</LayoutBlockSection>
 					) }
 					{ data && (

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -16,8 +16,10 @@ export default function SiteProfiler() {
 	const { data, isFetching } = useDomainAnalyzerQuery( domain );
 	const { data: hostingProviderData } = useHostingProviderQuery( domain );
 	const conversionAction = useDefineConversionAction(
+		domain,
 		data?.is_domain_available,
 		data?.whois.name_server,
+		data?.whois.registrar,
 		hostingProviderData?.hosting_provider
 	);
 

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -18,7 +18,6 @@ export default function SiteProfiler() {
 	const conversionAction = useDefineConversionAction(
 		domain,
 		data?.is_domain_available,
-		data?.whois.name_server,
 		data?.whois.registrar,
 		hostingProviderData?.hosting_provider
 	);

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -29,7 +29,7 @@ export default function SiteProfiler() {
 				<LayoutBlock>
 					{ data && (
 						<LayoutBlockSection>
-							<HeadingInformation />
+							<HeadingInformation domain={ domain } />
 						</LayoutBlockSection>
 					) }
 					{ data && (

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -4,6 +4,7 @@ import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-
 import { getFixedDomainSearch, extractDomainFromInput } from 'calypso/lib/domains';
 import HostingInto from 'calypso/site-profiler/components/hosting-into';
 import { LayoutBlock, LayoutBlockSection } from 'calypso/site-profiler/components/layout';
+import { useDefineConversionAction } from 'calypso/site-profiler/hooks/use-define-conversion-action';
 import DomainAnalyzer from './domain-analyzer';
 import DomainInformation from './domain-information';
 import HeadingInformation from './heading-information';
@@ -14,6 +15,11 @@ export default function SiteProfiler() {
 	const [ domain, setDomain ] = useState( '' );
 	const { data, isFetching } = useDomainAnalyzerQuery( domain );
 	const { data: hostingProviderData } = useHostingProviderQuery( domain );
+	const conversionAction = useDefineConversionAction(
+		data?.is_domain_available,
+		data?.whois.name_server,
+		hostingProviderData?.hosting_provider
+	);
 
 	const onFormSubmit = ( domain: string ) => {
 		setDomain( getFixedDomainSearch( extractDomainFromInput( domain ) ) );
@@ -31,21 +37,29 @@ export default function SiteProfiler() {
 				<LayoutBlock>
 					{ data && (
 						<LayoutBlockSection>
-							<HeadingInformation domain={ domain } onCheckAnotherSite={ () => setDomain( '' ) } />
-						</LayoutBlockSection>
-					) }
-					{ data && (
-						<LayoutBlockSection>
-							<HostingInformation
-								dns={ data.dns }
-								hostingProvider={ hostingProviderData?.hosting_provider }
+							<HeadingInformation
+								domain={ domain }
+								conversionAction={ conversionAction }
+								onCheckAnotherSite={ () => setDomain( '' ) }
 							/>
 						</LayoutBlockSection>
 					) }
-					{ data?.whois && (
-						<LayoutBlockSection>
-							<DomainInformation domain={ domain } whois={ data.whois } />
-						</LayoutBlockSection>
+					{ ! data.is_domain_available && (
+						<>
+							{ data && (
+								<LayoutBlockSection>
+									<HostingInformation
+										dns={ data.dns }
+										hostingProvider={ hostingProviderData?.hosting_provider }
+									/>
+								</LayoutBlockSection>
+							) }
+							{ data?.whois && (
+								<LayoutBlockSection>
+									<DomainInformation domain={ domain } whois={ data.whois } />
+								</LayoutBlockSection>
+							) }
+						</>
 					) }
 				</LayoutBlock>
 			) }

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -89,4 +89,29 @@
 			max-width: 300px;
 		}
 	}
+
+	.status-icon {
+		display: inline-flex;
+		margin-right: 0.5rem;
+		border-radius: 100%;
+		padding: 8px;
+		position: relative;
+		top: -2px;
+
+		svg {
+			fill: #fff;
+		}
+
+		&.green {
+			background: var(--studio-green-50);
+		}
+
+		&.blue {
+			background: var(--wp-admin-theme-color);
+		}
+
+		&.red {
+			background: var(--studio-red-50);
+		}
+	}
 }

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -96,14 +96,14 @@
 		border-radius: 100%;
 		padding: 8px;
 		position: relative;
-		top: -2px;
+		top: -5px;
 
 		svg {
 			fill: #fff;
 		}
 
 		&.green {
-			background: var(--studio-green-50);
+			background: var(--studio-green-30);
 		}
 
 		&.blue {

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -1,4 +1,5 @@
 .is-section-site-profiler .layout__content {
+	background: #fff;
 	padding: 0;
 
 	h1 {
@@ -39,6 +40,23 @@
 
 		&:hover {
 			color: var(--wp-admin-theme-color-darker-20);
+		}
+	}
+
+	.button-action {
+		color: #fff;
+		background: var(--wp-admin-theme-color);
+		border-radius: 4px;
+		font-size: 1rem;
+		font-weight: 500;
+		padding: 1.5rem;
+
+		&:hover {
+			color: #fff !important;
+		}
+
+		&.is-busy {
+			background-image: linear-gradient(-45deg, var(--wp-admin-theme-color) 33%, var(--wp-admin-theme-color-darker-20) 33%, var(--wp-admin-theme-color-darker-20) 70%, var(--wp-admin-theme-color) 70%);
 		}
 	}
 

--- a/client/site-profiler/hooks/use-define-conversion-action.ts
+++ b/client/site-profiler/hooks/use-define-conversion-action.ts
@@ -8,21 +8,29 @@ export type CONVERSION_ACTION =
 	| 'idle';
 
 export function useDefineConversionAction(
+	domain: string,
 	isDomainAvailable?: boolean,
 	nameServer: string[] = [],
+	registrar = '',
 	hostingProvider?: HostingProvider
 ): CONVERSION_ACTION | undefined {
-	const isWpNs = !! nameServer.filter(
-		( ns ) => ns.includes( 'automattic.com' ) || ns.includes( 'wordpress.com' )
-	).length;
+	const isWpDomain = domain.toLowerCase().includes( 'wordpress.com' );
+	const isWpAtomicDomain = domain.toLowerCase().includes( 'wpcomstaging.com' );
+	const isA8cRegistrar = registrar.toLowerCase().includes( 'automattic' );
+	const isA8cNameServer = !! nameServer
+		.map( ( ns ) => ns.toLowerCase() )
+		.filter( ( ns ) => ns.includes( 'automattic.com' ) || ns.includes( 'wordpress.com' ) ).length;
+
+	const isA8cDomain = isA8cRegistrar || isA8cNameServer || isWpDomain || isWpAtomicDomain;
+	const isA8cHosting = hostingProvider?.slug === 'automattic';
 
 	if ( isDomainAvailable ) {
 		return 'register-domain';
-	} else if ( isWpNs && hostingProvider?.slug !== 'automattic' ) {
+	} else if ( isA8cDomain && ! isA8cHosting ) {
 		return 'transfer-hosting';
-	} else if ( ! isWpNs && hostingProvider?.slug === 'automattic' ) {
+	} else if ( ! isA8cDomain && isA8cHosting ) {
 		return 'transfer-domain';
-	} else if ( ! isWpNs && hostingProvider?.slug !== 'automattic' ) {
+	} else if ( ! isA8cDomain && ! isA8cHosting ) {
 		return 'transfer-domain-hosting';
 	}
 	return 'idle';

--- a/client/site-profiler/hooks/use-define-conversion-action.ts
+++ b/client/site-profiler/hooks/use-define-conversion-action.ts
@@ -1,0 +1,29 @@
+import type { HostingProvider } from 'calypso/data/site-profiler/types';
+
+export type CONVERSION_ACTION =
+	| 'register-domain'
+	| 'transfer-domain'
+	| 'transfer-hosting'
+	| 'transfer-domain-hosting'
+	| 'idle';
+
+export function useDefineConversionAction(
+	isDomainAvailable?: boolean,
+	nameServer: string[] = [],
+	hostingProvider?: HostingProvider
+): CONVERSION_ACTION | undefined {
+	const isWpNs = !! nameServer.filter(
+		( ns ) => ns.includes( 'automattic.com' ) || ns.includes( 'wordpress.com' )
+	).length;
+
+	if ( isDomainAvailable ) {
+		return 'register-domain';
+	} else if ( isWpNs && hostingProvider?.slug !== 'automattic' ) {
+		return 'transfer-hosting';
+	} else if ( ! isWpNs && hostingProvider?.slug === 'automattic' ) {
+		return 'transfer-domain';
+	} else if ( ! isWpNs && hostingProvider?.slug !== 'automattic' ) {
+		return 'transfer-domain-hosting';
+	}
+	return 'idle';
+}

--- a/client/site-profiler/hooks/use-define-conversion-action.ts
+++ b/client/site-profiler/hooks/use-define-conversion-action.ts
@@ -10,18 +10,14 @@ export type CONVERSION_ACTION =
 export function useDefineConversionAction(
 	domain: string,
 	isDomainAvailable?: boolean,
-	nameServer: string[] = [],
 	registrar = '',
 	hostingProvider?: HostingProvider
 ): CONVERSION_ACTION | undefined {
 	const isWpDomain = domain.toLowerCase().includes( 'wordpress.com' );
 	const isWpAtomicDomain = domain.toLowerCase().includes( 'wpcomstaging.com' );
 	const isA8cRegistrar = registrar.toLowerCase().includes( 'automattic' );
-	const isA8cNameServer = !! nameServer
-		.map( ( ns ) => ns.toLowerCase() )
-		.filter( ( ns ) => ns.includes( 'automattic.com' ) || ns.includes( 'wordpress.com' ) ).length;
 
-	const isA8cDomain = isA8cRegistrar || isA8cNameServer || isWpDomain || isWpAtomicDomain;
+	const isA8cDomain = isA8cRegistrar || isWpDomain || isWpAtomicDomain;
 	const isA8cHosting = hostingProvider?.slug === 'automattic';
 
 	if ( isDomainAvailable ) {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/81727

## Proposed Changes

* Created a HeadingInformation block with presentational logic based on entered domain details.
* Created helper components isolating specific logic for easy maintenance.
* Adapted the main SiteProfiler component matching Figma design.

## Testing Instructions

* Go to `/site-profiler`
* Enter any domain (available for registration, WP hosted, etc.)
* Check if the DomainAnalyzer block disappears and  HeadingBlock shows instead
* Check the result inside the HeadingInformation block based on entered domain
* Click on "Check another site" link
* Repeat domain check a few times

**NOTE:**
- CTA buttons are not implemented yet (next iterations)
- Spacial edge cases are not handled (such as google domain registrant detection)
- Localisation

<img width="1249" alt="Screenshot 2023-09-19 at 23 40 16" src="https://github.com/Automattic/wp-calypso/assets/1241413/7a202f74-b1dd-41a0-a344-e05b2a3c0cca">
<img width="1271" alt="Screenshot 2023-09-19 at 23 39 16" src="https://github.com/Automattic/wp-calypso/assets/1241413/79bbd6e0-9956-4f68-8c84-fdf9b8c6a0e6">
<img width="1256" alt="Screenshot 2023-09-19 at 23 40 34" src="https://github.com/Automattic/wp-calypso/assets/1241413/b3c2ee66-04d8-4ef3-bd3a-ab364ad00893">
<img width="1241" alt="Screenshot 2023-09-19 at 23 39 30" src="https://github.com/Automattic/wp-calypso/assets/1241413/ef68d29c-0a9f-472e-9250-ca470cc79ab8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?