### PR TITLE
Stats: fix checkbox style for Jetpack purchase page

### DIFF
--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -196,6 +196,18 @@ $button-padding: 8px 32px;
 
 	.stats-purchase-wizard__persnal-checklist {
 		margin-bottom: 24px;
+
+		.components-checkbox-control__input[type="checkbox"]:checked {
+			background: var(--color-primary);
+			border-color: var(--color-primary);
+		}
+	}
+
+	.stats-purchase-single__persnal-checklist {
+		.components-checkbox-control__input[type="checkbox"]:checked {
+			background: var(--color-primary);
+			border-color: var(--color-primary);
+		}
 	}
 
 	ul {

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -12,6 +12,35 @@ $button-padding: 8px 32px;
 	--stats-purchase-left-min-width: 500px;
 	--stats-purchase-left-max-width: 700px;
 	--stats-purchase-right-width: 456px;
+
+	// Apply Jetpack dedicated styling upon the Calypso theme base.
+	&:not(.stats-purchase-page--is-wpcom) {
+		.stats-purchase-wizard__persnal-checklist {
+			.components-checkbox-control__input[type="checkbox"] {
+				&:checked {
+					background-color: var(--studio-jetpack-green-50);
+					border-color: var(--studio-jetpack-green-50);
+				}
+
+				&:focus {
+					box-shadow: 0 0 0 var(--wp-admin-border-width-focus) #fff, 0 0 0 calc(2 * var(--wp-admin-border-width-focus)) var(--studio-jetpack-green-50);
+				}
+			}
+		}
+
+		.stats-purchase-single__persnal-checklist {
+			.components-checkbox-control__input[type="checkbox"] {
+				&:checked {
+					background-color: var(--studio-jetpack-green-50);
+					border-color: var(--studio-jetpack-green-50);
+				}
+
+				&:focus {
+					box-shadow: 0 0 0 var(--wp-admin-border-width-focus) #fff, 0 0 0 calc(2 * var(--wp-admin-border-width-focus)) var(--studio-jetpack-green-50);
+				}
+			}
+		}
+	}
 }
 
 // Adjust purchase page styling for WPCOM.
@@ -196,18 +225,6 @@ $button-padding: 8px 32px;
 
 	.stats-purchase-wizard__persnal-checklist {
 		margin-bottom: 24px;
-
-		.components-checkbox-control__input[type="checkbox"]:checked {
-			background: var(--color-primary);
-			border-color: var(--color-primary);
-		}
-	}
-
-	.stats-purchase-single__persnal-checklist {
-		.components-checkbox-control__input[type="checkbox"]:checked {
-			background: var(--color-primary);
-			border-color: var(--color-primary);
-		}
 	}
 
 	ul {


### PR DESCRIPTION
## Proposed Changes

The PR proposes to apply Jetpack colours to checkboxes on the purchase page for Jetpack sites. The colour would be applied to the Odyssey purchase page too.

## Testing Instructions

1. Spin this change up on the local Calypso.
2. Prepare a **JETPACK** site without any Stats product or plan.
1. Navigate to page for the site: `/stats/purchase/{site-slug}`.
2. Force the `isCommercial` flag to be `null`:
https://github.com/Automattic/wp-calypso/blob/553fc4e26e97c29bd9a1f88e526ebcae3769a3a7/client/my-sites/stats/stats-notices/index.tsx#L52
3. Choose personal site
4. Ensure the checkboxes are Jetpack styled - green

<img width="511" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/e1ae5e05-b91a-49bb-a576-99b945b7073f">

6. Set the `isCommercial` flag to be `true`.
7. Refresh `/stats/purchase/{site-slug}`.
4. Ensure the checkboxes are Jetpack styled - green

<img width="517" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/7c410e9e-104b-4f39-b68d-97c56ef449d5">

6. Set the `isCommercial` flag to be `false`.
7. Refresh `/stats/purchase/{site-slug}`.
4. Ensure the checkboxes are Jetpack styled - green

<img width="550" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/c2b91d54-4425-4820-b5eb-93a4cf78ffc5">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
