### PR TITLE
100 year plan: Fixes 100 year plan policies to not have the domain renewal disclaimer

### DIFF
--- a/client/my-sites/checkout/src/components/refund-policies.tsx
+++ b/client/my-sites/checkout/src/components/refund-policies.tsx
@@ -161,7 +161,11 @@ export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
 	};
 
 	// Account for the fact that users can purchase a bundled domain separately from a paid plan
-	if ( ! cartHasPlanBundlePolicy && cartHasDomainBundleProduct && ! cartHasHundredYearPlan ) {
+	if (
+		! cartHasPlanBundlePolicy &&
+		cartHasDomainBundleProduct &&
+		! cartHasHundredYearPlan( cart )
+	) {
 		refundPolicies.push( RefundPolicy.DomainNameRegistrationBundled );
 	}
 

--- a/client/my-sites/checkout/src/components/refund-policies.tsx
+++ b/client/my-sites/checkout/src/components/refund-policies.tsx
@@ -1,5 +1,4 @@
 import {
-	is100YearPlan,
 	isBiennially,
 	isBundled,
 	isDomainRegistration,
@@ -13,6 +12,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { isWpComProductRenewal as isRenewal } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import { has100YearPlan } from 'calypso/lib/cart-values/cart-items';
 import { DOMAIN_CANCEL, REFUNDS } from 'calypso/lib/url/support';
 import CheckoutTermsItem from './checkout-terms-item';
 import type { ResponseCart } from '@automattic/shopping-cart';
@@ -154,18 +154,9 @@ export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
 		( product ) => isDomainRegistration( product ) && isBundled( product )
 	);
 
-	const cartHasHundredYearPlan = ( { products = [] }: ResponseCart ) => {
-		return (
-			products.length > 0 && products.some( ( product ) => is100YearPlan( product.product_slug ) )
-		);
-	};
-
 	// Account for the fact that users can purchase a bundled domain separately from a paid plan
-	if (
-		! cartHasPlanBundlePolicy &&
-		cartHasDomainBundleProduct &&
-		! cartHasHundredYearPlan( cart )
-	) {
+	// However, if the bundled plan is a 100 year plan, we don't need to show the domain refund policy
+	if ( ! cartHasPlanBundlePolicy && cartHasDomainBundleProduct && ! has100YearPlan( cart ) ) {
 		refundPolicies.push( RefundPolicy.DomainNameRegistrationBundled );
 	}
 

--- a/client/my-sites/checkout/src/components/refund-policies.tsx
+++ b/client/my-sites/checkout/src/components/refund-policies.tsx
@@ -1,4 +1,5 @@
 import {
+	is100YearPlan,
 	isBiennially,
 	isBundled,
 	isDomainRegistration,
@@ -153,8 +154,14 @@ export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
 		( product ) => isDomainRegistration( product ) && isBundled( product )
 	);
 
+	const cartHasHundredYearPlan = ( { products = [] }: ResponseCart ) => {
+		return (
+			products.length > 0 && products.some( ( product ) => is100YearPlan( product.product_slug ) )
+		);
+	};
+
 	// Account for the fact that users can purchase a bundled domain separately from a paid plan
-	if ( ! cartHasPlanBundlePolicy && cartHasDomainBundleProduct ) {
+	if ( ! cartHasPlanBundlePolicy && cartHasDomainBundleProduct && ! cartHasHundredYearPlan ) {
 		refundPolicies.push( RefundPolicy.DomainNameRegistrationBundled );
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove the domain refunds disclaimer since the 100 year pland includes free renewal for all 100 years and any refunds related to the 100 year plan will be related to refunding the entire plan and domain.

Discussion: p1695661256798179-slack-C05MY0XM1GB

| Before | After |
|--|--|
| ![image](https://github.com/Automattic/wp-calypso/assets/3422709/b7d7ad15-ee5f-41b6-933d-ce96915bf2f1) | <img width="820" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/ce2b2fc4-14e9-43b6-8dc9-7f9db4e5020b"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/hundred-year-plan` 
* Continue flow until you reach checkout
* Make sure the policies are as follow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?