### PR TITLE
Odyssey Stats: use empty SVG URL for Odyssey

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-svg.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-svg.tsx
@@ -1,3 +1,4 @@
+import configApi from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import calypsoStatsPurchaseGraphSVG from 'calypso/assets/images/stats/calypso-purchase-stats-graph.svg';
 import statsPurchaseCelebrationSVG from 'calypso/assets/images/stats/purchase-stats-celebration.svg';
@@ -20,10 +21,13 @@ const StatsPurchaseSVG = ( {
 }: StatsPurchaseSVG ) => {
 	const translate = useTranslate();
 	const message = translate( 'Thanks for being one of our biggest supporters!' );
+	const isOdyssey = configApi.isEnabled( 'is_running_in_jetpack_site' );
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
-	const purchaseGraphSVG = isWPCOMSite ? calypsoStatsPurchaseGraphSVG : statsPurchaseGraphSVG;
+	// For Odyssey Stats, the SVG is loaded separately from the sprite located in `widgets.wp.com/odyssey-stats/common/` for CORS reasons.
+	let purchaseGraphSVG = isWPCOMSite ? calypsoStatsPurchaseGraphSVG : statsPurchaseGraphSVG;
+	purchaseGraphSVG = ! isOdyssey ? purchaseGraphSVG : '';
 
 	return (
 		<>


### PR DESCRIPTION
## Proposed Changes

The shapes are all added to the shared SVG sprite [which is loaded by Jetpack](https://github.com/Automattic/jetpack/blob/e51a9731dbdda59d742606f0b4fa1a0043b5771a/projects/packages/stats-admin/src/class-dashboard.php#L98) to walk around the SVG CORS issue. From Odyssey, the SVG could be simply referred to by id, e.g. `stats`, without the URL.

Related: pejTkB-2s-p2 / D122964-code


## Testing Instructions

* Apply `D122964-code` to your sandbox
* Sandbox `widgets.wp.com`
* Build Jetpack if necessary `jetpack build plugins/jetpack`
* Build Odyssey Stats locally `STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
* Open `/wp-admin/admin.php?page=stats#!/stats/purchase/:siteSlug`
* Ensure the svg on the right half of the page is showing

![image](https://github.com/Automattic/wp-calypso/assets/1425433/6ac16bab-6d18-43e1-9854-ab75e0668c40)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?