### PR TITLE
Domain Transfers: Ensure user is logged in before showing the whois contact form

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-user-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-user-transfer.ts
@@ -1,5 +1,17 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useEffect } from '@wordpress/element';
+import { getLocaleFromPathname } from 'calypso/boot/locale';
+import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
+import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
+import {
+	AssertConditionResult,
+	AssertConditionState,
+	Flow,
+	ProvidedDependencies,
+} from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import DomainContactInfo from './internals/steps-repository/domain-contact-info';
-import type { Flow, ProvidedDependencies } from './internals/types';
 
 const domainUserTransfer: Flow = {
 	name: 'domain-user-transfer',
@@ -7,8 +19,12 @@ const domainUserTransfer: Flow = {
 		return [ { slug: 'domain-contact-info', component: DomainContactInfo } ];
 	},
 
-	useStepNavigation( _currentStep, navigate ) {
+	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
+
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, '', flowName, currentStep );
+
 			return providedDependencies;
 		}
 
@@ -17,7 +33,7 @@ const domainUserTransfer: Flow = {
 		};
 
 		const goNext = () => {
-			switch ( _currentStep ) {
+			switch ( currentStep ) {
 				case 'contact-info':
 					return navigate( '/manage/domains' );
 			}
@@ -28,6 +44,39 @@ const domainUserTransfer: Flow = {
 		};
 
 		return { goNext, goBack, goToStep, submit };
+	},
+
+	useAssertConditions(): AssertConditionResult {
+		const flowName = this.name;
+		const isLoggedIn = useSelector( isUserLoggedIn );
+
+		// There is a race condition where useLocale is reporting english,
+		// despite there being a locale in the URL so we need to look it up manually.
+		const useLocaleSlug = useLocale();
+		const pathLocaleSlug = getLocaleFromPathname();
+		const locale = pathLocaleSlug || useLocaleSlug;
+
+		const logInUrl =
+			locale && locale !== 'en'
+				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Receive%20domain&redirect_to=/setup/${ flowName }`
+				: `/start/account/user?variationName=${ flowName }&pageTitle=Receive%20domain&redirect_to=/setup/${ flowName }`;
+
+		useEffect( () => {
+			if ( ! isLoggedIn ) {
+				redirect( logInUrl );
+			}
+		}, [] );
+
+		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
+
+		if ( ! isLoggedIn ) {
+			result = {
+				state: AssertConditionState.CHECKING,
+				message: `${ flowName } requires a logged in user`,
+			};
+		}
+
+		return result;
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/domain-user-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-user-transfer.ts
@@ -9,6 +9,7 @@ import {
 	Flow,
 	ProvidedDependencies,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { useDomainParams } from 'calypso/landing/stepper/hooks/use-domain-params';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import DomainContactInfo from './internals/steps-repository/domain-contact-info';
@@ -56,10 +57,12 @@ const domainUserTransfer: Flow = {
 		const pathLocaleSlug = getLocaleFromPathname();
 		const locale = pathLocaleSlug || useLocaleSlug;
 
+		const { domain } = useDomainParams();
+
 		const logInUrl =
 			locale && locale !== 'en'
-				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Receive%20domain&redirect_to=/setup/${ flowName }`
-				: `/start/account/user?variationName=${ flowName }&pageTitle=Receive%20domain&redirect_to=/setup/${ flowName }`;
+				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Receive%20domain&redirect_to=/setup/${ flowName }?domain=${ domain }`
+				: `/start/account/user?variationName=${ flowName }&pageTitle=Receive%20domain&redirect_to=/setup/${ flowName }?domain=${ domain }`;
 
 		useEffect( () => {
 			if ( ! isLoggedIn ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3843

## Proposed Changes

* Adds a redirect to the login flow for logged out users attempting to receive domain transfer

## Testing Instructions

* Logout
* Visit the domain transfer step http://calypso.localhost:3000/setup/domain-user-transfer/domain-contact-info?domain=test-345678.blog
* Should be redirected to login or create an account
* Test both account creation and
* Login flows to ensure they both redirect back to the step