### PR TITLE
Domain Management i1: Show confirmation dialog for WWD domains

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
@@ -144,13 +144,11 @@ export default function BulkEditContactInfoPage( {
 					successNotice( noticeMessage, {
 						showDismiss: true,
 						isPersistent: true,
-						duration: 3000,
+						duration: 5000,
 					} )
 				);
 			}
-			setTimeout( () => {
-				page( domainsListPath );
-			}, 3000 );
+			page( domainsListPath );
 		},
 		mutationFn: createBulkAction,
 	} );

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
@@ -137,23 +137,21 @@ export default function BulkEditContactInfoPage( {
 		selectedSite?.options?.is_domain_only
 	);
 
-	const goToDomainsList = () => {
-		if ( noticeMessage ) {
-			dispatch(
-				successNotice( noticeMessage, {
-					showDismiss: true,
-					isPersistent: true,
-					duration: 3000,
-				} )
-			);
-		}
-		setTimeout( () => {
-			page( domainsListPath );
-		}, 3000 );
-	};
-
 	const { updateContactInfo } = useDomainsBulkActionsMutation( {
-		onSuccess: goToDomainsList,
+		onSuccess: () => {
+			if ( noticeMessage ) {
+				dispatch(
+					successNotice( noticeMessage, {
+						showDismiss: true,
+						isPersistent: true,
+						duration: 3000,
+					} )
+				);
+			}
+			setTimeout( () => {
+				page( domainsListPath );
+			}, 3000 );
+		},
 		mutationFn: createBulkAction,
 	} );
 
@@ -423,7 +421,7 @@ export default function BulkEditContactInfoPage( {
 				{ selectedDomains?.map( ( domain ) => (
 					<QueryWhois domain={ domain.domain } key={ domain.domain } />
 				) ) }
-				<DomainMainPlaceholder goBack={ goToDomainsList } />
+				<DomainMainPlaceholder goBack={ () => page( domainsListPath ) } />
 			</>
 		);
 	}

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
@@ -20,12 +20,15 @@ import ExternalLink from 'calypso/components/external-link';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain } from 'calypso/lib/domains';
+import { registrar as registrarNames } from 'calypso/lib/domains/constants';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import InfoNotice from 'calypso/my-sites/domains/domain-management/components/domain/info-notice';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
 import DomainHeader from 'calypso/my-sites/domains/domain-management/components/domain-header';
 import { domainManagementList, isUnderDomainManagementAll } from 'calypso/my-sites/domains/paths';
