### PR TITLE
Stats: Adjust the commercial dispute email receiver according to WPCOM or Jetpack

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -94,6 +94,11 @@ const StatsCommercialPurchase = ( {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	const handleClick = ( event: React.MouseEvent, isOdysseyStats: boolean ) => {
+		event.preventDefault();
+
+		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
+		recordTracksEvent( `${ event_from }_stats_purchase_commercial_update_classification_clicked` );
+
 		const emailSubject = translate( 'Jetpack Stats Commercial Classification Dispute' );
 		const emailBody = `Hi Jetpack Team,\n
 I'm writing to dispute the classification of my site '${ siteSlug }' as commercial.\n
@@ -106,12 +111,6 @@ Thanks\n\n`;
 		const emailHref = `mailto:support@jetpack.com?subject=${ encodeURIComponent(
 			emailSubject
 		) }&body=${ encodeURIComponent( emailBody ) }`;
-
-		event.preventDefault();
-
-		const type = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-
-		recordTracksEvent( `${ type }_stats_purchase_commercial_update_classification_clicked` );
 
 		setTimeout( () => ( window.location.href = emailHref ), 250 );
 	};

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -99,6 +99,7 @@ const StatsCommercialPurchase = ( {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 		recordTracksEvent( `${ event_from }_stats_purchase_commercial_update_classification_clicked` );
 
+		const mailTo = isOdysseyStats ? 'support@jetpack.com' : 'help@wordpress.com';
 		const emailSubject = translate( 'Jetpack Stats Commercial Classification Dispute' );
 		const emailBody = `Hi Jetpack Team,\n
 I'm writing to dispute the classification of my site '${ siteSlug }' as commercial.\n
@@ -108,7 +109,7 @@ I can confirm that,
 - I don't promote a business on my site.\n
 Could you please take a look at my site and update the classification if necessary?\n
 Thanks\n\n`;
-		const emailHref = `mailto:support@jetpack.com?subject=${ encodeURIComponent(
+		const emailHref = `mailto:${ mailTo }?subject=${ encodeURIComponent(
 			emailSubject
 		) }&body=${ encodeURIComponent( emailBody ) }`;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81662 

## Proposed Changes

* Modify mail receiver of the commercial sites dispute email according to **WPCOM** or **Jetpack** platforms.

<img width="1131" alt="截圖 2023-09-19 下午9 46 50" src="https://github.com/Automattic/wp-calypso/assets/6869813/20ecd953-a639-461d-b6a9-fba73c74b670">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Calypso Stats
* Spin this change up on local Calypso.
* Navigate to the standalone commercial purchase page: `/stats/purchase/{site-slug}?productType=commercial`.
* Enforce showing the commercial site dispute form by setting `showClassificationDispute` to true:
https://github.com/Automattic/wp-calypso/blob/cf64fd23c889667cd6266f5340331bcebfaa05b4/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx#L135
* Check all checkboxes and submit the request.
* Ensure the mail client is opened and setting the receiver `help@wordpress.com` by default.

#### Odyssey Stats
* Spin this change up on local Jetpack: `cd apps/odyssey-stats && STATS_PACKAGE_PATH=/path-to-jetpack/projects/packages/stats-admin yarn dev`.
* Navigate to the standalone commercial purchase page: `/wp-admin/admin.php?page=stats#!/stats/purchase/{site-slug}?productType=commercial`.
* Enforce showing the commercial site dispute form by setting `showClassificationDispute` to true:
https://github.com/Automattic/wp-calypso/blob/cf64fd23c889667cd6266f5340331bcebfaa05b4/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx#L135
* Check all checkboxes and submit the request.
* Ensure the mail client is opened and setting the receiver `support@jetpack.com` by default.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?