### PR TITLE
Newsletter Categories: Enable settings for all simple sites and blogs with specific sticker.

### DIFF
--- a/client/data/newsletter-categories/index.ts
+++ b/client/data/newsletter-categories/index.ts
@@ -1,5 +1,5 @@
 export { default as useCategoriesQuery } from './use-categories-query';
-export { default as useNewsletterCategoriesFeatureEnabled } from './use-newsletter-categories-feature-enabled';
+export { default as useNewsletterCategoriesBlogSticker } from './use-newsletter-categories-blog-sticker';
 export { default as useNewsletterCategoriesQuery } from './use-newsletter-categories-query';
 export { default as useMarkAsNewsletterCategoryMutation } from './use-mark-as-newsletter-category-mutation';
 export { default as useUnmarkAsNewsletterCategoryMutation } from './use-unmark-as-newsletter-category-mutation';

--- a/client/data/newsletter-categories/test/use-newsletter-categories-feature-enabled.tsx
+++ b/client/data/newsletter-categories/test/use-newsletter-categories-feature-enabled.tsx
@@ -4,15 +4,15 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import React from 'react';
+import React, { FC, ReactNode } from 'react';
 import request from 'wpcom-proxy-request';
-import useNewsletterCategoriesFeatureEnabled from '../use-newsletter-categories-feature-enabled';
+import useNewsletterCategoriesBlogSticker from '../use-newsletter-categories-blog-sticker';
 
 jest.mock( 'wpcom-proxy-request', () => jest.fn() );
 
