### PR TITLE
Fix calling twice the subscribers endpoint everytime

### DIFF
--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -69,8 +69,6 @@ export const SubscribersPageProvider = ( {
 		filterOption === SubscribersFilterBy.All && hasManySubscribers
 			? SubscribersFilterBy.WPCOM
 			: filterOption;
-	const grandTotalQueryResult = useSubscribersQuery( { siteId, filterOption: subscriberType } );
-	const grandTotal = grandTotalQueryResult.data?.total || 0;
 
 	const dispatch = useDispatch();
 
@@ -80,8 +78,10 @@ export const SubscribersPageProvider = ( {
 		search: debouncedSearchTerm,
 		siteId,
 		sortTerm,
-		filterOption,
+		filterOption: subscriberType,
 	} );
+
+	const grandTotal = subscribersQueryResult.data?.total || 0;
 
 	const { pageChangeCallback } = usePagination(
 		pageNumber,


### PR DESCRIPTION
## Proposed Changes

This PR fixes the problem of calling the Subscribers endpoint twice every time we load the Subscribers page.

## Testing Instructions

1. Apply this PR and start the application.
2. Open the developer tools, network tab.
3. Go to `http://calypso.localhost:3000/subscribers/[domain-of-your-testing-site]`.
4. Check that the endpoint for retrieving subscribers has been called only once: `/wpcom/v2/sites/[blog-id]/subscribers`.
5. Check that the page still retrieves the right subscribers when playing with the filters.

## Pre-merge Checklist
- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?