### PR TITLE
Domain Transfers: Add notice to explain why the info is required

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -190,7 +190,7 @@ function ContactInfo( {
 				<div className="domain-contact-info__sidebar-content">
 					<p>
 						{ translate(
-							'{{icannLinkComponent}}ICANN{{/icannLinkComponent}} requires accurate contact information for registrants. This information will be verified after purchase. Failure to verify your contact information will result in domain suspension.',
+							'{{icannLinkComponent}}ICANN{{/icannLinkComponent}} requires accurate contact information for registrants. This information will be verified after transfer. Failure to verify your contact information will result in domain suspension.',
 							{
 								components: {
 									icannLinkComponent: icannLink,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -190,7 +190,7 @@ function ContactInfo( {
 				<div className="domain-contact-info__sidebar-content">
 					<p>
 						{ translate(
-							'{{icannLinkComponent}}ICANN{{/icannLinkComponent}} requires accurate contact information for registrants. This information will be verified after transfer. Failure to verify your contact information will result in domain suspension.',
+							'{{icannLinkComponent}}ICANN{{/icannLinkComponent}} requires accurate contact information for registrants. This information will be verified after your domain has been transferred. Failure to verify your contact information will result in domain suspension.',
 							{
 								components: {
 									icannLinkComponent: icannLink,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -6,6 +6,8 @@ import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import ContactDetailsFormFields from 'calypso/components/domains/contact-details-form-fields';
+import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layout';
+import ExternalLink from 'calypso/components/external-link';
 import FormattedHeader from 'calypso/components/formatted-header';
 import {
 	useDomainTransferReceive,
@@ -105,8 +107,8 @@ function ContactInfo( {
 		onSubmit?.( contactInfo );
 	}
 
-	return (
-		<form className="domain-contact-info-form">
+	const renderContent = () => {
+		return (
 			<ContactDetailsFormFields
 				eventFormName="Edit Contact Info"
 				contactDetails={ {
@@ -157,6 +159,63 @@ function ContactInfo( {
 					</p>
 				</div>
 			</ContactDetailsFormFields>
+		);
+	};
+
+	const renderSidebar = () => {
+		const supportLink = (
+			<ExternalLink
+				href={ localizeUrl(
+					'https://wordpress.com/support/domains/domain-registrations-and-privacy/#privacy-protection'
+				) }
+				target="_blank"
+				icon={ false }
+			/>
+		);
+		const icannLink = (
+			<ExternalLink
+				href="https://www.icann.org/resources/pages/contact-verification-2013-05-03-en"
+				target="_blank"
+				icon={ false }
+			/>
+		);
+
+		return (
+			<div className="domain-contact-info__sidebar">
+				<div className="domain-contact-info__sidebar-title">
+					<p>
+						<strong>{ translate( 'Provide accurate contact information' ) }</strong>
+					</p>
+				</div>
+				<div className="domain-contact-info__sidebar-content">
+					<p>
+						{ translate(
+							'{{icannLinkComponent}}ICANN{{/icannLinkComponent}} requires accurate contact information for registrants. This information will be validated after purchase. Failure to validate your contact information will result in domain suspension.',
+							{
+								components: {
+									icannLinkComponent: icannLink,
+								},
+							}
+						) }
+					</p>
+					<p>
+						{ translate(
+							'Domain privacy service is included for free on applicable domains. {{supportLinkComponent}}Learn more{{/supportLinkComponent}}.',
+							{
+								components: {
+									supportLinkComponent: supportLink,
+								},
+							}
+						) }
+					</p>
+				</div>
+			</div>
+		);
+	};
+
+	return (
+		<form className="domain-contact-info-form">
+			<TwoColumnsLayout content={ renderContent() } sidebar={ renderSidebar() } />
 		</form>
 	);
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -190,7 +190,7 @@ function ContactInfo( {
 				<div className="domain-contact-info__sidebar-content">
 					<p>
 						{ translate(
-							'{{icannLinkComponent}}ICANN{{/icannLinkComponent}} requires accurate contact information for registrants. This information will be validated after purchase. Failure to validate your contact information will result in domain suspension.',
+							'{{icannLinkComponent}}ICANN{{/icannLinkComponent}} requires accurate contact information for registrants. This information will be verified after purchase. Failure to verify your contact information will result in domain suspension.',
 							{
 								components: {
 									icannLinkComponent: icannLink,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -190,12 +190,17 @@ function ContactInfo( {
 				<div className="domain-contact-info__sidebar-content">
 					<p>
 						{ translate(
-							'{{icannLinkComponent}}ICANN{{/icannLinkComponent}} requires accurate contact information for registrants. This information will be verified after your domain has been transferred. Failure to verify your contact information will result in domain suspension.',
+							'{{icannLinkComponent}}ICANN{{/icannLinkComponent}} requires accurate contact information for registrants.',
 							{
 								components: {
 									icannLinkComponent: icannLink,
 								},
 							}
+						) }
+					</p>
+					<p>
+						{ translate(
+							'Contact information will be verified after your domain has been transferred. Failure to verify your contact information will result in domain suspension.'
 						) }
 					</p>
 					<p>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
@@ -7,6 +7,19 @@ $heading-font-family: "SF Pro Display", $sans;
 .domain-contact-info {
 	padding: 16px 24px;
 
+	@media (max-width: $break-xlarge ) {
+		max-width: 600px;
+		margin: 0 auto;
+	}
+
+	@media (max-width: $break-small ) {
+		padding-top: 36px;
+	}
+
+	.step-container__header {
+		margin-bottom: 24px;
+	}
+
 	.domain-contact-info-header {
 		margin: 0 auto;
 
@@ -20,9 +33,7 @@ $heading-font-family: "SF Pro Display", $sans;
 			padding-left: 24px;
 			position: relative;
 			font-size: $font-body-small;
-
 			margin-left: 0;
-			margin-top: 10px;
 
 			> svg {
 				position: absolute;
@@ -51,16 +62,16 @@ $heading-font-family: "SF Pro Display", $sans;
 			}
 		}
 		.contact-details-form-fields__contact-details {
-			margin-bottom: 15px;
+			margin-bottom: 24px;
 		}
 		.contact-details-form-fields__extra-fields {
-			margin-bottom: 40px;
-		}
-		.contact-details-form-fields > div:last-child {
-			margin: 0 auto;
+			margin-bottom: 24px;
 		}
 		.contact-details-form-fields__submit-button {
 			padding: 8px 60px;
+			@media (max-width: $break-small ) {
+				width: 100%;
+			}
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
@@ -5,8 +5,6 @@ $font-family: "SF Pro Text", $sans;
 $heading-font-family: "SF Pro Display", $sans;
 
 .domain-contact-info {
-	max-width: 700px;
-	margin: 0 auto;
 	padding: 16px 24px;
 
 	.domain-contact-info-header {
@@ -46,6 +44,12 @@ $heading-font-family: "SF Pro Display", $sans;
 			}
 		}
 
+		.contact-details-form-fields {
+			padding: 0;
+			@media (max-width: $break-xlarge ) {
+				padding: 0 0 24px;
+			}
+		}
 		.contact-details-form-fields__contact-details {
 			margin-bottom: 15px;
 		}
@@ -57,6 +61,29 @@ $heading-font-family: "SF Pro Display", $sans;
 		}
 		.contact-details-form-fields__submit-button {
 			padding: 8px 60px;
+		}
+	}
+
+	&__sidebar {
+		padding: 24px;
+		background-color: var(--studio-gray-0);
+		font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		line-height: 20px;
+		&-content {
+			p {
+				margin: 0 0 1em;
+				&:last-child {
+					margin-bottom: 0;
+				}
+			}
+		}
+		&-title {
+			p {
+				margin-bottom: 0.5em;
+			}
+		}
+		ul {
+			margin: 0 0 0 1em;
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
@@ -78,7 +78,7 @@ $heading-font-family: "SF Pro Display", $sans;
 	&__sidebar {
 		padding: 24px;
 		background-color: var(--studio-gray-0);
-		font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: $font-body-small;
 		line-height: 20px;
 		&-content {
 			p {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3845

## Proposed Changes

We add a notice explaining why we required the contact information on Domain Transfer.

## To Do
Get the correct copy for the notice:

#### Current
```
Provide accurate contact information

ICANN requires accurate contact information for registrants. This information will be validated after purchase. Failure to validate your contact information will result in domain suspension.

Domain privacy service is included for free on applicable domains. Learn more.
```


| Mobile | <1080 desktop | >1080 desktop |
| --- | --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/0a5faf98-cf08-464d-ba44-53c531478085) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/ea9e513d-7bbc-4931-ada9-763d7ab9aab6) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/0d3d19bf-c66b-4105-9d88-d27f8a7ea9e3) |

## Testing Instructions

- Test the contact info form http://calypso.localhost:3000/setup/domain-user-transfer/domain-contact-info?domain=test345678.blog

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?