### PR TITLE
Subscriber modal: clean up translation checks

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/newsletter-section/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-section/SubscribeModalSetting.tsx
@@ -5,7 +5,6 @@ import { useSelector } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 export const SUBSCRIBE_MODAL_OPTION = 'sm_enabled';
 
@@ -32,7 +31,6 @@ export const SubscribeModalSetting = ( {
 }: SubscribeModalSettingProps ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
-	const isAtomicSite = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 
 	// Construct a link to edit the modal
 	const { data: activeThemeData } = useActiveThemeQuery( siteId, true );
@@ -67,7 +65,7 @@ export const SubscribeModalSetting = ( {
 					: translate(
 							'Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll.'
 					  ) }
-				{ isModalEditTranslated && subscribeModalEditorUrl && ! isAtomicSite && (
+				{ isModalEditTranslated && subscribeModalEditorUrl && (
 					<>
 						{ ' ' }
 						<ExternalLink href={ subscribeModalEditorUrl }>

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-section/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-section/SubscribeModalSetting.tsx
@@ -1,6 +1,6 @@
 import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
-import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
@@ -13,16 +13,6 @@ type SubscribeModalSettingProps = {
 	handleToggle: ( field: string ) => ( value: boolean ) => void;
 	disabled?: boolean;
 };
-
-const isModalEditTranslated =
-	getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'Preview and edit the popup' );
-const isModalToggleTranslated =
-	getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'Enable subscriber pop-up' );
-const isModalToggleHelpTranslated =
-	getLocaleSlug()?.startsWith( 'en' ) ||
-	i18n.hasTranslation(
-		'Grow your subscriber list by enabling a pop-up modal with a subscribe form. This will show as readers scroll.'
-	);
 
 export const SubscribeModalSetting = ( {
 	value = false,
@@ -51,21 +41,13 @@ export const SubscribeModalSetting = ( {
 				checked={ !! value }
 				onChange={ handleToggle( SUBSCRIBE_MODAL_OPTION ) }
 				disabled={ disabled }
-				label={
-					isModalToggleTranslated
-						? translate( 'Enable subscriber pop-up' )
-						: translate( 'Enable subscriber modal' )
-				}
+				label={ translate( 'Enable subscriber pop-up' ) }
 			/>
 			<FormSettingExplanation>
-				{ isModalToggleHelpTranslated
-					? translate(
-							'Grow your subscriber list by enabling a pop-up modal with a subscribe form. This will show as readers scroll.'
-					  )
-					: translate(
-							'Grow your subscriber list by enabling a popup modal with a subscribe form. This will show as readers scroll.'
-					  ) }
-				{ isModalEditTranslated && subscribeModalEditorUrl && (
+				{ translate(
+					'Grow your subscriber list by enabling a pop-up modal with a subscribe form. This will show as readers scroll.'
+				) }
+				{ subscribeModalEditorUrl && (
 					<>
 						{ ' ' }
 						<ExternalLink href={ subscribeModalEditorUrl }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

As a follow up to https://github.com/Automattic/wp-calypso/pull/82115, some code-cleanup.

## Proposed Changes

* Remove i18n checks. These strings are now translated so we don't need to check for them.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/settings/newsletter` and ensure modal toggle still looks fine.

![image](https://github.com/Automattic/wp-calypso/assets/87168/f9a0621a-bce6-4759-8599-dfe5db8173e2)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?