### PR TITLE
Site profiler: Layout block: Add fade in animation

### DIFF
--- a/client/site-profiler/components/domain-information/styles.scss
+++ b/client/site-profiler/components/domain-information/styles.scss
@@ -1,5 +1,7 @@
 .domain-information-details {
 	.whois-raw-data {
+		animation: l-block-fade-in 250ms ease-in;
+
 		button {
 			margin-bottom: 0.5rem;
 		}
@@ -12,6 +14,7 @@
 		}
 
 		pre {
+			background: transparent;
 			font-size: 0.875rem;
 			/* stylelint-disable-next-line */
 			line-height: 1.25rem;

--- a/client/site-profiler/components/layout/index.tsx
+++ b/client/site-profiler/components/layout/index.tsx
@@ -6,13 +6,16 @@ interface Props {
 	children: React.ReactNode;
 	className?: string;
 	isMonoBg?: boolean;
+	animate?: boolean;
 }
 
 export function LayoutBlock( props: Props ) {
-	const { children, className, isMonoBg } = props;
+	const { children, className, isMonoBg, animate = true } = props;
 
 	return (
-		<div className={ classnames( 'l-block', className, { 'is-mono-bg': isMonoBg } ) }>
+		<div
+			className={ classnames( 'l-block', className, { 'is-mono-bg': isMonoBg, animate: animate } ) }
+		>
 			<div className="l-block-content">{ children }</div>
 		</div>
 	);

--- a/client/site-profiler/components/layout/styles.scss
+++ b/client/site-profiler/components/layout/styles.scss
@@ -4,6 +4,10 @@
 	&.is-mono-bg {
 		background-color: #e9eff5;
 	}
+
+	&.animate {
+		animation: l-block-fade-in 250ms ease-in;
+	}
 }
 
 .l-block-content {
@@ -13,4 +17,13 @@
 
 .l-block-section {
 	padding: 1.5rem 0;
+}
+
+@keyframes l-block-fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
 }


### PR DESCRIPTION
## Proposed Changes

* Added fadeIn animation to layout-block
* Added animation to WHOIS block appearance 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site-profiler`
* Enter any domain and submit the form
* Check if there is an animation on the result appearance
* Click on "Display raw WHOIS output" button
* Check if there is the same animation on the whois data result

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?