### PR TITLE
Checkout tos links: Update tos links page-ids

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -12,7 +12,7 @@ const contextLinks = {
 	},
 	autorenewal: {
 		link: 'https://wordpress.com/support/manage-purchases/automatic-renewal/',
-		post_id: 111349,
+		post_id: 267092,
 	},
 	backups: {
 		link: 'https://wordpress.com/support/restore/',
@@ -32,7 +32,7 @@ const contextLinks = {
 	},
 	cancel_purchase: {
 		link: 'https://wordpress.com/support/manage-purchases/cancel-a-purchase/',
-		post_id: 111349,
+		post_id: 267077,
 	},
 	categories: {
 		link: 'https://wordpress.com/support/posts/categories/',


### PR DESCRIPTION
As reported here: p1695649366246469-slack-C0117V2PCAE

This PR updates the page-ids for the support links in the checkout ToS section. These page-ids are required for the help center support preview to work correctly.

<img width="1356" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/7d62f401-4b8b-4fe0-a37d-5e844e7c3fef">

Related to #81500 

## Testing Instructions
- Go to checkout and scroll to the ToS section at the bottom of the page
- Click on 'How your subscription works' and 'how to cancel' and ensure the help center preview displays the correct support pages (i.e the url the link points to)