### PR TITLE
Domains: Show "disconnect" button for domain registrations only

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/disconnect/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/disconnect/index.tsx
@@ -2,6 +2,7 @@ import { Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import { type as domainType } from 'calypso/lib/domains/constants';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import wpcom from 'calypso/lib/wp';
 import { useDispatch } from 'calypso/state';
@@ -12,6 +13,7 @@ import type { DisconnectDomainResult } from './types';
 import type { DomainInfoCardProps } from '../types';
 
 const DisconnectDomainCard = ( { domain, selectedSite }: DomainInfoCardProps ) => {
+	const disconnectableTypes = [ domainType.REGISTERED ] as const;
 	const [ isDialogVisible, setDialogVisible ] = useState( false );
 	const [ isDisconnecting, setDisconnecting ] = useState( false );
 	const translate = useTranslate();
@@ -22,7 +24,8 @@ const DisconnectDomainCard = ( { domain, selectedSite }: DomainInfoCardProps ) =
 		! domain.currentUserIsOwner ||
 		domain.isMoveToNewSitePending ||
 		! selectedSite ||
-		selectedSite.options?.is_domain_only
+		selectedSite.options?.is_domain_only ||
+		! disconnectableTypes.includes( domain.type )
 	) {
 		return null;
 	}


### PR DESCRIPTION
We're currently showing the "Disconnect" button on the management page for all domain types. It should only be displayed for registrations. This PR fixes it.

## Testing Instructions
- Go to the domains page (`/domains/manage`) of the domain you're testing;
- If it's a registration:
  - If the domain is in a domain-only site, ensure the "Disconnect" button isn't rendered.
  - If the domain is not in a domain-only site, ensure that the "Disconnect" button gets rendered. 
- Otherwise, there should be no "Disconnect" button/section.

### Before
![image](https://github.com/Automattic/wp-calypso/assets/18705930/2f947e3f-7340-4871-8079-d4eb81b4e96c)

### After
![image](https://github.com/Automattic/wp-calypso/assets/18705930/aa447b00-83d5-44c8-bc91-bcdf823efb97)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?