### PR TITLE
Gravatar: Customize the page's title and favicon for the passwordless login

### DIFF
--- a/client/components/data/document-head/index.jsx
+++ b/client/components/data/document-head/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import TranslatableString from 'calypso/components/translatable/proptype';
+import { isGravPoweredOAuth2Client } from 'calypso/lib/oauth2-clients';
 import {
 	setDocumentHeadTitle as setTitle,
 	setDocumentHeadLink as setLink,
@@ -11,6 +12,7 @@ import {
 } from 'calypso/state/document-head/actions';
 import { getDocumentHeadFormattedTitle } from 'calypso/state/document-head/selectors/get-document-head-formatted-title';
 import { getDocumentHeadTitle } from 'calypso/state/document-head/selectors/get-document-head-title';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 
 const isServer = typeof document === 'undefined';
 
@@ -88,11 +90,18 @@ DocumentHead.propTypes = {
 };
 
 export default connect(
-	( state, props ) => ( {
-		formattedTitle: props.skipTitleFormatting
+	( state, props ) => {
+		const oauth2Client = getCurrentOAuth2Client( state );
+		const formattedTitle = props.skipTitleFormatting
 			? getDocumentHeadTitle( state )
-			: getDocumentHeadFormattedTitle( state ),
-	} ),
+			: getDocumentHeadFormattedTitle( state );
+
+		return {
+			formattedTitle: isGravPoweredOAuth2Client( oauth2Client )
+				? oauth2Client.title
+				: formattedTitle,
+		};
+	},
 	{
 		setTitle,
 		setLink,

--- a/client/components/head/README.md
+++ b/client/components/head/README.md
@@ -27,6 +27,16 @@ Below is a list of supported props.
 
 The HTML page's `title`.
 
+### `faviconUrl`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>undefined</code></td></tr>
+</table>
+
+The URL of the favicon to use. If not provided, the default WordPress.com favicon will be used.
+
 ### `children`
 
 <table>

--- a/client/components/head/index.jsx
+++ b/client/components/head/index.jsx
@@ -2,7 +2,13 @@ import config from '@automattic/calypso-config';
 import PropTypes from 'prop-types';
 import Favicons from './favicons';
 
-const Head = ( { title = 'WordPress.com', children, branchName, inlineScriptNonce } ) => {
+const Head = ( {
+	title = 'WordPress.com',
+	children,
+	branchName,
+	inlineScriptNonce,
+	faviconUrl,
+} ) => {
 	return (
 		<head>
 			<title>{ title }</title>
@@ -22,7 +28,7 @@ const Head = ( { title = 'WordPress.com', children, branchName, inlineScriptNonc
 				href="https://public-api.wordpress.com/wp-admin/rest-proxy/?v=2.0"
 			/>
 
-			<Favicons environmentFaviconURL={ config( 'favicon_url' ) } />
+			<Favicons environmentFaviconURL={ faviconUrl || config( 'favicon_url' ) } />
 
 			<link rel="profile" href="http://gmpg.org/xfn/11" />
 
@@ -71,6 +77,7 @@ Head.propTypes = {
 	title: PropTypes.string,
 	children: PropTypes.node,
 	branchName: PropTypes.string,
+	faviconUrl: PropTypes.string,
 };
 
 export default Head;

--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -27,12 +27,14 @@ export const initialClientsData = {
 		name: 'gravatar',
 		title: 'Gravatar',
 		icon: 'https://gravatar.com/images/grav-logo-blue.svg',
+		favicon: 'https://gravatar.com/favicon.ico',
 	},
 	90057: {
 		id: 90057,
 		name: 'wpjobmanager',
 		title: 'WP Job Manager',
 		icon: 'https://wpjobmanager.com/wp-content/uploads/2023/06/JM-Letters.png',
+		favicon: 'https://wpjobmanager.com/wp-content/uploads/2023/06/cropped-JM-512x512-1.png?w=32',
 	},
 	2665: {
 		id: 2665,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 105879-Automattic/gravatar

## Proposed Changes

* Customize the page's title and favicon for Gravatar passwordless login flow in SSR
* Customize the page's title and favicon for Gravatar passwordless login flow in CSR
* Add a `faviconUrl` prop for the Head component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `public-api.wordpress.com`, and then apply this diff: `arc patch D123169`
* Setup Calypso, and run `yarn start`
* (Test SSR) Log out of your account. Go to the login page of [Gravatar](http://calypso.localhost:3000/log-in/link?client_id=1854&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3Dbfa7ea95b0a07d39e3f23e1d923ce77b35016295d986b51361d4334a6e571206%26redirect_uri%3Dhttps%253A%252F%252Fen.gravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1) and [WPJM](http://calypso.localhost:3000/log-in/link/?client_id=90057&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthenticate%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3D01b7d7bfcfd126450053529ce09fefb5%26redirect_uri%3Dhttp%253A%252F%252Fwpjobmanagercom.vipdev.lndo.site%253A8000%252Fwp-json%252Fwpjmcom-auth%252Fv1%252Fcallback&create_account=1). The page's title and favicon should work as below:

| Grav | WPJM |
| - | - |
| <img width="260" alt="截圖 2023-09-26 下午9 00 24" src="https://github.com/Automattic/wp-calypso/assets/21308003/e6caf182-6cb5-4dfd-829b-cee6d2747e2e"> | <img width="259" alt="截圖 2023-09-26 下午9 00 52" src="https://github.com/Automattic/wp-calypso/assets/21308003/55b4a0b7-9bdf-4f0f-a4c1-d917357cc1b9"> |

* (Test CSR) Click the "Sign in another way" link, the password / social login page, the page's title and favicon should work  as below:

| Grav | WPJM |
| - | - |
| <img width="260" alt="截圖 2023-09-26 下午9 00 24" src="https://github.com/Automattic/wp-calypso/assets/21308003/e6caf182-6cb5-4dfd-829b-cee6d2747e2e"> | <img width="259" alt="截圖 2023-09-26 下午9 00 52" src="https://github.com/Automattic/wp-calypso/assets/21308003/55b4a0b7-9bdf-4f0f-a4c1-d917357cc1b9"> |

* Login and then confirm your login link. The page's title and favicon on the loading page should work as below:

| Grav | WPJM |
| - | - |
| <img width="260" alt="截圖 2023-09-26 下午9 00 24" src="https://github.com/Automattic/wp-calypso/assets/21308003/e6caf182-6cb5-4dfd-829b-cee6d2747e2e"> | <img width="259" alt="截圖 2023-09-26 下午9 00 52" src="https://github.com/Automattic/wp-calypso/assets/21308003/55b4a0b7-9bdf-4f0f-a4c1-d917357cc1b9"> |

* The page's title and favicon of WP.com's [login page](http://calypso.localhost:3000/log-in), [magic login page](http://calypso.localhost:3000/log-in/link), and the related login pages still work the same.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
