### PR TITLE
Plans 2023: Move plans-wrapper styles out of the grid components

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -734,7 +734,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 		} = this.props;
 
 		return (
-			<div className="plans-wrapper">
+			<>
 				<QueryActivePromotions />
 				<PlansGridContextProvider
 					intent={ intent }
@@ -813,7 +813,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 						</PlansGridContextProvider>
 					</div>
 				) : null }
-			</div>
+			</>
 		);
 	}
 }

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1049,47 +1049,6 @@ body.is-section-signup.is-white-signup,
 	}
 }
 
-.plan-features-2023-grid__toggle-plan-comparison-button-container {
-	display: flex;
-	justify-content: center;
-	margin-top: 32px;
-	margin-left: 20px;
-	margin-right: 20px;
-
-	@include plans-section-custom-mobile-breakpoint {
-		// margin-left: 0;
-		// margin-right: 0;
-	}
-
-	button {
-		background: var(--studio-white);
-		border: 1px solid var(--studio-gray-10);
-		border-radius: 4px;
-		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-		color: var(--studio-gray-100);
-		font-size: $font-body-small;
-		font-weight: 500;
-		height: 48px;
-		justify-content: center;
-		line-height: 20px;
-		padding: 0 24px;
-		width: 100%;
-		transition: border-color 0.15s ease-out;
-
-		@include plans-2023-break-small {
-			width: initial;
-			height: 40px;
-		}
-
-		&:not([disabled]):hover,
-		&:not([disabled]):focus {
-			border-color: var(--studio-gray-100);
-			box-shadow: none;
-			color: inherit;
-		}
-	}
-}
-
 /**
  * We auto-scroll to the plan comparison grid when it is shown.
  * However, on the /plans page, due to the presence of the masterbar on top,

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -172,418 +172,366 @@ $mobile-card-max-width: 440px;
 	margin-top: 10px;
 }
 
-.is-2023-pricing-grid .plans-wrapper {
-	margin: 0 20px;
-	padding: 0 0 10px;
-	overflow-x: visible;
+.plan-features-2023-grid__mobile-view {
+	flex-direction: column;
+	align-items: stretch;
+	gap: 20px;
+	margin: 0 auto;
+	max-width: $mobile-card-max-width;
 
-	@include plans-2023-break-small {
-		padding-top: 35px; // enough to cover `plan-features-2023-grid__popular-badge` repositioning (top: -35px)
-		margin: 0;
+	.plan-features-2023-grid__mobile-plan-card {
+		background-color: var(--studio-white);
+		border: 1px solid #e0e0e0;
+		/* stylelint-disable-next-line */
+		border-radius: 5px;
+		padding: 38px 0 20px 0;
+
+		@include plans-section-custom-mobile-breakpoint {
+			margin-left: 0;
+			margin-right: 0;
+		}
+
+		&:first-of-type {
+			margin-top: 0;
+		}
+
+		.foldable-card__main .foldable-card__expand .gridicon {
+			width: 14px;
+		}
+
+		&.is-free-plan .foldable-card__main {
+			color: var(--studio-blue-50);
+
+			.foldable-card__expand .gridicon {
+				fill: var(--studio-blue-50);
+			}
+		}
+
+		&.is-personal-plan .foldable-card__main {
+			color: var(--studio-blue-60);
+
+			.foldable-card__expand .gridicon {
+				fill: var(--studio-blue-60);
+			}
+		}
+
+		&.is-premium-plan .foldable-card__main {
+			color: #004687;
+
+			.foldable-card__expand .gridicon {
+				fill: #004687;
+			}
+		}
+
+		&.is-business-plan .foldable-card__main {
+			color: #7f54b3;
+
+			.foldable-card__expand .gridicon {
+				fill: #7f54b3;
+			}
+		}
+
+		&.is-ecommerce-plan .foldable-card__main {
+			color: #55347d;
+
+			.foldable-card__expand .gridicon {
+				fill: #55347d;
+			}
+		}
+
+		&.plan-features-2023-grid__mobile-plan-card {
+			.plan-features-2023-grid__table-item {
+				&.plan-features-2023-grid__storage {
+					padding-top: 0;
+				}
+			}
+		}
+
+		.components-custom-select-control {
+			.components-custom-select-control__button {
+				height: 40px;
+			}
+		}
 	}
 
