### PR TITLE
Gravatar: Update links to new Profile Editor

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -214,7 +214,7 @@ export class EditGravatar extends Component {
 	render() {
 		const { isGravatarProfileHidden, isUploading, translate, user, additionalUploadHtml } =
 			this.props;
-		const gravatarLink = `https://gravatar.com/${ user.username || '' }`;
+		const gravatarLink = `https://gravatar.com/profile`;
 		// use imgSize = 400 for caching
 		// it's the popular value for large Gravatars in Calypso
 		const GRAVATAR_IMG_SIZE = 400;

--- a/client/me/profile/updated-gravatar-string.js
+++ b/client/me/profile/updated-gravatar-string.js
@@ -10,7 +10,7 @@ class UpdatedGravatarString extends Component {
 				spanExtra: <span className="profile__link-destination-label-extra" />,
 				profileLink: <a href={ gravatarProfileLink } target="_blank" rel="noreferrer" />,
 				deleteLink: (
-					<a href="https://gravatar.com/account/disable/" target="_blank" rel="noreferrer" />
+					<a href="https://gravatar.com/profile/disable-account" target="_blank" rel="noreferrer" />
 				),
 			},
 		};


### PR DESCRIPTION
In this PR, we update the Gravatar.com links to point to the new Gravatar.com Profile Editor.


## Testing instructions

Navigate to http://calypso.localhost:3000/me and click on the (i) icon next to "Your profile photo is public.". There should be one hypertext link to Gravatar which should take you to https://gravatar.com/profile, which is the new profile editor.

Below on that page there's "Hide my photo and Gravatar profile. Under that text, there's a link within the "Gravatar profiles can be deleted at [Gravatar.com](https://gravatar.com/profile/disable-account)." sentence. Click on the link and verify it takes you to https://gravatar.com/profile/disable-account.

I went through all the remaining "gravatar.com" mentions in the codebase and this seems to be the only places where we need to update the links.