### PR TITLE
Jetpack Manage: Issue hosting license on CTA click and navigate to licenses list

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -1,5 +1,7 @@
 import { Button } from '@automattic/components';
+import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import QueryJetpackPartnerPortalLicenseCounts from 'calypso/components/data/query-jetpack-partner-portal-license-counts';
 import SiteAddLicenseNotification from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification';
@@ -15,6 +17,7 @@ import {
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { infoNotice } from 'calypso/state/notices/actions';
 import {
 	getLicenseCounts,
 	hasFetchedLicenseCounts,
@@ -50,6 +53,20 @@ export default function Licenses( {
 	const counts = useSelector( getLicenseCounts );
 	const hasFetched = useSelector( hasFetchedLicenseCounts );
 	const allLicensesCount = counts[ 'all' ];
+	const provisioningSite = getQueryArg( window.location.href, 'provisioning' ) as string;
+
+	useEffect( () => {
+		if ( 'true' === provisioningSite ) {
+			dispatch(
+				infoNotice(
+					translate(
+						'We are creating a WordPress.com site in the background. It will appear on your dashboard shortly.'
+					),
+					{ id: 'provisioning-site-notice' }
+				)
+			);
+		}
+	}, [ provisioningSite, translate, dispatch ] );
 
 	const context = {
 		filter,

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -2,8 +2,10 @@ import { getPlan, PLAN_BUSINESS, PLAN_ECOMMERCE } from '@automattic/calypso-prod
 import { Button, JetpackLogo, WooLogo, CloudLogo } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useCallback, useRef, useState } from 'react';
 import Tooltip from 'calypso/components/tooltip';
+import useIssueLicenses from 'calypso/jetpack-cloud/sections/partner-portal/hooks/use-issue-licenses';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -107,9 +109,16 @@ export default function CardContent( { planSlug }: { planSlug: string } ) {
 
 	const plan = getPlanInfo( planSlug );
 
-	const onCTAClick = useCallback( () => {
+	const { issueLicenses } = useIssueLicenses();
+
+	const onCTAClick = useCallback( async () => {
+		const productSlug =
+			planSlug === PLAN_BUSINESS ? 'wpcom-hosting-business' : 'wpcom-hosting-ecommerce';
+
+		await issueLicenses( [ productSlug ] );
 		dispatch( recordTracksEvent( getCTAEventName( planSlug ) ) );
-	}, [ dispatch, planSlug ] );
+		page.redirect( `/partner-portal/licenses` );
+	}, [ dispatch, planSlug, issueLicenses ] );
 
 	if ( ! plan ) {
 		return null;

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/index.tsx
@@ -1,7 +1,7 @@
 import { PLAN_BUSINESS, PLAN_ECOMMERCE } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -15,6 +15,7 @@ export default function WPCOMAtomicHosting() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const title = translate( 'Create a new WordPress.com site' );
+	const [ isRequesting, setIsRequesting ] = useState( false );
 
 	const plansToBeDisplayed = [ PLAN_BUSINESS, PLAN_ECOMMERCE ];
 
@@ -34,7 +35,11 @@ export default function WPCOMAtomicHosting() {
 			<div className="wpcom-atomic-hosting__card-container">
 				{ plansToBeDisplayed.map( ( plan ) => (
 					<Card key={ plan } className="wpcom-atomic-hosting__card" compact>
-						<CardContent planSlug={ plan } />
+						<CardContent
+							planSlug={ plan }
+							isRequesting={ isRequesting }
+							setIsRequesting={ setIsRequesting }
+						/>
 					</Card>
 				) ) }
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds options to the "Add Site" CTA on the agency dashboard to make it possible to create a WPCOM Business or E-commerce site from there.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://jetpack.cloud.localhost:3000/dashboard
* Click on the arrow to the side of the "Add site" button, select "Create a new WordPress.com site"
* Select Business or E-Commerce
* Your site should show up on the dashboard, after a short while

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?