### PR TITLE
Update reader edit button to new version.

### DIFF
--- a/client/blocks/post-edit-button/index.jsx
+++ b/client/blocks/post-edit-button/index.jsx
@@ -1,6 +1,6 @@
-import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import ReaderEditIcon from 'calypso/reader/components/icons/edit-button';
 import { getEditURL } from 'calypso/state/posts/utils';
 
 import './style.scss';
@@ -9,7 +9,7 @@ const PostEditButton = ( { post, site, iconSize, onClick, translate } ) => {
 	const editUrl = getEditURL( post, site );
 	return (
 		<a className="post-edit-button" href={ editUrl } onClick={ onClick }>
-			<Gridicon icon="pencil" size={ iconSize } className="post-edit-button__icon" />
+			{ ReaderEditIcon( { iconSize } ) }
 			<span className="post-edit-button__label">{ translate( 'Edit' ) }</span>
 		</a>
 	);

--- a/client/reader/components/icons/edit-button.jsx
+++ b/client/reader/components/icons/edit-button.jsx
@@ -1,0 +1,20 @@
+export default function ReaderEditIcon( { iconSize } ) {
+	return (
+		<svg
+			key="edit"
+			className="post-edit-button__icon"
+			viewBox="0 0 24 24"
+			width={ iconSize }
+			height={ iconSize }
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		>
+			<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+			<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+		</svg>
+	);
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* @davemart-in proposes a new SVG for our edit icon in the reader. this PR attempts to replace the reader edit icons with the new version.

Currently, we need to settle size issues on the reader full post:
<img width="143" alt="Screenshot 2023-09-22 at 1 15 41 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/6c6311d0-b512-416d-a4d5-d7b3be552096">

We have also yet to update the icon used in the ellipsis menu on the reader post cards:

<img width="173" alt="Screenshot 2023-09-22 at 1 16 28 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/20f75a8d-16b7-44d8-b768-77a2f9dfd8b4">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
