### PR TITLE
Jetpack Manage: Update partner portal to utilized has_jetpack_partner_access to determine partner access.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -29,6 +29,7 @@ import {
 	getCurrentPartner,
 	hasActivePartnerKey,
 	doesPartnerRequireAPaymentMethod,
+	hasJetpackPartnerAccess,
 } from 'calypso/state/partner-portal/partner/selectors';
 import { ToSConsent } from 'calypso/state/partner-portal/types';
 import getSites from 'calypso/state/selectors/get-sites';
@@ -173,16 +174,15 @@ export function wpcomAtomicHostingContext( context: PageJS.Context, next: () => 
 
 /**
  * Require the user to have a partner with at least 1 active partner key.
- *
  * @param {PageJS.Context} context PageJS context.
  * @param {() => void} next Next context callback.
  */
 export function requireAccessContext( context: PageJS.Context, next: () => void ): void {
 	const state = context.store.getState();
-	const partner = getCurrentPartner( state );
+	const hasPartnerAccess = hasJetpackPartnerAccess( state );
 	const { pathname, search } = window.location;
 
-	if ( partner ) {
+	if ( hasPartnerAccess ) {
 		next();
 		return;
 	}
@@ -199,7 +199,6 @@ export function requireAccessContext( context: PageJS.Context, next: () => void 
 
 /**
  * Require the user to have consented to the terms of service.
- *
  * @param {PageJS.Context} context PageJS context.
  * @param {() => void} next Next context callback.
  */
@@ -230,7 +229,6 @@ export function requireTermsOfServiceConsentContext(
 
 /**
  * Require the user to have selected a partner key to use.
- *
  * @param {PageJS.Context} context PageJS context.
  * @param {() => void} next Next context callback.
  */
@@ -261,7 +259,6 @@ export function requireSelectedPartnerKeyContext(
 
 /**
  * Require the user to have a valid payment method registered.
- *
  * @param {PageJS.Context} context PageJS context.
  * @param {() => void} next Next context callback.
  */

--- a/client/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent/index.tsx
@@ -67,7 +67,7 @@ export default function TermsOfServiceConsent() {
 
 			{ ! fetchedPartner && <Spinner /> }
 
-			{ ! hasConsented && (
+			{ fetchedPartner && ! hasConsented && (
 				<Card>
 					<CardHeading>{ translate( 'Terms of Service' ) }</CardHeading>
 


### PR DESCRIPTION

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?