+import { useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPreviousPath from 'calypso/state/selectors/get-previous-path';
 import isRequestingWhoisSelector from 'calypso/state/selectors/is-requesting-whois';
@@ -47,6 +50,7 @@ export default function BulkEditContactInfoPage( {
 	context,
 }: BulkEditContactInfoPageProps ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const selectedDomainsArg = getQueryArg( '?' + context.querystring, 'selected' );
 
@@ -105,7 +109,7 @@ export default function BulkEditContactInfoPage( {
 		} ) ?? false;
 
 	const [ showAllSelectedDomains, setShowAllSelectedDomains ] = useState( false );
-	const [ showConfirmationNotice, setShowConfirmationNotice ] = useState( false );
+	const [ noticeMessage, setNoticeMessage ] = useState< string | undefined >();
 	const domainListElementId = useId();
 
 	const reduxDomains: ResponseDomain[] | undefined = useSelector(
@@ -134,7 +138,18 @@ export default function BulkEditContactInfoPage( {
 	);
 
 	const goToDomainsList = () => {
-		page( domainsListPath );
+		if ( noticeMessage ) {
+			dispatch(
+				successNotice( noticeMessage, {
+					showDismiss: true,
+					isPersistent: true,
+					duration: 3000,
+				} )
+			);
+		}
+		setTimeout( () => {
+			page( domainsListPath );
+		}, 3000 );
 	};
 
 	const { updateContactInfo } = useDomainsBulkActionsMutation( {
@@ -142,22 +157,17 @@ export default function BulkEditContactInfoPage( {
 		mutationFn: createBulkAction,
 	} );
 
-	const handleSubmitButtonClick = (
+	const bulkUpdateContactInfo = (
 		newContactDetails: Record< string, string >,
 		transferLock: boolean,
-		requiresConfirmation: boolean
+		noticeMessage: string
 	) => {
 		const domainNames = selectedDomains?.map( ( domain ) => domain.domain );
 
 		if ( domainNames ) {
+			setNoticeMessage( noticeMessage );
 			updateContactInfo( domainNames, transferLock, newContactDetails );
 		}
-
-		if ( requiresConfirmation ) {
-			setShowConfirmationNotice( true );
-		}
-
-		return 'cancel';
 	};
 
 	const getFieldMapping = ( field: string ) => {
@@ -257,6 +267,10 @@ export default function BulkEditContactInfoPage( {
 			);
 		}
 
+		const wwdDomains = selectedDomains?.filter(
+			( domain ) => domain.registrar === registrarNames.WWD
+		);
+
 		return (
 			<EditContactInfoFormCard
 				forceShowTransferLockOptOut={ anyDomainSupportsTransferLockOptOut }
@@ -268,8 +282,9 @@ export default function BulkEditContactInfoPage( {
 				selectedSite={ selectedSite }
 				showContactInfoNote={ false }
 				backUrl={ domainsListPath }
-				onSubmitButtonClick={ handleSubmitButtonClick }
+				bulkUpdateContactInfo={ bulkUpdateContactInfo }
 				bulkEdit={ true }
+				wwdDomains={ wwdDomains }
 			/>
 		);
 	};

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
@@ -105,6 +105,7 @@ export default function BulkEditContactInfoPage( {
 		} ) ?? false;
 
 	const [ showAllSelectedDomains, setShowAllSelectedDomains ] = useState( false );
+	const [ showConfirmationNotice, setShowConfirmationNotice ] = useState( false );
 	const domainListElementId = useId();
 
 	const reduxDomains: ResponseDomain[] | undefined = useSelector(
@@ -143,12 +144,17 @@ export default function BulkEditContactInfoPage( {
 
 	const handleSubmitButtonClick = (
 		newContactDetails: Record< string, string >,
-		transferLock: boolean
+		transferLock: boolean,
+		requiresConfirmation: boolean
 	) => {
 		const domainNames = selectedDomains?.map( ( domain ) => domain.domain );
 
 		if ( domainNames ) {
 			updateContactInfo( domainNames, transferLock, newContactDetails );
+		}
+
+		if ( requiresConfirmation ) {
+			setShowConfirmationNotice( true );
 		}
 
 		return 'cancel';

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -137,7 +137,7 @@ class EditContactInfoFormCard extends Component {
 		const { firstName, lastName, organization, email } = this.getContactFormFieldValues();
 		const isWwdDomain =
 			this.props.selectedDomain.registrar === registrarNames.WWD ||
-			this.props.wwdDomains?.length > 0;
+			( this.props.bulkEdit && this.props.wwdDomains?.length > 0 );
 
 		const primaryFieldsChanged = ! (
 			firstName === newContactDetails.firstName &&
@@ -238,7 +238,7 @@ class EditContactInfoFormCard extends Component {
 				onClose={ this.handleDialogClose }
 			>
 				<h1>{ translate( 'Confirmation Needed' ) }</h1>
-				{ this.props.wwdDomains?.length > 0 && (
+				{ this.props.bulkEdit && this.props.wwdDomains?.length > 0 && (
 					<>
 						<span>{ translate( 'Confirmation is needed for the following domains:' ) }</span>
 						<ul>

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -276,6 +276,19 @@ class EditContactInfoFormCard extends Component {
 			return;
 		}
 
+		if ( this.props.onSubmitButtonClick ) {
+			const result = this.props.onSubmitButtonClick(
+				newContactDetails,
+				this.state.transferLock,
+				this.state.updateWpcomEmail,
+				this.state.requiresConfirmation
+			);
+			this.updateWpcomEmail( newContactDetails, this.state.updateWpcomEmail );
+			if ( result === 'cancel' ) {
+				return;
+			}
+		}
+
 		this.contactFormFieldValues = newContactDetails;
 
 		this.setState(
@@ -385,18 +398,6 @@ class EditContactInfoFormCard extends Component {
 	};
 
 	handleSubmitButtonClick = ( newContactDetails ) => {
-		if ( this.props.onSubmitButtonClick ) {
-			const result = this.props.onSubmitButtonClick(
-				newContactDetails,
-				this.state.transferLock,
-				this.state.updateWpcomEmail
-			);
-			this.updateWpcomEmail( newContactDetails, this.state.updateWpcomEmail );
-			if ( result === 'cancel' ) {
-				return;
-			}
-		}
-
 		this.setState(
 			{
 				requiresConfirmation: this.requiresConfirmation( newContactDetails ),

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -46,8 +46,9 @@ class EditContactInfoFormCard extends Component {
 		whoisSaveSuccess: PropTypes.bool,
 		showContactInfoNote: PropTypes.bool,
 		backUrl: PropTypes.string.isRequired,
-		onSubmitButtonClick: PropTypes.func, // Callback can return "cancel" to cancel the default form handling
 		bulkEdit: PropTypes.bool,
+		wwdDomains: [ PropTypes.object ],
+		bulkUpdateContactInfo: PropTypes.func,
 		forceShowTransferLockOptOut: PropTypes.bool,
 	};
 
@@ -134,7 +135,9 @@ class EditContactInfoFormCard extends Component {
 
 	requiresConfirmation( newContactDetails ) {
 		const { firstName, lastName, organization, email } = this.getContactFormFieldValues();
-		const isWwdDomain = this.props.selectedDomain.registrar === registrarNames.WWD;
+		const isWwdDomain =
+			this.props.selectedDomain.registrar === registrarNames.WWD ||
+			this.props.wwdDomains?.length > 0;
 
 		const primaryFieldsChanged = ! (
 			firstName === newContactDetails.firstName &&
@@ -235,6 +238,18 @@ class EditContactInfoFormCard extends Component {
 				onClose={ this.handleDialogClose }
 			>
 				<h1>{ translate( 'Confirmation Needed' ) }</h1>
+				{ this.props.wwdDomains?.length > 0 && (
+					<>
+						<span>{ translate( 'Confirmation is needed for the following domains:' ) }</span>
+						<ul>
+							{ this.props.wwdDomains.map( ( domain ) => (
+								<li key={ domain }>
+									<strong>{ domain.domain }</strong>
+								</li>
+							) ) }
+						</ul>
+					</>
+				) }
 				<p>{ text }</p>
 				{ email !== wpcomEmail && this.renderBackupEmail() }
 			</Dialog>
@@ -276,19 +291,6 @@ class EditContactInfoFormCard extends Component {
 			return;
 		}
 
-		if ( this.props.onSubmitButtonClick ) {
-			const result = this.props.onSubmitButtonClick(
-				newContactDetails,
-				this.state.transferLock,
-				this.state.updateWpcomEmail,
-				this.state.requiresConfirmation
-			);
-			this.updateWpcomEmail( newContactDetails, this.state.updateWpcomEmail );
-			if ( result === 'cancel' ) {
-				return;
-			}
-		}
-
 		this.contactFormFieldValues = newContactDetails;
 
 		this.setState(
@@ -297,6 +299,15 @@ class EditContactInfoFormCard extends Component {
 				showNonDaConfirmationDialog: false,
 			},
 			() => {
+				if ( this.props.bulkEdit ) {
+					this.updateWpcomEmail( newContactDetails, updateWpcomEmail );
+					this.props.bulkUpdateContactInfo?.(
+						newContactDetails,
+						transferLock,
+						this.getNoticeMessage()
+					);
+					return;
+				}
 				this.props.saveWhois(
 					selectedDomain.name,
 					newContactDetails,
@@ -320,14 +331,15 @@ class EditContactInfoFormCard extends Component {
 			),
 		} );
 
+		this.showNoticeAndGoBack( this.getNoticeMessage() );
+	};
+
+	getNoticeMessage = () => {
 		if ( ! this.state.requiresConfirmation ) {
-			this.showNoticeAndGoBack(
-				this.props.translate(
-					'The contact info has been updated. ' +
-						'There may be a short delay before the changes show up in the public records.'
-				)
+			return this.props.translate(
+				'The contact info has been updated. ' +
+					'There may be a short delay before the changes show up in the public records.'
 			);
-			return;
 		}
 
 		const { email } = this.getContactFormFieldValues();
@@ -355,7 +367,7 @@ class EditContactInfoFormCard extends Component {
 			);
 		}
 
-		this.showNoticeAndGoBack( message );
+		return message;
 	};
 
 	getReturnDestination = () => {
@@ -420,7 +432,7 @@ class EditContactInfoFormCard extends Component {
 	};
 
 	getIsFieldDisabled = ( name ) => {
-		if ( this.props.bulkEdit ) {
+		if ( this.props.bulkEdit && ! this.state.formSubmitting ) {
 			return false;
 		}
 		const unmodifiableFields = get(

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -47,7 +47,7 @@ class EditContactInfoFormCard extends Component {
 		showContactInfoNote: PropTypes.bool,
 		backUrl: PropTypes.string.isRequired,
 		bulkEdit: PropTypes.bool,
-		wwdDomains: [ PropTypes.object ],
+		wwdDomains: PropTypes.arrayOf( PropTypes.object ),
 		bulkUpdateContactInfo: PropTypes.func,
 		forceShowTransferLockOptOut: PropTypes.bool,
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
For compliance reasons we need to show the confirmation request forms for `wwd` domains. This PR shows that form with the list of domains it applies to. 
Related to #

## Proposed Changes

* Show confirmation dialog on bulk update confirmation form when we have wwd domains.
* move `bulkUpdateContactInfo` method into `saveContactInfo` so that other form states such as submitting state can be applied.
* get notice message based on contact details change and show it when bulk updates happen.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
**Note:** can return true in this [function](https://github.com/Automattic/wp-calypso/blob/8f398d44a3fee67142e5d8c3c31247587d105a5f/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx#L136) if you do not have a `wwd` domain 
* browse `/domains/manage?flags=domains/bulk-actions-contact-info-editing`
* Select a `wwd` domain and edit contact information
* Change organisation and click save 
* Verify the confirmation dialog is shown
* Pass an array of domains to wwdDomains prop and verify the domains are shown in the confirmation dialog.
![image](https://github.com/Automattic/wp-calypso/assets/47489215/6efdb88a-6e24-4630-8b4c-7055b0e702ea)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?