### PR TITLE
Jetpack Manage: Show in-progress status for Boost column & expanded site content in the Sites Dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
@@ -20,7 +20,7 @@ const formatStatsData = ( site: Site ): StatsNode => ( {
 } );
 
 const formatBoostData = ( site: Site ): BoostNode => ( {
-	status: site.has_boost && site.has_pending_boost_one_time_score ? 'progress' : 'active',
+	status: site.has_pending_boost_one_time_score ? 'progress' : 'active',
 	type: 'boost',
 	value: site.jetpack_boost_scores,
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
@@ -20,7 +20,7 @@ const formatStatsData = ( site: Site ): StatsNode => ( {
 } );
 
 const formatBoostData = ( site: Site ): BoostNode => ( {
-	status: site.has_pending_boost_one_time_score ? 'progress' : 'active',
+	status: site.has_boost && site.has_pending_boost_one_time_score ? 'progress' : 'active',
 	type: 'boost',
 	value: site.jetpack_boost_scores,
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
@@ -20,7 +20,7 @@ const formatStatsData = ( site: Site ): StatsNode => ( {
 } );
 
 const formatBoostData = ( site: Site ): BoostNode => ( {
-	status: 'active',
+	status: site.has_pending_boost_one_time_score ? 'progress' : 'active',
 	type: 'boost',
 	value: site.jetpack_boost_scores,
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -84,7 +84,7 @@ export default function BoostSitePerformance( {
 				<div className="site-expanded-content__card-content">
 					<div className="site-expanded-content__card-content-column">
 						{ hasPendingScore ? (
-							<InProgressIcon id={ `${ siteId }-boost-fetching-score-overall` } />
+							<InProgressIcon />
 						) : (
 							<div
 								className={ classNames(
@@ -118,7 +118,7 @@ export default function BoostSitePerformance( {
 					</div>
 					<div className="site-expanded-content__card-content-column">
 						{ hasPendingScore ? (
-							<InProgressIcon id={ `${ siteId }-boost-fetching-score-overall` } />
+							<InProgressIcon />
 						) : (
 							<>
 								<div className="site-expanded-content__device-score-container">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -7,6 +7,7 @@ import Tooltip from 'calypso/components/tooltip';
 import { jetpackBoostDesktopIcon, jetpackBoostMobileIcon } from '../../icons';
 import { getBoostRating, getBoostRatingClass } from '../lib/boost';
 import ExpandedCard from './expanded-card';
+import InProgressIcon from './in-progress-icon';
 import type { BoostData } from '../types';
 
 interface Props {
@@ -16,6 +17,7 @@ interface Props {
 	siteUrlWithScheme: string;
 	trackEvent: ( eventName: string ) => void;
 	hasError: boolean;
+	hasPendingScore: boolean;
 }
 
 export default function BoostSitePerformance( {
@@ -25,6 +27,7 @@ export default function BoostSitePerformance( {
 	siteUrlWithScheme,
 	trackEvent,
 	hasError,
+	hasPendingScore,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -80,57 +83,67 @@ export default function BoostSitePerformance( {
 			<div className="site-expanded-content__card-content-container">
 				<div className="site-expanded-content__card-content">
 					<div className="site-expanded-content__card-content-column">
-						<div
-							className={ classNames(
-								'site-expanded-content__card-content-score',
-								getBoostRatingClass( overallScore )
-							) }
-						>
-							{ getBoostRating( overallScore ) }
+						{ hasPendingScore ? (
+							<InProgressIcon id={ `${ siteId }-boost-fetching-score-overall` } />
+						) : (
+							<div
+								className={ classNames(
+									'site-expanded-content__card-content-score',
+									getBoostRatingClass( overallScore )
+								) }
+							>
+								{ getBoostRating( overallScore ) }
 
-							<span
-								ref={ helpIconRef }
-								onMouseEnter={ () => setShowTooltip( true ) }
-								onMouseLeave={ () => setShowTooltip( false ) }
-							>
-								<Icon size={ 20 } className="site-expanded-content__help-icon" icon={ help } />
-							</span>
-							<Tooltip
-								id={ `${ siteId }-boost-help-text` }
-								context={ helpIconRef.current }
-								isVisible={ showTooltip }
-								position="bottom"
-								className="site-expanded-content__tooltip"
-							>
-								{ tooltip }
-							</Tooltip>
-						</div>
+								<span
+									ref={ helpIconRef }
+									onMouseEnter={ () => setShowTooltip( true ) }
+									onMouseLeave={ () => setShowTooltip( false ) }
+								>
+									<Icon size={ 20 } className="site-expanded-content__help-icon" icon={ help } />
+								</span>
+								<Tooltip
+									id={ `${ siteId }-boost-help-text` }
+									context={ helpIconRef.current }
+									isVisible={ showTooltip }
+									position="bottom"
+									className="site-expanded-content__tooltip"
+								>
+									{ tooltip }
+								</Tooltip>
+							</div>
+						) }
 						<div className="site-expanded-content__card-content-score-title">
 							{ translate( 'Overall' ) }
 						</div>
 					</div>
 					<div className="site-expanded-content__card-content-column">
-						<div className="site-expanded-content__device-score-container">
-							<div className="site-expanded-content__card-content-column">
-								<Icon
-									size={ 24 }
-									className="site-expanded-content__device-icon"
-									icon={ jetpackBoostDesktopIcon }
-								/>
-								<span className="site-expanded-content__device-score">{ desktopScore }</span>
-							</div>
-							<div className="site-expanded-content__card-content-column site-expanded-content__card-content-column-mobile">
-								<Icon
-									className="site-expanded-content__device-icon"
-									size={ 24 }
-									icon={ jetpackBoostMobileIcon }
-								/>
-								<span className="site-expanded-content__device-score">{ mobileScore }</span>
-							</div>
-						</div>
-						<div className="site-expanded-content__card-content-score-title">
-							{ translate( 'Devices' ) }
-						</div>
+						{ hasPendingScore ? (
+							<InProgressIcon id={ `${ siteId }-boost-fetching-score-overall` } />
+						) : (
+							<>
+								<div className="site-expanded-content__device-score-container">
+									<div className="site-expanded-content__card-content-column">
+										<Icon
+											size={ 24 }
+											className="site-expanded-content__device-icon"
+											icon={ jetpackBoostDesktopIcon }
+										/>
+										<span className="site-expanded-content__device-score">{ desktopScore }</span>
+									</div>
+									<div className="site-expanded-content__card-content-column site-expanded-content__card-content-column-mobile">
+										<Icon
+											className="site-expanded-content__device-icon"
+											size={ 24 }
+											icon={ jetpackBoostMobileIcon }
+										/>
+										<span className="site-expanded-content__device-score">{ mobileScore }</span>
+									</div>
+								</div>
+								<div className="site-expanded-content__card-content-score-title">
+									{ translate( 'Devices' ) }
+								</div>
+							</>
+						) }
 					</div>
 				</div>
 				<div className="site-expanded-content__card-footer">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/in-progress-icon.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/in-progress-icon.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import Tooltip from 'calypso/components/tooltip';
 
-export default function InProgressIcon( { id }: { id: string } ) {
+export default function InProgressIcon() {
 	const translate = useTranslate();
 
 	const [ showTooltip, setShowTooltip ] = useState( false );
@@ -18,7 +18,7 @@ export default function InProgressIcon( { id }: { id: string } ) {
 			>
 				<Gridicon icon="time" size={ 18 } className="site-expanded-content__progress-icon" />
 			</span>
-			<Tooltip id={ id } context={ iconRef.current } isVisible={ showTooltip } position="bottom">
+			<Tooltip context={ iconRef.current } isVisible={ showTooltip } position="bottom">
 				{ translate( 'Fetching Scores' ) }
 			</Tooltip>
 		</>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/in-progress-icon.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/in-progress-icon.tsx
@@ -1,0 +1,26 @@
+import { Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useRef, useState } from 'react';
+import Tooltip from 'calypso/components/tooltip';
+
+export default function InProgressIcon( { id }: { id: string } ) {
+	const translate = useTranslate();
+
+	const [ showTooltip, setShowTooltip ] = useState( false );
+	const iconRef = useRef< HTMLElement | null >( null );
+
+	return (
+		<>
+			<span
+				ref={ iconRef }
+				onMouseEnter={ () => setShowTooltip( true ) }
+				onMouseLeave={ () => setShowTooltip( false ) }
+			>
+				<Gridicon icon="time" size={ 18 } className="site-expanded-content__progress-icon" />
+			</span>
+			<Tooltip id={ id } context={ iconRef.current } isVisible={ showTooltip } position="bottom">
+				{ translate( 'Fetching Scores' ) }
+			</Tooltip>
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -53,6 +53,7 @@ export default function SiteExpandedContent( {
 					hasBoost={ site.has_boost }
 					trackEvent={ trackEvent }
 					hasError={ hasError }
+					hasPendingScore={ site.has_pending_boost_one_time_score }
 				/>
 			) }
 			{ columns.includes( 'backup' ) && stats && (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -283,3 +283,9 @@ $color-yellow: var(--studio-yellow-50);
 	opacity: 0.5;
 	cursor: not-allowed;
 }
+
+.site-expanded-content__progress-icon {
+	vertical-align: middle;
+	color: var(--studio-gray-40);
+	margin-block: 6px;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-tooltip.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-tooltip.ts
@@ -35,11 +35,16 @@ const plugin: TooltipGetter = {
 	success: ( translate ) => translate( 'No plugin updates found' ),
 };
 
+const boost: TooltipGetter = {
+	progress: ( translate ) => translate( 'Fetching Scores' ),
+};
+
 const ALL_TOOLTIPS: Partial< Record< AllowedRowType, TooltipGetter > > = {
 	backup,
 	scan,
 	monitor,
 	plugin,
+	boost,
 };
 
 const useTooltip = (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { getUrlParts } from '@automattic/calypso-url';
 import { Button, Gridicon, ShortenedNumber, WordPressLogo } from '@automattic/components';
 import { Icon, arrowUp, arrowDown } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
@@ -14,15 +13,14 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectLicense, unselectLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { hasSelectedLicensesOfType } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
-import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
 import ToggleActivateMonitoring from '../../downtime-monitoring/toggle-activate-monitoring';
 import SitesOverviewContext from '../context';
-import { getBoostRating, getBoostRatingClass } from '../lib/boost';
 import { DASHBOARD_PRODUCT_SLUGS_BY_TYPE } from '../lib/constants';
 import SiteBackupStaging from '../site-backup-staging';
 import SiteSelectCheckbox from '../site-select-checkbox';
 import SiteSetFavorite from '../site-set-favorite';
 import useRowMetadata from './hooks/use-row-metadata';
+import SiteBoostColumn from './site-boost-column';
 import type { AllowedTypes, SiteData } from '../types';
 
 interface Props {
@@ -110,17 +108,9 @@ export default function SiteStatusContent( {
 		return page( issueLicenseRedirectUrl );
 	};
 
-	const handleGetBoostScoreAction = () => {
-		// TODO - should open a modal.
-	};
-
 	const handleDeselectLicenseAction = () => {
 		dispatch( unselectLicense( siteId, type ) );
 	};
-
-	const hasBoost = rows.site.value.has_boost;
-
-	const adminUrl = useSelector( ( state ) => getJetpackAdminUrl( state, siteId ) );
 
 	function getTrendIcon( viewsTrend: 'up' | 'down' ) {
 		if ( viewsTrend === 'up' ) {
@@ -278,50 +268,7 @@ export default function SiteStatusContent( {
 
 		// We will show a progress icon when the site score is being fetched.
 		if ( type === 'boost' && status !== 'progress' ) {
-			const overallScore = rows.site.value.jetpack_boost_scores.overall;
-
-			if ( overallScore ) {
-				return (
-					<div
-						className={ classNames(
-							'sites-overview__boost-score',
-							getBoostRatingClass( overallScore )
-						) }
-					>
-						{ translate( '%(rating)s Score', {
-							args: { rating: getBoostRating( overallScore ) },
-							comment: '%rating will be replaced by boost rating, e.g. "A", "B", "C", "D", or "F"',
-						} ) }
-					</div>
-				);
-			}
-
-			if ( hasBoost ) {
-				const { origin, pathname } = getUrlParts( adminUrl ?? '' );
-				return (
-					<a
-						className="sites-overview__column-action-button"
-						href={
-							adminUrl
-								? `${ origin }${ pathname }?page=my-jetpack#/add-boost`
-								: `https://${ siteUrl }/wp-admin/admin.php?page=jetpack`
-						}
-						target="_blank"
-						rel="noreferrer"
-					>
-						{ translate( 'Configure Boost' ) }
-					</a>
-				);
-			}
-
-			return (
-				<button
-					className="sites-overview__column-action-button"
-					onClick={ handleGetBoostScoreAction }
-				>
-					{ translate( 'Get Score' ) }
-				</button>
-			);
+			return <SiteBoostColumn site={ rows.site.value } />;
 		}
 
 		switch ( status ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -276,7 +276,8 @@ export default function SiteStatusContent( {
 			);
 		}
 
-		if ( type === 'boost' ) {
+		// We will show a progress icon when the site score is being fetched.
+		if ( type === 'boost' && status !== 'progress' ) {
 			const overallScore = rows.site.value.jetpack_boost_scores.overall;
 
 			if ( overallScore ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
@@ -1,0 +1,68 @@
+import { getUrlParts } from '@automattic/calypso-url';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
+import { getBoostRating, getBoostRatingClass } from '../../lib/boost';
+import { Site } from '../../types';
+
+interface Props {
+	site: Site;
+}
+
+export default function SiteBoostColumn( { site }: Props ) {
+	const translate = useTranslate();
+
+	const overallScore = site.jetpack_boost_scores?.overall;
+	const hasBoost = site.has_boost;
+	const adminUrl = useSelector( ( state ) => getJetpackAdminUrl( state, site.blog_id ) );
+
+	const handleGetBoostScoreAction = () => {
+		// TODO - should open a modal.
+	};
+
+	if ( overallScore ) {
+		return (
+			<div
+				className={ classNames(
+					'sites-overview__boost-score',
+					getBoostRatingClass( overallScore )
+				) }
+			>
+				{ translate( '%(rating)s Score', {
+					args: { rating: getBoostRating( overallScore ) },
+					comment: '%rating will be replaced by boost rating, e.g. "A", "B", "C", "D", or "F"',
+				} ) }
+			</div>
+		);
+	}
+
+	if ( hasBoost ) {
+		const { origin, pathname } = getUrlParts( adminUrl ?? '' );
+		return (
+			<a
+				className="sites-overview__column-action-button"
+				href={
+					adminUrl
+						? `${ origin }${ pathname }?page=my-jetpack#/add-boost`
+						: `https://${ site.url }/wp-admin/admin.php?page=jetpack`
+				}
+				target="_blank"
+				rel="noreferrer"
+			>
+				{ translate( 'Configure Boost' ) }
+			</a>
+		);
+	}
+
+	return (
+		<>
+			<button
+				className="sites-overview__column-action-button"
+				onClick={ handleGetBoostScoreAction }
+			>
+				{ translate( 'Get Score' ) }
+			</button>
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -98,6 +98,7 @@ export interface Site {
 	is_connected: boolean;
 	has_paid_agency_monitor: boolean;
 	is_atomic: boolean;
+	has_pending_boost_one_time_score: boolean;
 }
 export interface SiteNode {
 	value: Site;


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/28

## Proposed Changes

- This PR updates the Boost column & the expanded site content on the Sites Dashboard to show the progress status when the Boost scores are being fetched.
- Refactor the boost column content into a new component

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/show-boost-in-progress-status` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
4. We are using the `has_pending_boost_one_time_score` property, which will be added later, so we need to manually make some changes to test this. 
5. Visit this file /client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts#L23 and change the `status` to `progress`.
6. Now, verify that you see a progress icon with a tooltip as shown below

<img width="190" alt="Screenshot 2023-09-25 at 10 49 43 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4ae16ee0-5377-46f9-a7ff-ec1a9b869a8f">

7. Visit the file /client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx#L56 and change the prop `hasPendingScore` to `true` and verify that you see the progress icons with tooltip as shown below

<img width="380" alt="Screenshot 2023-09-25 at 11 09 19 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b21bad5e-673d-41c4-83a7-3ec359716e4a">
<img width="375" alt="Screenshot 2023-09-25 at 11 23 55 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/dbe67241-701b-47d0-b497-4cce6e54fa22">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?