### PR TITLE
Stats: Update standalone Stats purchase page headline and CTA text

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -214,7 +214,7 @@ const PersonalPurchase = ( {
 						} )
 					}
 				>
-					{ isStandalone ? translate( 'Get Stats Personal' ) : translate( 'Get Jetpack Stats' ) }
+					{ isStandalone ? translate( 'Get Stats' ) : translate( 'Get Jetpack Stats' ) }
 				</ButtonComponent>
 			) }
 		</div>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -224,7 +224,7 @@ const StatsPersonalPurchase = ( {
 
 	return (
 		<>
-			<h1>{ translate( 'Jetpack Stats Personal' ) }</h1>
+			<h1>{ translate( 'Jetpack Stats' ) }</h1>
 			<p>{ translate( 'The most advanced stats Jetpack has to offer.' ) }</p>
 			<PersonalPurchase
 				subscriptionValue={ subscriptionValue }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -119,7 +119,7 @@ Thanks\n\n`;
 
 	return (
 		<>
-			<h1>{ translate( 'Jetpack Stats Commercial' ) }</h1>
+			<h1>{ translate( 'Jetpack Stats' ) }</h1>
 			<p>{ translate( 'The most advanced stats Jetpack has to offer.' ) }</p>
 			<StatsBenefitsCommercial />
 			<StatsCommercialPriceDisplay planValue={ planValue } currencyCode={ currencyCode } />
@@ -130,7 +130,7 @@ Thanks\n\n`;
 					gotoCheckoutPage( { from, type: 'commercial', siteSlug, adminUrl, redirectUri } )
 				}
 			>
-				{ translate( 'Get Stats Commercial' ) }
+				{ translate( 'Get Stats' ) }
 			</ButtonComponent>
 
 			{ showClassificationDispute && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1HpG7-oGl-p2#comment-66282

## Proposed Changes

* Update the headline and CTA button text of the standalone personal and commercial purchase pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Odyssey Stats
* Build Jetpack if necessary: `jetpack build plugins/jetpack`.
* Spin this change up on the local Jetpack site: `cd apps/odyssey-stats && STATS_PACKAGE_PATH=/path-to/jetpack/projects/packages/stats-admin yarn dev`.
1. Navigate to Stas > `Traffic` page with a site purchasing the Stats free product.
2. Click on the `Upgrade my Stats` button of the upgrade notice.
3. Ensure the Stats `Personal` purchase page's headline and CTA button text are updated.

|Before|After|
|-|-|
|<img width="1447" alt="截圖 2023-09-26 下午10 07 47" src="https://github.com/Automattic/wp-calypso/assets/6869813/0cb1ab10-6e24-4dfb-a254-d188a6e2e19a">|<img width="1395" alt="截圖 2023-09-26 下午9 39 45" src="https://github.com/Automattic/wp-calypso/assets/6869813/37876378-6439-4fd6-83c8-0edddae043a2">|

4. Modify the URL query string `&productType=personal` to `&productType=commercial`.
5. Ensure the Stats `Commercial` purchase page's headline and CTA button text are updated.

|Before|After|
|-|-|
|<img width="1448" alt="截圖 2023-09-26 下午10 08 02" src="https://github.com/Automattic/wp-calypso/assets/6869813/39a25ee4-22da-483b-9fb3-a184c0da4dcc">|<img width="1259" alt="截圖 2023-09-26 下午9 39 28" src="https://github.com/Automattic/wp-calypso/assets/6869813/06e3d3be-987f-422d-a21f-390c6fca24fd">|

#### Calypso Stats
* Spin this change with the Calypso Live link.
* Test with steps `1 ~ 5` above and ensure the result is the same.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?