### PR TITLE
Domains: Show SRV records with target `.` correctly

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -157,6 +157,11 @@ class DnsAddNew extends React.Component {
 			return '';
 		}
 
+		// SRV records can have a target of '.', which means that service is unavailable
+		if ( 'SRV' === recordToEdit.type && 'target' === field && '.' === recordToEdit[ field ] ) {
+			return '.';
+		}
+
 		if ( [ 'data', 'target' ].includes( field ) && 'TXT' !== recordToEdit.type ) {
 			return recordToEdit[ field ].replace( /\.$/, '' );
 		}

--- a/client/my-sites/domains/domain-management/dns/dns-record-data.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-record-data.jsx
@@ -21,7 +21,7 @@ class DnsRecordData extends Component {
 		const { dnsRecord, translate } = this.props;
 		const { type, aux, port, weight } = dnsRecord;
 		const data = this.trimDot( dnsRecord.data );
-		const target = this.trimDot( dnsRecord.target );
+		const target = dnsRecord.target !== '.' ? this.trimDot( dnsRecord.target ) : '.';
 
 		// TODO: Remove this once we stop displaying the protected records
 		if ( dnsRecord.protected_field ) {

--- a/client/my-sites/domains/domain-management/settings/dns/dns-record-item.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/dns-record-item.tsx
@@ -10,7 +10,7 @@ const DnsRecordItem = ( { dnsRecord, selectedDomainName }: DnsRecordItemProps ) 
 	const handledBy = () => {
 		const { type, aux, port, weight } = dnsRecord;
 		const data = trimDot( dnsRecord.data );
-		const target = trimDot( dnsRecord.target );
+		const target = '.' !== dnsRecord.target ? trimDot( dnsRecord.target ) : '.';
 
 		// TODO: Remove this once we stop displaying the protected records
 		if ( dnsRecord.protected_field ) {


### PR DESCRIPTION
## Proposed Changes

This PR updates the domain DNS management pages to show SRV records with target `.` correctly. A single period as target indicates that service is unavailable (https://datatracker.ietf.org/doc/html/rfc2782).

Depends on D122917-code.

### Screenshots (before)

- Period is missing in the DNS records list in the domain management page

![Markup on 2023-09-25 at 20:06:54](https://github.com/Automattic/wp-calypso/assets/5324818/a4704245-8959-4643-b260-20f363a7f679)

- Period is missing in the DNS records list

![Markup on 2023-09-25 at 19:56:09](https://github.com/Automattic/wp-calypso/assets/5324818/eb913716-61f3-4217-8f33-8bebf32d7e28)

- "Target" field is empty

![Markup on 2023-09-25 at 19:56:37](https://github.com/Automattic/wp-calypso/assets/5324818/5715edaa-34be-4d81-9a60-c61886fb191b)

### Screenshots (after)

- Period is shown correctly in the DNS records list in the domain management page

![Markup on 2023-09-25 at 20:06:37](https://github.com/Automattic/wp-calypso/assets/5324818/f671659d-b65e-418b-8323-012825b25e42)

- Period is shown correctly in the DNS records list

![Markup on 2023-09-25 at 19:54:28](https://github.com/Automattic/wp-calypso/assets/5324818/c65dd41a-ac51-4588-beb8-7d68ce483112)

- Period is shown correctly in the "target" field
 
![Markup on 2023-09-25 at 19:53:59](https://github.com/Automattic/wp-calypso/assets/5324818/ff1ee22f-8c50-4263-a2d9-e743cf9b3916)

## Testing Instructions

- This PR depends on D122917-code, so please apply that diff to your backend and sandbox `public-api`
- Open the live Calypso link or build this branch locally
- Go to a domain's DNS management page
- Add a SRV record with target `.` (a single period)
- Ensure it looks correct in the domain management page, in the DNS records list page and in the DNS record update page, as shown in the screenshots

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
