### PR TITLE
Implement the SRM A/A tests

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -269,6 +269,7 @@ const PlansFeaturesMain = ( {
 	useEffect( () => {
 		if ( flowName === 'onboarding' ) {
 			loadExperimentAssignment( 'calypso_srm_test_plans_page_view_free_plan_modal_view' );
+			loadExperimentAssignment( 'calypso_srm_test_plans_page_view_free_plan_button_click' );
 		}
 	}, [] );
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -29,6 +29,7 @@ import {
 	planItem as getCartItemForPlan,
 	getPlanCartItem,
 } from 'calypso/lib/cart-values/cart-items';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { isValidFeatureKey, FEATURES_LIST } from 'calypso/lib/plans/features-list';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import PlanFeatures2023Grid from 'calypso/my-sites/plan-features-2023-grid';
@@ -261,6 +262,16 @@ const PlansFeaturesMain = ( {
 		useGetFreeSubdomainSuggestion(
 			paidDomainName || siteTitle || signupFlowUserName || currentUserName
 		);
+
+	// the A/A tests for identifying SRM issue. See peP6yB-11Y-p2
+	// We can use `useExperiment()` and its `isEligible` check to avoid the condition, but it's intentional to use loadExperimentAssignment() here
+	// to be consistent with the other A/A tests.
+	useEffect( () => {
+		if ( flowName === 'onboarding' ) {
+			loadExperimentAssignment( 'calypso_srm_test_plans_page_view_free_plan_modal_view' );
+		}
+	}, [] );
+
 	const resolvedSubdomainName: DataResponse< string > = {
 		isLoading: signupFlowSubdomain ? false : wpcomFreeDomainSuggestion.isLoading,
 		result: signupFlowSubdomain

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -289,6 +289,9 @@ class DomainsStep extends Component {
 					loadExperimentAssignment(
 						'calypso_onboarding_plans_paid_domain_on_free_plan_confidence_check'
 					);
+
+					// the A/A test for identifying SRM issue. See peP6yB-11Y-p2
+					loadExperimentAssignment( 'calypso_srm_test_paid_domain_click_free_plan_button_click' );
 				} else {
 					loadExperimentAssignment(
 						'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3'

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -141,6 +141,12 @@ class DomainsStep extends Component {
 				}
 			);
 		}
+
+		// the A/A tests for identifying SRM issue. See peP6yB-11Y-p2
+		if ( this.props.flowName === 'onboarding ' ) {
+			loadExperimentAssignment( 'calypso_srm_test_paid_domain_click_free_plan_button_click' );
+			loadExperimentAssignment( 'calypso_srm_test_domain_page_view_free_plan_modal_view' );
+		}
 	}
 
 	getLocale() {
@@ -290,7 +296,7 @@ class DomainsStep extends Component {
 						'calypso_onboarding_plans_paid_domain_on_free_plan_confidence_check'
 					);
 
-					// the first two variations of the A/A tests for identifying SRM issue. See peP6yB-11Y-p2
+					// the A/A tests for identifying SRM issue. See peP6yB-11Y-p2
 					loadExperimentAssignment( 'calypso_srm_test_paid_domain_click_free_plan_button_click' );
 					loadExperimentAssignment( 'calypso_srm_test_paid_domain_click_free_plan_modal_view' );
 				} else {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -143,8 +143,8 @@ class DomainsStep extends Component {
 		}
 
 		// the A/A tests for identifying SRM issue. See peP6yB-11Y-p2
-		if ( this.props.flowName === 'onboarding ' ) {
-			loadExperimentAssignment( 'calypso_srm_test_paid_domain_click_free_plan_button_click' );
+		if ( this.props.flowName === 'onboarding' ) {
+			loadExperimentAssignment( 'calypso_srm_test_domain_page_view_free_plan_button_click' );
 			loadExperimentAssignment( 'calypso_srm_test_domain_page_view_free_plan_modal_view' );
 		}
 	}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -290,8 +290,9 @@ class DomainsStep extends Component {
 						'calypso_onboarding_plans_paid_domain_on_free_plan_confidence_check'
 					);
 
-					// the A/A test for identifying SRM issue. See peP6yB-11Y-p2
+					// the first two variations of the A/A tests for identifying SRM issue. See peP6yB-11Y-p2
 					loadExperimentAssignment( 'calypso_srm_test_paid_domain_click_free_plan_button_click' );
+					loadExperimentAssignment( 'calypso_srm_test_paid_domain_click_free_plan_modal_view' );
 				} else {
 					loadExperimentAssignment(
 						'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/growth-foundations#205

## Proposed Changes

This PR implements the 5 A/A tests listed in Automattic/growth-foundations#205 for identifying the SRM issue we've observed in the paid domain/free plan modal test(e.g. the confidence check round implemented in https://github.com/Automattic/wp-calypso/pull/81408). 

Since we only want to check under which conditions the unbalanced variation assignment would happen, we only need to load respective ExPlat experiment instances accordingly.

## Testing Instructions

Since there is no UX difference for each experiment, we just need to use the network inspector to make sure the requests to the explat endpoint happen at the right timing. e.g.

<img width="1252" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1842898/e549d310-c7b9-4db8-8460-e653b30efef1">

The exposure events are configured in Abacus as part of the analysis strategy, so there is no related code change introduced.

* The 5 A/A tests should only happen in `/start`
* Upon visting `/start/domains`, the fetch requests to the experiment assignment endpoint for the following two experiments should be found:
    * `calypso_srm_test_domain_page_view_free_plan_button_click`
    * `calypso_srm_test_domain_page_view_free_plan_modal_view`
* At `/start/domains`, upon clicking a paid domain, the fetch requests to the experiment assignment endpoint for the following two experiments should be found:
    * `calypso_srm_test_paid_domain_click_free_plan_button_click` 
    * `calypso_srm_test_paid_domain_click_free_plan_modal_view`
* Upon visiting `/start/plans`, the request for `calypso_srm_test_plans_page_view_free_plan_modal_view` should be found.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
