### PR TITLE
Domain Management i1: Fix blank domain screen 

### DIFF
--- a/client/my-sites/domains/domain-management/domains-table-fetch-functions.ts
+++ b/client/my-sites/domains/domain-management/domains-table-fetch-functions.ts
@@ -29,10 +29,7 @@ export async function fetchSite(
 export async function fetchSiteDomains(
 	siteIdOrSlug: number | string | null | undefined
 ): Promise< SiteDomainsQueryFnData > {
-	return wp.req.get( {
-		path: `/sites/${ siteIdOrSlug }/domains`,
-		apiVersion: '1.2',
-	} );
+	return wp.req.get( `/sites/${ siteIdOrSlug }/domains`, { apiVersion: '1.2' } );
 }
 
 export async function createBulkAction( variables: BulkUpdateVariables ): Promise< void > {

--- a/packages/domains-table/src/domains-table/domains-table-expires-renew-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-expires-renew-cell.tsx
@@ -16,12 +16,13 @@ export const DomainsTableExpiresRewnewsOnCell = ( {
 	const isExpired = domain.expiry && moment( domain.expiry ).utc().isBefore( moment().utc() );
 	const { __ } = useI18n();
 
-	const expiryDate = domain.has_registration
-		? new Intl.DateTimeFormat( localeSlug, { dateStyle: 'medium' } ).format(
-				new Date( domain.expiry )
-		  )
-		: null;
-
+	const isInvalidDate = isNaN( Date.parse( domain.expiry ) );
+	const expiryDate =
+		domain.has_registration && ! isInvalidDate
+			? new Intl.DateTimeFormat( localeSlug, { dateStyle: 'medium' } ).format(
+					new Date( domain.expiry )
+			  )
+			: null;
 	const notice = isExpired
 		? sprintf(
 				/* translators: %s - The date on which the domain was expired */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
This PR fixes issue where the users domain screen is blank. This is caused by an exception when parsing the domain expiry date.
Related to #

## Proposed Changes

* Add logic to handle exception
* use the correct api version for fetching domains, the correct version returns the date in the correct utc format

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* browse `/domains/siteSlug/domains`
* verify renews on date is present
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?