### PR TITLE
Launchpad: Fixed `drive_traffic` completion logic

### DIFF
--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -11,6 +11,7 @@ const TASKS_TO_COMPLETE_ON_CLICK = [
 	'earn_money',
 	'manage_subscribers',
 	'connect_social_media',
+	'drive_traffic',
 ];
 
 export const setUpActionsForTasks = ( {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82153
Context: p9Jlb4-8Tq-p2

## Proposed Changes

* This PR added the `drive_traffic` task to the list of tasks to be completed on click.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Using Calypso live:
- Create a site and follow the onboarding until you get to the post-launch Launchpad tasklist.
- Click on the "Drive traffic to my site" task
- Go back to customer home and verify the task is marked as completed
![image](https://github.com/Automattic/wp-calypso/assets/3801502/497b017d-8894-49dd-ae19-24564cdf0907)

