### PR TITLE
Thank You page for Themes: Add a 'onboarding' flag to avoid show Activation Modal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -453,7 +453,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		// When the user is done with checkout, send them back to the current url
 		// If the theme is externally managed, send them to the marketplace thank you page
 		const destination = selectedDesign?.is_externally_managed
-			? addQueryArgs( `/marketplace/thank-you/${ siteSlug }`, {
+			? addQueryArgs( `/marketplace/thank-you/${ siteSlug }?onboarding`, {
 					themes: selectedDesign?.slug,
 			  } )
 			: window.location.href.replace( window.location.origin, '' );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -105,7 +105,13 @@ const ThemeNameSectionWrapper = styled.div`
 	flex-wrap: wrap;
 `;
 
-export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
+export const ThankYouThemeSection = ( {
+	theme,
+	onboardingFlow,
+}: {
+	theme: any;
+	onboardingFlow: boolean;
+} ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -140,7 +146,7 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 			return;
 		}
 		sendTrackEvent( 'calypso_theme_thank_you_activate_theme_click' );
-		dispatch( activate( theme.id, siteId, 'marketplace-thank-you' ) );
+		dispatch( activate( theme.id, siteId, 'marketplace-thank-you', false, false, onboardingFlow ) );
 	};
 
 	return (

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -107,10 +107,10 @@ const ThemeNameSectionWrapper = styled.div`
 
 export const ThankYouThemeSection = ( {
 	theme,
-	onboardingFlow,
+	isOnboardingFlow,
 }: {
 	theme: any;
-	onboardingFlow: boolean;
+	isOnboardingFlow: boolean;
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -146,7 +146,9 @@ export const ThankYouThemeSection = ( {
 			return;
 		}
 		sendTrackEvent( 'calypso_theme_thank_you_activate_theme_click' );
-		dispatch( activate( theme.id, siteId, 'marketplace-thank-you', false, false, onboardingFlow ) );
+		dispatch(
+			activate( theme.id, siteId, 'marketplace-thank-you', false, false, isOnboardingFlow )
+		);
 	};
 
 	return (

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -26,11 +26,11 @@ import './style.scss';
 const MarketplaceThankYou = ( {
 	pluginSlugs,
 	themeSlugs,
-	onboardingFlow,
+	isOnboardingFlow,
 }: {
 	pluginSlugs: Array< string >;
 	themeSlugs: Array< string >;
-	onboardingFlow: boolean;
+	isOnboardingFlow: boolean;
 } ) => {
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
@@ -58,7 +58,7 @@ const MarketplaceThankYou = ( {
 		themeSubtitle,
 		themesProgressbarSteps,
 		isAtomicNeededForThemes,
-	] = useThemesThankYouData( themeSlugs, onboardingFlow );
+	] = useThemesThankYouData( themeSlugs, isOnboardingFlow );
 
 	const [ hasPlugins, hasThemes ] = [ pluginSlugs, themeSlugs ].map(
 		( slugs ) => slugs.length !== 0

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -26,9 +26,11 @@ import './style.scss';
 const MarketplaceThankYou = ( {
 	pluginSlugs,
 	themeSlugs,
+	onboardingFlow,
 }: {
 	pluginSlugs: Array< string >;
 	themeSlugs: Array< string >;
+	onboardingFlow: boolean;
 } ) => {
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
@@ -56,7 +58,7 @@ const MarketplaceThankYou = ( {
 		themeSubtitle,
 		themesProgressbarSteps,
 		isAtomicNeededForThemes,
-	] = useThemesThankYouData( themeSlugs );
+	] = useThemesThankYouData( themeSlugs, onboardingFlow );
 
 	const [ hasPlugins, hasThemes ] = [ pluginSlugs, themeSlugs ].map(
 		( slugs ) => slugs.length !== 0

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -14,7 +14,7 @@ import MasterbarStyled from './masterbar-styled';
 
 export function useThemesThankYouData(
 	themeSlugs: string[],
-	onboardingFlow: boolean
+	isOnboardingFlow: boolean
 ): ThankYouData {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -53,7 +53,7 @@ export function useThemesThankYouData(
 			.filter( ( theme ) => theme )
 			.map( ( theme ) => ( {
 				stepKey: `theme_information_${ theme.id }`,
-				stepSection: <ThankYouThemeSection theme={ theme } onboardingFlow={ onboardingFlow } />,
+				stepSection: <ThankYouThemeSection theme={ theme } isOnboardingFlow={ isOnboardingFlow } />,
 			} ) ),
 	};
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -12,7 +12,10 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import { ThankYouThemeSection } from './marketplace-thank-you-theme-section';
 import MasterbarStyled from './masterbar-styled';
 
-export function useThemesThankYouData( themeSlugs: string[] ): ThankYouData {
+export function useThemesThankYouData(
+	themeSlugs: string[],
+	onboardingFlow: boolean
+): ThankYouData {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
@@ -50,7 +53,7 @@ export function useThemesThankYouData( themeSlugs: string[] ): ThankYouData {
 			.filter( ( theme ) => theme )
 			.map( ( theme ) => ( {
 				stepKey: `theme_information_${ theme.id }`,
-				stepSection: <ThankYouThemeSection theme={ theme } />,
+				stepSection: <ThankYouThemeSection theme={ theme } onboardingFlow={ onboardingFlow } />,
 			} ) ),
 	};
 

--- a/client/my-sites/marketplace/controller.js
+++ b/client/my-sites/marketplace/controller.js
@@ -24,11 +24,17 @@ export function renderThemesInstallPage( context, next ) {
 }
 
 export function renderMarketplaceThankYou( context, next ) {
-	const { plugins, themes } = context.query;
+	const { plugins, themes, onboarding } = context.query;
 	const pluginSlugs = plugins ? plugins.split( ',' ) : [];
 	const themeSlugs = themes ? themes.split( ',' ) : [];
 
-	context.primary = <MarketplaceThankYou pluginSlugs={ pluginSlugs } themeSlugs={ themeSlugs } />;
+	context.primary = (
+		<MarketplaceThankYou
+			pluginSlugs={ pluginSlugs }
+			themeSlugs={ themeSlugs }
+			onboardingFlow={ onboarding !== undefined }
+		/>
+	);
 	next();
 }
 

--- a/client/my-sites/marketplace/controller.js
+++ b/client/my-sites/marketplace/controller.js
@@ -32,7 +32,7 @@ export function renderMarketplaceThankYou( context, next ) {
 		<MarketplaceThankYou
 			pluginSlugs={ pluginSlugs }
 			themeSlugs={ themeSlugs }
-			onboardingFlow={ onboarding !== undefined }
+			isOnboardingFlow={ onboarding !== undefined }
 		/>
 	);
 	next();

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -26,6 +26,7 @@ import { shouldRedirectToThankYouPage } from 'calypso/state/themes/selectors/sho
  * @param  {string}   source    The source that is requesting theme activation, e.g. 'showcase'
  * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
  * @param  {boolean}  keepCurrentHomepage Prevent theme from switching homepage content if this is what it'd normally do when activated
+ * @param  {boolean}  skipActivationModal Skip the Activation Modal to be shown even if needed on flows that don't require it
  * @returns {Function}          Action thunk
  */
 export function activate(
@@ -33,7 +34,8 @@ export function activate(
 	siteId,
 	source = 'unknown',
 	purchased = false,
-	keepCurrentHomepage = false
+	keepCurrentHomepage = false,
+	skipActivationModal = false
 ) {
 	return ( dispatch, getState ) => {
 		if ( ! isEnabled( 'themes/atomic-homepage-replace' ) ) {
@@ -55,9 +57,9 @@ export function activate(
 		}
 
 		/**
-		 * Check whether the user has confirmed the activation.
+		 * Check whether the user has confirmed the activation or is in a flow that doesn't require acceptance.
 		 */
-		if ( ! hasActivationModalAccepted( getState(), themeId ) ) {
+		if ( ! hasActivationModalAccepted( getState(), themeId ) && ! skipActivationModal ) {
 			return dispatch( showActivationModal( themeId ) );
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/81917

Related to pekYwv-2UG-p2
Related to pdh6GB-3cP-p2#comment-3928

## Proposed Changes

* Add a new flag (`onboarding`) on the Thank You page to avoid showing the Activation Modal for Theme Activation when this flag is present
* Pass this flag when redirecting to the Thank You page as users from Onboarding shouldn't have content on the site yet.

## Testing Instructions

* Apply the diff D118900-code to your sandbox and direct requests to the sandbox
* Go to the Design Picker page with a Marketplace theme selected `/setup/update-design/designSetup?siteSlug=:site&theme=:theme_slug`. Theme slugs such as `makoney` and `olsen-fse` can be used.
* Click on `Unlock Theme`
* You should see the modal with the updated layout.
* Click to proceed and complete the purchase
* After completing the purchase you should be redirected to the Thank You page to activate the theme.
* Click on `Activate this design` and the theme should be activated WITHOUT any additional modal

**Regression test**
* From the themes directory (`/themes/:site`)
* Select a partner theme to be installed
* Click to install 
* In this case the Activation modal should be shown