### PR TITLE
Earn: Add Launchpad 

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -33,6 +33,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { isRequestingWordAdsApprovalForSite } from 'calypso/state/wordads/approve/selectors';
 import StatsSection from './components/stats';
+import EarnLaunchpad from './launchpad';
 
 import './style.scss';
 
@@ -494,10 +495,11 @@ const Home = () => {
 				</div>
 			) }
 			{ ! isLoading && (
-				<>
+				<div>
+					<EarnLaunchpad />
 					<StatsSection />
 					<PromoSection { ...promos } />
-				</>
+				</div>
 			) }
 		</>
 	);

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -4,7 +4,9 @@ import {
 	PLAN_JETPACK_SECURITY_DAILY,
 	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
+import { useLaunchpad } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Task } from '@automattic/launchpad';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { compact } from 'lodash';
@@ -64,6 +66,17 @@ const Home = () => {
 	const isNonAtomicJetpack = Boolean( isJetpack && ! isSiteTransfer );
 	const hasSetupAds = Boolean( site?.options?.wordads || isRequestingWordAds );
 	const isLoading = hasConnectedAccount === null || sitePlanSlug === null;
+
+	const {
+		data: { checklist },
+	} = useLaunchpad( site?.slug ?? null, 'earn' );
+	const numberOfSteps = checklist?.length || 0;
+	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
+	const tasklistCompleted = completedSteps >= numberOfSteps;
+
+	const shouldLoadLaunchpad = () => {
+		return ! tasklistCompleted && numberOfSteps > 0;
+	};
 
 	function trackUpgrade( plan: string, feature: string ) {
 		dispatch(
@@ -496,8 +509,15 @@ const Home = () => {
 			) }
 			{ ! isLoading && (
 				<div>
-					<EarnLaunchpad />
-					<StatsSection />
+					{ shouldLoadLaunchpad() ? (
+						<EarnLaunchpad
+							tasklistCompleted={ tasklistCompleted }
+							numberOfSteps={ numberOfSteps }
+							completedSteps={ completedSteps }
+						/>
+					) : (
+						<StatsSection />
+					) }
 					<PromoSection { ...promos } />
 				</div>
 			) }

--- a/client/my-sites/earn/launchpad/index.tsx
+++ b/client/my-sites/earn/launchpad/index.tsx
@@ -1,26 +1,59 @@
 import { CircularProgressBar } from '@automattic/components';
 import { useLaunchpad } from '@automattic/data-stores';
-import { Launchpad, Task } from '@automattic/launchpad';
+import { Launchpad, Task, setUpActionsForTasks } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const EarnLaunchpad = () => {
-	const checklistSlug = 'earn-newsletter';
 	const translate = useTranslate();
 
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const isNewsletterOrWriteIntent =
+		site?.options?.site_intent === 'newsletter' || site?.options?.site_intent === 'write';
 
 	const {
 		data: { checklist },
-	} = useLaunchpad( site?.slug ?? null, checklistSlug );
+	} = useLaunchpad( site?.slug ?? null, getChecklistSlug() );
 
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
+	const tasklistCompleted = completedSteps >= numberOfSteps;
+
+	const tracksData = {
+		recordTracksEvent,
+		checklistSlug: getChecklistSlug(),
+		tasklistCompleted,
+		launchpadContext: 'earn',
+	};
+
+	function getChecklistSlug() {
+		return isNewsletterOrWriteIntent ? 'earn-newsletter' : '';
+	}
+
+	function shouldLoadLaunchpad() {
+		return isNewsletterOrWriteIntent && ! tasklistCompleted && numberOfSteps > 0;
+	}
+
+	const taskFilter = ( tasks: Task[] ) => {
+		return setUpActionsForTasks( {
+			tasks,
+			siteSlug: site?.slug ?? null,
+			tracksData,
+		} );
+	};
+
+	if ( ! shouldLoadLaunchpad() ) {
+		return null;
+	}
 
 	return (
 		<div className="earn__launchpad">
 			<div className="earn__launchpad-header">
+				<h2 className="earn__launchpad-title">
+					{ translate( 'Create your paid newsletter in two steps.' ) }
+				</h2>
 				<div className="earn__launchpad-progress-bar-container">
 					<CircularProgressBar
 						size={ 30 }
@@ -29,14 +62,11 @@ const EarnLaunchpad = () => {
 						currentStep={ completedSteps }
 					/>
 				</div>
-				<h2 className="earn__launchpad-title">
-					{ translate( 'Create your paid newsletter in two steps.' ) }
-				</h2>
 			</div>
 			<Launchpad
 				siteSlug={ site?.slug ?? null }
-				checklistSlug={ checklistSlug }
-				// taskFilter={ taskFilter }
+				checklistSlug={ getChecklistSlug() }
+				taskFilter={ taskFilter }
 			/>
 		</div>
 	);

--- a/client/my-sites/earn/launchpad/index.tsx
+++ b/client/my-sites/earn/launchpad/index.tsx
@@ -1,5 +1,5 @@
 import { CircularProgressBar } from '@automattic/components';
-import { useLaunchpad, LaunchpadNavigator } from '@automattic/data-stores';
+import { LaunchpadNavigator } from '@automattic/data-stores';
 import { Launchpad, Task, setUpActionsForTasks } from '@automattic/launchpad';
 import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -7,20 +7,22 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-const EarnLaunchpad = () => {
+type EarnLaunchpadProps = {
+	tasklistCompleted: boolean;
+	numberOfSteps: number;
+	completedSteps: number;
+};
+
+const EarnLaunchpad = ( {
+	tasklistCompleted,
+	numberOfSteps,
+	completedSteps,
+}: EarnLaunchpadProps ) => {
 	const translate = useTranslate();
 
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 
-	const {
-		data: { checklist },
-	} = useLaunchpad( site?.slug ?? null, 'earn' );
-
 	const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
-
-	const numberOfSteps = checklist?.length || 0;
-	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
-	const tasklistCompleted = completedSteps >= numberOfSteps;
 
 	const tracksData = {
 		recordTracksEvent,
@@ -28,10 +30,6 @@ const EarnLaunchpad = () => {
 		tasklistCompleted,
 		launchpadContext: 'earn',
 	};
-
-	function shouldLoadLaunchpad() {
-		return numberOfSteps > 0;
-	}
 
 	const taskFilter = ( tasks: Task[] ) => {
 		return setUpActionsForTasks( {
@@ -41,10 +39,6 @@ const EarnLaunchpad = () => {
 			extraActions: { setActiveChecklist },
 		} );
 	};
-
-	if ( ! shouldLoadLaunchpad() ) {
-		return null;
-	}
 
 	return (
 		<div className="earn__launchpad">

--- a/client/my-sites/earn/launchpad/index.tsx
+++ b/client/my-sites/earn/launchpad/index.tsx
@@ -1,6 +1,7 @@
 import { CircularProgressBar } from '@automattic/components';
-import { useLaunchpad } from '@automattic/data-stores';
+import { useLaunchpad, LaunchpadNavigator } from '@automattic/data-stores';
 import { Launchpad, Task, setUpActionsForTasks } from '@automattic/launchpad';
+import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
@@ -10,12 +11,12 @@ const EarnLaunchpad = () => {
 	const translate = useTranslate();
 
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
-	const isNewsletterOrWriteIntent =
-		site?.options?.site_intent === 'newsletter' || site?.options?.site_intent === 'write';
 
 	const {
 		data: { checklist },
-	} = useLaunchpad( site?.slug ?? null, getChecklistSlug() );
+	} = useLaunchpad( site?.slug ?? null, 'earn' );
+
+	const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
@@ -23,17 +24,13 @@ const EarnLaunchpad = () => {
 
 	const tracksData = {
 		recordTracksEvent,
-		checklistSlug: getChecklistSlug(),
+		checklistSlug: 'earn',
 		tasklistCompleted,
 		launchpadContext: 'earn',
 	};
 
-	function getChecklistSlug() {
-		return isNewsletterOrWriteIntent ? 'earn-newsletter' : '';
-	}
-
 	function shouldLoadLaunchpad() {
-		return isNewsletterOrWriteIntent && ! tasklistCompleted && numberOfSteps > 0;
+		return numberOfSteps > 0;
 	}
 
 	const taskFilter = ( tasks: Task[] ) => {
@@ -41,6 +38,7 @@ const EarnLaunchpad = () => {
 			tasks,
 			siteSlug: site?.slug ?? null,
 			tracksData,
+			extraActions: { setActiveChecklist },
 		} );
 	};
 
@@ -51,23 +49,22 @@ const EarnLaunchpad = () => {
 	return (
 		<div className="earn__launchpad">
 			<div className="earn__launchpad-header">
-				<h2 className="earn__launchpad-title">
-					{ translate( 'Create your paid newsletter in two steps.' ) }
-				</h2>
 				<div className="earn__launchpad-progress-bar-container">
 					<CircularProgressBar
-						size={ 30 }
+						size={ 40 }
 						enableDesktopScaling
 						numberOfSteps={ numberOfSteps }
 						currentStep={ completedSteps }
 					/>
 				</div>
+				<h2 className="earn__launchpad-title">
+					{ translate( 'Create your paid offering in two steps.' ) }
+				</h2>
+				<p className="earn__launchpad-description">
+					{ translate( 'Let your fans support your art, writing, or project directly.' ) }
+				</p>
 			</div>
-			<Launchpad
-				siteSlug={ site?.slug ?? null }
-				checklistSlug={ getChecklistSlug() }
-				taskFilter={ taskFilter }
-			/>
+			<Launchpad siteSlug={ site?.slug ?? null } checklistSlug="earn" taskFilter={ taskFilter } />
 		</div>
 	);
 };

--- a/client/my-sites/earn/launchpad/index.tsx
+++ b/client/my-sites/earn/launchpad/index.tsx
@@ -1,0 +1,45 @@
+import { CircularProgressBar } from '@automattic/components';
+import { useLaunchpad } from '@automattic/data-stores';
+import { Launchpad, Task } from '@automattic/launchpad';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+const EarnLaunchpad = () => {
+	const checklistSlug = 'earn-newsletter';
+	const translate = useTranslate();
+
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+
+	const {
+		data: { checklist },
+	} = useLaunchpad( site?.slug ?? null, checklistSlug );
+
+	const numberOfSteps = checklist?.length || 0;
+	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
+
+	return (
+		<div className="earn__launchpad">
+			<div className="earn__launchpad-header">
+				<div className="earn__launchpad-progress-bar-container">
+					<CircularProgressBar
+						size={ 30 }
+						enableDesktopScaling
+						numberOfSteps={ numberOfSteps }
+						currentStep={ completedSteps }
+					/>
+				</div>
+				<h2 className="earn__launchpad-title">
+					{ translate( 'Create your paid newsletter in two steps.' ) }
+				</h2>
+			</div>
+			<Launchpad
+				siteSlug={ site?.slug ?? null }
+				checklistSlug={ checklistSlug }
+				// taskFilter={ taskFilter }
+			/>
+		</div>
+	);
+};
+
+export default EarnLaunchpad;

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -11,29 +11,35 @@
 	background: #fff;
 
 	.earn__launchpad-header {
-		display: flex;
-		align-items: center;
-		gap: 10px;
-
+		padding: 20px 0;
 		.earn__launchpad-progress-bar-container {
-			margin: 5px;
+			margin: 0 0 10px 6px;
 		}
-
 		.earn__launchpad-title {
-			flex: 1;
-			font-size: 1rem;
-			font-weight: 500;
-			font-family: $font-sf-pro-display;
+			font-weight: 600;
+		}
+		.earn__launchpad-description {
+			margin-bottom: 0;
+			color: var(--color-neutral-60);
+			font-size: $font-body-small;
 		}
 	}
 	.launchpad__checklist-wrapper {
 		flex: 1;
-	}
-	.checklist-item__task-content {
-		padding: 12px 0;
-		&.is-placeholder:nth-of-type(3),
-		&.is-placeholder:nth-of-type(4) {
-			display: none;
+		display: flex;
+		align-items: center;
+		.checklist__tasks {
+			flex: 1;
+			.checklist-item__task-content {
+				padding: 12px 0;
+				&.is-placeholder:nth-of-type(3),
+				&.is-placeholder:nth-of-type(4) {
+					display: none;
+				}
+				.checklist-item__text {
+					font-weight: 400;
+				}
+			}
 		}
 	}
 }

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -1,5 +1,38 @@
 @import "@wordpress/base-styles/breakpoints";
+@import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/mixins";
+
+.earn__launchpad {
+	padding: 4px 20px;
+	box-shadow: 0 0 0 1px var(--color-border-subtle);
+	margin-bottom: 16px;
+	display: flex;
+	gap: 30px;
+	background: #fff;
+
+	.earn__launchpad-header {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+
+		.earn__launchpad-progress-bar-container {
+			margin: 5px;
+		}
+
+		.earn__launchpad-title {
+			flex: 1;
+			font-size: 1rem;
+			font-weight: 500;
+			font-family: $font-sf-pro-display;
+		}
+	}
+	.launchpad__checklist-wrapper {
+		flex: 1;
+	}
+	.checklist-item__task-content {
+		padding: 12px 0;
+	}
+}
 
 .earn .promo-section__promos img {
 	width: 48px;

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -31,6 +31,10 @@
 	}
 	.checklist-item__task-content {
 		padding: 12px 0;
+		&.is-placeholder:nth-of-type(3),
+		&.is-placeholder:nth-of-type(4) {
+			display: none;
+		}
 	}
 }
 

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -22,7 +22,11 @@ export const setUpActionsForTasks = ( {
 	uiContext = 'calypso',
 }: LaunchpadTaskActionsProps ): Task[] => {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
-	const { setShareSiteModalIsOpen, siteLaunched, setActiveChecklist } = extraActions;
+	const {
+		setShareSiteModalIsOpen = undefined,
+		siteLaunched = undefined,
+		setActiveChecklist,
+	} = extraActions;
 
 	//Record click events for tasks
 	const recordTaskClickTracksEvent = ( task: Task ) => {

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -22,11 +22,7 @@ export const setUpActionsForTasks = ( {
 	uiContext = 'calypso',
 }: LaunchpadTaskActionsProps ): Task[] => {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
-	const {
-		setShareSiteModalIsOpen = undefined,
-		siteLaunched = undefined,
-		setActiveChecklist,
-	} = extraActions;
+	const { setShareSiteModalIsOpen, siteLaunched, setActiveChecklist } = extraActions;
 
 	//Record click events for tasks
 	const recordTaskClickTracksEvent = ( task: Task ) => {


### PR DESCRIPTION
## Proposed Changes

- Adds Launchpad checklist to Earn page for sites with newsletter/write intent
- Will show Launchpad until stripe is connected and at least one product/offer is added. After that, launchpad no longer shows, and we show the stats component. 
- Note we're effectively hardcoding the launchpad checklist slug to be 'earn' for all sites. We may obviously want to load conditional launchpad checklists depending on site intent later. 
- We could still improve loading indicator behavior (it's a bit tricky because of conditional loading and nested loading indicators) 

**When launchpad tasks are still incomplete:**
<img width="1072" alt="earn-launchpad" src="https://github.com/Automattic/wp-calypso/assets/21228350/b7131d2b-022f-4d04-9d9e-cb9e3a1d3902">

**After all launchpad tasks are complete:**
<img width="1056" alt="earn-stats" src="https://github.com/Automattic/wp-calypso/assets/21228350/25817d5f-7b09-4272-86a4-00ff013b043e">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1) You'll need to test this alongside the backend PR at https://github.com/Automattic/jetpack/pull/33200 that adds a launchpad checklist for 'earn'. Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/earn-newsletter-launchpad-checklist` in your sandbox to load that branch. Then update your hosts file to sandbox public-api.wordpress.com. 
2) Create or access any simple site that does not have stripe connected.
3) Go to the Earn page and confirm the launchpad loads.
4) Complete the two steps and confirm that Launchpad statuses update as expected. 
5) When all tasks are completed, confirm that the Launchpad no longer shows, and that the stats component shows instead. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?