### PR TITLE
revert  cafc407cdefa5c51d5a8ba92a20aab29acfa2161

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
@@ -333,21 +333,18 @@ export default function BulkEditContactInfoPage( {
 					</div>
 				) }
 				{ domainsWithUnmodifiableContactInfo && domainsWithUnmodifiableContactInfo.length > 0 && (
-					<div
-						className="edit-contact-info-page__sidebar"
-						style={ { marginBottom: '8px', background: 'transparent' } }
-					>
+					<div className="edit-contact-info-page__sidebar" style={ { marginBottom: '8px' } }>
 						<div className="edit-contact-info-page__sidebar-title">
 							<p>
 								<strong>{ translate( 'The following domain fields will not be updated:' ) }</strong>
 							</p>
 						</div>
 						<div className="edit-contact-info-page__sidebar-content">
-							<ul style={ { listStyleType: 'none', margin: 0 } }>
+							<ul>
 								{ domainsWithUnmodifiableContactInfo.map( ( domain ) => (
 									<li key={ domain.domain }>
 										<strong>{ domain.domain }</strong>
-										<ul style={ { listStylePosition: 'inside' } }>
+										<ul style={ { listStyleType: 'circle' } }>
 											{ domain.whois_update_unmodifiable_fields.map( ( field: string ) => (
 												<li key={ field }>{ getFieldMapping( field ) }</li>
 											) ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
