### PR TITLE
Replace the shadow dom with iframe for the campaign preview

### DIFF
--- a/client/data/promote-post/use-promote-post-campaigns-query.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query.ts
@@ -25,6 +25,7 @@ export type CampaignResponse = {
 	ui_status: string;
 	target_urn: string;
 	delivery_percent: number;
+	format: string;
 	campaign_stats: {
 		impressions_total: number;
 		clicks_total: number;

--- a/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
+++ b/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
@@ -1,4 +1,5 @@
 import './style.scss';
+import classNames from 'classnames';
 import { useEffect } from 'react';
 
 interface Props {
@@ -9,7 +10,7 @@ interface Props {
 
 export default function AdPreview( { htmlCode, isLoading, templateFormat }: Props ) {
 	useEffect( () => {
-		if ( ! isLoading && templateFormat === 'html5_v2' ) {
+		if ( ! isLoading && templateFormat !== 'html5_v2' ) {
 			// we only need this listener to resize the iframe for html5_v2 templates
 			window.addEventListener( 'message', function ( msg ) {
 				if ( typeof msg.data !== 'object' ) {
@@ -43,16 +44,13 @@ export default function AdPreview( { htmlCode, isLoading, templateFormat }: Prop
 		);
 	}
 
-	if ( templateFormat === 'html5_v2' ) {
-		return (
-			<div className="campaign-item-details__preview-content-v02">
-				<iframe srcDoc={ htmlCode } title="adPreview" width="100%" height="200" />
-			</div>
-		);
-	}
+	const classes = classNames( 'campaign-item-details__preview-content', {
+		v02: templateFormat !== 'html5_v2',
+	} );
+
 	return (
-		<div className="campaign-item-details__preview-content">
-			<iframe srcDoc={ htmlCode } title="adPreview" width="300" height="250" />
+		<div className={ classes }>
+			<iframe srcDoc={ htmlCode } title="adPreview" />
 		</div>
 	);
 }

--- a/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
+++ b/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export default function AdPreview( { htmlCode, isLoading, templateFormat }: Props ) {
 	useEffect( () => {
-		if ( ! isLoading && templateFormat !== 'html5_v2' ) {
+		if ( ! isLoading && templateFormat === 'html5_v2' ) {
 			// we only need this listener to resize the iframe for html5_v2 templates
 			window.addEventListener( 'message', function ( msg ) {
 				if ( typeof msg.data !== 'object' ) {
@@ -45,7 +45,7 @@ export default function AdPreview( { htmlCode, isLoading, templateFormat }: Prop
 	}
 
 	const classes = classNames( 'campaign-item-details__preview-content', {
-		v02: templateFormat !== 'html5_v2',
+		v02: templateFormat === 'html5_v2',
 	} );
 
 	return (

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -98,6 +98,7 @@ export default function CampaignItemDetails( props: Props ) {
 		target_urn,
 		delivery_percent,
 		created_at,
+		format,
 	} = campaign || {};
 
 	const {
@@ -619,9 +620,11 @@ export default function CampaignItemDetails( props: Props ) {
 								</div>
 							</div>
 							{ isSmallScreen && <hr className="campaign-item-ad-header-line" /> }
-							<div className="campaign-item-details__preview-content">
-								<AdPreview isLoading={ isLoading } htmlCode={ creative_html || '' } />
-							</div>
+							<AdPreview
+								isLoading={ isLoading }
+								htmlCode={ creative_html || '' }
+								templateFormat={ format || '' }
+							/>
 							<p className="campaign-item-details__preview-disclosure">
 								{ translate(
 									'Depending on the platform, the ad may seem differently from the preview.'

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -610,7 +610,7 @@ export default function CampaignItemDetails( props: Props ) {
 									{ translate( 'Ad preview' ) }
 								</div>
 								<div className="campaign-item-details__preview-header-dimensions">
-									{ ! isLoading ? (
+									{ ! isLoading && format !== 'html5_v2' ? (
 										<>
 											<span>{ `${ width }x${ height }` }</span>
 										</>

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -421,10 +421,20 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 		width: 300px;
 	}
 
-	.campaign-item-details__preview-content-v02 {
+	.campaign-item-details__preview-content iframe {
+		height: 250px;
+		width: 300px;
+	}
+
+	.campaign-item-details__preview-content.v02 {
 		margin: 0 auto;
-		width: 100%;
 		min-width: 300px;
+		width: 100%;
+	}
+
+	.campaign-item-details__preview-content.v02 iframe {
+		height: 200px;
+		width: 100%;
 	}
 
 	.campaign-item-details__preview-disclosure {

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -418,7 +418,13 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 
 	.campaign-item-details__preview-content {
 		margin: 0 auto;
-		max-width: 300px;
+		width: 300px;
+	}
+
+	.campaign-item-details__preview-content-v02 {
+		margin: 0 auto;
+		width: 100%;
+		min-width: 300px;
 	}
 
 	.campaign-item-details__preview-disclosure {


### PR DESCRIPTION
 - use the new format flag to differentiate between the 2 formats
 - add the event listener to resize the iframe

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 
SELFSERVE-749

## Proposed Changes

Change the shadow dom element for the preview of the campaign details page of the dsp (in tools->advertising-> campaigns-> campaign details page)

the code changes at the moment should not have any effect for the end user 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*
You need to checkout locally the 747 branch of the dsp project

you can hardcode the condition in the client/my-sites/promote-post-i2/components/ad-preview/index.tsx file to show the new template

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
