### PR TITLE
Staging Sites: Add staging to production sync

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -16,7 +16,8 @@ const SiteRow = styled.div( {
 	'.site-icon': { flexShrink: 0 },
 } );
 
-const LeftActionsContainer = styled.div( {
+const SyncActionsContainer = styled.div( {
+	marginTop: 12,
 	gap: '1em',
 	display: 'flex',
 	flexDirection: 'row',
@@ -61,10 +62,6 @@ const ActionButtons = styled.div( {
 		flexDirection: 'column',
 		'.button': { flexGrow: 1 },
 	},
-} );
-
-const ActionButtonsJustifyBetween = styled( ActionButtons )( {
-	justifyContent: 'space-between',
 } );
 
 type CardContentProps = {
@@ -185,14 +182,16 @@ export const ManageStagingSiteCardContent = ( {
 					</SiteInfo>
 				</SiteRow>
 				{ isStagingSitesI3Enabled ? (
-					<ActionButtonsJustifyBetween>
-						<LeftActionsContainer>
+					<>
+						<ActionButtons>
 							<ManageStagingSiteButton />
+							<ConfirmationDeleteButton />
+						</ActionButtons>
+						<SyncActionsContainer>
 							<ConfirmationPushChangesButton />
 							<ConfirmationPullChangesButton />
-						</LeftActionsContainer>
-						<ConfirmationDeleteButton />
-					</ActionButtonsJustifyBetween>
+						</SyncActionsContainer>
+					</>
 				) : (
 					<ActionButtons>
 						<ManageStagingSiteButton />

--- a/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -71,6 +71,7 @@ type CardContentProps = {
 	stagingSite: StagingSite;
 	onDeleteClick: () => void;
 	onPushClick: () => void;
+	onPullClick: () => void;
 	isButtonDisabled: boolean;
 	isBusy: boolean;
 };
@@ -79,6 +80,7 @@ export const ManageStagingSiteCardContent = ( {
 	stagingSite,
 	onDeleteClick,
 	onPushClick,
+	onPullClick,
 	isButtonDisabled,
 	isBusy,
 }: CardContentProps ) => {
@@ -100,6 +102,24 @@ export const ManageStagingSiteCardContent = ( {
 				>
 					<Gridicon icon="arrow-up" />
 					<span>{ translate( 'Push to staging' ) }</span>
+				</ConfirmationModal>
+			);
+		};
+
+		const ConfirmationPullChangesButton = () => {
+			return (
+				<ConfirmationModal
+					disabled={ isButtonDisabled }
+					onConfirm={ onPullClick }
+					modalTitle={ translate( 'Confirm pull your changes to your production site' ) }
+					modalMessage={ translate(
+						'Are you sure you want to pull your staging changes to your production site?'
+					) }
+					confirmLabel={ translate( 'Pull from staging' ) }
+					cancelLabel={ translate( 'Cancel' ) }
+				>
+					<Gridicon icon="arrow-down" />
+					<span>{ translate( 'Pull from staging' ) }</span>
 				</ConfirmationModal>
 			);
 		};
@@ -169,6 +189,7 @@ export const ManageStagingSiteCardContent = ( {
 						<LeftActionsContainer>
 							<ManageStagingSiteButton />
 							<ConfirmationPushChangesButton />
+							<ConfirmationPullChangesButton />
 						</LeftActionsContainer>
 						<ConfirmationDeleteButton />
 					</ActionButtonsJustifyBetween>

--- a/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -113,7 +113,7 @@ export const ManageStagingSiteCardContent = ( {
 					onConfirm={ onPullClick }
 					modalTitle={ translate( 'Confirm pull your changes from your staging site' ) }
 					modalMessage={ translate(
-						'Are you sure you want to pull your staging changes to your production site?'
+						'Are you sure you want to pull your changes from your staging site?'
 					) }
 					confirmLabel={ translate( 'Pull from staging' ) }
 					cancelLabel={ translate( 'Cancel' ) }

--- a/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -92,7 +92,7 @@ export const ManageStagingSiteCardContent = ( {
 					onConfirm={ onPushClick }
 					modalTitle={ translate( 'Confirm pushing changes to your staging site' ) }
 					modalMessage={ translate(
-						'Are you sure you want to push your production changes to your staging site?'
+						'Are you sure you want to push your changes to your staging site?'
 					) }
 					confirmLabel={ translate( 'Push to staging' ) }
 					cancelLabel={ translate( 'Cancel' ) }

--- a/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -111,7 +111,7 @@ export const ManageStagingSiteCardContent = ( {
 				<ConfirmationModal
 					disabled={ isButtonDisabled }
 					onConfirm={ onPullClick }
-					modalTitle={ translate( 'Confirm pull your changes to your production site' ) }
+					modalTitle={ translate( 'Confirm pull your changes from your staging site' ) }
 					modalMessage={ translate(
 						'Are you sure you want to pull your staging changes to your production site?'
 					) }

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -24,7 +24,7 @@ import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteId, getSelectedSite } from 'calypso/state/ui/selectors';
 import { useDeleteStagingSite } from './use-delete-staging-site';
-import { usePushToStagingMutation } from './use-staging-sync';
+import { usePullFromStagingMutation, usePushToStagingMutation } from './use-staging-sync';
 const stagingSiteAddSuccessNoticeId = 'staging-site-add-success';
 const stagingSiteAddFailureNoticeId = 'staging-site-add-failure';
 const stagingSiteDeleteSuccessNoticeId = 'staging-site-remove-success';
@@ -216,6 +216,16 @@ export const StagingSiteCard = ( {
 		},
 	} );
 
+	const { pullFromStaging } = usePullFromStagingMutation( siteId, stagingSite?.id, {
+		onError: ( error ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_hosting_configuration_staging_site_pull_failure', {
+					code: error.code,
+				} )
+			);
+		},
+	} );
+
 	const getTransferringStagingSiteContent = useCallback( () => {
 		return (
 			<>
@@ -271,6 +281,7 @@ export const StagingSiteCard = ( {
 				stagingSite={ stagingSite }
 				onDeleteClick={ deleteStagingSite }
 				onPushClick={ pushToStaging }
+				onPullClick={ pullFromStaging }
 				isButtonDisabled={ disabled }
 				isBusy={ isReverting }
 			/>

--- a/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
@@ -107,7 +107,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 						<>
 							<ConfirmationModal
 								onConfirm={ pushToStaging }
-								modalTitle={ translate( 'Confirm pulling changes to your staging site.' ) }
+								modalTitle={ translate( 'Confirm pulling changes from your production site.' ) }
 								modalMessage={ translate(
 									'Are you sure you want to pull your changes from your production site?'
 								) }

--- a/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
@@ -26,6 +26,10 @@ const ActionButtons = styled.div( {
 	gap: '1em',
 } );
 
+const SyncActionsContainer = styled( ActionButtons )( {
+	marginTop: 12,
+} );
+
 type CardProps = {
 	disabled: boolean;
 	siteId: number;
@@ -103,35 +107,35 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 					>
 						<span>{ __( 'Switch to production site' ) }</span>
 					</Button>
-					{ isStagingSitesI3Enabled && (
-						<>
-							<ConfirmationModal
-								onConfirm={ pushToStaging }
-								modalTitle={ translate( 'Confirm pulling changes from your production site.' ) }
-								modalMessage={ translate(
-									'Are you sure you want to pull your changes from your production site?'
-								) }
-								confirmLabel={ translate( 'Pull from production' ) }
-								cancelLabel={ translate( 'Cancel' ) }
-							>
-								<Gridicon icon="arrow-down" />
-								<span>{ translate( 'Pull from production' ) }</span>
-							</ConfirmationModal>
-							<ConfirmationModal
-								onConfirm={ pullFromStaging }
-								modalTitle={ translate( 'Confirm pushing changes to your production site.' ) }
-								modalMessage={ translate(
-									'Are you sure you want to push your changes to your production site?'
-								) }
-								confirmLabel={ translate( 'Push to production' ) }
-								cancelLabel={ translate( 'Cancel' ) }
-							>
-								<Gridicon icon="arrow-up" />
-								<span>{ translate( 'Push to production' ) }</span>
-							</ConfirmationModal>
-						</>
-					) }
 				</ActionButtons>
+				{ isStagingSitesI3Enabled && (
+					<SyncActionsContainer>
+						<ConfirmationModal
+							onConfirm={ pushToStaging }
+							modalTitle={ translate( 'Confirm pulling changes from your production site.' ) }
+							modalMessage={ translate(
+								'Are you sure you want to pull your changes from your production site?'
+							) }
+							confirmLabel={ translate( 'Pull from production' ) }
+							cancelLabel={ translate( 'Cancel' ) }
+						>
+							<Gridicon icon="arrow-down" />
+							<span>{ translate( 'Pull from production' ) }</span>
+						</ConfirmationModal>
+						<ConfirmationModal
+							onConfirm={ pullFromStaging }
+							modalTitle={ translate( 'Confirm pushing changes to your production site.' ) }
+							modalMessage={ translate(
+								'Are you sure you want to push your changes to your production site?'
+							) }
+							confirmLabel={ translate( 'Push to production' ) }
+							cancelLabel={ translate( 'Cancel' ) }
+						>
+							<Gridicon icon="arrow-up" />
+							<span>{ translate( 'Push to production' ) }</span>
+						</ConfirmationModal>
+					</SyncActionsContainer>
+				) }
 			</>
 		);
 	};

--- a/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
@@ -109,7 +109,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 								onConfirm={ pushToStaging }
 								modalTitle={ translate( 'Confirm pulling changes to your staging site.' ) }
 								modalMessage={ translate(
-									'Are you sure you want to pull your production changes to your staging site?'
+									'Are you sure you want to pull your changes from your production site?'
 								) }
 								confirmLabel={ translate( 'Pull from production' ) }
 								cancelLabel={ translate( 'Cancel' ) }

--- a/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
@@ -19,7 +19,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { IAppState } from 'calypso/state/types';
 import { ConfirmationModal } from './confirmation-modal';
-import { usePushToStagingMutation } from './use-staging-sync';
+import { usePullFromStagingMutation, usePushToStagingMutation } from './use-staging-sync';
 
 const ActionButtons = styled.div( {
 	display: 'flex',
@@ -51,6 +51,18 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	} );
 
 	const { pushToStaging } = usePushToStagingMutation( productionSite?.id as number, siteId, {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		onError: ( error: any ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_hosting_configuration_staging_site_push_failure', {
+					code: error.code,
+				} )
+			);
+			setLoadingError( error );
+		},
+	} );
+
+	const { pullFromStaging } = usePullFromStagingMutation( productionSite?.id as number, siteId, {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		onError: ( error: any ) => {
 			dispatch(
@@ -92,18 +104,32 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 						<span>{ __( 'Switch to production site' ) }</span>
 					</Button>
 					{ isStagingSitesI3Enabled && (
-						<ConfirmationModal
-							onConfirm={ pushToStaging }
-							modalTitle={ translate( 'Confirm pulling changes to your staging site.' ) }
-							modalMessage={ translate(
-								'Are you sure you want to pull your production changes to your staging site?'
-							) }
-							confirmLabel={ translate( 'Pull from production' ) }
-							cancelLabel={ translate( 'Cancel' ) }
-						>
-							<Gridicon icon="arrow-down" />
-							<span>{ translate( 'Pull from production' ) }</span>
-						</ConfirmationModal>
+						<>
+							<ConfirmationModal
+								onConfirm={ pushToStaging }
+								modalTitle={ translate( 'Confirm pulling changes to your staging site.' ) }
+								modalMessage={ translate(
+									'Are you sure you want to pull your production changes to your staging site?'
+								) }
+								confirmLabel={ translate( 'Pull from production' ) }
+								cancelLabel={ translate( 'Cancel' ) }
+							>
+								<Gridicon icon="arrow-down" />
+								<span>{ translate( 'Pull from production' ) }</span>
+							</ConfirmationModal>
+							<ConfirmationModal
+								onConfirm={ pullFromStaging }
+								modalTitle={ translate( 'Confirm pushing changes to your production site.' ) }
+								modalMessage={ translate(
+									'Are you sure you want to push your staging changes to your production site?'
+								) }
+								confirmLabel={ translate( 'Push to production' ) }
+								cancelLabel={ translate( 'Cancel' ) }
+							>
+								<Gridicon icon="arrow-up" />
+								<span>{ translate( 'Push to production' ) }</span>
+							</ConfirmationModal>
+						</>
 					) }
 				</ActionButtons>
 			</>

--- a/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
@@ -121,7 +121,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 								onConfirm={ pullFromStaging }
 								modalTitle={ translate( 'Confirm pushing changes to your production site.' ) }
 								modalMessage={ translate(
-									'Are you sure you want to push your staging changes to your production site?'
+									'Are you sure you want to push your changes to your production site?'
 								) }
 								confirmLabel={ translate( 'Push to production' ) }
 								cancelLabel={ translate( 'Cancel' ) }

--- a/client/my-sites/hosting/staging-site-card/test/index.js
+++ b/client/my-sites/hosting/staging-site-card/test/index.js
@@ -87,6 +87,11 @@ jest.mock( 'calypso/my-sites/hosting/staging-site-card/use-staging-sync', () => 
 			pushToStaging: jest.fn(),
 		};
 	} ),
+	usePullFromStagingMutation: jest.fn( () => {
+		return {
+			pullFromStaging: jest.fn(),
+		};
+	} ),
 } ) );
 
 jest.mock( 'calypso/my-sites/hosting/staging-site-card/use-staging-site', () => ( {

--- a/client/my-sites/hosting/staging-site-card/use-staging-sync.ts
+++ b/client/my-sites/hosting/staging-site-card/use-staging-sync.ts
@@ -11,6 +11,7 @@ interface PushStagingMutationError {
 }
 
 export const PUSH_TO_STAGING = 'push-to-staging-site-mutation-key';
+export const PULL_FROM_STAGING = 'pull-from-staging-site-mutation-key';
 
 export const usePushToStagingMutation = (
 	productionSiteId: number,
@@ -37,4 +38,31 @@ export const usePushToStagingMutation = (
 	const isLoading = useIsMutating( { mutationKey: [ PUSH_TO_STAGING, stagingSiteId ] } ) > 0;
 
 	return { pushToStaging: mutate, isLoading };
+};
+
+export const usePullFromStagingMutation = (
+	productionSiteId: number,
+	stagingSiteId: number,
+	options: UseMutationOptions< PushStagingMutationResponse, PushStagingMutationError >
+) => {
+	const mutation = useMutation( {
+		mutationFn: async () =>
+			wp.req.post( {
+				path: `/sites/${ productionSiteId }/staging-site/pull-from-staging/${ stagingSiteId }`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		...options,
+		mutationKey: [ PULL_FROM_STAGING, stagingSiteId ],
+		onSuccess: async ( ...args ) => {
+			options.onSuccess?.( ...args );
+		},
+	} );
+
+	const { mutate } = mutation;
+	// isMutating is returning a number. Greater than 0 means we have some pending mutations for
+	// the provided key. This is preserved across different pages, while isLoading it's not.
+	// TODO: Remove that when react-query v5 is out. They seem to have added isPending variable for this.
+	const isLoading = useIsMutating( { mutationKey: [ PULL_FROM_STAGING, stagingSiteId ] } ) > 0;
+
+	return { pullFromStaging: mutate, isLoading };
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3692

## Proposed Changes

This pr adds a prototype for staging -> production sync

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Apply D123500-code

### Test 1: UI
1. Create a WoA site
2. Add a staging site
3. While being on the production site, ensure that you see a "Pull from staging" button like below:
![2023-09-28T12:11:17,419544892+03:00](https://github.com/Automattic/wp-calypso/assets/497103/4de55783-bcdb-4408-a892-022ea913a864)

4. Press the button. Ensure that you see the following modal:
![2023-09-28T12:11:53,828376063+03:00](https://github.com/Automattic/wp-calypso/assets/497103/899f462a-dbf3-4271-b8c6-b75a9e3a3fd8)
5. Navigate to the staging side:
6. Ensure that you see a "Push to production" button.
![2023-09-28T12:11:26,588236491+03:00](https://github.com/Automattic/wp-calypso/assets/497103/54e1e098-48f5-4bd0-9263-1b07980b3b11)
7. Press the button. Ensure that you see the following modal:
![2023-09-28T12:11:36,956043091+03:00](https://github.com/Automattic/wp-calypso/assets/497103/42eee2f1-0ffa-4483-94af-c951e9eb79aa)

### Test 2: Functionality
1. Create a WoA site
2. Add a staging site
3. Apply D123500-code.
4. At your staging site, change your theme ( eg: `Awburn` ).
5. While on the production side, press the pull button. Ensure that the endpoint called is `/wpcom/v2/sites/<prod_id>/staging-site/pull-from-staging/<staging_id>`
6. While on the staging side, press the push button. Ensure that the endpoint called is `/wpcom/v2/sites/<production_id>/staging-site/pull-from-staging/<staging_site_id>`
7. Navigate to rewind debugger. Ensure that you see a new queued job.
9. Navigate to `Appearance -> Themes` at your production site and ensure that your theme has been changed.

### Test 3: Analytics
1. Create a WoA site
2. Add a staging site
3. Apply D123500-code
4. Change the code to return an error.
5. While on the production side, press the push button. Ensure that you see `calypso_hosting_configuration_staging_site_pull_failure` event to being dispatched.
6. While on the staging side, press the pull button.  Ensure that you see `calypso_hosting_configuration_staging_site_pull_failure` being dispatched.


NOTE: Please ignore the ugly buttons for now. The UI will be redesigned in an upcoming pr

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?