### PR TITLE
Attempt to block PWA install prompt on checkout screens when detectable

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -182,6 +182,13 @@ export function checkout( context, next ) {
 		} );
 	}
 
+	// On checkout routes, block the PWA install prompt if we can detect it
+	// beforeInstallPrompt is technically an experimental event, but if we pick it up, we can prevent the browser from showing the prompt
+	window.addEventListener( 'beforeinstallprompt', function ( e ) {
+		e.preventDefault();
+		return false;
+	} );
+
 	context.primary = (
 		<>
 			<CheckoutDocumentTitle />


### PR DESCRIPTION
## Proposed Changes

* Adds an event listener for beforeinstallprompt to not show the PWA install prompt when on checkout routes.

## Testing Instructions

* This is best tested on an android mobile browser, you should no longer see a prompt to "Install WordPress.com"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?