### PR TITLE
Newsletter Settings: Add newsletter settings usage tracking.

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -171,6 +171,9 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 			if ( path === '/settings/reading/:site' ) {
 				trackTracksEvent( 'calypso_settings_reading_saved' );
 			}
+			if ( path === '/settings/newsletter/:site' ) {
+				trackTracksEvent( 'calypso_settings_newsletter_saved' );
+			}
 			this.submitForm();
 			this.props.trackEvent( 'Clicked Save Settings Button' );
 		};
@@ -231,6 +234,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 			this.props.trackEvent( `Toggled ${ name }` );
 			this.props.trackTracksEvent( 'calypso_settings_autosaving_toggle_updated', {
 				name,
+				value: ! this.props.fields[ name ],
 				path: this.props.path,
 			} );
 			this.props.updateFields( { [ name ]: ! this.props.fields[ name ] }, () => {


### PR DESCRIPTION
## Proposed Changes

* Add the tracks event  `calypso_settings_newsletter_saved` whenever a setting is changed in Newsletter Settings.
* Add the prop `value` to the existing event `calypso_settings_autosaving_toggle_updated`.

## Testing Instructions

* Go to newsletter settings page `/settings/newsletter/<your_site_here>`.
* Open up dev console's network panel, and filter it down to `t.gif`.
* Toggle `Enable newsletter categories`, you should see the `calypso_settings_autosaving_toggle_updated` tracks event recorded with the `value` prop containing the value.
* Click on "Save settings" anywhere, you should see the `calypso_settings_newsletter_saved` tracks event recorded.

<img width="1342" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/37f5bad4-a459-4ca1-88ef-b062eb24e24f">

<img width="1044" alt="2023-09-22_11-47-18" src="https://github.com/Automattic/wp-calypso/assets/1287077/e8072754-53f9-40f4-b6a4-a118dfa880cf">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?