### PR TITLE
Add loading placeholders to subscribers page

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-container/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-list-container/style.scss
@@ -23,4 +23,24 @@
 	.subscriber-list-container__pagination {
 		margin-top: 48px;
 	}
+
+	.loading-placeholder {
+		@include placeholder();
+		display: inline-block;
+		margin-bottom: 30px;
+
+		&.big {
+			width: 50%;
+		}
+
+		&.small {
+			width: 10%;
+			margin-left: 5%;
+		}
+
+		&.hidden {
+			background-color: transparent;
+			animation: none;
+		}
+	}
 }

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -19,39 +19,42 @@ const SubscriberListContainer = ( {
 	onClickView,
 	onClickUnsubscribe,
 }: SubscriberListContainerProps ) => {
-	const { grandTotal, total, perPage, page, pageChangeCallback, searchTerm, isFetching } =
+	const { grandTotal, total, perPage, page, pageChangeCallback, searchTerm, isLoading } =
 		useSubscribersPage();
 	useRecordSearch();
 
 	return (
 		<section className="subscriber-list-container">
-			{ grandTotal ? (
-				<>
-					<div className="subscriber-list-container__header">
-						<span className="subscriber-list-container__title">
-							{ translate( 'Total', {
-								context: 'Total number of subscribers',
-							} ) }
-						</span>{ ' ' }
-						<span className="subscriber-list-container__subscriber-count">
-							{ numberFormat( total, 0 ) }
-						</span>
+			<div className="subscriber-list-container__header">
+				<span className="subscriber-list-container__title">
+					{ translate( 'Total', {
+						context: 'Total number of subscribers',
+					} ) }
+				</span>{ ' ' }
+				<span
+					className={ `subscriber-list-container__subscriber-count ${
+						isLoading ? 'loading-placeholder' : ''
+					}` }
+				>
+					{ numberFormat( total, 0 ) }
+				</span>
+			</div>
+			<SubscriberListActionsBar />
+			{ isLoading &&
+				new Array( 10 ).fill( null ).map( ( _, index ) => (
+					<div key={ index } data-ignored={ _ }>
+						<div className="loading-placeholder big"></div>
+						<div className="loading-placeholder small"></div>
+						<div className="loading-placeholder small"></div>
+						<div className="loading-placeholder small hidden"></div>
 					</div>
-					<SubscriberListActionsBar />
-
-					{ isFetching &&
-						new Array( 10 ).fill( null ).map( ( _, index ) => (
-							<div key={ index } data-ignored={ _ }>
-								<div className="loading-placeholder big"></div>
-								<div className="loading-placeholder small"></div>
-								<div className="loading-placeholder small"></div>
-								<div className="loading-placeholder small hidden"></div>
-							</div>
-						) ) }
-					{ ! isFetching && total && (
+				) ) }
+			{ ! isLoading && grandTotal && (
+				<>
+					{ total && (
 						<SubscriberList onView={ onClickView } onUnsubscribe={ onClickUnsubscribe } />
 					) }
-					{ ! isFetching && ! total && <NoSearchResults searchTerm={ searchTerm } /> }
+					{ ! total && <NoSearchResults searchTerm={ searchTerm } /> }
 
 					<Pagination
 						className="subscriber-list-container__pagination"
@@ -63,9 +66,8 @@ const SubscriberListContainer = ( {
 
 					<GrowYourAudience />
 				</>
-			) : (
-				<EmptyListView />
 			) }
+			{ ! isLoading && ! grandTotal && <EmptyListView /> }
 		</section>
 	);
 };

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -19,7 +19,8 @@ const SubscriberListContainer = ( {
 	onClickView,
 	onClickUnsubscribe,
 }: SubscriberListContainerProps ) => {
-	const { grandTotal, total, perPage, page, pageChangeCallback, searchTerm } = useSubscribersPage();
+	const { grandTotal, total, perPage, page, pageChangeCallback, searchTerm, isFetching } =
+		useSubscribersPage();
 	useRecordSearch();
 
 	return (
@@ -38,11 +39,19 @@ const SubscriberListContainer = ( {
 					</div>
 					<SubscriberListActionsBar />
 
-					{ total ? (
+					{ isFetching &&
+						new Array( 10 ).fill( null ).map( ( _, index ) => (
+							<div key={ index } data-ignored={ _ }>
+								<div className="loading-placeholder big"></div>
+								<div className="loading-placeholder small"></div>
+								<div className="loading-placeholder small"></div>
+								<div className="loading-placeholder small hidden"></div>
+							</div>
+						) ) }
+					{ ! isFetching && total && (
 						<SubscriberList onView={ onClickView } onUnsubscribe={ onClickUnsubscribe } />
-					) : (
-						<NoSearchResults searchTerm={ searchTerm } />
 					) }
+					{ ! isFetching && ! total && <NoSearchResults searchTerm={ searchTerm } /> }
 
 					<Pagination
 						className="subscriber-list-container__pagination"

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -40,6 +40,7 @@ type SubscribersPageContextProps = {
 	setShowAddSubscribersModal: ( show: boolean ) => void;
 	addSubscribersCallback: () => void;
 	siteId: number | null;
+	isFetching: boolean;
 };
 
 const SubscribersPageContext = createContext< SubscribersPageContextProps | undefined >(
@@ -141,6 +142,7 @@ export const SubscribersPageProvider = ( {
 				setShowAddSubscribersModal,
 				addSubscribersCallback,
 				siteId,
+				isFetching: subscribersQueryResult.isFetching,
 			} }
 		>
 			{ children }

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -40,7 +40,7 @@ type SubscribersPageContextProps = {
 	setShowAddSubscribersModal: ( show: boolean ) => void;
 	addSubscribersCallback: () => void;
 	siteId: number | null;
-	isFetching: boolean;
+	isLoading: boolean;
 };
 
 const SubscribersPageContext = createContext< SubscribersPageContextProps | undefined >(
@@ -142,7 +142,7 @@ export const SubscribersPageProvider = ( {
 				setShowAddSubscribersModal,
 				addSubscribersCallback,
 				siteId,
-				isFetching: subscribersQueryResult.isFetching,
+				isLoading: subscribersQueryResult.isLoading,
 			} }
 		>
 			{ children }


### PR DESCRIPTION
## Proposed Changes

This PR adds loader placeholders to subscribers page:

<img width="925" alt="Screenshot 2023-09-21 at 17 38 07" src="https://github.com/Automattic/wp-calypso/assets/3832570/936a1627-dba1-4830-8ee4-d1a8a28707a5">


## Testing Instructions

1. Apply this PR and run the application.
2. Go to `Users -> Subscribers`.
3. For a short period of time you should see the page like in the image above.
4. If you want to see it for more time, you can go to `client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx` and change line 145 and change it from this:
`isFetching: subscribersQueryResult.isFetching,`
to this:
`isFetching: true`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?