### PR TITLE
Translate the path names for my-sites group

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -153,6 +153,48 @@ class Sites extends Component {
 			case 'site-monitoring':
 				path = translate( 'Site Monitoring' );
 				break;
+			case 'customize':
+				path = translate( 'Customizer' );
+				break;
+			case 'purchases':
+				path = translate( 'Purchases' );
+				break;
+			case 'marketing':
+				path = translate( 'Marketing' );
+				break;
+			case 'subscribers':
+				path = translate( 'Subscribers' );
+				break;
+			case 'email':
+				path = translate( 'Email' );
+				break;
+			case 'themes':
+				path = translate( 'Themes' );
+				break;
+			case 'earn':
+				path = translate( 'Earn' );
+				break;
+			case 'comments':
+				path = translate( 'Comments' );
+				break;
+			case 'view':
+				path = translate( 'View' );
+				break;
+			case 'import':
+				path = translate( 'Import' );
+				break;
+			case 'export':
+				path = translate( 'Export' );
+				break;
+			case 'backup':
+				path = translate( 'Backup' );
+				break;
+			case 'scan':
+				path = translate( 'Scan' );
+				break;
+			case 'store':
+				path = translate( 'Store' );
+				break;
 		}
 
 		return translate( 'Select a site to open {{strong}}%(path)s{{/strong}}', {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The `My Sites` selector shows a user-friendly header at the top, prompting the user to select the site to use a specific feature for that site. The name of the feature/path is translated for some routes, but not all of them. This diff takes the remaining routes for `sites` group from https://github.com/Automattic/wp-calypso/blob/trunk/client/sections.js and adds translation support for them in the `My Sites` selector.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
