### PR TITLE
Site profiler: Hosting introduction block

### DIFF
--- a/client/site-profiler/components/hosting-intro/index.tsx
+++ b/client/site-profiler/components/hosting-intro/index.tsx
@@ -1,17 +1,31 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 
 export default function HostingIntro() {
 	return (
-		<>
-			<h2>{ translate( 'The best WordPress Hosting on the planet' ) }</h2>
-			<p>
-				{ translate(
-					'Whatever you’re building, WordPress.com has everything you need: ' +
-						'unmetered bandwidth, unmatched speed, unstoppable security, ' +
-						'and intuitive multi-site management.'
-				) }
-			</p>
-			<p>{ translate( 'Bring your WordPress site to WordPress.com and get it all.' ) }</p>
-		</>
+		<div className="hosting-intro-block l-block-col-2">
+			<div className="l-block-content">
+				<h2>{ translate( 'The best WordPress Hosting on the planet' ) }</h2>
+				<p>
+					{ translate(
+						'Whatever you’re building, WordPress.com has everything you need: ' +
+							'unmetered bandwidth, unmatched speed, unstoppable security, ' +
+							'and intuitive multi-site management.'
+					) }
+				</p>
+				<p>{ translate( 'Bring your WordPress site to WordPress.com and get it all.' ) }</p>
+				<Button href={ localizeUrl( 'https://wordpress.com/hosting' ) } className="button-action">
+					{ translate( 'Learn more' ) }
+				</Button>
+			</div>
+			<div className="l-block-content">
+				<img
+					src="https://wpcom.files.wordpress.com/2023/08/people-smile.jpg"
+					role="presentation"
+					alt="Hosting"
+				/>
+			</div>
+		</div>
 	);
 }

--- a/client/site-profiler/components/layout/index.tsx
+++ b/client/site-profiler/components/layout/index.tsx
@@ -22,7 +22,7 @@ export function LayoutBlock( props: Props ) {
 				animate: animate,
 			} ) }
 		>
-			<div className="l-block-content">{ children }</div>
+			<div className="l-block-wrapper">{ children }</div>
 		</div>
 	);
 }

--- a/client/site-profiler/components/layout/styles.scss
+++ b/client/site-profiler/components/layout/styles.scss
@@ -10,19 +10,19 @@
 	}
 
 	&.width-small {
-		.l-block-content {
+		.l-block-wrapper {
 			max-width: 600px;
 		}
 	}
 
 	&.width-medium {
-		.l-block-content {
+		.l-block-wrapper {
 			max-width: 1015px;
 		}
 	}
 }
 
-.l-block-content {
+.l-block-wrapper {
 	max-width: 1224px;
 	margin: 0 auto;
 	padding: 0 1.5rem;

--- a/client/site-profiler/components/layout/styles.scss
+++ b/client/site-profiler/components/layout/styles.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .l-block {
 	padding: 5rem 0;
 
@@ -36,6 +38,16 @@
 	.l-block-col-2 .l-block-content {
 		box-sizing: border-box;
 		width: 50%;
+	}
+
+	@media (max-width: $break-medium) {
+		.l-block-col-2 {
+			flex-direction: column;
+
+			.l-block-content {
+				width: 100%;
+			}
+		}
 	}
 }
 

--- a/client/site-profiler/components/layout/styles.scss
+++ b/client/site-profiler/components/layout/styles.scss
@@ -26,6 +26,17 @@
 	max-width: 1224px;
 	margin: 0 auto;
 	padding: 0 1.5rem;
+
+	.l-block-col-2 {
+		gap: 5rem;
+		display: flex;
+		justify-content: space-between;
+	}
+
+	.l-block-col-2 .l-block-content {
+		box-sizing: border-box;
+		width: 50%;
+	}
 }
 
 .l-block-section {

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -61,6 +61,7 @@
 		font-size: 1rem;
 		font-weight: 500;
 		padding: 1.5rem;
+		text-decoration: none;
 
 		&:hover {
 			color: #fff !important;
@@ -149,6 +150,12 @@
 
 		&.red {
 			background: var(--studio-red-50);
+		}
+	}
+
+	.hosting-intro-block {
+		h2 {
+			max-width: 400px;
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/81724

## Proposed Changes

* Created two columns layout
* Added "Learn more" link
* Added temp image until we got the production-ready

## Testing Instructions

* Go to `/site-profiler`
* Check if there is a new version of the "Hosting intro" block
* Check the mobile device support

<img width="1264" alt="Screenshot 2023-09-25 at 13 21 13" src="https://github.com/Automattic/wp-calypso/assets/1241413/3f677cc9-41d2-457a-ac3d-91b8b8c3f112">
<img width="751" alt="Screenshot 2023-09-25 at 13 21 24" src="https://github.com/Automattic/wp-calypso/assets/1241413/739cf64f-321a-4646-a2ad-74780079151c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?