### PR TITLE
Subscriptions Management: Add Manage notification settings button in reader

### DIFF
--- a/client/reader/site-subscriptions-manager/comment-subscriptions-manager/comment-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/comment-subscriptions-manager/comment-subscriptions-manager.tsx
@@ -1,7 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { Comments } from 'calypso/landing/subscriptions/components/tab-views';
 import SubscriptionsManagerWrapper from '../subscriptions-manager-wrapper';
-import '../style.scss';
 
 const CommentSubscriptionsManager = () => {
 	const translate = useTranslate();

--- a/client/reader/site-subscriptions-manager/pending-subscriptions-manager/pending-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/pending-subscriptions-manager/pending-subscriptions-manager.tsx
@@ -1,7 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { Pending } from 'calypso/landing/subscriptions/components/tab-views';
 import SubscriptionsManagerWrapper from '../subscriptions-manager-wrapper';
-import '../style.scss';
 
 const PendingSubscriptionsManager = () => {
 	const translate = useTranslate();

--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -7,7 +7,6 @@ import { AddSitesButton } from 'calypso/landing/subscriptions/components/add-sit
 import { downloadCloud, uploadCloud } from 'calypso/reader/icons';
 import ReaderSiteSubscriptions from './reader-site-subscriptions';
 import SubscriptionsManagerWrapper from './subscriptions-manager-wrapper';
-import './style.scss';
 
 const SiteSubscriptionsManager = () => {
 	const translate = useTranslate();

--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -30,6 +30,7 @@
 					font-family: inherit;
 					line-height: inherit;
 					text-decoration: none;
+					color: var(--color-primary);
 				}
 			}
 		}

--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -24,6 +24,13 @@
 
 			&__subtitle {
 				margin-bottom: 0;
+
+				a.site-subscriptions-manager__manage-notifications-button {
+					font-size: inherit;
+					font-family: inherit;
+					line-height: inherit;
+					text-decoration: none;
+				}
 			}
 		}
 	}

--- a/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
+++ b/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
@@ -1,11 +1,12 @@
 import { SubscriptionManager } from '@automattic/data-stores';
 import {
+	Button,
 	__experimentalHStack as HStack,
 	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
@@ -46,7 +47,7 @@ type SubscriptionsManagerWrapperProps = {
 	children: React.ReactNode;
 	ellipsisMenuItems?: React.ReactNode;
 	headerText: string;
-	subHeaderText: string;
+	subHeaderText: React.ReactNode;
 };
 
 const SubscriptionsManagerWrapper = ( {
@@ -74,7 +75,18 @@ const SubscriptionsManagerWrapper = ( {
 				<HStack className="site-subscriptions-manager__header-h-stack">
 					<FormattedHeader
 						headerText={ headerText }
-						subHeaderText={ subHeaderText }
+						subHeaderText={
+							<>
+								{ subHeaderText }{ ' ' }
+								<Button
+									className="site-subscriptions-manager__manage-notifications-button"
+									variant="link"
+									href="/me/notifications"
+								>
+									{ translate( 'Manage notification settings' ) }
+								</Button>
+							</>
+						}
 						align="left"
 						brandFont
 					/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/81966
Resolves https://github.com/Automattic/wp-calypso/issues/78795

![Markup 2023-09-22 at 18 04 08](https://github.com/Automattic/wp-calypso/assets/2019970/c615c993-0805-4a35-bc83-a60d5c5d1828)

## Proposed Changes

* Add **Manage notification settings** button to `/read/subscriptions`.
* The button should be present beside the subheader text in all 3 tabs, i.e. "Sites", "Comments" and "Pending"

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/read/subscriptions`
* Switch between the "Sites", "Comments", and "Pending" tabs. Ensure the button is present for each tab view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?