### PR TITLE
Checkout: Use custom data registry for credit card payment method tests

### DIFF
--- a/client/my-sites/checkout/src/test/credit-card.tsx
+++ b/client/my-sites/checkout/src/test/credit-card.tsx
@@ -20,7 +20,6 @@ import {
 	createCreditCardPaymentMethodStore,
 	createCreditCardMethod,
 } from 'calypso/my-sites/checkout/src/payment-methods/credit-card';
-import { errorNotice } from 'calypso/state/notices/actions';
 import { createTestReduxStore, fetchStripeConfiguration, stripeConfiguration } from './util';
 import type { CardStoreType } from 'calypso/my-sites/checkout/src/payment-methods/credit-card/types';
 
@@ -97,18 +96,7 @@ function CompleteCreditCardFields() {
 	return <button onClick={ completeFields }>Mark credit fields as complete</button>;
 }
 
-jest.mock( 'calypso/state/notices/actions' );
-
 describe( 'Credit card payment method', () => {
-	beforeEach( () => {
-		( errorNotice as jest.Mock ).mockImplementation( ( value ) => {
-			return {
-				type: 'errorNotice',
-				value,
-			};
-		} );
-	} );
-
 	it( 'renders a credit card option', async () => {
 		render( <TestWrapper /> );
 		await waitFor( () => {
@@ -173,7 +161,6 @@ describe( 'Credit card payment method', () => {
 		await user.type( screen.getAllByLabelText( /Cardholder name/i )[ 1 ], customerName );
 		await user.type( screen.getByLabelText( /Card number/i ), cardNumber );
 		await user.type( screen.getByLabelText( /Expiry date/i ), cardExpiry );
-		//await user.type( screen.getAllByLabelText( /Security code/i )[ 0 ], '' );
 
 		// Try to submit the form
 		await user.click( await screen.findByText( activePayButtonText ) );

--- a/client/my-sites/checkout/src/test/credit-card.tsx
+++ b/client/my-sites/checkout/src/test/credit-card.tsx
@@ -12,40 +12,54 @@ import {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useDispatch } from '@wordpress/data';
-import { useEffect } from 'react';
+import { RegistryProvider, createRegistry, useDispatch, useRegistry } from '@wordpress/data';
+import { useState } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import GlobalNotices from 'calypso/components/global-notices';
 import {
 	createCreditCardPaymentMethodStore,
 	createCreditCardMethod,
 } from 'calypso/my-sites/checkout/src/payment-methods/credit-card';
-import { actions } from 'calypso/my-sites/checkout/src/payment-methods/credit-card/store';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { createTestReduxStore, fetchStripeConfiguration, stripeConfiguration } from './util';
 import type { CardStoreType } from 'calypso/my-sites/checkout/src/payment-methods/credit-card/types';
 
-function TestWrapper( { paymentMethods, paymentProcessors = undefined } ) {
-	const store = createTestReduxStore();
-	const queryClient = new QueryClient();
+function TestWrapper( { paymentProcessors = undefined } ) {
+	const [ store ] = useState( () => createTestReduxStore() );
+	const [ queryClient ] = useState( () => new QueryClient() );
+	const [ testRegistry ] = useState( () => createRegistry( {} ) );
+
 	return (
-		<ReduxProvider store={ store }>
-			<QueryClientProvider client={ queryClient }>
-				<GlobalNotices />
-				<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
-					<CheckoutProvider
-						paymentMethods={ paymentMethods }
-						selectFirstAvailablePaymentMethod
-						paymentProcessors={ paymentProcessors ?? {} }
-					>
-						<CheckoutStepGroup>
-							<PaymentMethodStep />
-							<CheckoutFormSubmit />
-						</CheckoutStepGroup>
-					</CheckoutProvider>
-				</StripeHookProvider>
-			</QueryClientProvider>
-		</ReduxProvider>
+		<RegistryProvider value={ testRegistry }>
+			<ReduxProvider store={ store }>
+				<QueryClientProvider client={ queryClient }>
+					<TestWrapperInner paymentProcessors={ paymentProcessors } />
+				</QueryClientProvider>
+			</ReduxProvider>
+		</RegistryProvider>
+	);
+}
+
+function TestWrapperInner( { paymentProcessors = undefined } ) {
+	const creditCardStore = useCreateCreditCardStore();
+	const paymentMethod = useCreateCreditCardMethod( creditCardStore );
+	return (
+		<>
+			<GlobalNotices />
+			<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
+				<CheckoutProvider
+					paymentMethods={ [ paymentMethod ] }
+					selectFirstAvailablePaymentMethod
+					paymentProcessors={ paymentProcessors ?? {} }
+				>
+					<CheckoutStepGroup>
+						<CompleteCreditCardFields />
+						<PaymentMethodStep />
+						<CheckoutFormSubmit />
+					</CheckoutStepGroup>
+				</CheckoutProvider>
+			</StripeHookProvider>
+		</>
 	);
 }
 
@@ -54,18 +68,33 @@ const cardNumber = '4242424242424242';
 const cardExpiry = '05/99';
 const cardCvv = '123';
 const activePayButtonText = 'Complete Checkout';
-function getPaymentMethod( store: CardStoreType, additionalArgs = {} ) {
-	return createCreditCardMethod( {
-		store,
-		...additionalArgs,
-	} );
+function useCreateCreditCardMethod( store: CardStoreType, additionalArgs = {} ) {
+	const [ method ] = useState( () =>
+		createCreditCardMethod( {
+			store,
+			...additionalArgs,
+		} )
+	);
+	return method;
 }
 
-function ResetCreditCardStoreFields() {
-	const { resetFields } = useDispatch( 'wpcom-credit-card' );
-	useEffect( () => {
-		resetFields();
-	} );
+function useCreateCreditCardStore() {
+	// NOTE: the return type of useRegistry is `Function` which is incorrect
+	// and causes a type error here, but it does actually return a registry.
+	const registry = useRegistry();
+	const [ store ] = useState( () => createCreditCardPaymentMethodStore( { registry } ) );
+	return store;
+}
+
+function CompleteCreditCardFields() {
+	const { setCardDataComplete } = useDispatch( 'wpcom-credit-card' );
+	const completeFields = () => {
+		// Stripe fields will not actually operate in this test so we have to pretend they are complete.
+		setCardDataComplete( 'cardNumber', true );
+		setCardDataComplete( 'cardExpiry', true );
+		setCardDataComplete( 'cardCvc', true );
+	};
+	return <button onClick={ completeFields }>Mark credit fields as complete</button>;
 }
 
 jest.mock( 'calypso/state/notices/actions' );
@@ -81,18 +110,14 @@ describe( 'Credit card payment method', () => {
 	} );
 
 	it( 'renders a credit card option', async () => {
-		const store = createCreditCardPaymentMethodStore( {} );
-		const paymentMethod = getPaymentMethod( store );
-		render( <TestWrapper paymentMethods={ [ paymentMethod ] }></TestWrapper> );
+		render( <TestWrapper /> );
 		await waitFor( () => {
 			expect( screen.queryByText( 'Credit or debit card' ) ).toBeInTheDocument();
 		} );
 	} );
 
 	it( 'renders submit button when credit card is selected', async () => {
-		const store = createCreditCardPaymentMethodStore( {} );
-		const paymentMethod = getPaymentMethod( store );
-		render( <TestWrapper paymentMethods={ [ paymentMethod ] }></TestWrapper> );
+		render( <TestWrapper /> );
 		await waitFor( () => {
 			expect( screen.queryByText( activePayButtonText ) ).toBeInTheDocument();
 		} );
@@ -100,15 +125,8 @@ describe( 'Credit card payment method', () => {
 
 	it( 'submits the data to the processor when the submit button is pressed', async () => {
 		const user = userEvent.setup();
-		const store = createCreditCardPaymentMethodStore( {} );
-		const paymentMethod = getPaymentMethod( store );
 		const processorFunction = jest.fn( () => Promise.resolve( makeSuccessResponse( {} ) ) );
-		render(
-			<TestWrapper
-				paymentMethods={ [ paymentMethod ] }
-				paymentProcessors={ { card: processorFunction } }
-			></TestWrapper>
-		);
+		render( <TestWrapper paymentProcessors={ { card: processorFunction } }></TestWrapper> );
 		await waitFor( () => expect( screen.getByText( activePayButtonText ) ).not.toBeDisabled() );
 
 		await user.type( screen.getAllByLabelText( /Cardholder name/i )[ 1 ], customerName );
@@ -116,10 +134,7 @@ describe( 'Credit card payment method', () => {
 		await user.type( screen.getByLabelText( /Expiry date/i ), cardExpiry );
 		await user.type( screen.getAllByLabelText( /Security code/i )[ 0 ], cardCvv );
 
-		// Stripe fields will not actually operate in this test so we have to pretend they are complete.
-		store.dispatch( actions.setCardDataComplete( 'cardNumber', true ) );
-		store.dispatch( actions.setCardDataComplete( 'cardExpiry', true ) );
-		store.dispatch( actions.setCardDataComplete( 'cardCvc', true ) );
+		await user.click( await screen.findByText( 'Mark credit fields as complete' ) );
 
 		await user.click( await screen.findByText( activePayButtonText ) );
 		await waitFor( () => {
@@ -135,21 +150,11 @@ describe( 'Credit card payment method', () => {
 				useForAllSubscriptions: false,
 			} );
 		} );
-
-		// Manually reset the `wpcom-credit-card` store fields.
-		render( <ResetCreditCardStoreFields /> );
 	} );
 
 	it( 'does not submit the data to the processor when the submit button is pressed if fields are missing', async () => {
-		const store = createCreditCardPaymentMethodStore( {} );
-		const paymentMethod = getPaymentMethod( store );
 		const processorFunction = jest.fn( () => Promise.resolve( makeSuccessResponse( {} ) ) );
-		render(
-			<TestWrapper
-				paymentMethods={ [ paymentMethod ] }
-				paymentProcessors={ { card: processorFunction } }
-			></TestWrapper>
-		);
+		render( <TestWrapper paymentProcessors={ { card: processorFunction } }></TestWrapper> );
 		await waitFor( () => expect( screen.getByText( activePayButtonText ) ).not.toBeDisabled() );
 		await userEvent.click( await screen.findByText( activePayButtonText ) );
 		await waitFor( () => {
@@ -159,15 +164,8 @@ describe( 'Credit card payment method', () => {
 
 	it( 'displays error message overlay when a credit card field is empty and submit is clicked', async () => {
 		const user = userEvent.setup();
-		const store = createCreditCardPaymentMethodStore( {} );
-		const paymentMethod = getPaymentMethod( store );
 		const processorFunction = jest.fn( () => Promise.resolve( makeSuccessResponse( {} ) ) );
-		render(
-			<TestWrapper
-				paymentMethods={ [ paymentMethod ] }
-				paymentProcessors={ { card: processorFunction } }
-			></TestWrapper>
-		);
+		render( <TestWrapper paymentProcessors={ { card: processorFunction } }></TestWrapper> );
 
 		await waitFor( () => expect( screen.getByText( activePayButtonText ) ).not.toBeDisabled() );
 
@@ -181,8 +179,7 @@ describe( 'Credit card payment method', () => {
 		await user.click( await screen.findByText( activePayButtonText ) );
 
 		// Verify the error message overlay appears
-		expect( errorNotice ).toHaveBeenCalledWith(
-			expect.stringMatching( /Something seems to be missing/ )
-		);
+		const element = await screen.findByText( /Something seems to be missing/i );
+		expect( element ).not.toBeFalsy();
 	} );
 } );


### PR DESCRIPTION
This is a follow-up to https://github.com/Automattic/wp-calypso/pull/81106

## Proposed Changes

In this PR, we refactor the credit card payment method tests to use a `RegistryProvider` from the `@wordpress/data` package to isolate each test from its neighbors, instead of using the global registry. This will provide more accurate tests (we should do it in other tests as well, eventually) since the data store will be recreated for every test.

## Testing Instructions

Automated tests.