### PR TITLE
Launchpad: Add skip feature to the Start Writing flow

### DIFF
--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -19,6 +19,7 @@ import { freeSiteAddressType } from 'calypso/lib/domains/constants';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { requestSiteAddressChange } from 'calypso/state/site-address-change/actions';
+import { useSiteIdParam } from '../hooks/use-site-id-param';
 
 const startWriting: Flow = {
 	name: START_WRITING_FLOW,
@@ -64,6 +65,7 @@ const startWriting: Flow = {
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
 		const siteSlug = useSiteSlug();
+		const siteId = useSiteIdParam();
 		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
 		const { setSelectedSite } = useDispatch( ONBOARD_STORE );
 		const state = useSelect(
@@ -182,7 +184,18 @@ const startWriting: Flow = {
 					return window.location.assign( providedDependencies.destinationUrl as string );
 			}
 		}
-		return { submit };
+
+		const goNext = async () => {
+			switch ( currentStep ) {
+				case 'launchpad':
+					if ( siteSlug ) {
+						await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );
+					}
+					return window.location.assign( `/home/${ siteId ?? siteSlug }` );
+			}
+		};
+
+		return { goNext, submit };
 	},
 
 	useAssertConditions(): AssertConditionResult {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* D123011-code
* https://github.com/Automattic/jetpack/pull/33281

## Proposed Changes

* Adds the skip the Launchpad feature to the `Start Writing` flow. Skipping the fullscreen launchpad should redirect the user to the Customer Home and display the compact version of the pre-launch Launchpad.
* Please, review https://github.com/Automattic/wp-calypso/pull/82066 first.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the D123011-code diff to your sandbox
* Apply the Jetpack(https://github.com/Automattic/jetpack/pull/33281) changes to your sandbox:
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/launchpad-skip-start-writing
```
* Use the Calypso Live link or apply this PR to your local environment.
* On an incognito tab, navigate to `/setup/start-writing`
* Create a new account
* After creating the account, you'll be redirected to the editor, where you need to make a post.
* After publishing your post, you'll be redirected to the stepper flow. Go through the flow until you reach the launchpad step.
* Click on the "Skip for now" link in the top right corner
* You should be redirected to the Customer Home, and the pre-launch Launchpad should be injected.
* Click on the tasks and ensure you are redirected to the appropriate pages. You should also complete all of them.
* After completing all the tasks, the Launch task should be available. Clicking on it should Launch the site the pre-launch Launchpad should disappear.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?