### PR TITLE
Reader: add follow-tag button to discover page

### DIFF
--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -84,7 +84,7 @@ const DiscoverStream = ( props ) => {
 				</>
 			);
 		} else if ( ! ( isDefaultTab || selectedTab === 'latest' ) ) {
-			return <ReaderTagSidebar tag={ selectedTab } />;
+			return <ReaderTagSidebar tag={ selectedTab } showFollow={ true } />;
 		}
 	};
 

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -107,7 +107,6 @@ const ReaderTagSidebar = ( { tag, showFollow } ) => {
 					<FollowButton
 						followLabel={ translate( 'Follow tag' ) }
 						followingLabel={ translate( 'Following tag' ) }
-						iconSize={ 24 }
 						following={ isFollowing }
 						onFollowToggle={ toggleFollowing }
 						followIcon={ ReaderFollowFeedIcon( { iconSize: 20 } ) }

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -3,18 +3,24 @@ import { Button } from '@automattic/components';
 import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
+import FollowButton from 'calypso/blocks/follow-button/button';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
 import { useRelatedMetaByTag } from 'calypso/data/reader/use-related-meta-by-tag';
 import { useTagStats } from 'calypso/data/reader/use-tag-stats';
 import formatNumberCompact from 'calypso/lib/format-number-compact';
+import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl } from 'calypso/lib/paths';
+import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-icon';
+import ReaderFollowingFeedIcon from 'calypso/reader/components/icons/following-feed-icon';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import ReaderListFollowingItem from 'calypso/reader/stream/reader-list-followed-sites/item';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { requestFollowTag, requestUnfollowTag } from 'calypso/state/reader/tags/items/actions';
+import { getReaderTagBySlug } from 'calypso/state/reader/tags/selectors';
 import '../style.scss';
 
-const ReaderTagSidebar = ( { tag } ) => {
+const ReaderTagSidebar = ( { tag, showFollow } ) => {
 	const translate = useTranslate();
 	const relatedMetaByTag = useRelatedMetaByTag( tag );
 	const tagStats = useTagStats( tag );
@@ -25,6 +31,8 @@ const ReaderTagSidebar = ( { tag } ) => {
 		redirectTo: pathname,
 		ref: 'reader-tag-sidebar',
 	} );
+	const isFollowing = useSelector( ( state ) => getReaderTagBySlug( state, tag )?.isFollowing );
+	const isLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
 
 	if ( relatedMetaByTag === undefined ) {
 		return null;
@@ -58,6 +66,24 @@ const ReaderTagSidebar = ( { tag } ) => {
 	) );
 	const tagsPageUrl = addLocaleToPathLocaleInFront( '/tags' );
 
+	const toggleFollowing = () => {
+		const toggleAction = isFollowing ? requestUnfollowTag : requestFollowTag;
+		if ( ! isLoggedIn ) {
+			return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
+		}
+
+		dispatch( toggleAction( tag ) );
+		recordAction( isFollowing ? 'unfollowed_topic' : 'followed_topic' );
+		recordGaEvent( isFollowing ? 'Clicked Unfollow Topic' : 'Clicked Follow Topic', tag );
+		dispatch(
+			recordReaderTracksEvent(
+				isFollowing ? 'calypso_reader_reader_tag_unfollowed' : 'calypso_reader_reader_tag_followed',
+				{
+					tag: tag,
+				}
+			)
+		);
+	};
 	return (
 		<>
 			{ tagStats && (
@@ -74,6 +100,19 @@ const ReaderTagSidebar = ( { tag } ) => {
 						</span>
 						<span className="reader-tag-sidebar-stats__title">{ translate( 'Sites' ) }</span>
 					</div>
+				</div>
+			) }
+			{ showFollow && (
+				<div className="reader-tag-sidebar-related-tags__follow-button">
+					<FollowButton
+						followLabel={ translate( 'Follow tag' ) }
+						followingLabel={ translate( 'Following tag' ) }
+						iconSize={ 24 }
+						following={ isFollowing }
+						onFollowToggle={ toggleFollowing }
+						followIcon={ ReaderFollowFeedIcon( { iconSize: 20 } ) }
+						followingIcon={ ReaderFollowingFeedIcon( { iconSize: 20 } ) }
+					/>
 				</div>
 			) }
 			{ tagLinks && (

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -721,6 +721,9 @@
 			margin-bottom: 14px;
 		}
 	}
+	.reader-tag-sidebar-related-tags__follow-button {
+		margin-bottom: 20px;
+	}
 	.reader-tag-sidebar-tags-page {
 		display: block;
 		font-size: $font-body-small;

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -722,7 +722,8 @@
 		}
 	}
 	.reader-tag-sidebar-related-tags__follow-button {
-		margin-bottom: 20px;
+		// compensate for line height so that visual margin is 36px;
+		margin-bottom: 27px;
 	}
 	.reader-tag-sidebar-tags-page {
 		display: block;
@@ -737,7 +738,8 @@
 		display: flex;
 		flex-direction: row;
 		gap: 20px;
-		margin-bottom: 32px;
+		// compensate for line height so that visual margin is 36px;
+		margin-bottom: 29px;
 
 		.reader-tag-sidebar-stats__item {
 			display: flex;

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -43,7 +43,6 @@ class TagStreamHeader extends Component {
 						<FollowButton
 							followLabel={ translate( 'Follow tag' ) }
 							followingLabel={ translate( 'Following tag' ) }
-							iconSize={ 24 }
 							following={ following }
 							onFollowToggle={ onFollowToggle }
 							followIcon={ ReaderFollowFeedIcon( { iconSize: 20 } ) }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -153,7 +153,9 @@ class TagStream extends Component {
 				streamHeader={ tagHeader }
 				showSiteNameOnCards={ false }
 				useCompactCards={ true }
-				streamSidebar={ () => <ReaderTagSidebar tag={ this.props.decodedTagSlug } /> }
+				streamSidebar={ () => (
+					<ReaderTagSidebar tag={ this.props.decodedTagSlug } showFollow={ false } />
+				) }
 				sidebarTabTitle={ this.props.translate( 'Related' ) }
 			>
 				<QueryReaderFollowedTags />

--- a/client/state/reader/tags/selectors/index.js
+++ b/client/state/reader/tags/selectors/index.js
@@ -1,2 +1,3 @@
 export { default as getReaderTags } from './get-reader-tags';
 export { default as getReaderFollowedTags } from './get-reader-followed-tags';
+export { default as getReaderTagBySlug } from './get-reader-tag-by-slug';


### PR DESCRIPTION
Part of pe7F0s-1gP-p2, Adds the "follow tag" link to the discover page as described.

![following](https://github.com/Automattic/wp-calypso/assets/22446385/1e5c45f2-de3b-48cc-9009-1980deb2ff2d)

### Test instructions

Go to the /discover page, the "follow tag" button should be in the sidebar, and should follow the tag and represent the following state.
A tracks event should be recorded on click.
The "follow tag" button 
When logged out, the "follow tag" button should redirect to log in
