### PR TITLE
Domain transfers: Fix recipient typo

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -111,7 +111,7 @@ function ContactInfo( {
 				dispatch(
 					errorNotice(
 						translate(
-							'The receiving user’s email address must match the email address of the domain receipient.'
+							'The receiving user’s email address must match the email address of the domain recipient.'
 						),
 						{
 							duration: 10000,


### PR DESCRIPTION
## Proposed Changes

* Fixes "recipient" typo

## Testing Instructions

http://calypso.localhost:3000/setup/domain-user-transfer/domain-contact-info?domain=test-345678.blog

![Screenshot 2023-09-25 at 10-22-24 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/cc9e4afb-1ecb-4e3a-acf0-93ea35665076)
