### PR TITLE
Jetpack Manage: Fix issues with Dashboard columns misalignment and button text wrap.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -13,7 +13,7 @@
 
 	.sites-overview__row-text {
 		margin-inline-start: 32px;
-		width: calc(100% - 55px);
+		width: calc(100% - 30px);
 		font-size: 0.875rem !important;
 	}
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -154,6 +154,7 @@
 	border: 1px solid var(--studio-gray-5);
 	padding: 2px 11px;
 	cursor: pointer;
+	white-space: nowrap;
 
 	span {
 		margin: 0 0.2em;
@@ -250,7 +251,7 @@
 .fixed-host-column {
 	display: none;
 	margin-inline-end: 10px;
-	width: 40px;
+	min-width: 40px;
 	text-align: center;
 
 	.wordpress-logo {


### PR DESCRIPTION
This PR fixes multiple issues w/ the Dashboard columns. 

* **issue # 1** - The Host column needs to be aligned when there are long site names.
<img width="254" alt="Screen Shot 2023-09-21 at 3 29 41 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/8d2f6998-e191-46f4-ab09-5d0762e50d8a">

* **issue # 2** - When the site name is long, the Fade effect is not visible.
<img width="476" alt="Screen Shot 2023-09-21 at 3 30 54 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/78d215cb-4662-40fd-94e9-fc6d31130d98">

* **issue # 3** - When screen is smaller. The Boost column buttons' text is wrapping.
<img width="309" alt="Screen Shot 2023-09-21 at 3 32 21 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/946e3aef-adee-40dc-b278-7cc02a74ec1e">


## Proposed Changes

* Update the Host column so it has a minimum width of 40px. This ensures that the column retains its alignment even with long site names.
* Update the site name container so it spans `(100% - 30px)` width instead of `(100% -55px)`. This increases the maximum length of the container, allowing it to naturally reach the edge of the column and overlap with the fade overlay element.
* Set the CTA button's `white-space` to `nowrap` in the Boost column.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack cloud live link below and goto `/dashboard?flags=jetpack/pro-dashboard-wpcom-atomic-hosting,jetpack/pro-dashboard-jetpack-boost`.
* Set your browser's zoom level to **125%**.
* Confirm that the **Host** column is no longer misaligned.
<img width="378" alt="Screen Shot 2023-09-21 at 3 42 27 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/892b04bf-fb2c-41ec-90f0-255480b97dbc">

* Confirm that the fade effect is visible for long site names.
<img width="284" alt="Screen Shot 2023-09-21 at 3 43 59 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9b857ab6-4684-47ad-9e11-bd8dffacb5e6">

* Confirm that the Boost column's button no longer splits into two lines.

<img width="430" alt="Screen Shot 2023-09-21 at 3 43 03 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/98303016-e26f-4f4a-b146-61d6cb65270b">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
