### PR TITLE
Added a feature flag for the v2 search experience

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -202,6 +202,7 @@
 		"themes/block-theme-previews": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
+		"themes/search-v2": true,
 		"themes/subscription-purchases": true,
 		"themes/theme-switch-persist-template": false,
 		"titan/iframe-control-panel": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -138,6 +138,7 @@
 		"themes/block-theme-previews": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
+		"themes/search-v2": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
 		"unified-pages/virtual-home-page": true,

--- a/config/production.json
+++ b/config/production.json
@@ -167,6 +167,7 @@
 		"themes/block-theme-previews": false,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
+		"themes/search-v2": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
 		"unified-pages/virtual-home-page": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -162,6 +162,7 @@
 		"themes/block-theme-previews": false,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
+		"themes/search-v2": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
 		"unified-pages/virtual-home-page": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -172,6 +172,7 @@
 		"themes/block-theme-previews": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
+		"themes/search-v2": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
 		"unified-pages/virtual-home-page": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/82164

## Proposed Changes

* Added a feature flag so that we can develop the new search experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch locally.
* Run this command: `yarn feature-search themes/search `
* You should see that the feature is only enabled in development.

![Captura de pantalla 2023-09-26 a las 10 21 05](https://github.com/Automattic/wp-calypso/assets/1989914/5dd755f0-f562-4946-86f2-c7c0f4309291)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?