### PR TITLE
Domain transfers: Receive flow - Add form submission handling

### DIFF
--- a/client/data/domains/transfers/use-domain-transfer-receive.ts
+++ b/client/data/domains/transfers/use-domain-transfer-receive.ts
@@ -19,10 +19,15 @@ export type TransferInfo = {
 	termsAccepted: boolean;
 };
 
+export type DomainsReceiveTransferResponse = {
+	success: boolean;
+	domain: string;
+};
+
 export function useDomainTransferReceive(
 	domainName: string,
 	queryOptions: {
-		onSuccess?: () => void;
+		onSuccess?: ( data: DomainsReceiveTransferResponse ) => void;
 		onError?: ( error: DomainsApiError ) => void;
 	}
 ) {
@@ -44,8 +49,8 @@ export function useDomainTransferReceive(
 				terms_accepted: info.termsAccepted,
 			} ),
 		...queryOptions,
-		onSuccess() {
-			queryOptions.onSuccess?.();
+		onSuccess( data: DomainsReceiveTransferResponse ) {
+			queryOptions.onSuccess?.( data );
 		},
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -55,23 +55,60 @@ function ContactInfo( {
 	const dispatch = useDispatch();
 
 	const { domainTransferReceive } = useDomainTransferReceive( domain ?? '', {
-		onSuccess() {
-			dispatch(
-				successNotice(
-					translate( 'Your domain is on its way to you, we’ll email you once it’s set up.' ),
-					{
-						duration: 10000,
-						isPersistent: true,
-					}
-				)
-			);
+		onSuccess( data ) {
+			if ( data.success ) {
+				dispatch(
+					successNotice(
+						translate(
+							'Your domain transfer is underway and will take a few minutes, we’ll email you once it’s set up.'
+						),
+						{
+							duration: 10000,
+							isPersistent: true,
+						}
+					)
+				);
+			} else {
+				dispatch(
+					errorNotice(
+						translate( 'Domain transfers are currently unavailable, please try again later.' ),
+						{
+							duration: 10000,
+						}
+					)
+				);
+			}
 		},
-		onError() {
-			dispatch(
-				errorNotice( translate( 'An error occurred while transferring the domain.' ), {
-					duration: 5000,
-				} )
-			);
+		onError( error ) {
+			if ( error.error === 'authorization_required' ) {
+				dispatch(
+					errorNotice(
+						translate(
+							'The receiving user’s email address must match the email address of the domain receipient.'
+						),
+						{
+							duration: 10000,
+						}
+					)
+				);
+			} else if ( error.error === 'invite_expired' ) {
+				dispatch(
+					errorNotice(
+						translate(
+							'The domain transfer invitation is no longer valid, please ask the domain owner to request a new transfer.'
+						),
+						{
+							duration: 10000,
+						}
+					)
+				);
+			} else {
+				dispatch(
+					errorNotice( translate( 'An error occurred while transferring the domain.' ), {
+						duration: 10000,
+					} )
+				);
+			}
 		},
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
@@ -97,4 +97,10 @@ $heading-font-family: "SF Pro Display", $sans;
 			margin: 0 0 0 1em;
 		}
 	}
+
+	.domain-contact-info__success {
+		display: flex;
+		justify-content: center;
+		margin-top: 2em;
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3846

## Proposed Changes

* Add form submission
* Improve error handling and notice messaging based on changes in D122612-code (merged)

## Testing Instructions

* Create a domain transfer as a sending user
* Attempt to receive the domain transfer as some other user
* Receive the domain transfer as the receiving user

Before (Single page and notice)
![Screenshot 2023-09-21 at 13-17-41 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/afb6249c-58d5-4497-844e-aa9083e29843)


After (two stages)

Updated title / subheading to be more about domain transfers and less about contact info - users show up here after clicking a link to accept a domain transfer.

![Screenshot 2023-09-21 at 14-18-04 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/3d88ec83-20e4-4dfc-9d1e-57e394bb031e)

A successful form submission now shows this heading and button combo with animated confetti. I could use some design help here but it's good enough to ship as a v1.
![Screenshot 2023-09-21 at 14-18-08 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/46126468-9520-4899-a7b0-4ee596ab82f2)

Errors remain on the first stage:
(old titles, but the errors are the same)

![Screenshot 2023-09-21 at 13-03-37 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/f678b9f6-4787-4b0f-b147-7827bca756a2)
![Screenshot 2023-09-21 at 13-02-26 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/724d43f9-42e4-42fa-8495-9427b283fe67)
![Screenshot 2023-09-21 at 13-01-11 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/c823d121-73e1-44f6-b07f-45f17fd97782)


