### PR TITLE
Checkout page: fix style for purchase detail

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/style.scss
@@ -128,7 +128,6 @@
 				display: block;
 
 				>div {
-					padding: 0 25px;
 					margin-bottom: 50px;
 					justify-content: space-between;
 					flex-wrap: nowrap;
@@ -168,6 +167,14 @@
 						}
 					}
 				}
+			}
+		}
+	}
+
+	&.is-redesign-v2 {
+		div.checkout-thank-you__purchase-details-list {
+			>div {
+				padding: 0 25px;
 			}
 		}
 	}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/style.scss
@@ -167,9 +167,6 @@
 							display: none;
 						}
 					}
-
-					display: flex;
-					gap: 40px;
 				}
 			}
 		}


### PR DESCRIPTION
Context: https://github.com/Automattic/wp-calypso/pull/79546#discussion_r1332090080

In https://github.com/Automattic/wp-calypso/pull/79546 we introduced styles that break the normal checkout page

Example:

![image](https://github.com/Automattic/wp-calypso/assets/52076348/e6d04ec9-6837-4215-9e61-671de2b81ef4)

## Testing
1. Live link
2. Go to the normal checkout page and check the css