### PR TITLE
Assembler - Pattern Categories - Add Intro category and hide CTA

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -29,13 +29,14 @@ export const INITIAL_SCREEN = 'main';
  */
 export const PATTERN_CATEGORIES = [
 	//'featured', // -- Not exists
+	'intro',
 	'about',
 	//'buttons', -- Not exist
 	//'banner', -- Not exist
 	//'query', -- Not exist
 	'blog',
 	'posts', // Reused as "Blog Posts"
-	'call-to-action',
+	//'call-to-action', -- Hidden
 	//'columns', -- Not exist
 	//'coming-soon', -- Hidden
 	'contact',
@@ -46,18 +47,18 @@ export const PATTERN_CATEGORIES = [
 	//'link-in-bio', -- Hidden
 	//'media', -- Not exist
 	'newsletter',
-	// 'podcast', -- Hidden
-	// 'portfolio', -- Hidden
+	//'podcast', -- Hidden
+	//'portfolio', -- Hidden
 	'quotes',
 	'services',
 	'store',
 	//'team', -- Not exist
 	//'testimonials', -- Not exist
-	// 'text', -- Hidden
+	//'text', -- Hidden
 ];
 
 export const ORDERED_PATTERN_CATEGORIES = [
-	'call-to-action',
+	'intro',
 	'about',
 	'services',
 	'store',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1695349021013959/1695251719.233489-slack-CRWCHQGUB

## Proposed Changes

* Add "Intro" category and show it on the first position
* Hide "Call to Action"

Note: the category Intro is being added to the Dotcom source site and appears in the editor.


|BEFORE|AFTER|
|--|--|
|<img width="694" alt="Screenshot 2566-09-22 at 10 12 10" src="https://github.com/Automattic/wp-calypso/assets/1881481/1e6d078a-6086-4baa-85f0-05d2e4b21e23">|<img width="699" alt="Screenshot 2566-09-22 at 10 11 50" src="https://github.com/Automattic/wp-calypso/assets/1881481/dc262cf1-54d1-4a59-b000-1cd3b08902bd">|


|BEFORE|AFTER|
|--|--|
|<img width="651" alt="Screenshot 2566-09-22 at 10 14 31" src="https://github.com/Automattic/wp-calypso/assets/1881481/76cfaa14-081e-4749-ad3d-b80f26ad5b58">|<img width="650" alt="Screenshot 2566-09-22 at 10 13 47" src="https://github.com/Automattic/wp-calypso/assets/1881481/3a7ff5d5-5291-455f-8d72-b7c365cac831">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }`
* Verify the Intro category is the first
* Verify the Call to Action category is hidden

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?