### PR TITLE
Ships free/free and partial paid/free experiment variants

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -8,10 +8,18 @@ const useIsCustomDomainAllowedOnFreePlan = (
 	const EXPERIMENT_NAME =
 		flowName === 'onboarding'
 			? 'calypso_onboarding_plans_paid_domain_on_free_plan_confidence_check'
-			: 'calypso_onboardingpm_plans_paid_domain_on_free_plan';
+			: '';
 	const [ isLoading, assignment ] = useExperiment( EXPERIMENT_NAME, {
-		isEligible: [ 'onboarding', 'onboarding-pm' ].includes( flowName ?? '' ) && hasPaidDomainName,
+		isEligible: flowName === 'onboarding' && hasPaidDomainName,
 	} );
+
+	/** Ships experiment variant to onboarding-pm flow only  */
+	if ( flowName === 'onboarding-pm' ) {
+		return {
+			isLoading: false,
+			result: true,
+		};
+	}
 
 	return {
 		isLoading,

--- a/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
@@ -1,21 +1,17 @@
-import { useExperiment } from 'calypso/lib/explat';
 import type { DataResponse } from 'calypso/my-sites/plans-grid/types';
 
+/**
+ * TODO: Cleanup pending, this condition needs to be removed
+ */
 const useIsPlanUpsellEnabledOnFreeDomain = (
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	flowName?: string | null,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	hasPaidDomain?: boolean
 ): DataResponse< boolean > => {
-	const ONBOARDING_EXPERIMENT = 'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3';
-	const ONBOARDING_PM_EXPERIMENT =
-		'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3';
-	const relevantExperiment =
-		flowName === 'onboarding' ? ONBOARDING_EXPERIMENT : ONBOARDING_PM_EXPERIMENT;
-	const [ isLoading, experimentAssignment ] = useExperiment( relevantExperiment, {
-		isEligible: [ 'onboarding', 'onboarding-pm' ].includes( flowName ?? '' ) && ! hasPaidDomain,
-	} );
 	return {
-		isLoading,
-		result: experimentAssignment?.variationName === 'treatment',
+		isLoading: false,
+		result: true,
 	};
 };
 


### PR DESCRIPTION
## Proposed Changes
- Ships free/free experiment variant to both `Onboarding` and `Onboarding-PM` flows
- Ship paid/free variant to only the onboarding-pm flow
- A more thorough cleanup is being done here
     - https://github.com/Automattic/wp-calypso/pull/81644 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Case 1
* Go through `/start`
* Select free domain
* Select a free plan
* A modal should appear

#### Case 2
* Make sure that you are assigned to CONTROL in experiment -  21394-explat-experiment
* Go through `/start`
* Select paid domain
* Select a free plan
* The following modal should  appear
*![image](https://github.com/Automattic/wp-calypso/assets/3422709/74bf274f-efda-4f29-97ed-72d09017426c)

#### Case 3
* Make sure that you are assigned to VARIANT in experiment -  21394-explat-experiment
* Go through `/start`
* Select paid domain
* Select a free plan
* The following modal `redirect` modal should  appear 
<img width="691" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/a1d1fd0d-ca68-4e31-8b55-bc297a3f03ef">

#### Case 4
* Go through `/start/onboarding-pm`
* Select free/paid domain
* Select a free plan
* A modal should appear on both free and paid domain selections
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?