### PR TITLE
setup -> set up typo

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -56,7 +56,7 @@ function ContactInfo( {
 		onSuccess() {
 			dispatch(
 				successNotice(
-					translate( 'Your domain is on its way to you, we’ll email you once it’s setup.' ),
+					translate( 'Your domain is on its way to you, we’ll email you once it’s set up.' ),
 					{
 						duration: 10000,
 						isPersistent: true,


### PR DESCRIPTION
Related to #

## Proposed Changes

* setup -> set up

## Testing Instructions

* http://calypso.localhost:3000/setup/domain-user-transfer/domain-contact-info?domain=test345678.blog
