### PR TITLE
Stats: Update Paid Stats support page links for WPCOM sites

### DIFF
--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -1,9 +1,12 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import NoticeBanner from '@automattic/components/src/notice-banner';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
+import { useSelector } from 'calypso/state';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { StatsNoticeProps } from './types';
 
 const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) => {
@@ -18,6 +21,7 @@ const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) =
 
 const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps ) => {
 	const translate = useTranslate();
+	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 	const { mutateAsync: postponeNoticeAsync } = useNoticeVisibilityMutation(
 		siteId,
@@ -60,6 +64,10 @@ const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticePro
 		return null;
 	}
 
+	const learnMoreLink = isWPCOMSite
+		? 'https://wordpress.com/support/stats/#purchase-the-stats-add-on'
+		: 'https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing';
+
 	return (
 		<div
 			className={ `inner-notice-container has-odyssey-stats-bg-color ${
@@ -86,7 +94,7 @@ const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticePro
 							commercialUpgradeLink: (
 								<a
 									className="notice-banner__action-link"
-									href="https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing"
+									href={ localizeUrl( learnMoreLink ) }
 									target="_blank"
 									rel="noreferrer"
 								/>

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -1,9 +1,12 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import NoticeBanner from '@automattic/components/src/notice-banner';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
+import { useSelector } from 'calypso/state';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { StatsNoticeProps } from './types';
 
 const getStatsPurchaseURL = (
@@ -28,6 +31,7 @@ const DoYouLoveJetpackStatsNotice = ( {
 	isOdysseyStats,
 }: StatsNoticeProps ) => {
 	const translate = useTranslate();
+	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 	const { mutateAsync: postponeNoticeAsync } = useNoticeVisibilityMutation(
 		siteId,
@@ -75,6 +79,10 @@ const DoYouLoveJetpackStatsNotice = ( {
 	const noPurchaseTitle = translate( 'Do you love Jetpack Stats?' );
 	const freeTitle = translate( 'Want to get the most out of Jetpack Stats?' );
 
+	const learnMoreLink = isWPCOMSite
+		? 'https://wordpress.com/support/stats/#purchase-the-stats-add-on'
+		: 'https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing';
+
 	return (
 		<div
 			className={ `inner-notice-container has-odyssey-stats-bg-color ${
@@ -101,7 +109,7 @@ const DoYouLoveJetpackStatsNotice = ( {
 							learnMoreLink: (
 								<a
 									className="notice-banner__action-link"
-									href="https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing"
+									href={ localizeUrl( learnMoreLink ) }
 									target="_blank"
 									rel="noreferrer"
 								/>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-commercial.tsx
@@ -1,4 +1,5 @@
 import { Button as CalypsoButton } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -32,6 +33,9 @@ const CommercialPurchase = ( {
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 	// The button of @automattic/components has built-in color scheme support for Calypso.
 	const ButtonComponent = isWPCOMSite ? CalypsoButton : Button;
+	const learnMoreLink = isWPCOMSite
+		? 'https://wordpress.com/support/stats/#purchase-the-stats-add-on'
+		: 'https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-site-types';
 
 	return (
 		<div>
@@ -46,7 +50,7 @@ const CommercialPurchase = ( {
 				) }
 				<Button
 					variant="link"
-					href="https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-site-types"
+					href={ localizeUrl( learnMoreLink ) }
 					target="_blank"
 					rel="noopener noreferrer"
 				>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80883, #80884

## Proposed Changes

* Update the Paid Stats support page link for WPCOM sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up on the local Calypso.
* Prepare a **WPCOM** site without any Stats product or plan.
#### On Stats upsell notices
1. Navigate to Stats > `Traffic` page for the site: `/stats/day/{site-slug}`.
2. Enforce the `isCommercial` flag to be `null`:
https://github.com/Automattic/wp-calypso/blob/553fc4e26e97c29bd9a1f88e526ebcae3769a3a7/client/my-sites/stats/stats-notices/index.tsx#L52
3. Ensure the `Learn more` link on the upsell notice `Do you love Jetpack Stats?` is linked to https://wordpress.com/support/stats/#purchase-the-stats-add-on.
4. Enforce the `isCommercial` flag to be `true`.
5. Ensure the `Learn more` link on the upsell notice `Upgrade to Stats Commercial` is linked to https://wordpress.com/support/stats/#purchase-the-stats-add-on.
#### On Stats purchase page
6. Navigate to the Stats purchase page for the site: `/stats/purchase/{site-slug}`.
7. Enforce the `isCommercial` flag to be `null`:
https://github.com/Automattic/wp-calypso/blob/553fc4e26e97c29bd9a1f88e526ebcae3769a3a7/client/my-sites/stats/stats-purchase/index.tsx#L53
8. Click on the `Commercial site` button.
9. Ensure the `Learn more` link on the noting section is linked to https://wordpress.com/support/stats/#purchase-the-stats-add-on.

* Prepare a **Jetpack** site without any Stats product or plan and test with steps 1 ~ 9 above.
* Ensure the links work as previously.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?