### PR TITLE
[DO NOT MERGE] Jetpack Manage: Create modal for "Get Score" action for Boost

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-install-boost.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-install-boost.ts
@@ -1,0 +1,113 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState, useCallback } from 'react';
+import { useDispatch } from 'calypso/state';
+import useInstallPluginMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-install-plugin-mutation';
+import useRequestBoostScoreMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-request-boost-score-mutation';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import type { Site } from '../types';
+
+export default function useInstallBoost(
+	siteId: number,
+	queryKey: any[]
+): {
+	installBoost: () => void;
+	status: string;
+	requestBoostScore: () => void;
+} {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const queryClient = useQueryClient();
+
+	const [ status, setStatus ] = useState( 'idle' );
+
+	const { mutate: requestBoostScore, status: requestBoostStatus } = useRequestBoostScoreMutation( {
+		retry: false,
+		onMutate: async () => {
+			// Cancel any current refetches, so they don't overwrite our optimistic update
+			await queryClient.cancelQueries( queryKey );
+
+			// Snapshot the previous value
+			const previousSites = queryClient.getQueryData( queryKey );
+
+			// Optimistically update to the new value
+			const updatedData = queryClient.setQueryData( queryKey, ( oldSites: any ) => {
+				return {
+					...oldSites,
+					sites: oldSites?.sites.map( ( site: Site ) => {
+						if ( site.blog_id === siteId ) {
+							return {
+								...site,
+								has_pending_boost_one_time_score: true,
+							};
+						}
+						return site;
+					} ),
+				};
+			} );
+
+			queryClient.setQueryData( queryKey, updatedData );
+
+			// Store previous settings in case of failure
+			return { previousSites };
+		},
+	} );
+
+	const errorMessage = translate(
+		'Something went wrong while installing Boost. Please try again.'
+	);
+
+	const handleRequestBoostScore = useCallback( () => {
+		requestBoostScore( { site_ids: [ siteId ] } );
+	}, [ requestBoostScore, siteId ] );
+
+	const handleRequestBoostScoreSuccess = useCallback( async () => {
+		// TODO: Add a mutation to update the site's boost status
+	}, [] );
+
+	useEffect( () => {
+		if ( requestBoostStatus === 'success' ) {
+			setStatus( 'success' );
+			dispatch(
+				successNotice(
+					translate(
+						'Boost has been installed and activated. You can now configure Boost settings.'
+					)
+				)
+			);
+			handleRequestBoostScoreSuccess();
+		}
+		if ( requestBoostStatus === 'error' ) {
+			dispatch( errorNotice( errorMessage ) );
+		}
+	}, [ requestBoostStatus, dispatch, errorMessage, translate, handleRequestBoostScoreSuccess ] );
+
+	const installPlugin = useInstallPluginMutation( {
+		retry: false,
+	} );
+
+	const installBoost = () => {
+		installPlugin.mutate( {
+			site_id: siteId,
+			plugin_slug: 'jetpack_boost',
+		} );
+	};
+
+	useEffect( () => {
+		if ( installPlugin.status === 'loading' ) {
+			setStatus( 'progress' );
+		}
+		if ( installPlugin.status === 'success' ) {
+			handleRequestBoostScore();
+		}
+		if ( installPlugin.status === 'error' ) {
+			dispatch( errorNotice( errorMessage ) );
+		}
+	}, [ installPlugin.status, siteId, dispatch, errorMessage, handleRequestBoostScore ] );
+
+	return {
+		installBoost,
+		status,
+		requestBoostScore: handleRequestBoostScore,
+	};
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
@@ -15,6 +15,8 @@ interface Props {
 	onClose?: () => void;
 	siteId?: number;
 	extraContent?: JSX.Element;
+	isDisabled?: boolean;
+	onCtaClick?: () => void;
 }
 
 export default function LicenseInfoModal( {
@@ -23,6 +25,8 @@ export default function LicenseInfoModal( {
 	onClose,
 	siteId,
 	extraContent,
+	isDisabled,
+	onCtaClick,
 }: Props ) {
 	const isMobile = useMobileBreakpoint();
 	const translate = useTranslate();
@@ -52,7 +56,7 @@ export default function LicenseInfoModal( {
 			recordEvent( 'issue_license_info', {
 				product: currentLicenseProductSlug,
 			} );
-			// Update to handle the boost flow
+			onCtaClick?.();
 			onHideLicenseInfo();
 			page(
 				addQueryArgs(
@@ -72,6 +76,7 @@ export default function LicenseInfoModal( {
 			<LicenseLightbox
 				product={ currentLicenseProduct }
 				ctaLabel={ label ?? translate( 'Issue License' ) }
+				isDisabled={ isDisabled }
 				onActivate={ onIssueLicense }
 				onClose={ onHideLicenseInfo }
 				extraContent={ extraContent }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
@@ -1,0 +1,81 @@
+import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import { useContext, useMemo } from 'react';
+import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox';
+import { addQueryArgs } from 'calypso/lib/url';
+import useJetpackAgencyDashboardRecordTrackEvent from '../../hooks/use-jetpack-agency-dashboard-record-track-event';
+import SitesOverviewContext from '../context';
+import DashboardDataContext from '../dashboard-data-context';
+import { DASHBOARD_PRODUCT_SLUGS_BY_TYPE } from '../lib/constants';
+
+interface Props {
+	label?: string;
+	currentLicenseInfo: string | null;
+	onClose?: () => void;
+	siteId?: number;
+	extraContent?: JSX.Element;
+}
+
+export default function LicenseInfoModal( {
+	label,
+	currentLicenseInfo,
+	onClose,
+	siteId,
+	extraContent,
+}: Props ) {
+	const isMobile = useMobileBreakpoint();
+	const translate = useTranslate();
+
+	const { hideLicenseInfo } = useContext( SitesOverviewContext );
+
+	const { products } = useContext( DashboardDataContext );
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, ! isMobile );
+
+	const currentLicenseProductSlug = currentLicenseInfo
+		? DASHBOARD_PRODUCT_SLUGS_BY_TYPE[ currentLicenseInfo ]
+		: null;
+
+	const currentLicenseProduct = useMemo( () => {
+		return currentLicenseProductSlug && products
+			? products.find( ( product ) => product.slug === currentLicenseProductSlug )
+			: null;
+	}, [ currentLicenseProductSlug, products ] );
+
+	const onHideLicenseInfo = () => {
+		hideLicenseInfo();
+		onClose?.();
+	};
+
+	const onIssueLicense = () => {
+		if ( currentLicenseProductSlug ) {
+			recordEvent( 'issue_license_info', {
+				product: currentLicenseProductSlug,
+			} );
+			// Update to handle the boost flow
+			onHideLicenseInfo();
+			page(
+				addQueryArgs(
+					{
+						product_slug: currentLicenseProductSlug,
+						source: 'dashboard',
+						site_id: siteId,
+					},
+					'/partner-portal/issue-license/'
+				)
+			);
+		}
+	};
+
+	return (
+		currentLicenseProduct && (
+			<LicenseLightbox
+				product={ currentLicenseProduct }
+				ctaLabel={ label ?? translate( 'Issue License' ) }
+				onActivate={ onIssueLicense }
+				onClose={ onHideLicenseInfo }
+				extraContent={ extraContent }
+			/>
+		)
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
@@ -20,7 +20,7 @@ const formatStatsData = ( site: Site ): StatsNode => ( {
 } );
 
 const formatBoostData = ( site: Site ): BoostNode => ( {
-	status: site.has_boost && site.has_pending_boost_one_time_score ? 'progress' : 'active',
+	status: site.has_pending_boost_one_time_score ? 'progress' : 'active',
 	type: 'boost',
 	value: site.jetpack_boost_scores,
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
@@ -20,7 +20,7 @@ const formatStatsData = ( site: Site ): StatsNode => ( {
 } );
 
 const formatBoostData = ( site: Site ): BoostNode => ( {
-	status: site.has_pending_boost_one_time_score ? 'progress' : 'active',
+	status: site.has_boost && site.has_pending_boost_one_time_score ? 'progress' : 'active',
 	type: 'boost',
 	value: site.jetpack_boost_scores,
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -1,24 +1,22 @@
 import { Card } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
-import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useContext, forwardRef, useMemo } from 'react';
+import { useContext, forwardRef } from 'react';
 import Pagination from 'calypso/components/pagination';
-import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { addQueryArgs } from 'calypso/lib/url';
 import EditButton from '../../dashboard-bulk-actions/edit-button';
-import useJetpackAgencyDashboardRecordTrackEvent from '../../hooks/use-jetpack-agency-dashboard-record-track-event';
 import DashboardDataContext from '../../sites-overview/dashboard-data-context';
 import SitesOverviewContext from '../context';
 import useDefaultSiteColumns from '../hooks/use-default-site-columns';
-import { DASHBOARD_PRODUCT_SLUGS_BY_TYPE } from '../lib/constants';
+import SiteBoostLicenseModal from '../license-info-modal';
 import SiteBulkSelect from '../site-bulk-select';
 import SiteCard from '../site-card';
 import SiteSort from '../site-sort';
 import SiteTable from '../site-table';
 import { Site } from '../types';
 import useFormattedSites from './hooks/use-formatted-sites';
+
 import './style.scss';
 
 const addPageArgs = ( pageNumber: number ) => {
@@ -39,13 +37,9 @@ interface Props {
 const SiteContent = ( { data, isLoading, currentPage, isFavoritesTab }: Props, ref: any ) => {
 	const isMobile = useMobileBreakpoint();
 
-	const translate = useTranslate();
+	const { isBulkManagementActive, currentLicenseInfo } = useContext( SitesOverviewContext );
 
-	const { isBulkManagementActive, currentLicenseInfo, hideLicenseInfo } =
-		useContext( SitesOverviewContext );
-
-	const { products, isLargeScreen } = useContext( DashboardDataContext );
-	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, ! isMobile );
+	const { isLargeScreen } = useContext( DashboardDataContext );
 
 	const sites = useFormattedSites( data?.sites ?? [] );
 
@@ -55,38 +49,6 @@ const SiteContent = ( { data, isLoading, currentPage, isFavoritesTab }: Props, r
 
 	const siteColumns = useDefaultSiteColumns();
 	const firstColumn = siteColumns[ 0 ];
-
-	const currentLicenseProductSlug = currentLicenseInfo
-		? DASHBOARD_PRODUCT_SLUGS_BY_TYPE[ currentLicenseInfo ]
-		: null;
-
-	const currentLicenseProduct = useMemo( () => {
-		return currentLicenseProductSlug && products
-			? products.find( ( product ) => product.slug === currentLicenseProductSlug )
-			: null;
-	}, [ currentLicenseProductSlug, products ] );
-
-	const onIssueLicense = () => {
-		if ( currentLicenseProductSlug ) {
-			recordEvent( 'issue_license_info', {
-				product: currentLicenseProductSlug,
-			} );
-			hideLicenseInfo();
-			page(
-				addQueryArgs(
-					{
-						product_slug: currentLicenseProductSlug,
-						source: 'dashboard',
-					},
-					'/partner-portal/issue-license/'
-				)
-			);
-		}
-	};
-
-	const onHideLicenseInfo = () => {
-		hideLicenseInfo();
-	};
 
 	return (
 		<>
@@ -126,7 +88,6 @@ const SiteContent = ( { data, isLoading, currentPage, isFavoritesTab }: Props, r
 					</div>
 				</div>
 			) }
-
 			{ data && data?.total > 0 && (
 				<Pagination
 					compact={ isMobile }
@@ -136,15 +97,7 @@ const SiteContent = ( { data, isLoading, currentPage, isFavoritesTab }: Props, r
 					pageClick={ handlePageClick }
 				/>
 			) }
-
-			{ currentLicenseProduct && (
-				<LicenseLightbox
-					product={ currentLicenseProduct }
-					ctaLabel={ translate( 'Issue License' ) }
-					onActivate={ onIssueLicense }
-					onClose={ onHideLicenseInfo }
-				/>
-			) }
+			{ currentLicenseInfo && <SiteBoostLicenseModal currentLicenseInfo={ currentLicenseInfo } /> }
 		</>
 	);
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -46,7 +46,7 @@ export default function BoostSitePerformance( {
 		'Your Overall Score is a summary of your website performance across both mobile and desktop devices.'
 	);
 
-	const isEnabled = !! ( hasBoost || overallScore );
+	const isEnabled = !! ( hasBoost || overallScore ) || hasPendingScore;
 
 	const buttonProps = useMemo(
 		() =>
@@ -119,10 +119,10 @@ export default function BoostSitePerformance( {
 						</div>
 					</div>
 					<div className="site-expanded-content__card-content-column">
-						{ hasPendingScore ? (
-							<InProgressIcon />
-						) : (
-							<>
+						<>
+							{ hasPendingScore ? (
+								<InProgressIcon />
+							) : (
 								<div className="site-expanded-content__device-score-container">
 									<div className="site-expanded-content__card-content-column">
 										<Icon
@@ -141,11 +141,11 @@ export default function BoostSitePerformance( {
 										<span className="site-expanded-content__device-score">{ mobileScore }</span>
 									</div>
 								</div>
-								<div className="site-expanded-content__card-content-score-title">
-									{ translate( 'Devices' ) }
-								</div>
-							</>
-						) }
+							) }
+							<div className="site-expanded-content__card-content-score-title">
+								{ translate( 'Devices' ) }
+							</div>
+						</>
 					</div>
 				</div>
 				<div className="site-expanded-content__card-footer">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -2,9 +2,10 @@ import { Button } from '@automattic/components';
 import { Icon, help } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useRef, useState } from 'react';
+import { useRef, useState, useContext, useMemo } from 'react';
 import Tooltip from 'calypso/components/tooltip';
 import { jetpackBoostDesktopIcon, jetpackBoostMobileIcon } from '../../icons';
+import SitesOverviewContext from '../context';
 import { getBoostRating, getBoostRatingClass } from '../lib/boost';
 import ExpandedCard from './expanded-card';
 import InProgressIcon from './in-progress-icon';
@@ -33,6 +34,7 @@ export default function BoostSitePerformance( {
 
 	const helpIconRef = useRef< HTMLElement | null >( null );
 	const [ showTooltip, setShowTooltip ] = useState( false );
+	const { showLicenseInfo } = useContext( SitesOverviewContext );
 
 	const { overall: overallScore, mobile: mobileScore, desktop: desktopScore } = boostData;
 
@@ -63,7 +65,7 @@ export default function BoostSitePerformance( {
 	);
 
 	const handleOnClick = () => {
-		// TODO - should open a modal.
+		showLicenseInfo( 'boost' );
 	};
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -2,11 +2,11 @@ import { Button } from '@automattic/components';
 import { Icon, help } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useRef, useState, useContext, useMemo } from 'react';
+import { useRef, useState, useMemo } from 'react';
 import Tooltip from 'calypso/components/tooltip';
 import { jetpackBoostDesktopIcon, jetpackBoostMobileIcon } from '../../icons';
-import SitesOverviewContext from '../context';
 import { getBoostRating, getBoostRatingClass } from '../lib/boost';
+import BoostLicenseInfoModal from '../site-status-content/site-boost-column/boost-license-info-modal';
 import ExpandedCard from './expanded-card';
 import InProgressIcon from './in-progress-icon';
 import type { BoostData } from '../types';
@@ -34,7 +34,7 @@ export default function BoostSitePerformance( {
 
 	const helpIconRef = useRef< HTMLElement | null >( null );
 	const [ showTooltip, setShowTooltip ] = useState( false );
-	const { showLicenseInfo } = useContext( SitesOverviewContext );
+	const [ showBoostModal, setShowBoostModal ] = useState( false );
 
 	const { overall: overallScore, mobile: mobileScore, desktop: desktopScore } = boostData;
 
@@ -65,7 +65,7 @@ export default function BoostSitePerformance( {
 	);
 
 	const handleOnClick = () => {
-		showLicenseInfo( 'boost' );
+		setShowBoostModal( true );
 	};
 
 	return (
@@ -160,6 +160,9 @@ export default function BoostSitePerformance( {
 					</Button>
 				</div>
 			</div>
+			{ showBoostModal && (
+				<BoostLicenseInfoModal onClose={ () => setShowBoostModal( false ) } siteId={ siteId } />
+			) }
 		</ExpandedCard>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
@@ -1,5 +1,8 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useContext, useEffect } from 'react';
+import SitesOverviewContext from '../../context';
+import useInstallBoost from '../../hooks/use-install-boost';
 import LicenseInfoModal from '../../license-info-modal';
 
 import './style.scss';
@@ -12,9 +15,27 @@ interface Props {
 export default function BoostLicenseInfoModal( { onClose, siteId }: Props ) {
 	const translate = useTranslate();
 
-	const handleOnClick = () => {
-		// Update handle click
+	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
+
+	const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter, sort ];
+
+	const { installBoost, requestBoostScore, status } = useInstallBoost( siteId, queryKey );
+
+	const handleInstallBoost = () => {
+		installBoost();
 	};
+
+	const handlePurchaseBoost = () => {
+		requestBoostScore();
+	};
+
+	const inProgress = status === 'progress';
+
+	useEffect( () => {
+		if ( status === 'success' ) {
+			onClose();
+		}
+	}, [ status, onClose ] );
 
 	return (
 		<LicenseInfoModal
@@ -22,11 +43,17 @@ export default function BoostLicenseInfoModal( { onClose, siteId }: Props ) {
 			label={ translate( 'Purchase Boost License' ) }
 			onClose={ onClose }
 			siteId={ siteId }
+			onCtaClick={ handlePurchaseBoost }
 			extraContent={
-				<Button className="site-boost-column__extra-button" onClick={ handleOnClick }>
-					{ translate( 'Generate one-time score' ) }
+				<Button
+					disabled={ inProgress }
+					className="site-boost-column__extra-button"
+					onClick={ handleInstallBoost }
+				>
+					{ translate( 'Start Free' ) }
 				</Button>
 			}
+			isDisabled={ inProgress }
 		/>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
@@ -1,0 +1,32 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import LicenseInfoModal from '../../license-info-modal';
+
+import './style.scss';
+
+interface Props {
+	onClose: () => void;
+	siteId: number;
+}
+
+export default function BoostLicenseInfoModal( { onClose, siteId }: Props ) {
+	const translate = useTranslate();
+
+	const handleOnClick = () => {
+		// Update handle click
+	};
+
+	return (
+		<LicenseInfoModal
+			currentLicenseInfo="boost"
+			label={ translate( 'Purchase Boost License' ) }
+			onClose={ onClose }
+			siteId={ siteId }
+			extraContent={
+				<Button className="site-boost-column__extra-button" onClick={ handleOnClick }>
+					{ translate( 'Generate one-time score' ) }
+				</Button>
+			}
+		/>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
@@ -1,12 +1,12 @@
 import { getUrlParts } from '@automattic/calypso-url';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useContext } from 'react';
+import { useState } from 'react';
 import { useSelector } from 'calypso/state';
 import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
-import SitesOverviewContext from '../../context';
 import { getBoostRating, getBoostRatingClass } from '../../lib/boost';
-import { Site } from '../../types';
+import BoostLicenseInfoModal from './boost-license-info-modal';
+import type { Site } from '../../types';
 
 interface Props {
 	site: Site;
@@ -15,14 +15,14 @@ interface Props {
 export default function SiteBoostColumn( { site }: Props ) {
 	const translate = useTranslate();
 
-	const { showLicenseInfo } = useContext( SitesOverviewContext );
-
 	const overallScore = site.jetpack_boost_scores?.overall;
 	const hasBoost = site.has_boost;
 	const adminUrl = useSelector( ( state ) => getJetpackAdminUrl( state, site.blog_id ) );
 
+	const [ showBoostModal, setShowBoostModal ] = useState( false );
+
 	const handleGetBoostScoreAction = () => {
-		showLicenseInfo( 'boost' );
+		setShowBoostModal( true );
 	};
 
 	if ( overallScore ) {
@@ -64,6 +64,12 @@ export default function SiteBoostColumn( { site }: Props ) {
 			>
 				{ translate( 'Get Score' ) }
 			</button>
+			{ showBoostModal && (
+				<BoostLicenseInfoModal
+					onClose={ () => setShowBoostModal( false ) }
+					siteId={ site.blog_id }
+				/>
+			) }
 		</>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
@@ -1,8 +1,10 @@
 import { getUrlParts } from '@automattic/calypso-url';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useContext } from 'react';
 import { useSelector } from 'calypso/state';
 import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
+import SitesOverviewContext from '../../context';
 import { getBoostRating, getBoostRatingClass } from '../../lib/boost';
 import { Site } from '../../types';
 
@@ -13,12 +15,14 @@ interface Props {
 export default function SiteBoostColumn( { site }: Props ) {
 	const translate = useTranslate();
 
+	const { showLicenseInfo } = useContext( SitesOverviewContext );
+
 	const overallScore = site.jetpack_boost_scores?.overall;
 	const hasBoost = site.has_boost;
 	const adminUrl = useSelector( ( state ) => getJetpackAdminUrl( state, site.blog_id ) );
 
 	const handleGetBoostScoreAction = () => {
-		// TODO - should open a modal.
+		showLicenseInfo( 'boost' );
 	};
 
 	if ( overallScore ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/style.scss
@@ -1,0 +1,6 @@
+.site-boost-column__extra-button {
+	margin-block-start: 1rem;
+	margin-block-end: 0;
+	width: 100%;
+	padding: 10px 16px;
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
@@ -20,6 +20,7 @@ export type LicenseLightBoxProps = {
 	onActivate: ( product: APIProductFamilyProduct ) => void;
 	onClose: () => void;
 	product: APIProductFamilyProduct;
+	extraContent?: JSX.Element;
 };
 
 const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
@@ -29,6 +30,7 @@ const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
 	onActivate,
 	onClose,
 	product,
+	extraContent,
 } ) => {
 	const isLargeScreen = useBreakpoint( '>782px' );
 	const { title, product: productInfo } = useLicenseLightboxData( product );
@@ -64,6 +66,7 @@ const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
 				>
 					{ ctaLabel }
 				</Button>
+				{ extraContent }
 			</JetpackLightboxAside>
 		</JetpackLightbox>
 	);

--- a/client/state/jetpack-agency-dashboard/hooks/use-install-plugin-mutation.ts
+++ b/client/state/jetpack-agency-dashboard/hooks/use-install-plugin-mutation.ts
@@ -1,0 +1,29 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import type { APIError } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+interface APIResponse {
+	success: boolean;
+}
+
+interface InstallPluginParams {
+	site_id: number;
+	plugin_slug: string;
+}
+
+function mutationInstallPlugin( params: InstallPluginParams ): Promise< APIResponse > {
+	return wpcomJpl.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: '/jetpack-agency/sites/plugins/install',
+		body: params,
+	} );
+}
+
+export default function useInstallPlugin< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, InstallPluginParams, TContext >
+): UseMutationResult< APIResponse, APIError, InstallPluginParams, TContext > {
+	return useMutation< APIResponse, APIError, InstallPluginParams, TContext >( {
+		...options,
+		mutationFn: mutationInstallPlugin,
+	} );
+}

--- a/client/state/jetpack-agency-dashboard/hooks/use-request-boost-score-mutation.ts
+++ b/client/state/jetpack-agency-dashboard/hooks/use-request-boost-score-mutation.ts
@@ -1,0 +1,28 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import type { APIError } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+interface APIResponse {
+	success: boolean;
+}
+
+interface RequestBoostScoreParams {
+	site_ids: number[];
+}
+
+function mutationRequestBoostScore( params: RequestBoostScoreParams ): Promise< APIResponse > {
+	return wpcomJpl.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: '/jetpack-agency/sites/boost-scores',
+		body: params,
+	} );
+}
+
+export default function useRequestBoostScore< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, RequestBoostScoreParams, TContext >
+): UseMutationResult< APIResponse, APIError, RequestBoostScoreParams, TContext > {
+	return useMutation< APIResponse, APIError, RequestBoostScoreParams, TContext >( {
+		...options,
+		mutationFn: mutationRequestBoostScore,
+	} );
+}


### PR DESCRIPTION


<img width="1076" alt="Screenshot 2023-09-26 at 4 13 39 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/705dd6f4-3867-44c9-be3e-c6e5cc1510dc">

<img width="1070" alt="Screenshot 2023-09-26 at 4 13 46 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/24ed55d3-904f-4eb4-a807-b7cfdec5504a">


## Proposed Changes

TBD

## Testing Instructions

* TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?