### PR TITLE
Newsletter categories: Ensure that newsletterCategoryIds is an array in `<NewsletterCategoriesSettings />`

### DIFF
--- a/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
+++ b/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
@@ -15,6 +15,18 @@ type NewsletterCategoriesSettingsProps = {
 	updateFields: ( fields: { [ key: string ]: unknown } ) => void;
 };
 
+function ensureArray( value: unknown ): number[] {
+	if ( Array.isArray( value ) ) {
+		return value;
+	}
+
+	if ( typeof value === 'object' ) {
+		return Object.values( value as object );
+	}
+
+	return [];
+}
+
 const NewsletterCategoriesSettings = ( {
 	disabled,
 	handleAutosavingToggle,
@@ -24,6 +36,8 @@ const NewsletterCategoriesSettings = ( {
 	updateFields,
 }: NewsletterCategoriesSettingsProps ) => {
 	const translate = useTranslate();
+
+	const validatedNewsletterCategoryIds = ensureArray( newsletterCategoryIds );
 
 	return (
 		<div className="newsletter-categories-settings">
@@ -43,20 +57,19 @@ const NewsletterCategoriesSettings = ( {
 					taxonomy="category"
 					addTerm={ true }
 					multiple={ true }
-					selected={ newsletterCategoryIds }
+					selected={ validatedNewsletterCategoryIds }
 					onChange={ (
 						category: { ID: number },
 						{ target: { checked } }: React.ChangeEvent< HTMLInputElement >
 					) => {
 						const updatedValue = checked
-							? [ ...newsletterCategoryIds, category.ID ]
-							: newsletterCategoryIds.filter( ( id ) => id !== category.ID );
-
+							? [ ...validatedNewsletterCategoryIds, category.ID ]
+							: validatedNewsletterCategoryIds.filter( ( id ) => id !== category.ID );
 						updateFields( { wpcom_newsletter_categories: updatedValue } );
 					} }
 					onAddTermSuccess={ ( category: { ID: number } ) => {
 						updateFields( {
-							wpcom_newsletter_categories: [ ...newsletterCategoryIds, category.ID ],
+							wpcom_newsletter_categories: [ ...validatedNewsletterCategoryIds, category.ID ],
 						} );
 					} }
 					height={ 218 }


### PR DESCRIPTION
## Proposed Changes

* Ensures newsletterCategoryIds is an array.

p1695371060513839-slack-C02TCEHP3HA

## Testing Instructions

1. Apply this PR
2. Ensure there are no regressions when visiting Settings > Newsletter & manipulating the newsletter categories

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?