### PR TITLE
Reader Discover feeds - dont filter followed tags out of interest tags.

### DIFF
--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -48,10 +48,6 @@ const DiscoverStream = ( props ) => {
 
 	const isDefaultTab = selectedTab === DEFAULT_TAB;
 
-	// Filter followed tags out of interestTags to get recommendedTags.
-	const followedTagSlugs = followedTags ? followedTags.map( ( tag ) => tag.slug ) : [];
-	const recommendedTags = interestTags.filter( ( tag ) => ! followedTagSlugs.includes( tag.slug ) );
-
 	// Do not supply a fallback empty array as null is good data for getDiscoverStreamTags.
 	const recommendedStreamTags = getDiscoverStreamTags(
 		followedTags && followedTags.map( ( tag ) => tag.slug ),
@@ -106,7 +102,7 @@ const DiscoverStream = ( props ) => {
 			<DiscoverNavigation
 				width={ props.width }
 				selectedTab={ selectedTab }
-				recommendedTags={ recommendedTags }
+				recommendedTags={ interestTags }
 			/>
 			<Stream { ...streamProps } />
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-1gP-p2

## Proposed Changes

* Stops filtering followed tags out of the interest tags that get used to populate the discover navigation tabs.

Before:

<img width="1001" alt="Screenshot 2023-09-22 at 7 58 45 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/f378892f-3c26-4ea8-9b38-9c3c0f38475c">


After:


<img width="1025" alt="Screenshot 2023-09-22 at 7 58 52 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/c8cc4acc-531f-486d-b6bd-d049236e1a1d">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* visit discover
* note names of some of the tabs in the navigation
* go to tags and follow one or more of those noted tag names
* return to discover and verify the tags are still present in discover navigation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?