### PR TITLE
Site Profiler: sanitize input and return domain if it is an URL

### DIFF
--- a/client/lib/domains/get-domain-from-input.ts
+++ b/client/lib/domains/get-domain-from-input.ts
@@ -1,0 +1,10 @@
+import { parseUrl } from 'calypso/lib/importer/url-validation';
+export function extractDomainFromInput( input: string ) {
+	try {
+		const parsedUrl = parseUrl( input );
+		const { hostname } = parsedUrl;
+		return hostname || input;
+	} catch ( error ) {
+		return input;
+	}
+}

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -35,3 +35,4 @@ export { getRegisteredDomains, isFreeUrlDomain, isRegisteredDomain } from './reg
 export { resendIcannVerification } from './resend-icann-verification';
 export { resolveDomainStatus } from './resolve-domain-status';
 export { startInboundTransfer } from './start-inbound-transfer';
+export { extractDomainFromInput } from './get-domain-from-input';

--- a/client/lib/importer/url-validation.js
+++ b/client/lib/importer/url-validation.js
@@ -1,7 +1,7 @@
 import { translate } from 'i18n-calypso';
 import { trim } from 'lodash';
 
-const parseUrl = function ( value = '' ) {
+export const parseUrl = function ( value = '' ) {
 	const rawUrl = trim( value );
 	const hasProtocol = value.startsWith( 'https://' ) || value.startsWith( 'http://' );
 

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useDomainAnalyzerQuery } from 'calypso/data/site-profiler/use-domain-analyzer-query';
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
+import { getFixedDomainSearch, extractDomainFromInput } from 'calypso/lib/domains';
 import HostingInto from 'calypso/site-profiler/components/hosting-into';
 import { LayoutBlock, LayoutBlockSection } from 'calypso/site-profiler/components/layout';
 import DomainAnalyzer from './domain-analyzer';
@@ -15,7 +16,7 @@ export default function SiteProfiler() {
 	const { data: hostingProviderData } = useHostingProviderQuery( domain );
 
 	const onFormSubmit = ( domain: string ) => {
-		setDomain( domain );
+		setDomain( getFixedDomainSearch( extractDomainFromInput( domain ) ) );
 	};
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/dotcom-forge#3765

## Proposed Changes

* Based on the current site profiler API, we can only pass the domain name to it, so if user puts a URL with sub directory or query string, we'll need to remove it and only return the domain. If user inputs a value that contains `www`, it'll be removed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `http://calypso.localhost:3000/site-profiler`
* Try out different URLs or domains and see if you get a response you expected.

For example:
- `https://news.ycombinator.com/`
- `news.ycombinator.com`
- `https://news.ycombinator.com?test=1&a=2`
- `https://news.ycombinator.com/newcomments`
- `www.ycombinator.com`
- 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)