### PR TITLE
Assembler - Metrics - Add prop has_global_styles_selected to track improvements in style selection UI

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -149,6 +149,7 @@ const PatternAssembler = ( {
 				font_variation_title: getVariationTitle( fontVariation ),
 				font_variation_type: getVariationType( fontVariation ),
 				assembler_source: getAssemblerSource( selectedDesign ),
+				has_premium_styles_selected: shouldUnlockGlobalStyles,
 			} ),
 		[ flow, stepName, intent, stylesheet, colorVariation, fontVariation ]
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -149,7 +149,7 @@ const PatternAssembler = ( {
 				font_variation_title: getVariationTitle( fontVariation ),
 				font_variation_type: getVariationType( fontVariation ),
 				assembler_source: getAssemblerSource( selectedDesign ),
-				has_premium_styles_selected: shouldUnlockGlobalStyles,
+				has_premium_styles_selected: numOfSelectedGlobalStyles > 0,
 			} ),
 		[ flow, stepName, intent, stylesheet, colorVariation, fontVariation ]
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -149,7 +149,7 @@ const PatternAssembler = ( {
 				font_variation_title: getVariationTitle( fontVariation ),
 				font_variation_type: getVariationType( fontVariation ),
 				assembler_source: getAssemblerSource( selectedDesign ),
-				has_premium_styles_selected: numOfSelectedGlobalStyles > 0,
+				has_global_styles_selected: numOfSelectedGlobalStyles > 0,
 			} ),
 		[ flow, stepName, intent, stylesheet, colorVariation, fontVariation ]
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -151,7 +151,7 @@ const PatternAssembler = ( {
 				assembler_source: getAssemblerSource( selectedDesign ),
 				has_global_styles_selected: numOfSelectedGlobalStyles > 0,
 			} ),
-		[ flow, stepName, intent, stylesheet, colorVariation, fontVariation ]
+		[ flow, stepName, intent, stylesheet, colorVariation, fontVariation, numOfSelectedGlobalStyles ]
 	);
 
 	const selectedVariations = useMemo(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add the prop `has_global_styles_selected` to all events to help metrics know when users have selected premium styles

Note: this new prop will remain `true` even when users are already on a Premium plan or when they reset styles because the goal is to help identify when the UI makes more users select styles no matter the plan, the step, or the style.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler`
* Select a custom font or color
* Click to `Save and continue`
* Verify the prop `has_global_styles_selected` is `true`

<img width="781" alt="Screenshot 2566-09-25 at 18 20 07" src="https://github.com/Automattic/wp-calypso/assets/1881481/a57a05fe-976b-497c-8f1b-c9b464824e13">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?