### PR TITLE
Newsletter Categories: Update newsletter categories settings description.

### DIFF
--- a/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
+++ b/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-settings.tsx
@@ -1,8 +1,11 @@
 import { Button } from '@automattic/components';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import TermTreeSelector from 'calypso/blocks/term-tree-selector';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import NewsletterCategoriesToggle from './newsletter-categories-toggle';
 import './style.scss';
 
@@ -24,6 +27,8 @@ const NewsletterCategoriesSettings = ( {
 	updateFields,
 }: NewsletterCategoriesSettingsProps ) => {
 	const translate = useTranslate();
+	const { hasTranslation } = useI18n();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	return (
 		<div className="newsletter-categories-settings">
@@ -61,11 +66,18 @@ const NewsletterCategoriesSettings = ( {
 					} }
 					height={ 218 }
 				/>
-				<p className="newsletter-categories-settings__description">
-					{ translate(
-						'When adding a new newsletter category, your subscribers will be automatically subscribed to it. They won’t receive any email notification when the category is created.'
-					) }
-				</p>
+				<FormSettingExplanation className="newsletter-categories-settings__description">
+					{ isEnglishLocale ||
+					hasTranslation(
+						'When you add a new category, your existing subscribers will be automatically subscribed to it.'
+					)
+						? translate(
+								'When you add a new category, your existing subscribers will be automatically subscribed to it.'
+						  )
+						: translate(
+								'When adding a new newsletter category, your subscribers will be automatically subscribed to it. They won’t receive any email notification when the category is created.'
+						  ) }
+				</FormSettingExplanation>
 				<Button
 					primary
 					compact

--- a/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-toggle.tsx
+++ b/client/my-sites/site-settings/newsletter-categories-settings/newsletter-categories-toggle.tsx
@@ -1,4 +1,6 @@
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 
@@ -16,6 +18,8 @@ const NewsletterCategoriesToggle = ( {
 	value = false,
 }: NewsletterCategoriesToggleProps ) => {
 	const translate = useTranslate();
+	const { hasTranslation } = useI18n();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	return (
 		<div className="newsletter-categories-toggle">
@@ -26,9 +30,20 @@ const NewsletterCategoriesToggle = ( {
 				label={ translate( 'Enable newsletter categories' ) }
 			/>
 			<FormSettingExplanation>
-				{ translate(
-					'This will allow your visitors to specifically subscribe to the selected categories. When this is enabled, only posts published under the created newsletter categories will be sent out to your subscribers.'
-				) }
+				{ isEnglishLocale ||
+				hasTranslation(
+					'Newsletter categories allow visitors to subscribe only to specific topics.'
+				)
+					? translate(
+							'Newsletter categories allow visitors to subscribe only to specific topics.'
+					  ) +
+					  ' ' +
+					  translate(
+							'When enabled, only posts published under the categories selected below will be emailed to your subscribers.'
+					  )
+					: translate(
+							'This will allow your visitors to specifically subscribe to the selected categories. When this is enabled, only posts published under the created newsletter categories will be sent out to your subscribers.'
+					  ) }
 			</FormSettingExplanation>
 		</div>
 	);

--- a/client/my-sites/site-settings/newsletter-categories-settings/style.scss
+++ b/client/my-sites/site-settings/newsletter-categories-settings/style.scss
@@ -29,11 +29,7 @@
 	}
 
 	.newsletter-categories-settings__description {
-		color: $studio-gray-70;
-		font-family: "SF Pro Text", $sans;
-		font-size: $font-body-small;
-		font-weight: 400;
-		line-height: 20px;
+		margin-top: -12px;
 		margin-bottom: 0;
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Update newsletter categories settings description.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/settings/newsletter/<your_site_here>`.
* You should see the new description as seen in the file change.

Before:
<img width="839" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/946512c4-3656-4542-88cd-fd48d2e46e9a">

After:
<img width="785" alt="2023-09-22_13-23-30" src="https://github.com/Automattic/wp-calypso/assets/1287077/b9921694-e851-4fea-8cd8-6fb4658e61c2">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?