### PR TITLE
Domain transfers: Add pending transfer information

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/style.scss
@@ -59,6 +59,30 @@
 			margin-left: 24px;
 		}
 	}
+
+	.transfer-domain-to-any-user__pending-transfer-card {
+		h2 {
+			font-size: $font-title-small;
+			margin-bottom: 1rem;
+			font-weight: 600;
+		}
+
+		.transfer-domain-to-any-user__pending-detail {
+			margin-bottom: 1rem;
+			overflow: hidden;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+
+			strong {
+				color: var(--studio-gray-70);
+			}
+
+			.transfer-domain-to-any-user__pending-status {
+				color: var(--color-warning);
+			}
+		}
+	}
+
 }
 
 .transfer-domain-to-any-user__notice {

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/style.scss
@@ -15,7 +15,7 @@
 	}
 
 	&__container {
-		margin: 16px;
+		margin: 0 16px 16px 16px;
 
 		@include breakpoint-deprecated( ">660px" ) {
 			margin: 0;
@@ -23,9 +23,6 @@
 	}
 
 	.transfer-domain-to-any-user__container {
-		.transfer-domain-to-any-user__main {
-			margin: 16px;
-		}
 		@include break-xlarge {
 			@include grid-row( 1, 1 );
 			@include grid-column( 1, 12 );

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/transfer-domain-to-any-user.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/transfer-domain-to-any-user.tsx
@@ -9,8 +9,10 @@ import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
-import Notice from 'calypso/components/notice';
+import useDomainTransferRequestDelete from 'calypso/data/domains/transfers/use-domain-transfer-request-delete';
+import useDomainTransferRequestQuery from 'calypso/data/domains/transfers/use-domain-transfer-request-query';
 import useDomainTransferRequestUpdate from 'calypso/data/domains/transfers/use-domain-transfer-request-update';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain } from 'calypso/lib/domains';
@@ -28,12 +30,16 @@ import {
 	isUnderDomainManagementAll,
 } from 'calypso/my-sites/domains/paths';
 import { useSelector } from 'calypso/state';
-import { errorNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import TransferUnavailableNotice from '../transfer-unavailable-notice';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 import './style.scss';
+
+const noticeOptions = {
+	duration: 5000,
+};
 
 export default function TransferDomainToAnyUser( {
 	domains,
@@ -50,25 +56,60 @@ export default function TransferDomainToAnyUser( {
 } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+	const currentRoute = useSelector( getCurrentRoute );
+
+	const { data, isLoading } = useDomainTransferRequestQuery(
+		selectedSite.slug,
+		selectedDomainName
+	);
+	const transferEmail = data?.email ?? false;
+
+	const expiresAt = new Date( data?.requested_at || '' );
+	expiresAt.setHours( expiresAt.getHours() + 24 );
+
 	const [ email, setEmail ] = useState( '' );
 	const [ isValidEmail, setIsValidEmail ] = useState( true );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
-	const [ submitSuccess, setSubmitSuccess ] = useState( false );
-
-	const currentRoute = useSelector( getCurrentRoute );
 
 	const { domainTransferRequestUpdate } = useDomainTransferRequestUpdate(
-		selectedSite?.slug,
+		selectedSite.slug,
 		selectedDomainName,
 		{
 			onSuccess() {
-				setSubmitSuccess( true );
+				dispatch(
+					successNotice(
+						translate( 'A domain transfer request has been emailed to the recipient’s address.' ),
+						noticeOptions
+					)
+				);
 			},
 			onError() {
 				dispatch(
-					errorNotice( translate( 'An error occurred while initiating the domain transfer.' ), {
-						duration: 5000,
-					} )
+					errorNotice(
+						translate( 'An error occurred while initiating the domain transfer.' ),
+						noticeOptions
+					)
+				);
+			},
+		}
+	);
+
+	const { domainTransferRequestDelete } = useDomainTransferRequestDelete(
+		selectedSite.slug,
+		selectedDomainName,
+		{
+			onSuccess() {
+				dispatch(
+					successNotice( translate( 'Your domain transfer has been cancelled.' ), noticeOptions )
+				);
+			},
+			onError() {
+				dispatch(
+					errorNotice(
+						translate( 'The domain transfer cannot be cancelled at this time.' ),
+						noticeOptions
+					)
 				);
 			},
 		}
@@ -79,7 +120,7 @@ export default function TransferDomainToAnyUser( {
 		selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
 	}
 
-	const isLoading = ! hasSiteDomainsLoaded || isRequestingSiteDomains;
+	const disableForm = ! hasSiteDomainsLoaded || isRequestingSiteDomains || transferEmail;
 
 	const handleEmailChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		const email = event.target.value;
@@ -104,6 +145,17 @@ export default function TransferDomainToAnyUser( {
 		}
 
 		domainTransferRequestUpdate( email );
+
+		return false;
+	};
+
+	const handleDelete = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+
+		setEmail( '' );
+		setIsValidEmail( true );
+		setErrorMessage( '' );
+		domainTransferRequestDelete();
 
 		return false;
 	};
@@ -136,18 +188,6 @@ export default function TransferDomainToAnyUser( {
 
 		return (
 			<Card className="transfer-domain-to-any-user__card">
-				{ submitSuccess && (
-					<Notice
-						text={ translate(
-							'A domain transfer request has been emailed to the recipient’s address.'
-						) }
-						status="is-success"
-						onDismissClick={ () => {
-							setSubmitSuccess( false );
-							setEmail( '' );
-						} }
-					/>
-				) }
 				<p>
 					{ translate(
 						'You can transfer the domain to any WordPress.com user. If the user does not have a WordPress.com account, they will be prompted to create one.'
@@ -158,45 +198,73 @@ export default function TransferDomainToAnyUser( {
 						'The recipient will need to provide updated contact information and accept the request before the domain transfer can be completed.'
 					) }
 				</p>
+				{ transferEmail && (
+					<Card className="transfer-domain-to-any-user__pending-transfer-card">
+						<form onSubmit={ handleDelete }>
+							<h2>{ translate( 'Domain transfer pending' ) }</h2>
+							<div className="transfer-domain-to-any-user__pending-detail">
+								<strong>{ translate( 'Status' ) }</strong>
+								<div>
+									<span className="transfer-domain-to-any-user__pending-status">
+										{ translate( 'Pending' ) }
+									</span>
+								</div>
+							</div>
+							<div className="transfer-domain-to-any-user__pending-detail">
+								<strong>{ translate( 'Transfer receipient' ) }</strong>
+								<div>
+									<span>{ transferEmail }</span>
+								</div>
+							</div>
 
-				<form onSubmit={ handleSubmit }>
-					<FormFieldset>
-						<FormLabel>{ translate( 'Enter domain recipient’s email for transfer' ) }</FormLabel>
-						<FormTextInput
-							disabled={ isLoading }
-							name="email"
-							onChange={ handleEmailChange }
-							value={ email }
-							className={ classNames( 'transfer-domain-to-any-user__input', {
-								'is-error': ! isValidEmail,
-							} ) }
-							maxLength={ 1000 }
-						/>
-						{ ! isValidEmail && <FormInputValidation isError={ true } text={ errorMessage } /> }
-					</FormFieldset>
-					<div className="transfer-domain-to-any-user__notice">
-						<Gridicon icon="info-outline" size={ 18 } />
-						<p>
-							{ translate(
-								'Transferring a domain to another user will give all the rights of this domain to that user. You will no longer be able to manage the domain.'
-							) }
-						</p>
-					</div>
-					{ hasEmailWithUs && (
+							<div className="transfer-domain-to-any-user__pending-detail">
+								<strong>{ translate( 'Valid until' ) }</strong>
+								<div>{ moment( expiresAt ).format( 'LLL' ) }</div>
+							</div>
+							<FormButton type="submit">{ translate( 'Cancel transfer' ) }</FormButton>
+						</form>
+					</Card>
+				) }
+				{ ! transferEmail && (
+					<form onSubmit={ handleSubmit }>
+						<FormFieldset>
+							<FormLabel>{ translate( 'Enter domain recipient’s email for transfer' ) }</FormLabel>
+							<FormTextInput
+								disabled={ disableForm }
+								name="email"
+								onChange={ handleEmailChange }
+								value={ email }
+								className={ classNames( 'transfer-domain-to-any-user__input', {
+									'is-error': ! isValidEmail,
+								} ) }
+								maxLength={ 1000 }
+							/>
+							{ ! isValidEmail && <FormInputValidation isError={ true } text={ errorMessage } /> }
+						</FormFieldset>
 						<div className="transfer-domain-to-any-user__notice">
 							<Gridicon icon="info-outline" size={ 18 } />
 							<p>
 								{ translate(
-									'The email subscription for %(domainName)s will be transferred along with the domain.',
-									{ args: { domainName: selectedDomainName } }
+									'Transferring a domain to another user will give all the rights of this domain to that user. You will no longer be able to manage the domain.'
 								) }
 							</p>
 						</div>
-					) }
-					<FormButton disabled={ isLoading } type="submit">
-						{ translate( 'Transfer domain' ) }
-					</FormButton>
-				</form>
+						{ hasEmailWithUs && (
+							<div className="transfer-domain-to-any-user__notice">
+								<Gridicon icon="info-outline" size={ 18 } />
+								<p>
+									{ translate(
+										'The email subscription for %(domainName)s will be transferred along with the domain.',
+										{ args: { domainName: selectedDomainName } }
+									) }
+								</p>
+							</div>
+						) }
+						<FormButton disabled={ disableForm } type="submit">
+							{ translate( 'Transfer domain' ) }
+						</FormButton>
+					</form>
+				) }
 			</Card>
 		);
 	};

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/transfer-domain-to-any-user.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/transfer-domain-to-any-user.tsx
@@ -150,7 +150,7 @@ export default function TransferDomainToAnyUser( {
 				) }
 				<p>
 					{ translate(
-						'You can transfer the domain to any WordPress.com user, even if they do not have a site. If the user does not have a WordPress.com account, they will be prompted to create one.'
+						'You can transfer the domain to any WordPress.com user. If the user does not have a WordPress.com account, they will be prompted to create one.'
 					) }
 				</p>
 				<p>

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/transfer-domain-to-any-user.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/transfer-domain-to-any-user.tsx
@@ -120,7 +120,7 @@ export default function TransferDomainToAnyUser( {
 		selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
 	}
 
-	const disableForm = ! hasSiteDomainsLoaded || isRequestingSiteDomains || transferEmail;
+	const disableForm = ! hasSiteDomainsLoaded || isRequestingSiteDomains || isLoading;
 
 	const handleEmailChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		const email = event.target.value;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3685

## Proposed Changes

* Adds pending transfers and a button to cancel the transfer

## Testing Instructions

* http://calypso.localhost:3000/domains/manage/all/test-345678.blog/transfer/any-user/test-345678.blog
* Enter an email address
* View the new transfer information
* Clear the transfer

![Screenshot 2023-09-26 at 15-06-39 test-345678 blog — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/f51dcd99-deaa-4c53-b890-c996f5eb2d65)

https://github.com/Automattic/wp-calypso/assets/811776/ed69aae5-be4a-4283-a395-16f2cdabdc08

