### PR TITLE
Lazy Images: add notice to settings UI preparing for deprecation

### DIFF
--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -141,7 +141,7 @@ class SpeedUpSiteSettings extends Component {
 									'Modern browsers now support lazy loading, and WordPress itself bundles lazy loading features for images and videos. This feature will consequently be removed from Jetpack in November.'
 								) }
 							>
-								<NoticeAction href={ lazyImagesSupportUrl }>
+								<NoticeAction href={ lazyImagesSupportUrl } external>
 									{ translate( 'Learn more' ) }
 								</NoticeAction>
 							</Notice>

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -1,19 +1,26 @@
 import { Card, CompactCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 import SupportInfo from 'calypso/components/support-info';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
 import { isPluginActive } from 'calypso/state/plugins/installed/selectors-ts';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-site-in-development-mode';
-import { isJetpackSite, getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import {
+	isJetpackSite,
+	getSiteAdminUrl,
+	isJetpackMinimumVersion,
+} from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 class SpeedUpSiteSettings extends Component {
@@ -24,8 +31,10 @@ class SpeedUpSiteSettings extends Component {
 		updateFields: PropTypes.func.isRequired,
 
 		// Connected props
+		lazyImagesModuleActive: PropTypes.bool,
 		photonModuleUnavailable: PropTypes.bool,
 		selectedSiteId: PropTypes.number,
+		shouldShowLazyImagesSettings: PropTypes.bool,
 		siteAcceleratorStatus: PropTypes.bool,
 	};
 
@@ -47,9 +56,11 @@ class SpeedUpSiteSettings extends Component {
 			isPageOptimizeActive,
 			isRequestingSettings,
 			isSavingSettings,
+			lazyImagesModuleActive,
 			pageOptimizeUrl,
 			photonModuleUnavailable,
 			selectedSiteId,
+			shouldShowLazyImagesSettings,
 			siteAcceleratorStatus,
 			siteIsJetpack,
 			siteIsAtomic,
@@ -57,6 +68,22 @@ class SpeedUpSiteSettings extends Component {
 		} = this.props;
 
 		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
+
+		const lazyImagesSupportUrl = siteIsAtomic
+			? localizeUrl(
+					'https://wordpress.com/support/settings/performance-settings/#lazy-load-images'
+			  )
+			: 'https://jetpack.com/support/lazy-images/';
+		const lazyImagesDescription = translate(
+			'Jetpack’s Lazy Loading feature is no longer necessary.'
+		);
+		const lazyImagesRecommendation = lazyImagesModuleActive
+			? translate(
+					'You have the option to disable it on your website, and you will immediately begin benefiting from the native lazy loading feature offered by WordPress itself.'
+			  )
+			: translate(
+					'It is now disabled on your website. You now benefit from the native lazy loading feature offered by WordPress itself.'
+			  );
 
 		return (
 			<div className="site-settings__module-settings site-settings__speed-up-site-settings">
@@ -105,31 +132,29 @@ class SpeedUpSiteSettings extends Component {
 						</div>
 					</FormFieldset>
 
-					{ siteIsJetpack && (
+					{ siteIsJetpack && shouldShowLazyImagesSettings && (
 						<FormFieldset className="site-settings__formfieldset has-divider is-top-only jetpack-lazy-images-settings">
-							<SupportInfo
+							<Notice
+								status="is-info"
+								showDismiss={ false }
 								text={ translate(
-									"Delays the loading of images until they are visible in the visitor's browser."
+									'Modern browsers now support lazy loading, and WordPress itself bundles lazy loading features for images and videos. This feature will consequently be removed from Jetpack in November.'
 								) }
-								link={
-									siteIsAtomic
-										? localizeUrl(
-												'https://wordpress.com/support/settings/performance-settings/#lazy-load-images'
-										  )
-										: 'https://jetpack.com/support/lazy-images/'
-								}
-								privacyLink={ ! siteIsAtomic }
-							/>
+							>
+								<NoticeAction href={ lazyImagesSupportUrl }>
+									{ translate( 'Learn more' ) }
+								</NoticeAction>
+							</Notice>
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }
 								moduleSlug="lazy-images"
 								label={ translate( 'Lazy load images' ) }
-								description={ translate(
-									'Most modern browsers already support lazy loading. ' +
-										'With over 90% of current browsers offering native support, ' +
-										'enabling this feature may be unnecessary.'
+								description={ sprintf(
+									'%1$s %2$s',
+									lazyImagesDescription,
+									lazyImagesRecommendation
 								) }
-								disabled={ isRequestingOrSaving }
+								disabled={ isRequestingOrSaving || ! lazyImagesModuleActive }
 							/>
 						</FormFieldset>
 					) }
@@ -156,16 +181,19 @@ export default connect( ( state ) => {
 	);
 	const photonModuleActive = isJetpackModuleActive( state, selectedSiteId, 'photon' );
 	const assetCdnModuleActive = isJetpackModuleActive( state, selectedSiteId, 'photon-cdn' );
+	const lazyImagesModuleActive = isJetpackModuleActive( state, selectedSiteId, 'lazy-images' );
 
 	// Status of the main site accelerator toggle.
 	const siteAcceleratorStatus = !! ( photonModuleActive || assetCdnModuleActive );
 
 	return {
+		lazyImagesModuleActive,
 		photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 		selectedSiteId,
 		siteAcceleratorStatus,
 		siteIsJetpack: isJetpackSite( state, selectedSiteId ),
 		isPageOptimizeActive: isPluginActive( state, selectedSiteId, 'page-optimize' ),
 		pageOptimizeUrl: getSiteAdminUrl( state, selectedSiteId, 'admin.php?page=page-optimize' ),
+		shouldShowLazyImagesSettings: ! isJetpackMinimumVersion( state, selectedSiteId, '12.8' ),
 	};
 } )( localize( SpeedUpSiteSettings ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/33169

## Proposed Changes

The Lazy Images feature will be deprecated in Jetpack 12.8, scheduled for release in November. When that happens, we want the UI to disappear.

Until then, we want to:

- warn folks that use the feature today that they can disable it.
- stop folks from enabling it if it is not enabled on their site today.

This logic does not take Gutenberg into account, but that is something that will be handled in the Jetpack plugin itself, in https://github.com/Automattic/jetpack/pull/33208/
-> the module will get disabled, thus updating the UI in Calypso in turn.

**When the feature is active**

<img width="812" alt="image" src="https://github.com/Automattic/wp-calypso/assets/426388/ff9668d3-6d05-48d1-93eb-5a4da8cb3afb">

**When the feature has been deactivated**

<img width="803" alt="image" src="https://github.com/Automattic/wp-calypso/assets/426388/1e81a0e2-9f2f-43b5-bc2e-9afc8b86e45c">

## Testing Instructions

* Start with a Jetpack site, connected to WordPress.com.
* Go to Jetpack > Settings > Performance in wp-admin.
* Enable Lazy Images.
* Load Calypso with this branch, and go to Settings > Performance.
* Notice the UI, and disable the feature.
* Notice the updated UI.
* You should not be able to enable the feature back.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
