### PR TITLE
Domain Transfers: Copy and design improvements

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -25,15 +25,13 @@ export default function DomainContactInfo( { navigation }: StepProps ) {
 	return (
 		<StepContainer
 			hideBack
-			stepName="domain-contact-info"
+			stepName="domain-contact-info-header"
 			isLargeSkipLayout={ false }
 			formattedHeader={
 				<FormattedHeader
-					id="domain-contact-info__header"
+					className="domain-contact-info-header"
 					headerText={ __( 'Enter your contact information' ) }
-					subHeaderText={ __(
-						'Domain owners are required to provide correct contact information.'
-					) }
+					subHeaderText={ __( 'Domain owners are required to provide correct information.' ) }
 				/>
 			}
 			stepContent={ <ContactInfo onSubmit={ submit } /> }
@@ -108,7 +106,7 @@ function ContactInfo( {
 	}
 
 	return (
-		<form className="domain-contact-info">
+		<form className="domain-contact-info-form">
 			<ContactDetailsFormFields
 				eventFormName="Edit Contact Info"
 				contactDetails={ {
@@ -134,7 +132,7 @@ function ContactInfo( {
 				updateWpcomEmailCheckboxHidden={ true }
 				cancelHidden={ true }
 			>
-				<div className="domain-contact-info__terms">
+				<div className="domain-contact-info-form__terms">
 					<Gridicon icon="info-outline" size={ 18 } />
 					<p>
 						{ translate(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
@@ -5,39 +5,58 @@ $font-family: "SF Pro Text", $sans;
 $heading-font-family: "SF Pro Display", $sans;
 
 .domain-contact-info {
-	.domain-contact-info__terms {
-		padding-left: 24px;
-		position: relative;
-		font-size: $font-body-small;
+	max-width: 700px;
+	margin: 0 auto;
+	padding: 16px 24px;
 
-		margin-left: 0;
-		margin-top: 10px;
+	.domain-contact-info-header {
+		margin: 0 auto;
 
-		> svg {
-			position: absolute;
-			top: 0;
-			left: 0;
-			width: 16px;
-			height: 16px;
+		.formatted-header__subtitle {
+			text-align: center !important;
+		}
+	}
 
-			.rtl & {
-				left: auto;
-				right: 0;
+	.domain-contact-info-form {
+		&__terms {
+			padding-left: 24px;
+			position: relative;
+			font-size: $font-body-small;
+
+			margin-left: 0;
+			margin-top: 10px;
+
+			> svg {
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 16px;
+				height: 16px;
+
+				.rtl & {
+					left: auto;
+					right: 0;
+				}
+			}
+
+			p {
+				font-size: $font-body-small;
+				margin: 0;
+				word-break: break-word;
 			}
 		}
 
-		p {
-			font-size: $font-body-small;
-			margin: 0;
-			word-break: break-word;
+		.contact-details-form-fields__contact-details {
+			margin-bottom: 15px;
+		}
+		.contact-details-form-fields__extra-fields {
+			margin-bottom: 40px;
+		}
+		.contact-details-form-fields > div:last-child {
+			margin: 0 auto;
+		}
+		.contact-details-form-fields__submit-button {
+			padding: 8px 60px;
 		}
 	}
-
-	.contact-details-form-fields__contact-details {
-		margin-bottom: 15px;
-	}
-	.contact-details-form-fields__extra-fields {
-		margin-bottom: 20px;
-	}
-
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3845

## Proposed Changes

Address feedback from this issue: https://github.com/Automattic/dotcom-forge/issues/3761

## TO DO
- [x] Let's keep the title and the copy centered
- [x] Let's reduce the form's width; the input fields are quite large when there are 2 in a row and XXL when there is just one. I would keep it max width at 700px
- [x] The word contact is repeated twice on the top copy
- [x] Let's add a bit more space between the form and the CTA
- [x] Let's have the CTA centered and increase the CTA width to +60 px on both sides

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/c7ff6138-2a69-4af0-9ed9-41cd36cc7abb) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/7bc5da7a-41db-4e89-947c-53b9fd942eca) |

## Testing Instructions

- Test the contact info form http://calypso.localhost:3000/setup/domain-user-transfer/domain-contact-info?domain=test345678.blog

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?