### PR TITLE
Site profiler: Defined CTA actions and added a few more info at the result screen

### DIFF
--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -27,6 +27,12 @@ export default function DomainInformation( props: Props ) {
 			<h3>Domain information</h3>
 
 			<ul className="domain-information-details result-list">
+				{ whois.domain_name && (
+					<li>
+						<div className="name">Domain name</div>
+						<div>{ whois.domain_name }</div>
+					</li>
+				) }
 				{ whois.registrar && (
 					<li>
 						<div className="name">Registrar</div>

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { useNavigate } from 'react-router-dom';
+import page from 'page';
 import StatusCtaInfo from '../heading-information/status-cta-info';
 import StatusIcon from '../heading-information/status-icon';
 import StatusInfo from '../heading-information/status-info';
@@ -13,19 +13,22 @@ interface Props {
 }
 
 export default function HeadingInformation( props: Props ) {
-	const navigate = useNavigate();
 	const { domain, conversionAction, onCheckAnotherSite } = props;
 
 	const onRegisterDomain = () => {
-		navigate( `/start/domain/domain-only?new=${ domain }&search=yes` );
+		page( `/start/domain/domain-only?new=${ domain }&search=yes` );
 	};
 
 	const onTransferDomain = () => {
-		navigate( `/setup/domain-transfer/intro?new=${ domain }&search=yes` );
+		page( `/setup/domain-transfer/intro?new=${ domain }&search=yes` );
 	};
 
 	const onMigrateSite = () => {
-		navigate( `/setup/import-hosted-site?from=${ domain }` );
+		page( `/setup/import-hosted-site?from=${ domain }` );
+	};
+
+	const onTransferDomainFree = () => {
+		page( `/setup/google-transfer/intro?new=${ domain }` );
 	};
 
 	return (
@@ -50,6 +53,11 @@ export default function HeadingInformation( props: Props ) {
 						conversionAction === 'transfer-domain-hosting' ) && (
 						<Button className="button-action" onClick={ onTransferDomain }>
 							Transfer domain
+						</Button>
+					) }
+					{ conversionAction === 'transfer-google-domain' && (
+						<Button className="button-action" onClick={ onTransferDomainFree }>
+							Transfer domain for free
 						</Button>
 					) }
 					{ conversionAction === 'transfer-hosting' && (

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -55,7 +55,8 @@ export default function HeadingInformation( props: Props ) {
 							Transfer domain
 						</Button>
 					) }
-					{ conversionAction === 'transfer-google-domain' && (
+					{ ( conversionAction === 'transfer-google-domain' ||
+						conversionAction === 'transfer-google-domain-hosting' ) && (
 						<Button className="button-action" onClick={ onTransferDomainFree }>
 							Transfer domain for free
 						</Button>

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@wordpress/components';
+import { useNavigate } from 'react-router-dom';
 import StatusCtaInfo from '../heading-information/status-cta-info';
 import StatusIcon from '../heading-information/status-icon';
 import StatusInfo from '../heading-information/status-info';
@@ -12,7 +13,20 @@ interface Props {
 }
 
 export default function HeadingInformation( props: Props ) {
+	const navigate = useNavigate();
 	const { domain, conversionAction, onCheckAnotherSite } = props;
+
+	const onRegisterDomain = () => {
+		navigate( `/start/domain/domain-only?new=${ domain }&search=yes` );
+	};
+
+	const onTransferDomain = () => {
+		navigate( `/setup/domain-transfer/intro?new=${ domain }&search=yes` );
+	};
+
+	const onMigrateSite = () => {
+		navigate( `/setup/import-hosted-site?from=${ domain }` );
+	};
 
 	return (
 		<div className="heading-information">
@@ -28,14 +42,20 @@ export default function HeadingInformation( props: Props ) {
 				<StatusCtaInfo conversionAction={ conversionAction } />
 				<div className="cta-wrapper">
 					{ conversionAction === 'register-domain' && (
-						<Button className="button-action">Register domain</Button>
+						<Button className="button-action" onClick={ onRegisterDomain }>
+							Register domain
+						</Button>
 					) }
 					{ ( conversionAction === 'transfer-domain' ||
 						conversionAction === 'transfer-domain-hosting' ) && (
-						<Button className="button-action">Transfer domain</Button>
+						<Button className="button-action" onClick={ onTransferDomain }>
+							Transfer domain
+						</Button>
 					) }
 					{ conversionAction === 'transfer-hosting' && (
-						<Button className="button-action">Migrate site</Button>
+						<Button className="button-action" onClick={ onMigrateSite }>
+							Migrate site
+						</Button>
 					) }
 
 					{ onCheckAnotherSite && (

--- a/client/site-profiler/components/heading-information/status-cta-info.tsx
+++ b/client/site-profiler/components/heading-information/status-cta-info.tsx
@@ -22,6 +22,7 @@ export default function StatusCtaInfo( props: Props ) {
 				</p>
 			);
 		case 'transfer-google-domain':
+		case 'transfer-google-domain-hosting':
 			return (
 				<p>
 					If you own this domain, transfer it to <strong>WordPress.com</strong> and benefit from the

--- a/client/site-profiler/components/heading-information/status-cta-info.tsx
+++ b/client/site-profiler/components/heading-information/status-cta-info.tsx
@@ -21,6 +21,16 @@ export default function StatusCtaInfo( props: Props ) {
 					best-performing, most reliable registrar in the business.
 				</p>
 			);
+		case 'transfer-google-domain':
+			return (
+				<p>
+					If you own this domain, transfer it to <strong>WordPress.com</strong> and benefit from the
+					best-performing, most reliable registrar in the business.
+					<br />
+					And because it’s registered with Google Domains{ ' ' }
+					<strong>we’ll pay for an extra year of registration</strong> when you transfer it.
+				</p>
+			);
 		case 'transfer-hosting':
 			return (
 				<p>

--- a/client/site-profiler/components/heading-information/status-icon.tsx
+++ b/client/site-profiler/components/heading-information/status-icon.tsx
@@ -19,6 +19,7 @@ export default function StatusIcon( props: Props ) {
 			case 'transfer-domain':
 			case 'transfer-hosting':
 			case 'transfer-google-domain':
+			case 'transfer-google-domain-hosting':
 			case 'transfer-domain-hosting':
 				setStatusIcon( 'cross' );
 				setStatusColor( 'red' );

--- a/client/site-profiler/components/heading-information/status-icon.tsx
+++ b/client/site-profiler/components/heading-information/status-icon.tsx
@@ -12,7 +12,7 @@ export default function StatusIcon( props: Props ) {
 
 	useEffect( () => {
 		switch ( conversionAction ) {
-			case 'register-domain':
+			case 'idle':
 				setStatusIcon( 'checkmark' );
 				setStatusColor( 'green' );
 				break;
@@ -24,7 +24,7 @@ export default function StatusIcon( props: Props ) {
 				setStatusIcon( 'cross' );
 				setStatusColor( 'red' );
 				break;
-			case 'idle':
+			case 'register-domain':
 			default:
 				setStatusIcon( 'checkmark' );
 				setStatusColor( 'blue' );

--- a/client/site-profiler/components/heading-information/status-icon.tsx
+++ b/client/site-profiler/components/heading-information/status-icon.tsx
@@ -18,6 +18,7 @@ export default function StatusIcon( props: Props ) {
 				break;
 			case 'transfer-domain':
 			case 'transfer-hosting':
+			case 'transfer-google-domain':
 			case 'transfer-domain-hosting':
 				setStatusIcon( 'cross' );
 				setStatusColor( 'red' );

--- a/client/site-profiler/components/heading-information/status-info.tsx
+++ b/client/site-profiler/components/heading-information/status-info.tsx
@@ -8,7 +8,7 @@ export default function StatusInfo( props: Props ) {
 
 	switch ( conversionAction ) {
 		case 'register-domain':
-			return <p>Nice! This site and its domain are fully hosted on WordPress.com!</p>;
+			return <p>Nice find! This site is available and could be yours today!</p>;
 		case 'transfer-domain':
 		case 'transfer-google-domain':
 			return (

--- a/client/site-profiler/components/heading-information/status-info.tsx
+++ b/client/site-profiler/components/heading-information/status-info.tsx
@@ -10,6 +10,7 @@ export default function StatusInfo( props: Props ) {
 		case 'register-domain':
 			return <p>Nice! This site and its domain are fully hosted on WordPress.com!</p>;
 		case 'transfer-domain':
+		case 'transfer-google-domain':
 			return (
 				<p>
 					This site is hosted on <strong>WordPress.com</strong> but the domain is registered
@@ -24,6 +25,7 @@ export default function StatusInfo( props: Props ) {
 				</p>
 			);
 		case 'transfer-domain-hosting':
+		case 'transfer-google-domain-hosting':
 			return (
 				<p>
 					The hosting and domain of this site are not on <strong>WordPress.com</strong>, but they

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -37,12 +37,22 @@ export default function HostingInformation( props: Props ) {
 				) }
 				<li>
 					<div className="name">A Records</div>
-					<div>
+					<div className="col">
 						<ul>
 							{ aRecordIps.map( ( x, i ) => (
-								<li key={ i } className="col-container">
-									<div className="col">{ x.host }</div>
-									<div className="col">{ x.ip }</div>
+								<li key={ i }>
+									{ ! x.host && '-' }
+									{ x.host && `${ x.host }` }
+								</li>
+							) ) }
+						</ul>
+					</div>
+					<div className="col">
+						<ul>
+							{ aRecordIps.map( ( x, i ) => (
+								<li key={ i }>
+									{ ! x.ip && '-' }
+									{ x.ip && `${ x.ip }` }
 								</li>
 							) ) }
 						</ul>

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -40,7 +40,10 @@ export default function HostingInformation( props: Props ) {
 					<div>
 						<ul>
 							{ aRecordIps.map( ( x, i ) => (
-								<li key={ i }>{ x.ip }</li>
+								<li key={ i } className="col-container">
+									<div className="col">{ x.host }</div>
+									<div className="col">{ x.ip }</div>
+								</li>
 							) ) }
 						</ul>
 					</div>

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -22,8 +22,8 @@ export default function SiteProfiler() {
 	const { data: hostingProviderData } = useHostingProviderQuery( domain );
 	const conversionAction = useDefineConversionAction(
 		domain,
+		data?.whois,
 		data?.is_domain_available,
-		data?.whois.registrar,
 		hostingProviderData?.hosting_provider
 	);
 

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -85,11 +85,6 @@
 			}
 		}
 
-		.col-container {
-			display: flex;
-			gap: 2rem;
-		}
-
 		.col {
 			max-width: 300px;
 		}

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -85,6 +85,11 @@
 			}
 		}
 
+		.col-container {
+			display: flex;
+			gap: 2rem;
+		}
+
 		.col {
 			max-width: 300px;
 		}

--- a/client/site-profiler/hooks/use-define-conversion-action.ts
+++ b/client/site-profiler/hooks/use-define-conversion-action.ts
@@ -4,6 +4,7 @@ export type CONVERSION_ACTION =
 	| 'register-domain'
 	| 'transfer-domain'
 	| 'transfer-google-domain'
+	| 'transfer-google-domain-hosting'
 	| 'transfer-hosting'
 	| 'transfer-domain-hosting'
 	| 'idle';
@@ -29,8 +30,10 @@ export default function useDefineConversionAction(
 		return 'register-domain';
 	} else if ( isA8cDomain && ! isA8cHosting ) {
 		return 'transfer-hosting';
-	} else if ( ! isA8cDomain && isGoogleRegistrar ) {
+	} else if ( ! isA8cDomain && isGoogleRegistrar && isA8cHosting ) {
 		return 'transfer-google-domain';
+	} else if ( ! isA8cDomain && isGoogleRegistrar && ! isA8cHosting ) {
+		return 'transfer-google-domain-hosting';
 	} else if ( ! isA8cDomain && isA8cHosting ) {
 		return 'transfer-domain';
 	} else if ( ! isA8cDomain && ! isA8cHosting ) {

--- a/client/site-profiler/hooks/use-define-conversion-action.ts
+++ b/client/site-profiler/hooks/use-define-conversion-action.ts
@@ -17,11 +17,11 @@ export default function useDefineConversionAction(
 ): CONVERSION_ACTION | undefined {
 	const isWpDomain = domain.toLowerCase().includes( 'wordpress.com' );
 	const isWpAtomicDomain = domain.toLowerCase().includes( 'wpcomstaging.com' );
-	const isA8cRegistrar = whois?.registrar.toLowerCase().includes( 'automattic' );
+	const isA8cRegistrar = whois?.registrar?.toLowerCase().includes( 'automattic' );
 	const isGoogleRegistrar =
-		whois?.registrar.toLowerCase().includes( 'google' ) ||
-		whois?.registrar_whois_server.toLowerCase().includes( 'google' ) ||
-		whois?.registrant_organization.toLowerCase().includes( 'google' );
+		whois?.registrar?.toLowerCase().includes( 'google' ) ||
+		whois?.registrar_whois_server?.toLowerCase().includes( 'google' ) ||
+		whois?.registrant_organization?.toLowerCase().includes( 'google' );
 
 	const isA8cDomain = isA8cRegistrar || isWpDomain || isWpAtomicDomain;
 	const isA8cHosting = hostingProvider?.slug === 'automattic';

--- a/client/site-profiler/hooks/use-define-conversion-action.ts
+++ b/client/site-profiler/hooks/use-define-conversion-action.ts
@@ -1,21 +1,26 @@
-import type { HostingProvider } from 'calypso/data/site-profiler/types';
+import type { HostingProvider, WhoIs } from 'calypso/data/site-profiler/types';
 
 export type CONVERSION_ACTION =
 	| 'register-domain'
 	| 'transfer-domain'
+	| 'transfer-google-domain'
 	| 'transfer-hosting'
 	| 'transfer-domain-hosting'
 	| 'idle';
 
 export default function useDefineConversionAction(
 	domain: string,
+	whois?: WhoIs,
 	isDomainAvailable?: boolean,
-	registrar = '',
 	hostingProvider?: HostingProvider
 ): CONVERSION_ACTION | undefined {
 	const isWpDomain = domain.toLowerCase().includes( 'wordpress.com' );
 	const isWpAtomicDomain = domain.toLowerCase().includes( 'wpcomstaging.com' );
-	const isA8cRegistrar = registrar.toLowerCase().includes( 'automattic' );
+	const isA8cRegistrar = whois?.registrar.toLowerCase().includes( 'automattic' );
+	const isGoogleRegistrar =
+		whois?.registrar.toLowerCase().includes( 'google' ) ||
+		whois?.registrar_whois_server.toLowerCase().includes( 'google' ) ||
+		whois?.registrant_organization.toLowerCase().includes( 'google' );
 
 	const isA8cDomain = isA8cRegistrar || isWpDomain || isWpAtomicDomain;
 	const isA8cHosting = hostingProvider?.slug === 'automattic';
@@ -24,6 +29,8 @@ export default function useDefineConversionAction(
 		return 'register-domain';
 	} else if ( isA8cDomain && ! isA8cHosting ) {
 		return 'transfer-hosting';
+	} else if ( ! isA8cDomain && isGoogleRegistrar ) {
+		return 'transfer-google-domain';
 	} else if ( ! isA8cDomain && isA8cHosting ) {
 		return 'transfer-domain';
 	} else if ( ! isA8cDomain && ! isA8cHosting ) {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82001
Closes https://github.com/Automattic/wp-calypso/issues/82002
Closes https://github.com/Automattic/wp-calypso/issues/81950

## Proposed Changes

* Added domain name value as a first row of the "Domain Information" block
* A Records section: Added `host` value next to the `ip`
* Handled CTAs for different use cases

## Testing Instructions

- Go to `/site-profiler`
- Enter any domain
- See "Hosting information" block and check if there is 'host' data next to the 'ip' (screenshot 1)
- See "Domain information" block and check if there is a new 'Domain name' row (screenshot 2)
- Click "Check another site" and enter domain registered by Google domains
- See the "Heading information" block and check the info provided and CTA 'Transfer domain for free' (screenshot 3)
- Check "Heading information" block CTAs for each use case (register domain, transfer domain, and transfer for free)

**1. Domain name row:**
<img width="596" alt="Screenshot 2023-09-21 at 13 37 36" src="https://github.com/Automattic/wp-calypso/assets/1241413/323103f3-7edc-467d-82be-508b27aaa6c9">

**2. A records: domain host next to the ip**
<img width="551" alt="Screenshot 2023-09-21 at 13 58 36" src="https://github.com/Automattic/wp-calypso/assets/1241413/331b3763-e6b8-45bf-8493-94993e4736d6">

**3. Google domain CTAs**
<img width="1275" alt="Screenshot 2023-09-21 at 21 17 03" src="https://github.com/Automattic/wp-calypso/assets/1241413/68ff3c09-358c-46ca-b7ed-a8a2026bec94">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?