### PR TITLE
Added query to get subscribers count, with tests

### DIFF
--- a/client/my-sites/subscribers/hooks/use-many-subs-site.ts
+++ b/client/my-sites/subscribers/hooks/use-many-subs-site.ts
@@ -1,9 +1,14 @@
-import useSubscribersTotalsQueries from 'calypso/my-sites/stats/hooks/use-subscribers-totals-query';
+import { UseQueryResult } from '@tanstack/react-query';
+import { useSubscriberCountQuery } from '../queries';
+import { SubscribersTotals, defaultSubscribersTotals } from '../queries/use-subscriber-count-query';
 
 const useManySubsSite = ( siteId: number | null ) => {
-	const { data: subscribersTotals = { total: 0 }, isLoading } =
-		useSubscribersTotalsQueries( siteId );
-	const totalSubscribers = subscribersTotals?.total ?? 0;
+	// email_subscribers includes WPCom subscribers and email subscribers
+	const {
+		data: subscribersTotals = defaultSubscribersTotals,
+		isLoading,
+	}: UseQueryResult< SubscribersTotals > = useSubscriberCountQuery( siteId );
+	const totalSubscribers = subscribersTotals?.email_subscribers ?? 0;
 	const hasManySubscribers = totalSubscribers > 30000; // 30000 is the limit of subscribers that can be fetched without breaking the endpoint. This is a temporal solution.
 
 	return { hasManySubscribers, isLoading };

--- a/client/my-sites/subscribers/queries/index.ts
+++ b/client/my-sites/subscribers/queries/index.ts
@@ -1,3 +1,4 @@
 export { default as useSubscriberDetailsQuery } from './use-subscriber-details-query';
 export { default as useSubscriberStatsQuery } from './use-subscriber-stats-query';
 export { default as useSubscribersQuery } from './use-subscribers-query';
+export { default as useSubscriberCountQuery } from './use-subscriber-count-query';

--- a/client/my-sites/subscribers/queries/test/use-subscriber-count-query-test.tsx
+++ b/client/my-sites/subscribers/queries/test/use-subscriber-count-query-test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import wpcom from 'calypso/lib/wp';
+import useSubscriberCountQuery, { defaultSubscribersTotals } from '../use-subscriber-count-query';
+
+const mockResponse = {
+	counts: {
+		email_subscribers: 100,
+		paid_subscribers: 50,
+		social_followers: 200,
+	},
+};
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: {
+		get: jest.fn(),
+	},
+} ) );
+
+describe( 'useSubscriberCountQuery', () => {
+	let queryClient: QueryClient;
+	let wrapper: React.FC< React.PropsWithChildren< any > >;
+
+	beforeEach( () => {
+		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockReset();
+
+		queryClient = new QueryClient( {
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		} );
+
+		wrapper = ( { children }: React.PropsWithChildren< any > ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should call wpcom.req.get with the right parameters', async () => {
+		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue(
+			mockResponse
+		);
+
+		const { result } = renderHook( () => useSubscriberCountQuery( 123 ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( wpcom.req.get ).toHaveBeenCalledWith( {
+			apiNamespace: 'wpcom/v2',
+			path: `/sites/123/subscribers/counts`,
+		} );
+	} );
+
+	it( 'should return expected data when successful', async () => {
+		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue(
+			mockResponse
+		);
+
+		const { result } = renderHook( () => useSubscriberCountQuery( 123 ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( result.current.data ).toEqual( mockResponse.counts );
+	} );
+
+	it( 'should handle empty response', async () => {
+		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue( {} );
+
+		const { result } = renderHook( () => useSubscriberCountQuery( 123 ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( result.current.data ).toEqual( defaultSubscribersTotals );
+	} );
+} );

--- a/client/my-sites/subscribers/queries/use-subscriber-count-query.ts
+++ b/client/my-sites/subscribers/queries/use-subscriber-count-query.ts
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+export interface SubscribersTotals {
+	email_subscribers: number;
+	paid_subscribers: number;
+	social_followers: number;
+}
+
+export const defaultSubscribersTotals = {
+	email_subscribers: 0,
+	paid_subscribers: 0,
+	social_followers: 0,
+};
+
+const getSubscriberCount = ( siteId: number | null ): Promise< any > => {
+	return wpcom.req.get( {
+		apiNamespace: 'wpcom/v2',
+		path: `/sites/${ siteId }/subscribers/counts`,
+	} );
+};
+
+export default function useSubscriberCountQuery( siteId: number | null ) {
+	return useQuery< SubscribersTotals >( {
+		queryKey: [ 'subscribers', 'count', siteId ],
+		queryFn: () => {
+			return getSubscriberCount( siteId ).then( ( response ) => {
+				return response.counts || defaultSubscribersTotals;
+			} );
+		},
+		enabled: !! siteId,
+		keepPreviousData: true,
+	} );
+}


### PR DESCRIPTION
## Proposed Changes

This PR fix a problem with the way we got the number of subscribers in the Subscriber Page. We were using `useSubscribersTotalsQueries` but that calls the `/stats/followers` endpoint that is not required for Subscribers Page (and fails under certain circumstances because quota exceeded).

What I do in this PR to fix it is to create a query to retrieve call just the endpoint I need to count the number of subscribers in Subscribers Page: `/sites/[site-id]/subscribers/counts`.

## Testing Instructions

1.     Apply this PR and start the application.
2.     Open the developer tools, Network tab.
3.     Go to Users -> Subscribers.
4.     Check that the endpoint `/stats/followers` is not called but the site still works fine.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?