### PR TITLE
Reader: Hide border on desktop

### DIFF
--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -11,12 +11,8 @@
 }
 
 .reader__content .tag-stream__header {
-	border-bottom: 1px solid #e9e9ea;
 	margin-bottom: 0;
 	padding-bottom: 55px;
-	@include breakpoint-deprecated( ">1280px" ) {
-		margin-bottom: none;
-	}
 }
 
 .reader__content .tag-stream__header.has-description {

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -14,6 +14,9 @@
 	border-bottom: 1px solid #e9e9ea;
 	margin-bottom: 0;
 	padding-bottom: 55px;
+	@include breakpoint-deprecated( ">1280px" ) {
+		margin-bottom: none;
+	}
 }
 
 .reader__content .tag-stream__header.has-description {


### PR DESCRIPTION
Part of pe7F0s-1gP-p2
Simple PR to hide border bottom on desktop of tags page
A different rule is used for the border on the smaller page.
### Test instructions 

/tags/:tag page on desktop and mobile.