### PR TITLE
Enable design-picker/query-marketplace-themes flag

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -33,7 +33,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
-		"design-picker/query-marketplace-themes": false,
+		"design-picker/query-marketplace-themes": true,
 		"desktop-promo": true,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -30,7 +30,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
-		"design-picker/query-marketplace-themes": false,
+		"design-picker/query-marketplace-themes": true,
 		"desktop-promo": true,
 		"dev/preferences-helper": true,
 		"domains/gdpr-consent-page": true,


### PR DESCRIPTION
Fixed #82138
## Proposed Changes

Enable the `design-picker/query-marketplace-themes` flag in staging and production.

## Testing Instructions

**On prod**
* Apply the diff D118900-code to your sandbox and direct requests to the sandbox
* Go to the Design Picker page  `/setup/update-design/designSetup?siteSlug=:site&theme=:theme_slug`. 
* No themes should have the `Partner` badge

**On this branch**
* Go to the Design Picker page  `/setup/update-design/designSetup?siteSlug=:site&theme=:theme_slug`. 
* You should see themes with the `Partner` badge

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
