### PR TITLE
Disable uk,fr,ca tld's from being transfered between users

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -141,7 +141,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 			);
 		} else if (
 			isEnabled( 'domains/transfer-to-any-user' ) &&
-			! [ 'uk', 'fr', 'ca' ].includes( getTopLevelOfTld( selectedDomainName ) )
+			! [ 'uk', 'fr', 'ca', 'de', 'jp' ].includes( getTopLevelOfTld( selectedDomainName ) )
 		) {
 			options.push(
 				<ActionCard

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -139,7 +139,10 @@ const TransferPage = ( props: TransferPageProps ) => {
 					mainText={ mainText }
 				/>
 			);
-		} else if ( isEnabled( 'domains/transfer-to-any-user' ) ) {
+		} else if (
+			isEnabled( 'domains/transfer-to-any-user' ) &&
+			! [ 'uk', 'fr', 'ca' ].includes( getTopLevelOfTld( selectedDomainName ) )
+		) {
 			options.push(
 				<ActionCard
 					key="transfer-to-any-user"


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3836

## Proposed Changes

* Disable uk,fr,ca tld's from being transfered between users

## Testing Instructions

Compare:
* http://calypso.localhost:3000/domains/manage/all/test345678.blog/transfer/test345678.blog
* http://calypso.localhost:3000/domains/manage/all/test1412312.co.uk/transfer/test1412312.co.uk

The UK one should not show the option to transfer domains between users.

![Screenshot 2023-09-22 at 17-04-55 test345678 blog — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/c601adf0-a01c-4901-a34f-aed738beac2d)
![Screenshot 2023-09-22 at 17-04-30 test1412312 co uk — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/1a1ab797-f4c7-4402-8026-0b782c10613d)
