### PR TITLE
Domains Management i1: Ensure auto-renew drop down appears above domains table header

### DIFF
--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -1,7 +1,9 @@
 @import "@automattic/typography/styles/variables";
 @import "@automattic/onboarding/styles/mixins";
 
-@media ( max-width: 480px ) {
+$domains-table-mobile-breakpoint: 480px;
+
+@media ( max-width: $domains-table-mobile-breakpoint ) {
 	.navigation-header {
 		position: sticky;
 		/*
@@ -27,6 +29,11 @@
 	.domains-table-toolbar {
 		--domains-table-toolbar-height: 40px;
 		background: var(--color-surface-backdrop);
+
+		@media ( min-width: $domains-table-mobile-breakpoint ) {
+			position: relative;
+			z-index: 2; // Ensure the dropdown appears overtop of the sticky table header
+		}
 	}
 
 	table {
@@ -87,7 +94,7 @@
 		gap: 4px;
 		font-size: $font-body-small;
 
-		@media ( min-width: 480px) {
+		@media ( min-width: $domains-table-mobile-breakpoint ) {
 			width: 100px;
 		}
 


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

The sticky domains table header has an explicit z-index. This overrides the z-index of the auto-renew dropdown. This diff places everything in the table toolbar into a higher z-index.

**Before**
<img width="449" alt="CleanShot 2023-09-20 at 14 27 09@2x" src="https://github.com/Automattic/wp-calypso/assets/1500769/e07886cb-8c2e-48f2-a7cf-bbc3ccf99423">

**After**
<img width="418" alt="CleanShot 2023-09-20 at 14 27 34@2x" src="https://github.com/Automattic/wp-calypso/assets/1500769/7332fe77-f9be-4584-8b74-b8fb1aa14d88">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test mobile layout too to ensure the stick toolbar still works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?