### PR TITLE
Site Profiler: Add l10n

### DIFF
--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@wordpress/components';
+import { translate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useDomainAnalyzerWhoisRawDataQuery } from 'calypso/data/site-profiler/use-domain-whois-raw-data-query';
@@ -22,20 +23,27 @@ export default function DomainInformation( props: Props ) {
 		isError: whoisRawDataFetchingError,
 	} = useDomainAnalyzerWhoisRawDataQuery( domain, fetchWhoisRawData );
 
+	function contactArgs( name: string ) {
+		return {
+			args: [ name ],
+			components: { strong: <strong /> },
+		};
+	}
+
 	return (
 		<div className="domain-information">
-			<h3>Domain information</h3>
+			<h3>{ translate( 'Domain information' ) }</h3>
 
 			<ul className="domain-information-details result-list">
 				{ whois.domain_name && (
 					<li>
-						<div className="name">Domain name</div>
+						<div className="name">{ translate( 'Domain name' ) }</div>
 						<div>{ whois.domain_name }</div>
 					</li>
 				) }
 				{ whois.registrar && (
 					<li>
-						<div className="name">Registrar</div>
+						<div className="name">{ translate( 'Registrar' ) }</div>
 						<div>
 							{ whois.registrar_url && (
 								<a href={ whois.registrar_url } target="_blank" rel="noopener noreferrer">
@@ -48,25 +56,25 @@ export default function DomainInformation( props: Props ) {
 				) }
 				{ whois.creation_date && (
 					<li>
-						<div className="name">Registered on</div>
+						<div className="name">{ translate( 'Registered on' ) }</div>
 						<div>{ moment.utc( whois.creation_date ).format( momentFormat ) }</div>
 					</li>
 				) }
 				{ whois.registry_expiry_date && (
 					<li>
-						<div className="name">Expires on</div>
+						<div className="name">{ translate( 'Expires on' ) }</div>
 						<div>{ moment.utc( whois.registry_expiry_date ).format( momentFormat ) }</div>
 					</li>
 				) }
 				{ whois.updated_date && (
 					<li>
-						<div className="name">Updated on</div>
+						<div className="name">{ translate( 'Updated on' ) }</div>
 						<div>{ moment.utc( whois.updated_date ).format( momentFormat ) }</div>
 					</li>
 				) }
 				{ whois.name_server && (
 					<li>
-						<div className="name">Name servers</div>
+						<div className="name">{ translate( 'Name servers' ) }</div>
 						<div>
 							<ul>
 								{ whois.name_server.map( ( x, i ) => (
@@ -80,156 +88,210 @@ export default function DomainInformation( props: Props ) {
 					<div className="name">Contact</div>
 					<div className="col">
 						<h4>
-							<strong>Registrant contact</strong>
+							<strong>{ translate( 'Registrant contact' ) }</strong>
 						</h4>
 						<ul>
 							{ whois.registrant_name && (
 								<li>
-									<strong>Name:</strong> { whois.registrant_name }
+									{ translate(
+										'{{strong}}Name:{{/strong}} %s',
+										contactArgs( whois.registrant_name )
+									) }
 								</li>
 							) }
 							{ whois.registrant_organization && (
 								<li>
-									<strong>Organization:</strong> { whois.registrant_organization }
+									{ translate(
+										'{{strong}}Organization:{{/strong}} %s',
+										contactArgs( whois.registrant_organization )
+									) }
 								</li>
 							) }
 							{ whois.registrant_street && (
 								<li>
-									<strong>Street:</strong> { whois.registrant_street }
+									{ translate(
+										'{{strong}}Street:{{/strong}} %s',
+										contactArgs( whois.registrant_street )
+									) }
 								</li>
 							) }
 							{ whois.registrant_city && (
 								<li>
-									<strong>City:</strong> { whois.registrant_city }
+									{ translate(
+										'{{strong}}City:{{/strong}} %s',
+										contactArgs( whois.registrant_city )
+									) }
 								</li>
 							) }
 							{ whois.registrant_state && (
 								<li>
-									<strong>State:</strong> { whois.registrant_state }
+									{ translate(
+										'{{strong}}State:{{/strong}} %s',
+										contactArgs( whois.registrant_state )
+									) }
 								</li>
 							) }
 							{ whois.registrant_postal_code && (
 								<li>
-									<strong>Postal Code:</strong> { whois.registrant_postal_code }
+									{ translate(
+										'{{strong}}Postal Code:{{/strong}} %s',
+										contactArgs( whois.registrant_postal_code )
+									) }
 								</li>
 							) }
 							{ whois.registrant_country && (
 								<li>
-									<strong>Country:</strong> { whois.registrant_country }
+									{ translate(
+										'{{strong}}Country:{{/strong}} %s',
+										contactArgs( whois.registrant_country )
+									) }
 								</li>
 							) }
 							{ whois.registrant_phone && (
 								<li>
-									<strong>Phone:</strong> { whois.registrant_phone }
+									{ translate(
+										'{{strong}}Phone:{{/strong}} %s',
+										contactArgs( whois.registrant_phone )
+									) }
 								</li>
 							) }
 							{ whois.registrant_email && (
 								<li>
-									<a href={ `mailto:${ whois.registrant_email }` }>Email</a>
+									<a href={ `mailto:${ whois.registrant_email }` }>{ translate( 'Email' ) }</a>
 								</li>
 							) }
 						</ul>
 					</div>
 					<div className="col">
 						<h4>
-							<strong>Administrative contact</strong>
+							<strong>{ translate( 'Administrative contact' ) }</strong>
 						</h4>
 						<ul>
 							{ whois.admin_name && (
 								<li>
-									<strong>Name:</strong> { whois.admin_name }
+									{ translate( '{{strong}}Name:{{/strong}} %s', contactArgs( whois.admin_name ) ) }
 								</li>
 							) }
 							{ whois.admin_organization && (
 								<li>
-									<strong>Organization:</strong> { whois.admin_organization }
+									{ translate(
+										'{{strong}}Organization:{{/strong}} %s',
+										contactArgs( whois.admin_organization )
+									) }
 								</li>
 							) }
 							{ whois.admin_street && (
 								<li>
-									<strong>Street:</strong> { whois.admin_street }
+									{ translate(
+										'{{strong}}Street:{{/strong}} %s',
+										contactArgs( whois.admin_street )
+									) }
 								</li>
 							) }
 							{ whois.admin_city && (
 								<li>
-									<strong>City:</strong> { whois.admin_city }
+									{ translate( '{{strong}}City:{{/strong}} %s', contactArgs( whois.admin_city ) ) }
 								</li>
 							) }
 							{ whois.admin_state && (
 								<li>
-									<strong>State:</strong> { whois.admin_state }
+									{ translate(
+										'{{strong}}State:{{/strong}} %s',
+										contactArgs( whois.admin_state )
+									) }
 								</li>
 							) }
 							{ whois.admin_postal_code && (
 								<li>
-									<strong>Postal Code:</strong> { whois.admin_postal_code }
+									{ translate(
+										'{{strong}}Postal Code:{{/strong}} %s',
+										contactArgs( whois.admin_postal_code )
+									) }
 								</li>
 							) }
 							{ whois.admin_country && (
 								<li>
-									<strong>Country:</strong> { whois.admin_country }
+									{ translate(
+										'{{strong}}Country:{{/strong}} %s',
+										contactArgs( whois.admin_country )
+									) }
 								</li>
 							) }
 							{ whois.admin_phone && (
 								<li>
-									<strong>Phone:</strong> { whois.admin_phone }
+									{ translate(
+										'{{strong}}Phone:{{/strong}} %s',
+										contactArgs( whois.admin_phone )
+									) }
 								</li>
 							) }
 							{ whois.admin_email && (
 								<li>
-									<a href={ `mailto:${ whois.admin_email }` }>Email</a>
+									<a href={ `mailto:${ whois.admin_email }` }>{ translate( 'Email' ) }</a>
 								</li>
 							) }
 						</ul>
 					</div>
 					<div className="col">
 						<h4>
-							<strong>Technical contact</strong>
+							<strong>{ translate( 'Technical contact' ) }</strong>
 						</h4>
 						<ul>
 							{ whois.tech_name && (
 								<li>
-									<strong>Name:</strong> { whois.tech_name }
+									{ translate( '{{strong}}Name:{{/strong}} %s', contactArgs( whois.tech_name ) ) }
 								</li>
 							) }
 							{ whois.tech_organization && (
 								<li>
-									<strong>Organization:</strong> { whois.tech_organization }
+									{ translate(
+										'{{strong}}Organization:{{/strong}} %s',
+										contactArgs( whois.tech_organization )
+									) }
 								</li>
 							) }
 							{ whois.tech_street && (
 								<li>
-									<strong>Street:</strong> { whois.tech_street }
+									{ translate(
+										'{{strong}}Street:{{/strong}} %s',
+										contactArgs( whois.tech_street )
+									) }
 								</li>
 							) }
 							{ whois.tech_city && (
 								<li>
-									<strong>City:</strong> { whois.tech_city }
+									{ translate( '{{strong}}City:{{/strong}} %s', contactArgs( whois.tech_city ) ) }
 								</li>
 							) }
 							{ whois.tech_state && (
 								<li>
-									<strong>State:</strong> { whois.tech_state }
+									{ translate( '{{strong}}State:{{/strong}} %s', contactArgs( whois.tech_state ) ) }
 								</li>
 							) }
 							{ whois.tech_postal_code && (
 								<li>
-									<strong>Postal Code:</strong> { whois.tech_postal_code }
+									{ translate(
+										'{{strong}}Postal Code:{{/strong}} %s',
+										contactArgs( whois.tech_postal_code )
+									) }
 								</li>
 							) }
 							{ whois.tech_country && (
 								<li>
-									<strong>Country:</strong> { whois.tech_country }
+									{ translate(
+										'{{strong}}Country:{{/strong}} %s',
+										contactArgs( whois.tech_country )
+									) }
 								</li>
 							) }
 							{ whois.tech_phone && (
 								<li>
-									<strong>Phone:</strong> { whois.tech_phone }
+									{ translate( '{{strong}}Phone:{{/strong}} %s', contactArgs( whois.tech_phone ) ) }
 								</li>
 							) }
 							{ whois.tech_email && (
 								<li>
-									<a href={ `mailto:${ whois.tech_email }` }>Email</a>
+									<a href={ `mailto:${ whois.tech_email }` }>{ translate( 'Email' ) }</a>
 								</li>
 							) }
 						</ul>
@@ -244,22 +306,26 @@ export default function DomainInformation( props: Props ) {
 								onClick={ () => setFetchWhoisRawData( true ) }
 								variant="link"
 							>
-								Display raw WHOIS output
+								{ translate( 'Display raw WHOIS output' ) }
 							</Button>
 						) }
 
 						{ whoisRawDataFetchingError && (
-							<p>Error fetching WHOIS data; please try again later.</p>
+							<p>{ translate( 'Error fetching WHOIS data; please try again later.' ) }</p>
 						) }
 
 						{ whoisRawData && (
 							<div className="whois-raw-data">
 								<p>
-									This WHOIS data is provided for information purposes for domains registered
-									through WordPress.com. We do not guarantee its accuracy. This information is shown
-									for the sole purpose of assisting you in obtaining information about domain name
-									registration records; any use of this data for any other purpose is expressly
-									forbidden.
+									{ translate(
+										'This WHOIS data is provided for information purposes ' +
+											'for domains registered through WordPress.com. We ' +
+											'do not guarantee its accuracy. This information ' +
+											'is shown for the sole purpose of assisting you in ' +
+											'obtaining information about domain name registration ' +
+											'records; any use of this data for any other purpose ' +
+											'is expressly forbidden.'
+									) }
 								</p>
 								<pre>{ whoisRawData.whois.join( '\n' ) }</pre>
 							</div>

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@wordpress/components';
+import { translate } from 'i18n-calypso';
 import page from 'page';
 import StatusCtaInfo from '../heading-information/status-cta-info';
 import StatusIcon from '../heading-information/status-icon';
@@ -34,7 +35,7 @@ export default function HeadingInformation( props: Props ) {
 	return (
 		<div className="heading-information">
 			<summary>
-				<h5>Who Hosts This Site?</h5>
+				<h5>{ translate( 'Who Hosts This Site?' ) }</h5>
 				<div className="domain">
 					<StatusIcon conversionAction={ conversionAction } />
 					{ domain }
@@ -46,30 +47,30 @@ export default function HeadingInformation( props: Props ) {
 				<div className="cta-wrapper">
 					{ conversionAction === 'register-domain' && (
 						<Button className="button-action" onClick={ onRegisterDomain }>
-							Register domain
+							{ translate( 'Register domain' ) }
 						</Button>
 					) }
 					{ ( conversionAction === 'transfer-domain' ||
 						conversionAction === 'transfer-domain-hosting' ) && (
 						<Button className="button-action" onClick={ onTransferDomain }>
-							Transfer domain
+							{ translate( 'Transfer domain' ) }
 						</Button>
 					) }
 					{ ( conversionAction === 'transfer-google-domain' ||
 						conversionAction === 'transfer-google-domain-hosting' ) && (
 						<Button className="button-action" onClick={ onTransferDomainFree }>
-							Transfer domain for free
+							{ translate( 'Transfer domain for free' ) }
 						</Button>
 					) }
 					{ conversionAction === 'transfer-hosting' && (
 						<Button className="button-action" onClick={ onMigrateSite }>
-							Migrate site
+							{ translate( 'Migrate site' ) }
 						</Button>
 					) }
 
 					{ onCheckAnotherSite && (
 						<Button variant="link" onClick={ onCheckAnotherSite }>
-							Check another site
+							{ translate( 'Check another site' ) }
 						</Button>
 					) }
 				</div>

--- a/client/site-profiler/components/heading-information/status-cta-info.tsx
+++ b/client/site-profiler/components/heading-information/status-cta-info.tsx
@@ -1,3 +1,4 @@
+import { translate } from 'i18n-calypso';
 import { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
 
 interface Props {
@@ -10,40 +11,64 @@ export default function StatusCtaInfo( props: Props ) {
 		case 'register-domain':
 			return (
 				<p>
-					Register your domain with <strong>WordPress.com</strong> and benefit from one of the best
-					hosting platforms in the world.
+					{ translate(
+						'Register your domain with {{strong}}WordPress.com{{/strong}} ' +
+							'and benefit from one of the best hosting platforms in the world.',
+						{
+							components: { strong: <strong /> },
+						}
+					) }
 				</p>
 			);
 		case 'transfer-domain':
 			return (
 				<p>
-					If you own this domain, transfer it to <strong>WordPress.com</strong> and benefit from the
-					best-performing, most reliable registrar in the business.
+					{ translate(
+						'If you own this domain, transfer it to {{strong}}WordPress.com{{/strong}} ' +
+							'and benefit from the best-performing, most reliable registrar in the business.',
+						{
+							components: { strong: <strong /> },
+						}
+					) }
 				</p>
 			);
 		case 'transfer-google-domain':
 		case 'transfer-google-domain-hosting':
 			return (
 				<p>
-					If you own this domain, transfer it to <strong>WordPress.com</strong> and benefit from the
-					best-performing, most reliable registrar in the business.
-					<br />
-					And because it’s registered with Google Domains{ ' ' }
-					<strong>we’ll pay for an extra year of registration</strong> when you transfer it.
+					{ translate(
+						'If you own this domain, transfer it to {{strong}}WordPress.com{{/strong}} ' +
+							'and benefit from the best-performing, most reliable registrar in the business.' +
+							'{{br/}}And because it’s registered with Google Domains ' +
+							'{{strong}}we’ll pay for an extra year of registration{{/strong}} when you transfer it.',
+						{
+							components: { br: <br />, strong: <strong /> },
+						}
+					) }
 				</p>
 			);
 		case 'transfer-hosting':
 			return (
 				<p>
-					If you own this site, host it with <strong>WordPress.com</strong> and benefit from one of
-					the best hosting platforms in the world.
+					{ translate(
+						'If you own this site, host it with {{strong}}WordPress.com{{/strong}} and ' +
+							'benefit from one of the best hosting platforms in the world.',
+						{
+							components: { strong: <strong /> },
+						}
+					) }
 				</p>
 			);
 		case 'transfer-domain-hosting':
 			return (
 				<p>
-					If you are the owner, bring your site and domain to <strong>WordPress.com</strong> and
-					benefit from one of the best hosting platforms in the world.{ ' ' }
+					{ translate(
+						'If you are the owner, bring your site and domain to {{strong}}WordPress.com{{/strong}} ' +
+							'and benefit from one of the best hosting platforms in the world.',
+						{
+							components: { strong: <strong /> },
+						}
+					) }
 				</p>
 			);
 		default:

--- a/client/site-profiler/components/heading-information/status-info.tsx
+++ b/client/site-profiler/components/heading-information/status-info.tsx
@@ -1,3 +1,4 @@
+import { translate } from 'i18n-calypso';
 import { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
 
 interface Props {
@@ -8,34 +9,51 @@ export default function StatusInfo( props: Props ) {
 
 	switch ( conversionAction ) {
 		case 'register-domain':
-			return <p>Nice find! This site is available and could be yours today!</p>;
+			return <p>{ translate( 'Nice find! This site is available and could be yours today!' ) }</p>;
 		case 'transfer-domain':
 		case 'transfer-google-domain':
 			return (
 				<p>
-					This site is hosted on <strong>WordPress.com</strong> but the domain is registered
-					elsewhere.
+					{ translate(
+						'This site is hosted on {{strong}}WordPress.com{{/strong}} but the domain is registered elsewhere.',
+						{
+							components: { strong: <strong /> },
+						}
+					) }
 				</p>
 			);
 		case 'transfer-hosting':
 			return (
 				<p>
-					This site is using <strong>WordPress.com</strong> to manage the domain, but the site is
-					hosted elsewhere.
+					{ translate(
+						'This site is using {{strong}}WordPress.com{{/strong}} to manage the domain, but the site is hosted elsewhere.',
+						{
+							components: { strong: <strong /> },
+						}
+					) }
 				</p>
 			);
 		case 'transfer-domain-hosting':
 		case 'transfer-google-domain-hosting':
 			return (
 				<p>
-					The hosting and domain of this site are not on <strong>WordPress.com</strong>, but they
-					could be!
+					{ translate(
+						'The hosting and domain of this site are not on {{strong}}WordPress.com{{/strong}}, but they could be!',
+						{
+							components: { strong: <strong /> },
+						}
+					) }
 				</p>
 			);
 		case 'idle':
 			return (
 				<p>
-					Nice! This site and its domain are fully hosted on <strong>WordPress.com</strong>!
+					{ translate(
+						'Nice! This site and its domain are fully hosted on {{strong}}WordPress.com{{/strong}}!',
+						{
+							components: { strong: <strong /> },
+						}
+					) }
 				</p>
 			);
 		default:

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -1,4 +1,5 @@
 import { localizeUrl } from '@automattic/i18n-utils';
+import { translate } from 'i18n-calypso';
 import { DNS, HostingProvider } from 'calypso/data/site-profiler/types';
 
 interface Props {
@@ -15,14 +16,16 @@ export default function HostingInformation( props: Props ) {
 			<h3>Hosting information</h3>
 			<ul className="hosting-information-details result-list">
 				<li>
-					<div className="name">Provider</div>
+					<div className="name">{ translate( 'Provider' ) }</div>
 					<div>
 						{ hostingProvider?.slug !== 'automattic' && <>{ hostingProvider?.name }</> }
 						{ hostingProvider?.slug === 'automattic' && (
 							<>
 								<a href={ localizeUrl( 'https://automattic.com' ) }>{ hostingProvider?.name }</a>
 								&nbsp;&nbsp;
-								<a href={ localizeUrl( 'https://automattic.com/login' ) }>(login)</a>
+								<a href={ localizeUrl( 'https://automattic.com/login' ) }>
+									({ translate( 'login' ) })
+								</a>
 							</>
 						) }
 					</div>
@@ -31,12 +34,19 @@ export default function HostingInformation( props: Props ) {
 					<li>
 						<div className="name">Support</div>
 						<div>
-							<a href={ localizeUrl( 'https://wordpress.com/help/contact' ) }>Contact support</a>
+							<a href={ localizeUrl( 'https://wordpress.com/help/contact' ) }>
+								{ translate( 'Contact support' ) }
+							</a>
 						</div>
 					</li>
 				) }
 				<li>
-					<div className="name">A Records</div>
+					<div className="name">
+						{
+							/* translators: "A Records" refer to the DNS records of type "A". */
+							translate( 'A Records' )
+						}
+					</div>
 					<div className="col">
 						<ul>
 							{ aRecordIps.map( ( x, i ) => (

--- a/client/site-profiler/components/hosting-into/index.tsx
+++ b/client/site-profiler/components/hosting-into/index.tsx
@@ -1,12 +1,17 @@
+import { translate } from 'i18n-calypso';
+
 export default function HostingInto() {
 	return (
 		<>
-			<h2>The best WordPress Hosting on the planet</h2>
+			<h2>{ translate( 'The best WordPress Hosting on the planet' ) }</h2>
 			<p>
-				Whatever you’re building, WordPress.com has everything you need: unmetered bandwidth,
-				unmatched speed, unstoppable security, and intuitive multi-site management.
+				{ translate(
+					'Whatever you’re building, WordPress.com has everything you need: ' +
+						'unmetered bandwidth, unmatched speed, unstoppable security, ' +
+						'and intuitive multi-site management.'
+				) }
 			</p>
-			<p>Bring your WordPress site to WordPress.com and get it all.</p>
+			<p>{ translate( 'Bring your WordPress site to WordPress.com and get it all.' ) }</p>
 		</>
 	);
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/81810

## Proposed Changes

* Add localization to all site-profiler components

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open http://calypso.localhost:3000/site-profiler
* Enter any domain.
* Check if all the text output is the same of the previous one.

## Screenshot 1
![screenshot-1](https://github.com/Automattic/wp-calypso/assets/167611/312fd69d-0f6c-43f1-81fa-825e6b169b69)

## Screenshot 2
![screenshot-2](https://github.com/Automattic/wp-calypso/assets/167611/a68f90e5-0c44-4401-a45f-d43e3337fc18)

## Screenshot 3
![screenshot-3](https://github.com/Automattic/wp-calypso/assets/167611/dba5b84b-34a5-4664-a1d2-7cfed608ddec)

## Screenshot 4
![screenshot-4](https://github.com/Automattic/wp-calypso/assets/167611/b7e8794a-174d-4b92-97d4-f91d2c65d05a)

## Screenshot 5
![screenshot-5](https://github.com/Automattic/wp-calypso/assets/167611/73aac3a3-18e9-4ab7-84b9-0847d704b7fa)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?