### PR TITLE
Fix calling the two subscriber endpoints when many subscribers

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -31,7 +31,7 @@ const ListActionsBar = () => {
 	} = useSubscribersPage();
 	const sortOptions = useMemo( () => getSortOptions( translate ), [ translate ] );
 	const recordSort = useRecordSort();
-	const hasManySubscribers = useManySubsSite( siteId );
+	const { hasManySubscribers } = useManySubsSite( siteId );
 	const filterOptions = useSubscribersFilterOptions( hasManySubscribers, siteId );
 	const selectedText = translate( 'Subscribers: %s', {
 		args: getOptionLabel( filterOptions, filterOption ) || '',

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -64,7 +64,7 @@ export const SubscribersPageProvider = ( {
 	const [ perPage, setPerPage ] = useState( DEFAULT_PER_PAGE );
 	const [ showAddSubscribersModal, setShowAddSubscribersModal ] = useState( false );
 	const [ debouncedSearchTerm ] = useDebounce( searchTerm, 300 );
-	const hasManySubscribers = useManySubsSite( siteId );
+	const { hasManySubscribers } = useManySubsSite( siteId );
 
 	const subscriberType =
 		filterOption === SubscribersFilterBy.All && hasManySubscribers
@@ -81,7 +81,6 @@ export const SubscribersPageProvider = ( {
 		sortTerm,
 		filterOption: subscriberType,
 	} );
-
 	const grandTotal = subscribersQueryResult.data?.total || 0;
 
 	const { pageChangeCallback } = usePagination(

--- a/client/my-sites/subscribers/hooks/use-many-subs-site.ts
+++ b/client/my-sites/subscribers/hooks/use-many-subs-site.ts
@@ -1,11 +1,12 @@
 import useSubscribersTotalsQueries from 'calypso/my-sites/stats/hooks/use-subscribers-totals-query';
 
 const useManySubsSite = ( siteId: number | null ) => {
-	const { data: subscribersTotals = { total: 0 } } = useSubscribersTotalsQueries( siteId );
+	const { data: subscribersTotals = { total: 0 }, isLoading } =
+		useSubscribersTotalsQueries( siteId );
 	const totalSubscribers = subscribersTotals?.total ?? 0;
 	const hasManySubscribers = totalSubscribers > 30000; // 30000 is the limit of subscribers that can be fetched without breaking the endpoint. This is a temporal solution.
 
-	return hasManySubscribers;
+	return { hasManySubscribers, isLoading };
 };
 
 export default useManySubsSite;

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { DEFAULT_PER_PAGE, SubscribersFilterBy, SubscribersSortBy } from '../constants';
 import { getSubscribersCacheKey } from '../helpers';
@@ -22,7 +23,13 @@ const useSubscribersQuery = ( {
 	sortTerm = SubscribersSortBy.DateSubscribed,
 	filterOption = SubscribersFilterBy.All,
 }: SubscriberQueryParams ) => {
-	const hasManySubscribers = useManySubsSite( siteId );
+	const { hasManySubscribers, isLoading } = useManySubsSite( siteId );
+	const [ shouldFetch, setShouldFetch ] = useState( false );
+	useEffect( () => {
+		if ( ! isLoading ) {
+			setShouldFetch( true );
+		}
+	}, [ isLoading ] );
 
 	return useQuery< SubscriberEndpointResponse >( {
 		queryKey: getSubscribersCacheKey( siteId, page, perPage, search, sortTerm, filterOption ),
@@ -43,7 +50,7 @@ const useSubscribersQuery = ( {
 				apiNamespace: 'wpcom/v2',
 			} );
 		},
-		enabled: !! siteId,
+		enabled: !! siteId && shouldFetch,
 		keepPreviousData: true,
 	} );
 };

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { DEFAULT_PER_PAGE, SubscribersFilterBy, SubscribersSortBy } from '../constants';
 import { getSubscribersCacheKey } from '../helpers';
@@ -24,12 +23,7 @@ const useSubscribersQuery = ( {
 	filterOption = SubscribersFilterBy.All,
 }: SubscriberQueryParams ) => {
 	const { hasManySubscribers, isLoading } = useManySubsSite( siteId );
-	const [ shouldFetch, setShouldFetch ] = useState( false );
-	useEffect( () => {
-		if ( ! isLoading ) {
-			setShouldFetch( true );
-		}
-	}, [ isLoading ] );
+	const shouldFetch = ! isLoading;
 
 	return useQuery< SubscriberEndpointResponse >( {
 		queryKey: getSubscribersCacheKey( siteId, page, perPage, search, sortTerm, filterOption ),


### PR DESCRIPTION
## Proposed Changes

This PR fixes a problem with sites with many subscribers. When the admin of these sites entered the Subscribers page, the two versions of the subscriber endpoint were called: `subscribers` and `subscribers_by_user_type`.

### Why was this happening?

The react query was executed before the system could detect if the site had many subscribers or not. That made the endpoint for sites with fewer subscribers to be called (`subscribe`. Then, almost immediately, the many subscribers detect mechanism detested the site to be a big one, so it called the new endpoint: `subscribers_by_user_type`.

This PR makes sure Calypso detects if the site has many subscribers before calling any endpoint.

## Testing Instructions

1. Apply this PR and start the application.
2. Select a site with many subscribers (more than 30k).
3. Open the developer tools, Network tab.
4. Go to `Users -> Subscribers`.
5. Check that the only endpoint being called is `subscribers_by_user_type`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?