### PR TITLE
Stats: Updating copy for the free plan summary

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
@@ -107,7 +107,7 @@ const StatsFreeOwnedNotice = ( { siteId, siteSlug } ) => {
 			<h1>{ translate( 'You have already purchased Jetpack Stats Free Plan!' ) }</h1>
 			<p>
 				{ translate(
-					'It appears that you have already purchased a license for this product, and it has been successfully activated. You now have access to:'
+					'You already have a free license for this product, and it has been successfully activated. Currently have access to:'
 				) }
 			</p>
 			<StatsBenefitsFree />

--- a/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
@@ -41,7 +41,7 @@ const StatsCommercialOwned = ( { siteSlug } ) => {
 			<h1>{ translate( 'You have already purchased Jetpack Stats Commercial!' ) }</h1>
 			<p>
 				{ translate(
-					'It appears that you have already purchased a license or a plan that supports this product, and it has been successfully activated. You now have access to:'
+					'You have already purchased a license or a plan that supports this product, and it has been successfully activated. You now have access to:'
 				) }
 			</p>
 			<StatsBenefitsCommercial />
@@ -70,7 +70,7 @@ const StatsPWYWOwnedNotice = ( { siteId, siteSlug } ) => {
 			<h1>{ translate( 'You have already purchased Jetpack Stats Personal Plan!' ) }</h1>
 			<p>
 				{ translate(
-					'It appears that you have already purchased a license for this product, and it has been successfully activated. You now have access to:'
+					'You have already purchased a license for this product, and it has been successfully activated. You now have access to:'
 				) }
 			</p>
 			<StatsBenefitsPersonal />

--- a/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
@@ -38,10 +38,10 @@ const StatsCommercialOwned = ( { siteSlug } ) => {
 
 	return (
 		<>
-			<h1>{ translate( 'You have already purchased Jetpack Stats Commercial!' ) }</h1>
+			<h1>{ translate( 'You have already purchased Jetpack Stats!' ) }</h1>
 			<p>
 				{ translate(
-					'You have already purchased a license or a plan that supports this product, and it has been successfully activated. You now have access to:'
+					'You have already purchased a commercial license or a plan that supports this product, and it has been successfully activated. You now have access to:'
 				) }
 			</p>
 			<StatsBenefitsCommercial />
@@ -67,10 +67,10 @@ const StatsPWYWOwnedNotice = ( { siteId, siteSlug } ) => {
 
 	return (
 		<StatsSingleItemPagePurchaseFrame>
-			<h1>{ translate( 'You have already purchased Jetpack Stats Personal Plan!' ) }</h1>
+			<h1>{ translate( 'You have already purchased Jetpack Stats!' ) }</h1>
 			<p>
 				{ translate(
-					'You have already purchased a license for this product, and it has been successfully activated. You now have access to:'
+					'You have already purchased a personal license for this product, and it has been successfully activated. You now have access to:'
 				) }
 			</p>
 			<StatsBenefitsPersonal />

--- a/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
@@ -104,7 +104,7 @@ const StatsFreeOwnedNotice = ( { siteId, siteSlug } ) => {
 
 	return (
 		<StatsSingleItemPagePurchaseFrame isFree>
-			<h1>{ translate( 'You have already purchased Jetpack Stats Free Plan!' ) }</h1>
+			<h1>{ translate( 'You already have a free license for Jetpack Stats.' ) }</h1>
 			<p>
 				{ translate(
 					'You already have a free license for this product, and it has been successfully activated. Currently have access to:'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81745

## Proposed Changes

* update copy reflecting that the customer already purchased a free product

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to the live branch and purchase a free stats subscription
* click on the upgrade link on the success banner and verify that it redirects directly to PWYW purchase screen (not the summary page)
* navigate to the purchase page manually by updating the URL to `/stats/purchase/<id>` and verify that the copy is the same as in the screenshot below

| Before | After |
| --- | --- |
| <img width="1185" alt="SCR-20230925-oomc" src="https://github.com/Automattic/wp-calypso/assets/112354940/2c0fc1f4-b7c0-4aaf-98d6-9677e532d2e3"> | <img width="1180" alt="SCR-20230925-opch" src="https://github.com/Automattic/wp-calypso/assets/112354940/cd9e3735-de0d-459b-b8f7-06b1c8c69091"> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?