### PR TITLE
Add WP.com/WP.org article in a new tab

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -314,6 +314,8 @@ function PluginDetails( props ) {
 						href={ localizeUrl(
 							'https://wordpress.com/go/website-building/wordpress-com-vs-wordpress-org/'
 						) }
+						target="_blank"
+						rel="noreferrer noopener"
 					/>
 				),
 			},


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/81857

## Proposed Changes

Add a target `_blank` to open the link in a new tab. 

The idea is to allow users to open the link to learn the differences and then act on the already opened plugin page.


## Testing Instructions

* follow the instructions on https://github.com/Automattic/wp-calypso/pull/81857
* Check if the "WordPress self-hosted" link opens in a new tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
