### PR TITLE
Jetpack WPCOM Hosting: Update plan information on the hosting selection page in Jetpack Manage

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -1,16 +1,15 @@
+import { getPlan, PLAN_BUSINESS, PLAN_ECOMMERCE } from '@automattic/calypso-products';
 import { Button, JetpackLogo, WooLogo, CloudLogo } from '@automattic/components';
+import { formatCurrency } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import Tooltip from 'calypso/components/tooltip';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import FeatureItem from './feature-item';
 
 import './style.scss';
-
-// FIXME: These should be imported from a shared file when available
-const JETPACK_HOSTING_WPCOM_BUSINESS = 'JETPACK_HOSTING_WPCOM_BUSINESS';
-const JETPACK_HOSTING_WPCOM_ECOMMERCE = 'JETPACK_HOSTING_WPCOM_ECOMMERCE';
 
 interface PlanInfo {
 	title: string;
@@ -28,12 +27,13 @@ export default function CardContent( { planSlug }: { planSlug: string } ) {
 	const translate = useTranslate();
 	const tooltipRef = useRef< HTMLDivElement | null >( null );
 	const [ showPopover, setShowPopover ] = useState( false );
+	const { data: agencyProducts } = useProductsQuery();
 
 	const getLogo = ( planSlug: string ) => {
 		switch ( planSlug ) {
-			case JETPACK_HOSTING_WPCOM_BUSINESS:
+			case PLAN_BUSINESS:
 				return <CloudLogo />;
-			case JETPACK_HOSTING_WPCOM_ECOMMERCE:
+			case PLAN_ECOMMERCE:
 				return <WooLogo />;
 			default:
 				return null;
@@ -42,9 +42,9 @@ export default function CardContent( { planSlug }: { planSlug: string } ) {
 
 	const getCTAEventName = ( planSlug: string ) => {
 		switch ( planSlug ) {
-			case JETPACK_HOSTING_WPCOM_BUSINESS:
+			case PLAN_BUSINESS:
 				return 'calypso_jetpack_agency_dashboard_wpcom_atomic_hosting_business_cta_click';
-			case JETPACK_HOSTING_WPCOM_ECOMMERCE:
+			case PLAN_ECOMMERCE:
 				return 'calypso_jetpack_agency_dashboard_wpcom_atomic_hosting_ecommerce_cta_click';
 			default:
 				return null;
@@ -52,11 +52,16 @@ export default function CardContent( { planSlug }: { planSlug: string } ) {
 	};
 
 	const getPlanInfo = ( planSlug: string ): PlanInfo => {
-		// FIXME: This is a placeholder until we have the real data
+		const plan = getPlan( planSlug );
+		const productId = plan?.getProductId?.();
+		const agencyProduct = agencyProducts?.find(
+			( agencyProduct ) => agencyProduct.product_id === productId
+		);
+
 		return {
-			title: 'Plan Title',
-			description: 'Plan description goes here',
-			price: '$25',
+			title: plan?.getTitle?.().toString() || '',
+			description: plan?.getPlanTagline?.().toString() || '',
+			price: formatCurrency( agencyProduct?.amount || 0, 'USD', { stripZeros: true } ),
 			interval: 'month',
 			wpcomFeatures: [
 				{ text: 'Feature 1', tooltipText: 'Tooltip for Feature 1' },
@@ -66,7 +71,7 @@ export default function CardContent( { planSlug }: { planSlug: string } ) {
 				{ text: 'Feature 5', tooltipText: 'Tooltip for Feature 5' },
 			],
 			jetpackFeatures:
-				planSlug === JETPACK_HOSTING_WPCOM_BUSINESS
+				planSlug === PLAN_BUSINESS
 					? [
 							{ text: 'Feature 1', tooltipText: 'Tooltip for Feature 1' },
 							{ text: 'Feature 2', tooltipText: 'Tooltip for Feature 2' },

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -63,6 +63,17 @@ export default function CardContent( { planSlug }: { planSlug: string } ) {
 		}
 	};
 
+	const getProductTagline = ( planSlug: string ) => {
+		switch ( planSlug ) {
+			case PLAN_BUSINESS:
+				return translate( 'Unlock the power of WordPress with plugins and cloud tools.' );
+			case PLAN_ECOMMERCE:
+				return translate( 'Create a powerful online store with built-in premium extensions.' );
+			default:
+				return '';
+		}
+	};
+
 	const getPlanInfo = ( planSlug: string ): PlanInfo => {
 		const plan = getPlan( planSlug );
 
@@ -77,7 +88,7 @@ export default function CardContent( { planSlug }: { planSlug: string } ) {
 
 		return {
 			title: plan?.getTitle?.().toString() || '',
-			description: plan?.getPlanTagline?.().toString() || '',
+			description: getProductTagline( planSlug ) || '',
 			price: formatCurrency( agencyProduct?.amount || 0, 'USD', { stripZeros: true } ),
 			interval: 'month',
 			wpcomFeatures: planFeaturesObject.map( ( feature ) => ( {

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/index.tsx
@@ -1,3 +1,4 @@
+import { PLAN_BUSINESS, PLAN_ECOMMERCE } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -15,10 +16,7 @@ export default function WPCOMAtomicHosting() {
 	const dispatch = useDispatch();
 	const title = translate( 'Create a new WordPress.com site' );
 
-	const plansToBeDisplayed = [
-		'JETPACK_HOSTING_WPCOM_BUSINESS',
-		'JETPACK_HOSTING_WPCOM_ECOMMERCE',
-	]; // Get the plans from the API
+	const plansToBeDisplayed = [ PLAN_BUSINESS, PLAN_ECOMMERCE ];
 
 	useEffect( () => {
 		// Track page view


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The hosting options page in Jetpack Manage currently contains placeholder content. This PR will replace the placeholder content with either API fetched plan information, or hard-coded information about the plan choices.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Load up `http://jetpack.cloud.localhost:3000/partner-portal/create-site` and:
- Ensure that you see pricing appropriate to your billing scheme
- Ensure that WPCOM features and Jetpack features are listed
- Ensure the titles and taglines of both plans are shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?