### PR TITLE
Add Woo Express intro offer tracks

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -54,6 +54,7 @@ import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/src/hooks/use-val
 import { leaveCheckout } from 'calypso/my-sites/checkout/src/lib/leave-checkout';
 import { prepareDomainContactValidationRequest } from 'calypso/my-sites/checkout/src/types/wpcom-store-state';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import useOneDollarOfferTrack from 'calypso/my-sites/plans/hooks/use-onedollar-offer-track';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { saveContactDetailsCache } from 'calypso/state/domains/management/actions';
@@ -344,6 +345,8 @@ export default function WPCheckout( {
 		}
 		return true;
 	};
+
+	useOneDollarOfferTrack( siteId, 'checkout' );
 
 	if ( ! checkoutActions ) {
 		return null;

--- a/client/my-sites/plans/current-plan/trials/trial-current-plan.tsx
+++ b/client/my-sites/plans/current-plan/trials/trial-current-plan.tsx
@@ -13,6 +13,7 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import useOneDollarOfferTrack from '../../hooks/use-onedollar-offer-track';
 import TrialBanner from '../../trials/trial-banner';
 import BusinessTrialIncluded from './business-trial-included';
 import EcommerceTrialIncluded from './ecommerce-trial-included';
@@ -44,6 +45,8 @@ const TrialCurrentPlan = () => {
 	const trackEvent = isEcommerceTrial
 		? 'calypso_wooexpress_my_plan_cta'
 		: 'calypso_migration_my_plan_cta';
+
+	useOneDollarOfferTrack( selectedSite?.ID, 'plans' );
 
 	/**
 	 * Redirects to the checkout page with Plan on cart.

--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -2,6 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { plansLink } from '@automattic/calypso-products';
 import { useCallback } from 'react';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import useOneDollarOfferTrack from '../hooks/use-onedollar-offer-track';
 import TrialBanner from '../trials/trial-banner';
 import { WooExpressPlans } from './wooexpress-plans';
 import type { Site } from 'calypso/my-sites/scan/types';
@@ -23,6 +24,8 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 			plan_slug: planSlug,
 		} );
 	}, [] );
+
+	useOneDollarOfferTrack( siteId, 'plans' );
 
 	return (
 		<>

--- a/client/my-sites/plans/hooks/use-onedollar-offer-track.ts
+++ b/client/my-sites/plans/hooks/use-onedollar-offer-track.ts
@@ -1,0 +1,28 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Plans } from '@automattic/data-stores';
+import { useEffect } from '@wordpress/element';
+
+type Location = 'plans' | 'trialexpired' | 'homescreen' | 'checkout';
+
+/**
+ * Fires a track if the site has a $1 offer.
+ *
+ * @param siteId Site ID
+ * @param location Location of the track being fired, i.e. 'plans', 'trialexpired', 'homescreen', 'checkout'
+ */
+const useOneDollarOfferTrack = ( siteId: number | null | undefined, location: Location ) => {
+	const wooExpressIntroOffers = Plans.useIntroOffersForWooExpress( { siteId } );
+	const hasWooExpressIntroOffer = Object.values( wooExpressIntroOffers ?? {} ).length > 0;
+
+	useEffect( () => {
+		if ( ! location || ! hasWooExpressIntroOffer ) {
+			return;
+		}
+
+		recordTracksEvent( 'calypso_wooexpress_one_dollar_offer', {
+			location,
+		} );
+	}, [ hasWooExpressIntroOffer, location ] );
+};
+
+export default useOneDollarOfferTrack;


### PR DESCRIPTION
Related to peapX7-3ad-p2

## Proposed Changes

* Adds `useOneDollarOfferTrack` hook to send track
* Adds track to Plans screen
* Adds track to Checkout screen

## Testing Instructions

* You need to use an a12n account and proxy
* Use an existing Woo Express free trial site
* Alternatively, go to https://woocommerce.com/start/#/ and go through the whole NUX flow and set up a free trial site
* After the site is created, go to http://calypso.localhost:3000/plans and open up developer console
* Run `localStorage.setItem('debug', 'calypso:analytics');` to enable debugging
* Open up plans screen on with your free trial site
* In console, look for the track `calypso_wooexpress_one_dollar_offer` with props `location: plans`
* Click on `Get performance` to navigate to checkout screen
* In console, look for the track `calypso_wooexpress_one_dollar_offer` with props `location: checkout`

<img width="819" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3747241/93de52f0-4e3c-472f-a63f-961c6a78ab67">

<img width="834" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3747241/256c8f4f-8601-4b99-b79e-84df26da837f">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
