### PR TITLE
Site profiler: Add form validation

### DIFF
--- a/client/data/site-profiler/use-domain-analyzer-query.ts
+++ b/client/data/site-profiler/use-domain-analyzer-query.ts
@@ -7,7 +7,7 @@ export interface MigrationStatusError {
 	message: string;
 }
 
-export const useDomainAnalyzerQuery = ( domain: string ) => {
+export const useDomainAnalyzerQuery = ( domain: string, isValid?: boolean ) => {
 	return useQuery( {
 		queryKey: [ 'domain-', domain ],
 		queryFn: (): Promise< DomainAnalyzerQueryResponse > =>
@@ -18,7 +18,7 @@ export const useDomainAnalyzerQuery = ( domain: string ) => {
 		meta: {
 			persist: false,
 		},
-		enabled: !! domain,
+		enabled: !! domain && isValid,
 		retry: false,
 		refetchOnWindowFocus: false,
 	} );

--- a/client/data/site-profiler/use-hosting-provider-query.ts
+++ b/client/data/site-profiler/use-hosting-provider-query.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { HostingProviderQueryResponse } from 'calypso/data/site-profiler/types';
 import wp from 'calypso/lib/wp';
 
-export const useHostingProviderQuery = ( domain: string ) => {
+export const useHostingProviderQuery = ( domain: string, isValid?: boolean ) => {
 	return useQuery( {
 		queryKey: [ 'hosting-provider-', domain ],
 		queryFn: (): Promise< HostingProviderQueryResponse > =>
@@ -13,7 +13,7 @@ export const useHostingProviderQuery = ( domain: string ) => {
 		meta: {
 			persist: false,
 		},
-		enabled: !! domain,
+		enabled: !! domain && isValid,
 		retry: false,
 		refetchOnWindowFocus: false,
 	} );

--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -1,17 +1,20 @@
 import { Button } from '@wordpress/components';
+import { Icon, info } from '@wordpress/icons';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { FormEvent } from 'react';
+import React, { FormEvent } from 'react';
 import './styles.scss';
 
 interface Props {
 	domain?: string;
 	isBusy?: boolean;
+	isDomainValid?: boolean;
 	onFormSubmit: ( domain: string ) => void;
 }
 
 export default function DomainAnalyzer( props: Props ) {
 	const translate = useTranslate();
-	const { domain, isBusy, onFormSubmit } = props;
+	const { domain, isBusy, isDomainValid, onFormSubmit } = props;
 
 	const onSubmit = ( e: FormEvent< HTMLFormElement > ) => {
 		e.preventDefault();
@@ -31,7 +34,10 @@ export default function DomainAnalyzer( props: Props ) {
 				) }
 			</p>
 
-			<form className="domain-analyzer--form" onSubmit={ onSubmit }>
+			<form
+				className={ classnames( 'domain-analyzer--form', { 'is-error': isDomainValid === false } ) }
+				onSubmit={ onSubmit }
+			>
 				<div className="domain-analyzer--form-container">
 					<div className="col-1">
 						<input
@@ -47,6 +53,17 @@ export default function DomainAnalyzer( props: Props ) {
 							{ translate( 'Check site' ) }
 						</Button>
 					</div>
+				</div>
+				<div className="domain-analyzer--msg">
+					{ ( isDomainValid || isDomainValid === undefined ) && (
+						<p className="center">{ translate( 'Enter the URL of the site you want to check' ) }</p>
+					) }
+					{ isDomainValid === false && (
+						<p className="error">
+							<Icon icon={ info } size={ 20 } />{ ' ' }
+							{ translate( 'Please enter a valid website address' ) }
+						</p>
+					) }
 				</div>
 			</form>
 		</div>

--- a/client/site-profiler/components/domain-analyzer/styles.scss
+++ b/client/site-profiler/components/domain-analyzer/styles.scss
@@ -42,3 +42,35 @@
 		}
 	}
 }
+
+.domain-analyzer--form {
+	&.is-error {
+		.domain-analyzer--form-container {
+			border: 1px solid var(--studio-red-50);
+		}
+	}
+}
+
+.domain-analyzer--msg {
+	margin-top: 1rem;
+
+	p {
+		font-size: 1rem !important;
+		margin: 0;
+	}
+
+	.center {
+		text-align: center;
+	}
+
+	.error {
+		color: var(--studio-red-50) !important;
+
+		svg {
+			top: 4px;
+			position: relative;
+			fill: var(--studio-red-50);
+			transform: rotate(180deg);
+		}
+	}
+}

--- a/client/site-profiler/components/domain-analyzer/styles.scss
+++ b/client/site-profiler/components/domain-analyzer/styles.scss
@@ -7,6 +7,7 @@
 .domain-analyzer--form-container {
 	background: #fff;
 	box-shadow: 0 5px 10px 0 #0000000d;
+	border: 1px solid transparent;
 	/* stylelint-disable-next-line */
 	border-radius: 8px;
 	padding: 0.625rem 1.5rem;

--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -64,11 +64,12 @@ export default function DomainInformation( props: Props ) {
 							{ whois.registrar_url?.toLowerCase().includes( 'automattic' ) && (
 								<VerifiedProvider />
 							) }
-							{ ! whois.registrar_url?.toLowerCase().includes( 'automattic' ) && (
-								<a href={ whois.registrar_url } target="_blank" rel="noopener noreferrer">
-									{ whois.registrar }
-								</a>
-							) }
+							{ whois.registrar_url &&
+								! whois.registrar_url?.toLowerCase().includes( 'automattic' ) && (
+									<a href={ whois.registrar_url } target="_blank" rel="noopener noreferrer">
+										{ whois.registrar }
+									</a>
+								) }
 							{ ! whois.registrar_url && <span>{ whois.registrar }</span> }
 						</div>
 					</li>

--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -176,7 +176,7 @@ export default function DomainInformation( props: Props ) {
 							) }
 							{ whois.registrant_email && (
 								<li>
-									{ whois.registrant_email.includes( '@' ) && (
+									{ whois.registrant_email?.includes( '@' ) && (
 										<a href={ `mailto:${ whois.registrant_email }` }>{ translate( 'Email' ) }</a>
 									) }
 									{ urlRegex.test( whois.registrant_email ) &&

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -18,10 +18,10 @@ export default function SiteProfiler() {
 	const location = useLocation();
 	const navigate = useNavigate();
 	const queryParams = useQuery();
-	const domain = useDomainQueryParam();
+	const { domain, isValid: isDomainValid } = useDomainQueryParam();
 
-	const { data, isFetching } = useDomainAnalyzerQuery( domain );
-	const { data: hostingProviderData } = useHostingProviderQuery( domain );
+	const { data, isFetching } = useDomainAnalyzerQuery( domain, isDomainValid );
+	const { data: hostingProviderData } = useHostingProviderQuery( domain, isDomainValid );
 	const conversionAction = useDefineConversionAction(
 		domain,
 		data?.whois,
@@ -32,7 +32,8 @@ export default function SiteProfiler() {
 	const updateDomainQueryParam = ( value: string ) => {
 		// Update the domain query param;
 		// URL param is the source of truth
-		queryParams.set( 'domain', value );
+		value ? queryParams.set( 'domain', value ) : queryParams.delete( 'domain' );
+
 		navigate( location.pathname + '?' + queryParams.toString() );
 	};
 
@@ -43,6 +44,7 @@ export default function SiteProfiler() {
 					<DocumentHead title={ translate( 'Site Profiler' ) } />
 					<DomainAnalyzer
 						domain={ domain }
+						isDomainValid={ isDomainValid }
 						onFormSubmit={ updateDomainQueryParam }
 						isBusy={ isFetching }
 					/>

--- a/client/site-profiler/hooks/use-domain-query-param.ts
+++ b/client/site-profiler/hooks/use-domain-query-param.ts
@@ -1,18 +1,20 @@
 import { useEffect, useState } from 'react';
+import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { extractDomainFromInput, getFixedDomainSearch } from 'calypso/lib/domains';
 
 export default function useDomainQueryParam( sanitize = true ) {
 	const [ domain, setDomain ] = useState( '' );
+	const [ isValid, setIsValid ] = useState< undefined | boolean >();
 	const queryParams = useQuery();
 
 	useEffect( () => {
-		setDomain(
-			sanitize
-				? getFixedDomainSearch( extractDomainFromInput( queryParams.get( 'domain' ) || '' ) )
-				: domain
-		);
+		const _domain = queryParams.get( 'domain' ) || '';
+
+		setIsValid( _domain ? CAPTURE_URL_RGX.test( _domain ) : undefined );
+
+		setDomain( sanitize ? getFixedDomainSearch( extractDomainFromInput( _domain ) ) : _domain );
 	}, [ queryParams ] );
 
-	return domain;
+	return { domain, isValid };
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/81948

## Proposed Changes

* Added form validation based on the query param
* Fixed issue accessing undefined param
* Fixed issue with printing registrar value

## Testing Instructions

* Go to site profiler
* Enter any invalid domain and press enter
* Check if there is validation message
* Enter any invalid domain directly in `?domain` query param
* Check if there is validation message without triggering `/site-profiler` endpoint

<img width="1084" alt="Screenshot 2023-09-26 at 15 38 36" src="https://github.com/Automattic/wp-calypso/assets/1241413/2efd32d4-0b81-4251-9dd6-518ac28e2be5">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?