### PR TITLE
allows siteless purchases to be removed

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -16,6 +16,7 @@ import enrichedSurveyData from 'calypso/components/marketing-survey/cancel-purch
 import { getName, isExpired } from 'calypso/lib/purchases';
 import { submitSurvey } from 'calypso/lib/purchases/actions';
 import { isOutsideCalypso } from 'calypso/lib/url';
+import { isJetpackTemporarySitePurchase } from 'calypso/me/purchases/utils';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCancellationOfferApplySuccess from 'calypso/state/cancellation-offers/selectors/get-cancellation-offer-apply-success';
@@ -55,7 +56,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 	const dispatch = useDispatch();
 	const initialCancellationStep = useMemo( () => {
 		// If the subscription is expired, the only step in the survey is the removal confirmation
-		if ( isExpired( purchase ) ) {
+		if ( isExpired( purchase ) || isJetpackTemporarySitePurchase( purchase ) ) {
 			return steps.CANCEL_CONFIRM_STEP;
 		}
 
@@ -146,10 +147,10 @@ const CancelJetpackForm: React.FC< Props > = ( {
 	const availableSurveySteps = useMemo( () => {
 		const availableSteps = [];
 
-		// If the plan is already expired, we only need one "confirm" step for the user to click to confirm
-		// Don't need to show any benefits lost (plan is not working anymore)
-		// Don't need to show a survey, the product did not get renewed - it's already "cancelled"
-		if ( isExpired( purchase ) ) {
+		// If the plan is already expired or is a temporary Jetpack purchase (license),
+		// we only need one "confirm" step for the user to click to confirm.
+		// A product that is not in use does not need to collect the survey or show benefits
+		if ( isExpired( purchase ) || isJetpackTemporarySitePurchase( purchase ) ) {
 			return [ steps.CANCEL_CONFIRM_STEP ];
 		}
 

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1330,10 +1330,7 @@ class ManagePurchase extends Component<
 						{ this.renderReinstall() }
 						{ this.renderCancelPurchaseNavItem() }
 						{ this.renderCancelSurvey() }
-						{ /* We don't want to show the Cancel/Remove nav item for "Jetpack" temporary sites, but we DO
-						show it for "Akismet" temporary sites. (And all other types of purchases) */ }
-						{ /* TODO: Add ability to Cancel Akismet subscription */ }
-						{ ! isJetpackTemporarySitePurchase( purchase ) && this.renderRemovePurchaseNavItem() }
+						{ this.renderRemovePurchaseNavItem() }
 					</>
 				) }
 			</Fragment>


### PR DESCRIPTION
## Proposed Changes

This PR allows Jetpack license purchases that are not assigned to a site to be removed. At the moment, license based purchases can only be removed from a user account after they are attached to a real Jetpack site.

This restriction was first introduced here: https://github.com/Automattic/wp-calypso/pull/54853

See references for more context: 
- 1200479326344990-as-1200631299519252
- D63228#1321598-code
- pNPgK-5gx-p2#comment-21275

This restriction is not particularly necessary, removing it makes subscription management for licenses less cumbersome.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Obtain a siteless (license) Jetpack purchase
* With this patch applied, confirm that you can remove the purchase yourself from the purchase management in Calypso

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?