### PR TITLE
Revert "Jetpack Manage: Issue hosting license on CTA click and navigate to licenses list"

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -1,7 +1,5 @@
 import { Button } from '@automattic/components';
-import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import QueryJetpackPartnerPortalLicenseCounts from 'calypso/components/data/query-jetpack-partner-portal-license-counts';
 import SiteAddLicenseNotification from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification';
@@ -17,7 +15,6 @@ import {
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { infoNotice } from 'calypso/state/notices/actions';
 import {
 	getLicenseCounts,
 	hasFetchedLicenseCounts,
@@ -53,20 +50,6 @@ export default function Licenses( {
 	const counts = useSelector( getLicenseCounts );
 	const hasFetched = useSelector( hasFetchedLicenseCounts );
 	const allLicensesCount = counts[ 'all' ];
-	const provisioningSite = getQueryArg( window.location.href, 'provisioning' ) as string;
-
-	useEffect( () => {
-		if ( 'true' === provisioningSite ) {
-			dispatch(
-				infoNotice(
-					translate(
-						'We are creating a WordPress.com site in the background. It will appear on your dashboard shortly.'
-					),
-					{ id: 'provisioning-site-notice' }
-				)
-			);
-		}
-	}, [ provisioningSite, translate, dispatch ] );
 
 	const context = {
 		filter,

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -2,14 +2,11 @@ import { getPlan, PLAN_BUSINESS, PLAN_ECOMMERCE } from '@automattic/calypso-prod
 import { Button, JetpackLogo, WooLogo, CloudLogo } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import { useCallback, useRef, useState } from 'react';
 import Tooltip from 'calypso/components/tooltip';
-import useIssueLicenses from 'calypso/jetpack-cloud/sections/partner-portal/hooks/use-issue-licenses';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { infoNotice } from 'calypso/state/notices/actions';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import FeatureItem from './feature-item';
 import './style.scss';
@@ -26,15 +23,7 @@ interface PlanInfo {
 	previousProductName: string;
 }
 
-export default function CardContent( {
-	planSlug,
-	isRequesting,
-	setIsRequesting,
-}: {
-	planSlug: string;
-	isRequesting: boolean;
-	setIsRequesting: any;
-} ) {
+export default function CardContent( { planSlug }: { planSlug: string } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const tooltipRef = useRef< HTMLDivElement | null >( null );
@@ -118,22 +107,9 @@ export default function CardContent( {
 
 	const plan = getPlanInfo( planSlug );
 
-	const { issueLicenses } = useIssueLicenses();
-
 	const onCTAClick = useCallback( () => {
-		const productSlug =
-			planSlug === PLAN_BUSINESS ? 'wpcom-hosting-business' : 'wpcom-hosting-ecommerce';
-
-		setIsRequesting( true );
-
-		dispatch( infoNotice( translate( 'A new WordPress.com site is on the way!' ) ) );
 		dispatch( recordTracksEvent( getCTAEventName( planSlug ) ) );
-
-		issueLicenses( [ productSlug ] );
-
-		setIsRequesting( false );
-		page.redirect( `/partner-portal/licenses?provisioning=true` );
-	}, [ dispatch, planSlug, issueLicenses, translate, setIsRequesting ] );
+	}, [ dispatch, planSlug ] );
 
 	if ( ! plan ) {
 		return null;
@@ -150,12 +126,7 @@ export default function CardContent( {
 					{ plan.interval === 'day' && translate( '/USD per license per day' ) }
 					{ plan.interval === 'month' && translate( '/USD per license per month' ) }
 				</div>
-				<Button
-					className="wpcom-atomic-hosting__card-button"
-					primary
-					onClick={ onCTAClick }
-					disabled={ isRequesting }
-				>
+				<Button className="wpcom-atomic-hosting__card-button" primary onClick={ onCTAClick }>
 					{ translate( 'Get %(title)s', {
 						args: {
 							title: plan.title,

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/index.tsx
@@ -1,7 +1,7 @@
 import { PLAN_BUSINESS, PLAN_ECOMMERCE } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -15,7 +15,6 @@ export default function WPCOMAtomicHosting() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const title = translate( 'Create a new WordPress.com site' );
-	const [ isRequesting, setIsRequesting ] = useState( false );
 
 	const plansToBeDisplayed = [ PLAN_BUSINESS, PLAN_ECOMMERCE ];
 
@@ -35,11 +34,7 @@ export default function WPCOMAtomicHosting() {
 			<div className="wpcom-atomic-hosting__card-container">
 				{ plansToBeDisplayed.map( ( plan ) => (
 					<Card key={ plan } className="wpcom-atomic-hosting__card" compact>
-						<CardContent
-							planSlug={ plan }
-							isRequesting={ isRequesting }
-							setIsRequesting={ setIsRequesting }
-						/>
+						<CardContent planSlug={ plan } />
 					</Card>
 				) ) }
 			</div>


### PR DESCRIPTION
Reverts Automattic/wp-calypso#82026