### PR TITLE
Domains Management i1:  add missing label

### DIFF
--- a/packages/domains-table/src/utils/resolve-domain-status.tsx
+++ b/packages/domains-table/src/utils/resolve-domain-status.tsx
@@ -98,7 +98,7 @@ export function resolveDomainStatus(
 
 	const paymentSetupCallToAction = {
 		href: '/me/purchases/payment-methods',
-		label: translate( 'Go to payment methods' ),
+		label: translate( 'Fix' ),
 	};
 
 	switch ( domain.type ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/82034

## Proposed Changes

* Adds "Fix" label that was missed from https://github.com/Automattic/wp-calypso/pull/82034. See https://github.com/Automattic/wp-calypso/pull/82034#issuecomment-1732680595. 

<img width="432" alt="Screenshot 2566-09-25 at 09 23 06" src="https://github.com/Automattic/wp-calypso/assets/6851384/9e818dc0-7786-4f0d-9f3c-f57fb2a1e897">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Refer to https://github.com/Automattic/wp-calypso/pull/82034

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?