### PR TITLE
Subscription Management: Display the comments page at `/read/subscriptions/comments`

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -339,3 +339,10 @@ export async function siteSubscription( context, next ) {
 	);
 	return next();
 }
+
+export async function commentSubscriptionsManager( context, next ) {
+	context.primary = (
+		<AsyncLoad require="calypso/reader/site-subscriptions-manager/comment-subscriptions-manager" />
+	);
+	return next();
+}

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -21,6 +21,7 @@ import {
 	blogDiscoveryByFeedId,
 	siteSubscriptionsManager,
 	siteSubscription,
+	commentSubscriptionsManager,
 } from './controller';
 
 import './style.scss';
@@ -123,20 +124,29 @@ export default async function () {
 
 	// Sites subscription management
 	page(
-		'/read/subscriptions/:subscription_id',
-		redirectLoggedOut,
-		updateLastRoute,
-		sidebar,
-		siteSubscription,
-		makeLayout,
-		clientRender
-	);
-	page(
 		'/read/subscriptions',
 		redirectLoggedOut,
 		updateLastRoute,
 		sidebar,
 		siteSubscriptionsManager,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/read/subscriptions/comments',
+		redirectLoggedOut,
+		updateLastRoute,
+		sidebar,
+		commentSubscriptionsManager,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/read/subscriptions/:subscription_id',
+		redirectLoggedOut,
+		updateLastRoute,
+		sidebar,
+		siteSubscription,
 		makeLayout,
 		clientRender
 	);

--- a/client/reader/site-subscriptions-manager/comment-subscriptions-manager/comment-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/comment-subscriptions-manager/comment-subscriptions-manager.tsx
@@ -1,0 +1,19 @@
+import { useTranslate } from 'i18n-calypso';
+import { Comments } from 'calypso/landing/subscriptions/components/tab-views';
+import SubscriptionsManagerWrapper from '../subscriptions-manager-wrapper';
+import '../style.scss';
+
+const CommentSubscriptionsManager = () => {
+	const translate = useTranslate();
+
+	return (
+		<SubscriptionsManagerWrapper
+			headerText={ translate( 'Manage subscribed posts' ) }
+			subHeaderText={ translate( 'Manage your site, RSS, and newsletter subscriptions.' ) }
+		>
+			<Comments />
+		</SubscriptionsManagerWrapper>
+	);
+};
+
+export default CommentSubscriptionsManager;

--- a/client/reader/site-subscriptions-manager/comment-subscriptions-manager/index.tsx
+++ b/client/reader/site-subscriptions-manager/comment-subscriptions-manager/index.tsx
@@ -1,0 +1,3 @@
+import CommentSubscriptionsManager from './comment-subscriptions-manager';
+
+export default () => <CommentSubscriptionsManager />;

--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -1,90 +1,20 @@
-import { useLocale } from '@automattic/i18n-utils';
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	__experimentalSpacer as Spacer,
-} from '@wordpress/components';
-import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
-import ReaderExportButton from 'calypso/blocks/reader-export-button';
-import { READER_EXPORT_TYPE_SUBSCRIPTIONS } from 'calypso/blocks/reader-export-button/constants';
-import ReaderImportButton from 'calypso/blocks/reader-import-button';
-import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
-import Main from 'calypso/components/main';
 import { AddSitesButton } from 'calypso/landing/subscriptions/components/add-sites-button';
-import {
-	SubscriptionsPortal,
-	SubscriptionManagerContextProvider,
-} from 'calypso/landing/subscriptions/components/subscription-manager-context';
-import { SubscriptionsEllipsisMenu } from 'calypso/landing/subscriptions/components/subscriptions-ellipsis-menu';
-import { downloadCloud, uploadCloud } from 'calypso/reader/icons';
-import { useDispatch } from 'calypso/state';
-import { markFollowsAsStale } from 'calypso/state/reader/follows/actions';
 import ReaderSiteSubscriptions from './reader-site-subscriptions';
+import SubscriptionsManagerWrapper from './subscriptions-manager-wrapper';
 import './style.scss';
