### PR TITLE
Design Picker: redirect to Theme Showcase if preselected theme is unlisted in the grid

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
@@ -16,6 +16,7 @@ const useRecipe = (
 	siteId = 0,
 	allDesigns: StarterDesigns | undefined,
 	pickDesign: ( design?: Design, options?: { shouldGoToAssembler: boolean } ) => void,
+	pickUnlistedDesign: ( theme: string ) => void,
 	recordPreviewDesign: ( design: Design, styleVariation?: StyleVariation ) => void,
 	recordPreviewStyleVariation: ( design: Design, styleVariation?: StyleVariation ) => void
 ) => {
@@ -187,6 +188,7 @@ const useRecipe = (
 				: design.slug === preselectedTheme
 		);
 		if ( ! requestedDesign ) {
+			pickUnlistedDesign( preselectedTheme );
 			return;
 		}
 
@@ -204,6 +206,7 @@ const useRecipe = (
 		preselectedTheme,
 		preselectedStyle,
 		allDesigns,
+		pickUnlistedDesign,
 		setSelectedDesign,
 		setSelectedStyleVariation,
 	] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -121,6 +121,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	);
 	useEffect( () => {
 		if ( isAtomic ) {
+			// TODO: move this logic from this step to the flow(s). See: https://wp.me/pdDR7T-KR
 			exitFlow?.( `/site-editor/${ siteSlugOrId }` );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -205,6 +206,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		site?.ID,
 		allDesigns,
 		pickDesign,
+		pickUnlistedDesign,
 		recordPreviewDesign,
 		recordPreviewStyleVariation
 	);
@@ -619,6 +621,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				{ ...( positionIndex >= 0 && { position_index: positionIndex } ) }
 			);
 		}
+	}
+
+	function pickUnlistedDesign( theme: string ) {
+		// TODO: move this logic from this step to the flow(s). See: https://wp.me/pdDR7T-KR
+		exitFlow?.( `/theme/${ theme }/${ siteSlug }` );
 	}
 
 	function designYourOwn( design: Design ) {


### PR DESCRIPTION
Related to:

- #78556

## Proposed Changes

In the `/with-theme` flow, when the user selects a Free or Premium theme from Logged-out Theme Showcase, we send the user to the Design Picker with the preselected theme in the preview mode. See:

- https://github.com/Automattic/wp-calypso/pull/76040

However, not all Free and Premium themes are listed in the Design Picker grid. This flow is broken for such themes.

This PR fixes this by redirecting the user to the Logged-in Theme Showcase instead.

This is not the cleanest solution, as the Design Picker step is making the decision to exit the flow. We might consider to refactor this logic in the future. See: pdDR7T-KR-p2 

## Testing Instructions

1. Checkout this PR or use Calypso Live.
2. Log out.
3. Open `/themes`.
4. Select one of these themes (or repeat the testing instructions with all of them)
   - Geologist - Slate (a "delisted" variation of Geologist, a free theme)
   - Videomaker White (a "delisted" variation of Videomaker, a premium theme)
   - Heiwa (a delisted theme, to be retired)
5. Go through the user signup process.
6. Go through the domain and plan selection.
7. Verify that you land in the theme details page in the Theme Showcase.
8. Verify that the theme is actually activated.

|Before|After|
|-|-|
|<img width="1543" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/2f21cd06-040f-4ba9-9cc4-2622976b9961">|<img width="1479" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/76c1f661-b493-444f-ba42-fc6fa6b3a77b">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?