### PR TITLE
Jetpack Manage: Update the blank state for the Boost card in the expandable block

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -43,17 +43,25 @@ export default function BoostSitePerformance( {
 
 	const href = `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`;
 
+	const isEnabled = !! hasBoost;
+
+	const handleOnClick = () => {
+		// TODO - should open a modal.
+	};
+
 	return (
 		<ExpandedCard
 			header={ translate( 'Boost site performance' ) }
-			isEnabled={ !! hasBoost }
+			isEnabled={ isEnabled }
 			emptyContent={ translate(
-				'Add {{strong}}Boost{{/strong}} to see your site performance scores',
+				'{{strong}}Get Score{{/strong}} to see your site performance scores',
 				{
 					components,
 				}
 			) }
 			hasError={ hasError }
+			// Allow to click on the card only if Boost is not active
+			onClick={ ! isEnabled ? handleOnClick : undefined }
 		>
 			<div className="site-expanded-content__card-content-container">
 				<div className="site-expanded-content__card-content">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
@@ -55,7 +55,7 @@ describe( 'BoostSitePerformance', () => {
 
 		const emptyContent = screen.getByText( /see your site performance scores/i );
 		expect( emptyContent ).toBeInTheDocument();
-		const strongTag = screen.getByText( /Boost/i );
+		const strongTag = screen.getByText( /get score/i );
 		expect( strongTag ).toHaveStyle( 'font-weight: bold' );
 	} );
 


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-genesis/issues/29

## Proposed Changes

This PR updates the blank state for the Boost card in the expandable block.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Run `git checkout update/blank-state-for-boost-in-expandable-block` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Expand the site where Boost is not enabled.
4. Verify that the Boost card now shows the text as shown below (this might change based on the updated design)

<img width="370" alt="Screenshot 2023-09-21 at 10 43 32 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/76f584bc-7f8b-492b-bd67-8c66a2c1dafa">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?