### PR TITLE
Domains: Add "premium" label to premium domain transfers in checkout

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -717,10 +717,12 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 	}
 
 	if ( isDomainTransfer ) {
+		const premiumLabel = product.extra?.premium ? translate( 'Premium' ) : '';
+
 		return (
 			<>
-				<DefaultLineItemSublabel product={ product } />: { translate( 'billed annually' ) }{ ' ' }
-				{ price }
+				{ premiumLabel } <DefaultLineItemSublabel product={ product } />:{ ' ' }
+				{ translate( 'billed annually' ) } { price }
 			</>
 		);
 	}


### PR DESCRIPTION
## Proposed Changes

This PR adds a "premium" label to premium domain transfers in checkout.

Related to #81626

### Screenshot

![Markup on 2023-09-25 at 16:38:01](https://github.com/Automattic/wp-calypso/assets/5324818/434f573e-6663-42ea-ada0-0d3a78f2cda6)

## Testing Instructions

This PR depends on D121111-code, so apply that to your backend and sandbox `public-api` first

- Open the live Calypso link or build this branch locally
- Try to transfer a premium domain to one of your sites (check D121111-code for some examples)
- Ensure the product name contains the "Premium" label as shown in the screenshot

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
