### PR TITLE
Reader - Fixing 3 image layout

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -756,6 +756,9 @@
 			width: 100%;
 		}
 		/* Second and third images */
+		.column-two .reader-post-card__featured-images {
+			margin-top: 0;
+		}
 		.reader-post-card__featured-images-item.column-two {
 			width: calc(50% - 1px);
 		}


### PR DESCRIPTION
## Description

It looks like the margin-top we added to the top of images within reader cards is pushing the second column down in the 3 image layout.

## Before
![image](https://github.com/Automattic/wp-calypso/assets/5634774/ca762bf0-50f7-4dc0-8b6f-396823ada851)

## After
<img width="669" alt="CleanShot 2023-09-21 at 13 58 51@2x" src="https://github.com/Automattic/wp-calypso/assets/5634774/26dde197-c702-4d41-8858-9f1c143eaaa2">

## Testing

- Click Calypso live link
- Go to reader
- Follow https://ourblackunion.com/
- Look for the above post near the top of the queue
