### PR TITLE
Domain Forwarding: Improve error handling

### DIFF
--- a/client/data/domains/forwarding/use-update-domain-forwarding-mutation.ts
+++ b/client/data/domains/forwarding/use-update-domain-forwarding-mutation.ts
@@ -21,6 +21,9 @@ export default function useUpdateDomainForwardingMutation(
 			queryClient.invalidateQueries( domainForwardingQueryKey( domainName ) );
 			queryOptions.onSuccess?.();
 		},
+		onError( error: DomainsApiError ) {
+			queryOptions.onError?.( error );
+		},
 	} );
 
 	const { mutate } = mutation;

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -38,6 +38,7 @@ type ResolveDomainStatusReturn =
 			icon: 'info' | 'verifying' | 'check_circle' | 'cached' | 'cloud_upload' | 'download_done';
 			listStatusWeight?: number;
 			noticeText?: TranslateResult | Array< TranslateResult > | null;
+			isDismissable?: boolean;
 	  }
 	| Record< string, never >;
 
@@ -538,6 +539,7 @@ export function resolveDomainStatus(
 					icon: 'info',
 					noticeText: hasTranslation ? newCopy : oldCopy,
 					listStatusWeight: 600,
+					isDismissable: true,
 				};
 			}
 

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -27,6 +27,7 @@ import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import { validateDomainForwarding } from './utils/domain-forwarding';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
+
 import './style.scss';
 
 const noticeOptions = {
@@ -64,14 +65,11 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 			dispatch(
 				successNotice( translate( 'Domain forward updated and enabled.' ), noticeOptions )
 			);
+			// TODO: open the edition of the new forwarding we just created
+			setEditingId( 0 );
 		},
-		onError() {
-			dispatch(
-				errorNotice(
-					translate( 'An error occurred while updating the domain forward.' ),
-					noticeOptions
-				)
-			);
+		onError( error ) {
+			dispatch( errorNotice( error.message, noticeOptions ) );
 		},
 	} );
 
@@ -246,9 +244,6 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 			forward_paths: forwardPaths,
 			is_permanent: isPermanent,
 		} );
-
-		// TODO: open the edition of the new forwarding we just created
-		setEditingId( 0 );
 
 		return false;
 	};

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -4,6 +4,7 @@ import { home, Icon, info } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useCurrentRoute } from 'calypso/components/route';
 import { resolveDomainStatus } from 'calypso/lib/domains';
@@ -31,14 +32,22 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 	const dispatch = useDispatch();
 	const { currentRoute } = useCurrentRoute();
 	const hasNoticePreferences = useSelector( hasReceivedRemotePreferences );
-	const noticeDismissPreference = `domain-status-notice-${ domain.name }`;
-	const isNoticeDismissed = useSelector( ( state ) =>
-		getPreference( state, noticeDismissPreference )
+	const noticeDismissPreferenceName = `domain-status-notice-${ domain.name }`;
+	const noticeDismissPreferences = useSelector( ( state ) =>
+		getPreference( state, noticeDismissPreferenceName )
 	);
 
-	const handleNoticeDismiss = () => {
-		dispatch( savePreference( noticeDismissPreference, 1 ) );
-	};
+	const handleNoticeDismiss = useCallback(
+		( type: string ) => {
+			dispatch(
+				savePreference( noticeDismissPreferenceName, {
+					...noticeDismissPreferences,
+					[ type ]: true,
+				} )
+			);
+		},
+		[ dispatch, noticeDismissPreferenceName, noticeDismissPreferences ]
+	);
 
 	const renderCircle = () => (
 		<SVG viewBox="0 0 24 24" height={ 8 } width={ 8 }>
@@ -133,7 +142,10 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 			}
 		);
 
-		if ( isDismissable && ( ! hasNoticePreferences || isNoticeDismissed ) ) {
+		if (
+			isDismissable &&
+			( ! hasNoticePreferences || noticeDismissPreferences?.[ statusClass ] )
+		) {
 			return null;
 		}
 
@@ -157,7 +169,7 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 						<button
 							className="settings-header__domain-notice-dismiss-button"
 							aria-label={ translate( 'Dismiss' ) }
-							onClick={ handleNoticeDismiss }
+							onClick={ handleNoticeDismiss.bind( null, statusClass ) }
 						>
 							<Gridicon icon="cross" width={ 18 } />
 						</button>

--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -148,6 +148,19 @@ body.edit__body-white.theme-default.color-scheme {
 			}
 		}
 	}
+
+	&__domain-notice-dismiss-button {
+		margin-left: auto;
+		width: 18px;
+		height: 18px;
+		color: var(--color-text-subtle);
+		cursor: pointer;
+
+		@include break-small {
+			width: 24px;
+			height: 24px;
+		}
+	}
 }
 
 .domain-settings-page {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3611

## Proposed Changes

Show the backend error messages instead of a generic error message

### TO DO
- [ ] Fix E2E tests
- [ ] Check all type of errors on add/edit.
- [ ] Check all type of errors on delete.

## Testing Instructions

* Apply D123099-code
* Create a domain forward with an error, like `goggle.co123$#@$@34423` as a Destination URL.
* Check error messages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?