### PR TITLE
Subscription Management: Display the pending page at `/read/subscriptions/pending`

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -346,3 +346,10 @@ export async function commentSubscriptionsManager( context, next ) {
 	);
 	return next();
 }
+
+export async function pendingSubscriptionsManager( context, next ) {
+	context.primary = (
+		<AsyncLoad require="calypso/reader/site-subscriptions-manager/pending-subscriptions-manager" />
+	);
+	return next();
+}

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -22,6 +22,7 @@ import {
 	siteSubscriptionsManager,
 	siteSubscription,
 	commentSubscriptionsManager,
+	pendingSubscriptionsManager,
 } from './controller';
 
 import './style.scss';
@@ -138,6 +139,15 @@ export default async function () {
 		updateLastRoute,
 		sidebar,
 		commentSubscriptionsManager,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/read/subscriptions/pending',
+		redirectLoggedOut,
+		updateLastRoute,
+		sidebar,
+		pendingSubscriptionsManager,
 		makeLayout,
 		clientRender
 	);

--- a/client/reader/site-subscriptions-manager/pending-subscriptions-manager/index.tsx
+++ b/client/reader/site-subscriptions-manager/pending-subscriptions-manager/index.tsx
@@ -1,0 +1,3 @@
+import PendingSubscriptionsManager from './pending-subscriptions-manager';
+
+export default () => <PendingSubscriptionsManager />;

--- a/client/reader/site-subscriptions-manager/pending-subscriptions-manager/pending-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/pending-subscriptions-manager/pending-subscriptions-manager.tsx
@@ -1,0 +1,19 @@
+import { useTranslate } from 'i18n-calypso';
+import { Pending } from 'calypso/landing/subscriptions/components/tab-views';
+import SubscriptionsManagerWrapper from '../subscriptions-manager-wrapper';
+import '../style.scss';
+
+const PendingSubscriptionsManager = () => {
+	const translate = useTranslate();
+
+	return (
+		<SubscriptionsManagerWrapper
+			headerText={ translate( 'Manage pending subscriptions' ) }
+			subHeaderText={ translate( 'Manage your site, RSS, and newsletter subscriptions.' ) }
+		>
+			<Pending />
+		</SubscriptionsManagerWrapper>
+	);
+};
+
+export default PendingSubscriptionsManager;

--- a/client/sections.js
+++ b/client/sections.js
@@ -418,6 +418,7 @@ const sections = [
 		paths: [
 			'/read/subscriptions',
 			'/read/subscriptions/comments',
+			'/read/subscriptions/pending',
 			'^/read/subscriptions/(\\d+)(/)?$',
 		],
 		module: 'calypso/reader/site-subscriptions-manager',


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82011

## Proposed Changes

* Create `PendingSubscriptionsManager` component
* Create `/read/subscriptions/pending` route to display the comments page

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/read/subscriptions/pending
* You should see the Pendings page (with pending subscriptions listed)

<img width="1237" alt="Screenshot 2023-09-21 at 13 06 29" src="https://github.com/Automattic/wp-calypso/assets/3113712/e9925cbe-5ecb-456b-a392-412050a51ecf">

* Perform regression tests on the existing subscription management
  * Go to http://calypso.localhost:3000/read/subscriptions
  * Verify if the page is functional as before
  * Click on a subscription to go to the subscription details page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?