### PR TITLE
Domain Transfer: Keep CTA enabled & CSS details

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -70,6 +70,7 @@ export class ContactDetailsFormFields extends Component {
 		updateWpcomEmailCheckboxDisabled: PropTypes.bool,
 		onUpdateWpcomEmailCheckboxChange: PropTypes.func,
 		updateWpcomEmailCheckboxHidden: PropTypes.bool,
+		ignoreCountryOnDisableSubmit: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -94,6 +95,7 @@ export class ContactDetailsFormFields extends Component {
 		shouldForceRenderOnPropChange: false,
 		updateWpcomEmailCheckboxDisabled: false,
 		updateWpcomEmailCheckboxHidden: false,
+		ignoreCountryOnDisableSubmit: false,
 	};
 
 	constructor( props ) {
@@ -534,8 +536,14 @@ export class ContactDetailsFormFields extends Component {
 	}
 
 	render() {
-		const { translate, onCancel, disableSubmitButton, labelTexts, contactDetailsErrors } =
-			this.props;
+		const {
+			translate,
+			onCancel,
+			disableSubmitButton,
+			labelTexts,
+			contactDetailsErrors,
+			ignoreCountryOnDisableSubmit,
+		} = this.props;
 
 		if ( ! this.state.form ) {
 			return null;
@@ -585,7 +593,9 @@ export class ContactDetailsFormFields extends Component {
 						{ this.props.onSubmit && (
 							<FormButton
 								className="contact-details-form-fields__submit-button"
-								disabled={ ! countryCode || disableSubmitButton }
+								disabled={
+									( ! ignoreCountryOnDisableSubmit && ! countryCode ) || disableSubmitButton
+								}
 								onClick={ this.handleSubmitButtonClick }
 							>
 								{ labelTexts.submitButton || translate( 'Submit' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -197,6 +197,7 @@ function ContactInfo( {
 				isSubmitting={ false }
 				updateWpcomEmailCheckboxHidden={ true }
 				cancelHidden={ true }
+				ignoreCountryOnDisableSubmit={ true }
 			>
 				<div className="domain-contact-info-form__terms">
 					<Gridicon icon="info-outline" size={ 18 } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
@@ -25,6 +25,7 @@ $heading-font-family: "SF Pro Display", $sans;
 
 		.formatted-header__subtitle {
 			text-align: center !important;
+			margin-top: 8px !important;
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3882

## Proposed Changes

- [x] Change CTA to enable by default and if they click on it without the form being filled out then we show an error message.
- [x] The distance between the title and the subtitle seems bigger on mobile than on desktop

## Testing Instructions

- Test the contact info form http://calypso.localhost:3000/setup/domain-user-transfer/domain-contact-info?domain=test345678.blog

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?