### PR TITLE
Site Profiler: add custom document title

### DIFF
--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -53,7 +53,7 @@ export default function SiteProfiler() {
 				<LayoutBlock className="domain-result-block">
 					{
 						// Translators: %s is the domain name searched
-						<DocumentHead title={ translate( '%s < Site Profiler', { args: [ domain ] } ) } />
+						<DocumentHead title={ translate( '%s ‹ Site Profiler', { args: [ domain ] } ) } />
 					}
 					{ data && (
 						<LayoutBlockSection>

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -1,4 +1,6 @@
+import { translate } from 'i18n-calypso';
 import { useNavigate, useLocation } from 'react-router-dom';
+import DocumentHead from 'calypso/components/data/document-head';
 import { useDomainAnalyzerQuery } from 'calypso/data/site-profiler/use-domain-analyzer-query';
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -38,6 +40,7 @@ export default function SiteProfiler() {
 		<>
 			{ ! data && (
 				<LayoutBlock className="domain-analyzer-block" width="medium">
+					<DocumentHead title={ translate( 'Site Profiler' ) } />
 					<DomainAnalyzer
 						domain={ domain }
 						onFormSubmit={ updateDomainQueryParam }
@@ -48,6 +51,10 @@ export default function SiteProfiler() {
 
 			{ data && (
 				<LayoutBlock className="domain-result-block">
+					{
+						// Translators: %s is the domain name searched
+						<DocumentHead title={ translate( '%s < Site Profiler', { args: [ domain ] } ) } />
+					}
 					{ data && (
 						<LayoutBlockSection>
 							<HeadingInformation


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82161

## Proposed Changes

* Change document title of Site Profiler page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site-profiler`
* The document title should be `Site Profiler - WordPress.com`
* Search for a domain
* The document title should be `__domain_name__ < Site Profiler - WordPress.com` 
* Search for another domain, before entering the new URL the title should go back to `Site Profiler - WordPress.com`

![image](https://github.com/Automattic/wp-calypso/assets/167611/a00c7daa-ef0e-4e52-8929-200b4fe35069)

![image](https://github.com/Automattic/wp-calypso/assets/167611/77ba9bcc-e7f9-459a-8403-c041e6cceb6a)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?