### PR TITLE
Add feature flags for theme discovery

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -201,6 +201,8 @@
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,
+		"themes/discovery-lits": true,
+		"themes/discovery-lots": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -137,6 +137,8 @@
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,
+		"themes/discovery-lits": false,
+		"themes/discovery-lots": false,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,

--- a/config/production.json
+++ b/config/production.json
@@ -166,6 +166,8 @@
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": false,
+		"themes/discovery-lits": false,
+		"themes/discovery-lots": false,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -161,6 +161,8 @@
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": false,
+		"themes/discovery-lits": false,
+		"themes/discovery-lots": false,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -171,6 +171,8 @@
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,
+		"themes/discovery-lits": false,
+		"themes/discovery-lots": false,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3960

## Proposed Changes

Added separate feature flags for the new theme discovery experience for the logged-in theme showcase and the logged-out theme showcase as we plan to develop behind feature flags, launch on logged out first to test the waters and then launch on the logged in theme showcase..

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. Checkout this branch locally.
2. Run this command: `yarn feature-search themes/discovery-lits`
3. You should see that the feature is only enabled in development.
4. Repeat with the lots feature flag: `yarn feature-search themes/discovery-lots`
5. You should see that the feature is only enabled in development.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?