### PR TITLE
Remove the domains/transfer-to-any-user config flag

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Card, Spinner } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
@@ -140,7 +139,6 @@ const TransferPage = ( props: TransferPageProps ) => {
 				/>
 			);
 		} else if (
-			isEnabled( 'domains/transfer-to-any-user' ) &&
 			! [ 'uk', 'fr', 'ca', 'de', 'jp' ].includes( getTopLevelOfTld( selectedDomainName ) )
 		) {
 			options.push(

--- a/config/development.json
+++ b/config/development.json
@@ -61,7 +61,6 @@
 		"domains/bulk-actions-contact-info-editing": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"domains/transfer-to-any-user": true,
 		"email-accounts/enabled": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -40,7 +40,6 @@
 		"domains/bulk-actions-contact-info-editing": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"domains/transfer-to-any-user": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3847
Fixes https://github.com/Automattic/dotcom-forge/issues/3509

## Proposed Changes

* Removes the config flag `domains/transfer-to-any-user` and usage, effectively enabling (for all users) domain transfers between users for domain only sites.

## Testing Instructions

* Using an account with a domain only site / domain.
* You should now have this transfer option available on production, where previously it was only available on development or behind the feature flag.

![Screenshot(9)](https://github.com/Automattic/wp-calypso/assets/811776/6d24e7a4-bd58-4af5-b30d-c9f1cd6e59c6)



