### PR TITLE
Enable the storage add-on feature flag across envs.

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -145,7 +145,7 @@
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plans/updated-storage-labels": true,
-		"plans/upgradeable-storage": false,
+		"plans/upgradeable-storage": true,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -88,7 +88,7 @@
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plans/updated-storage-labels": true,
-		"plans/upgradeable-storage": false,
+		"plans/upgradeable-storage": true,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,

--- a/config/production.json
+++ b/config/production.json
@@ -111,7 +111,7 @@
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plans/updated-storage-labels": true,
-		"plans/upgradeable-storage": false,
+		"plans/upgradeable-storage": true,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -108,7 +108,7 @@
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plans/updated-storage-labels": true,
-		"plans/upgradeable-storage": false,
+		"plans/upgradeable-storage": true,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -118,7 +118,7 @@
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plans/updated-storage-labels": true,
-		"plans/upgradeable-storage": false,
+		"plans/upgradeable-storage": true,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#2023

## Proposed Changes

This PR enables the storage add-on dropdown in /start across envs. 

## Testing Instructions

Confirm that the storage add-on dropdown works as expected in `/start/`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
