### PR TITLE
Design picker & Assembler - Fix vertical and horizontal spacings for style, font and color variations 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
@@ -24,7 +24,7 @@
 	.global-styles-variations__container {
 		display: flex;
 		flex-direction: column;
-		gap: 20px;
+		gap: 32px;
 		padding-top: 4px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.scss
@@ -20,6 +20,13 @@
 		width: 348px;
 		padding: 24px;
 	}
+
+	.global-styles-variations__container {
+		display: flex;
+		flex-direction: column;
+		gap: 20px;
+		padding-top: 4px;
+	}
 }
 
 .pattern-list-panel__title {

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -316,10 +316,20 @@ $design-preview-sidebar-width: 311px;
 
 	@include break-large {
 		padding: 0 12px;
-		margin: 8px -12px 0;
+		margin: 32px -12px 0;
 		animation: none;
 		overflow-x: hidden;
 		overflow-y: scroll;
+		width: auto;
+
+		&.design-preview__sidebar-variations--styles {
+			margin-left: -15px;
+			margin-right: -15px;
+		}
+
+		.components-navigator-screen & {
+			margin-top: 2px;
+		}
 
 		@supports ( scrollbar-gutter: stable ) {
 			overflow-y: auto;
@@ -347,11 +357,10 @@ $design-preview-sidebar-width: 311px;
 		.font-pairing-variations {
 			display: grid;
 			gap: 12px;
-			margin: 14px -2px 26px;
-			padding-inline-end: 6px;
+			margin: 14px -2px 2px;
 
 			.global-styles-variation__item {
-				width: 100%;
+				width: auto;
 			}
 		}
 	}

--- a/packages/design-preview/src/hooks/use-screens.tsx
+++ b/packages/design-preview/src/hooks/use-screens.tsx
@@ -65,20 +65,18 @@ const useScreens = ( {
 						label: translate( 'Styles' ),
 						path: '/style-variations',
 						content: (
-							<div className="design-preview__sidebar-variations">
-								<div className="design-preview__sidebar-variations-grid">
-									<GlobalStylesVariations
-										key="style-variations"
-										globalStylesVariations={ variations as GlobalStylesObject[] }
-										selectedGlobalStylesVariation={ selectedVariation as GlobalStylesObject }
-										splitDefaultVariation={ splitDefaultVariation }
-										displayFreeLabel={ splitDefaultVariation }
-										showOnlyHoverViewDefaultVariation={ false }
-										onSelect={ ( globalStyleVariation: GlobalStylesObject ) =>
-											onSelectVariation( globalStyleVariation as StyleVariation )
-										}
-									/>
-								</div>
+							<div className="design-preview__sidebar-variations design-preview__sidebar-variations--styles">
+								<GlobalStylesVariations
+									key="style-variations"
+									globalStylesVariations={ variations as GlobalStylesObject[] }
+									selectedGlobalStylesVariation={ selectedVariation as GlobalStylesObject }
+									splitDefaultVariation={ splitDefaultVariation }
+									displayFreeLabel={ splitDefaultVariation }
+									showOnlyHoverViewDefaultVariation={ false }
+									onSelect={ ( globalStyleVariation: GlobalStylesObject ) =>
+										onSelectVariation( globalStyleVariation as StyleVariation )
+									}
+								/>
 							</div>
 						),
 						actionText: translate( 'Save styles' ),

--- a/packages/global-styles/src/components/color-palette-variations/style.scss
+++ b/packages/global-styles/src/components/color-palette-variations/style.scss
@@ -4,7 +4,7 @@
 	grid-template-columns: repeat(3, 1fr);
 	min-width: 100%;
 	box-sizing: border-box;
-	margin: 14px -2px 26px;
+	margin: 14px -2px 2px;
 
 	.global-styles-variation-container__iframe {
 		max-height: 52px;
@@ -62,6 +62,7 @@
 	font-weight: 500;
 	letter-spacing: -0.15px;
 	line-height: 1.7;
+	align-items: center;
 }
 
 .global-styles-variations__group-title-actual {

--- a/packages/global-styles/src/components/font-pairing-variations/style.scss
+++ b/packages/global-styles/src/components/font-pairing-variations/style.scss
@@ -4,7 +4,7 @@
 	grid-template-columns: repeat(2, 1fr);
 	min-width: 100%;
 	box-sizing: border-box;
-	margin: 14px -2px 26px;
+	margin: 14px -2px 2px;
 
 	.global-styles-variation-container__iframe {
 		max-height: 106px;
@@ -61,7 +61,8 @@
 	font-size: $font-body-small;
 	font-weight: 500;
 	letter-spacing: -0.15px;
-	line-height: 1.4;
+	line-height: 1.7;
+	align-items: center;
 }
 
 .global-styles-variations__group-title-actual {

--- a/packages/global-styles/src/components/global-styles-variations/style.scss
+++ b/packages/global-styles/src/components/global-styles-variations/style.scss
@@ -3,7 +3,7 @@
 
 .global-styles-variations__container {
 	display: flex;
-	gap: 12px;
+	gap: 32px;
 	flex-direction: row;
 	@include break-large {
 		flex-direction: column;
@@ -25,6 +25,7 @@
 
 	@include break-large {
 		padding-top: 12px;
+		padding-bottom: 2px;
 	}
 
 	@include breakpoint-deprecated( "<960px" ) {
@@ -42,7 +43,6 @@
 	width: 100%;
 	margin-left: 3px;
 	color: var(--studio-gray-50);
-
 
 	.global-styles-variations__free-badge {
 		display: none;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes
* Fix the horizontal spacing
  * Making the variations fit 100% of the sidebar width 
* Fix the line-height of headings
* Fix the top padding of the headings using 32px 
  * In the assembler it's 20px because the top padding of the panel title is only 20px

Note: this is tricky because the components are reused and mounted in different containers and screens.

### Fewer
**Style variations** 

|BEFORE|AFTER|
|--|--|
|<img width="352" alt="Screenshot 2566-09-19 at 20 37 58" src="https://github.com/Automattic/wp-calypso/assets/1881481/d160578b-3249-4775-933a-fd3a8388fead">|<img width="351" alt="Screenshot 2566-09-19 at 20 37 32" src="https://github.com/Automattic/wp-calypso/assets/1881481/a3256442-a703-4646-b270-8a6d89aad28a">|

### Grammer One
**Colors and Fonts in Navigator**

|BEFORE|AFTER|
|--|--|
|**Colors**|**Colors**|
|<img width="350" alt="Screenshot 2566-09-19 at 20 39 35" src="https://github.com/Automattic/wp-calypso/assets/1881481/a5ebce83-afbb-4b9c-89f9-b17e39d0b80d">|<img width="352" alt="Screenshot 2566-09-19 at 20 43 25" src="https://github.com/Automattic/wp-calypso/assets/1881481/768a0a67-1f66-4690-ab41-45b8a7997ea4">|
|**Fonts**|**Fonts**|
|<img width="353" alt="Screenshot 2566-09-19 at 20 40 00" src="https://github.com/Automattic/wp-calypso/assets/1881481/22ee7206-571b-4dd4-92d4-6f3012c7e485">|<img width="353" alt="Screenshot 2566-09-19 at 20 43 54" src="https://github.com/Automattic/wp-calypso/assets/1881481/01d19687-e519-4925-8a69-e671f88ed064">|

### Project Detail
**Fonts in Virtual theme**

|BEFORE|AFTER|
|--|--|
|<img width="353" alt="Screenshot 2566-09-19 at 20 06 51" src="https://github.com/Automattic/wp-calypso/assets/1881481/5cc75f67-29a7-4a58-9c04-8c47ef015a3b">|<img width="353" alt="Screenshot 2566-09-19 at 20 06 03" src="https://github.com/Automattic/wp-calypso/assets/1881481/4b0f583a-70e3-4160-80db-22a331577f73">|

### Tenaz
**Fonts in theme**

|BEFORE|AFTER|
|--|--|
|<img width="352" alt="Screenshot 2566-09-19 at 20 55 51" src="https://github.com/Automattic/wp-calypso/assets/1881481/4e089331-bd96-4d4c-ac5b-c8b737f07ffd">|<img width="352" alt="Screenshot 2566-09-19 at 20 55 17" src="https://github.com/Automattic/wp-calypso/assets/1881481/878c4cef-7e02-46ac-835a-fa8b6dbe6276">|


### Assembler
**Colors and Fonts**

|BEFORE|AFTER|
|--|--|
|**Colors**|**Colors**|
|<img width="696" alt="Screenshot 2566-09-19 at 21 02 02" src="https://github.com/Automattic/wp-calypso/assets/1881481/e4a3b3ce-ab66-43c1-b15d-b73226471c68">|<img width="696" alt="Screenshot 2566-09-20 at 10 34 20" src="https://github.com/Automattic/wp-calypso/assets/1881481/77e5a577-d0a2-441d-9a54-d3130a869e75">|
|**Fonts**|**Fonts**|
|<img width="697" alt="Screenshot 2566-09-19 at 21 02 20" src="https://github.com/Automattic/wp-calypso/assets/1881481/4d07447b-90c6-4712-9687-2a6a4034f0cc">|<img width="698" alt="Screenshot 2566-09-20 at 10 34 06" src="https://github.com/Automattic/wp-calypso/assets/1881481/90586184-b316-4020-ac30-40d48173899e">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the Design Picker
* Verify that the top padding of the headings is ~32px when selecting
  * Fewer `/setup/site-setup/designSetup?siteSlug={ SITE }&theme=fewer`
    * Verify the headings of the Style variations 
  * Grammer One `&theme=grammerone`
    * Verify the headings when you click Colors and Fonts 
  * Project Details `&theme=creatio-project-detail-with-description-3`
    * Verify the headings of Fonts 
  * Tenaz `&theme=tenaz`
    * Verify the headings of Fonts 
* Access the Assembler
 * Choose a pattern and click on `Pick your style`
 * Verify the headings when you click Colors and Fonts

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?