### PR TITLE
Subscription Management: Add a navigation menu for Sites, Comments & Pending page

### DIFF
--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -28,6 +28,10 @@
 		}
 	}
 
+	.site-subscriptions-manager__nav {
+		margin-bottom: 32px;
+	}
+
 	hr.subscriptions__separator {
 		width: 100%;
 		height: 0;

--- a/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
+++ b/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
@@ -92,7 +92,7 @@ const SubscriptionsManagerWrapper = ( {
 					) }
 				</HStack>
 
-				<Nav>
+				<Nav className="site-subscriptions-manager__nav">
 					<NavTabs>
 						<NavItem
 							count={ counts?.blogs }

--- a/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
+++ b/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
@@ -1,12 +1,17 @@
+import { SubscriptionManager } from '@automattic/data-stores';
 import {
 	__experimentalHStack as HStack,
 	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import Nav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
 import {
 	SubscriptionsPortal,
 	SubscriptionManagerContextProvider,
@@ -26,6 +31,16 @@ const useMarkFollowsAsStaleOnUnmount = () => {
 	}, [] );
 };
 
+const getSelectedTab = ( pathname: string ) => {
+	if ( pathname.includes( 'comments' ) ) {
+		return 'comments';
+	}
+	if ( pathname.includes( 'pending' ) ) {
+		return 'pending';
+	}
+	return 'sites';
+};
+
 type SubscriptionsManagerWrapperProps = {
 	actionButton?: React.ReactNode;
 	children: React.ReactNode;
@@ -42,6 +57,8 @@ const SubscriptionsManagerWrapper = ( {
 	subHeaderText,
 }: SubscriptionsManagerWrapperProps ) => {
 	const translate = useTranslate();
+	const { data: counts } = SubscriptionManager.useSubscriptionsCountQuery();
+	const selectedTab = getSelectedTab( page.current );
 
 	// Mark follows as stale on unmount to ensure that the reader
 	// redux store is in a consistent state when the user navigates.
@@ -74,6 +91,34 @@ const SubscriptionsManagerWrapper = ( {
 						</SubscriptionsEllipsisMenu>
 					) }
 				</HStack>
+
+				<Nav>
+					<NavTabs>
+						<NavItem
+							count={ counts?.blogs }
+							selected={ selectedTab === 'sites' }
+							onClick={ () => page( '/read/subscriptions' ) }
+						>
+							{ translate( 'Sites' ) }
+						</NavItem>
+						<NavItem
+							count={ counts?.comments }
+							selected={ selectedTab === 'comments' }
+							onClick={ () => page( '/read/subscriptions/comments' ) }
+						>
+							{ translate( 'Comments' ) }
+						</NavItem>
+						{ !! counts?.pending && (
+							<NavItem
+								count={ counts?.pending }
+								selected={ selectedTab === 'pending' }
+								onClick={ () => page( '/read/subscriptions/pending' ) }
+							>
+								{ translate( 'Pending' ) }
+							</NavItem>
+						) }
+					</NavTabs>
+				</Nav>
 
 				{ children }
 			</Main>


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/81846

## Proposed Changes

* Add a navigation menu for Sites, Comments & Pending page

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/read/subscriptions
* You should see the nav menu with Sites, Comments, and Pending tabs
  * The Pending tab should be hidden if you have no pending items
* Click on the tabs to navigate through the pages
* The current page should have the respective tab with the selected state

<img width="1236" alt="Screenshot 2023-09-22 at 11 28 59" src="https://github.com/Automattic/wp-calypso/assets/3113712/28c9c5fe-f6d7-4356-b445-271bcf9d307d">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?