### PR TITLE
Domains Table: Arrange domains table columns using CSS grid

### DIFF
--- a/packages/domains-table/src/domains-table-header/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table-header/__tests__/index.tsx
@@ -38,6 +38,8 @@ test( 'domain columns are rendered in the header', () => {
 			bulkSelectionStatus="no-domains"
 			onBulkSelectionChange={ noop }
 			canSelectAnyDomains
+			domainCount={ 1 }
+			selectedDomainsCount={ 0 }
 		/>
 	);
 
@@ -64,6 +66,8 @@ test( 'renders custom header component', () => {
 			onChangeSortOrder={ jest.fn() }
 			bulkSelectionStatus="no-domains"
 			onBulkSelectionChange={ noop }
+			domainCount={ 1 }
+			selectedDomainsCount={ 0 }
 		/>
 	);
 
@@ -80,6 +84,8 @@ test( 'renders a chevron next to sortable columns', () => {
 			onChangeSortOrder={ jest.fn() }
 			bulkSelectionStatus="no-domains"
 			onBulkSelectionChange={ noop }
+			domainCount={ 1 }
+			selectedDomainsCount={ 0 }
 		/>
 	);
 
@@ -99,6 +105,8 @@ test( 'columns that are not sortable do not renders a chevron', () => {
 			onChangeSortOrder={ jest.fn() }
 			bulkSelectionStatus="no-domains"
 			onBulkSelectionChange={ noop }
+			domainCount={ 1 }
+			selectedDomainsCount={ 0 }
 		/>
 	);
 
@@ -119,6 +127,8 @@ test( 'no checkbox is rendered if no domains are selectable', () => {
 			bulkSelectionStatus="no-domains"
 			onBulkSelectionChange={ noop }
 			canSelectAnyDomains={ false }
+			domainCount={ 1 }
+			selectedDomainsCount={ 0 }
 		/>
 	);
 

--- a/packages/domains-table/src/domains-table-header/columns.ts
+++ b/packages/domains-table/src/domains-table-header/columns.ts
@@ -35,7 +35,6 @@ export const allSitesViewColumns = (
 		initialSortDirection: 'asc',
 		supportsOrderSwitching: true,
 		sortFunctions: [ getSimpleSortFunctionBy( 'domain' ) ],
-		width: '25%',
 	},
 	{
 		name: 'owner',
@@ -89,7 +88,6 @@ export const siteSpecificViewColumns = (
 		initialSortDirection: 'asc',
 		supportsOrderSwitching: true,
 		sortFunctions: [ getSimpleSortFunctionBy( 'domain' ) ],
-		width: '35%',
 	},
 	{
 		name: 'owner',

--- a/packages/domains-table/src/domains-table-header/columns.ts
+++ b/packages/domains-table/src/domains-table-header/columns.ts
@@ -73,7 +73,7 @@ export const allSitesViewColumns = (
 		label: null,
 		isSortable: false,
 	},
-	{ name: 'action', label: null, className: 'domains-table__action-ellipsis-column-header' },
+	{ name: 'action', label: null },
 ];
 
 export const siteSpecificViewColumns = (
@@ -123,7 +123,7 @@ export const siteSpecificViewColumns = (
 		label: null,
 		isSortable: false,
 	},
-	{ name: 'action', label: null, className: 'domains-table__action-ellipsis-column-header' },
+	{ name: 'action', label: null },
 ];
 export const applyColumnSort = (
 	domains: PartialDomainData[],

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -85,8 +85,8 @@ export const DomainsTableHeader = ( {
 	return (
 		<thead className={ listHeaderClasses }>
 			<tr>
-				<th>
-					{ canSelectAnyDomains && (
+				{ canSelectAnyDomains && (
+					<th>
 						<CheckboxControl
 							data-testid="domains-select-all-checkbox"
 							__nextHasNoMarginBottom
@@ -98,8 +98,8 @@ export const DomainsTableHeader = ( {
 								__i18n_text_domain__
 							) }
 						/>
-					) }
-				</th>
+					</th>
+				) }
 
 				{ columns.map( ( column ) => {
 					return (

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -87,7 +87,7 @@ export const DomainsTableHeader = ( {
 	return (
 		<thead className={ listHeaderClasses }>
 			<tr>
-				<th className="domains-table__bulk-action-container">
+				<th>
 					{ canSelectAnyDomains && (
 						<CheckboxControl
 							data-testid="domains-select-all-checkbox"

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -4,7 +4,7 @@ import { CheckboxControl, Icon } from '@wordpress/components';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
-import { CSSProperties, ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import './style.scss';
 
@@ -17,7 +17,6 @@ interface BaseDomainsTableColumn {
 		( first: DomainData, second: DomainData, sortOrder: number, sites?: SiteDetails[] ) => number
 	>;
 	headerComponent?: ReactNode;
-	width?: CSSProperties[ 'width' ];
 	className?: string;
 }
 
@@ -109,11 +108,7 @@ export const DomainsTableHeader = ( {
 						return null;
 					}
 					return (
-						<th
-							key={ column.name }
-							className={ column.className }
-							style={ { width: column.width } }
-						>
+						<th key={ column.name } className={ column.className }>
 							<Button
 								plain
 								onClick={ () => onChangeSortOrder( column ) }

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -45,7 +45,6 @@ type DomainsTableHeaderProps = {
 	domainCount: number;
 	selectedDomainsCount: number;
 	headerClasses?: string;
-	hideOwnerColumn?: boolean;
 	domainsRequiringAttention?: number;
 	canSelectAnyDomains?: boolean;
 };
@@ -60,7 +59,6 @@ export const DomainsTableHeader = ( {
 	domainCount,
 	selectedDomainsCount,
 	headerClasses,
-	hideOwnerColumn = false,
 	domainsRequiringAttention,
 	canSelectAnyDomains = true,
 }: DomainsTableHeaderProps ) => {
@@ -104,9 +102,6 @@ export const DomainsTableHeader = ( {
 				</th>
 
 				{ columns.map( ( column ) => {
-					if ( column.name === 'owner' && hideOwnerColumn ) {
-						return null;
-					}
 					return (
 						<th key={ column.name } className={ column.className }>
 							<Button

--- a/packages/domains-table/src/domains-table-header/style.scss
+++ b/packages/domains-table/src/domains-table-header/style.scss
@@ -19,7 +19,8 @@
 		padding: 16px 0;
 		margin-bottom: calc(-1 * var(--row-gap));
 		color: var(--studio-gray-60);
-		vertical-align: middle;
+		display: flex;
+		align-items: center;
 		font-size: $font-body-small;
 		font-style: normal;
 		font-weight: 500;

--- a/packages/domains-table/src/domains-table-header/style.scss
+++ b/packages/domains-table/src/domains-table-header/style.scss
@@ -17,6 +17,7 @@
 
 	th {
 		padding: 16px 0;
+		margin-bottom: calc(-1 * var(--row-gap));
 		color: var(--studio-gray-60);
 		vertical-align: middle;
 		font-size: $font-body-small;

--- a/packages/domains-table/src/domains-table/domains-table-expires-renew-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-expires-renew-cell.tsx
@@ -8,11 +8,13 @@ import moment from 'moment';
 interface DomainsTableExpiresRewnewsOnCellProps {
 	domain: PartialDomainData;
 	isCompact?: boolean;
+	as?: 'td' | 'div';
 }
 
 export const DomainsTableExpiresRewnewsOnCell = ( {
 	domain,
 	isCompact = false,
+	as: Element = 'div',
 }: DomainsTableExpiresRewnewsOnCellProps ) => {
 	const localeSlug = useLocale();
 	const isExpired = domain.expiry && moment( domain.expiry ).utc().isBefore( moment().utc() );
@@ -38,7 +40,7 @@ export const DomainsTableExpiresRewnewsOnCell = ( {
 		  );
 
 	return (
-		<div className="domains-table-row__renews-on-cell">
+		<Element className="domains-table-row__renews-on-cell">
 			{ expiryDate ? (
 				<>
 					{ ! isCompact && (
@@ -49,6 +51,6 @@ export const DomainsTableExpiresRewnewsOnCell = ( {
 			) : (
 				'-'
 			) }
-		</div>
+		</Element>
 	);
 };

--- a/packages/domains-table/src/domains-table/domains-table-header.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-header.tsx
@@ -8,7 +8,6 @@ export const DomainsTableHeader = () => {
 		onSortChange,
 		getBulkSelectionStatus,
 		changeBulkSelection,
-		hideOwnerColumn,
 		domainsRequiringAttention,
 		canSelectAnyDomains,
 		filteredData,
@@ -24,7 +23,6 @@ export const DomainsTableHeader = () => {
 			bulkSelectionStatus={ getBulkSelectionStatus() }
 			onBulkSelectionChange={ changeBulkSelection }
 			onChangeSortOrder={ onSortChange }
-			hideOwnerColumn={ hideOwnerColumn }
 			domainsRequiringAttention={ domainsRequiringAttention }
 			canSelectAnyDomains={ canSelectAnyDomains }
 			domainCount={ filteredData.length }

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
@@ -83,7 +83,7 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 			<div>
 				<span className="domains-table-mobile-card-label"> { __( 'Expires / renews on' ) } </span>
 				<span className="domains-table-mobile-card-registered-date">
-					<DomainsTableExpiresRewnewsOnCell domain={ domain } />
+					<DomainsTableExpiresRewnewsOnCell domain={ domain } as="div" />
 				</span>
 			</div>
 
@@ -96,6 +96,7 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 						<DomainsTableStatusCell
 							domainStatus={ domainStatus }
 							pendingUpdates={ pendingUpdates }
+							as="div"
 						/>
 						{ domainStatus?.callToAction && (
 							<DomainsTableStatusCTA callToAction={ domainStatus.callToAction } />

--- a/packages/domains-table/src/domains-table/domains-table-row-loading.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-loading.tsx
@@ -2,7 +2,7 @@ import { LoadingPlaceholder } from '@automattic/components';
 import { useDomainsTable } from './domains-table';
 
 export default function DomainsTableRowLoading() {
-	const { hideOwnerColumn } = useDomainsTable();
+	const { domainsTableColumns } = useDomainsTable();
 	return (
 		<tr className="domains-table-row-loading-placeholder">
 			<td className="domains-table-row-loading-placeholder-checkbox-column">
@@ -11,7 +11,7 @@ export default function DomainsTableRowLoading() {
 			<td className="domains-table-row-loading-placeholder-domain-column">
 				<LoadingPlaceholder delayMS={ 50 } />
 			</td>
-			{ hideOwnerColumn && (
+			{ domainsTableColumns.some( ( column ) => column.name === 'owner' ) && (
 				<td className="domains-table-row-loading-placeholder-owner-column">
 					<LoadingPlaceholder delayMS={ 50 } />
 				</td>

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -82,8 +82,9 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 	};
 
 	return (
-		<tr key={ domain.domain } ref={ ref }>
-			<td>
+		<tr key={ domain.domain }>
+			{ /* display:contents appears to break the in-view logic so attach the in-view ref to the first cell instead */ }
+			<td ref={ ref }>
 				{ canSelectAnyDomains && canBulkUpdate( domain ) && (
 					<CheckboxControl
 						__nextHasNoMarginBottom
@@ -99,7 +100,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 			{ domainsTableColumns.map( ( column ) => {
 				if ( column.name === 'domain' ) {
 					return (
-						<td key={ column.name }>
+						<td key={ column.name } className="domains-table-row__domain">
 							{ shouldDisplayPrimaryDomainLabel && <PrimaryDomainLabel /> }
 							{ isManageableDomain ? (
 								<a

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -82,24 +82,26 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 
 	return (
 		<tr key={ domain.domain }>
-			{ /* display:contents appears to break the in-view logic so attach the in-view ref to the first cell instead */ }
-			<td ref={ ref }>
-				{ canSelectAnyDomains && canBulkUpdate( domain ) && (
-					<CheckboxControl
-						__nextHasNoMarginBottom
-						checked={ isSelected }
-						onChange={ () => handleSelectDomain( domain ) }
-						/* translators: Label for a checkbox control that selects a domain name.*/
-						aria-label={ sprintf( __( 'Tick box for %(domain)s', __i18n_text_domain__ ), {
-							domain: domain.domain,
-						} ) }
-					/>
-				) }
-			</td>
+			{ canSelectAnyDomains && (
+				<td>
+					{ canBulkUpdate( domain ) && (
+						<CheckboxControl
+							__nextHasNoMarginBottom
+							checked={ isSelected }
+							onChange={ () => handleSelectDomain( domain ) }
+							/* translators: Label for a checkbox control that selects a domain name.*/
+							aria-label={ sprintf( __( 'Tick box for %(domain)s', __i18n_text_domain__ ), {
+								domain: domain.domain,
+							} ) }
+						/>
+					) }
+				</td>
+			) }
 			{ domainsTableColumns.map( ( column ) => {
 				if ( column.name === 'domain' ) {
 					return (
-						<td key={ column.name } className="domains-table-row__domain">
+						// The in-view ref is attached to the domain cell because the <tr> is display:contents, which appears to break the in-view logic
+						<td key={ column.name } className="domains-table-row__domain" ref={ ref }>
 							{ shouldDisplayPrimaryDomainLabel && <PrimaryDomainLabel /> }
 							{ isManageableDomain ? (
 								<a

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -40,7 +40,6 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 		isSelected,
 		handleSelectDomain,
 		isAllSitesView,
-		hideOwnerColumn,
 		domainStatus,
 		pendingUpdates,
 	} = useDomainRow( domain );
@@ -123,11 +122,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 				}
 
 				if ( column.name === 'owner' ) {
-					if ( ! hideOwnerColumn ) {
-						return <td key={ column.name }>{ renderOwnerCell() }</td>;
-					}
-
-					return null;
+					return <td key={ column.name }>{ renderOwnerCell() }</td>;
 				}
 
 				if ( column.name === 'site' ) {

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -136,24 +136,27 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 
 				if ( column.name === 'expire_renew' ) {
 					return (
-						<td key={ column.name }>
-							<DomainsTableExpiresRewnewsOnCell domain={ domain } isCompact={ isCompact } />
-						</td>
+						<DomainsTableExpiresRewnewsOnCell
+							key={ column.name }
+							as="td"
+							domain={ domain }
+							isCompact={ isCompact }
+						/>
 					);
 				}
 
 				if ( column.name === 'status' ) {
-					return (
+					return isLoadingRowDetails ? (
 						<td key={ column.name }>
-							{ isLoadingRowDetails ? (
-								<LoadingPlaceholder style={ { width: `${ placeholderWidth }%` } } />
-							) : (
-								<DomainsTableStatusCell
-									domainStatus={ domainStatus }
-									pendingUpdates={ pendingUpdates }
-								/>
-							) }
+							<LoadingPlaceholder style={ { width: `${ placeholderWidth }%` } } />
 						</td>
+					) : (
+						<DomainsTableStatusCell
+							key={ column.name }
+							as="td"
+							domainStatus={ domainStatus }
+							pendingUpdates={ pendingUpdates }
+						/>
 					);
 				}
 

--- a/packages/domains-table/src/domains-table/domains-table-status-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-status-cell.tsx
@@ -9,11 +9,13 @@ import { ResolveDomainStatusReturn } from '../utils/resolve-domain-status';
 interface DomainsTableStatusCellProps {
 	domainStatus: ResolveDomainStatusReturn | null;
 	pendingUpdates: DomainUpdateStatus[];
+	as?: 'td' | 'div';
 }
 
 export const DomainsTableStatusCell = ( {
 	domainStatus,
 	pendingUpdates,
+	as: Element = 'div',
 }: DomainsTableStatusCellProps ) => {
 	const translate = useTranslate();
 	const locale = useLocale();
@@ -40,7 +42,7 @@ export const DomainsTableStatusCell = ( {
 	};
 
 	return (
-		<div
+		<Element
 			className={ classNames( 'domains-table-row__status-cell', {
 				[ `domains-table-row__status-cell__${ domainStatus?.statusClass }` ]:
 					!! domainStatus?.statusClass,
@@ -75,6 +77,6 @@ export const DomainsTableStatusCell = ( {
 					{ domainStatus.noticeText }
 				</StatusPopover>
 			) }
-		</div>
+		</Element>
 	);
 };

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -236,6 +236,10 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		domainsTableColumns = removeColumns( domainsTableColumns, 'site', 'owner' );
 	}
 
+	if ( shouldHideOwnerColumn( Object.values< DomainData[] >( fetchedSiteDomains ).flat() ) ) {
+		domainsTableColumns = removeColumns( domainsTableColumns, 'owner' );
+	}
+
 	const sortedDomains = useMemo( () => {
 		if ( ! domains ) {
 			return;
@@ -358,10 +362,6 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 
 		page( formLink );
 	};
-
-	if ( shouldHideOwnerColumn( Object.values< DomainData[] >( fetchedSiteDomains ).flat() ) ) {
-		domainsTableColumns = removeColumns( domainsTableColumns, 'owner' );
-	}
 
 	const currentUsersOwnsAllSelectedDomains = ! Array.from( selectedDomains ).some( ( selected ) =>
 		( domains ?? [] ).find(

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -96,7 +96,6 @@ type Value = {
 	deleteBulkActionStatus?: () => Promise< void >;
 	isAllSitesView: boolean;
 	domainStatusPurchaseActions?: DomainStatusPurchaseActions;
-	hideOwnerColumn: boolean;
 	canSelectAnyDomains: boolean;
 	domainsRequiringAttention?: number;
 	sortKey: string;
@@ -360,9 +359,9 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		page( formLink );
 	};
 
-	const hideOwnerColumn = shouldHideOwnerColumn(
-		Object.values< DomainData[] >( fetchedSiteDomains ).flat()
-	);
+	if ( shouldHideOwnerColumn( Object.values< DomainData[] >( fetchedSiteDomains ).flat() ) ) {
+		domainsTableColumns = removeColumns( domainsTableColumns, 'owner' );
+	}
 
 	const currentUsersOwnsAllSelectedDomains = ! Array.from( selectedDomains ).some( ( selected ) =>
 		( domains ?? [] ).find(
@@ -381,7 +380,6 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		deleteBulkActionStatus,
 		isAllSitesView,
 		domainStatusPurchaseActions,
-		hideOwnerColumn,
 		canSelectAnyDomains,
 		domainsRequiringAttention,
 		sortKey,

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -19,15 +19,7 @@ import { useQueries } from '@tanstack/react-query';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import {
-	useCallback,
-	useLayoutEffect,
-	useMemo,
-	useState,
-	createContext,
-	useContext,
-	ReactNode,
-} from 'react';
+import { useCallback, useLayoutEffect, useMemo, useState, createContext, useContext } from 'react';
 import { DomainsTableFilter } from '../domains-table-filters/index';
 import {
 	allSitesViewColumns,
@@ -76,11 +68,9 @@ interface BaseDomainsTableProps {
 	currentUserCanBulkUpdateContactInfo?: boolean;
 }
 
-export type DomainsTablePropsNoChildren =
+export type DomainsTableProps =
 	| ( BaseDomainsTableProps & { isAllSitesView: true } )
 	| ( BaseDomainsTableProps & { isAllSitesView: false; siteSlug: string | null } );
-
-export type DomainsTableProps = DomainsTablePropsNoChildren & { children: ReactNode | ReactNode[] };
 
 interface DomainsTableUpdatingDomain {
 	action: DomainAction;
@@ -135,11 +125,11 @@ type Value = {
 	isCompact: boolean;
 };
 
-const Context = createContext< Value | undefined >( undefined );
+export const DomainsTableStateContext = createContext< Value | undefined >( undefined );
 
-export const useDomainsTable = () => useContext( Context ) as Value;
+export const useDomainsTable = () => useContext( DomainsTableStateContext ) as Value;
 
-export const DomainsTable = ( props: DomainsTableProps ) => {
+export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 	const {
 		domains: allDomains,
 		fetchAllDomains,
@@ -150,7 +140,6 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		deleteBulkActionStatus,
 		isAllSitesView,
 		domainStatusPurchaseActions,
-		children,
 		onDomainAction,
 		userCanSetPrimaryDomains,
 		shouldDisplayContactInfoBulkAction = false,
@@ -442,9 +431,5 @@ export const DomainsTable = ( props: DomainsTableProps ) => {
 		isCompact,
 	};
 
-	return (
-		<Context.Provider value={ value }>
-			<div className="domains-table">{ children }</div>
-		</Context.Provider>
-	);
+	return value;
 };

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -1,6 +1,11 @@
 import { useMobileBreakpoint } from '@automattic/viewport-react';
+import classname from 'classnames';
 import { ReactNode } from 'react';
-import { DomainsTable as InternalDomainsTable, DomainsTablePropsNoChildren } from './domains-table';
+import {
+	DomainsTableProps,
+	DomainsTableStateContext,
+	useGenerateDomainsTableState,
+} from './domains-table';
 import { DomainsTableBody } from './domains-table-body';
 import { DomainsTableBulkUpdateNotice } from './domains-table-bulk-update-notice';
 import { DomainsTableHeader } from './domains-table-header';
@@ -8,23 +13,31 @@ import { DomainsTableMobileCards } from './domains-table-mobile-cards';
 import { DomainsTableToolbar } from './domains-table-toolbar';
 import './style.scss';
 
-export function DomainsTable( props: DomainsTablePropsNoChildren & { footer?: ReactNode } ) {
+export function DomainsTable( props: DomainsTableProps & { footer?: ReactNode } ) {
 	const isMobile = useMobileBreakpoint();
 	const { footer, ...allProps } = props;
 
+	const state = useGenerateDomainsTableState( allProps );
+
 	return (
-		<InternalDomainsTable { ...allProps }>
-			<DomainsTableBulkUpdateNotice />
-			<DomainsTableToolbar />
-			{ isMobile ? (
-				<DomainsTableMobileCards />
-			) : (
-				<table>
-					<DomainsTableHeader />
-					<DomainsTableBody />
-				</table>
-			) }
-			{ props.footer }
-		</InternalDomainsTable>
+		<DomainsTableStateContext.Provider value={ state }>
+			<div className="domains-table">
+				<DomainsTableBulkUpdateNotice />
+				<DomainsTableToolbar />
+				{ isMobile ? (
+					<DomainsTableMobileCards />
+				) : (
+					<table
+						className={ classname( {
+							'is-owner-hidden': state.hideOwnerColumn,
+						} ) }
+					>
+						<DomainsTableHeader />
+						<DomainsTableBody />
+					</table>
+				) }
+				{ props.footer }
+			</div>
+		</DomainsTableStateContext.Provider>
 	);
 }

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -1,5 +1,4 @@
 import { useMobileBreakpoint } from '@automattic/viewport-react';
-import classname from 'classnames';
 import { ReactNode } from 'react';
 import {
 	DomainsTableProps,
@@ -27,11 +26,7 @@ export function DomainsTable( props: DomainsTableProps & { footer?: ReactNode } 
 				{ isMobile ? (
 					<DomainsTableMobileCards />
 				) : (
-					<table
-						className={ classname( {
-							'is-owner-hidden': state.hideOwnerColumn,
-						} ) }
-					>
+					<table className={ `is-${ state.domainsTableColumns.length }-column` }>
 						<DomainsTableHeader />
 						<DomainsTableBody />
 					</table>

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -1,4 +1,5 @@
 import { useMobileBreakpoint } from '@automattic/viewport-react';
+import classnames from 'classnames';
 import { ReactNode } from 'react';
 import {
 	DomainsTableProps,
@@ -26,7 +27,11 @@ export function DomainsTable( props: DomainsTableProps & { footer?: ReactNode } 
 				{ isMobile ? (
 					<DomainsTableMobileCards />
 				) : (
-					<table className={ `is-${ state.domainsTableColumns.length }-column` }>
+					<table
+						className={ classnames( `is-${ state.domainsTableColumns.length }-column`, {
+							'has-checkbox': state.canSelectAnyDomains,
+						} ) }
+					>
 						<DomainsTableHeader />
 						<DomainsTableBody />
 					</table>

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -45,9 +45,14 @@ $domains-table-mobile-breakpoint: 480px;
 		display: grid;
 		gap: var(--row-gap) 16px;
 
-		grid-template-columns: 20px 2fr 1fr 1fr auto auto auto 36px;
-		&.is-owner-hidden {
+		&.is-7-column {
+			grid-template-columns: 20px 2fr 1fr 1fr auto auto auto 36px;
+		}
+		&.is-6-column {
 			grid-template-columns: 20px 1fr 1fr auto auto auto 36px;
+		}
+		&.is-5-column {
+			grid-template-columns: 20px 1fr auto auto auto 36px;
 		}
 
 		tr::after {

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -40,29 +40,29 @@ $domains-table-mobile-breakpoint: 480px;
 		margin-top: 14px; /* 30px - 16px of the table heading padding */
 		border-collapse: collapse;
 
+		display: grid;
+		grid-template-columns: 20px 2fr 1fr 1fr auto auto auto 36px;
+		column-gap: 16px;
+
 		tr {
 			border-bottom: 1px solid #f0f0f0;
 		}
 	}
 
-	.domains-table__bulk-action-container {
-		width: 0;
-		min-width: fit-content;
-
-		.components-checkbox-control__input-container {
-			margin-right: 16px;
-		}
-	}
-
-	.domains-table__action-ellipsis-column-header {
-		width: 0;
-		min-width: fit-content;
+	thead,
+	tbody,
+	tr {
+		// For CSS gird to work the table cells need to be direct children of the grid parent.
+		// display: contents prevents the intermediate table elements from generating their own CSS boxes.
+		// This means we can keep the HTML semantics of a table for accessibility.
+		display: contents;
 	}
 
 	td {
 		padding: 20px 0;
-		height: 44px;
-		vertical-align: middle;
+		min-height: 44px;
+		display: flex;
+		align-items: center;
 
 		color: var(--studio-gray-50);
 		font-size: $font-body-small;
@@ -94,10 +94,6 @@ $domains-table-mobile-breakpoint: 480px;
 		gap: 4px;
 		font-size: $font-body-small;
 
-		@media ( min-width: $domains-table-mobile-breakpoint ) {
-			width: 150px;
-		}
-
 		svg {
 			color: currentColor;
 		}
@@ -116,6 +112,12 @@ $domains-table-mobile-breakpoint: 480px;
 		&__status-error {
 			color: var(--studio-red-50);
 		}
+	}
+
+	.domains-table-row__domain {
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: center;
 	}
 
 	.domains-table-row__actions {

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -40,12 +40,18 @@ $domains-table-mobile-breakpoint: 480px;
 		margin-top: 14px; /* 30px - 16px of the table heading padding */
 		border-collapse: collapse;
 
+		--row-gap: 20px;
+
 		display: grid;
 		grid-template-columns: 20px 2fr 1fr 1fr auto auto auto 36px;
-		column-gap: 16px;
+		gap: var(--row-gap) 16px;
 
-		tr {
-			border-bottom: 1px solid #f0f0f0;
+		tr::after {
+			display: block;
+			content: "";
+			height: 1px;
+			background: #f0f0f0;
+			grid-column: 1 / -1;
 		}
 	}
 
@@ -59,7 +65,6 @@ $domains-table-mobile-breakpoint: 480px;
 	}
 
 	td {
-		padding: 20px 0;
 		min-height: 44px;
 		display: flex;
 		align-items: center;

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -45,14 +45,25 @@ $domains-table-mobile-breakpoint: 480px;
 		display: grid;
 		gap: var(--row-gap) 16px;
 
+		// Note: The checkbox does not count for column counting purposes
+
 		&.is-7-column {
 			grid-template-columns: 20px 2fr 1fr 1fr auto auto auto 36px;
+		}
+		&.is-7-column:not(.has-checkbox) {
+			grid-template-columns: 2fr 1fr 1fr auto auto auto 36px;
 		}
 		&.is-6-column {
 			grid-template-columns: 20px 2fr 1fr minmax(auto, 1fr) auto auto 36px;
 		}
+		&.is-6-column:not(.has-checkbox) {
+			grid-template-columns: 2fr 1fr minmax(auto, 1fr) auto auto 36px;
+		}
 		&.is-5-column {
 			grid-template-columns: 20px 1fr minmax(auto, 1fr) auto auto 36px;
+		}
+		&.is-5-column:not(.has-checkbox) {
+			grid-template-columns: 1fr minmax(auto, 1fr) auto auto 36px;
 		}
 
 		tr::after {

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -43,8 +43,12 @@ $domains-table-mobile-breakpoint: 480px;
 		--row-gap: 20px;
 
 		display: grid;
-		grid-template-columns: 20px 2fr 1fr 1fr auto auto auto 36px;
 		gap: var(--row-gap) 16px;
+
+		grid-template-columns: 20px 2fr 1fr 1fr auto auto auto 36px;
+		&.is-owner-hidden {
+			grid-template-columns: 20px 1fr 1fr auto auto auto 36px;
+		}
 
 		tr::after {
 			display: block;

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -49,10 +49,10 @@ $domains-table-mobile-breakpoint: 480px;
 			grid-template-columns: 20px 2fr 1fr 1fr auto auto auto 36px;
 		}
 		&.is-6-column {
-			grid-template-columns: 20px 1fr 1fr auto auto auto 36px;
+			grid-template-columns: 20px 2fr 1fr minmax(auto, 1fr) auto auto 36px;
 		}
 		&.is-5-column {
-			grid-template-columns: 20px 1fr auto auto auto 36px;
+			grid-template-columns: 20px 1fr minmax(auto, 1fr) auto auto 36px;
 		}
 
 		tr::after {

--- a/packages/domains-table/src/use-domain-row.ts
+++ b/packages/domains-table/src/use-domain-row.ts
@@ -12,7 +12,6 @@ const notNull = < T >( x: T ): x is Exclude< T, null > => x !== null;
 
 export const useDomainRow = ( domain: PartialDomainData ) => {
 	const {
-		hideOwnerColumn,
 		isAllSitesView,
 		fetchSiteDomains,
 		domainStatusPurchaseActions,
@@ -148,7 +147,6 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 		isManageableDomain,
 		userCanAddSiteToDomain,
 		domainsRequiringAttention,
-		hideOwnerColumn,
 		placeholderWidth,
 		shouldDisplayPrimaryDomainLabel,
 		isLoadingRowDetails,

--- a/packages/domains-table/src/utils.ts
+++ b/packages/domains-table/src/utils.ts
@@ -64,6 +64,7 @@ export const getStatusSortFunctions = (
 export const shouldHideOwnerColumn = ( domains: DomainData[] ) => {
 	return ! domains.some( ( domain ) => domain.owner && ! domain.current_user_is_owner );
 };
+
 export const countDomainsRequiringAttention = (
 	domainStatutes: ResolveDomainStatusReturn[] | undefined
 ) =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Lay out the table using CSS grid
* The table context object no longer contains `hideOwnerColumn`. The column will be removed from `domainsTableColumns` like we already do for other situations when we want to hide columns
* `<InternalDomainsTable>`, which was just a skeleton component for calculating the table's context object, is now a hook: `useGenerateDomainsTableState`. This is because I needed some of that calculated state in the root component. The table context object can still be accessed with `useDomainsTable`
* Remove some unnecessary wrapper elements in renewal and status cells

Some implementation notes:

CSS grid expects all the grid cells to be direct children of the grid parent. But we want to keep the HTML semantics of `tbody`, `tr`, etc. for a11y. By setting the intermediary table elements to `display:content` they don't generate a CSS box and CSS treats the `td` elements as if they're a child of `table`.

You'll notice the borders are no longer implemented with `border-bottom`. That's because borders do not span grid "gaps". The border is now a 1px high pseudo element which has been told to span all the columns.

`vertical-align:middle` no longer works, so each cell is now `display:flex` to correctly centre the cell content.

The status CTA column (for the button) is still always visible. To hide it we would need to calculate the status action for every single domain at the root of the table so we knew whether any of them had a CTA. I'm not ruling out doing this in the future.

![CleanShot 2023-09-25 at 17 49 02@2x](https://github.com/Automattic/wp-calypso/assets/1500769/ed7d1399-57cb-4b76-9d51-a64532c5c11e)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test mobile layout
* Test desktop layout
* Test site-specific table at different browser widths
* Test all-domains table at different browser widths
* Test when owner column disappears due to all domains belonging to the same person
* Test when none of the domains can be selected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?