### PR TITLE
Reader Inline Comments - fix line clamp styles on safari.

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -235,7 +235,7 @@ class PostCommentList extends Component {
 
 		// Query selector ALL since we might be showing the readers reply as well.
 		const commentContentEles = this.listRef.current.querySelectorAll(
-			'.comments__comment-content'
+			'.comments__comment-content-wrapper'
 		);
 		let isClampedComment = false;
 

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -235,7 +235,7 @@ class PostCommentList extends Component {
 
 		// Query selector ALL since we might be showing the readers reply as well.
 		const commentContentEles = this.listRef.current.querySelectorAll(
-			'.comments__comment-content-wrapper'
+			'.comments__comment-content'
 		);
 		let isClampedComment = false;
 

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -54,13 +54,13 @@
 	}
 
 	&.is-inline.is-collapsed {
-		.comments__comment-content-wrapper {
+		.comments__comment-content {
 			display: -webkit-box;
 			overflow: hidden;
 			-webkit-box-orient: vertical;
 			-webkit-line-clamp: 1;
 
-			.comments__comment-content {
+			* {
 				display: inline;
 			}
 		}

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -54,13 +54,13 @@
 	}
 
 	&.is-inline.is-collapsed {
-		.comments__comment-content {
+		.comments__comment-content-wrapper {
 			display: -webkit-box;
 			overflow: hidden;
 			-webkit-box-orient: vertical;
 			-webkit-line-clamp: 1;
 
-			p {
+			.comments__comment-content {
 				display: inline;
 			}
 		}

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -62,6 +62,7 @@
 
 			* {
 				display: inline;
+				background: transparent;
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1695644805297639-slack-C03NLNTPZ2T

## Proposed Changes

* Updates line clamping styles to target all children for `display: inline` instead of just paragraphs. This change should be most visible on Safari and with p2 feeds. Other browsers dont require inline children for line-clamping, and non-p2 feeds dont often have comment content outside of normal text.

Before/After: Since this is primarily regarding p2 feeds i will not post images here. If you explore p2 feeds on safari you should see examples similar to what was shared in the slack link above.




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test inline comments on multiple browsers including safari.
* Test in p2 feeds where there are more blocks (images, quotes, etc.) in the content than just text in p tags.
* Verify inline comments are clamped correctly and work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?