### PR TITLE
Reader post cards - move follow button from post actions to ellipsis menu.

### DIFF
--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -1,15 +1,12 @@
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { useState } from 'react';
 import CommentButton from 'calypso/blocks/comment-button';
 import { shouldShowComments } from 'calypso/blocks/comments/helper';
 import PostEditButton from 'calypso/blocks/post-edit-button';
 import ShareButton from 'calypso/blocks/reader-share';
 import { shouldShowShare, shouldShowReblog } from 'calypso/blocks/reader-share/helper';
-import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
 import ReaderCommentIcon from 'calypso/reader/components/icons/comment-icon';
-import ReaderFollowButton from 'calypso/reader/follow-button';
 import LikeButton from 'calypso/reader/like-button';
 import { shouldShowLikes } from 'calypso/reader/like-helper';
 import * as stats from 'calypso/reader/stats';
@@ -20,29 +17,9 @@ import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import './style.scss';
 
 const ReaderPostActions = ( props ) => {
-	const {
-		post,
-		site,
-		onCommentClick,
-		showEdit,
-		showSuggestedFollows,
-		iconSize,
-		className,
-		fullPost,
-		showFollow,
-	} = props;
-
-	const [ isSuggestedFollowsModalOpen, setIsSuggestedFollowsModalOpen ] = useState( false );
+	const { post, site, onCommentClick, showEdit, iconSize, className, fullPost } = props;
 
 	const hasSites = !! useSelector( getPrimarySiteId );
-
-	const openSuggestedFollowsModal = ( followClicked ) => {
-		setIsSuggestedFollowsModalOpen( followClicked );
-	};
-
-	const onCloseSuggestedFollowModal = () => {
-		setIsSuggestedFollowsModalOpen( false );
-	};
 
 	const onEditClick = () => {
 		stats.recordAction( 'edit_post' );
@@ -67,23 +44,7 @@ const ReaderPostActions = ( props ) => {
 					/>
 				</li>
 			) }
-			{ showSuggestedFollows && post.site_ID && (
-				<ReaderSuggestedFollowsDialog
-					onClose={ onCloseSuggestedFollowModal }
-					siteId={ +post.site_ID }
-					postId={ +post.ID }
-					isVisible={ isSuggestedFollowsModalOpen }
-				/>
-			) }
-			{ showFollow && shouldShowLikes( post ) && (
-				<li className="reader-post-actions__item">
-					<ReaderFollowButton
-						siteUrl={ post.feed_URL || post.site_URL }
-						iconSize={ iconSize }
-						onFollowToggle={ openSuggestedFollowsModal }
-					/>
-				</li>
-			) }
+
 			{ shouldShowShare( post ) && (
 				<li className="reader-post-actions__item">
 					<ShareButton post={ post } position="bottom" tagName="div" iconSize={ iconSize } />
@@ -140,7 +101,6 @@ ReaderPostActions.propTypes = {
 	onCommentClick: PropTypes.func,
 	showEdit: PropTypes.bool,
 	showFollow: PropTypes.bool,
-	showSuggestedFollows: PropTypes.bool,
 	iconSize: PropTypes.number,
 	visitUrl: PropTypes.string,
 	fullPost: PropTypes.bool,
@@ -150,7 +110,6 @@ ReaderPostActions.defaultProps = {
 	showEdit: true,
 	showFollow: true,
 	showVisit: false,
-	showSuggestedFollows: false,
 	iconSize: 20,
 };
 

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -22,10 +22,12 @@ class PostByline extends Component {
 		teams: PropTypes.array,
 		showFollow: PropTypes.bool,
 		compact: PropTypes.bool,
+		showSuggestedFollows: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		showAvatar: true,
+		showSuggestedFollows: false,
 	};
 
 	recordDateClick = () => {
@@ -37,7 +39,8 @@ class PostByline extends Component {
 	};
 
 	render() {
-		const { post, site, feed, showSiteName, showAvatar, teams, compact } = this.props;
+		const { post, site, feed, showSiteName, showAvatar, teams, compact, showSuggestedFollows } =
+			this.props;
 		const feedId = feed ? feed.feed_ID : get( post, 'feed_ID' );
 		const feedIcon = feed ? feed.site_icon ?? get( feed, 'image' ) : null;
 		const siteId = get( site, 'ID' );
@@ -126,7 +129,8 @@ class PostByline extends Component {
 						site={ site }
 						teams={ teams }
 						post={ post }
-						showFollow={ false }
+						showFollow={ true }
+						showSuggestedFollows={ showSuggestedFollows }
 					/>
 				) }
 			</div>

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -22,12 +22,11 @@ class PostByline extends Component {
 		teams: PropTypes.array,
 		showFollow: PropTypes.bool,
 		compact: PropTypes.bool,
-		showSuggestedFollows: PropTypes.bool,
+		openSuggestedFollows: PropTypes.func,
 	};
 
 	static defaultProps = {
 		showAvatar: true,
-		showSuggestedFollows: false,
 	};
 
 	recordDateClick = () => {
@@ -39,7 +38,7 @@ class PostByline extends Component {
 	};
 
 	render() {
-		const { post, site, feed, showSiteName, showAvatar, teams, compact, showSuggestedFollows } =
+		const { post, site, feed, showSiteName, showAvatar, teams, compact, openSuggestedFollows } =
 			this.props;
 		const feedId = feed ? feed.feed_ID : get( post, 'feed_ID' );
 		const feedIcon = feed ? feed.site_icon ?? get( feed, 'image' ) : null;
@@ -130,7 +129,7 @@ class PostByline extends Component {
 						teams={ teams }
 						post={ post }
 						showFollow={ true }
-						showSuggestedFollows={ showSuggestedFollows }
+						openSuggestedFollows={ openSuggestedFollows }
 					/>
 				) }
 			</div>

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -14,7 +14,7 @@ const CompactPost = ( {
 	site,
 	postByline,
 	teams,
-	showSuggestedFollows,
+	openSuggestedFollows,
 } ) => {
 	const onVideoThumbnailClick =
 		post.canonical_media?.mediaType === 'video'
@@ -44,7 +44,7 @@ const CompactPost = ( {
 								teams={ teams }
 								post={ post }
 								showFollow={ true }
-								showSuggestedFollows={ showSuggestedFollows }
+								openSuggestedFollows={ openSuggestedFollows }
 							/>
 						) }
 					</div>
@@ -58,7 +58,7 @@ const CompactPost = ( {
 								teams={ teams }
 								post={ post }
 								showFollow={ true }
-								showSuggestedFollows={ showSuggestedFollows }
+								openSuggestedFollows={ openSuggestedFollows }
 							/>
 						) }
 						<FeaturedAsset
@@ -80,7 +80,7 @@ const CompactPost = ( {
 CompactPost.propTypes = {
 	post: PropTypes.object.isRequired,
 	postByline: PropTypes.object,
-	showSuggestedFollows: PropTypes.bool,
+	openSuggestedFollows: PropTypes.func,
 };
 
 export default CompactPost;

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -14,6 +14,7 @@ const CompactPost = ( {
 	site,
 	postByline,
 	teams,
+	showSuggestedFollows,
 } ) => {
 	const onVideoThumbnailClick =
 		post.canonical_media?.mediaType === 'video'
@@ -42,7 +43,8 @@ const CompactPost = ( {
 								site={ site }
 								teams={ teams }
 								post={ post }
-								showFollow={ false }
+								showFollow={ true }
+								showSuggestedFollows={ showSuggestedFollows }
 							/>
 						) }
 					</div>
@@ -55,7 +57,8 @@ const CompactPost = ( {
 								site={ site }
 								teams={ teams }
 								post={ post }
-								showFollow={ false }
+								showFollow={ true }
+								showSuggestedFollows={ showSuggestedFollows }
 							/>
 						) }
 						<FeaturedAsset
@@ -77,6 +80,7 @@ const CompactPost = ( {
 CompactPost.propTypes = {
 	post: PropTypes.object.isRequired,
 	postByline: PropTypes.object,
+	showSuggestedFollows: PropTypes.bool,
 };
 
 export default CompactPost;

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -11,6 +11,7 @@ import DailyPostButton from 'calypso/blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'calypso/blocks/daily-post-button/helper';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
 import CompactPostCard from 'calypso/blocks/reader-post-card/compact';
+import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
 import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import * as stats from 'calypso/reader/stats';
 import { hasReaderFollowOrganization } from 'calypso/state/reader/follows/selectors';
@@ -57,6 +58,18 @@ class ReaderPostCard extends Component {
 		handleClick: noop,
 		isSelected: false,
 		showSiteName: true,
+	};
+
+	state = {
+		isSuggestedFollowsModalOpen: false,
+	};
+
+	openSuggestedFollowsModal = () => {
+		this.setState( { isSuggestedFollowsModalOpen: true } );
+	};
+
+	onCloseSuggestedFollowModal = () => {
+		this.setState( { isSuggestedFollowsModalOpen: false } );
 	};
 
 	propagateCardClick = () => {
@@ -191,7 +204,7 @@ class ReaderPostCard extends Component {
 				showAvatar={ ! compact }
 				teams={ teams }
 				showFollow={ true }
-				showSuggestedFollows={ isReaderSearchPage }
+				openSuggestedFollows={ this.openSuggestedFollowsModal }
 				compact={ compact }
 			/>
 		);
@@ -219,7 +232,7 @@ class ReaderPostCard extends Component {
 					postKey={ postKey }
 					postByline={ postByline }
 					onClick={ this.handleCardClick }
-					showSuggestedFollows={ isReaderSearchPage }
+					openSuggestedFollows={ this.openSuggestedFollowsModal }
 				>
 					{ readerPostActions }
 				</CompactPostCard>
@@ -262,12 +275,21 @@ class ReaderPostCard extends Component {
 			);
 		}
 
+		const showSuggestedFollows = isReaderSearchPage;
 		const onClick = ! isPhotoPost ? this.handleCardClick : noop;
 		return (
 			<Card className={ classes } onClick={ onClick } tagName="article">
 				{ ! compact && postByline }
 				{ readerPostCard }
 				{ this.props.children }
+				{ showSuggestedFollows && post.site_ID && (
+					<ReaderSuggestedFollowsDialog
+						onClose={ this.onCloseSuggestedFollowModal }
+						siteId={ +post.site_ID }
+						postId={ +post.ID }
+						isVisible={ this.state.isSuggestedFollowsModalOpen }
+					/>
+				) }
 				{ shouldShowPostCardComments && (
 					<PostCardComments
 						post={ post }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -47,7 +47,6 @@ class ReaderPostCard extends Component {
 		isWPForTeamsItem: PropTypes.bool,
 		teams: PropTypes.array,
 		hasOrganization: PropTypes.bool,
-		showFollowButton: PropTypes.bool,
 		fixedHeaderHeight: PropTypes.number,
 		streamKey: PropTypes.string,
 	};
@@ -58,7 +57,6 @@ class ReaderPostCard extends Component {
 		handleClick: noop,
 		isSelected: false,
 		showSiteName: true,
-		showFollowButton: true,
 	};
 
 	propagateCardClick = () => {
@@ -140,7 +138,6 @@ class ReaderPostCard extends Component {
 			hasOrganization,
 			isWPForTeamsItem,
 			teams,
-			showFollowButton,
 		} = this.props;
 
 		let isSeen = false;
@@ -175,12 +172,9 @@ class ReaderPostCard extends Component {
 				post={ post }
 				site={ site }
 				visitUrl={ post.URL }
-				showFollow={ showFollowButton }
-				showVisit={ true }
 				fullPost={ false }
 				onCommentClick={ onCommentClick }
 				showEdit={ false }
-				showSuggestedFollows={ isReaderSearchPage }
 				className="ignore-click"
 				iconSize={ 20 }
 			/>
@@ -196,7 +190,8 @@ class ReaderPostCard extends Component {
 				showSiteName={ showSiteName }
 				showAvatar={ ! compact }
 				teams={ teams }
-				showFollow={ false }
+				showFollow={ true }
+				showSuggestedFollows={ isReaderSearchPage }
 				compact={ compact }
 			/>
 		);
@@ -224,6 +219,7 @@ class ReaderPostCard extends Component {
 					postKey={ postKey }
 					postByline={ postByline }
 					onClick={ this.handleCardClick }
+					showSuggestedFollows={ isReaderSearchPage }
 				>
 					{ readerPostActions }
 				</CompactPostCard>

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -9,6 +9,23 @@
 
 .reader-post-options-menu__popover .popover__menu .popover__menu-item {
 	display: flex;
+
+	&.follow-button:hover,
+	&.follow-button:focus {
+		.follow-button__label {
+			color: var(--color-text-inverted);
+		}
+		.reader-following-feed,
+		.reader-follow-feed {
+			.following-icon-background,
+			path {
+				fill: var(--color-text-inverted);
+			}
+			.following-icon-tick {
+				stroke: var(--color-text-inverted);
+			}
+		}
+	}
 }
 
 .reader-post-card.card {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -7,6 +7,10 @@
 	}
 }
 
+.reader-post-options-menu__popover .popover__menu .popover__menu-item {
+	display: flex;
+}
+
 .reader-post-card.card {
 	border-bottom: 5px solid var(--color-neutral-0);
 	/* stylelint-disable-next-line scales/radii */

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -6,11 +6,13 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
 import { shouldShowConversationFollowButton } from 'calypso/blocks/conversation-follow-button/helper';
+import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import ReaderExternalIcon from 'calypso/reader/components/icons/external-icon';
 import ReaderFollowConversationIcon from 'calypso/reader/components/icons/follow-conversation-icon';
 import ReaderFollowingConversationIcon from 'calypso/reader/components/icons/following-conversation-icon';
+import ReaderFollowButton from 'calypso/reader/follow-button';
 import { READER_POST_OPTIONS_MENU } from 'calypso/reader/follow-sources';
 import { canBeMarkedAsSeen, isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
@@ -42,6 +44,7 @@ class ReaderPostEllipsisMenu extends Component {
 		showVisitPost: PropTypes.bool,
 		showEditPost: PropTypes.bool,
 		showConversationFollow: PropTypes.bool,
+		showSuggestedFollows: PropTypes.bool,
 		showReportPost: PropTypes.bool,
 		showReportSite: PropTypes.bool,
 		position: PropTypes.string,
@@ -56,9 +59,24 @@ class ReaderPostEllipsisMenu extends Component {
 		showVisitPost: true,
 		showEditPost: true,
 		showConversationFollow: true,
+		showSuggestedFollows: false,
 		showReportPost: true,
 		showReportSite: false,
 		posts: [],
+	};
+
+	state = {
+		isSuggestedFollowsModalOpen: false,
+	};
+
+	openSuggestedFollowsModal = ( shouldOpen ) => {
+		if ( shouldOpen ) {
+			this.setState( { isSuggestedFollowsModalOpen: true } );
+		}
+	};
+
+	onCloseSuggestedFollowModal = () => {
+		this.setState( { isSuggestedFollowsModalOpen: false } );
 	};
 
 	blockSite = () => {
@@ -126,6 +144,9 @@ class ReaderPostEllipsisMenu extends Component {
 			'calypso_reader_post_options_menu_' + ( isMenuVisible ? 'opened' : 'closed' ),
 			this.props.post
 		);
+		if ( ! isMenuVisible ) {
+			this.onCloseSuggestedFollowModal();
+		}
 	};
 
 	editPost = () => {
@@ -292,6 +313,27 @@ class ReaderPostEllipsisMenu extends Component {
 						followSource={ READER_POST_OPTIONS_MENU }
 						followIcon={ ReaderFollowConversationIcon( { iconSize: 20 } ) }
 						followingIcon={ ReaderFollowingConversationIcon( { iconSize: 20 } ) }
+					/>
+				) }
+
+				{ this.props.showSuggestedFollows && post.site_ID && (
+					<ReaderSuggestedFollowsDialog
+						onClose={ this.onCloseSuggestedFollowModal }
+						siteId={ +post.site_ID }
+						postId={ +post.ID }
+						isVisible={ this.state.isSuggestedFollowsModalOpen }
+					/>
+				) }
+
+				{ this.props.showFollow && (
+					<ReaderFollowButton
+						tagName={ PopoverMenuItem }
+						siteUrl={ post.feed_URL || post.site_URL }
+						followSource={ READER_POST_OPTIONS_MENU }
+						iconSize={ 20 }
+						followLabel={ translate( 'Follow blog' ) }
+						followingLabel={ translate( 'Following blog' ) }
+						onFollowToggle={ this.openSuggestedFollowsModal }
 					/>
 				) }
 

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -6,7 +6,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
 import { shouldShowConversationFollowButton } from 'calypso/blocks/conversation-follow-button/helper';
-import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import ReaderExternalIcon from 'calypso/reader/components/icons/external-icon';
@@ -40,11 +39,11 @@ class ReaderPostEllipsisMenu extends Component {
 		post: PropTypes.object,
 		feed: PropTypes.object,
 		onBlock: PropTypes.func,
+		openSuggestedFollows: PropTypes.func,
 		showFollow: PropTypes.bool,
 		showVisitPost: PropTypes.bool,
 		showEditPost: PropTypes.bool,
 		showConversationFollow: PropTypes.bool,
-		showSuggestedFollows: PropTypes.bool,
 		showReportPost: PropTypes.bool,
 		showReportSite: PropTypes.bool,
 		position: PropTypes.string,
@@ -54,29 +53,21 @@ class ReaderPostEllipsisMenu extends Component {
 
 	static defaultProps = {
 		onBlock: noop,
+		openSuggestedFollows: noop,
 		position: 'top left',
 		showFollow: true,
 		showVisitPost: true,
 		showEditPost: true,
 		showConversationFollow: true,
-		showSuggestedFollows: false,
 		showReportPost: true,
 		showReportSite: false,
 		posts: [],
 	};
 
-	state = {
-		isSuggestedFollowsModalOpen: false,
-	};
-
 	openSuggestedFollowsModal = ( shouldOpen ) => {
 		if ( shouldOpen ) {
-			this.setState( { isSuggestedFollowsModalOpen: true } );
+			this.props.openSuggestedFollows();
 		}
-	};
-
-	onCloseSuggestedFollowModal = () => {
-		this.setState( { isSuggestedFollowsModalOpen: false } );
 	};
 
 	blockSite = () => {
@@ -144,9 +135,6 @@ class ReaderPostEllipsisMenu extends Component {
 			'calypso_reader_post_options_menu_' + ( isMenuVisible ? 'opened' : 'closed' ),
 			this.props.post
 		);
-		if ( ! isMenuVisible ) {
-			this.onCloseSuggestedFollowModal();
-		}
 	};
 
 	editPost = () => {
@@ -313,15 +301,6 @@ class ReaderPostEllipsisMenu extends Component {
 						followSource={ READER_POST_OPTIONS_MENU }
 						followIcon={ ReaderFollowConversationIcon( { iconSize: 20 } ) }
 						followingIcon={ ReaderFollowingConversationIcon( { iconSize: 20 } ) }
-					/>
-				) }
-
-				{ this.props.showSuggestedFollows && post.site_ID && (
-					<ReaderSuggestedFollowsDialog
-						onClose={ this.onCloseSuggestedFollowModal }
-						siteId={ +post.site_ID }
-						postId={ +post.ID }
-						isVisible={ this.state.isSuggestedFollowsModalOpen }
 					/>
 				) }
 

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -311,7 +311,7 @@ class ReaderPostEllipsisMenu extends Component {
 						followSource={ READER_POST_OPTIONS_MENU }
 						iconSize={ 20 }
 						followLabel={ translate( 'Follow blog' ) }
-						followingLabel={ translate( 'Following blog' ) }
+						followingLabel={ translate( 'Unfollow blog' ) }
 						onFollowToggle={ this.openSuggestedFollowsModal }
 					/>
 				) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-1fb-p2

## Proposed Changes

IN PROGRESS

* Removes the "Follow" (blog/site) button from the reader post actions area.
* Adds a "Follow blog" button to the post card ellipsis menu.
* Moves the corresponding `ReaderSuggestedFollowsDialogue` from post actions to the post card and updated it to be triggered by the new button in the ellipsis menu. Suggested follows should still look and work the same, but triggered from this new button location the same as it was with the old one.

Before:
<img width="482" alt="Screenshot 2023-09-21 at 12 03 26 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/ee551038-d6fd-4ea8-b169-4b0a15422c1d">
<img width="175" alt="Screenshot 2023-09-21 at 12 03 46 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/9ed05f2a-7a09-4311-aa9b-e8e643d59990">

After:
<img width="475" alt="Screenshot 2023-09-21 at 12 04 13 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/3983ad13-2200-460d-8087-2777fbaba119">
<img width="184" alt="Screenshot 2023-09-21 at 12 04 22 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/7ec672b5-e874-4378-981a-57082610d912">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso PR.
* Verify the follow button is no longer in the post actions section of the post card (below the post content/images and above comments).
* Verify the follow button is in the ellipsis menu and works.
* Do this for both compact and regular sized cards (discover vs. recent).
* On the Search feed, verify following a blog from this new button opens the Suggested Follows Dialogue and that this modal works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?