### PR TITLE
Migration: Fix some issues around recording events and necessary props

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/confirm.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm.tsx
@@ -5,7 +5,7 @@ import { Icon, check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { getQueryArg } from '@wordpress/url';
 import classnames from 'classnames';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
 import { convertToFriendlyWebsiteName } from 'calypso/blocks/import/util';
 import SiteIcon from 'calypso/blocks/site-icon';
@@ -49,7 +49,27 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 	const sourceSiteSlug = sourceSite?.slug ?? '';
 
 	/**
-	 ↓ Effects
+	 ↓ Functions
+	 */
+	const showConfirmDialogOrStartImport = useCallback( () => {
+		if ( showConfirmDialog ) {
+			setIsModalDetailsOpen( true );
+		} else {
+			startImport();
+		}
+	}, [ showConfirmDialog, startImport ] );
+
+	const startImportCta = useCallback( () => {
+		recordTracksEvent( 'calypso_signup_step_start', {
+			flow: 'importer',
+			step: 'importerWordpress',
+			action: 'startImport',
+		} );
+		showConfirmDialogOrStartImport();
+	}, [ showConfirmDialogOrStartImport ] );
+
+	/**
+	↓ Effects
 	 */
 	useEffect( () => {
 		const skipCta = getQueryArg( window.location.href, 'skipCta' );
@@ -57,26 +77,7 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 		if ( isTargetSitePlanCompatible && isMigrateFromWp && skipCta ) {
 			startImportCta();
 		}
-	}, [] );
-
-	/**
-	 ↓ Functions
-	 */
-	function showConfirmDialogOrStartImport() {
-		if ( showConfirmDialog ) {
-			setIsModalDetailsOpen( true );
-		} else {
-			startImport();
-		}
-	}
-	function startImportCta() {
-		recordTracksEvent( 'calypso_signup_step_start', {
-			flow: 'importer',
-			step: 'importerWordpress',
-			action: 'startImport',
-		} );
-		showConfirmDialogOrStartImport();
-	}
+	}, [ isMigrateFromWp, isTargetSitePlanCompatible, startImportCta ] );
 
 	return (
 		<>

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -49,11 +49,11 @@ interface State {
 }
 
 type ExtraParams = {
-	[ key: string ]: any;
+	[ key: string ]: unknown;
 };
 
 export class ImportEverything extends SectionMigrate {
-	componentDidUpdate( prevProps: any, prevState: State ) {
+	componentDidUpdate( prevProps: unknown, prevState: State ) {
 		super.componentDidUpdate( prevProps, prevState );
 		this.recordMigrationStatusChange( prevState );
 	}

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-helper.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-helper.tsx
@@ -14,7 +14,7 @@ interface Props {
 	selectedProtocol: 'ftp' | 'ssh';
 }
 
-export const CredentialsHelper = ( props: Props ) => {
+export const CredentialsHelper = ( { onHostChange, selectedProtocol }: Props ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -30,8 +30,8 @@ export const CredentialsHelper = ( props: Props ) => {
 	};
 
 	useEffect( () => {
-		props.onHostChange( selectedProvider );
-	}, [ selectedProvider ] );
+		onHostChange( selectedProvider );
+	}, [ selectedProvider, onHostChange ] );
 
 	const renderHelpText = () => {
 		const hostDetails = getHostInfoFromId( selectedProvider );
@@ -73,7 +73,7 @@ export const CredentialsHelper = ( props: Props ) => {
 		}
 
 		if ( hostDetails.supportLink ) {
-			const protocol = props.selectedProtocol === 'ftp' ? 'ftp' : 'sftp';
+			const protocol = selectedProtocol === 'ftp' ? 'ftp' : 'sftp';
 
 			const link =
 				hostDetails.credentialLinks && hostDetails.credentialLinks[ protocol ]

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/migration-credentials-form.tsx
@@ -29,8 +29,14 @@ interface Props {
 	onChangeProtocol: ( protocol: CredentialsProtocol ) => void;
 }
 
-export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( props ) => {
-	const { sourceSite, targetSite, migrationTrackingProps, startImport } = props;
+export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( {
+	sourceSite,
+	targetSite,
+	migrationTrackingProps,
+	startImport,
+	onChangeProtocol,
+	selectedHost,
+} ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { hostname } = new URL( sourceSite.URL );
@@ -59,7 +65,7 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 			setShowConfirmModal( false );
 			startImport( args );
 		},
-		[ startImport ]
+		[ setMigrationConfirmed, startImport ]
 	);
 
 	const handleUpdateCredentials = () => {
@@ -116,7 +122,7 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 	// Clear the hasMissingFields flag when there are no more errors.
 	useEffect( () => {
 		! formHasErrors && setHasMissingFields( false );
-	}, [ formErrors ] );
+	}, [ formHasErrors ] );
 
 	// validate changes to the credentials form
 	useEffect( () => {
@@ -138,11 +144,11 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 		}
 
 		setFormErrors( errors );
-	}, [ formState, formMode ] );
+	}, [ formState, formMode, translate ] );
 
 	useEffect( () => {
-		props.onChangeProtocol( formState.protocol as CredentialsProtocol );
-	}, [ formState.protocol ] );
+		onChangeProtocol( formState.protocol as CredentialsProtocol );
+	}, [ formState.protocol, onChangeProtocol ] );
 
 	useEffect( () => {
 		switch ( formSubmissionStatus ) {
@@ -150,12 +156,12 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 				startImportCallback( { type: 'with-credentials', ...migrationTrackingProps } );
 				break;
 		}
-	}, [ formSubmissionStatus, startImportCallback ] );
+	}, [ formSubmissionStatus, migrationTrackingProps, startImportCallback ] );
 
 	useEffect( () => {
 		updateError &&
 			dispatch( recordTracksEvent( 'calypso_site_migration_credentials_update_error' ) );
-	}, [ updateError ] );
+	}, [ dispatch, updateError ] );
 
 	return (
 		<>
@@ -176,7 +182,7 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 					formErrors={ formErrors }
 					formMode={ formMode }
 					formState={ formState }
-					host={ props.selectedHost }
+					host={ selectedHost }
 					role="main"
 					onFormStateChange={ setFormState }
 					onModeChange={ setFormMode }

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/update-plugins.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/update-plugins.tsx
@@ -24,7 +24,7 @@ export const UpdatePluginInfo: React.FunctionComponent< Props > = ( props: Props
 			plugins_info: isMigrateFromWp ? 'wpcom_migration_plugin' : 'jetpack',
 			...migrationTrackingProps,
 		} );
