### PR TITLE
Reader tracking - update Discover sections ui_algo for better feed specificity

### DIFF
--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -73,8 +73,8 @@ function getLocation( path ) {
 		return 'following_manage';
 	}
 	if ( path.indexOf( '/discover' ) === 0 ) {
-		const queryArgs = new URLSearchParams( window.location.search );
-		const selectedTab = queryArgs.get( 'selectedTab' );
+		const searchParams = new URLSearchParams( window.location.search );
+		const selectedTab = searchParams.get( 'selectedTab' );
 		if ( ! selectedTab || selectedTab === 'recommended' ) {
 			return 'discover_recommended';
 		} else if ( selectedTab === 'latest' ) {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -73,7 +73,16 @@ function getLocation( path ) {
 		return 'following_manage';
 	}
 	if ( path.indexOf( '/discover' ) === 0 ) {
-		return 'discover';
+		const queryArgs = new URLSearchParams( window.location.search );
+		const selectedTab = queryArgs.get( 'selectedTab' );
+		if ( ! selectedTab || selectedTab === 'recommended' ) {
+			return 'discover_recommended';
+		} else if ( selectedTab === 'latest' ) {
+			return 'discover_latest';
+		} else if ( selectedTab === 'firstposts' ) {
+			return 'discover_firstposts';
+		}
+		return `discover_tag:${ selectedTab }`;
 	}
 	if ( path.indexOf( '/read/recommendations/posts' ) === 0 ) {
 		return 'recommended_posts';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1695312086939019-slack-C03NLNTPZ2T

## Proposed Changes

* Updates the logic for `getLocation` used in reader stats to handle discover feeds more specifically. Instead of resulting a ui_aldo or source prop simply as "discover", we should now see separate values for different discover feeds: `discover_recommended`, `discover_latest`, `discover_firstposts` (wip), and `discover_tag:{tagName}`.

<img width="547" alt="Screenshot 2023-09-25 at 1 38 18 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/38fccc38-7daf-47ea-8efc-a6141a9bf731">
<img width="507" alt="Screenshot 2023-09-25 at 1 39 23 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/e9041c77-a691-4bda-88b3-4643bfc5b99f">
<img width="487" alt="Screenshot 2023-09-25 at 1 38 41 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/a3abdd37-9564-4f62-997d-d45fd5bcc7ba">

Note - some reader events using the newer `recordReaderTracksEvent` method do not include this `ui_algo` info. I will work to carry this functionality to those in a followup.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* try liking a post in the reader and view the sent event via tracks vigilante.
* verify `ui_algo` is now specific to the feed type (recommended vs. latest vs. tag feeds, etc.)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?