### PR TITLE
Update: fix the back button for the transfer domain page

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -201,7 +201,7 @@ const useMyDomain = ( context, next ) => {
 			path += `?suggestion=${ context.query.initialQuery }`;
 
 			if ( context.query.initialMode ) {
-				path = `/domains/manage/${ context.params.site }/edit/${ context.params.site }`;
+				path = `/domains/manage/${ context.query.initialQuery }/edit/${ context.params.site }`;
 			}
 		}
 

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -201,7 +201,7 @@ const useMyDomain = ( context, next ) => {
 			path += `?suggestion=${ context.query.initialQuery }`;
 
 			if ( context.query.initialMode ) {
-				path = `/domains/manage/${ context.params.site }`;
+				path = `/domains/manage/${ context.params.site }/edit/${ context.params.site }`;
 			}
 		}
 


### PR DESCRIPTION
This change is required to be present in the mobile Jetpack app so that the user doesn't end up on the domain listing page. 

But we think the change also make sense for the web.

Related to pcdRpT-3PI-p2

## Proposed Changes

* Update the  back button url  from `/domain/manage/${domain}` -> `/domains/manage/${domain}/edit/${domain}`;

## Testing Instructions

1. Navigate to the domain transfer page.
2. Click the back button. Are you take to the correct page as expected? 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?