### PR TITLE
Launchpad: Fixed `share_site` task modal icon

### DIFF
--- a/client/my-sites/customer-home/components/share-site-modal.tsx
+++ b/client/my-sites/customer-home/components/share-site-modal.tsx
@@ -1,7 +1,7 @@
-import { Gridicon } from '@automattic/components';
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button, Modal } from '@wordpress/components';
+import { Icon, link } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
 import Tooltip from 'calypso/components/tooltip';
@@ -64,7 +64,7 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 							</div>
 
 							<Button onClick={ copyHandler } className="share-site-modal__modal-view-site">
-								<Gridicon icon="link" size={ 18 } />
+								<Icon icon={ link } size={ 22 } />
 								<span className="share-site-modal__modal-view-site-text">
 									{ translate( 'Copy' ) }
 								</span>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82154

## Proposed Changes

* This PR changes the Icon displayed in the "Share Site" Launchpad task.

## Testing Instructions

- Create a new site (`/start`)  using `build` intent.
- Follow onboarding steps until you get to customer home
- Launch the site
- Click on the "Share site" task
- Check the new icon

![image](https://github.com/Automattic/wp-calypso/assets/3801502/79c79c06-256f-4566-9c82-a47a8d700f9c)
