### PR TITLE
Site migration: add site slug check for both with www and without www

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -174,7 +174,9 @@ export class ImportEverything extends SectionMigrate {
 			return (
 				<NotAuthorized
 					onStartBuilding={ () => {
-						recordTracksEvent( 'calypso_site_importer_skip_to_dashboard' );
+						recordTracksEvent( 'calypso_site_importer_skip_to_dashboard', {
+							from: 'target-staging',
+						} );
 						stepNavigator.goToDashboardPage();
 					} }
 					onStartBuildingText={ translate( 'Skip to dashboard' ) }
@@ -192,8 +194,15 @@ export class ImportEverything extends SectionMigrate {
 					isMigrateFromWp={ isMigrateFromWp }
 					isTrial={ isMigrationTrialSite( this.props.targetSite ) }
 					onContentOnlyClick={ onContentOnlySelection }
+					sourceSite={ sourceSite }
 					onFreeTrialClick={ () => {
 						stepNavigator?.navigate( `migrationTrial${ window.location.search }` );
+					} }
+					onNotAuthorizedClick={ () => {
+						recordTracksEvent( 'calypso_site_importer_skip_to_dashboard', {
+							from: 'pre-migration',
+						} );
+						stepNavigator?.goToDashboardPage();
 					} }
 				/>
 			);

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -23,6 +23,7 @@ import { getCredentials } from 'calypso/state/jetpack/credentials/actions';
 import getJetpackCredentials from 'calypso/state/selectors/get-jetpack-credentials';
 import isRequestingSiteCredentials from 'calypso/state/selectors/is-requesting-site-credentials';
 import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
+import NotAuthorized from '../../../components/not-authorized';
 import ConfirmModal from './confirm-modal';
 import { CredentialsHelper } from './credentials-helper';
 import { StartImportTrackingProps } from './types';
@@ -37,7 +38,9 @@ interface PreMigrationProps {
 	isMigrateFromWp: boolean;
 	isTrial?: boolean;
 	onContentOnlyClick: () => void;
+	sourceSite?: SiteDetails;
 	onFreeTrialClick: () => void;
+	onNotAuthorizedClick: () => void;
 }
 
 export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = (
@@ -52,6 +55,8 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		isTrial,
 		onContentOnlyClick,
 		onFreeTrialClick,
+		sourceSite,
+		onNotAuthorizedClick,
 	} = props;
 
 	const translate = useTranslate();
@@ -70,7 +75,6 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 
 	const {
 		sourceSiteId,
-		sourceSite,
 		fetchMigrationEnabledStatus,
 		isFetchingData: isFetchingMigrationData,
 		siteCanMigrate,
@@ -170,10 +174,10 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		if ( showUpdatePluginInfo || ! continueImport ) {
 			return;
 		}
-		if ( sourceSite ) {
+		if ( sourceSiteId ) {
 			startImport( migrationTrackingProps );
 		}
-	}, [ continueImport, sourceSite, startImport, showUpdatePluginInfo ] );
+	}, [ continueImport, sourceSiteId, startImport, showUpdatePluginInfo ] );
 
 	function renderCredentialsFormSection() {
 		// We do not show the credentials form if we already have credentials
@@ -229,6 +233,13 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		// Show a loading state when we are trying to fetch existing credentials
 		if ( ! hasLoaded || isRequestingCredentials ) {
 			return <LoadingEllipsis />;
+		}
+
+		if ( ! sourceSite || ( sourceSite && sourceSite.ID !== sourceSiteId ) ) {
+			<NotAuthorized
+				onStartBuilding={ onNotAuthorizedClick }
+				onStartBuildingText={ translate( 'Skip to dashboard' ) }
+			/>;
 		}
 
 		return (

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
@@ -166,6 +166,7 @@ describe( 'PreMigration', () => {
 			isTargetSitePlanCompatible: true,
 			isMigrateFromWp: true,
 			onContentOnlyClick,
+			sourceSite: sourceSite,
 		} );
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore

--- a/client/blocks/importer/wordpress/index.tsx
+++ b/client/blocks/importer/wordpress/index.tsx
@@ -55,8 +55,11 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 		showConfirmDialog,
 	} = props;
 	const siteItem = useSelector( ( state ) => getSite( state, siteId ) );
-	const fromSiteItem = useSelector( ( state ) =>
-		getSiteBySlug( state, fromSite ? convertToFriendlyWebsiteName( fromSite ) : '' )
+	const fromSiteSlug = fromSite ? convertToFriendlyWebsiteName( fromSite ) : '';
+	// Check domain without the www first, and with www as a backup
+	const fromSiteItem = useSelector(
+		( state ) =>
+			getSiteBySlug( state, fromSiteSlug ) || getSiteBySlug( state, `www.${ fromSiteSlug }` )
 	);
 	const isSiteAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 	const isSiteJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/dotcom-forge#3924

## Proposed Changes

* Please see the issue above for more context, in this PR, we've added site slug check to check the user input first, and adding a site slug check with `www` prepended as a backup.
* We've also guarding the source site check on the migration ready screen more. In [section-migrate.jsx](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/migrate/section-migrate.jsx#L239) We're picking up source site object via a  site slug lookup in sites object, but in the new migration ready screen we're grabbing the source site object via blog id, so the result might be different. In the PR we also check if the sourceSite object grabbed via sites object matches the blog id returns from the API.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Find a self-hosted site with custom domain `www` recorded in the blog report card. For example, when you see the report card it needs to be something like `www.example.com` and not `example.com`.
* Navigate to `http://calypso.localhost:3000/setup/import-focused/import?siteSlug=:target_site_slug` and go through the migration flow.
* Type the source site URL with and without www and see if the migration can be started fine.
* Try out different migration flow scenarios and see if everything works fine. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?