-	@include plans-2023-break-medium {
-		margin: 0 20px;
+	.foldable-card {
+		box-shadow: unset;
+		margin-top: 24px;
+
+		.foldable-card__main {
+			color: var(--studio-blue-60);
+			font-family: Inter, $sans;
+			font-weight: 500;
+			font-size: $font-body-small;
+			letter-spacing: -0.24px;
+			line-height: 20px;
+		}
+
+		&.is-compact .foldable-card__header {
+			padding: 0 20px;
+		}
+
+		&.is-expanded .foldable-card__content {
+			border-top: none;
+			padding: 24px 0 0;
+		}
 	}
 
-	@include plans-section-break-medium {
-		margin: 0;
-	}
-
-	@include plans-2023-break-medium {
-		margin: 0 20px;
-	}
-
-	@include plans-section-break-medium {
-		margin: 0;
+	.plan-features-2023-grid__highlighted-feature .plan-features-2023-grid__item {
+		padding-bottom: 24px;
 	}
 }
 
-.is-2023-pricing-grid {
+.plan-features-2023-grid__table {
+	font-size: $font-body-small;
+	color: var(--color-text-subtle);
+	table-layout: fixed;
+	border: 1px solid #e0e0e0;
+	border-radius: 5px; /* stylelint-disable-line */
+	background-color: #fff;
 	margin: 0 auto;
+	border-spacing: 0;
+	width: 100%;
 
-	.signup__steps & {
-		width: auto;
+	&.has-1-cols {
+		max-width: $table-cell-max-width;
 	}
 
-	.is-section-stepper &,
-	.is-section-signup & {
-		@include plan-features-layout-switcher;
+	&.has-2-cols {
+		max-width: $table-cell-max-width * 2;
 	}
 
-	.is-section-plans:not(.is-sidebar-collapsed) & {
-		@include plan-features-layout-switcher-with-sidebar;
+	&.has-3-cols {
+		max-width: $table-cell-max-width * 3;
 	}
 
-	.is-section-plans.is-sidebar-collapsed & {
-		@include plan-features-layout-switcher;
+	&.has-4-cols {
+		max-width: $table-cell-max-width * 4;
 	}
 
-	.plan-features-2023-grid__mobile-view {
-		flex-direction: column;
-		align-items: stretch;
-		gap: 20px;
-		margin: 0 auto;
-		max-width: $mobile-card-max-width;
-
-		.plan-features-2023-grid__mobile-plan-card {
-			background-color: var(--studio-white);
-			border: 1px solid #e0e0e0;
-			/* stylelint-disable-next-line */
-			border-radius: 5px;
-			padding: 38px 0 20px 0;
-
-			@include plans-section-custom-mobile-breakpoint {
-				margin-left: 0;
-				margin-right: 0;
-			}
-
-			&:first-of-type {
-				margin-top: 0;
-			}
-
-			.foldable-card__main .foldable-card__expand .gridicon {
-				width: 14px;
-			}
-
-			&.is-free-plan .foldable-card__main {
-				color: var(--studio-blue-50);
-
-				.foldable-card__expand .gridicon {
-					fill: var(--studio-blue-50);
-				}
-			}
-
-			&.is-personal-plan .foldable-card__main {
-				color: var(--studio-blue-60);
-
-				.foldable-card__expand .gridicon {
-					fill: var(--studio-blue-60);
-				}
-			}
-
-			&.is-premium-plan .foldable-card__main {
-				color: #004687;
-
-				.foldable-card__expand .gridicon {
-					fill: #004687;
-				}
-			}
-
-			&.is-business-plan .foldable-card__main {
-				color: #7f54b3;
-
-				.foldable-card__expand .gridicon {
-					fill: #7f54b3;
-				}
-			}
-
-			&.is-ecommerce-plan .foldable-card__main {
-				color: #55347d;
-
-				.foldable-card__expand .gridicon {
-					fill: #55347d;
-				}
-			}
-
-			&.plan-features-2023-grid__mobile-plan-card {
-				.plan-features-2023-grid__table-item {
-					&.plan-features-2023-grid__storage {
-						padding-top: 0;
-					}
-				}
-			}
-
-			.components-custom-select-control {
-				.components-custom-select-control__button {
-					height: 40px;
-				}
-			}
-		}
-
-		.foldable-card {
-			box-shadow: unset;
-			margin-top: 24px;
-
-			.foldable-card__main {
-				color: var(--studio-blue-60);
-				font-family: Inter, $sans;
-				font-weight: 500;
-				font-size: $font-body-small;
-				letter-spacing: -0.24px;
-				line-height: 20px;
-			}
-
-			&.is-compact .foldable-card__header {
-				padding: 0 20px;
-			}
-
-			&.is-expanded .foldable-card__content {
-				border-top: none;
-				padding: 24px 0 0;
-			}
-		}
-
-		.plan-features-2023-grid__highlighted-feature .plan-features-2023-grid__item {
-			padding-bottom: 24px;
-		}
-	}
-
-	.signup__steps .plans-features-main__group.is-scrollable & {
-		max-width: 100%;
-	}
-
-	.plan-features-2023-grid__table {
-		font-size: $font-body-small;
-		color: var(--color-text-subtle);
-		table-layout: fixed;
-		border: 1px solid #e0e0e0;
-		border-radius: 5px; /* stylelint-disable-line */
-		background-color: #fff;
-		margin: 0 auto;
-		border-spacing: 0;
-		width: 100%;
-
-		&.has-1-cols {
-			max-width: $table-cell-max-width;
-		}
-
-		&.has-2-cols {
-			max-width: $table-cell-max-width * 2;
-		}
-
-		&.has-3-cols {
-			max-width: $table-cell-max-width * 3;
-		}
-
-		&.has-4-cols {
-			max-width: $table-cell-max-width * 4;
-		}
-
-		.components-custom-select-control__label {
-			color: var(--studio-gray-100);
-		}
-
-		.components-custom-select-control__menu {
-			margin-left: 0;
-		}
-	}
-
-	.plan-features-2023-grid__header-title {
-		margin-top: 0;
-		margin-bottom: 5px;
-		font-size: $font-title-large;
-		line-height: 0.7;
+	.components-custom-select-control__label {
 		color: var(--studio-gray-100);
-		font-weight: 400;
-		@include onboarding-font-recoleta;
-		letter-spacing: 0;
 	}
 
-	.plan-features-2023-grid__header-tagline {
-		font-size: $font-body;
-		line-height: 24px;
-		color: var(--studio-gray-80);
-		font-weight: 400;
-		padding: 0 20px 24px 20px;
+	.components-custom-select-control__menu {
+		margin-left: 0;
+	}
+}
 
+.plan-features-2023-grid__header-title {
+	margin-top: 0;
+	margin-bottom: 5px;
+	font-size: $font-title-large;
+	line-height: 0.7;
+	color: var(--studio-gray-100);
+	font-weight: 400;
+	@include onboarding-font-recoleta;
+	letter-spacing: 0;
+}
+
+.plan-features-2023-grid__header-tagline {
+	font-size: $font-body;
+	line-height: 24px;
+	color: var(--studio-gray-80);
+	font-weight: 400;
+	padding: 0 20px 24px 20px;
+
+	@include plans-2023-break-small {
+		font-size: $font-body-small;
+		line-height: 20px;
+	}
+
+	@include plans-2023-break-medium {
+		font-size: 0.813rem; /* stylelint-disable-line */
+		line-height: 16px;
+		padding-bottom: 8px;
+		min-height: 50px;
+	}
+}
+
+.plan-features-2023-grid__table-item {
+	text-align: left;
+	transition: opacity 0.05s;
+	border: none;
+	background-color: var(--color-surface);
+	position: relative;
+	vertical-align: baseline;
+
+	.is-bold {
+		font-weight: 600;
+	}
+
+	&.is-bottom-aligned {
+		vertical-align: bottom;
+	}
+
+
+	&.is-top-buttons {
+		padding: 0 20px;
+		vertical-align: bottom;
 		@include plans-2023-break-small {
-			font-size: $font-body-small;
-			line-height: 20px;
-		}
-
-		@include plans-2023-break-medium {
-			font-size: 0.813rem; /* stylelint-disable-line */
-			line-height: 16px;
-			padding-bottom: 8px;
-			min-height: 50px;
+			padding-top: 16px;
+			padding-bottom: 16px;
 		}
 	}
 
+	@include plans-2023-break-small {
+		border-left: solid 1px #e0e0e0;
+	}
+}
+
+.plan-features-2023-grid__desktop-view,
+.plan-features-2023-grid__tablet-view {
 	.plan-features-2023-grid__table-item {
-		text-align: left;
-		transition: opacity 0.05s;
-		border: none;
-		background-color: var(--color-surface);
-		position: relative;
-		vertical-align: baseline;
+		max-width: $table-cell-max-width;
+	}
+}
 
-		.is-bold {
-			font-weight: 600;
-		}
+.plan-features-2023-grid__plan-spotlight {
+	background-color: var(--studio-white);
+	.plan-features-2023-grid__plan-spotlight-card {
+		max-width: 100%;
+		margin-bottom: 64px;
+		border: 1px solid #e0e0e0;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 0 0 5px 5px;
+		div.plan-features-2023-grid__table-item {
+			border: none;
+			&.is-top-buttons {
+				position: absolute;
+				top: 46px;
+				right: 0;
+				border-left: 0;
+			}
 
-		&.is-bottom-aligned {
-			vertical-align: bottom;
-		}
+			&.plan-features-2023-grid__header-billing-info {
+				padding-bottom: 32px;
+				@include plans-2023-break-small {
+					padding-bottom: 32px;
+				}
+			}
 
+			&.popular-plan-parent-class .plan-features-2023-grid__popular-badge {
+				padding-bottom: 23px;
+			}
 
-		&.is-top-buttons {
-			padding: 0 20px;
-			vertical-align: bottom;
-			@include plans-2023-break-small {
-				padding-top: 16px;
+			.plan-features-2023-grid__header-title {
+				margin-top: 24px;
+			}
+
+			.plan-features-2023-grid__header-tagline {
+				min-height: 0;
 				padding-bottom: 16px;
 			}
-		}
 
-		@include plans-2023-break-small {
-			border-left: solid 1px #e0e0e0;
-		}
-	}
-
-	.plan-features-2023-grid__desktop-view,
-	.plan-features-2023-grid__tablet-view {
-		.plan-features-2023-grid__table-item {
-			max-width: $table-cell-max-width;
-		}
-	}
-
-	.plan-features-2023-grid__plan-spotlight {
-		background-color: var(--studio-white);
-		.plan-features-2023-grid__plan-spotlight-card {
-			max-width: 100%;
-			margin-bottom: 64px;
-			border: 1px solid #e0e0e0;
-			/* stylelint-disable-next-line scales/radii */
-			border-radius: 0 0 5px 5px;
-			div.plan-features-2023-grid__table-item {
-				border: none;
-				&.is-top-buttons {
-					position: absolute;
-					top: 46px;
-					right: 0;
-					border-left: 0;
-				}
-
-				&.plan-features-2023-grid__header-billing-info {
-					padding-bottom: 32px;
-					@include plans-2023-break-small {
-						padding-bottom: 32px;
-					}
-				}
-
-				&.popular-plan-parent-class .plan-features-2023-grid__popular-badge {
-					padding-bottom: 23px;
-				}
-
-				.plan-features-2023-grid__header-title {
-					margin-top: 24px;
-				}
-
-				.plan-features-2023-grid__header-tagline {
-					min-height: 0;
-					padding-bottom: 16px;
-				}
-
-				.plan-features-2023-grid__header-logo {
-					display: none;
-				}
+			.plan-features-2023-grid__header-logo {
+				display: none;
 			}
 		}
 	}
+}
 
-	.plan-features-2023-grid__header-annual-discount {
-		color: var(--studio-green-60);
-		&-is-loading {
-			@include placeholder();
-		}
+.plan-features-2023-grid__header-annual-discount {
+	color: var(--studio-green-60);
+	&-is-loading {
+		@include placeholder();
 	}
+}
 
-	.plan-features-2023-grid__item-info {
-		display: flex;
-		flex-direction: column;
+.plan-features-2023-grid__item-info {
+	display: flex;
+	flex-direction: column;
+	flex: 1 0 0;
+	width: 100%;
+
+	.plan-features-2023-grid__item-title {
+		color: var(--studio-gray-80);
+		font-size: $font-body-small;
+		font-weight: 400;
+		line-height: 20px;
+		overflow-wrap: break-word;
+		margin: 0;
 		flex: 1 0 0;
 		width: 100%;
 
+		&.is-bold {
+			font-weight: 600;
+		}
+
+		@include plans-2023-break-small {
+			font-size: $font-body-extra-small;
+			line-height: 16px;
+		}
+	}
+
+	&:not(.is-available) {
+		color: var(--studio-gray-20);
+
 		.plan-features-2023-grid__item-title {
-			color: var(--studio-gray-80);
-			font-size: $font-body-small;
-			font-weight: 400;
-			line-height: 20px;
-			overflow-wrap: break-word;
+			text-decoration: line-through;
+		}
+	}
+}
+
+.plan-features-2023-grid__actions-button {
+	width: 100%;
+
+	&.disabled,
+	&[disabled] {
+		color: var(--color-neutral-light);
+	}
+}
+
+.plan-features-2023-grid__row:last-of-type .plan-features-2023-grid__table-item {
+	border-bottom: solid 1px var(--color-neutral-5);
+
+	&.is-last-feature {
+		.plan-features-2023-grid__item-info {
+			padding-bottom: 30px;
+		}
+	}
+}
+
+.plan-features-2023-grid__item {
+	padding: 0 20px 12px;
+	text-align: left;
+
+	&.plan-features-2023-grid__item-available {
+		display: flex;
+		flex-direction: column;
+		position: relative;
+
+		& .plan-features-2023-grid__item-info-container {
+			display: flex;
+		}
+	}
+
+	&.plan-features-2023-grid__enterprise-logo {
+		display: flex;
+		flex-wrap: wrap;
+		column-gap: 20px;
+		row-gap: 14px;
+		position: relative;
+		margin: 32px 0 0;
+
+		@include plans-2023-break-small {
 			margin: 0;
-			flex: 1 0 0;
-			width: 100%;
-
-			&.is-bold {
-				font-weight: 600;
-			}
-
-			@include plans-2023-break-small {
-				font-size: $font-body-extra-small;
-				line-height: 16px;
-			}
-		}
-
-		&:not(.is-available) {
-			color: var(--studio-gray-20);
-
-			.plan-features-2023-grid__item-title {
-				text-decoration: line-through;
-			}
+			top: 14px;
 		}
 	}
+}
 
-	.plan-features-2023-grid__actions-button {
-		width: 100%;
-
-		&.disabled,
-		&[disabled] {
-			color: var(--color-neutral-light);
-		}
+.components-custom-select-control {
+	.storage-add-on-dropdown-option__title {
+		font-size: 0.75rem;
 	}
 
-	.plan-features-2023-grid__row:last-of-type .plan-features-2023-grid__table-item {
-		border-bottom: solid 1px var(--color-neutral-5);
+	.storage-add-on-dropdown-option__price {
+		color: var(--studio-green-40);
 
-		&.is-last-feature {
-			.plan-features-2023-grid__item-info {
-				padding-bottom: 30px;
-			}
-		}
-	}
-
-	.plan-features-2023-grid__item {
-		padding: 0 20px 12px;
-		text-align: left;
-
-		&.plan-features-2023-grid__item-available {
-			display: flex;
-			flex-direction: column;
-			position: relative;
-
-			& .plan-features-2023-grid__item-info-container {
-				display: flex;
-			}
-		}
-
-		&.plan-features-2023-grid__enterprise-logo {
-			display: flex;
-			flex-wrap: wrap;
-			column-gap: 20px;
-			row-gap: 14px;
-			position: relative;
-			margin: 32px 0 0;
-
-			@include plans-2023-break-small {
-				margin: 0;
-				top: 14px;
-			}
-		}
-	}
-
-	.components-custom-select-control {
-		.storage-add-on-dropdown-option__title {
-			font-size: 0.75rem;
-		}
-
-		.storage-add-on-dropdown-option__price {
-			color: var(--studio-green-40);
-
-			// Non standard rem allows us to match font size of other storage labels
-			/* stylelint-disable-next-line scales/font-sizes */
-			font-size: 0.7rem;
-		}
+		// Non standard rem allows us to match font size of other storage labels
+		/* stylelint-disable-next-line scales/font-sizes */
+		font-size: 0.7rem;
 	}
 }
 
@@ -604,6 +552,7 @@ $mobile-card-max-width: 440px;
 body.is-section-stepper,
 body.is-section-signup.is-white-signup,
 .is-2023-pricing-grid {
+
 	.plan-features-2023-grid__table-item {
 		border-right: none;
 		background-color: transparent;
@@ -1096,6 +1045,47 @@ body.is-section-signup.is-white-signup,
 				font-size: $font-body-extra-small;
 				line-height: 16px;
 			}
+		}
+	}
+}
+
+.plan-features-2023-grid__toggle-plan-comparison-button-container {
+	display: flex;
+	justify-content: center;
+	margin-top: 32px;
+	margin-left: 20px;
+	margin-right: 20px;
+
+	@include plans-section-custom-mobile-breakpoint {
+		// margin-left: 0;
+		// margin-right: 0;
+	}
+
+	button {
+		background: var(--studio-white);
+		border: 1px solid var(--studio-gray-10);
+		border-radius: 4px;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+		color: var(--studio-gray-100);
+		font-size: $font-body-small;
+		font-weight: 500;
+		height: 48px;
+		justify-content: center;
+		line-height: 20px;
+		padding: 0 24px;
+		width: 100%;
+		transition: border-color 0.15s ease-out;
+
+		@include plans-2023-break-small {
+			width: initial;
+			height: 40px;
+		}
+
+		&:not([disabled]):hover,
+		&:not([disabled]):focus {
+			border-color: var(--studio-gray-100);
+			box-shadow: none;
+			color: inherit;
 		}
 	}
 }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -218,9 +218,7 @@ const PlansFeaturesMain = ( {
 	const [ isFreePlanPaidDomainDialogOpen, setIsFreePlanPaidDomainDialogOpen ] = useState( false );
 	const [ isFreePlanFreeDomainDialogOpen, setIsFreePlanFreeDomainDialogOpen ] = useState( false );
 	const [ showPlansComparisonGrid, setShowPlansComparisonGrid ] = useState( false );
-	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
 	const translate = useTranslate();
-	const plansComparisonGridRef = useRef< HTMLDivElement >( null );
 	const storageAddOns = useAddOns( siteId ?? undefined, isInSignup ).filter(
 		( addOn ) => addOn?.productSlug === PRODUCT_1GB_SPACE
 	);
@@ -514,6 +512,7 @@ const PlansFeaturesMain = ( {
 			  )
 			: undefined;
 
+	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
 	/**
 	 * Calculates the height of the masterbar if it exists, and passes it to the component as an offset
 	 * for the sticky CTA bar.
@@ -550,6 +549,10 @@ const PlansFeaturesMain = ( {
 		};
 	}, [] );
 
+	const plansComparisonGridRef = useRef< HTMLDivElement >( null );
+	/**
+	 * Scrolls the comparison grid smoothly into view when rendered.
+	 */
 	useLayoutEffect( () => {
 		if ( showPlansComparisonGrid ) {
 			setTimeout( () => {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -688,43 +688,45 @@ const PlansFeaturesMain = ( {
 						) }
 						data-e2e-plans="wpcom"
 					>
-						<PlanFeatures2023Grid
-							gridPlansForFeaturesGrid={ gridPlansForFeaturesGrid }
-							gridPlansForComparisonGrid={ gridPlansForComparisonGrid }
-							gridPlanForSpotlight={ gridPlanForSpotlight }
-							paidDomainName={ paidDomainName }
-							wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
-							isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-							isInSignup={ isInSignup }
-							isLaunchPage={ isLaunchPage }
-							onUpgradeClick={ handleUpgradeClick }
-							flowName={ flowName }
-							selectedFeature={ selectedFeature }
-							selectedPlan={ selectedPlan }
-							siteId={ siteId }
-							isReskinned={ isReskinned }
-							intervalType={ intervalType }
-							hidePlansFeatureComparison={ hidePlansFeatureComparison }
-							hideUnavailableFeatures={ hideUnavailableFeatures }
-							currentSitePlanSlug={ sitePlanSlug }
-							planActionOverrides={ planActionOverrides }
-							intent={ intent }
-							showLegacyStorageFeature={ showLegacyStorageFeature }
-							showUpgradeableStorage={ showUpgradeableStorage }
-							stickyRowOffset={ masterbarHeight }
-							usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
-							allFeaturesList={ FEATURES_LIST }
-							showPlansComparisonGrid={ showPlansComparisonGrid }
-							toggleShowPlansComparisonGrid={ toggleShowPlansComparisonGrid }
-							planTypeSelectorProps={ planTypeSelectorProps }
-							ref={ plansComparisonGridRef }
-							observableForOdieRef={ observableForOdieRef }
-							onStorageAddOnClick={ ( addOnSlug ) =>
-								recordTracksEvent( 'calypso_signup_storage_add_on_dropdown_option_click', {
-									add_on_slug: addOnSlug,
-								} )
-							}
-						/>
+						<div className="plans-wrapper">
+							<PlanFeatures2023Grid
+								gridPlansForFeaturesGrid={ gridPlansForFeaturesGrid }
+								gridPlansForComparisonGrid={ gridPlansForComparisonGrid }
+								gridPlanForSpotlight={ gridPlanForSpotlight }
+								paidDomainName={ paidDomainName }
+								wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+								isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
+								isInSignup={ isInSignup }
+								isLaunchPage={ isLaunchPage }
+								onUpgradeClick={ handleUpgradeClick }
+								flowName={ flowName }
+								selectedFeature={ selectedFeature }
+								selectedPlan={ selectedPlan }
+								siteId={ siteId }
+								isReskinned={ isReskinned }
+								intervalType={ intervalType }
+								hidePlansFeatureComparison={ hidePlansFeatureComparison }
+								hideUnavailableFeatures={ hideUnavailableFeatures }
+								currentSitePlanSlug={ sitePlanSlug }
+								planActionOverrides={ planActionOverrides }
+								intent={ intent }
+								showLegacyStorageFeature={ showLegacyStorageFeature }
+								showUpgradeableStorage={ showUpgradeableStorage }
+								stickyRowOffset={ masterbarHeight }
+								usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+								allFeaturesList={ FEATURES_LIST }
+								showPlansComparisonGrid={ showPlansComparisonGrid }
+								toggleShowPlansComparisonGrid={ toggleShowPlansComparisonGrid }
+								planTypeSelectorProps={ planTypeSelectorProps }
+								ref={ plansComparisonGridRef }
+								observableForOdieRef={ observableForOdieRef }
+								onStorageAddOnClick={ ( addOnSlug ) =>
+									recordTracksEvent( 'calypso_signup_storage_add_on_dropdown_option_click', {
+										add_on_slug: addOnSlug,
+									} )
+								}
+							/>
+						</div>
 					</div>
 				</>
 			) }

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -1,6 +1,63 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 @import "calypso/my-sites/plan-features-2023-grid/media-queries";
+
+:root {
+	--scss-font-body-small: #{$font-body-small};
+}
+
+.is-2023-pricing-grid {
+	margin: 0 auto;
+
+	.signup__steps & {
+		width: auto;
+	}
+
+	.is-section-stepper &,
+	.is-section-signup & {
+		@include plan-features-layout-switcher;
+	}
+
+	.is-section-plans:not(.is-sidebar-collapsed) & {
+		@include plan-features-layout-switcher-with-sidebar;
+	}
+
+	.is-section-plans.is-sidebar-collapsed & {
+		@include plan-features-layout-switcher;
+	}
+
+	.signup__steps .plans-features-main__group.is-scrollable & {
+		max-width: 100%;
+	}
+
+	.plans-wrapper {
+		margin: 0 20px;
+		padding: 0 0 10px;
+		overflow-x: visible;
+
+		@include plans-2023-break-small {
+			padding-top: 35px; // enough to cover `plan-features-2023-grid__popular-badge` repositioning (top: -35px)
+			margin: 0;
+		}
+
+		@include plans-2023-break-medium {
+			margin: 0 20px;
+		}
+
+		@include plans-section-break-medium {
+			margin: 0;
+		}
+
+		@include plans-2023-break-medium {
+			margin: 0 20px;
+		}
+
+		@include plans-section-break-medium {
+			margin: 0;
+		}
+	}
+}
 
 // Content group
 .plans-features-main__group {

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -142,7 +142,9 @@ describe( 'PlansFeaturesMain', () => {
 		test( 'Should render <PlanFeatures /> with WP.com data-e2e-plans when requested', () => {
 			renderWithProvider( <PlansFeaturesMain { ...props } /> );
 
-			expect( screen.getByTestId( 'plan-features' ).parentElement ).toHaveAttribute(
+			// immediate parent is <div className="plans-wrapper">
+			// data-e2e-plans is set on the parent of that
+			expect( screen.getByTestId( 'plan-features' ).parentElement.parentElement ).toHaveAttribute(
 				'data-e2e-plans',
 				'wpcom'
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78266

## Proposed Changes

Moves the `plans-wrapper` styles out of the grid components in `plans-features-2023-grid` and into the wrapper `plans-features-main`. Needed for splitting out the parts + reducing some of the dependency on the contextual media queries.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/[site]`, `/start`, and a stepper flow `/setup/newsletter`
* General confidence checks on the overall design/CSS functionality. Nitpicking on resizing, margins, highlight badges rendering properly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?