### PR TITLE
Stats: Fix upgrade button on already purchased notice

### DIFF
--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -131,7 +131,6 @@ const useModifiedActionPrimary = (
 				// Navigate to the stats purchase page, scrolled to the top.
 				const purchaseUrl = getStatsPurchaseURL(
 					siteId,
-					false,
 					addOnMeta.productSlug === PRODUCT_JETPACK_STATS_YEARLY ? 'commercial' : 'personal'
 				);
 				// TODO: Remove the feature flag once we enable Paid Stats for WPCOM sites.

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -18,7 +18,7 @@ import Main from 'calypso/components/main';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug, getSiteOption } from 'calypso/state/sites/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useStatsPurchases from '../hooks/use-stats-purchases';
@@ -50,7 +50,9 @@ const StatsPurchasePage = ( {
 	);
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 
-	const isCommercial = false;
+	const isCommercial = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'is_commercial' )
+	) as boolean;
 
 	const { isRequestingSitePurchases, isFreeOwned, isPWYWOwned, supportCommercialUse } =
 		useStatsPurchases( siteId );

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -18,7 +18,7 @@ import Main from 'calypso/components/main';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
-import { getSiteSlug, getSiteOption } from 'calypso/state/sites/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useStatsPurchases from '../hooks/use-stats-purchases';
@@ -50,9 +50,7 @@ const StatsPurchasePage = ( {
 	);
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 
-	const isCommercial = useSelector( ( state ) =>
-		getSiteOption( state, siteId, 'is_commercial' )
-	) as boolean;
+	const isCommercial = false;
 
 	const { isRequestingSitePurchases, isFreeOwned, isPWYWOwned, supportCommercialUse } =
 		useStatsPurchases( siteId );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
@@ -11,14 +11,8 @@ import {
 } from './stats-purchase-shared';
 import './styles.scss';
 
-const getStatsPurchaseURL = ( siteId, isOdysseyStats, productType = 'commercial' ) => {
-	const purchasePath = `/stats/purchase/${ siteId }?productType=${ productType }&flags=stats/type-detection`;
-
-	if ( ! isOdysseyStats ) {
-		return purchasePath;
-	}
-	return `https://wordpress.com${ purchasePath }`;
-};
+const getStatsPurchaseURL = ( siteId, productType = 'commercial' ) =>
+	`/stats/purchase/${ siteId }?productType=${ productType }&flags=stats/type-detection`;
 
 const handleUpgradeClick = ( event, upgradeUrl, isOdysseyStats ) => {
 	event.preventDefault();
@@ -27,7 +21,7 @@ const handleUpgradeClick = ( event, upgradeUrl, isOdysseyStats ) => {
 		? recordTracksEvent( 'jetpack_odyssey_stats_purchase_summary_screen_upgrade_clicked' )
 		: recordTracksEvent( 'calypso_stats_purchase_summary_screen_upgrade_clicked' );
 
-	setTimeout( () => ( window.location.href = upgradeUrl ), 250 );
+	setTimeout( () => page( upgradeUrl ), 250 );
 };
 
 const StatsCommercialOwned = ( { siteSlug } ) => {
@@ -86,11 +80,7 @@ const StatsPWYWOwnedNotice = ( { siteId, siteSlug } ) => {
 			<Button
 				variant="primary"
 				onClick={ ( e ) =>
-					handleUpgradeClick(
-						e,
-						getStatsPurchaseURL( siteId, isOdysseyStats, 'commercial' ),
-						isOdysseyStats
-					)
+					handleUpgradeClick( e, getStatsPurchaseURL( siteId, 'commercial' ), isOdysseyStats )
 				}
 			>
 				{ translate( 'Upgrade my Stats' ) }
@@ -128,11 +118,7 @@ const StatsFreeOwnedNotice = ( { siteId, siteSlug } ) => {
 			<Button
 				variant="primary"
 				onClick={ ( e ) =>
-					handleUpgradeClick(
-						e,
-						getStatsPurchaseURL( siteId, isOdysseyStats, 'personal' ),
-						isOdysseyStats
-					)
+					handleUpgradeClick( e, getStatsPurchaseURL( siteId, 'personal' ), isOdysseyStats )
 				}
 			>
 				{ translate( 'Upgrade my Stats' ) }


### PR DESCRIPTION
## Proposed Changes

The PR proposes to change the 'Upgrade my Stats' button to link to Calypso or Odyssey Stats based on where it is running from. It uses `page` to navigate to purchase, and the `page` lib would handle the difference behind the scenes.

## Testing Instructions

### Calypso Stats

- Open Calypso Live for a site with Stats free subscription
- Open `/stats/purchase/:siteSlug`
- Click `Upgrade my Stats`
- Ensure you are taking to purchase page (PWYW for personal or Commercial for commercial)

### Odyssey Stats

- Build Jetpack if necessary `jetpack build plugins/jetpack`
- Build Odyssey Stats `cd apps/odyssey-stats && STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
- Open `/wp-admin/admin.php?page=stats#!/stats/purchase/:siteSlug`
- Click `Upgrade my Stats`
- Ensure you are taking to purchase page within WP-Admin (PWYW for personal or Commercial for commercial)

<img width="612" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/951f74de-2d16-4e14-87c9-13fbd4ce5c13">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
