### PR TITLE
Domains Management i1: Show status information for domains with expiring credit cards

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -804,7 +804,7 @@ export function shouldRenderExpiringCreditCard( purchase: Purchase ) {
 	);
 }
 
-function monthsUntilCardExpires( purchase: Purchase ) {
+export function monthsUntilCardExpires( purchase: Purchase ) {
 	const creditCard = purchase.payment.creditCard;
 	const expiry = moment( creditCard?.expiryDate, 'MM/YY' );
 	return expiry.diff( moment(), 'months' );

--- a/client/my-sites/domains/domain-management/list/use-purchase-actions.ts
+++ b/client/my-sites/domains/domain-management/list/use-purchase-actions.ts
@@ -1,6 +1,10 @@
 import { DomainStatusPurchaseActions, ResponseDomain } from '@automattic/domains-table';
 import { useQueryUserPurchases } from 'calypso/components/data/query-user-purchases';
-import { handleRenewNowClick, shouldRenderExpiringCreditCard } from 'calypso/lib/purchases';
+import {
+	handleRenewNowClick,
+	monthsUntilCardExpires,
+	shouldRenderExpiringCreditCard,
+} from 'calypso/lib/purchases';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getUserPurchases } from 'calypso/state/purchases/selectors';
 
@@ -25,6 +29,14 @@ export const usePurchaseActions = () => {
 		return !! purchase;
 	};
 
+	const monthsUtilCreditCardExpires = ( domain: ResponseDomain ) => {
+		const purchase = purchases?.find(
+			( p ) => p.id === parseInt( domain.subscriptionId ?? '', 10 )
+		);
+
+		return purchase ? monthsUntilCardExpires( purchase ) : null;
+	};
+
 	const onRenewNowClick = ( siteSlug: string, domain: ResponseDomain ) => {
 		const purchase = purchases?.find(
 			( p ) => p.id === parseInt( domain.subscriptionId ?? '', 10 )
@@ -37,6 +49,7 @@ export const usePurchaseActions = () => {
 	const purchaseActions: DomainStatusPurchaseActions = {
 		isCreditCardExpiring,
 		isPurchasedDomain,
+		monthsUtilCreditCardExpires,
 		onRenewNowClick,
 	};
 

--- a/packages/domains-table/src/domains-table-header/columns.ts
+++ b/packages/domains-table/src/domains-table-header/columns.ts
@@ -157,3 +157,8 @@ export const applyColumnSort = (
 		return result;
 	} );
 };
+
+export const removeColumns = ( columns: DomainsTableColumn[], ...names: string[] ) => {
+	const _names = names ?? [];
+	return columns.filter( ( column ) => ! _names.includes( column.name ) );
+};

--- a/packages/domains-table/src/domains-table/domains-table-expires-renew-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-expires-renew-cell.tsx
@@ -7,10 +7,12 @@ import moment from 'moment';
 
 interface DomainsTableExpiresRewnewsOnCellProps {
 	domain: PartialDomainData;
+	isCompact?: boolean;
 }
 
 export const DomainsTableExpiresRewnewsOnCell = ( {
 	domain,
+	isCompact = false,
 }: DomainsTableExpiresRewnewsOnCellProps ) => {
 	const localeSlug = useLocale();
 	const isExpired = domain.expiry && moment( domain.expiry ).utc().isBefore( moment().utc() );
@@ -39,7 +41,9 @@ export const DomainsTableExpiresRewnewsOnCell = ( {
 		<div className="domains-table-row__renews-on-cell">
 			{ expiryDate ? (
 				<>
-					<Gridicon icon={ isExpired ? 'notice-outline' : 'reblog' } size={ 18 } />
+					{ ! isCompact && (
+						<Gridicon icon={ isExpired ? 'notice-outline' : 'reblog' } size={ 18 } />
+					) }
 					{ notice }
 				</>
 			) : (

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -44,7 +44,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 		domainStatus,
 		pendingUpdates,
 	} = useDomainRow( domain );
-	const { canSelectAnyDomains, domainsTableColumns } = useDomainsTable();
+	const { canSelectAnyDomains, domainsTableColumns, isCompact } = useDomainsTable();
 
 	const renderSiteCell = () => {
 		if ( site && currentDomainData ) {
@@ -111,6 +111,9 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 							) : (
 								<span className="domains-table__domain-name">{ domain.domain }</span>
 							) }
+
+							{ isCompact && <div>{ renderSiteCell() }</div> }
+
 							{ domainTypeText && (
 								<span className="domains-table-row__domain-type-text">{ domainTypeText }</span>
 							) }
@@ -133,7 +136,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 				if ( column.name === 'expire_renew' ) {
 					return (
 						<td key={ column.name }>
-							<DomainsTableExpiresRewnewsOnCell domain={ domain } />
+							<DomainsTableExpiresRewnewsOnCell domain={ domain } isCompact={ isCompact } />
 						</td>
 					);
 				}

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -14,6 +14,7 @@ import {
 } from '@automattic/data-stores';
 import { useFuzzySearch } from '@automattic/search';
 import { isMobile } from '@automattic/viewport';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { useQueries } from '@tanstack/react-query';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -32,6 +33,7 @@ import {
 	allSitesViewColumns,
 	siteSpecificViewColumns,
 	applyColumnSort,
+	removeColumns,
 } from '../domains-table-header/columns';
 import { DomainsTableColumn } from '../domains-table-header/index';
 import { getDomainId } from '../get-domain-id';
@@ -130,6 +132,7 @@ type Value = {
 	domainsTableColumns: DomainsTableColumn[];
 	currentUsersOwnsAllSelectedDomains: boolean;
 	currentUserCanBulkUpdateContactInfo: boolean;
+	isCompact: boolean;
 };
 
 const Context = createContext< Value | undefined >( undefined );
@@ -163,6 +166,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		sortDirection: 'asc',
 	} );
 
+	const isCompact = useBreakpoint( '<1280px' );
 	const [ showBulkActions, setShowBulkActions ] = useState( Boolean( ! isMobile() ) );
 	const [ selectedDomains, setSelectedDomains ] = useState( () => new Set< string >() );
 	const [ filter, setFilter ] = useState< DomainsTableFilter >( () => ( { query: '' } ) );
@@ -236,9 +240,13 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		} );
 	}, [ domains ] );
 	const translate = useTranslate();
