### PR TITLE
Add new placeholder text

### DIFF
--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -39,7 +39,7 @@ export default function DomainAnalyzer( props: Props ) {
 							name="domain"
 							autoComplete="off"
 							defaultValue={ domain }
-							placeholder={ translate( 'Enter a website URL or domain name' ) }
+							placeholder={ translate( 'Enter a website URL' ) }
 						/>
 					</div>
 					<div className="col-2">

--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -39,7 +39,7 @@ export default function DomainAnalyzer( props: Props ) {
 							name="domain"
 							autoComplete="off"
 							defaultValue={ domain }
-							placeholder={ translate( 'mysite.com' ) }
+							placeholder={ translate( 'Enter a website URL or domain name' ) }
 						/>
 					</div>
 					<div className="col-2">


### PR DESCRIPTION
Context: p1695729159471009-slack-C01A60HCGUA

The `mysite.com` domain used as a placeholder in the Site Profiler is an existing site. This PR changes it to a complete sentence.

## Proposed Changes

* Change site profiler placeholder test

## Testing Instructions

* Go to http://calypso.localhost:3000/site-profiler
* Check if the placeholder is "Enter a website URL"

<img width="1047" alt="image" src="https://github.com/Automattic/wp-calypso/assets/167611/b557b492-fb96-4bad-9b8b-1c5ed3865ab9">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?