### PR TITLE
Domains Management i1: Show loading placeholder when domains table is doing initial loading

### DIFF
--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -280,10 +280,6 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 
 	const [ updatingDomain, setUpdatingDomain ] = useState< Value[ 'updatingDomain' ] >( null );
 
-	if ( ! domains ) {
-		return null;
-	}
-
 	const onSortChange = ( selectedColumn: DomainsTableColumn, direction?: 'asc' | 'desc' ) => {
 		if ( ! selectedColumn.isSortable ) {
 			return;
@@ -304,7 +300,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 	};
 
 	const hasSelectedDomains = selectedDomains.size > 0;
-	const selectableDomains = domains.filter( canBulkUpdate );
+	const selectableDomains = ( domains || [] ).filter( canBulkUpdate );
 	const canSelectAnyDomains = selectableDomains.length > 0;
 	const areAllDomainsSelected = selectableDomains.length === selectedDomains.size;
 
@@ -333,14 +329,14 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 
 		if ( ! hasSelectedDomains || ! areAllDomainsSelected ) {
 			// filter out unselectable domains from bulk selection
-			setSelectedDomains( new Set( domains.filter( canBulkUpdate ).map( getDomainId ) ) );
+			setSelectedDomains( new Set( ( domains || [] ).filter( canBulkUpdate ).map( getDomainId ) ) );
 		} else {
 			setSelectedDomains( new Set() );
 		}
 	};
 
 	const handleAutoRenew = ( enable: boolean ) => {
-		const domainsToBulkUpdate = domains
+		const domainsToBulkUpdate = ( domains || [] )
 			.filter( ( domain ) => selectedDomains.has( getDomainId( domain ) ) )
 			.map( ( domain ) => domain.domain );
 		setAutoRenew( domainsToBulkUpdate, enable );
@@ -348,7 +344,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 	};
 
 	const handleUpdateContactInfo = () => {
-		const domainsToBulkUpdate = domains.filter( ( domain ) =>
+		const domainsToBulkUpdate = ( domains || [] ).filter( ( domain ) =>
 			selectedDomains.has( getDomainId( domain ) )
 		);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3744

## Proposed Changes

`<DomainsTable>` doesn't bail rendering when the `domains` prop is `null`. That way rendering can proceed and render the loading placeholder.

The placeholder was added in https://github.com/Automattic/wp-calypso/pull/81827. This PR is necessary for it to be shown.

<img width="1283" alt="CleanShot 2023-09-20 at 15 21 26@2x" src="https://github.com/Automattic/wp-calypso/assets/1500769/07fb12ef-33da-4f86-9865-7da1e09a3d3e">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You may need to clear your indexDB to get the loading state to show up.

Confirm the loading placeholder works in
- all sites table
- site specific table
- mobile layout

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?