-	}, [] );
+	}, [ isMigrateFromWp, migrationTrackingProps ] );
 
 	function renderTitle() {
 		return isMigrateFromWp

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
@@ -49,7 +49,7 @@ export const PreMigrationUpgradePlan: React.FunctionComponent< Props > = ( props
 		dispatch(
 			recordTracksEvent( 'calypso_site_migration_upgrade_plan_screen', migrationTrackingProps )
 		);
-	}, [] );
+	}, [ dispatch, migrationTrackingProps ] );
 
 	return (
 		<div

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -95,7 +95,7 @@ export class SectionMigrate extends Component {
 		}
 
 		wpcom.site( this.props.sourceSite.ID ).pluginsList( ( error, data ) => {
-			if ( data.plugins ) {
+			if ( data && data.plugins ) {
 				this.setState( { sourceSitePlugins: data.plugins } );
 			}
 		} );
@@ -109,6 +109,9 @@ export class SectionMigrate extends Component {
 					...data.themes.filter( ( theme ) => ! theme.active ),
 				];
 				this.setState( { sourceSiteThemes } );
+			} )
+			.catch( ( err ) => {
+				/* suppress this error for now */
 			} );
 	};
 


### PR DESCRIPTION
This is part of an investigation around migration events dropping off in a funnel, with the current theory being that one event has fired off twice (or more). This PR is an attempt to fix that.

In addition, this changes a bunch of logic at places to include required keys in dependency arrays.


## Testing Instructions

Test the migration flows and make sure that events are recorded only once.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~