### PR TITLE
Revert "Domain management i1: enable bulk contact info editing in production"

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -58,7 +58,7 @@
 		"domains/kracken-ui/max-characters-filter": false,
 		"domains/kracken-ui/pagination": true,
 		"domains/bulk-actions-table": true,
-		"domains/bulk-actions-contact-info-editing": true,
+		"domains/bulk-actions-contact-info-editing": false,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"domains/transfer-to-any-user": true,

--- a/config/production.json
+++ b/config/production.json
@@ -39,7 +39,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/bulk-actions-table": true,
-		"domains/bulk-actions-contact-info-editing": true,
+		"domains/bulk-actions-contact-info-editing": false,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -37,7 +37,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/bulk-actions-table": true,
-		"domains/bulk-actions-contact-info-editing": true,
+		"domains/bulk-actions-contact-info-editing": false,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,

--- a/config/test.json
+++ b/config/test.json
@@ -39,7 +39,7 @@
 		"devdocs/redirect-loggedout-homepage": true,
 		"difm/allow-extra-pages": false,
 		"domains/bulk-actions-table": true,
-		"domains/bulk-actions-contact-info-editing": true,
+		"domains/bulk-actions-contact-info-editing": false,
 		"cookie-banner": false,
 		"google-my-business": false,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -42,7 +42,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/bulk-actions-table": true,
-		"domains/bulk-actions-contact-info-editing": true,
+		"domains/bulk-actions-contact-info-editing": false,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#81964

It was merged too early. Need to wait on https://github.com/Automattic/wp-calypso/pull/81978