### PR TITLE
Partner Themes Onboarding: Use monthly plans

### DIFF
--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -81,6 +81,10 @@ export const ThemeUpgradeModal = ( {
 		( select ) => select( ProductsList.store ).getProductBySlug( 'business-bundle' ),
 		[]
 	);
+	const monthlyBusinessPlanProduct = useSelect(
+		( select ) => select( ProductsList.store ).getProductBySlug( 'business-bundle-monthly' ),
+		[]
+	);
 
 	//Wait until we have theme and product data to show content
 	const isLoading = ! premiumPlanProduct || ! businessPlanProduct || ! theme.data;
@@ -172,11 +176,11 @@ export const ThemeUpgradeModal = ( {
 	};
 
 	const getExternallyManagedPurchaseModalData = (): UpgradeModalContent => {
-		const businessPlanPrice = businessPlanProduct?.combined_cost_display;
+		const businessPlanPrice = monthlyBusinessPlanProduct?.combined_cost_display;
 		const productPrice = marketplaceProduct?.cost_display;
 
 		const businessPlanPriceText =
-			businessPlanProduct?.product_term === 'year'
+			monthlyBusinessPlanProduct?.product_term === 'year'
 				? translate( '%(cost)s per year', { args: { cost: businessPlanPrice || '' } } )
 				: translate( '%(cost)s per month', { args: { cost: businessPlanPrice || '' } } );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { PLAN_BUSINESS, WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
+import { PLAN_BUSINESS_MONTHLY, WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import {
 	Onboard,
@@ -352,7 +352,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		) || [];
 	const marketplaceProductSlug =
 		marketplaceThemeProducts.length !== 0
-			? getPreferredBillingCycleProductSlug( marketplaceThemeProducts, PLAN_BUSINESS )
+			? getPreferredBillingCycleProductSlug( marketplaceThemeProducts )
 			: null;
 
 	const selectedMarketplaceProduct =
@@ -445,7 +445,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		if ( themeHasWooCommerce ) {
 			plan = 'business-bundle';
 		} else if ( selectedDesign?.is_externally_managed ) {
-			plan = ! isExternallyManagedThemeAvailable ? PLAN_BUSINESS : '';
+			plan = ! isExternallyManagedThemeAvailable ? PLAN_BUSINESS_MONTHLY : '';
 		} else {
 			plan = isEligibleForProPlan && isEnabled( 'plans/pro-plan' ) ? 'pro' : 'premium';
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82031

## Proposed Changes

When adding Partner Themes during onboarding, use monthly variations for the plan and the product subscription.

## Testing Instructions

* Apply the diff D118900-code to your sandbox and direct requests to the sandbox
* Go to the Design Picker page with a Marketplace theme selected `/setup/update-design/designSetup?siteSlug=:site&theme=:theme_slug` with a below business site. Theme slugs such as `makoney` and `olsen-fse` can be used.
* Click on `Unlock Theme`
* You should see the modal with the updated layout.
* On the cart, check if the product variations displayed are monthly
* The user should be able to change the period

<img width="696" alt="CleanShot 2023-09-21 at 20 19 06@2x" src="https://github.com/Automattic/wp-calypso/assets/5039531/3efb7db1-d9c5-462f-b315-42b412dce69e">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
