### PR TITLE
Marketplace: adds a redirect and structured data to org plugins page

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -329,6 +329,13 @@ function PluginDetails( props ) {
 		}
 	);
 
+	const structuredData = JSON.stringify( {
+		'@context': 'https://schema.org',
+		'@type': 'SoftwareApplication',
+		name: fullPlugin?.name,
+		sameAs: 'https://wordpress.org/plugins/' + ( fullPlugin?.slug || '' ),
+	} );
+
 	return (
 		<MainComponent wideLayout>
 			<DocumentHead title={ getPageTitle() } />
@@ -439,6 +446,7 @@ function PluginDetails( props ) {
 								>
 									{ translate( 'Download' ) }
 								</Button>
+								<script type="application/ld+json">{ structuredData }</script>
 							</Card>
 						) }
 					</div>

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -306,10 +306,17 @@ function PluginDetails( props ) {
 	}
 
 	const downloadText = translate(
-		'This plugin is available for download to be used on your {{a}}WordPress self-hosted{{/a}} installation.',
+		'This plugin is {{org_link}}available for download{{/org_link}} to be used on your {{wpcom_vs_wporg_link}}WordPress self-hosted{{/wpcom_vs_wporg_link}} installation.',
 		{
 			components: {
-				a: (
+				org_link: (
+					<a
+						href={ localizeUrl( 'https://wordpress.org/plugins/' + ( fullPlugin?.slug || '' ) ) }
+						target="_blank"
+						rel="noreferrer noopener"
+					/>
+				),
+				wpcom_vs_wporg_link: (
 					<a
 						href={ localizeUrl(
 							'https://wordpress.com/go/website-building/wordpress-com-vs-wordpress-org/'

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -311,7 +311,7 @@ function PluginDetails( props ) {
 			components: {
 				org_link: (
 					<a
-						href={ localizeUrl( 'https://wordpress.org/plugins/' + ( fullPlugin?.slug || '' ) ) }
+						href={ 'https://wordpress.org/plugins/' + ( fullPlugin?.slug || '' ) }
 						target="_blank"
 						rel="noreferrer noopener"
 					/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the issue.
-->

Related to p1695115233707009/1694591936.210979-slack-C029GN3KD
Fixes https://github.com/Automattic/dotcom-forge/issues/3822

## Proposed Changes

* Adds a link to the wp.org plugin page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit a wp.org plugin
* Click "available for download" in the sidebar download banner
* Make sure a new page opens to the correct wp.org plugin details page.

![CleanShot 2023-09-25 at 15 36 11@2x](https://github.com/Automattic/wp-calypso/assets/12430020/cac0278f-73c8-4633-8029-addd1f343716)

<img width="1144" alt="CleanShot 2023-09-25 at 15 55 03@2x" src="https://github.com/Automattic/wp-calypso/assets/12430020/6c098f36-9400-44f9-8d8f-a0cdbb50e660">


Also, use https://chrome.google.com/webstore/detail/openlink-structured-data/egdaiaihbdoiibopledjahjaihbmjhdj/related and inspect that there are structured data hinting the `SoftwareApplication` type, the plugin name and the `SameAs` pointing to wp.org page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?