### PR TITLE
Odyssey Stats: update purchase URL in notices

### DIFF
--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -3,6 +3,7 @@ import NoticeBanner from '@automattic/components/src/notice-banner';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useEffect, useState } from 'react';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import { useSelector } from 'calypso/state';
@@ -12,11 +13,7 @@ import { StatsNoticeProps } from './types';
 const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) => {
 	const from = isOdysseyStats ? 'jetpack' : 'calypso';
 	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/type-detection,stats/paid-wpcom-stats&from=${ from }-stats-commercial-site-upgrade-notice&productType=commercial`;
-	if ( ! isOdysseyStats ) {
-		return purchasePath;
-	}
-	// We use absolute path here as it runs in Odyssey as well.
-	return `https://wordpress.com${ purchasePath }`;
+	return purchasePath;
 };
 
 const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps ) => {
@@ -46,10 +43,7 @@ const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticePro
 			  )
 			: recordTracksEvent( 'calypso_stats_commercial_site_upgrade_notice_support_button_clicked' );
 		// Allow some time for the event to be recorded before redirecting.
-		setTimeout(
-			() => ( window.location.href = getStatsPurchaseURL( siteId, isOdysseyStats ) ),
-			250
-		);
+		setTimeout( () => page( getStatsPurchaseURL( siteId, isOdysseyStats ) ), 250 );
 	};
 
 	useEffect( () => {

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -3,6 +3,7 @@ import NoticeBanner from '@automattic/components/src/notice-banner';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useEffect, useState } from 'react';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import { useSelector } from 'calypso/state';
@@ -18,11 +19,7 @@ const getStatsPurchaseURL = (
 	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/paid-wpcom-stats&from=${ from }-stats-upgrade-notice${
 		hasFreeStats ? '&productType=personal' : ''
 	}`;
-	if ( ! isOdysseyStats ) {
-		return purchasePath;
-	}
-	// We use absolute path here as it runs in Odyssey as well.
-	return `https://wordpress.com${ purchasePath }`;
+	return purchasePath;
 };
 
 const DoYouLoveJetpackStatsNotice = ( {
@@ -58,10 +55,7 @@ const DoYouLoveJetpackStatsNotice = ( {
 					'calypso_stats_do_you_love_jetpack_stats_notice_support_button_clicked'
 			  );
 		// Allow some time for the event to be recorded before redirecting.
-		setTimeout(
-			() => ( window.location.href = getStatsPurchaseURL( siteId, isOdysseyStats, hasFreeStats ) ),
-			250
-		);
+		setTimeout( () => page( getStatsPurchaseURL( siteId, isOdysseyStats, hasFreeStats ) ), 250 );
 	};
 
 	useEffect( () => {

--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -2,6 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useEffect, useState } from 'react';
 import { removeStatsPurchaseSuccessParamFromCurrentUrl } from './lib/remove-stats-purchase-success-param';
 import { StatsNoticeProps } from './types';
@@ -11,10 +12,7 @@ const getStatsPurchaseURL = ( siteId: number | null ) => {
 	const from = isOdysseyStats ? 'jetpack' : 'calypso';
 	const purchasePath = `/stats/purchase/${ siteId }?productType=personal&from=${ from }-free-stats-purchase-success-notice`;
 
-	if ( ! isOdysseyStats ) {
-		return purchasePath;
-	}
-	return `https://wordpress.com${ purchasePath }`;
+	return purchasePath;
 };
 
 const handleUpgradeClick = (
@@ -28,7 +26,7 @@ const handleUpgradeClick = (
 		? recordTracksEvent( 'jetpack_odyssey_stats_purchase_success_banner_upgrade_clicked' )
 		: recordTracksEvent( 'calypso_stats_purchase_success_banner_upgrade_clicked' );
 
-	setTimeout( () => ( window.location.href = upgradeUrl ), 250 );
+	setTimeout( () => page( upgradeUrl ), 250 );
 };
 
 const FreePlanPurchaseSuccessJetpackStatsNotice = ( {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
@@ -14,10 +14,7 @@ import './styles.scss';
 const getStatsPurchaseURL = ( siteId, isOdysseyStats, productType = 'commercial' ) => {
 	const purchasePath = `/stats/purchase/${ siteId }?productType=${ productType }&flags=stats/type-detection`;
 
-	if ( ! isOdysseyStats ) {
-		return purchasePath;
-	}
-	return `https://wordpress.com${ purchasePath }`;
+	return purchasePath;
 };
 
 const handleUpgradeClick = ( event, upgradeUrl, isOdysseyStats ) => {
@@ -27,7 +24,7 @@ const handleUpgradeClick = ( event, upgradeUrl, isOdysseyStats ) => {
 		? recordTracksEvent( 'jetpack_odyssey_stats_purchase_summary_screen_upgrade_clicked' )
 		: recordTracksEvent( 'calypso_stats_purchase_summary_screen_upgrade_clicked' );
 
-	setTimeout( () => ( window.location.href = upgradeUrl ), 250 );
+	setTimeout( () => page( upgradeUrl ), 250 );
 };
 
 const StatsCommercialOwned = ( { siteSlug } ) => {


### PR DESCRIPTION
## Proposed Changes

The PR replaces the purchase link in notices with the in-Odyssey one, which is to release the Odyssey purchase page and should be left to the last PR to merge.

The PR has a bit overlap with #81987 

## Testing Instructions

### Odyssey Stats

- Build Jetpack if necessary `jetpack build plugins/jetpack`
- Build Odyssey Stats `cd apps/odyssey-stats && STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
- Hardcode `isCommercial` to `false`

https://github.com/Automattic/wp-calypso/blob/c5c4ab04a0ae0cd76422a587f32a40e909e3bd30/client/my-sites/stats/stats-notices/index.tsx#L52

- Open `/wp-admin/admin.php?page=stats#!/stats/day/:siteSlug`
- Ensure you see the upgrade notice

<img width="698" alt="Screenshot 2023-09-22 at 11 42 08 AM" src="https://github.com/Automattic/wp-calypso/assets/1425433/8c446046-94f6-416a-a209-be748d0a13f3">

- Click `Upgrade my Stats`
- Ensure you are taken to PWYW purchase page within WP-Admin
- Ensure you can Purchase Stats Free

- Open `/wp-admin/admin.php?page=stats#!/stats/day/:siteSlug`
- Ensure you can see upgrade notice for Stats Free

<img width="671" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/f27543ac-7f2e-4783-8916-0c0aa24fee65">

- Click `Upgrade my Stats`
- Ensure you are taken to PWYW purchase page within WP-Admin
- Ensure you can purchase Stats Personal

- Remove Stats Personal subscription for the site
- Hardcode `isCommercial` to `true`

https://github.com/Automattic/wp-calypso/blob/c5c4ab04a0ae0cd76422a587f32a40e909e3bd30/client/my-sites/stats/stats-notices/index.tsx#L52


- Open `/wp-admin/admin.php?page=stats#!/stats/day/:siteSlug`
- Ensure you can see commercial upgrade notice

<img width="559" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/092b685d-6778-4851-af8f-1c2ae764b065">

- Click `Upgrade my Stats`
- Ensure you are taken to commercial purchase page within WP-Admin
- Ensure you can purchase Stats Commercial

### Calypso Stats

Please test locally with instructions similar to Odyssey Stats to ensure the upgrade buttons still work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
