### PR TITLE
Reader inline comments - update language for expand/collapse links

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -418,10 +418,10 @@ class PostCommentList extends Component {
 
 		const viewMoreText =
 			! shouldShowViewMoreToggle && this.state.showExpandWhenOnlyComments
-				? translate( 'View more' )
-				: translate( 'View more comments' );
+				? translate( 'Show more' )
+				: translate( 'Show more comments' );
 
-		let viewFewerText = translate( 'View fewer comments' );
+		let viewFewerText = translate( 'Show fewer comments' );
 		if ( this.props.isExpanded ) {
 			const { displayedCommentsCount: collapsedDisplayedCommentsCount } =
 				this.getDisplayedCollapsedInlineComments( commentsTreeToShow );
@@ -429,7 +429,7 @@ class PostCommentList extends Component {
 			// If collapsing will not reduce the number of comments shown (only line-clamp them
 			// visually), display 'View less' instead of 'View fewer comments'.
 			if ( displayedCommentsCount === collapsedDisplayedCommentsCount ) {
-				viewFewerText = translate( 'View less' );
+				viewFewerText = translate( 'Show less' );
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

 Related to # p1695644805297639-slack-C03NLNTPZ2T

## Proposed Changes

* Uses "Show" instead of "View" verbage for in-place comment expansion actions. "View" is commonly used within other links that navigate to other pages, while "Show" should read more intuitively as a local action to expand the comments section.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test inline comments in the reader
* Verify we say "Show more/less" instead of "View" for our links to expand and collapse the inline comments section.

Before:
<img width="294" alt="Screenshot 2023-09-25 at 10 30 38 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/e14f524e-18cd-4b2d-8c8b-f6ff497f39a5">


After:
<img width="208" alt="Screenshot 2023-09-25 at 10 30 55 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/c8fdb200-5859-45a2-81e2-768da9ef26f8">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?