### PR TITLE
BackupBrowser: Do not mark checkbox as checked if state is mixed

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
@@ -79,9 +79,7 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( { rewin
 			<div className="file-browser-header__selecting">
 				<CheckboxControl
 					__nextHasNoMarginBottom
-					checked={
-						rootNode ? rootNode.checkState === 'checked' || rootNode.checkState === 'mixed' : false
-					}
+					checked={ rootNode ? rootNode.checkState === 'checked' : false }
 					indeterminate={ rootNode && rootNode.checkState === 'mixed' }
 					onChange={ onCheckboxChange }
 					className={ `${ rootNode && rootNode.checkState === 'mixed' ? 'mixed' : '' }` }

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -211,11 +211,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 		return (
 			<CheckboxControl
 				__nextHasNoMarginBottom
-				checked={
-					browserNodeItem
-						? browserNodeItem.checkState === 'checked' || browserNodeItem.checkState === 'mixed'
-						: false
-				}
+				checked={ browserNodeItem ? browserNodeItem.checkState === 'checked' : false }
 				indeterminate={ browserNodeItem && browserNodeItem.checkState === 'mixed' }
 				onChange={ onCheckboxChange }
 			/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82088

## Proposed Changes

* Remove condition to select checkboxes when state is `mixed`. It will prevent a bug on Firefox overlapping checked and indeterminate state.

| Before (Firefox) | After (Firefox) |
|---|---|
| ![before](https://github.com/Automattic/wp-calypso/assets/1488641/43016111-7948-4d35-80be-a375ae92cf19) | ![after](https://github.com/Automattic/wp-calypso/assets/1488641/545e42d2-77f9-4bba-ad5a-a00f04d5c058) |

## Testing Instructions
* Using Firefox, spin up a Calypso or Jetpack Cloud live branch
* Select a site with a Jetpack VaultPress Backup plan
* Pick a backup and click on `View files` inside the `Actions (+)` menu. This option is only available on full/daily backups
* Try to select all files and then deselect some child files to ensure you see the indeterminate state (the selected checkbox with the dash in the middle).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?