### PR TITLE
BackupBrowser: use CheckboxControl for items selection

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@automattic/components';
+import { CheckboxControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { FunctionComponent } from 'react';
-import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import { backupDownloadPath } from 'calypso/my-sites/backup/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { rewindRequestGranularBackup } from 'calypso/state/activity-log/actions';
@@ -77,10 +77,12 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( { rewin
 				</div>
 			) }
 			<div className="file-browser-header__selecting">
-				<FormCheckbox
+				<CheckboxControl
+					__nextHasNoMarginBottom
 					checked={
 						rootNode ? rootNode.checkState === 'checked' || rootNode.checkState === 'mixed' : false
 					}
+					indeterminate={ rootNode && rootNode.checkState === 'mixed' }
 					onChange={ onCheckboxChange }
 					className={ `${ rootNode && rootNode.checkState === 'mixed' ? 'mixed' : '' }` }
 				/>

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -1,9 +1,8 @@
-import { Button, Icon } from '@wordpress/components';
+import { Button, CheckboxControl, Icon } from '@wordpress/components';
 import { useCallback, useState, useEffect } from '@wordpress/element';
 import { chevronDown, chevronRight } from '@wordpress/icons';
 import classNames from 'classnames';
 import { FunctionComponent } from 'react';
-import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import { useDispatch, useSelector } from 'calypso/state';
 import { addChildNodes, setNodeCheckState } from 'calypso/state/rewind/browser/actions';
 import getBackupBrowserNode from 'calypso/state/rewind/selectors/get-backup-browser-node';
@@ -209,20 +208,16 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 			return null;
 		}
 
-		// Mixed state will show checked but with a mixed class
-		// We'll use this to show an alternate background
-		// TODO: Replace with a [-] for mixed state
 		return (
-			<FormCheckbox
+			<CheckboxControl
+				__nextHasNoMarginBottom
 				checked={
 					browserNodeItem
 						? browserNodeItem.checkState === 'checked' || browserNodeItem.checkState === 'mixed'
 						: false
 				}
+				indeterminate={ browserNodeItem && browserNodeItem.checkState === 'mixed' }
 				onChange={ onCheckboxChange }
-				className={ `${
-					browserNodeItem && browserNodeItem.checkState === 'mixed' ? 'mixed' : ''
-				}` }
 			/>
 		);
 	};

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -1,5 +1,10 @@
 @import "@automattic/onboarding/styles/mixins";
 
+.theme-jetpack-cloud .backup-contents-page {
+	--wp-components-color-accent: var(--studio-jetpack-green-50);
+	--wp-admin-theme-color: var(--studio-jetpack-green-50);
+}
+
 .backup-contents-page {
 	.card {
 		padding: 24px 22px;
@@ -240,6 +245,32 @@
 					color: #fff;
 				}
 			}
+		}
+	}
+
+	.components-checkbox-control {
+		float: left;
+
+		.components-checkbox-control__input-container {
+			margin: 8px;
+			line-height: 0;
+			width: 16px;
+			height: 16px;
+		}
+
+		.components-checkbox-control__input {
+			height: 16px;
+			vertical-align: middle;
+			width: 16px;
+			min-width: 16px;
+		}
+
+		svg.components-checkbox-control__checked,
+		svg.components-checkbox-control__indeterminate {
+			left: -2px;
+			top: -2px;
+			height: 20px;
+			width: 20px;
 		}
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-backup-team/issues/162

## Proposed Changes

* Replace `FormCheckbox` with `CheckboxControl` from `@wordpress/components` for items selections in the backup browser.
* Add indeterminate state on parent node when some child items are selected.
* Improve checkboxes styles, using the `--studio-jetpack-green-50` color for Jetpack Cloud.

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/wp-calypso/assets/1488641/2a0d100e-0683-44e4-848f-f5bb5fe12dd5) | ![after](https://github.com/Automattic/wp-calypso/assets/1488641/de8933d8-5bfe-4561-ba91-5e158628ff9d) |

## Demo

https://github.com/Automattic/wp-calypso/assets/1488641/fa5b8a81-bdd7-4d9b-bc49-33af88d9340d

## Testing Instructions
* Spin up a Calypso or Jetpack Cloud live branch
* Select a site with a Jetpack VaultPress Backup plan
* Pick a backup and click on `View files` inside the `Actions (+)` menu. This option is only available on full/daily backups
* Try to select all files and then deselect some child files to ensure you see the indeterminate state (the selected checkbox with the dash in the middle).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
