### PR TITLE
Design Picker: Go to cart via URL redirection

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -468,6 +468,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				selectedDesign?.is_externally_managed && isMarketplaceThemeSubscriptionNeeded
 					? [ marketplaceProductSlug ]
 					: [],
+			forceRedirection: true,
 		} );
 	}
 	function handleCheckout() {

--- a/client/landing/stepper/hooks/use-checkout.ts
+++ b/client/landing/stepper/hooks/use-checkout.ts
@@ -14,6 +14,7 @@ interface GoToCheckoutProps {
 	plan?: string;
 	cancelDestination?: string;
 	extraProducts?: string[];
+	forceRedirection?: boolean;
 }
 
 const useCheckout = () => {
@@ -25,6 +26,7 @@ const useCheckout = () => {
 		plan,
 		cancelDestination,
 		extraProducts = [],
+		forceRedirection = false,
 	}: GoToCheckoutProps ) => {
 		const relativeCurrentPath = window.location.href.replace( window.location.origin, '' );
 		const params = new URLSearchParams( {
@@ -39,14 +41,18 @@ const useCheckout = () => {
 		setSignupCompleteStepName( stepName );
 
 		const products = [ ...( plan ? [ plan ] : [] ), ...extraProducts ];
+		const hasProducts = products.length > 0;
 
-		if ( products.length ) {
+		if ( hasProducts && ! forceRedirection ) {
 			openCheckoutModal( products, { redirect_to: destination } );
 		} else {
-			// If no products are provided, we might have added plan to the cart so we just go to the checkout page directly
+			// If no products are provided, we might have added plan to the cart so we just go to the checkout page directly.
+			// If the flag forceRedirection is true, we also go to the checkout page via redirection.
 			// The theme upsell link does not work with siteId and requires a siteSlug.
 			// See https://github.com/Automattic/wp-calypso/pull/64899
-			window.location.href = `/checkout/${ encodeURIComponent( siteSlug ) }?${ params }`;
+			window.location.href = `/checkout/${ encodeURIComponent( siteSlug ) }${
+				hasProducts ? `/${ products.join( ',' ) }` : ''
+			}?${ params }`;
 		}
 	};
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82007

## Proposed Changes

Use URL redirection to display the cart after selecting a theme on Design Picker.
Before this change, the cart modal was shown, but it presented layout issues.

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2023-09-21 at 09 23 02@2x](https://github.com/Automattic/wp-calypso/assets/5039531/d67cee7a-fa4a-44df-ba57-bcc153abbab0)|![CleanShot 2023-09-21 at 09 27 06@2x](https://github.com/Automattic/wp-calypso/assets/5039531/e77c0451-e44c-4610-8a2c-1229d4d3be1b)|

The `Complete Checkout` button will always be visible on this version.

<img width="435" alt="CleanShot 2023-09-21 at 09 28 07@2x" src="https://github.com/Automattic/wp-calypso/assets/5039531/db87ca20-701e-44af-b536-8f5a8802689d">

## Testing Instructions

* Apply the diff D118900-code to your sandbox and direct requests to the sandbox
* Go to the Design Picker page with a Marketplace theme selected `/setup/update-design/designSetup?siteSlug=:site&theme=:theme_slug`. Theme slugs such as `makoney` and `olsen-fse` can be used.
* Click on `Unlock Theme`
* You should see the modal with the updated layout.
* On the cart, check if the layouts for desktop and mobile match the layout above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
