### PR TITLE
Domain management i1: enable bulk table in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -38,7 +38,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"domains/bulk-actions-table": false,
+		"domains/bulk-actions-table": true,
 		"domains/bulk-actions-contact-info-editing": false,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,


### PR DESCRIPTION
## Proposed Changes

Once we're confident that the table is in usable state, let's roll the table to production. Note that the feature flag that enables bulk contact info edition is not yet going to be released to the public.

## Testing Instructions

Sanity tests: the table loads, the actions (back-end mutations, column sorting and searching etc) are completed successfully and reflected on the table.