### PR TITLE
Fixed a problem where the subscriber type dropdown doesn't refresh on site change

### DIFF
--- a/client/landing/subscriptions/hooks/use-subscribers-filter-options.ts
+++ b/client/landing/subscriptions/hooks/use-subscribers-filter-options.ts
@@ -4,7 +4,7 @@ import { SubscribersFilterBy } from 'calypso/my-sites/subscribers/constants';
 
 const FilterBy = SubscribersFilterBy;
 
-const useSubscribersFilterOptions = ( skipAllOption: boolean ) => {
+const useSubscribersFilterOptions = ( skipAllOption: boolean, siteId: number | null ) => {
 	const translate = useTranslate();
 
 	const options = skipAllOption ? [] : [ { value: FilterBy.All, label: translate( 'All' ) } ];
@@ -13,7 +13,7 @@ const useSubscribersFilterOptions = ( skipAllOption: boolean ) => {
 		{ value: FilterBy.WPCOM, label: translate( 'Via WordPress.com' ) }
 	);
 
-	return useMemo( () => options, [ translate ] );
+	return useMemo( () => options, [ translate, siteId ] );
 };
 
 export default useSubscribersFilterOptions;

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -32,7 +32,7 @@ const ListActionsBar = () => {
 	const sortOptions = useMemo( () => getSortOptions( translate ), [ translate ] );
 	const recordSort = useRecordSort();
 	const hasManySubscribers = useManySubsSite( siteId );
-	const filterOptions = useSubscribersFilterOptions( hasManySubscribers );
+	const filterOptions = useSubscribersFilterOptions( hasManySubscribers, siteId );
 	const selectedText = translate( 'Subscribers: %s', {
 		args: getOptionLabel( filterOptions, filterOption ) || '',
 	} );


### PR DESCRIPTION
## Proposed Changes

This PR fixes a problem in Subscribers page. Sites with many subscribers shouldn't have a "all" option in the Subscriber Type dropdown. That option is available for sites with fewer subscribers. The problem is when selecting a site with few subscribers and then selecting a site with many subscribers, the dropdown was not refreshing the possible values (effectively removing the "all" option).

## Testing Instructions

1. Apply this patch and start the application.
2. Make sure your selected site has less than 30k subscribers.
3. Go to `Users -> Subscribers`.
4. You should see 3 options in the Subscribers Type dropdown, one of them being "All".
5. Change to a site with more than 30k subscribers using the site selector in the top left menu option.
6. You should see 2 options now in the Subscribers Type dropdown, none of them being "All".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?