### PR TITLE
Stats: fix heading style for old purchase page

### DIFF
--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -130,6 +130,14 @@ $button-padding: 8px 32px;
 
 	.stats-purchase-wizard__card {
 		display: flex;
+		h1,
+		.components-panel__header h2 {
+			font-family: $font-sf-pro-display;
+			font-size: $font-headline-small;
+			font-weight: 700;
+			line-height: 40px;
+			margin-bottom: 24px;
+		}
 	}
 
 	.stats-purchase-wizard__card-inner--left {

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -132,11 +132,11 @@ $button-padding: 8px 32px;
 		display: flex;
 		h1,
 		.components-panel__header h2 {
+			color: var(--studio-black);
 			font-family: $font-sf-pro-display;
 			font-size: $font-headline-small;
 			font-weight: 700;
 			line-height: 40px;
-			margin-bottom: 24px;
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

The PR proposes the fix the heading styling for the old purchase page, which has the site type selector.

## Testing Instructions

* Spin this change up on the local Calypso.
* Prepare a **JETPACK** site without any Stats product or plan.
* Navigate to page for the site: `/stats/purchase/{site-slug}`.
*  Force the `isCommercial` flag to be `null`:
https://github.com/Automattic/wp-calypso/blob/553fc4e26e97c29bd9a1f88e526ebcae3769a3a7/client/my-sites/stats/stats-notices/index.tsx#L52

* Ensure 'Jetpack Stats' heading is showing correctly

| Before | After |
|--------|------|
| <img width="622" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/02f9cbc9-6ca5-438b-bf02-752d24a6a46d"> | <img width="630" alt="Screenshot 2023-09-21 at 12 38 42 PM" src="https://github.com/Automattic/wp-calypso/assets/1425433/6b81595e-662b-403a-9c75-a11d345a1481">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
