### PR TITLE
Domain Transfer: Add dismiss option for Transfer Success

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -38,6 +38,7 @@ type ResolveDomainStatusReturn =
 			icon: 'info' | 'verifying' | 'check_circle' | 'cached' | 'cloud_upload' | 'download_done';
 			listStatusWeight?: number;
 			noticeText?: TranslateResult | Array< TranslateResult > | null;
+			isDismissable?: boolean;
 	  }
 	| Record< string, never >;
 
@@ -538,6 +539,7 @@ export function resolveDomainStatus(
 					icon: 'info',
 					noticeText: hasTranslation ? newCopy : oldCopy,
 					listStatusWeight: 600,
+					isDismissable: true,
 				};
 			}
 

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -49,6 +49,7 @@ export type ResolveDomainStatusOptionsBag = {
 	siteSlug?: string | null;
 	currentRoute?: string | null;
 	getMappingErrors?: boolean | null;
+	dismissPreferences?: any;
 };
 
 export function resolveDomainStatus(
@@ -63,6 +64,7 @@ export function resolveDomainStatus(
 		siteSlug = null,
 		getMappingErrors = false,
 		currentRoute = null,
+		dismissPreferences = null,
 	}: ResolveDomainStatusOptionsBag = {}
 ): ResolveDomainStatusReturn {
 	const transferOptions = {
@@ -494,7 +496,12 @@ export function resolveDomainStatus(
 				};
 			}
 
-			if ( domain.transferStatus === transferStatus.COMPLETED && ! domain.pointsToWpcom ) {
+			// We use the statusClass to save which notice we dismissed. We plan to add a new option if we add the dismiss option to more notices
+			if (
+				! dismissPreferences?.[ 'status-success' ] &&
+				domain.transferStatus === transferStatus.COMPLETED &&
+				! domain.pointsToWpcom
+			) {
 				const hasTranslation =
 					englishLocales.includes( String( getLocaleSlug() ) ) ||
 					i18n.hasTranslation(

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -139,15 +139,9 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 				siteSlug: site.slug,
 				getMappingErrors: true,
 				currentRoute,
+				dismissPreferences: hasNoticePreferences ? noticeDismissPreferences : null,
 			}
 		);
-
-		if (
-			isDismissable &&
-			( ! hasNoticePreferences || noticeDismissPreferences?.[ statusClass ] )
-		) {
-			return null;
-		}
 
 		if ( noticeText && statusClass ) {
 			return (

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -4,6 +4,7 @@ import { home, Icon, info } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useCurrentRoute } from 'calypso/components/route';
 import { resolveDomainStatus } from 'calypso/lib/domains';
@@ -31,14 +32,22 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 	const dispatch = useDispatch();
 	const { currentRoute } = useCurrentRoute();
 	const hasNoticePreferences = useSelector( hasReceivedRemotePreferences );
-	const noticeDismissPreference = `domain-status-notice-${ domain.name }`;
-	const isNoticeDismissed = useSelector( ( state ) =>
-		getPreference( state, noticeDismissPreference )
+	const noticeDismissPreferenceName = `domain-status-notice-${ domain.name }`;
+	const noticeDismissPreferences = useSelector( ( state ) =>
+		getPreference( state, noticeDismissPreferenceName )
 	);
 
-	const handleNoticeDismiss = () => {
-		dispatch( savePreference( noticeDismissPreference, 1 ) );
-	};
+	const handleNoticeDismiss = useCallback(
+		( type: string ) => {
+			dispatch(
+				savePreference( noticeDismissPreferenceName, {
+					...noticeDismissPreferences,
+					[ type ]: true,
+				} )
+			);
+		},
+		[ dispatch, noticeDismissPreferenceName, noticeDismissPreferences ]
+	);
 
 	const renderCircle = () => (
 		<SVG viewBox="0 0 24 24" height={ 8 } width={ 8 }>
@@ -133,7 +142,10 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 			}
 		);
 
-		if ( isDismissable && ( ! hasNoticePreferences || isNoticeDismissed ) ) {
+		if (
+			isDismissable &&
+			( ! hasNoticePreferences || noticeDismissPreferences?.[ statusClass ] )
+		) {
 			return null;
 		}
 
@@ -157,7 +169,7 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 						<button
 							className="settings-header__domain-notice-dismiss-button"
 							aria-label={ translate( 'Dismiss' ) }
-							onClick={ handleNoticeDismiss }
+							onClick={ handleNoticeDismiss.bind( null, statusClass ) }
 						>
 							<Gridicon icon="cross" width={ 18 } />
 						</button>

--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -148,6 +148,19 @@ body.edit__body-white.theme-default.color-scheme {
 			}
 		}
 	}
+
+	&__domain-notice-dismiss-button {
+		margin-left: auto;
+		width: 18px;
+		height: 18px;
+		color: var(--color-text-subtle);
+		cursor: pointer;
+
+		@include break-small {
+			width: 24px;
+			height: 24px;
+		}
+	}
 }
 
 .domain-settings-page {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3823

## Proposed Changes

We added the dismiss option to the Domain Status Notice and implemented on domain edit page.
<img width="1098" alt="image" src="https://github.com/Automattic/wp-calypso/assets/402286/256defd9-ae23-49b6-b0cd-c63889d6a60d">

> [!NOTE]  
> This only dismiss when editing the domain

#### TO-DO
- [ ] Add dismiss on domains list.

## Testing Instructions

* With a transferred domain not pointing to WPCOM
* or changing [this conditional](https://github.com/Automattic/wp-calypso/blob/e34411265af1bc9abb5b2adb3bedbb54d9fbe6dd/client/lib/domains/resolve-domain-status.tsx#L496) to `1 === 1`
* Edit this domain
* You should see the notice like the screenshot
* You can dismiss it by clicking the `x` on the right of the notice
* Reload the page, and the notice should not show.
* To restore the notice, post this (with your domain_name), to `https://public-api.wordpress.com/rest/v1.1/me/preferences?http_envelope=1`
```
{
    "calypso_preferences": {
        "domain-status-notice-YOURDOMAINNAME": null,
    }
}
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?