### PR TITLE
Subscriptions Management: Add Manage notifications button in reader

### DIFF
--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -1,5 +1,7 @@
+import { Gridicon } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import {
+	Button,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalSpacer as Spacer,
@@ -23,6 +25,7 @@ import { downloadCloud, uploadCloud } from 'calypso/reader/icons';
 import { useDispatch } from 'calypso/state';
 import { markFollowsAsStale } from 'calypso/state/reader/follows/actions';
 import ReaderSiteSubscriptions from './reader-site-subscriptions';
+
 import './style.scss';
 
 const useMarkFollowsAsStaleOnUnmount = () => {
@@ -68,7 +71,8 @@ const SiteSubscriptionsManager = () => {
 
 					<SubscriptionsEllipsisMenu
 						toggleTitle={ translate( 'More' ) }
-						popoverClassName="site-subscriptions-manager__import-export-popover"
+						// popoverClassName="site-subscriptions-manager__import-export-popover"
+						popoverClassName="site-subscriptions-manager__more-actions-popover"
 						verticalToggle
 					>
 						<VStack spacing={ 1 }>
@@ -78,6 +82,9 @@ const SiteSubscriptionsManager = () => {
 								iconSize={ 20 }
 								exportType={ READER_EXPORT_TYPE_SUBSCRIPTIONS }
 							/>
+							<Button icon={ <Gridicon icon="bell" /> } href="/me/notifications">
+								{ translate( 'Manage notifications' ) }
+							</Button>
 						</VStack>
 					</SubscriptionsEllipsisMenu>
 				</HStack>

--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -71,7 +71,6 @@ const SiteSubscriptionsManager = () => {
 
 					<SubscriptionsEllipsisMenu
 						toggleTitle={ translate( 'More' ) }
-						// popoverClassName="site-subscriptions-manager__import-export-popover"
 						popoverClassName="site-subscriptions-manager__more-actions-popover"
 						verticalToggle
 					>

--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -37,16 +37,25 @@
 		border-top: 1px solid $studio-gray-5;
 	}
 
-	&__import-export-popover {
+	&__more-actions-popover {
 		box-sizing: border-box;
 		width: 305px;
 
-		button.components-button {
-			svg {
-				fill: none;
+		.components-button {
+			cursor: pointer;
+			justify-content: flex-start;
+
+			&:visited {
+				color: inherit;
 			}
 
-			justify-content: flex-start;
+			&.reader-import-button,
+			&.reader-export-button {
+				svg {
+					fill: none;
+				}
+			}
+
 
 			.reader-import-button__label,
 			.reader-export-button__label {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/78795

![RMWHvR.png](https://github.com/Automattic/wp-calypso/assets/2019970/247d65bd-c950-45d6-884c-41b59c44ca02)

## Proposed Changes

* Add "Manage notifications" button to the ellipsis menu on `/read/subscriptions` page. 
* When clicked the `/me/notifications` page is opened

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/read/subscriptions`
* Open down the ellipsis menu
* Ensure the "Manage notifications" button is present
* Click on the button, and ensure that you are taken to `/me/notifications` page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?