### PR TITLE
Enable domain transfers between users in staging

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -30,6 +30,7 @@
 		"domains/bulk-actions-table": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
+		"domains/transfer-to-any-user": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -40,6 +40,7 @@
 		"domains/bulk-actions-contact-info-editing": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
+		"domains/transfer-to-any-user": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,

--- a/config/test.json
+++ b/config/test.json
@@ -40,6 +40,7 @@
 		"difm/allow-extra-pages": false,
 		"domains/bulk-actions-table": true,
 		"domains/bulk-actions-contact-info-editing": true,
+		"domains/transfer-to-any-user": true,
 		"cookie-banner": false,
 		"google-my-business": false,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -45,6 +45,7 @@
 		"domains/bulk-actions-contact-info-editing": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
+		"domains/transfer-to-any-user": true,
 		"email-accounts/enabled": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3898
Related to https://github.com/Automattic/dotcom-forge/issues/3847

## Proposed Changes

* Adds the `domains/transfer-to-any-user` flag to staging and similar environments, enabling domain transfers between users for domain only sites. (for all proxied users)

## Testing Instructions

* Using an account with a domain only site / domain.
* You should now have this transfer option available on staging/calypso-live, where previously it was only available on development or behind the feature flag.

![Screenshot(9)](https://github.com/Automattic/wp-calypso/assets/811776/6d24e7a4-bd58-4af5-b30d-c9f1cd6e59c6)



