### PR TITLE
Allow PromoCard to show feature status

### DIFF
--- a/client/components/promo-section/index.tsx
+++ b/client/components/promo-section/index.tsx
@@ -28,6 +28,7 @@ const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
 } ) => {
 	const cta = actions?.cta;
 	const learnMoreLink = actions?.learnMoreLink;
+	const featureIncludedInPlan = actions?.featureIncludedInPlan;
 	const getCtaComponent = () => {
 		if ( ! cta ) {
 			return null;
@@ -35,7 +36,13 @@ const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
 		if ( 'component' in cta && cta.component ) {
 			return cta.component;
 		}
-		return <PromoCardCta cta={ cta } learnMoreLink={ learnMoreLink } />;
+		return (
+			<PromoCardCta
+				cta={ cta }
+				learnMoreLink={ learnMoreLink }
+				featureIncludedInPlan={ featureIncludedInPlan }
+			/>
+		);
 	};
 	const ctaComponent = getCtaComponent();
 	return (

--- a/client/components/promo-section/promo-card/cta.tsx
+++ b/client/components/promo-section/promo-card/cta.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
@@ -25,6 +25,7 @@ export interface CtaButton {
 export interface Props {
 	cta: CtaButton;
 	learnMoreLink?: CtaAction | null;
+	featureIncludedInPlan?: boolean;
 	isPrimary?: boolean;
 }
 
@@ -61,7 +62,12 @@ function buttonProps( button: CtaButton, isPrimary: boolean ) {
 		...actionProps,
 	};
 }
-const PromoCardCta: FunctionComponent< Props > = ( { cta, learnMoreLink, isPrimary } ) => {
+const PromoCardCta: FunctionComponent< Props > = ( {
+	cta,
+	learnMoreLink,
+	featureIncludedInPlan,
+	isPrimary,
+} ) => {
 	const ctaBtnProps = ( button: CtaButton ) => buttonProps( button, true === isPrimary );
 	const translate = useTranslate();
 	let learnMore = null;
@@ -79,6 +85,33 @@ const PromoCardCta: FunctionComponent< Props > = ( { cta, learnMoreLink, isPrima
 			  };
 	}
 
+	/*
+	 * Shows a notice for whether a promoted feature is
+	 * included in the user's current plan. For layout
+	 * reasons, we show this or learn more link, but not both.
+	 *
+	 * If featureIncludedInPlan is not passed (undefined), then
+	 * nothing will show. If featureIncludedInPlan is true, we show
+	 * a green check and notice. If featureIncludedInPlan is false,
+	 * we show a red cross and notice.
+	 */
+	const getAvailabilityNotice = () => {
+		if ( featureIncludedInPlan === undefined ) {
+			return null;
+		}
+		return featureIncludedInPlan ? (
+			<div className="promo-card__availability">
+				<Gridicon icon="checkmark" className="promo-card__checkmark" size={ 18 } />
+				<span>{ translate( 'Included in your plan' ) }</span>
+			</div>
+		) : (
+			<div className="promo-card__availability">
+				<Gridicon icon="cross-small" className="promo-card__cross" size={ 18 } />
+				<span>{ translate( 'Not included in your current plan' ) }</span>
+			</div>
+		);
+	};
+
 	return (
 		<ActionPanelCta>
 			<Button { ...ctaBtnProps( cta ) }>{ cta.text }</Button>
@@ -87,6 +120,7 @@ const PromoCardCta: FunctionComponent< Props > = ( { cta, learnMoreLink, isPrima
 					{ learnMoreLink?.label || translate( 'Learn more' ) }
 				</Button>
 			) }
+			{ ! learnMore && getAvailabilityNotice() }
 		</ActionPanelCta>
 	);
 };

--- a/client/components/promo-section/promo-card/cta.tsx
+++ b/client/components/promo-section/promo-card/cta.tsx
@@ -25,6 +25,10 @@ export interface CtaButton {
 export interface Props {
 	cta: CtaButton;
 	learnMoreLink?: CtaAction | null;
+	/**
+	 * Displays "Included in your current plan" if true or "Not included in your current plan" if false.
+	 * Ignored if undefined or if `learnMoreLink` is set.
+	 */
 	featureIncludedInPlan?: boolean;
 	isPrimary?: boolean;
 }
@@ -85,16 +89,6 @@ const PromoCardCta: FunctionComponent< Props > = ( {
 			  };
 	}
 
-	/*
-	 * Shows a notice for whether a promoted feature is
-	 * included in the user's current plan. For layout
-	 * reasons, we show this or learn more link, but not both.
-	 *
-	 * If featureIncludedInPlan is not passed (undefined), then
-	 * nothing will show. If featureIncludedInPlan is true, we show
-	 * a green check and notice. If featureIncludedInPlan is false,
-	 * we show a red cross and notice.
-	 */
 	const getAvailabilityNotice = () => {
 		if ( featureIncludedInPlan === undefined ) {
 			return null;

--- a/client/components/promo-section/promo-card/style.scss
+++ b/client/components/promo-section/promo-card/style.scss
@@ -93,6 +93,10 @@
 	}
 
 	.action-panel__cta {
+		display: flex;
+		align-items: center;
+		align-items: flex-start;
+		flex-wrap: wrap;
 		.button {
 			margin: 0 1em 4px 0;
 		}
@@ -121,6 +125,20 @@
 			font-size: $font-body-small;
 			color: var(--studio-green-50);
 			margin-left: 8px;
+		}
+	}
+	.promo-card__availability {
+		display: flex;
+		align-items: center;
+		gap: 0.5em;
+		margin: 8px 0;
+
+		.promo-card__checkmark {
+			color: var(--studio-green-30);
+		}
+
+		.promo-card__cross {
+			color: var(--studio-red-30);
 		}
 	}
 }

--- a/client/components/promo-section/promo-card/style.scss
+++ b/client/components/promo-section/promo-card/style.scss
@@ -95,7 +95,6 @@
 	.action-panel__cta {
 		display: flex;
 		align-items: center;
-		align-items: flex-start;
 		flex-wrap: wrap;
 		.button {
 			margin: 0 1em 4px 0;

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -345,7 +345,7 @@ const Home = () => {
 			return;
 		}
 		const cta = {
-			text: translate( 'Learn how to get started' ),
+			text: translate( 'Learn more' ),
 			action: () => {
 				trackCtaButton( 'learn-paid-newsletters' );
 				if ( window && window.location ) {
@@ -364,6 +364,7 @@ const Home = () => {
 			icon: 'mail',
 			actions: {
 				cta,
+				featureIncludedInPlan: true,
 			},
 		};
 	};

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -19,7 +19,7 @@
 	}
 }
 
-.earn .promo-section__promos .gridicon {
+.earn .promo-section__promos  .action-panel__figure .gridicon {
 	fill: var(--color-primary-10);
 	position: relative;
 	top: -8px;


### PR DESCRIPTION
## Proposed Changes

* Updates the PromoCard and PromoCardCta components to have the option to show whether a promoted feature is included in the users current plan. 
* This updates shared calypso components, so we'll want to be sure changes are made in a backwards compatible way that won't break existing uses of the component. 
* I've implemented the new option on one card on the Earn page as a test and demo. In a follow up, I would be updating most other Earn cards to show this as well, but I'd rather do that in a separate PR. The focus of this PR is really just updating the underlying component. 

**Example on Earn Page**
<img width="995" alt="promo-feature-status" src="https://github.com/Automattic/wp-calypso/assets/21228350/8e90a400-38e4-4782-a7fb-2f8bd4438d13">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Checkout this branch and go to http://calypso.localhost:3000/earn/YOURDOMAIN
2) Find the 'Send paid email newsletters' and confirm it renders as above with the new notice.
3) Using your dev tools, update your browser to show mobile display and confirm the card renders well. 
4) Confirm all other cards render as expected (ie, no regressions).
5) Review code and confirm that changes look safe for an older, shared component. 
5) Bonus: Find other screens that use the PromoSection components and confirm those continue to look and work as expected. Example: https://wordpress.com/backup/YOURDOMAIN

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?