### PR TITLE
Stats: Date picker - combine days/weeks/months/years buttons into a dropdown

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -251,9 +251,7 @@ class StatsSite extends Component {
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>
 						{ isDateControlEnabled ? (
-							<DateControl
-							// New DateControl component
-							/>
+							<DateControl period={ period } pathTemplate={ pathTemplate } />
 						) : (
 							<StatsPeriodHeader>
 								<StatsPeriodNavigation

--- a/client/my-sites/stats/stats-date-control/index.jsx
+++ b/client/my-sites/stats/stats-date-control/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import IntervalDropdown from '../stats-interval-dropdown';
 
 const DateControl = ( { period, pathTemplate } ) => {

--- a/client/my-sites/stats/stats-date-control/index.jsx
+++ b/client/my-sites/stats/stats-date-control/index.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
+import IntervalDropdown from '../stats-interval-dropdown';
 
-const DateControl = () => {
+const DateControl = ( { period, pathTemplate } ) => {
 	return (
 		<div>
-			{ /* New Component bits go here */ }
-			New DateControl Component
+			<IntervalDropdown period={ period } pathTemplate={ pathTemplate } />
 		</div>
 	);
 };

--- a/client/my-sites/stats/stats-interval-dropdown/index.jsx
+++ b/client/my-sites/stats/stats-interval-dropdown/index.jsx
@@ -1,0 +1,25 @@
+import { Button, Dropdown } from '@wordpress/components';
+import React from 'react';
+import Intervals from 'calypso/blocks/stats-navigation/intervals';
+
+const IntervalDropdown = ( { period, pathTemplate } ) => {
+	return (
+		<Dropdown
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<Button onClick={ onToggle } aria-expanded={ isOpen }>
+					Toggle Dropdown
+				</Button>
+			) }
+			renderContent={ ( { onClose } ) => (
+				<div>
+					<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
+					<Button variant="secondary" onClick={ onClose }>
+						Close
+					</Button>
+				</div>
+			) }
+		/>
+	);
+};
+
+export default IntervalDropdown;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81833

## Proposed Changes

* Moves the existing time navigation buttons into a dropdown element
* Encapsulates into a new `<IntervalDropdown>` component
* Is nested inside of the new `<DateControl>` component
* Is only visible behind the `stats/date-control` feature flag

## Testing Instructions

* Open the Calypso live branch
* Navigate to `/stats/day/{site URL}`
* Confirm that everything remains unchanged without the feature flag applied
* Append `?flags=stats/date-control` to the end of the URL
* Confirm that now instead of date range selector and navigation, there is a button which when clicked, loads a drop down list with `day` `week` `month` `year` options. 
* Try using the aforementioned options and confirm the changes are still reflected in the chart

**Note: This is not beautiful. It is just getting components into place (without styling) and choosing drop down component for the time being. Refinements in placement, style etc. will come in followup PRs**

![image](https://github.com/Automattic/wp-calypso/assets/30754158/0ead4a8b-ce23-4cd8-ad18-b524bce4b81c)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?