### PR TITLE
Zendesk Messaging: Only call setUpMessagingEventHandlers on first load

### DIFF
--- a/packages/help-center/src/hooks/use-zendesk-messaging.ts
+++ b/packages/help-center/src/hooks/use-zendesk-messaging.ts
@@ -26,16 +26,8 @@ export default function useZendeskMessaging(
 	const [ isMessagingScriptLoaded, setMessagingScriptLoaded ] = useState( false );
 	const zendeskKey: string = config( keyConfigName );
 	const { data: authData } = useMessagingAuth( isMessagingScriptLoaded && tryAuthenticating );
-
 	useEffect( () => {
-		if ( ! enabled ) {
-			return;
-		}
-
-		if ( document.getElementById( ZENDESK_SCRIPT_ID ) ) {
-			if ( typeof window.zE === 'function' ) {
-				setMessagingScriptLoaded( true );
-			}
+		if ( ! enabled || isMessagingScriptLoaded ) {
 			return;
 		}
 
@@ -47,7 +39,6 @@ export default function useZendeskMessaging(
 				return;
 			}
 			window.zE( 'messenger', 'hide' );
-
 			setMessagingScriptLoaded( true );
 		}
 
@@ -56,7 +47,16 @@ export default function useZendeskMessaging(
 			setUpMessagingEventHandlers,
 			{ id: ZENDESK_SCRIPT_ID }
 		);
-	}, [ setMessagingScriptLoaded, enabled, zendeskKey ] );
+	}, [ setMessagingScriptLoaded, enabled, zendeskKey, isMessagingScriptLoaded ] );
+
+	if (
+		document.getElementById( ZENDESK_SCRIPT_ID ) &&
+		enabled &&
+		typeof window.zE === 'function' &&
+		isMessagingScriptLoaded === false
+	) {
+		setMessagingScriptLoaded( true );
+	}
 
 	return {
 		isLoggedIn: authData?.isLoggedIn,


### PR DESCRIPTION
The function `useZendeskMessaging` is being run multiple times. This led to a desynchronization of each hook's state which would create unreliability when loading the chat widget.

## Proposed Changes

This PR moves the conditional block outside of the useEffect block to ensure that setMessagingScriptLoaded is always true when the script is loaded. 

Another condition was added to the guard to not run the effect to load the script if the script is already loaded.

## Testing Instructions
- Try loading a chat in multiple places, such as the Domains page and the Checkout page
- Test that the chat works as expected
- The bug was initially found in this PR https://github.com/Automattic/wp-calypso/pull/80724
- This is actually relatively difficult to test, initially the bug was seen when testing the custom chat button in the above PR. While testing I was console.logging `isMessagingScriptLoaded` and would get multiple renders with conflicting results (i.e some true some false when the script was already loaded, should've returned only true)