### PR TITLE
Domains contact info save: Always return to edit page

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -13,10 +13,7 @@ import { findRegistrantWhois } from 'calypso/lib/domains/whois/utils';
 import wp from 'calypso/lib/wp';
 import DesignatedAgentNotice from 'calypso/my-sites/domains/domain-management/components/designated-agent-notice';
 import TransferLockOptOutForm from 'calypso/my-sites/domains/domain-management/components/transfer-lock-opt-out-form';
-import {
-	domainManagementContactsPrivacy,
-	domainManagementEdit,
-} from 'calypso/my-sites/domains/paths';
+import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { requestWhois, saveWhois } from 'calypso/state/domains/management/actions';
 import {
@@ -373,20 +370,7 @@ class EditContactInfoFormCard extends Component {
 	getReturnDestination = () => {
 		const domainName = this.props.selectedDomain.name;
 		const siteSlug = this.props.selectedSite.slug;
-		const domainSettingsPage = domainManagementEdit(
-			siteSlug,
-			domainName,
-			this.props.currentRoute
-		);
-		const contactsPrivacyPage = domainManagementContactsPrivacy(
-			siteSlug,
-			domainName,
-			this.props.currentRoute
-		);
-
-		return this.props.previousPath?.startsWith( domainSettingsPage )
-			? domainSettingsPage
-			: contactsPrivacyPage;
+		return domainManagementEdit( siteSlug, domainName, this.props.currentRoute );
 	};
 
 	showNoticeAndGoBack = ( message ) => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3934

After saving contact information, if the previousPath contains the domains/edit url, saving will return you to the edit page. 

If there is no previousPath or previousPath does not match against the domains/edit url, saving will navigate you to the contacts-privacy page.

It looks like maybe this page doesn't exist / work anymore? 

In the case of https://github.com/Automattic/dotcom-forge/issues/3934, when you refresh the page or come in from a verify link, going to the contacts-privacy page continuously loads the whois endpoint and never renders anything other than the placeholder.

## Proposed Changes

* Always return to the edit page after saving contact information

## Testing Instructions

- http://calypso.localhost:3000/domains/manage/all/test345678.blog/edit/test345678.blog
- Edit contact info + Save, get returned to edit page
- Edit contact info, but before saving, refresh the page and then modify the contact info, saving should return to the edit page

Todo
- [x]  Find out if contacts-privacy is used in some flow that expects more props before it renders (suspect it's deadcode but it's hard to say for sure). Asking here: p1695621104359409-slack-C05CT832K2T