### PR TITLE
Update index.tsx

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
@@ -91,7 +91,7 @@ export default function SiteAddLicenseNotification() {
 			return licenses.length > 1
 				? translate(
 						'{{strong}}%(initialLicenseList)s%(conjunction)s%(lastLicenseItem)s{{/strong}} ' +
-							'were succesfully assigned to {{em}}%(selectedSite)s{{/em}}. ' +
+							'were successfully assigned to {{em}}%(selectedSite)s{{/em}}. ' +
 							'Please allow a few minutes for your features to activate.',
 						{
 							args: multipleLicensesArgs,
@@ -101,7 +101,7 @@ export default function SiteAddLicenseNotification() {
 						}
 				  )
 				: translate(
-						'{{strong}}%(licenseItem)s{{/strong}} was succesfully assigned to ' +
+						'{{strong}}%(licenseItem)s{{/strong}} was successfully assigned to ' +
 							'{{em}}%(selectedSite)s{{/em}}. Please allow a few minutes ' +
 							'for your features to activate.',
 						{


### PR DESCRIPTION
Fix a typo in the banner when a license is applied. Update succesfully to successfully

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Updates a typo in the banner when assigning a license to a site in Jetpack Manage. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify the spelling update in the PR. 
* Apply the PR.
* Visit the dashboard and issue and assign a new license.
* Verify the update in the license banner. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
