### PR TITLE
Site profiler: Add verified checkmark icon next to the WordPress.com provider

### DIFF
--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -3,6 +3,7 @@ import { translate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useDomainAnalyzerWhoisRawDataQuery } from 'calypso/data/site-profiler/use-domain-whois-raw-data-query';
+import VerifiedProvider from './verified-provider';
 import type { WhoIs } from 'calypso/data/site-profiler/types';
 import './styles.scss';
 
@@ -45,7 +46,10 @@ export default function DomainInformation( props: Props ) {
 					<li>
 						<div className="name">{ translate( 'Registrar' ) }</div>
 						<div>
-							{ whois.registrar_url && (
+							{ whois.registrar_url?.toLowerCase().includes( 'automattic' ) && (
+								<VerifiedProvider />
+							) }
+							{ ! whois.registrar_url?.toLowerCase().includes( 'automattic' ) && (
 								<a href={ whois.registrar_url } target="_blank" rel="noopener noreferrer">
 									{ whois.registrar }
 								</a>

--- a/client/site-profiler/components/domain-information/verified-provider.tsx
+++ b/client/site-profiler/components/domain-information/verified-provider.tsx
@@ -1,0 +1,17 @@
+import { Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { translate } from 'i18n-calypso';
+
+export default function VerifiedProvider() {
+	return (
+		<>
+			<span className="status-icon status-icon--small blue">
+				{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+				<Gridicon icon="checkmark" size={ 10 } />
+			</span>
+			<a href="https://wordpress.com">WordPress.com</a>
+			&nbsp;&nbsp;
+			<a href={ localizeUrl( 'https://wordpress.com/login' ) }>({ translate( 'login' ) })</a>
+		</>
+	);
+}

--- a/client/site-profiler/components/heading-information/status-icon.tsx
+++ b/client/site-profiler/components/heading-information/status-icon.tsx
@@ -12,7 +12,7 @@ export default function StatusIcon( props: Props ) {
 
 	useEffect( () => {
 		switch ( conversionAction ) {
-			case 'idle':
+			case 'register-domain':
 				setStatusIcon( 'checkmark' );
 				setStatusColor( 'green' );
 				break;
@@ -24,7 +24,7 @@ export default function StatusIcon( props: Props ) {
 				setStatusIcon( 'cross' );
 				setStatusColor( 'red' );
 				break;
-			case 'register-domain':
+			case 'idle':
 			default:
 				setStatusIcon( 'checkmark' );
 				setStatusColor( 'blue' );

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -1,6 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
-import { DNS, HostingProvider } from 'calypso/data/site-profiler/types';
+import VerifiedProvider from '../domain-information/verified-provider';
+import type { DNS, HostingProvider } from 'calypso/data/site-profiler/types';
 
 interface Props {
 	dns: DNS[];
@@ -19,15 +20,7 @@ export default function HostingInformation( props: Props ) {
 					<div className="name">{ translate( 'Provider' ) }</div>
 					<div>
 						{ hostingProvider?.slug !== 'automattic' && <>{ hostingProvider?.name }</> }
-						{ hostingProvider?.slug === 'automattic' && (
-							<>
-								<a href={ localizeUrl( 'https://automattic.com' ) }>{ hostingProvider?.name }</a>
-								&nbsp;&nbsp;
-								<a href={ localizeUrl( 'https://automattic.com/login' ) }>
-									({ translate( 'login' ) })
-								</a>
-							</>
-						) }
+						{ hostingProvider?.slug === 'automattic' && <VerifiedProvider /> }
 					</div>
 				</li>
 				{ hostingProvider?.slug === 'automattic' && (

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -153,6 +153,12 @@
 		}
 	}
 
+	.status-icon--small {
+		padding: 4px;
+		top: -2px;
+		margin-right: 0.25rem;
+	}
+
 	.hosting-intro-block {
 		h2 {
 			max-width: 400px;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82136

## Proposed Changes

* Added verified checkmark icon next to the WordPress.com provider

## Testing Instructions

* Go to `/site-profiler`
* Enter domain which is registered and hosted on the WordPress.com platform (example: [wecanwang.com](http://wecanwang.com/)
* Check if there is verified icon

<img width="596" alt="Screenshot 2023-09-25 at 19 20 12" src="https://github.com/Automattic/wp-calypso/assets/1241413/e77e1610-edea-48db-95a5-0111340c1367">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?