### PR TITLE
Domains Table: Only show mobile bulk action toggle when there are bulk actions

### DIFF
--- a/packages/domains-table/src/domains-table-filters/index.tsx
+++ b/packages/domains-table/src/domains-table-filters/index.tsx
@@ -29,6 +29,7 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 		setShowBulkActions,
 		showBulkActions,
 		domainsTableColumns,
+		canSelectAnyDomains,
 	} = useDomainsTable();
 
 	const options: ReactNode[] = [];
@@ -82,22 +83,24 @@ export const DomainsTableFilters = ( { onSearch, filter }: DomainsTableFiltersPr
 							{ options }
 						</SelectDropdown>
 
-						<DropdownMenu icon={ <Gridicon icon="ellipsis" /> } label={ __( 'Domain actions' ) }>
-							{ () => (
-								<MenuGroup>
-									<MenuItem
-										onClick={ () => setShowBulkActions( ! showBulkActions ) }
-										className="domains-table-mobile-cards-controls-bulk-toggle"
-									>
-										<ToggleControl
-											label={ __( 'Bulk actions ' ) }
-											onChange={ () => setShowBulkActions( ! showBulkActions ) }
-											checked={ showBulkActions }
-										/>
-									</MenuItem>
-								</MenuGroup>
-							) }
-						</DropdownMenu>
+						{ canSelectAnyDomains && (
+							<DropdownMenu icon={ <Gridicon icon="ellipsis" /> } label={ __( 'Domain actions' ) }>
+								{ () => (
+									<MenuGroup>
+										<MenuItem
+											onClick={ () => setShowBulkActions( ! showBulkActions ) }
+											className="domains-table-mobile-cards-controls-bulk-toggle"
+										>
+											<ToggleControl
+												label={ __( 'Bulk actions ' ) }
+												onChange={ () => setShowBulkActions( ! showBulkActions ) }
+												checked={ showBulkActions }
+											/>
+										</MenuItem>
+									</MenuGroup>
+								) }
+							</DropdownMenu>
+						) }
 					</div>
 				</>
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Hide bulk-actions toggle on mobile when there are no selectable domains

**Before**

<img width="419" alt="before" src="https://github.com/Automattic/wp-calypso/assets/1500769/040a92b8-8b2b-445b-8b00-d9de4ffe3ab7">


**After**

<img width="419" alt="after" src="https://github.com/Automattic/wp-calypso/assets/1500769/ff73a21d-7453-470f-be88-b577cc3d3363">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?