### PR TITLE
recordReaderTracksEvent - add default prop building for general props

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -312,22 +312,28 @@ class PostCommentList extends Component {
 		this.setActiveReplyComment( commentId );
 		recordAction( 'comment_reply_click' );
 		recordGaEvent( 'Clicked Reply to Comment' );
-		this.props.recordReaderTracksEvent( 'calypso_reader_comment_reply_click', {
-			blog_id: this.props.post.site_ID,
-			comment_id: commentId,
-			is_inline_comment: this.props.expandableView,
-		} );
+		this.props.recordReaderTracksEvent(
+			'calypso_reader_comment_reply_click',
+			{
+				comment_id: commentId,
+				is_inline_comment: this.props.expandableView,
+			},
+			{ post: this.props.post }
+		);
 	};
 
 	onReplyCancel = () => {
 		this.setState( { commentText: null } );
 		recordAction( 'comment_reply_cancel_click' );
 		recordGaEvent( 'Clicked Cancel Reply to Comment' );
-		this.props.recordReaderTracksEvent( 'calypso_reader_comment_reply_cancel_click', {
-			blog_id: this.props.post.site_ID,
-			comment_id: this.props.activeReplyCommentId,
-			is_inline_comment: this.props.expandableView,
-		} );
+		this.props.recordReaderTracksEvent(
+			'calypso_reader_comment_reply_cancel_click',
+			{
+				comment_id: this.props.activeReplyCommentId,
+				is_inline_comment: this.props.expandableView,
+			},
+			{ post: this.props.post }
+		);
 		this.resetActiveReplyComment();
 	};
 

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -117,12 +117,14 @@ class PostComment extends PureComponent {
 	handleAuthorClick = ( event ) => {
 		recordAction( 'comment_author_click' );
 		recordGaEvent( 'Clicked Author Name' );
-		this.props.recordReaderTracksEvent( 'calypso_reader_comment_author_click', {
-			blog_id: this.props.post.site_ID,
-			post_id: this.props.post.ID,
-			comment_id: this.props.commentId,
-			author_url: event.target.href,
-		} );
+		this.props.recordReaderTracksEvent(
+			'calypso_reader_comment_author_click',
+			{
+				comment_id: this.props.commentId,
+				author_url: event.target.href,
+			},
+			{ post: this.props.post }
+		);
 	};
 
 	handleCommentPermalinkClick = ( event ) => {
@@ -319,11 +321,15 @@ class PostComment extends PureComponent {
 			} );
 		recordAction( 'comment_read_more_click' );
 		recordGaEvent( 'Clicked Comment Read More' );
-		this.props.recordReaderTracksEvent( 'calypso_reader_comment_read_more_click', {
-			blog_id: this.props.post.site_ID,
-			post_id: this.props.post.ID,
-			comment_id: this.props.commentId,
-		} );
+		this.props.recordReaderTracksEvent(
+			'calypso_reader_comment_read_more_click',
+			{
+				comment_id: this.props.commentId,
+			},
+			{
+				post: this.props.post,
+			}
+		);
 	};
 
 	render() {

--- a/client/blocks/conversation-follow-button/index.jsx
+++ b/client/blocks/conversation-follow-button/index.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { getTracksPropertiesForPost } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { followConversation, muteConversation } from 'calypso/state/reader/conversations/actions';
 import { isFollowingReaderConversation } from 'calypso/state/reader/conversations/selectors';
@@ -33,20 +32,21 @@ class ConversationFollowButtonContainer extends Component {
 		const { siteId, postId, post, followSource } = this.props;
 
 		const tracksProperties = {
-			...getTracksPropertiesForPost( post ),
 			follow_source: followSource,
 		};
 
 		if ( isRequestingFollow ) {
 			this.props.recordReaderTracksEvent(
 				'calypso_reader_conversations_post_followed',
-				tracksProperties
+				tracksProperties,
+				{ post }
 			);
 			this.props.followConversation( { siteId, postId } );
 		} else {
 			this.props.recordReaderTracksEvent(
 				'calypso_reader_conversations_post_muted',
-				tracksProperties
+				tracksProperties,
+				{ post }
 			);
 			this.props.muteConversation( { siteId, postId } );
 		}

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -74,20 +74,26 @@ export class ConversationCommentList extends Component {
 		this.setActiveReplyComment( commentId );
 		recordAction( 'comment_reply_click' );
 		recordGaEvent( 'Clicked Reply to Comment' );
-		this.props.recordReaderTracksEvent( 'calypso_reader_comment_reply_click', {
-			blog_id: this.props.post.site_ID,
-			comment_id: commentId,
-		} );
+		this.props.recordReaderTracksEvent(
+			'calypso_reader_comment_reply_click',
+			{
+				comment_id: commentId,
+			},
+			{ post: this.props.post }
+		);
 	};
 
 	onReplyCancel = () => {
 		this.setState( { commentText: '' } );
 		recordAction( 'comment_reply_cancel_click' );
 		recordGaEvent( 'Clicked Cancel Reply to Comment' );
-		this.props.recordReaderTracksEvent( 'calypso_reader_comment_reply_cancel_click', {
-			blog_id: this.props.post.site_ID,
-			comment_id: this.props.activeReplyCommentId,
-		} );
+		this.props.recordReaderTracksEvent(
+			'calypso_reader_comment_reply_cancel_click',
+			{
+				comment_id: this.props.activeReplyCommentId,
+			},
+			{ post: this.props.post }
+		);
 		this.resetActiveReplyComment();
 	};
 

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -166,7 +166,7 @@ class ReaderPostEllipsisMenu extends Component {
 			return;
 		}
 
-		this.props.recordReaderTracksEvent( 'calypso_reader_mark_as_seen_clicked' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_mark_as_seen_clicked', {}, { post } );
 
 		const feedId = post.feed_ID;
 		let postIds = [ post.ID ];
@@ -211,7 +211,7 @@ class ReaderPostEllipsisMenu extends Component {
 			return;
 		}
 
-		this.props.recordReaderTracksEvent( 'calypso_reader_mark_as_unseen_clicked' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_mark_as_unseen_clicked', {}, { post } );
 
 		const feedId = post.feed_ID;
 		let postIds = [ post.ID ];

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -72,9 +72,13 @@ class ReaderShare extends Component {
 				: 'calypso_reader_share_opened';
 			stats.recordAction( actionName );
 			stats.recordGaEvent( eventName );
-			this.props.recordReaderTracksEvent( trackName, {
-				has_sites: this.props.hasSites,
-			} );
+			this.props.recordReaderTracksEvent(
+				trackName,
+				{
+					has_sites: this.props.hasSites,
+				},
+				{ post: this.props.post }
+			);
 		}
 		this.deferMenuChange( ! this.state.showingMenu );
 	};

--- a/client/blocks/reader-share/reblog.jsx
+++ b/client/blocks/reader-share/reblog.jsx
@@ -29,7 +29,11 @@ const ReaderReblogSelection = ( props ) => {
 		stats.recordAction( `share_wordpress${ props.comment ? '_comment' : '' }` );
 		stats.recordGaEvent( `Clicked on Share${ props.comment ? ' Comment' : '' } to WordPress` );
 		dispatch(
-			recordReaderTracksEvent( `calypso_reader_share${ props.comment ? '_comment' : '' }_to_site` )
+			recordReaderTracksEvent(
+				`calypso_reader_share${ props.comment ? '_comment' : '' }_to_site`,
+				{},
+				{ post: props.post }
+			)
 		);
 		window.open(
 			`/post/${ slug }?${ buildQuerystringForPost( props.post, props.comment ) }`,

--- a/client/blocks/reader-share/social.jsx
+++ b/client/blocks/reader-share/social.jsx
@@ -56,9 +56,13 @@ const ReaderSocialShareSelection = ( props ) => {
 			stats.recordAction( 'share_' + action );
 			stats.recordGaEvent( 'Clicked on Share to ' + action );
 			dispatch(
-				recordReaderTracksEvent( 'calypso_reader_share_action_picked', {
-					action: action,
-				} )
+				recordReaderTracksEvent(
+					'calypso_reader_share_action_picked',
+					{
+						action: action,
+					},
+					{ post: props.post }
+				)
 			);
 			actionFunc( props.post );
 		}

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -100,6 +100,23 @@ function getLocation( path ) {
 }
 
 /**
+ *
+ * @param {Object} eventProperties extra event properties to add
+ * @param {*} pathnameOverride Overwrites location used for determining ui_algo. See notes in
+ * `recordTrack` function docs below for more info.
+ * @param {Object|null} post Optional post object used to build post event props.
+ * @returns new eventProperties object with default reader values added.
+ */
+export function buildReaderTracksEventProps( eventProperties, pathnameOverride, post ) {
+	const location = getLocation( pathnameOverride || window.location.pathname );
+	eventProperties = Object.assign( { ui_algo: location }, eventProperties );
+	if ( post ) {
+		eventProperties = Object.assign( getTracksPropertiesForPost( post ), eventProperties );
+	}
+	return eventProperties;
+}
+
+/**
  * @param {*} eventName track event name
  * @param {*} eventProperties extra event props
  * @param {{pathnameOverride: string}} [pathnameOverride] Overwrites the location for ui_algo Useful for when
@@ -113,8 +130,7 @@ function getLocation( path ) {
 export function recordTrack( eventName, eventProperties, { pathnameOverride } = {} ) {
 	debug( 'reader track', ...arguments );
 
-	const location = getLocation( pathnameOverride || window.location.pathname );
-	eventProperties = Object.assign( { ui_algo: location }, eventProperties );
+	eventProperties = buildReaderTracksEventProps( eventProperties, pathnameOverride );
 
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if (

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -109,11 +109,11 @@ function getLocation( path ) {
  */
 export function buildReaderTracksEventProps( eventProperties, pathnameOverride, post ) {
 	const location = getLocation( pathnameOverride || window.location.pathname );
-	eventProperties = Object.assign( { ui_algo: location }, eventProperties );
+	let composedProperties = Object.assign( { ui_algo: location }, eventProperties );
 	if ( post ) {
-		eventProperties = Object.assign( getTracksPropertiesForPost( post ), eventProperties );
+		composedProperties = Object.assign( getTracksPropertiesForPost( post ), composedProperties );
 	}
-	return eventProperties;
+	return composedProperties;
 }
 
 /**

--- a/client/state/reader/analytics/actions.js
+++ b/client/state/reader/analytics/actions.js
@@ -5,12 +5,12 @@ import { getReaderFollowsCount } from 'calypso/state/reader/follows/selectors';
 export const recordReaderTracksEvent =
 	( name, properties, { pathnameOverride, post } = {} ) =>
 	( dispatch, getState ) => {
-		properties = buildReaderTracksEventProps( properties, pathnameOverride, post );
+		const eventProps = buildReaderTracksEventProps( properties, pathnameOverride, post );
 		const followsCount = getReaderFollowsCount( getState() );
 		dispatch(
 			recordTracksEvent( name, {
 				subscription_count: followsCount,
-				...properties,
+				...eventProps,
 			} )
 		);
 	};

--- a/client/state/reader/analytics/actions.js
+++ b/client/state/reader/analytics/actions.js
@@ -1,12 +1,16 @@
+import { buildReaderTracksEventProps } from 'calypso/reader/stats';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getReaderFollowsCount } from 'calypso/state/reader/follows/selectors';
 
-export const recordReaderTracksEvent = ( name, properties ) => ( dispatch, getState ) => {
-	const followsCount = getReaderFollowsCount( getState() );
-	dispatch(
-		recordTracksEvent( name, {
-			subscription_count: followsCount,
-			...properties,
-		} )
-	);
-};
+export const recordReaderTracksEvent =
+	( name, properties, { pathnameOverride, post } = {} ) =>
+	( dispatch, getState ) => {
+		properties = buildReaderTracksEventProps( properties, pathnameOverride, post );
+		const followsCount = getReaderFollowsCount( getState() );
+		dispatch(
+			recordTracksEvent( name, {
+				subscription_count: followsCount,
+				...properties,
+			} )
+		);
+	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1695312086939019-slack-C03NLNTPZ2T

## Proposed Changes

* Bring some functionality from reader/stats into `recordReaderTracksEvent` to build default tracks props for the reader.
* Adds an new optional prop to `recordReaderTracksEvent` to add options such as `pathnameOverride` (carried over from reader/stats) and `post`. The `post` option will add more default properties from the post object using existing `getTracksPropertiesForPost` method.
* Updates existing usage of `recordReaderTracksEvent` to leverage the `post` option for default prop building where possible.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* Go to a reader feed
* click on the share/reblog popovers
* verify (can use tracks vigilante) that the tracks events sent have the `ui_algo` property filled.
* Test other events that use the `recordReaderTracksEvent` action. You can find some below in the changelog (ex `calypso_reader_comment_author_click`). Verify these events show the same (or more) properties. Also, test a tracking event using this action that we did not update in the changelog (such as `calypso_reader_following_item_clicked`) and verify this still works as expected, has the same properties as before, as well as the `ui_algo` prop.
* Test an older event using tracking from reader/stats (such as `calypso_reader_article_liked`) and verify there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?