-describe( 'useNewsletterCategoriesFeatureEnabled', () => {
+describe( 'useNewsletterCategoriesBlogSticker', () => {
 	let queryClient: QueryClient;
-	let wrapper: any;
+	let wrapper: FC< { children: ReactNode } >;
 
 	beforeEach( () => {
 		( request as jest.MockedFunction< typeof request > ).mockReset();
@@ -40,7 +40,7 @@ describe( 'useNewsletterCategoriesFeatureEnabled', () => {
 			'some-other-category',
 		] );
 
-		const { result } = renderHook( () => useNewsletterCategoriesFeatureEnabled( { siteId: 123 } ), {
+		const { result } = renderHook( () => useNewsletterCategoriesBlogSticker( { siteId: 123 } ), {
 			wrapper,
 		} );
 
@@ -54,7 +54,7 @@ describe( 'useNewsletterCategoriesFeatureEnabled', () => {
 			'some-other-category',
 		] );
 
-		const { result } = renderHook( () => useNewsletterCategoriesFeatureEnabled( { siteId: 123 } ), {
+		const { result } = renderHook( () => useNewsletterCategoriesBlogSticker( { siteId: 123 } ), {
 			wrapper,
 		} );
 

--- a/client/data/newsletter-categories/use-newsletter-categories-blog-sticker.ts
+++ b/client/data/newsletter-categories/use-newsletter-categories-blog-sticker.ts
@@ -1,13 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import request from 'wpcom-proxy-request';
 
-type useNewsletterCategoriesBlogStickerProps = {
+type UseNewsletterCategoriesBlogStickerProps = {
 	siteId?: number | null;
 };
 
 const useNewsletterCategoriesBlogSticker = ( {
 	siteId,
-}: useNewsletterCategoriesBlogStickerProps ): boolean => {
+}: UseNewsletterCategoriesBlogStickerProps ): boolean => {
 	const { data } = useQuery< string[] >( {
 		queryKey: [ 'blog-stickers', siteId ],
 		queryFn: () => request( { path: `/sites/${ siteId }/blog-stickers` } ),

--- a/client/data/newsletter-categories/use-newsletter-categories-blog-sticker.ts
+++ b/client/data/newsletter-categories/use-newsletter-categories-blog-sticker.ts
@@ -1,13 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import request from 'wpcom-proxy-request';
 
-type useNewsletterCategoriesFeatureEnabledProps = {
-	siteId?: string | number;
+type useNewsletterCategoriesBlogStickerProps = {
+	siteId?: number | null;
 };
 
-const useNewsletterCategoriesFeatureEnabled = ( {
+const useNewsletterCategoriesBlogSticker = ( {
 	siteId,
-}: useNewsletterCategoriesFeatureEnabledProps ): boolean => {
+}: useNewsletterCategoriesBlogStickerProps ): boolean => {
 	const { data } = useQuery< string[] >( {
 		queryKey: [ 'blog-stickers', siteId ],
 		queryFn: () => request( { path: `/sites/${ siteId }/blog-stickers` } ),
@@ -17,4 +17,4 @@ const useNewsletterCategoriesFeatureEnabled = ( {
 	return data ? data.includes( 'newsletter-categories' ) : false;
 };
 
-export default useNewsletterCategoriesFeatureEnabled;
+export default useNewsletterCategoriesBlogSticker;

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -2,10 +2,11 @@ import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
-import { useNewsletterCategoriesFeatureEnabled } from 'calypso/data/newsletter-categories';
+import { useNewsletterCategoriesBlogSticker } from 'calypso/data/newsletter-categories';
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { useSelector } from 'calypso/state';
+import { isSimpleSite as isSimpleSiteSelector } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { NewsletterCategoriesSettings } from '../newsletter-categories-settings';
 import { SubscriptionOptions } from '../settings-reading/main';
@@ -51,7 +52,8 @@ export const NewsletterSettingsSection = ( {
 		subscription_options,
 		sm_enabled,
 	} = fields;
-	const siteId = useSelector( getSelectedSiteId ) as number;
+	const siteId = useSelector( getSelectedSiteId );
+	const isSimpleSite = useSelector( isSimpleSiteSelector );
 
 	// Update subscription_options form fields when savedSubscriptionOptions changes.
 	// This makes sure the form fields hold the current value after saving.
@@ -60,21 +62,22 @@ export const NewsletterSettingsSection = ( {
 
 		// If the URL has a hash, scroll to it.
 		scrollToAnchor( { offset: 15 } );
-	}, [ savedSubscriptionOptions ] );
+	}, [ savedSubscriptionOptions, updateFields ] );
 
-	const newsletterCategoriesEnabled = useNewsletterCategoriesFeatureEnabled( { siteId } );
+	const hasNewsletterCategoriesBlogSticker = useNewsletterCategoriesBlogSticker( { siteId } );
 
 	return (
 		<>
-			{ config.isEnabled( 'settings/newsletter-categories' ) && newsletterCategoriesEnabled && (
-				<Card className="site-settings__card">
-					<NewsletterCategoriesSettings
-						disabled={ disabled }
-						handleAutosavingToggle={ handleAutosavingToggle }
-						toggleValue={ wpcom_newsletter_categories_enabled }
-					/>
-				</Card>
-			) }
+			{ config.isEnabled( 'settings/newsletter-categories' ) &&
+				( isSimpleSite || hasNewsletterCategoriesBlogSticker ) && (
+					<Card className="site-settings__card">
+						<NewsletterCategoriesSettings
+							disabled={ disabled }
+							handleAutosavingToggle={ handleAutosavingToggle }
+							toggleValue={ wpcom_newsletter_categories_enabled }
+						/>
+					</Card>
+				) }
 			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
 			<SettingsSectionHeader
 				id="newsletter-settings"

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -139,6 +139,7 @@
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
+		"settings/newsletter-categories": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Display the newsletter categories settings for all simple sites (still behind the `settings/newsletter-categories` feature flag)
* Rename the `useNewsletterCategoriesFeatureEnabled` to  `hasNewsletterCategoriesBlogSticker`, so it is more descriptive
* Adjust the type of `UseNewsletterCategoriesBlogStickerProps`
* Enable the `settings/newsletter-categories` feature in `wpcalypso` env. It should have been done so already, when the feature was being enabled in `stage` env.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the PR branch to your Calypso env
* Test in an environment where the `settings/newsletter-categories` feature flag is enabled. At the moment of creating this PR it needs to be at least the `stage` environment. 

* Go to `/settings/newsletter/$simple-site-slug-without-blog-sticker`
* The newsletter categories settings **should be present**

* Go to `/settings/newsletter/$simple-site-slug-with-blog-sticker`
* The newsletter categories settings **should be present**

* Go to `/settings/newsletter/$atomic-site-slug-without-blog-sticker`
* The newsletter categories settings **should not be present**

* Go to `/settings/newsletter/$atomic-site-slug-with-blog-sticker`
* The newsletter categories settings **should be present**

* Go to `/settings/newsletter/$jetpack-connected-site-slug-without-blog-sticker`
* The newsletter categories settings **should not be present**

* Go to `/settings/newsletter/$jetpack-connected-site-slug-with-blog-sticker`
* The newsletter categories settings **should be present**

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?