### PR TITLE
ActivityPub: enable opt-in in all environments

### DIFF
--- a/client/my-sites/site-settings/settings-discussion/main.jsx
+++ b/client/my-sites/site-settings/settings-discussion/main.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -33,7 +32,7 @@ const SiteSettingsDiscussion = ( { site, translate } ) => (
 			hasScreenOptions
 		/>
 		<SiteSettingsNavigation site={ site } section="discussion" />
-		{ isEnabled( 'fediverse/allow-opt-in' ) && <FediverseSettingsSection /> }
+		<FediverseSettingsSection />
 		<DiscussionForm />
 	</Main>
 );

--- a/config/development.json
+++ b/config/development.json
@@ -67,7 +67,6 @@
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,
 		"external-media/openverse": true,
-		"fediverse/allow-opt-in": true,
 		"full-site-editing/beta-opt-in": true,
 		"cookie-banner": false,
 		"github-integration-i1": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -36,7 +36,6 @@
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,
 		"external-media/openverse": true,
-		"fediverse/allow-opt-in": true,
 		"full-site-editing/beta-opt-in": true,
 		"cookie-banner": true,
 		"google-my-business": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -52,7 +52,6 @@
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,
 		"external-media/openverse": true,
-		"fediverse/allow-opt-in": true,
 		"cookie-banner": true,
 		"github-integration-i1": false,
 		"google-my-business": true,


### PR DESCRIPTION
🎉 This will launch the "Fediverse settings" opt-in to all wpcom Simple sites!

## Proposed Changes

* Remove all config checks, this is live everywhere

Settings ➡️ Discussion
<img width="741" alt="Screenshot 2023-09-21 at 16 06 07" src="https://github.com/Automattic/wp-calypso/assets/195089/00c1991e-6a9b-4b5e-acb1-b11f0cf92c31">

## Testing Instructions

Once deployed, the Fediverse settings under Settings --> Reading should appear in all environments.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?