-	const domainsTableColumns = isAllSitesView
+	let domainsTableColumns = isAllSitesView
 		? allSitesViewColumns( translate, domainStatusPurchaseActions )
 		: siteSpecificViewColumns( translate, domainStatusPurchaseActions );
+
+	if ( isCompact ) {
+		domainsTableColumns = removeColumns( domainsTableColumns, 'site', 'owner' );
+	}
 
 	const sortedDomains = useMemo( () => {
 		if ( ! domains ) {
@@ -431,6 +439,7 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		domainsTableColumns,
 		isFetchingDomains,
 		currentUserCanBulkUpdateContactInfo,
+		isCompact,
 	};
 
 	return (

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -88,14 +88,14 @@ $domains-table-mobile-breakpoint: 480px;
 	}
 
 	.domains-table-row__status-cell {
-		white-space: nowrap;
+		white-space: pre-line;
 		display: flex;
 		align-items: center;
 		gap: 4px;
 		font-size: $font-body-small;
 
 		@media ( min-width: $domains-table-mobile-breakpoint ) {
-			width: 100px;
+			width: 150px;
 		}
 
 		svg {
@@ -120,7 +120,6 @@ $domains-table-mobile-breakpoint: 480px;
 
 	.domains-table-row__actions {
 		text-align: right;
-
 	}
 }
 
@@ -215,7 +214,7 @@ $domains-table-mobile-breakpoint: 480px;
 .domains-table-row__domain-type-text {
 	display: none;
 	font-size: $font-body-extra-small;
-	font-style: normal;
+	font-style: italic;
 	font-weight: 400;
 	line-height: 20px;
 

--- a/packages/domains-table/src/use-domain-row.ts
+++ b/packages/domains-table/src/use-domain-row.ts
@@ -136,6 +136,8 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 					domainStatusPurchaseActions?.isCreditCardExpiring?.( currentDomainData ),
 				onRenewNowClick: () =>
 					domainStatusPurchaseActions?.onRenewNowClick?.( siteSlug ?? '', currentDomainData ),
+				monthsUtilCreditCardExpires:
+					domainStatusPurchaseActions?.monthsUtilCreditCardExpires?.( currentDomainData ),
 		  } )
 		: null;
 

--- a/packages/domains-table/src/utils/resolve-domain-status.tsx
+++ b/packages/domains-table/src/utils/resolve-domain-status.tsx
@@ -52,12 +52,14 @@ export type ResolveDomainStatusOptionsBag = {
 	isPurchasedDomain?: boolean | null;
 	onRenewNowClick?(): void;
 	isCreditCardExpiring?: boolean | null;
+	monthsUtilCreditCardExpires?: number | null;
 };
 
 export type DomainStatusPurchaseActions = {
 	isCreditCardExpiring?: ( domain: ResponseDomain ) => boolean;
 	onRenewNowClick?: ( siteSlug: string, domain: ResponseDomain ) => void;
 	isPurchasedDomain?: ( domain: ResponseDomain ) => boolean;
+	monthsUtilCreditCardExpires?: ( domain: ResponseDomain ) => number | null;
 };
 
 export function resolveDomainStatus(
@@ -70,6 +72,7 @@ export function resolveDomainStatus(
 		isPurchasedDomain = false,
 		onRenewNowClick,
 		isCreditCardExpiring = false,
+		monthsUtilCreditCardExpires = null,
 	}: ResolveDomainStatusOptionsBag
 ): ResolveDomainStatusReturn | null {
 	const transferOptions = {
@@ -91,6 +94,11 @@ export function resolveDomainStatus(
 	const mappingSetupCallToAction = {
 		href: domainMappingSetup( siteSlug as string, domain.domain ),
 		label: translate( 'Go to setup' ),
+	};
+
+	const paymentSetupCallToAction = {
+		href: '/me/purchases/payment-methods',
+		label: translate( 'Go to payment methods' ),
 	};
 
 	switch ( domain.type ) {
@@ -214,14 +222,22 @@ export function resolveDomainStatus(
 					icon: 'cached',
 				};
 			}
-
-			if ( isPurchasedDomain && isCreditCardExpiring ) {
+			if (
+				isPurchasedDomain &&
+				isCreditCardExpiring &&
+				monthsUtilCreditCardExpires &&
+				monthsUtilCreditCardExpires < 3
+			) {
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
 					status: translate( 'Action required' ),
 					icon: 'info',
+					noticeText: translate(
+						'Your credit card expires before the next renewal. Please update your payment information.'
+					),
 					listStatusWeight: 600,
+					callToAction: paymentSetupCallToAction,
 				};
 			}
 
@@ -523,13 +539,22 @@ export function resolveDomainStatus(
 			};
 
 		case domainTypes.SITE_REDIRECT:
-			if ( isPurchasedDomain && isCreditCardExpiring ) {
+			if (
+				isPurchasedDomain &&
+				isCreditCardExpiring &&
+				monthsUtilCreditCardExpires &&
+				monthsUtilCreditCardExpires < 3
+			) {
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
 					status: translate( 'Action required' ),
 					icon: 'info',
+					noticeText: translate(
+						'Your credit card expires before the next renewal. Please update your payment information.'
+					),
 					listStatusWeight: 600,
+					callToAction: paymentSetupCallToAction,
 				};
 			}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR introduces an appropriate message to be displayed in the status column of the domains table for users with credit card expiring in the next 3 months and their domain renewal date is after the credit card expiry date.

I use less than 3 months as that's the period to show the same warning message at `me/purchases` page.

## Proposed Changes

* Pass the number of months before card expires to the domains table
* Show message and CTA to update payment method when card is expiring soon (3 months)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* update your payment method to expire in the next 2 months `/me/payment-methods`
* browse `/domains/manage`
* Verify the status message is shown along with CTA to payment methods
![image](https://github.com/Automattic/wp-calypso/assets/47489215/5ca0b39f-204b-42d1-955a-2f9cc9ae36d4)

You can also set `isCreditCardExpiring = true; monthsUtilCreditCardExpires = 1;` in `packages/domains-table/src/utils/resolve-domain-status.tsx` to test

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?