### PR TITLE
Assembler: Change the default design to Creatio 2

### DIFF
--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -69,10 +69,10 @@ export const STICKY_OFFSET_TOP = 109;
  * Hard-coded design
  */
 export const DEFAULT_ASSEMBLER_DESIGN = {
-	slug: 'creatio',
-	title: 'Creatio',
+	slug: 'creatio-2',
+	title: 'Creatio 2',
 	recipe: {
-		stylesheet: 'pub/creatio',
+		stylesheet: 'pub/creatio-2',
 	},
 	design_type: 'assembler',
 } as Design;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1695429763888219-slack-CRWCHQGUB

## Proposed Changes

* Change the default design of the Assembler to the `creatio-2`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Onboarding**

* Go to /setup?siteSlug=<your_site>
* Continue to the Design Picker
* Select “Design your own”
* On the Assembler screen, ensure the styles of the patterns match the new design

**Theme Showcase**

* Go to the Theme Showcase
* Scroll down to select the Assembler CTA
* On the Assembler screen, ensure the styles of the patterns match the new design

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?