### PR TITLE
Site profiler: Recognize URL inside the Email field

### DIFF
--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@wordpress/components';
+import { createElement, createInterpolateElement } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -15,6 +16,7 @@ export default function DomainInformation( props: Props ) {
 	const { domain, whois } = props;
 	const moment = useLocalizedMoment();
 	const momentFormat = 'YYYY-MM-DD HH:mm:ss UTC';
+	const urlRegex = /https?:\/\/[^\s/$.?#].[^\s]*/g;
 	const [ fetchWhoisRawData, setFetchWhoisRawData ] = useState( false );
 
 	const {
@@ -23,12 +25,25 @@ export default function DomainInformation( props: Props ) {
 		isError: whoisRawDataFetchingError,
 	} = useDomainAnalyzerWhoisRawDataQuery( domain, fetchWhoisRawData );
 
-	function contactArgs( name: string ) {
+	const contactArgs = ( name: string ) => {
 		return {
 			args: [ name ],
 			components: { strong: <strong /> },
 		};
-	}
+	};
+
+	const linkifyUrlFromText = ( text: string ) => {
+		let url = '';
+
+		const preparedText = text.replace( urlRegex, ( _url: string ) => {
+			url = _url;
+			return '<a>link</a>';
+		} );
+
+		return createInterpolateElement( preparedText, {
+			a: createElement( 'a', { href: url, target: '_blank' } ),
+		} );
+	};
 
 	return (
 		<div className="domain-information">
@@ -157,7 +172,11 @@ export default function DomainInformation( props: Props ) {
 							) }
 							{ whois.registrant_email && (
 								<li>
-									<a href={ `mailto:${ whois.registrant_email }` }>{ translate( 'Email' ) }</a>
+									{ whois.registrant_email.includes( '@' ) && (
+										<a href={ `mailto:${ whois.registrant_email }` }>{ translate( 'Email' ) }</a>
+									) }
+									{ urlRegex.test( whois.registrant_email ) &&
+										linkifyUrlFromText( whois.registrant_email ) }
 								</li>
 							) }
 						</ul>
@@ -225,11 +244,10 @@ export default function DomainInformation( props: Props ) {
 									) }
 								</li>
 							) }
-							{ whois.admin_email && (
-								<li>
-									<a href={ `mailto:${ whois.admin_email }` }>{ translate( 'Email' ) }</a>
-								</li>
+							{ whois.admin_email.includes( '@' ) && (
+								<a href={ `mailto:${ whois.admin_email }` }>{ translate( 'Email' ) }</a>
 							) }
+							{ urlRegex.test( whois.admin_email ) && linkifyUrlFromText( whois.admin_email ) }
 						</ul>
 					</div>
 					<div className="col">
@@ -289,11 +307,10 @@ export default function DomainInformation( props: Props ) {
 									{ translate( '{{strong}}Phone:{{/strong}} %s', contactArgs( whois.tech_phone ) ) }
 								</li>
 							) }
-							{ whois.tech_email && (
-								<li>
-									<a href={ `mailto:${ whois.tech_email }` }>{ translate( 'Email' ) }</a>
-								</li>
+							{ whois.tech_email.includes( '@' ) && (
+								<a href={ `mailto:${ whois.tech_email }` }>{ translate( 'Email' ) }</a>
 							) }
+							{ urlRegex.test( whois.tech_email ) && linkifyUrlFromText( whois.tech_email ) }
 						</ul>
 					</div>
 				</li>

--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -41,7 +41,7 @@ export default function DomainInformation( props: Props ) {
 		} );
 
 		return createInterpolateElement( preparedText, {
-			a: createElement( 'a', { href: url, target: '_blank' } ),
+			a: createElement( 'a', { href: url, target: '_blank', rel: 'nofollow noreferrer' } ),
 		} );
 	};
 


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/81887

## Proposed Changes

* Recognized URL inside the email field
* Handled it by if there is an email, render "Email" link, or linkify text which contains url inside

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site-profiler`
* Enter, for example: "google.com"
* Check if there is a "Select Request Email Form at [link](https://domains.markmonitor.com/whois/google.com)" sentence for the email field

<img width="1082" alt="Screenshot 2023-09-25 at 16 25 42" src="https://github.com/Automattic/wp-calypso/assets/1241413/00972a8e-7f42-4338-bd07-4cc1c2c74265">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?