### PR TITLE
Subscribers Page: Fix empty text when user is not subscribed to any category

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -77,7 +77,7 @@ const SubscriberDetails = ( {
 								{ translate( 'Receives emails for' ) }
 							</div>
 							<div className="subscriber-details__content-value">
-								{ newsletterCategoryNames
+								{ newsletterCategoryNames && newsletterCategoryNames.length > 0
 									? newsletterCategoryNames.join( ', ' )
 									: translate( 'Not subscribed to any newsletter categories' ) }
 							</div>


### PR DESCRIPTION
## Proposed Changes

* Fix empty text when the user is not subscribed to any category

## Testing Instructions

* Apply this PR to your local
* Subscribe a user to a site with newsletter categories
* As the subscriber, go to the subscription management and toggle off all categories
* As the admin, go to the subscribers page and open the detailed view for that subscriber
* You should see a message instead of an empty space

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?