### PR TITLE
[WordAds]: Fix stale settings state in ads dashboard

### DIFF
--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -2,7 +2,7 @@ import { Button, Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { isEmpty } from 'lodash';
+import { isEqual } from 'lodash';
 import { Fragment, useState, useEffect, ChangeEvent, FormEvent } from 'react';
 import QueryWordadsSettings from 'calypso/components/data/query-wordads-settings';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
@@ -69,17 +69,16 @@ const AdsFormSettings = () => {
 	const isWordAds = site?.options?.wordads;
 
 	useEffect( () => {
-		// Set default settings if settings are empty
-		const settingsAreEmptyAndWordadsSettingsExist =
-			isEmpty( settings ) && ! isEmpty( wordadsSettings );
+		const newSettings = {
+			...defaultSettings(),
+			...wordadsSettings,
+		};
 
-		if ( settingsAreEmptyAndWordadsSettingsExist ) {
-			setSettings( {
-				...defaultSettings(),
-				...wordadsSettings,
-			} );
+		const isUpdatedSettings = ! isEqual( wordadsSettings, settings );
+		if ( isUpdatedSettings ) {
+			setSettings( newSettings );
 		}
-	}, [ settings, wordadsSettings ] );
+	}, [ wordadsSettings ] );
 
 	useEffect( () => {
 		// siteId has changed, so we reset settings

--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -73,25 +73,11 @@ const AdsFormSettings = () => {
 			...defaultSettings(),
 			...wordadsSettings,
 		};
-
-		const isUpdatedSettings = ! isEqual( wordadsSettings, settings );
+		const isUpdatedSettings = ! isEqual( newSettings, settings );
 		if ( isUpdatedSettings ) {
 			setSettings( newSettings );
 		}
 	}, [ wordadsSettings ] );
-
-	useEffect( () => {
-		// siteId has changed, so we reset settings
-		// This code is here to directly mimic code that
-		// was in UNSAFE_componentWillReceiveProps
-		setSettings( {
-			...defaultSettings(),
-			...wordadsSettings,
-		} );
-
-		// Only run on siteId change
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ siteId ] );
 
 	function handleChange( event: ChangeEvent< HTMLInputElement > ) {
 		const name = event.currentTarget.name;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/82123

## Proposed Changes

* Fixes an issue where the latest Ads settings aren't reflected on the Earn dashboard on initial page load

## Testing Instructions

#### Before the fix:
* Checkout to `trunk`
* Use an existing site with WordAds enabled or set up a new test site.
* In the incognito tab open (to avoid any cache), go to `Tools > Earn > View ad dashboard > Settings` i.e `http://calypso.localhost:3000/earn/ads-settings/<site-id>`
* If you have existing settings such as PayPal address they would not appear on the page.
* If you DO NOT have any existing changes then:
* Change any of the ad settings such as PayPal address or toggle ad display locations.
* Save the changes and then reload the page
* The saved changes should not appear.
* Now navigate to another page like Tools > Marketing then back to the settings page
* The changes will then appear on the page

https://github.com/Automattic/wp-calypso/assets/9039613/8f218f50-08a8-4dd4-ab0c-abe15a61c8ea


#### After the fix:

* Checkout this branch `fix/ads-settings-load`
* Repeat the steps above but this time, your settings should appear immediately on the first page load

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
