### PR TITLE
Newsletter categories: Remove feature flag for newsletter categories

### DIFF
--- a/client/blocks/reader-site-subscription/subscribe-to-newsletter-categories.tsx
+++ b/client/blocks/reader-site-subscription/subscribe-to-newsletter-categories.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Spinner } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -36,10 +35,7 @@ const SubscribeToNewsletterCategories = ( { siteId }: SubscribeToNewsletterCateg
 		] );
 	};
 
-	if (
-		! config.isEnabled( 'settings/newsletter-categories' ) ||
-		! subscribedNewsletterCategoriesData?.enabled
-	) {
+	if ( ! subscribedNewsletterCategoriesData?.enabled ) {
 		return null;
 	}
 

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -71,21 +70,20 @@ export const NewsletterSettingsSection = ( {
 
 	return (
 		<>
-			{ config.isEnabled( 'settings/newsletter-categories' ) &&
-				( isSimpleSite || hasNewsletterCategoriesBlogSticker ) && (
-					<Card className="site-settings__card">
-						<NewsletterCategoriesSettings
-							disabled={ disabled }
-							newsletterCategoryIds={
-								fields.wpcom_newsletter_categories ?? defaultNewsletterCategoryIds
-							}
-							handleAutosavingToggle={ handleAutosavingToggle }
-							handleSubmitForm={ handleSubmitForm }
-							toggleValue={ wpcom_newsletter_categories_enabled }
-							updateFields={ updateFields }
-						/>
-					</Card>
-				) }
+			{ ( isSimpleSite || hasNewsletterCategoriesBlogSticker ) && (
+				<Card className="site-settings__card">
+					<NewsletterCategoriesSettings
+						disabled={ disabled }
+						newsletterCategoryIds={
+							fields.wpcom_newsletter_categories ?? defaultNewsletterCategoryIds
+						}
+						handleAutosavingToggle={ handleAutosavingToggle }
+						handleSubmitForm={ handleSubmitForm }
+						toggleValue={ wpcom_newsletter_categories_enabled }
+						updateFields={ updateFields }
+					/>
+				</Card>
+			) }
 			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
 			<SettingsSectionHeader
 				id="newsletter-settings"

--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -71,7 +71,7 @@ const SubscriberDetails = ( {
 							dateFormat="LL"
 						/>
 					</div>
-					{ config.isEnabled( 'settings/newsletter-categories' ) && newsletterCategoriesEnabled && (
+					{ newsletterCategoriesEnabled && (
 						<div className="subscriber-details__content-column">
 							<div className="subscriber-details__content-label">
 								{ translate( 'Receives emails for' ) }

--- a/config/development.json
+++ b/config/development.json
@@ -170,7 +170,6 @@
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
-		"settings/newsletter-categories": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -107,7 +107,6 @@
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
-		"settings/newsletter-categories": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -131,7 +131,6 @@
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
-		"settings/newsletter-categories": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -140,7 +140,6 @@
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
-		"settings/newsletter-categories": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,


### PR DESCRIPTION
The feature flag 'settings/newsletter-categories' has been removed as it is no longer necessary. The newsletter categories feature is stable and no longer needs to be toggleable. This change simplifies the code base and makes it more maintainable in the future.

## Proposed Changes

* Removes the feature flag

## Testing Instructions

Test these pages:
- Newsletter settings on a **simple site**: newsletter categories settings should show
- Newsletter settings on a **Atomic site**: newsletter categories settings shouldn't show
- Newsletter settings on a **Atomic site with blog sticker newsletter-categories set**: newsletter categories settings should show
- Subscription details in reader for a subscription to a site that has enabled NCs: categories should show
- Subscription details in subscription portal for a subscription to a site that has enabled NCs: categories should show
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?