-
-const useMarkFollowsAsStaleOnUnmount = () => {
-	const dispatch = useDispatch();
-	useEffect( () => {
-		return () => {
-			dispatch( markFollowsAsStale() );
-		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
-};
 
 const SiteSubscriptionsManager = () => {
 	const translate = useTranslate();
-	const locale = useLocale();
-	const { hasTranslation } = useI18n();
-
-	// Mark follows as stale on unmount to ensure that the reader
-	// redux store is in a consistent state when the user navigates.
-	// This is necessary because the subscription manager does not
-	// sync its subscriptions state with the reader redux store.
-	useMarkFollowsAsStaleOnUnmount();
 
 	return (
-		<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Reader }>
-			<Main className="site-subscriptions-manager">
-				<DocumentHead title={ translate( 'Manage subscriptions' ) } />
-
-				<HStack className="site-subscriptions-manager__header-h-stack">
-					<FormattedHeader
-						headerText={ translate( 'Manage subscribed sites' ) }
-						subHeaderText={
-							locale.startsWith( 'en' ) ||
-							hasTranslation( 'Manage your site, RSS, and newsletter subscriptions.' )
-								? translate( 'Manage your site, RSS, and newsletter subscriptions.' )
-								: translate( 'Manage your newsletter and blog subscriptions.' )
-						}
-						align="left"
-						brandFont
-					/>
-					<Spacer />
-					<AddSitesButton />
-
-					<SubscriptionsEllipsisMenu
-						toggleTitle={ translate( 'More' ) }
-						popoverClassName="site-subscriptions-manager__import-export-popover"
-						verticalToggle
-					>
-						<VStack spacing={ 1 }>
-							<ReaderImportButton icon={ uploadCloud } iconSize={ 20 } />
-							<ReaderExportButton
-								icon={ downloadCloud }
-								iconSize={ 20 }
-								exportType={ READER_EXPORT_TYPE_SUBSCRIPTIONS }
-							/>
-						</VStack>
-					</SubscriptionsEllipsisMenu>
-				</HStack>
-
-				<ReaderSiteSubscriptions />
-			</Main>
-		</SubscriptionManagerContextProvider>
+		<SubscriptionsManagerWrapper
+			actionButton={ <AddSitesButton /> }
+			headerText={ translate( 'Manage subscribed sites' ) }
+			subHeaderText={ translate( 'Manage your site, RSS, and newsletter subscriptions.' ) }
+		>
+			<ReaderSiteSubscriptions />
+		</SubscriptionsManagerWrapper>
 	);
 };
 

--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -1,5 +1,10 @@
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import ReaderExportButton from 'calypso/blocks/reader-export-button';
+import { READER_EXPORT_TYPE_SUBSCRIPTIONS } from 'calypso/blocks/reader-export-button/constants';
+import ReaderImportButton from 'calypso/blocks/reader-import-button';
 import { AddSitesButton } from 'calypso/landing/subscriptions/components/add-sites-button';
+import { downloadCloud, uploadCloud } from 'calypso/reader/icons';
 import ReaderSiteSubscriptions from './reader-site-subscriptions';
 import SubscriptionsManagerWrapper from './subscriptions-manager-wrapper';
 import './style.scss';
@@ -10,6 +15,16 @@ const SiteSubscriptionsManager = () => {
 	return (
 		<SubscriptionsManagerWrapper
 			actionButton={ <AddSitesButton /> }
+			ellipsisMenuItems={
+				<VStack spacing={ 1 }>
+					<ReaderImportButton icon={ uploadCloud } iconSize={ 20 } />
+					<ReaderExportButton
+						icon={ downloadCloud }
+						iconSize={ 20 }
+						exportType={ READER_EXPORT_TYPE_SUBSCRIPTIONS }
+					/>
+				</VStack>
+			}
 			headerText={ translate( 'Manage subscribed sites' ) }
 			subHeaderText={ translate( 'Manage your site, RSS, and newsletter subscriptions.' ) }
 		>

--- a/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
+++ b/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
@@ -1,13 +1,9 @@
 import {
 	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
-import ReaderExportButton from 'calypso/blocks/reader-export-button';
-import { READER_EXPORT_TYPE_SUBSCRIPTIONS } from 'calypso/blocks/reader-export-button/constants';
-import ReaderImportButton from 'calypso/blocks/reader-import-button';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
@@ -16,7 +12,6 @@ import {
 	SubscriptionManagerContextProvider,
 } from 'calypso/landing/subscriptions/components/subscription-manager-context';
 import { SubscriptionsEllipsisMenu } from 'calypso/landing/subscriptions/components/subscriptions-ellipsis-menu';
-import { downloadCloud, uploadCloud } from 'calypso/reader/icons';
 import { useDispatch } from 'calypso/state';
 import { markFollowsAsStale } from 'calypso/state/reader/follows/actions';
 import './style.scss';
@@ -34,6 +29,7 @@ const useMarkFollowsAsStaleOnUnmount = () => {
 type SubscriptionsManagerWrapperProps = {
 	actionButton?: React.ReactNode;
 	children: React.ReactNode;
+	ellipsisMenuItems?: React.ReactNode;
 	headerText: string;
 	subHeaderText: string;
 };
@@ -41,6 +37,7 @@ type SubscriptionsManagerWrapperProps = {
 const SubscriptionsManagerWrapper = ( {
 	actionButton,
 	children,
+	ellipsisMenuItems,
 	headerText,
 	subHeaderText,
 }: SubscriptionsManagerWrapperProps ) => {
@@ -67,20 +64,15 @@ const SubscriptionsManagerWrapper = ( {
 					<Spacer />
 					{ actionButton }
 
-					<SubscriptionsEllipsisMenu
-						toggleTitle={ translate( 'More' ) }
-						popoverClassName="site-subscriptions-manager__import-export-popover"
-						verticalToggle
-					>
-						<VStack spacing={ 1 }>
-							<ReaderImportButton icon={ uploadCloud } iconSize={ 20 } />
-							<ReaderExportButton
-								icon={ downloadCloud }
-								iconSize={ 20 }
-								exportType={ READER_EXPORT_TYPE_SUBSCRIPTIONS }
-							/>
-						</VStack>
-					</SubscriptionsEllipsisMenu>
+					{ ellipsisMenuItems && (
+						<SubscriptionsEllipsisMenu
+							toggleTitle={ translate( 'More' ) }
+							popoverClassName="site-subscriptions-manager__import-export-popover"
+							verticalToggle
+						>
+							{ ellipsisMenuItems }
+						</SubscriptionsEllipsisMenu>
+					) }
 				</HStack>
 
 				{ children }

--- a/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
+++ b/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
@@ -1,0 +1,92 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalSpacer as Spacer,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import ReaderExportButton from 'calypso/blocks/reader-export-button';
+import { READER_EXPORT_TYPE_SUBSCRIPTIONS } from 'calypso/blocks/reader-export-button/constants';
+import ReaderImportButton from 'calypso/blocks/reader-import-button';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
+import {
+	SubscriptionsPortal,
+	SubscriptionManagerContextProvider,
+} from 'calypso/landing/subscriptions/components/subscription-manager-context';
+import { SubscriptionsEllipsisMenu } from 'calypso/landing/subscriptions/components/subscriptions-ellipsis-menu';
+import { downloadCloud, uploadCloud } from 'calypso/reader/icons';
+import { useDispatch } from 'calypso/state';
+import { markFollowsAsStale } from 'calypso/state/reader/follows/actions';
+import './style.scss';
+
+const useMarkFollowsAsStaleOnUnmount = () => {
+	const dispatch = useDispatch();
+	useEffect( () => {
+		return () => {
+			dispatch( markFollowsAsStale() );
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+};
+
+type SubscriptionsManagerWrapperProps = {
+	actionButton?: React.ReactNode;
+	children: React.ReactNode;
+	headerText: string;
+	subHeaderText: string;
+};
+
+const SubscriptionsManagerWrapper = ( {
+	actionButton,
+	children,
+	headerText,
+	subHeaderText,
+}: SubscriptionsManagerWrapperProps ) => {
+	const translate = useTranslate();
+
+	// Mark follows as stale on unmount to ensure that the reader
+	// redux store is in a consistent state when the user navigates.
+	// This is necessary because the subscription manager does not
+	// sync its subscriptions state with the reader redux store.
+	useMarkFollowsAsStaleOnUnmount();
+
+	return (
+		<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Reader }>
+			<Main className="site-subscriptions-manager">
+				<DocumentHead title={ translate( 'Manage subscriptions' ) } />
+
+				<HStack className="site-subscriptions-manager__header-h-stack">
+					<FormattedHeader
+						headerText={ headerText }
+						subHeaderText={ subHeaderText }
+						align="left"
+						brandFont
+					/>
+					<Spacer />
+					{ actionButton }
+
+					<SubscriptionsEllipsisMenu
+						toggleTitle={ translate( 'More' ) }
+						popoverClassName="site-subscriptions-manager__import-export-popover"
+						verticalToggle
+					>
+						<VStack spacing={ 1 }>
+							<ReaderImportButton icon={ uploadCloud } iconSize={ 20 } />
+							<ReaderExportButton
+								icon={ downloadCloud }
+								iconSize={ 20 }
+								exportType={ READER_EXPORT_TYPE_SUBSCRIPTIONS }
+							/>
+						</VStack>
+					</SubscriptionsEllipsisMenu>
+				</HStack>
+
+				{ children }
+			</Main>
+		</SubscriptionManagerContextProvider>
+	);
+};
+
+export default SubscriptionsManagerWrapper;

--- a/client/sections.js
+++ b/client/sections.js
@@ -421,7 +421,11 @@ const sections = [
 	},
 	{
 		name: 'reader',
-		paths: [ '/read/subscriptions', '^/read/subscriptions/(\\d+)(/)?$' ],
+		paths: [
+			'/read/subscriptions',
+			'/read/subscriptions/comments',
+			'^/read/subscriptions/(\\d+)(/)?$',
+		],
 		module: 'calypso/reader/site-subscriptions-manager',
 		group: 'reader',
 	},


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/81896

## Proposed Changes

* Extract components from `SiteSubscriptionsManager` so they can be used as a wrapper for Sites, Comments, and Pending tabs. The `SubscriptionsManagerWrapper` can also be the component where the tabs will be placed.
* Create `CommentSubscriptionsManager` using the wrapper
* Create `/read/subscriptions/comments` route to display the comments page

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/read/subscriptions/comments
* You should see the Comments page (with subscribed posts listed)

![Screenshot](https://github.com/Automattic/wp-calypso/assets/3113712/afa8d3ef-3427-47a7-8388-e3aaa7dc5496)

* Perform regression tests on the existing subscription management
  * Go to http://calypso.localhost:3000/read/subscriptions
  * Verify if the page is functional as before
  * Click on a subscription to go to the subscription details page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?