### PR TITLE
Launchpad: Add the skip logic to the Goals step

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -63,6 +63,10 @@ import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-sto
 
 const SiteIntent = Onboard.SiteIntent;
 
+type ExitFlowOptions = {
+	skipLaunchpad?: boolean;
+};
+
 function isLaunchpadIntent( intent: string ) {
 	return intent === SiteIntent.Write || intent === SiteIntent.Build;
 }
@@ -189,7 +193,7 @@ const siteSetupFlow: Flow = {
 			setStepProgress( flowProgress );
 		}
 
-		const exitFlow = ( to: string ) => {
+		const exitFlow = ( to: string, options: ExitFlowOptions = {} ) => {
 			setPendingAction( () => {
 				/**
 				 * This implementation seems very hacky.
@@ -221,8 +225,12 @@ const siteSetupFlow: Flow = {
 
 					// Update Launchpad option based on site intent
 					if ( typeof siteId === 'number' ) {
-						const launchpadScreen =
-							isLaunchpadIntent( siteIntent ) && ! isLaunched ? 'full' : 'off';
+						let launchpadScreen;
+						if ( ! options.skipLaunchpad ) {
+							launchpadScreen = isLaunchpadIntent( siteIntent ) && ! isLaunched ? 'full' : 'off';
+						} else {
+							launchpadScreen = 'skipped';
+						}
 
 						settings.launchpad_screen = launchpadScreen;
 					}
@@ -588,7 +596,9 @@ const siteSetupFlow: Flow = {
 				case 'goals':
 					// Skip to dashboard must have been pressed
 					setIntent( SiteIntent.Build );
-					return exitFlow( `/home/${ siteId ?? siteSlug }` );
+					return exitFlow( `/home/${ siteId ?? siteSlug }`, {
+						skipLaunchpad: true,
+					} );
 
 				case 'import':
 					return navigate( 'importList' );

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -91,7 +91,7 @@ describe(
 			} );
 
 			it( 'See Home', async function () {
-				await page.waitForURL( /home/, { waitUntil: 'networkidle' } );
+				await page.waitForURL( /home/ );
 			} );
 		} );
 

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -90,12 +90,8 @@ describe(
 				await startSiteFlow.clickButton( 'Skip to dashboard' );
 			} );
 
-			it( 'Skip Launchpad', async function () {
-				await page.waitForURL( /launchpad/, { waitUntil: 'networkidle' } );
-				await page.getByRole( 'button', { name: 'Skip for now' } ).click( { timeout: 20 * 1000 } );
-
-				// Launchpad redirects to `/home` when skipped.
-				await page.waitForURL( /home/ );
+			it( 'See Home', async function () {
+				await page.waitForURL( /home/, { waitUntil: 'networkidle' } );
 			} );
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* When users click on the `Skip to dashboard` link on the Goals step, they are redirected to Customer Home. But they get redirected back to the onboarding flow, to the Fullscreen Launchpad step.
* This PR adds the Skip logic to the `Skip to dashboard` link, which now prevents the user to be redirected back to the onboarding flow, and displays the pre-launch Launchpad on the Customer Home.
* I had to revert https://github.com/Automattic/wp-calypso/pull/8218 because an E2E test failed. The problem was that the test waited for the user to be redirected back to the fullscreen launchpad page, but we now redirect to the Customer Home. I updated the tests to reflect my change
* Discussion: p1695733651258019-slack-C0Q664T29

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link or apply this PR to your local environment
* Navigate to `/start` and go through the flow until you reach the Goals step
* Click on the `Skip to Dashboard` link on the top right corner
* You should be redirected to the Customer Home, and see the compact version of the pre-launch Launchpad.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?