### PR TITLE
Fediverse settings: don't interleave with newsletter settings

### DIFF
--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -153,12 +153,12 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 						isSavingSettings={ isSavingSettings }
 						updateFields={ updateFields }
 					/>
+					{ isEnabled( 'fediverse/allow-opt-in' ) && <FediverseSettingsSection /> }
 					{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
 					<SettingsSectionHeader
 						id="newsletter-settings"
 						title={ translate( 'Newsletter settings' ) }
 					/>
-					{ isEnabled( 'fediverse/allow-opt-in' ) && <FediverseSettingsSection /> }
 					<Card className="site-settings__card">
 						<em>
 							{ translate( 'Newsletter settings have moved to their {{a}}own page{{/a}}.', {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81527 - tried to move our settings above newsletter and only made it halfway

## Proposed Changes

* don't try to live inside newsletter settings

## Testing Instructions

Settings --> Reading

Should look like
<img width="738" alt="Screenshot 2023-09-25 at 16 14 51" src="https://github.com/Automattic/wp-calypso/assets/195089/e1dc750c-43c0-4556-9c2c-03e1d3fffe7c">

Not like (before)
<img width="733" alt="Screenshot 2023-09-25 at 16 15 30" src="https://github.com/Automattic/wp-calypso/assets/195089/fd865077-db9e-48f8-83e5-6b384b3ed895">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
