### PR TITLE
Domain Upsell: Update banner margins

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -5,7 +5,7 @@
 body .customer-home__layout .domain-upsell__card {
 	padding: 16px 16px 20px;
 	@include break-small {
-		padding: 40px 46px;
+		padding: 32px 24px;
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3880

## Proposed Changes

Update margin for the Domain Upsell card to 32px (top-bottom) / 24px (left-right)
Context: p1695236837726679-slack-CKZHG0QCR

| Before | After | 
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/49be6c53-9fd7-413d-bd4c-96a5af81ae26) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/5ea6e832-fcfe-4852-aa28-6d7bfa2e453a) |

## Testing Instructions

* Use a free site.
* Go to `/home` and check Domain Upsell Card margins

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?