### PR TITLE
State: Fix a bug with undefined imports reducer subkey

### DIFF
--- a/client/state/imports/reducer.js
+++ b/client/state/imports/reducer.js
@@ -112,7 +112,7 @@ function importerStatus( state = {}, action ) {
 				[ action.importerId ]: {
 					...state[ action.importerId ],
 					customData: {
-						...state[ action.importerId ].customData,
+						...state[ action.importerId ]?.customData,
 						sourceAuthors: map(
 							get( state[ action.importerId ], 'customData.sourceAuthors' ),
 							( author ) =>


### PR DESCRIPTION
## Proposed Changes

This fixes a bug caught recently with the imports reducer trying to access the `customData` key without checking if it's defined, and it's potentially undefined in the beginning. Caught by [Sentry](https://a8c.sentry.io/issues/4359744954/?project=6313676).

## Testing Instructions

Smoke test an import with assigning posts to a specific author.