### PR TITLE
Stats: Date picker - create new feature flag and an empty shell component

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -45,6 +45,7 @@ import PromoCards from './promo-cards';
 import ChartTabs from './stats-chart-tabs';
 import Countries from './stats-countries';
 import DatePicker from './stats-date-picker';
+import DatePickerNew from './stats-date-picker-new';
 import StatsModule from './stats-module';
 import StatsModuleEmails from './stats-module-emails';
 import StatsNotices from './stats-notices';
@@ -186,6 +187,9 @@ class StatsSite extends Component {
 		const { period, endOf } = this.props.period;
 		const moduleStrings = statsStrings();
 
+		// For the new date picker
+		const isNewDatePickerEnabled = config.isEnabled( 'stats/date-picker' );
+
 		const query = memoizedQuery( period, endOf.format( 'YYYY-MM-DD' ) );
 
 		// For period option links
@@ -253,14 +257,21 @@ class StatsSite extends Component {
 								url={ `/stats/${ period }/${ slug }` }
 								queryParams={ context.query }
 							>
-								<DatePicker
-									period={ period }
-									date={ date }
-									query={ query }
-									statsType="statsTopPosts"
-									showQueryDate
-									isShort
-								/>
+								{ ' ' }
+								{ isNewDatePickerEnabled ? (
+									<DatePickerNew
+									// NewDatePicker component
+									/>
+								) : (
+									<DatePicker
+										period={ period }
+										date={ date }
+										query={ query }
+										statsType="statsTopPosts"
+										showQueryDate
+										isShort
+									/>
+								) }
 							</StatsPeriodNavigation>
 							<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
 						</StatsPeriodHeader>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -44,8 +44,8 @@ import MiniCarousel from './mini-carousel';
 import PromoCards from './promo-cards';
 import ChartTabs from './stats-chart-tabs';
 import Countries from './stats-countries';
+import DateControl from './stats-date-control';
 import DatePicker from './stats-date-picker';
-import DatePickerNew from './stats-date-picker-new';
 import StatsModule from './stats-module';
 import StatsModuleEmails from './stats-module-emails';
 import StatsNotices from './stats-notices';
@@ -188,7 +188,7 @@ class StatsSite extends Component {
 		const moduleStrings = statsStrings();
 
 		// For the new date picker
-		const isNewDatePickerEnabled = config.isEnabled( 'stats/date-picker' );
+		const isDateControlEnabled = config.isEnabled( 'stats/date-control' );
 
 		const query = memoizedQuery( period, endOf.format( 'YYYY-MM-DD' ) );
 
@@ -250,9 +250,9 @@ class StatsSite extends Component {
 				<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>
-						{ isNewDatePickerEnabled ? (
-							<DatePickerNew
-							// NewDatePicker component
+						{ isDateControlEnabled ? (
+							<DateControl
+							// New DateControl component
 							/>
 						) : (
 							<StatsPeriodHeader>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -250,19 +250,19 @@ class StatsSite extends Component {
 				<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>
-						<StatsPeriodHeader>
-							<StatsPeriodNavigation
-								date={ date }
-								period={ period }
-								url={ `/stats/${ period }/${ slug }` }
-								queryParams={ context.query }
-							>
-								{ ' ' }
-								{ isNewDatePickerEnabled ? (
-									<DatePickerNew
-									// NewDatePicker component
-									/>
-								) : (
+						{ isNewDatePickerEnabled ? (
+							<DatePickerNew
+							// NewDatePicker component
+							/>
+						) : (
+							<StatsPeriodHeader>
+								<StatsPeriodNavigation
+									date={ date }
+									period={ period }
+									url={ `/stats/${ period }/${ slug }` }
+									queryParams={ context.query }
+								>
+									{ ' ' }
 									<DatePicker
 										period={ period }
 										date={ date }
@@ -271,10 +271,10 @@ class StatsSite extends Component {
 										showQueryDate
 										isShort
 									/>
-								) }
-							</StatsPeriodNavigation>
-							<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
-						</StatsPeriodHeader>
+								</StatsPeriodNavigation>
+								<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
+							</StatsPeriodHeader>
+						) }
 
 						<ChartTabs
 							activeTab={ getActiveTab( this.props.chartTab ) }

--- a/client/my-sites/stats/stats-date-control/index.jsx
+++ b/client/my-sites/stats/stats-date-control/index.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-const DatePickerNew = () => {
+const DateControl = () => {
 	return (
 		<div>
 			{ /* New Component bits go here */ }
-			NewDatePicker Component
+			New DateControl Component
 		</div>
 	);
 };
 
-export default DatePickerNew;
+export default DateControl;

--- a/client/my-sites/stats/stats-date-picker-new/index.jsx
+++ b/client/my-sites/stats/stats-date-picker-new/index.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const DatePickerNew = () => {
+	return (
+		<div>
+			{ /* New Component bits go here */ }
+			NewDatePicker Component
+		</div>
+	);
+};
+
+export default DatePickerNew;

--- a/config/client.json
+++ b/config/client.json
@@ -23,6 +23,7 @@
 	"readerFollowingSource",
 	"siftscience_key",
 	"signup_url",
+	"stats/date-picker",
 	"stats/new-video-summary",
 	"stats/subscribers-chart-section",
 	"stats/paid-wpcom-stats",

--- a/config/client.json
+++ b/config/client.json
@@ -23,7 +23,7 @@
 	"readerFollowingSource",
 	"siftscience_key",
 	"signup_url",
-	"stats/date-picker",
+	"stats/date-control",
 	"stats/new-video-summary",
 	"stats/subscribers-chart-section",
 	"stats/paid-wpcom-stats",

--- a/config/development.json
+++ b/config/development.json
@@ -183,6 +183,7 @@
 		"site-indicator": true,
 		"site-profiler": true,
 		"ssr/prefetch-timebox": false,
+		"stats/date-picker": false,
 		"stats/new-video-summary": true,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,

--- a/config/development.json
+++ b/config/development.json
@@ -183,7 +183,7 @@
 		"site-indicator": true,
 		"site-profiler": true,
 		"ssr/prefetch-timebox": false,
-		"stats/date-picker": false,
+		"stats/date-control": false,
 		"stats/new-video-summary": true,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -120,7 +120,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,
-		"stats/date-picker": false,
+		"stats/date-control": false,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -120,6 +120,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,
+		"stats/date-picker": false,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/production.json
+++ b/config/production.json
@@ -149,6 +149,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,
+		"stats/date-picker": false,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/production.json
+++ b/config/production.json
@@ -149,7 +149,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,
-		"stats/date-picker": false,
+		"stats/date-control": false,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -146,6 +146,7 @@
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
+		"stats/date-picker": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -146,7 +146,7 @@
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
-		"stats/date-picker": false,
+		"stats/date-control": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/test.json
+++ b/config/test.json
@@ -101,7 +101,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,
-		"stats/date-picker": false,
+		"stats/date-control": false,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/test.json
+++ b/config/test.json
@@ -101,6 +101,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,
+		"stats/date-picker": false,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -153,6 +153,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,
+		"stats/date-picker": false,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -153,7 +153,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,
-		"stats/date-picker": false,
+		"stats/date-control": false,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81831

## Proposed Changes

* creates a new feature flag (`stats/date-control`) and an empty shell component `DateControl` 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* There's not a lot to test here other than trying out the live branch and ensuring that the `DateControl` component does not show up anywhere currently to ensure it's correctly hidden behind the flag
* Check that the code looks good
![image](https://github.com/Automattic/wp-calypso/assets/30754158/7ef84a77-2619-4533-89a6-e5ceddc4a625)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?