### PR TITLE
format-currency: Only override browser locale if not 'en'

### DIFF
--- a/client/state/ui/language/actions.ts
+++ b/client/state/ui/language/actions.ts
@@ -11,8 +11,16 @@ export const setLocale = (
 	localeSlug: string,
 	localeVariant: string | null | undefined = null
 ) => {
-	setCurrencyLocale( localeVariant || localeSlug );
-	switchLocale( localeVariant || localeSlug );
+	const newLocale = localeVariant || localeSlug;
+
+	// Side effect: change the current currency formatting locale.
+	// If the default ("English") is selected, instead allow the currency
+	// library to use its default, which is the browser's locale.
+	setCurrencyLocale( newLocale === 'en' ? undefined : newLocale );
+
+	// Side effect: change the current translation locale.
+	switchLocale( newLocale );
+
 	return {
 		type: LOCALE_SET,
 		localeSlug,

--- a/packages/format-currency/README.md
+++ b/packages/format-currency/README.md
@@ -68,7 +68,7 @@ Since rounding errors are common in floating point math, sometimes a price is pr
 
 ## setDefaultLocale()
 
-`setDefaultLocale( locale: string ): void`
+`setDefaultLocale( locale: string | undefined ): void`
 
 A function that can be used to set a default locale for use by `formatCurrency()` and `getCurrencyObject()`. Note that this is global and will override any browser locale that is set! Use it with care.
 

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -38,15 +38,17 @@ export function createFormatter(): CurrencyFormatter {
 		geoLocation = geoData.country_short;
 	}
 
+	function getLocaleToUse( options: CurrencyObjectOptions ): string {
+		return options.locale ?? defaultLocale ?? getLocaleFromBrowser();
+	}
+
 	function getFormatter(
 		number: number,
 		code: string,
 		options: CurrencyObjectOptions
 	): Intl.NumberFormat {
-		const locale = options.locale ?? defaultLocale ?? getLocaleFromBrowser();
-
 		return getCachedFormatter( {
-			locale,
+			locale: getLocaleToUse( options ),
 			currency: code,
 			noDecimals: isNoDecimals( number, options ),
 		} );
@@ -79,7 +81,6 @@ export function createFormatter(): CurrencyFormatter {
 	 *
 	 * If `isSmallestUnit` is set and the number is not an integer, it will be
 	 * rounded to an integer.
-	 *
 	 * @param      {number}                   number     number to format; assumed to be a float unless isSmallestUnit is set.
 	 * @param      {string}                   code       currency code e.g. 'USD'
 	 * @param      {CurrencyObjectOptions}    options    options object
@@ -90,7 +91,7 @@ export function createFormatter(): CurrencyFormatter {
 		code: string,
 		options: CurrencyObjectOptions = {}
 	): string {
-		const locale = options.locale ?? defaultLocale ?? getLocaleFromBrowser();
+		const locale = getLocaleToUse( options );
 		code = getValidCurrency( code );
 		const currencyOverride = getCurrencyOverride( code );
 		const currencyPrecision = getPrecisionForLocaleAndCurrency( locale, code );
@@ -144,7 +145,6 @@ export function createFormatter(): CurrencyFormatter {
 	 *
 	 * If `isSmallestUnit` is set and the number is not an integer, it will be
 	 * rounded to an integer.
-	 *
 	 * @param      {number}                   number     number to format; assumed to be a float unless isSmallestUnit is set.
 	 * @param      {string}                   code       currency code e.g. 'USD'
 	 * @param      {CurrencyObjectOptions}    options    options object
@@ -155,7 +155,7 @@ export function createFormatter(): CurrencyFormatter {
 		code: string,
 		options: CurrencyObjectOptions = {}
 	): CurrencyObject {
-		const locale = options.locale ?? defaultLocale ?? getLocaleFromBrowser();
+		const locale = getLocaleToUse( options );
 		code = getValidCurrency( code );
 		const currencyOverride = getCurrencyOverride( code );
 		const currencyPrecision = getPrecisionForLocaleAndCurrency( locale, code );

--- a/packages/format-currency/src/types.ts
+++ b/packages/format-currency/src/types.ts
@@ -1,6 +1,6 @@
 export interface CurrencyFormatter {
 	geolocateCurrencySymbol: () => Promise< void >;
-	setDefaultLocale: ( locale: string ) => void;
+	setDefaultLocale: ( locale: string | undefined ) => void;
 	setCurrencySymbol: ( currencyCode: string, currencySymbol: string | undefined ) => void;
 	formatCurrency: (
 		amount: number,


### PR DESCRIPTION
The `format-currency` package defaults to using the browser locale, but in calypso (since https://github.com/Automattic/wp-calypso/pull/71895) we override that with the user's selected "User Interface Language". This has a downside: users are restricted to having currencies formatted in the locales we make available for the user interface. For example, even though `en-IN` has a very different format than `en`, that is not an option.

## Proposed Changes

In this PR we instead only override the browser locale with the User Interface Language if the language selected is not `en`.

Fixes https://github.com/Automattic/payments-shilling/issues/2026

## Testing Instructions

Before:
<img width="566" alt="Screenshot 2023-09-19 at 12 39 34 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/4f169caf-4498-421d-b5f3-dafe52b09f94">

After:
<img width="571" alt="Screenshot 2023-09-19 at 12 39 43 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/6f62244d-4997-4073-b0d4-976cde921187">

- Use a web browser with its locale set to `fr-CA`. (If you need to change your web browser's locale, you can use the devtool "Sensors" panel in Google Chrome.)
- Set your user's currency to INR.
- Set your user's user interface language to "English" using the form at `/me/account`.
- Now add a product to your cart and visit checkout.
- Compare checkout with or without this PR. Verify that without this PR, the price is rendered with commas (eg: `₹29,016`), but after this PR the price is rendered with spaces (eg: `29 016 ₹`).
- Return to `/me/account` and set the interface language to "English (UK)".
- Visit checkout again and verify that with or without this PR, the price is rendered with commas (eg: `₹29,016`).