### PR TITLE
Jetpack Manage: Update 'Boost' column styling.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/test/use-default-site-columns.js
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/test/use-default-site-columns.js
@@ -28,7 +28,7 @@ describe( 'useSiteColumns', () => {
 		} = renderHook( () => useDefaultSiteColumns() );
 
 		const columnTitles = columns.map( ( { title } ) => title );
-		expect( columnTitles ).toContain( 'Boost' );
+		expect( columnTitles ).toContain( 'Boost score' );
 	} );
 
 	it( 'does not include the Boost column if Boost is not enabled on the dashboard', () => {
@@ -39,6 +39,6 @@ describe( 'useSiteColumns', () => {
 		} = renderHook( () => useDefaultSiteColumns() );
 
 		const columnTitles = columns.map( ( { title } ) => title );
-		expect( columnTitles ).not.toContain( 'Boost' );
+		expect( columnTitles ).not.toContain( 'Boost score' );
 	} );
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-default-site-columns.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-default-site-columns.tsx
@@ -26,7 +26,6 @@ const useDefaultSiteColumns = (): SiteColumns => {
 					{
 						key: 'boost',
 						title: translate( 'Boost score' ),
-						className: 'width-fit-content',
 						isExpandable: true,
 						showInfo: true,
 					},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-default-site-columns.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-default-site-columns.tsx
@@ -25,7 +25,7 @@ const useDefaultSiteColumns = (): SiteColumns => {
 			? [
 					{
 						key: 'boost',
-						title: translate( 'Boost' ),
+						title: translate( 'Boost score' ),
 						className: 'width-fit-content',
 						isExpandable: true,
 						showInfo: true,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
@@ -29,10 +29,7 @@ export default function SiteBoostColumn( { site }: Props ) {
 					getBoostRatingClass( overallScore )
 				) }
 			>
-				{ translate( '%(rating)s Score', {
-					args: { rating: getBoostRating( overallScore ) },
-					comment: '%rating will be replaced by boost rating, e.g. "A", "B", "C", "D", or "F"',
-				} ) }
+				{ getBoostRating( overallScore ) }
 			</div>
 		);
 	}
@@ -41,7 +38,7 @@ export default function SiteBoostColumn( { site }: Props ) {
 		const { origin, pathname } = getUrlParts( adminUrl ?? '' );
 		return (
 			<a
-				className="sites-overview__column-action-button"
+				className="sites-overview__column-action-button is-link"
 				href={
 					adminUrl
 						? `${ origin }${ pathname }?page=my-jetpack#/add-boost`
@@ -58,7 +55,7 @@ export default function SiteBoostColumn( { site }: Props ) {
 	return (
 		<>
 			<button
-				className="sites-overview__column-action-button"
+				className="sites-overview__column-action-button is-link"
 				onClick={ handleGetBoostScoreAction }
 			>
 				{ translate( 'Get Score' ) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -162,7 +162,7 @@
 	svg {
 		margin-inline-start: -0.4em;
 	}
-	&:hover {
+	&:hover:not(.is-link) {
 		background: var(--studio-gray-80);
 		color: var(--studio-white);
 	}
@@ -175,6 +175,19 @@
 		background: var(--studio-jetpack-green-50);
 		color: var(--studio-white);
 		border: none;
+	}
+
+	&.is-link {
+		border: none;
+		background: none;
+		text-decoration: underline;
+		outline: none;
+		margin: 0;
+		padding: 0;
+
+		&:hover {
+			color: var(--studio-gray-80);
+		}
 	}
 }
 
@@ -483,19 +496,31 @@
 }
 
 .sites-overview__boost-score {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 50%;
+	width: 24px;
+	height: 24px;
+	font-weight: 500;
+	user-select: none;
+
 	&.boost-score-good {
 		@extend .sites-overview__column-content;
 		color: var(--studio-green-50);
+		background-color: var(--studio-green-0);
 	}
 
 	&.boost-score-okay {
 		@extend .sites-overview__column-content;
 		color: var(--studio-yellow-50);
+		background-color: var(--studio-yellow-0);
 	}
 
 	&.boost-score-bad {
 		@extend .sites-overview__column-content;
 		color: var(--studio-red-50);
+		background-color: var(--studio-red-0);
 	}
 }
 


### PR DESCRIPTION
This PR updates the **'Boost'** column in Jetpack Manage to follow the new styling from the latest design.

<img width="272" alt="Screen Shot 2023-09-25 at 5 10 18 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b6c02a89-6d07-4d96-945d-3f5a6f839f93"> <img width="370" alt="Screen Shot 2023-09-25 at 5 02 43 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/4e76954f-50e0-4824-94a7-c1b17ebda956">


Closes https://github.com/Automattic/jetpack-genesis/issues/31

## Proposed Changes

1. Update column name to 'Boost score'.
1. Update the Boost score styling to be in a badge form.
1. Update the CTA buttons to appear like a link.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack cloud live link below and goto `/dashboard?flags=jetpack/pro-dashboard-jetpack-boost`
* Confirm that the Boost column follows the expected design.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React, or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?