### PR TITLE
Checkout Thank You: Fix copy for 100 year page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-plan-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-plan-thank-you/index.tsx
@@ -200,7 +200,7 @@ export default function HundredYearPlanThankYou( { siteSlug, receiptId }: Props 
 							</Header>
 							<Highlight isMobile={ isMobile }>
 								{ translate(
-									'The %(planTitle)s for (%(domain)s) is active. Our Premier Support team will be in touch by email shortly to schedule a welcome session and walk you through your exclusive benefits. We’re looking forward to supporting you every step of the way.',
+									'The %(planTitle)s for %(domain)s is active. Our Premier Support team will be in touch by email shortly to schedule a welcome session and walk you through your exclusive benefits. We’re looking forward to supporting you every step of the way.',
 									{
 										args: {
 											domain: registeredDomain?.domain || siteSlug,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fixes the copy for 100-year page by removing extra parentheses. (Please see code diff)

| Before | After |
|--------|--------|
|<img width="873" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/7996ad08-9910-4953-8eda-6600ba4ece65"> |<img width="894" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/3e9bc5a4-48e6-4a59-be62-0ac1900d466f"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The code change is small and self-explanatory and should not require testing.

Here are the test instructions for reference:
* If you have previously purchased the plan for a site, go to `/checkout/100-year/thank-you/<site slug>/<receipt id>`. The receipt ID can be obtained by going to `/me/purchases`.
* If not, go to `/setup/hundred-year-plan` and proceed through the flow steps and complete checkout.
* Confirm that the copy on this page matches the screenshot. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?