### PR TITLE
Update SiteDetails.options type to account for undefined

### DIFF
--- a/client/lib/media/utils/can-use-videopress.js
+++ b/client/lib/media/utils/can-use-videopress.js
@@ -1,7 +1,6 @@
 /**
  * Returns whether a site can use VideoPress.
- *
- * @param {Object} site Site object
+ * @param {import('@automattic/data-stores').SiteDetails} site Site object
  * @returns {boolean}
  */
 export function canUseVideoPress( site ) {
@@ -9,7 +8,9 @@ export function canUseVideoPress( site ) {
 	const isVideoPressEnabled = site.options && site.options.videopress_enabled;
 	const isVideoPressModuleActive =
 		! isSiteJetpack ||
-		( site.options.active_modules && site.options.active_modules.includes( 'videopress' ) );
+		( site.options &&
+			site.options.active_modules &&
+			site.options.active_modules.includes( 'videopress' ) );
 
 	return isVideoPressEnabled || isVideoPressModuleActive;
 }

--- a/client/lib/media/utils/can-use-videopress.js
+++ b/client/lib/media/utils/can-use-videopress.js
@@ -1,3 +1,5 @@
+import { isModuleActive } from 'calypso/lib/site/utils';
+
 /**
  * Returns whether a site can use VideoPress.
  * @param {import('@automattic/data-stores').SiteDetails} site Site object
@@ -5,12 +7,8 @@
  */
 export function canUseVideoPress( site ) {
 	const isSiteJetpack = !! site.jetpack;
-	const isVideoPressEnabled = site.options && site.options.videopress_enabled;
-	const isVideoPressModuleActive =
-		! isSiteJetpack ||
-		( site.options &&
-			site.options.active_modules &&
-			site.options.active_modules.includes( 'videopress' ) );
+	const isVideoPressEnabled = site.options?.videopress_enabled ?? false;
+	const isVideoPressModuleActive = ! isSiteJetpack || isModuleActive( site, 'videopress' );
 
 	return isVideoPressEnabled || isVideoPressModuleActive;
 }

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -103,11 +103,7 @@ export function hasCustomDomain( site ) {
 }
 
 export function isModuleActive( site, moduleId ) {
-	return (
-		site.options &&
-		site.options.active_modules &&
-		site.options.active_modules.indexOf( moduleId ) > -1
-	);
+	return site.options?.active_modules?.includes( moduleId );
 }
 
 /**

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -8,7 +8,6 @@ export function userCan( capability, site ) {
 
 /**
  * site's timezone getter
- *
  * @param   {Object} site - site object
  * @returns {string} timezone
  */
@@ -18,7 +17,6 @@ export function timezone( site ) {
 
 /**
  * site's gmt_offset getter
- *
  * @param   {Object} site - site object
  * @returns {string} gmt_offset
  */
@@ -93,7 +91,6 @@ export function isMainNetworkSite( site ) {
 
 /**
  * Checks whether a site has a custom mapped URL.
- *
  * @param   {undefined|null|{domain?: string; wpcom_url?: string}}   site Site object
  * @returns {boolean|null}      Whether site has custom domain
  */
@@ -106,12 +103,15 @@ export function hasCustomDomain( site ) {
 }
 
 export function isModuleActive( site, moduleId ) {
-	return site.options.active_modules && site.options.active_modules.indexOf( moduleId ) > -1;
+	return (
+		site.options &&
+		site.options.active_modules &&
+		site.options.active_modules.indexOf( moduleId ) > -1
+	);
 }
 
 /**
  * Returns the WordPress.com URL of a site (simple or Atomic)
- *
  * @param {Object} site Site object
  * @returns {?string} WordPress.com URL
  */
@@ -126,7 +126,6 @@ export function getUnmappedUrl( site ) {
 /**
  * Returns a filtered array of WordPress.com site IDs where a Jetpack site
  * exists in the set of sites with the same URL.
- *
  * @param {Array} siteList Array of site objects
  * @returns {number[]} Array of site IDs with URL collisions
  */

--- a/client/me/notification-settings/blogs-settings/blog.jsx
+++ b/client/me/notification-settings/blogs-settings/blog.jsx
@@ -70,7 +70,7 @@ class BlogSettings extends Component {
 			'draft_post_prompt',
 		];
 
-		if ( site.options.woocommerce_is_active ) {
+		if ( site.options?.woocommerce_is_active ) {
 			settingKeys.push( 'store_order' );
 		}
 

--- a/client/my-sites/customer-home/cards/actions/quick-links-for-hosted-sites/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links-for-hosted-sites/index.jsx
@@ -33,7 +33,7 @@ const QuickLinksForHostedSites = ( props ) => {
 	const currentSitePlanSlug = useSelector( ( state ) => getSitePlanSlug( state, siteId ) );
 	const site = useSelector( ( state ) => getSite( state, siteId ) );
 	const hasBackups = getAllFeaturesForPlan( currentSitePlanSlug ).includes( 'backups' );
-	const hasBoost = site?.options.jetpack_connection_active_plugins?.includes( 'jetpack-boost' );
+	const hasBoost = site?.options?.jetpack_connection_active_plugins?.includes( 'jetpack-boost' );
 	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
 
 	const dispatch = useDispatch();

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -85,7 +85,7 @@ export const QuickLinks = ( {
 	const currentSitePlanSlug = useSelector( ( state ) => getSitePlanSlug( state, siteId ) );
 	const site = useSelector( ( state ) => getSite( state, siteId ) );
 	const hasBackups = getAllFeaturesForPlan( currentSitePlanSlug ).includes( 'backups' );
-	const hasBoost = site?.options.jetpack_connection_active_plugins?.includes( 'jetpack-boost' );
+	const hasBoost = site?.options?.jetpack_connection_active_plugins?.includes( 'jetpack-boost' );
 
 	const addNewDomain = () => {
 		sendNudge( {
@@ -428,7 +428,6 @@ export const trackManageAllDomainsAction = ( isStaticHomePage ) => ( dispatch ) 
 /**
  * Select a list of domains that are eligible to add email to from a larger list.
  * WPCOM-specific domains like free and staging sub-domains are filtered from this list courtesy of `canCurrentUserAddEmail`
- *
  * @param domains An array domains to filter
  */
 const getDomainsThatCanAddEmail = ( domains ) =>

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -64,10 +64,10 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 	);
 
 	const canActivateWordadsInstant =
-		! site?.options.wordads && canActivateWordAds && hasWordAdsFeature;
-	const canUpgradeToUseWordAds = ! site?.options.wordads && ! hasWordAdsFeature;
+		! site?.options?.wordads && canActivateWordAds && hasWordAdsFeature;
+	const canUpgradeToUseWordAds = ! site?.options?.wordads && ! hasWordAdsFeature;
 	const isWordadsInstantEligibleButNotOwner =
-		! site?.options.wordads && hasWordAdsFeature && ! canActivateWordAds;
+		! site?.options?.wordads && hasWordAdsFeature && ! canActivateWordAds;
 	const isEnrolledWithIneligiblePlan =
 		site?.options?.wordads && ! hasWordAdsFeature && wordAdsStatus === WordAdsStatus.ineligible;
 
@@ -317,9 +317,9 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 			component = renderUpsell();
 		} else if ( ! canAccessAds ) {
 			component = renderEmptyContent();
-		} else if ( ! site?.options.wordads && ! ( site?.jetpack && canUpgradeToUseWordAds ) ) {
+		} else if ( ! site?.options?.wordads && ! ( site?.jetpack && canUpgradeToUseWordAds ) ) {
 			component = null;
-		} else if ( site.options.wordads && site.is_private ) {
+		} else if ( site.options?.wordads && site.is_private ) {
 			notice = renderNoticeSiteIsPrivate();
 		} else if ( isEnrolledWithIneligiblePlan ) {
 			component = renderContentWithUpsell( component );

--- a/client/my-sites/exporter/section-export.jsx
+++ b/client/my-sites/exporter/section-export.jsx
@@ -35,7 +35,7 @@ const SectionExport = ( { isJetpack, canUserExport, site, translate } ) => {
 				title={ translate( 'Want to export your site?' ) }
 				line={ translate( "Visit your site's wp-admin for all your import and export needs." ) }
 				action={ translate( 'Export %(siteTitle)s', { args: { siteTitle: site.title } } ) }
-				actionURL={ site.options.admin_url + 'export.php' }
+				actionURL={ site.options?.admin_url + 'export.php' }
 				actionTarget="_blank"
 			/>
 		);

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -189,7 +189,7 @@ class SectionImport extends Component {
 	renderIdleImporters( importerState ) {
 		const { site, siteSlug, siteTitle } = this.props;
 		const importers = getImporters( {
-			isAtomic: site.options.is_wpcom_atomic,
+			isAtomic: site.options?.is_wpcom_atomic,
 			isJetpack: site.jetpack,
 		} );
 
@@ -212,7 +212,7 @@ class SectionImport extends Component {
 					siteSlug={ siteSlug }
 					siteTitle={ siteTitle }
 					importerStatus={ importerStatus }
-					isAtomic={ site.options.is_wpcom_atomic }
+					isAtomic={ site.options?.is_wpcom_atomic }
 					isJetpack={ site.jetpack }
 				/>
 			);
@@ -222,7 +222,7 @@ class SectionImport extends Component {
 		return (
 			<>
 				{ importerElements }
-				<CompactCard href={ site.options.admin_url + 'import.php' }>
+				<CompactCard href={ site.options?.admin_url + 'import.php' }>
 					{ this.props.translate( 'Choose from full list' ) }
 				</CompactCard>
 			</>

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -125,10 +125,7 @@ class MediaLibrary extends Component {
 
 		switch ( filter ) {
 			case 'audio':
-				return ! (
-					( site && site.options && site.options.upgraded_filetypes_enabled ) ||
-					isJetpack
-				);
+				return ! ( site?.options?.upgraded_filetypes_enabled || isJetpack );
 
 			case 'videos':
 				return ! hasVideoUploadFeature;

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -125,7 +125,10 @@ class MediaLibrary extends Component {
 
 		switch ( filter ) {
 			case 'audio':
-				return ! ( ( site && site.options.upgraded_filetypes_enabled ) || isJetpack );
+				return ! (
+					( site && site.options && site.options.upgraded_filetypes_enabled ) ||
+					isJetpack
+				);
 
 			case 'videos':
 				return ! hasVideoUploadFeature;

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -197,7 +197,7 @@ class PlansSetup extends Component {
 			this.trackConfigFinished( 'calypso_plans_autoconfig_error', {
 				error: 'secondary_network_site',
 			} );
-		} else if ( site.options.is_multi_network ) {
+		} else if ( site.options && site.options.is_multi_network ) {
 			reason = translate( "We can't install plugins on multi-network sites." );
 			this.trackConfigFinished( 'calypso_plans_autoconfig_error', {
 				error: 'multinetwork',

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -197,7 +197,7 @@ class PlansSetup extends Component {
 			this.trackConfigFinished( 'calypso_plans_autoconfig_error', {
 				error: 'secondary_network_site',
 			} );
-		} else if ( site.options && site.options.is_multi_network ) {
+		} else if ( site.options?.is_multi_network ) {
 			reason = translate( "We can't install plugins on multi-network sites." );
 			this.trackConfigFinished( 'calypso_plans_autoconfig_error', {
 				error: 'multinetwork',

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -81,7 +81,7 @@ export class PluginAutoUpdateToggle extends Component {
 			);
 		}
 
-		if ( ! site ) {
+		if ( ! site || ! site.options ) {
 			// we don't have enough info
 			return null;
 		}

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -62,7 +62,7 @@ class PluginRemoveButton extends Component {
 	};
 
 	getDisabledInfo = () => {
-		if ( ! this.props.site ) {
+		if ( ! this.props.site || ! this.props.site.options ) {
 			// we don't have enough info
 			return null;
 		}

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -62,7 +62,7 @@ class PreviewMain extends Component {
 	}
 
 	updateUrl() {
-		if ( ! this.props.site ) {
+		if ( ! this.props.site || ! this.props.site.options ) {
 			if ( this.state.previewUrl !== null ) {
 				debug( 'unloaded page' );
 				this.setState( {

--- a/client/my-sites/site-indicator/index.jsx
+++ b/client/my-sites/site-indicator/index.jsx
@@ -136,7 +136,7 @@ export class SiteIndicator extends Component {
 			<span>
 				<WPAdminLink
 					onClick={ this.handleGenericUpdate }
-					href={ site.options.admin_url + 'update-core.php' }
+					href={ site.options?.admin_url + 'update-core.php' }
 				>
 					{ translate( 'There is an update available.', 'There are updates available.', {
 						count: siteUpdates.total,

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -54,7 +54,7 @@ class Sites extends Component {
 			if ( site?.is_wpcom_staging_site ) {
 				return false;
 			}
-			return ! site.jetpack || site.options.is_automated_transfer;
+			return ! site.jetpack || site.options?.is_automated_transfer;
 		}
 
 		// If a site is Jetpack, plans are available only when it is upgradeable.
@@ -84,7 +84,6 @@ class Sites extends Component {
 
 	/**
 	 * Get the site path the user is trying to access.
-	 *
 	 * @returns {string} The path.
 	 */
 	getPath() {

--- a/client/signup/steps/site-picker/index.jsx
+++ b/client/signup/steps/site-picker/index.jsx
@@ -17,7 +17,11 @@ class SitePicker extends Component {
 	};
 
 	filterSites = ( site ) => {
-		return site.capabilities.manage_options && ! site.jetpack && ! site.options.is_domain_only;
+		return (
+			site.capabilities.manage_options &&
+			! site.jetpack &&
+			! ( site.options && site.options.is_domain_only )
+		);
 	};
 
 	renderScreen() {

--- a/client/signup/steps/site-picker/index.jsx
+++ b/client/signup/steps/site-picker/index.jsx
@@ -17,11 +17,7 @@ class SitePicker extends Component {
 	};
 
 	filterSites = ( site ) => {
-		return (
-			site.capabilities.manage_options &&
-			! site.jetpack &&
-			! ( site.options && site.options.is_domain_only )
-		);
+		return site.capabilities.manage_options && ! site.jetpack && ! site.options?.is_domain_only;
 	};
 
 	renderScreen() {

--- a/client/sites-dashboard/components/link-in-bio-banner/link-in-bio-banner.tsx
+++ b/client/sites-dashboard/components/link-in-bio-banner/link-in-bio-banner.tsx
@@ -10,8 +10,7 @@ type Props = {
 const hasLinkInBioSite = ( sites: SiteExcerptData[] ) => {
 	return Boolean(
 		sites.find( ( site ) => {
-			const option = site.options || {};
-			return option.site_intent === 'link-in-bio';
+			return site.options?.site_intent === 'link-in-bio';
 		} )
 	);
 };

--- a/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
+++ b/client/sites-dashboard/components/sites-site-item-thumbnail.tsx
@@ -89,7 +89,7 @@ export const SiteItemThumbnail = ( {
 	function renderFallback() {
 		if (
 			site.p2_thumbnail_elements &&
-			site.options.is_wpforteams_site &&
+			site.options?.is_wpforteams_site &&
 			getSiteLaunchStatus( site ) !== 'public'
 		) {
 			return (

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -98,7 +98,7 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 
 	const validSiteIntent =
 		site.options?.launchpad_screen === 'full' &&
-		site.options.site_intent &&
+		site.options?.site_intent &&
 		[ 'link-in-bio' ].includes( site.options.site_intent )
 			? site.options.site_intent
 			: false;

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -97,7 +97,7 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 	}
 
 	const validSiteIntent =
-		site.options.launchpad_screen === 'full' &&
+		site.options?.launchpad_screen === 'full' &&
 		site.options.site_intent &&
 		[ 'link-in-bio' ].includes( site.options.site_intent )
 			? site.options.site_intent

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -565,7 +565,7 @@ export const normalizers = {
 		if ( ! data ) {
 			return null;
 		}
-		const adminUrl = site ? site.options.admin_url : null;
+		const adminUrl = site && site.options ? site.options.admin_url : null;
 
 		let authors = [];
 		if ( data.authors ) {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -565,7 +565,7 @@ export const normalizers = {
 		if ( ! data ) {
 			return null;
 		}
-		const adminUrl = site && site.options ? site.options.admin_url : null;
+		const adminUrl = site?.options?.admin_url ?? null;
 
 		let authors = [];
 		if ( data.authors ) {

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -121,7 +121,7 @@ export interface SiteDetails {
 	locale: string;
 	logo: { id: string; sizes: string[]; url: string };
 	name: string | undefined;
-	options: SiteDetailsOptions;
+	options?: SiteDetailsOptions;
 	p2_thumbnail_elements?: P2ThumbnailElements | null;
 	plan?: SiteDetailsPlan;
 	products?: SiteDetailsPlan[];
@@ -247,7 +247,7 @@ export interface SiteDetailsOptions {
 	is_commercial?: boolean | null;
 }
 
-export type SiteOption = keyof SiteDetails[ 'options' ];
+export type SiteOption = keyof NonNullable< SiteDetails[ 'options' ] >;
 
 export interface SiteError {
 	error: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81791

## Proposed Changes

* Corrects the `SiteDetails.options` type annotation to show it can be undefined.

The `GET /sites/%s` endpoint only returns an options field when the user has the correct permission. Updating the type in Calypso to catch errors before they happen.

I've done an audit of the Calypso code and it mostly took possible `undefined` values into account already. Only a few places needed updating, and luckily they already had an obvious way they should deal with the field being missing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Type errors will be caught during type checking in CI. Also smoke tested:
- customer home for atomic site
- sites dashboard
- earn and advertising dashboards


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?