### PR TITLE
Checkout: Ensure we check chat availability when we have products in cart

### DIFF
--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -53,12 +53,11 @@ function getGroupName( keyType: KeyType ) {
 export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabilityCheck = false ) {
 	const isEnglishLocale = useIsEnglishLocale();
 	const isWpMobileAppUser = isWpMobileApp();
+	const group = getGroupName( keyType );
 
-	const { canConnectToZendesk } = useChatStatus();
+	const { canConnectToZendesk } = useChatStatus( group, enabled );
 	const isEligibleForPresalesChat =
 		enabled && isEnglishLocale && canConnectToZendesk && ! isWpMobileAppUser;
-
-	const group = getGroupName( keyType );
 
 	const { data: chatAvailability, isInitialLoading: isLoadingAvailability } =
 		useMessagingAvailability( group, isEligibleForPresalesChat && ! skipAvailabilityCheck );

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -203,9 +203,11 @@ const OrderReviewTitle = () => {
 };
 
 const getPresalesChatKey = ( responseCart: ObjectWithProducts ) => {
-	const hasCartJetpackProductsOnly = responseCart?.products?.every( ( product ) =>
-		isJetpackPurchasableItem( product.product_slug )
-	);
+	const hasCartJetpackProductsOnly =
+		responseCart?.products?.length > 0 &&
+		responseCart?.products?.every( ( product ) =>
+			isJetpackPurchasableItem( product.product_slug )
+		);
 
 	if ( isAkismetCheckout() ) {
 		return 'akismet';
@@ -265,7 +267,7 @@ export default function WPCheckout( {
 	const couponFieldStateProps = useCouponFieldState( applyCoupon );
 	const total = useTotal();
 	const reduxDispatch = useReduxDispatch();
-	usePresalesChat( getPresalesChatKey( responseCart ) );
+	usePresalesChat( getPresalesChatKey( responseCart ), responseCart?.products?.length > 0 );
 
 	const areThereDomainProductsInCart =
 		hasDomainRegistration( responseCart ) || hasTransferProduct( responseCart );


### PR DESCRIPTION
Raised on Slack: p1695400582074369-slack-C4JPKKQBF

The checkout code was triggering the `usePresalesChat` hook too early with incomplete/incorrect data.
There's ~two~ three issues here:
- `responseCart.products` would be empty, which makes the `responseCart?.products?.every` check always return true (cause it's an empty array). Which in turn makes checkout think it's a Jetpack checkout which triggers JP Presales availability check.
- When we finally get the proper cart loaded, the same code now sees it's a WPCOM checkout after all and triggers WPCOM Presales availability check. Depending which one returns first and which one returns that it's available, that one gets loaded. Which resulted in JP Presales chat being loaded seemingly randomly for WPCOM sales.
- Even with the correct WPCOM presales key, there was another availability check triggered, because the default key was used when `useChatStatus` is called without parameters in `usePresalesChat`. The bug was introduced here: https://github.com/Automattic/wp-calypso/pull/79679/files#r1334699181


## Testing Instructions

- Go to `/plans` on a Free WPCOM site.
- Try to upgrade to Premium.
- Checkout opens with the Premium plan in cart.
- Refresh page.
- Check Network tab - without the patch, there should be two availability calls:
  - `https://public-api.wordpress.com/wpcom/v2/help/messaging/is-available?_envelope=1&group=wpcom_messaging&environment=development`
  - `https://public-api.wordpress.com/wpcom/v2/help/messaging/is-available?_envelope=1&group=jp_presales&environment=development`
- The `group` part is key. If your cart has only WPCOM items, the JP Presales call should not be made.
- Furthermore, only one availability check should triggered.

Without the patch, the green Jetpack presales will get loaded randomly:
<img width="748" alt="Screenshot 2023-09-22 at 18 33 17" src="https://github.com/Automattic/wp-calypso/assets/3392497/a549cf58-19a9-42a2-a324-dea779fac7fd">



With the patch, the WPCOM Presales chat should load consistently (as long as there's availability):

<img width="748" alt="Screenshot 2023-09-22 at 18 33 47" src="https://github.com/Automattic/wp-calypso/assets/3392497/1f154ee8-51a3-4e27-9159-93a5d8460fdc">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
