### PR TITLE
Siteless checkout: Allow to connect site after checkout.

### DIFF
--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -74,6 +74,13 @@ export default function CheckoutMainWrapper( {
 	jetpackPurchaseToken?: string;
 	isUserComingFromLoginForm?: boolean;
 	connectAfterCheckout?: boolean;
+	/**
+	 * `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	 * checkout), for use cases when the site slug cannot be retrieved from state, ie- when there
+	 * is not a site in context, such as in siteless checkout. As opposed to `siteSlug` which is
+	 * the site slug present when the site is in context (ie- when site is connected and user is
+	 * logged in).
+	 */
 	fromSiteSlug?: string;
 	adminUrl?: string;
 } ) {

--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -53,6 +53,9 @@ export default function CheckoutMainWrapper( {
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
 	isUserComingFromLoginForm,
+	connectAfterCheckout,
+	fromSiteSlug,
+	adminUrl,
 }: {
 	productAliasFromUrl?: string;
 	productSourceFromUrl?: string;
@@ -70,6 +73,9 @@ export default function CheckoutMainWrapper( {
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 	isUserComingFromLoginForm?: boolean;
+	connectAfterCheckout?: boolean;
+	fromSiteSlug?: string;
+	adminUrl?: string;
 } ) {
 	const translate = useTranslate();
 	const locale = useSelector( getCurrentUserLocale );
@@ -130,6 +136,9 @@ export default function CheckoutMainWrapper( {
 							jetpackSiteSlug={ jetpackSiteSlug }
 							jetpackPurchaseToken={ jetpackPurchaseToken }
 							isUserComingFromLoginForm={ isUserComingFromLoginForm }
+							connectAfterCheckout={ connectAfterCheckout }
+							fromSiteSlug={ fromSiteSlug }
+							adminUrl={ adminUrl }
 						/>
 					</StripeHookProvider>
 				</CalypsoShoppingCartProvider>

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -37,6 +37,10 @@ interface CheckoutPendingProps {
 	receiptId: number | undefined;
 	siteSlug?: string;
 	redirectTo?: string;
+	// `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	// checkout), for use cases when there is not a site in context, such as siteless checkout.
+	// As opposed to `siteSlug` which is the site slug present when the site is in context
+	// (ie- the site is available in state, such as when site is connected and user logged in).
 	fromSiteSlug?: string;
 }
 

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -37,10 +37,13 @@ interface CheckoutPendingProps {
 	receiptId: number | undefined;
 	siteSlug?: string;
 	redirectTo?: string;
-	// `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
-	// checkout), for use cases when there is not a site in context, such as siteless checkout.
-	// As opposed to `siteSlug` which is the site slug present when the site is in context
-	// (ie- the site is available in state, such as when site is connected and user logged in).
+	/**
+	 * `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	 * checkout), for use cases when the site slug cannot be retrieved from state, ie- when there
+	 * is not a site in context, such as in siteless checkout. As opposed to `siteSlug` which is
+	 * the site slug present when the site is in context (ie- when site is connected and user is
+	 * logged in).
+	 */
 	fromSiteSlug?: string;
 }
 
@@ -153,6 +156,13 @@ function useRedirectOnTransactionSuccess( {
 	receiptId: number | undefined;
 	siteSlug?: string;
 	redirectTo?: string;
+	/**
+	 * `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	 * checkout), for use cases when the site slug cannot be retrieved from state, ie- when there
+	 * is not a site in context, such as in siteless checkout. As opposed to `siteSlug` which is
+	 * the site slug present when the site is in context (ie- when site is connected and user is
+	 * logged in).
+	 */
 	fromSiteSlug?: string;
 } ): void {
 	const translate = useTranslate();

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -37,7 +37,7 @@ interface CheckoutPendingProps {
 	receiptId: number | undefined;
 	siteSlug?: string;
 	redirectTo?: string;
-	fromSite?: string;
+	fromSiteSlug?: string;
 }
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -73,7 +73,7 @@ function CheckoutPending( {
 	receiptId,
 	siteSlug,
 	redirectTo,
-	fromSite,
+	fromSiteSlug,
 }: CheckoutPendingProps ) {
 	const orderId = isValidOrderId( orderIdOrPlaceholder ) ? orderIdOrPlaceholder : undefined;
 
@@ -82,7 +82,7 @@ function CheckoutPending( {
 		receiptId,
 		siteSlug,
 		redirectTo,
-		fromSite,
+		fromSiteSlug,
 	} );
 
 	return (
@@ -143,13 +143,13 @@ function useRedirectOnTransactionSuccess( {
 	receiptId,
 	siteSlug,
 	redirectTo,
-	fromSite,
+	fromSiteSlug,
 }: {
 	orderId: number | undefined;
 	receiptId: number | undefined;
 	siteSlug?: string;
 	redirectTo?: string;
-	fromSite?: string;
+	fromSiteSlug?: string;
 } ): void {
 	const translate = useTranslate();
 	const transaction: OrderTransaction | null = useSelector( ( state ) =>
@@ -215,7 +215,7 @@ function useRedirectOnTransactionSuccess( {
 			redirectTo,
 			siteSlug,
 			saasRedirectUrl,
-			fromSite,
+			fromSiteSlug,
 		} );
 
 		if ( ! redirectInstructions ) {
@@ -247,7 +247,7 @@ function useRedirectOnTransactionSuccess( {
 		transaction,
 		translate,
 		willAutoRenew,
-		fromSite,
+		fromSiteSlug,
 	] );
 }
 

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -37,6 +37,7 @@ interface CheckoutPendingProps {
 	receiptId: number | undefined;
 	siteSlug?: string;
 	redirectTo?: string;
+	fromSite?: string;
 }
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -72,6 +73,7 @@ function CheckoutPending( {
 	receiptId,
 	siteSlug,
 	redirectTo,
+	fromSite,
 }: CheckoutPendingProps ) {
 	const orderId = isValidOrderId( orderIdOrPlaceholder ) ? orderIdOrPlaceholder : undefined;
 
@@ -80,6 +82,7 @@ function CheckoutPending( {
 		receiptId,
 		siteSlug,
 		redirectTo,
+		fromSite,
 	} );
 
 	return (
@@ -140,11 +143,13 @@ function useRedirectOnTransactionSuccess( {
 	receiptId,
 	siteSlug,
 	redirectTo,
+	fromSite,
 }: {
 	orderId: number | undefined;
 	receiptId: number | undefined;
 	siteSlug?: string;
 	redirectTo?: string;
+	fromSite?: string;
 } ): void {
 	const translate = useTranslate();
 	const transaction: OrderTransaction | null = useSelector( ( state ) =>
@@ -210,6 +215,7 @@ function useRedirectOnTransactionSuccess( {
 			redirectTo,
 			siteSlug,
 			saasRedirectUrl,
+			fromSite,
 		} );
 
 		if ( ! redirectInstructions ) {
@@ -241,6 +247,7 @@ function useRedirectOnTransactionSuccess( {
 		transaction,
 		translate,
 		willAutoRenew,
+		fromSite,
 	] );
 }
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -47,6 +47,15 @@ const debug = debugFactory( 'calypso:checkout-controller' );
 
 export function checkoutJetpackSiteless( context, next ) {
 	const connectAfterCheckout = context.query?.connect_after_checkout === 'true';
+	/**
+	 * `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	 * checkout), for use cases when the site slug cannot be retrieved from state, ie- when there
+	 * is not a site in context, such as siteless checkout. As opposed to `siteSlug` which is the
+	 * site slug present when the site is in context (ie- when site is connected and user is
+	 * logged in).
+	 *
+	 * @type {string|undefined}
+	 */
 	const fromSiteSlug = context.query?.from_site_slug;
 	const adminUrl = context.query?.admin_url;
 	sitelessCheckout( context, next, {
@@ -260,7 +269,16 @@ export function checkoutPending( context, next ) {
 		? Number( context.query.receiptId )
 		: undefined;
 
-	const fromSiteSlug = context.query.from_site_slug;
+	/**
+	 * `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	 * checkout), for use cases when the site slug cannot be retrieved from state, ie- when there
+	 * is not a site in context, such as siteless checkout. As opposed to `siteSlug` which is the
+	 * site slug present when the site is in context (ie- when site is connected and user is
+	 * logged in).
+	 *
+	 * @type {string|undefined}
+	 */
+	const fromSiteSlug = context.query?.from_site_slug;
 
 	setSectionMiddleware( { name: 'checkout-pending' } )( context );
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -260,7 +260,7 @@ export function checkoutPending( context, next ) {
 		? Number( context.query.receiptId )
 		: undefined;
 
-	const fromSite = context.query.from_site;
+	const fromSiteSlug = context.query.from_site_slug;
 
 	setSectionMiddleware( { name: 'checkout-pending' } )( context );
 
@@ -270,7 +270,7 @@ export function checkoutPending( context, next ) {
 			siteSlug={ siteSlug }
 			redirectTo={ redirectTo }
 			receiptId={ receiptId }
-			fromSite={ fromSite }
+			fromSiteSlug={ fromSiteSlug }
 		/>
 	);
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -46,7 +46,15 @@ import { getProductSlugFromContext, isContextJetpackSitelessCheckout } from './u
 const debug = debugFactory( 'calypso:checkout-controller' );
 
 export function checkoutJetpackSiteless( context, next ) {
-	sitelessCheckout( context, next, { sitelessCheckoutType: 'jetpack' } );
+	const connectAfterCheckout = context.query?.connect_after_checkout === 'true';
+	const fromSiteSlug = context.query?.from_site_slug;
+	const adminUrl = context.query?.admin_url;
+	sitelessCheckout( context, next, {
+		sitelessCheckoutType: 'jetpack',
+		connectAfterCheckout,
+		...( fromSiteSlug && { fromSiteSlug } ),
+		...( adminUrl && { adminUrl } ),
+	} );
 }
 
 export function checkoutAkismetSiteless( context, next ) {
@@ -252,6 +260,8 @@ export function checkoutPending( context, next ) {
 		? Number( context.query.receiptId )
 		: undefined;
 
+	const fromSite = context.query.from_site;
+
 	setSectionMiddleware( { name: 'checkout-pending' } )( context );
 
 	context.primary = (
@@ -260,6 +270,7 @@ export function checkoutPending( context, next ) {
 			siteSlug={ siteSlug }
 			redirectTo={ redirectTo }
 			receiptId={ receiptId }
+			fromSite={ fromSite }
 		/>
 	);
 

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -239,7 +239,9 @@ export default function getThankYouPageUrl( {
 		if ( connectAfterCheckout && adminUrl && fromSiteSlug ) {
 			debug( 'Redirecting to the site to initiate Jetpack connection' );
 			// TODO: Then after connection, transfer temporary site subscription to the target site.
-			const connectUrl = `${ adminUrl }admin.php?page=jetpack&connect_url_redirect&from=my-jetpack&redirect_after_auth=${ adminUrl }/admin.php?page=my-jetpack#/add-license`;
+			// TODO: Possibly change the final post-checkout/connect url (`redirect_after_auth` query arg).
+			// Note: Don't use Url hashes, they are stripped when passing to the payment processor.
+			const connectUrl = `${ adminUrl }admin.php?page=jetpack&connect_url_redirect&from=my-jetpack&redirect_after_auth=${ adminUrl }/admin.php?page=my-jetpack`;
 			return connectUrl;
 		}
 

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -99,10 +99,13 @@ export interface PostCheckoutUrlArguments {
 	adminPageRedirect?: string;
 	domains?: ResponseDomain[];
 	connectAfterCheckout?: boolean;
-	// `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
-	// checkout), for use cases when there is not a site in context, such as siteless checkout.
-	// As opposed to `siteSlug` which is the site slug present when the site is in context
-	// (ie- the site is available in state, such as when site is connected and user logged in).
+	/**
+	 * `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	 * checkout), for use cases when the site slug cannot be retrieved from state, ie- when there
+	 * is not a site in context, such as in siteless checkout. As opposed to `siteSlug` which is
+	 * the site slug present when the site is in context (ie- when site is connected and user is
+	 * logged in).
+	 */
 	fromSiteSlug?: string;
 }
 

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -235,7 +235,7 @@ export default function getThankYouPageUrl( {
 		if ( connectAfterCheckout && adminUrl && fromSiteSlug ) {
 			debug( 'Redirecting to the site to initiate Jetpack connection' );
 			// TODO: Then after connection, transfer temporary site subscription to the target site.
-			const connectUrl = `${ adminUrl }/admin.php?page=jetpack&connect_url_redirect&from=my-jetpack&redirect_after_auth=${ adminUrl }/admin.php?page=my-jetpack#/add-license`;
+			const connectUrl = `${ adminUrl }admin.php?page=jetpack&connect_url_redirect&from=my-jetpack&redirect_after_auth=${ adminUrl }/admin.php?page=my-jetpack#/add-license`;
 			return connectUrl;
 		}
 

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -99,6 +99,10 @@ export interface PostCheckoutUrlArguments {
 	adminPageRedirect?: string;
 	domains?: ResponseDomain[];
 	connectAfterCheckout?: boolean;
+	// `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	// checkout), for use cases when there is not a site in context, such as siteless checkout.
+	// As opposed to `siteSlug` which is the site slug present when the site is in context
+	// (ie- the site is available in state, such as when site is connected and user logged in).
 	fromSiteSlug?: string;
 }
 
@@ -221,7 +225,7 @@ export default function getThankYouPageUrl( {
 	const firstRenewalInCart =
 		cart && hasRenewalItem( cart ) ? getRenewalItems( cart )[ 0 ] : undefined;
 
-	// jetpack userless & siteless checkout uses a special thank you page
+	// Jetpack userless & siteless checkout uses a special thank you page
 	if ( sitelessCheckoutType === 'jetpack' ) {
 		// extract a product from the cart, in userless/siteless checkout there should only be one
 		const productSlug = cart?.products[ 0 ]?.product_slug ?? 'no_product';
@@ -231,7 +235,7 @@ export default function getThankYouPageUrl( {
 			return `/checkout/jetpack/thank-you/${ siteSlug }/${ productSlug }`;
 		}
 
-		// siteless checkout
+		// siteless checkout - "Connect After Checkout" flow.
 		if ( connectAfterCheckout && adminUrl && fromSiteSlug ) {
 			debug( 'Redirecting to the site to initiate Jetpack connection' );
 			// TODO: Then after connection, transfer temporary site subscription to the target site.
@@ -239,6 +243,7 @@ export default function getThankYouPageUrl( {
 			return connectUrl;
 		}
 
+		// siteless checkout
 		debug( 'redirecting to siteless jetpack thank you' );
 		const thankYouUrl = `/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }`;
 

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -29,6 +29,7 @@ import {
 } from '@automattic/calypso-url';
 import { isTailoredSignupFlow } from '@automattic/onboarding';
 import debugFactory from 'debug';
+import { REMOTE_PATH_AUTH } from 'calypso/jetpack-connect/constants';
 import {
 	getGoogleApps,
 	hasGoogleApps,
@@ -241,10 +242,10 @@ export default function getThankYouPageUrl( {
 		// siteless checkout - "Connect After Checkout" flow.
 		if ( connectAfterCheckout && adminUrl && fromSiteSlug ) {
 			debug( 'Redirecting to the site to initiate Jetpack connection' );
-			// TODO: Then after connection, transfer temporary site subscription to the target site.
-			// TODO: Possibly change the final post-checkout/connect url (`redirect_after_auth` query arg).
-			// Note: Don't use Url hashes, they are stripped when passing to the payment processor.
-			const connectUrl = `${ adminUrl }admin.php?page=jetpack&connect_url_redirect&from=my-jetpack&redirect_after_auth=${ adminUrl }/admin.php?page=my-jetpack`;
+			// Remove "/wp-admin/" from the beginning of the REMOTE_PATH_AUTH because it's already part of the `adminUrl`.
+			const jetpackSiteAuthPath = REMOTE_PATH_AUTH.replace( /^\/wp-admin\//, '' );
+			const redirectAfterAuthUrl = `${ adminUrl }admin.php?page=my-jetpack`;
+			const connectUrl = `${ adminUrl }${ jetpackSiteAuthPath }&redirect_after_auth=${ redirectAfterAuthUrl }`;
 			return connectUrl;
 		}
 

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -98,6 +98,8 @@ export interface PostCheckoutUrlArguments {
 	jetpackTemporarySiteId?: string;
 	adminPageRedirect?: string;
 	domains?: ResponseDomain[];
+	connectAfterCheckout?: boolean;
+	fromSiteSlug?: string;
 }
 
 /**
@@ -134,6 +136,8 @@ export default function getThankYouPageUrl( {
 	jetpackTemporarySiteId,
 	adminPageRedirect,
 	domains,
+	connectAfterCheckout,
+	fromSiteSlug,
 }: PostCheckoutUrlArguments ): string {
 	debug( 'starting getThankYouPageUrl' );
 
@@ -228,6 +232,13 @@ export default function getThankYouPageUrl( {
 		}
 
 		// siteless checkout
+		if ( connectAfterCheckout && adminUrl && fromSiteSlug ) {
+			debug( 'Redirecting to the site to initiate Jetpack connection' );
+			// TODO: Then after connection, transfer temporary site subscription to the target site.
+			const connectUrl = `${ adminUrl }/admin.php?page=jetpack&connect_url_redirect&from=my-jetpack&redirect_after_auth=${ adminUrl }/admin.php?page=my-jetpack#/add-license`;
+			return connectUrl;
+		}
+
 		debug( 'redirecting to siteless jetpack thank you' );
 		const thankYouUrl = `/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }`;
 

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1666,6 +1666,7 @@ describe( 'getThankYouPageUrl', () => {
 		} );
 	} );
 
+	// Siteless checkout flow
 	describe( 'Jetpack Siteless Checkout Thank You', () => {
 		it( 'redirects when jetpack checkout arg is set, but siteSlug is undefined.', () => {
 			const cart = {
@@ -1756,8 +1757,10 @@ describe( 'getThankYouPageUrl', () => {
 			);
 		} );
 
-		// siteless "Connect after checkout" flow.
-		it( "redirects to the site's wp-admin cunnect_url_redirect url to initiate Jetpack connection", () => {
+		// Jetpack siteless "Connect after checkout" flow.
+		// Triggered when `connectAfterCheckout: true`, `adminUrl` is set, `fromSiteSlug` is set,
+		// and `siteSlug` is falsy(undefined).
+		it( "redirects to the site's wp-admin `connect_url_redirect` url to initiate Jetpack connection", () => {
 			const adminUrl = 'https://my.site/wp-admin/';
 			const cart = {
 				...getMockCart(),

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1756,6 +1756,33 @@ describe( 'getThankYouPageUrl', () => {
 			);
 		} );
 
+		// siteless "Connect after checkout" flow.
+		it( "redirects to the site's wp-admin cunnect_url_redirect url to initiate Jetpack connection", () => {
+			const adminUrl = 'https://my.site/wp-admin/';
+			const cart = {
+				...getMockCart(),
+				products: [
+					{
+						...getEmptyResponseCartProduct(),
+						product_slug: 'jetpack_backup_daily',
+					},
+				],
+			};
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				siteSlug: undefined,
+				cart,
+				sitelessCheckoutType: 'jetpack',
+				connectAfterCheckout: true,
+				adminUrl: adminUrl,
+				fromSiteSlug: 'my.site',
+				receiptId: 'invalid receipt ID' as any,
+			} );
+			expect( url ).toBe(
+				`${ adminUrl }admin.php?page=jetpack&connect_url_redirect&from=my-jetpack&redirect_after_auth=${ adminUrl }/admin.php?page=my-jetpack#/add-license`
+			);
+		} );
+
 		it( 'Redirects to the 100 year plan thank-you page when the 100 year plan is available', () => {
 			const cart = {
 				...getMockCart(),

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1782,7 +1782,7 @@ describe( 'getThankYouPageUrl', () => {
 				receiptId: 'invalid receipt ID' as any,
 			} );
 			expect( url ).toBe(
-				`${ adminUrl }admin.php?page=jetpack&connect_url_redirect&from=my-jetpack&redirect_after_auth=${ adminUrl }/admin.php?page=my-jetpack#/add-license`
+				`${ adminUrl }admin.php?page=jetpack&connect_url_redirect=true&jetpack_connect_login_redirect=true&redirect_after_auth=${ adminUrl }admin.php?page=my-jetpack`
 			);
 		} );
 

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -103,10 +103,13 @@ export interface CheckoutMainProps {
 	isUserComingFromLoginForm?: boolean;
 	customizedPreviousPath?: string;
 	connectAfterCheckout?: boolean;
-	// `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
-	// checkout), for use cases when there is not a site in context, such as siteless checkout.
-	// As opposed to `siteSlug` which is the site slug present when the site is in context
-	// (ie- the site is available in state, such as when site is connected and user logged in).
+	/**
+	 * `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	 * checkout), for use cases when the site slug cannot be retrieved from state, ie- when there
+	 * is not a site in context, such as in siteless checkout. As opposed to `siteSlug` which is
+	 * the site slug present when the site is in context (ie- when site is connected and user is
+	 * logged in).
+	 */
 	fromSiteSlug?: string;
 	adminUrl?: string;
 }

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -449,6 +449,7 @@ export default function CheckoutMain( {
 			stripeConfiguration,
 			stripe,
 			recaptchaClientId,
+			fromSiteSlug,
 		} ),
 		[
 			contactDetails,
@@ -463,6 +464,7 @@ export default function CheckoutMain( {
 			stripeConfiguration,
 			updatedSiteSlug,
 			recaptchaClientId,
+			fromSiteSlug,
 		]
 	);
 

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -102,6 +102,9 @@ export interface CheckoutMainProps {
 	jetpackPurchaseToken?: string;
 	isUserComingFromLoginForm?: boolean;
 	customizedPreviousPath?: string;
+	connectAfterCheckout?: boolean;
+	fromSiteSlug?: string;
+	adminUrl?: string;
 }
 
 export default function CheckoutMain( {
@@ -129,6 +132,9 @@ export default function CheckoutMain( {
 	jetpackPurchaseToken,
 	isUserComingFromLoginForm,
 	customizedPreviousPath,
+	connectAfterCheckout,
+	fromSiteSlug,
+	adminUrl,
 }: CheckoutMainProps ) {
 	const translate = useTranslate();
 
@@ -257,6 +263,9 @@ export default function CheckoutMain( {
 		sitelessCheckoutType,
 		isInModal,
 		domains,
+		connectAfterCheckout,
+		adminUrl,
+		fromSiteSlug,
 	} );
 
 	const getThankYouUrl = useCallback( () => {
@@ -590,6 +599,9 @@ export default function CheckoutMain( {
 		siteSlug: updatedSiteSlug,
 		sitelessCheckoutType,
 		checkoutFlow,
+		connectAfterCheckout,
+		adminUrl,
+		fromSiteSlug,
 	} );
 
 	const handleStepChanged = useCallback(

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -103,6 +103,10 @@ export interface CheckoutMainProps {
 	isUserComingFromLoginForm?: boolean;
 	customizedPreviousPath?: string;
 	connectAfterCheckout?: boolean;
+	// `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	// checkout), for use cases when there is not a site in context, such as siteless checkout.
+	// As opposed to `siteSlug` which is the site slug present when the site is in context
+	// (ie- the site is available in state, such as when site is connected and user logged in).
 	fromSiteSlug?: string;
 	adminUrl?: string;
 }

--- a/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
@@ -64,6 +64,9 @@ export default function useCreatePaymentCompleteCallback( {
 	siteSlug,
 	sitelessCheckoutType,
 	checkoutFlow,
+	connectAfterCheckout,
+	adminUrl: wpAdminUrl,
+	fromSiteSlug,
 }: {
 	createUserAndSiteBeforeTransaction?: boolean;
 	productAliasFromUrl?: string | undefined;
@@ -76,13 +79,16 @@ export default function useCreatePaymentCompleteCallback( {
 	siteSlug: string | undefined;
 	sitelessCheckoutType?: SitelessCheckoutType;
 	checkoutFlow?: string;
+	connectAfterCheckout?: boolean;
+	adminUrl?: string;
+	fromSiteSlug?: string;
 } ): PaymentEventCallback {
 	const cartKey = useCartKey();
 	const { responseCart, reloadFromServer: reloadCart } = useShoppingCart( cartKey );
 	const reduxDispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
 	const selectedSiteData = useSelector( getSelectedSite );
-	const adminUrl = selectedSiteData?.options?.admin_url;
+	const adminUrl = selectedSiteData?.options?.admin_url || wpAdminUrl;
 	const sitePlanSlug = selectedSiteData?.plan?.product_slug;
 	const isJetpackNotAtomic =
 		useSelector(
@@ -134,6 +140,8 @@ export default function useCreatePaymentCompleteCallback( {
 				jetpackTemporarySiteId,
 				adminPageRedirect,
 				domains,
+				connectAfterCheckout,
+				fromSiteSlug,
 			};
 
 			debug( 'getThankYouUrl called with', getThankYouPageUrlArguments );
@@ -227,6 +235,7 @@ export default function useCreatePaymentCompleteCallback( {
 					siteSlug,
 					orderId: 'order_id' in transactionResult ? transactionResult.order_id : undefined,
 					receiptId: 'receipt_id' in transactionResult ? transactionResult.receipt_id : undefined,
+					fromSiteSlug,
 				} );
 				return;
 			}
@@ -261,6 +270,8 @@ export default function useCreatePaymentCompleteCallback( {
 			adminPageRedirect,
 			domains,
 			sitePlanSlug,
+			connectAfterCheckout,
+			fromSiteSlug,
 		]
 	);
 }

--- a/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
@@ -81,6 +81,10 @@ export default function useCreatePaymentCompleteCallback( {
 	checkoutFlow?: string;
 	connectAfterCheckout?: boolean;
 	adminUrl?: string;
+	// `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	// checkout), for use cases when there is not a site in context, such as siteless checkout.
+	// As opposed to `siteSlug` which is the site slug present when the site is in context
+	// (ie- the site is available in state, such as when site is connected and user logged in).
 	fromSiteSlug?: string;
 } ): PaymentEventCallback {
 	const cartKey = useCartKey();

--- a/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
@@ -81,10 +81,13 @@ export default function useCreatePaymentCompleteCallback( {
 	checkoutFlow?: string;
 	connectAfterCheckout?: boolean;
 	adminUrl?: string;
-	// `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
-	// checkout), for use cases when there is not a site in context, such as siteless checkout.
-	// As opposed to `siteSlug` which is the site slug present when the site is in context
-	// (ie- the site is available in state, such as when site is connected and user logged in).
+	/**
+	 * `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	 * checkout), for use cases when the site slug cannot be retrieved from state, ie- when there
+	 * is not a site in context, such as in siteless checkout. As opposed to `siteSlug` which is
+	 * the site slug present when the site is in context (ie- when site is connected and user is
+	 * logged in).
+	 */
 	fromSiteSlug?: string;
 } ): PaymentEventCallback {
 	const cartKey = useCartKey();

--- a/client/my-sites/checkout/src/hooks/use-get-thank-you-url/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-get-thank-you-url/index.tsx
@@ -36,10 +36,13 @@ export default function useGetThankYouUrl( {
 	hideNudge,
 	isInModal,
 	domains,
+	connectAfterCheckout,
+	adminUrl: wpAdminUrl,
+	fromSiteSlug,
 }: GetThankYouUrlProps ): GetThankYouUrl {
 	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
 
-	const adminUrl = selectedSiteData?.options?.admin_url;
+	const adminUrl = selectedSiteData?.options?.admin_url || wpAdminUrl;
 
 	const getThankYouUrl = useCallback( () => {
 		const getThankYouPageUrlArguments: PostCheckoutUrlArguments = {
@@ -55,8 +58,9 @@ export default function useGetThankYouUrl( {
 			hideNudge,
 			isInModal,
 			domains,
+			connectAfterCheckout,
+			fromSiteSlug,
 		};
-
 		debug( 'getThankYouUrl called with', getThankYouPageUrlArguments );
 		const url = getThankYouPageUrl( getThankYouPageUrlArguments );
 		debug( 'getThankYouUrl returned', url );
@@ -75,6 +79,8 @@ export default function useGetThankYouUrl( {
 		hideNudge,
 		sitelessCheckoutType,
 		domains,
+		connectAfterCheckout,
+		fromSiteSlug,
 	] );
 	return getThankYouUrl;
 }
@@ -91,4 +97,7 @@ export interface GetThankYouUrlProps {
 	isInModal?: boolean;
 	isJetpackNotAtomic?: boolean;
 	domains: ResponseDomain[] | undefined;
+	connectAfterCheckout?: boolean;
+	adminUrl?: string;
+	fromSiteSlug?: string;
 }

--- a/client/my-sites/checkout/src/hooks/use-get-thank-you-url/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-get-thank-you-url/index.tsx
@@ -99,9 +99,12 @@ export interface GetThankYouUrlProps {
 	domains: ResponseDomain[] | undefined;
 	connectAfterCheckout?: boolean;
 	adminUrl?: string;
-	// `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
-	// checkout), for use cases when there is not a site in context, such as siteless checkout.
-	// As opposed to `siteSlug` which is the site slug present when the site is in context
-	// (ie- the site is available in state, such as when site is connected and user logged in).
+	/**
+	 * `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	 * checkout), for use cases when the site slug cannot be retrieved from state, ie- when there
+	 * is not a site in context, such as in siteless checkout. As opposed to `siteSlug` which is
+	 * the site slug present when the site is in context (ie- when site is connected and user is
+	 * logged in).
+	 */
 	fromSiteSlug?: string;
 }

--- a/client/my-sites/checkout/src/hooks/use-get-thank-you-url/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-get-thank-you-url/index.tsx
@@ -99,5 +99,9 @@ export interface GetThankYouUrlProps {
 	domains: ResponseDomain[] | undefined;
 	connectAfterCheckout?: boolean;
 	adminUrl?: string;
+	// `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	// checkout), for use cases when there is not a site in context, such as siteless checkout.
+	// As opposed to `siteSlug` which is the site slug present when the site is in context
+	// (ie- the site is available in state, such as when site is connected and user logged in).
 	fromSiteSlug?: string;
 }

--- a/client/my-sites/checkout/src/lib/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/src/lib/generic-redirect-processor.ts
@@ -30,6 +30,7 @@ export default async function genericRedirectProcessor(
 		reduxDispatch,
 		responseCart,
 		contactDetails,
+		fromSiteSlug,
 	} = transactionOptions;
 	if ( ! isValidTransactionData( submitData ) ) {
 		throw new Error( 'Required purchase data is missing' );
@@ -47,6 +48,7 @@ export default async function genericRedirectProcessor(
 	const thankYouUrl = getThankYouUrl() || 'https://wordpress.com';
 	const successUrl = addUrlToPendingPageRedirect( thankYouUrl, {
 		siteSlug,
+		fromSiteSlug,
 		urlType: 'absolute',
 	} );
 	const cancelUrl = `${ origin }${ pathname }${ search }`;

--- a/client/my-sites/checkout/src/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/src/lib/paypal-express-processor.ts
@@ -29,6 +29,7 @@ export default async function payPalProcessor(
 		siteId,
 		siteSlug,
 		contactDetails,
+		fromSiteSlug,
 	} = transactionOptions;
 	reduxDispatch( recordTransactionBeginAnalytics( { paymentMethodId: 'paypal' } ) );
 
@@ -52,6 +53,7 @@ export default async function payPalProcessor(
 	const successUrl = addUrlToPendingPageRedirect( thankYouUrl, {
 		siteSlug,
 		urlType: 'absolute',
+		fromSiteSlug,
 	} );
 
 	const formattedTransactionData = createPayPalExpressEndpointRequestPayloadFromLineItems( {

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -24,7 +24,7 @@ export interface RedirectForTransactionStatusArgs {
 	redirectTo?: string;
 	siteSlug?: string;
 	saasRedirectUrl?: string;
-	fromSite?: string;
+	fromSiteSlug?: string;
 }
 
 /**
@@ -178,7 +178,9 @@ export function addUrlToPendingPageRedirect(
 	const successUrlObject = new URL( successUrlBase );
 	successUrlObject.searchParams.set( 'redirectTo', url );
 	successUrlObject.searchParams.set( 'receiptId', String( receiptId ) );
-	fromSiteSlug && successUrlObject.searchParams.set( 'from_site', fromSiteSlug );
+	if ( fromSiteSlug ) {
+		successUrlObject.searchParams.set( 'from_site_slug', fromSiteSlug );
+	}
 	if ( urlType === 'relative' ) {
 		return successUrlObject.pathname + successUrlObject.search + successUrlObject.hash;
 	}
@@ -323,7 +325,7 @@ export function getRedirectFromPendingPage( {
 	redirectTo,
 	siteSlug,
 	saasRedirectUrl,
-	fromSite,
+	fromSiteSlug,
 }: RedirectForTransactionStatusArgs ): RedirectInstructions | undefined {
 	const defaultFailUrl = siteSlug ? `/checkout/${ siteSlug }` : '/';
 	const planRoute = siteSlug ? `/plans/my-plan/${ siteSlug }` : '/pricing';
@@ -345,7 +347,7 @@ export function getRedirectFromPendingPage( {
 					redirectTo ?? getDefaultSuccessUrl( siteSlug, receiptId ),
 					receiptId
 				),
-				siteSlug || fromSite,
+				siteSlug || fromSiteSlug,
 				getDefaultSuccessUrl( siteSlug, receiptId )
 			),
 		};

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -7,6 +7,13 @@ export interface PendingPageRedirectOptions {
 	orderId?: string | number | undefined;
 	receiptId?: string | number | undefined;
 	urlType?: 'relative' | 'absolute';
+	/**
+	 * `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	 * checkout), for use cases when the site slug cannot be retrieved from state, ie- when there
+	 * is not a site in context, such as in siteless checkout. As opposed to `siteSlug` which is
+	 * the site slug present when the site is in context (ie- when site is connected and user is
+	 * logged in).
+	 */
 	fromSiteSlug?: string;
 }
 
@@ -24,6 +31,13 @@ export interface RedirectForTransactionStatusArgs {
 	redirectTo?: string;
 	siteSlug?: string;
 	saasRedirectUrl?: string;
+	/**
+	 * `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	 * checkout), for use cases when the site slug cannot be retrieved from state, ie- when there
+	 * is not a site in context, such as in siteless checkout. As opposed to `siteSlug` which is
+	 * the site slug present when the site is in context (ie- when site is connected and user is
+	 * logged in).
+	 */
 	fromSiteSlug?: string;
 }
 
@@ -167,10 +181,6 @@ export function addUrlToPendingPageRedirect(
 		orderId,
 		urlType = 'absolute',
 		receiptId = ':receiptId',
-		// `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
-		// checkout), for use cases when there is not a site in context, such as siteless checkout.
-		// As opposed to `siteSlug` which is the site slug present when the site is in context
-		// (ie- the site is available in state, such as when site is connected and user logged in).
 		fromSiteSlug,
 	} = options;
 
@@ -329,10 +339,6 @@ export function getRedirectFromPendingPage( {
 	redirectTo,
 	siteSlug,
 	saasRedirectUrl,
-	// `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
-	// checkout), for use cases when there is not a site in context, such as siteless checkout.
-	// As opposed to `siteSlug` which is the site slug present when the site is in context
-	// (ie- the site is available in state, such as when site is connected and user logged in).
 	fromSiteSlug,
 }: RedirectForTransactionStatusArgs ): RedirectInstructions | undefined {
 	const defaultFailUrl = siteSlug ? `/checkout/${ siteSlug }` : '/';

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -167,6 +167,10 @@ export function addUrlToPendingPageRedirect(
 		orderId,
 		urlType = 'absolute',
 		receiptId = ':receiptId',
+		// `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+		// checkout), for use cases when there is not a site in context, such as siteless checkout.
+		// As opposed to `siteSlug` which is the site slug present when the site is in context
+		// (ie- the site is available in state, such as when site is connected and user logged in).
 		fromSiteSlug,
 	} = options;
 
@@ -325,6 +329,10 @@ export function getRedirectFromPendingPage( {
 	redirectTo,
 	siteSlug,
 	saasRedirectUrl,
+	// `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	// checkout), for use cases when there is not a site in context, such as siteless checkout.
+	// As opposed to `siteSlug` which is the site slug present when the site is in context
+	// (ie- the site is available in state, such as when site is connected and user logged in).
 	fromSiteSlug,
 }: RedirectForTransactionStatusArgs ): RedirectInstructions | undefined {
 	const defaultFailUrl = siteSlug ? `/checkout/${ siteSlug }` : '/';

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -7,6 +7,7 @@ export interface PendingPageRedirectOptions {
 	orderId?: string | number | undefined;
 	receiptId?: string | number | undefined;
 	urlType?: 'relative' | 'absolute';
+	fromSiteSlug?: string;
 }
 
 export interface RedirectInstructions {
@@ -23,6 +24,7 @@ export interface RedirectForTransactionStatusArgs {
 	redirectTo?: string;
 	siteSlug?: string;
 	saasRedirectUrl?: string;
+	fromSite?: string;
 }
 
 /**
@@ -160,7 +162,13 @@ export function addUrlToPendingPageRedirect(
 	url: string,
 	options: PendingPageRedirectOptions
 ): string {
-	const { siteSlug, orderId, urlType = 'absolute', receiptId = ':receiptId' } = options;
+	const {
+		siteSlug,
+		orderId,
+		urlType = 'absolute',
+		receiptId = ':receiptId',
+		fromSiteSlug,
+	} = options;
 
 	const { origin = 'https://wordpress.com' } = typeof window !== 'undefined' ? window.location : {};
 	const successUrlPath =
@@ -170,6 +178,7 @@ export function addUrlToPendingPageRedirect(
 	const successUrlObject = new URL( successUrlBase );
 	successUrlObject.searchParams.set( 'redirectTo', url );
 	successUrlObject.searchParams.set( 'receiptId', String( receiptId ) );
+	fromSiteSlug && successUrlObject.searchParams.set( 'from_site', fromSiteSlug );
 	if ( urlType === 'relative' ) {
 		return successUrlObject.pathname + successUrlObject.search + successUrlObject.hash;
 	}
@@ -314,6 +323,7 @@ export function getRedirectFromPendingPage( {
 	redirectTo,
 	siteSlug,
 	saasRedirectUrl,
+	fromSite,
 }: RedirectForTransactionStatusArgs ): RedirectInstructions | undefined {
 	const defaultFailUrl = siteSlug ? `/checkout/${ siteSlug }` : '/';
 	const planRoute = siteSlug ? `/plans/my-plan/${ siteSlug }` : '/pricing';
@@ -335,7 +345,7 @@ export function getRedirectFromPendingPage( {
 					redirectTo ?? getDefaultSuccessUrl( siteSlug, receiptId ),
 					receiptId
 				),
-				siteSlug,
+				siteSlug || fromSite,
 				getDefaultSuccessUrl( siteSlug, receiptId )
 			),
 		};

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -386,7 +386,7 @@ export function getRedirectFromPendingPage( {
 						redirectTo ?? getDefaultSuccessUrl( siteSlug, transactionReceiptId ),
 						transactionReceiptId
 					),
-					siteSlug,
+					siteSlug || fromSiteSlug,
 					getDefaultSuccessUrl( siteSlug, transactionReceiptId )
 				),
 			};

--- a/client/my-sites/checkout/src/test/pending-page.ts
+++ b/client/my-sites/checkout/src/test/pending-page.ts
@@ -87,7 +87,7 @@ describe( 'addUrlToPendingPageRedirect', () => {
 		);
 	} );
 
-	it( 'returns a no-site URL and a site slug as `from_site_slug` if no siteSlug is provided but fromSiteSlug is provided', () => {
+	it( 'returns a no-site URL and a siteSlug as `from_site_slug` if no siteSlug is provided but fromSiteSlug is provided', () => {
 		const finalUrl = '/foo/bar/baz';
 		const orderId = '12345';
 		const fromSiteSlug = 'myJetpack.site';
@@ -201,6 +201,17 @@ describe( 'getRedirectFromPendingPage', () => {
 			siteSlug: 'example.com',
 		} );
 		expect( actual ).toEqual( { url: 'https://example.com/home' } );
+	} );
+
+	it( 'returns a simple absolute url if it matches the `fromSiteSlug` and there is no `siteSlug` and there is also a receipt', () => {
+		const actual = getRedirectFromPendingPage( {
+			redirectTo: 'https://example.com/wp-admin/pamin.php?page=jetpack&connect_url_redirect',
+			receiptId: 12345,
+			fromSiteSlug: 'example.com',
+		} );
+		expect( actual ).toEqual( {
+			url: 'https://example.com/wp-admin/pamin.php?page=jetpack&connect_url_redirect',
+		} );
 	} );
 
 	it( 'returns a receipt interpolated absolute url if it is allowed and there is also a receipt', () => {

--- a/client/my-sites/checkout/src/test/pending-page.ts
+++ b/client/my-sites/checkout/src/test/pending-page.ts
@@ -87,6 +87,21 @@ describe( 'addUrlToPendingPageRedirect', () => {
 		);
 	} );
 
+	it( 'returns a no-site URL and a site slug as `from_site_slug` if no siteSlug is provided but fromSiteSlug is provided', () => {
+		const finalUrl = '/foo/bar/baz';
+		const orderId = '12345';
+		const fromSiteSlug = 'myJetpack.site';
+		const actual = addUrlToPendingPageRedirect( finalUrl, {
+			orderId,
+			fromSiteSlug,
+		} );
+		expect( actual ).toEqual(
+			`${ currentWindowOrigin }/checkout/thank-you/no-site/pending/${ orderId }?redirectTo=${ encodeURIComponent(
+				finalUrl
+			) }&receiptId=${ encodedReceiptPlaceholder }&from_site_slug=${ fromSiteSlug }`
+		);
+	} );
+
 	it( 'returns a order ID placeholder when no order ID is provided', () => {
 		const finalUrl = '/foo/bar/baz';
 		const siteSlug = 'example2.com';

--- a/client/my-sites/checkout/src/types/payment-processors.ts
+++ b/client/my-sites/checkout/src/types/payment-processors.ts
@@ -18,5 +18,12 @@ export interface PaymentProcessorOptions {
 	siteId: number | undefined;
 	contactDetails: ManagedContactDetails | undefined;
 	recaptchaClientId?: number;
+	/**
+	 * `fromSiteSlug` is the Jetpack site slug passed from the site via url query arg (into
+	 * checkout), for use cases when the site slug cannot be retrieved from state, ie- when there
+	 * is not a site in context, such as in siteless checkout. As opposed to `siteSlug` which is
+	 * the site slug present when the site is in context (ie- when site is connected and user is
+	 * logged in).
+	 */
 	fromSiteSlug?: string;
 }

--- a/client/my-sites/checkout/src/types/payment-processors.ts
+++ b/client/my-sites/checkout/src/types/payment-processors.ts
@@ -18,4 +18,5 @@ export interface PaymentProcessorOptions {
 	siteId: number | undefined;
 	contactDetails: ManagedContactDetails | undefined;
 	recaptchaClientId?: number;
+	fromSiteSlug?: string;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR adds the ability to connect the user's Jetpack site after product purchase (checkout), if given the appropriate query args in the siteless (license-based) checkout url.

This PR can be tested along with Jetpack PR https://github.com/Automattic/jetpack/pull/33257 .

## Proposed Changes

* Updated the checkout flow to receive 3 new query args (`connect_after_checkout`, `admin_url`, and `from_site_slug`) - My Jetpack, in the plugin, will be passing these query args into checkout.
* When these query args are received in the siteless chekout flow, checkout will redirect to the site's connection/authorization url after purchase is completed.

Still TODO: Then after connection complete, activate the product license key (transfer the temporary site subscription to the target site) - In a separate, follow-up diff/PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow testing instructions in Jetpack PR https://github.com/Automattic/jetpack/pull/33257


#### Unit tests:

Run:

`yarn test-client client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts`
`yarn test-client client/my-sites/checkout/src/test/pending-page.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?