### PR TITLE
Upgrade wp-prettier to v3.0.3 (final)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -14,3 +14,7 @@ b7a4a072ae2a13785fb6ccbf9c34ed8e65739705
 fb0aab8f67a8738d25d5426343df8599935cdd29
 # Eslint format in #72348
 a14b6727ffc1ed68b951c95f8a43ca6e1cb15ccc
+# Prettier format (2.8.5) in #74775
+d6c65e414a1041b53f2efc726d4bf664e0484718
+# Prettier format (3.0.3) in #81899
+d26e6d3d415d1a56256dc3a9beec2a2bab3bf386

--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
 		"postcss": "^8.4.5",
 		"postcss-cli": "^9.0.1",
 		"postcss-custom-properties": "^11.0.0",
-		"prettier": "npm:wp-prettier@3.0.3-beta-4",
+		"prettier": "npm:wp-prettier@3.0.3",
 		"react-refresh": "^0.14.0",
 		"readline-sync": "^1.4.10",
 		"recursive-copy": "^2.0.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24638,12 +24638,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:wp-prettier@3.0.3-beta-4":
-  version: 3.0.3-beta-4
-  resolution: "wp-prettier@npm:3.0.3-beta-4"
+"prettier@npm:wp-prettier@3.0.3":
+  version: 3.0.3
+  resolution: "wp-prettier@npm:3.0.3"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 07f5d0bcb65a9fce47a38ff594108a994c0fe4df359f0330627830dde7e9884c0c7f572c735b015a078959c3231bdb27959f1fa9708a8e82e9457bc08ddb1fa8
+  checksum: a8026c481a9d7957826da0ab8bfa6d79032d159a0bb99a322a53962874913b08b9f0470803fc465da0a8287b78004079cba606fdcd89f3086edefd42de2a545c
   languageName: node
   linkType: hard
 
@@ -31604,7 +31604,7 @@ __metadata:
     postcss: ^8.4.5
     postcss-cli: ^9.0.1
     postcss-custom-properties: ^11.0.0
-    prettier: "npm:wp-prettier@3.0.3-beta-4"
+    prettier: "npm:wp-prettier@3.0.3"
     react: ^18.2.0
     react-dom: ^18.2.0
     react-intersection-observer: ^9.4.3


### PR DESCRIPTION
Finalizes the Prettier upgrade to 3.0.3. After a week without discovering any new bugs, I released final 3.0.3 version of `wp-prettier` (previous releases were betas), and updated Calypso's `package.json` file to use the final version.

I also added the reformatting commits for 3.0.3 and 2.8.5 to the `.git-blame-ignore-revs` file.