### PR TITLE
Reader/Discover: Swap out cards API for new Discover stream behind feature flag

### DIFF
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -204,9 +204,9 @@ const streamApis = {
 			if ( streamKeySuffix( streamKey ).includes( 'recommended' ) ) {
 				return '/read/tags/cards';
 			} else if ( streamKeySuffix( streamKey ).includes( 'latest' ) ) {
-				return '/read/tags/posts';
+				return '/read/streams/discover';
 			}
-			return `/read/tags/${ streamKeySuffix( streamKey ) }/cards`;
+			return `/read/streams/discover?tags=${ streamKeySuffix( streamKey ) }`;
 		},
 		dateProperty: 'date',
 		query: ( extras, { streamKey } ) =>

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import warn from '@wordpress/warning';
 import i18n from 'i18n-calypso';
 import { random, map, includes, get } from 'lodash';
@@ -202,11 +203,15 @@ const streamApis = {
 	discover: {
 		path: ( { streamKey } ) => {
 			if ( streamKeySuffix( streamKey ).includes( 'recommended' ) ) {
+				if ( config.isEnabled( 'reader/discover-stream' ) ) {
+					return '/read/streams/discover';
+				}
+
 				return '/read/tags/cards';
 			} else if ( streamKeySuffix( streamKey ).includes( 'latest' ) ) {
-				return '/read/streams/discover';
+				return '/read/tags/posts';
 			}
-			return `/read/streams/discover?tags=${ streamKeySuffix( streamKey ) }`;
+			return `/read/tags/${ streamKeySuffix( streamKey ) }/cards`;
 		},
 		dateProperty: 'date',
 		query: ( extras, { streamKey } ) =>

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import deepfreeze from 'deep-freeze';
 import { getAfterDateForFeed } from 'calypso/reader/discover/helper';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
@@ -76,7 +77,9 @@ describe( 'streams', () => {
 					stream: 'discover:recommended',
 					expected: {
 						method: 'GET',
-						path: '/read/tags/cards',
+						path: config.isEnabled( 'reader/discover-stream' )
+							? '/read/streams/discover'
+							: '/read/tags/cards',
 						apiNamespace: 'wpcom/v2',
 						query: {
 							...query,


### PR DESCRIPTION
Fixes #82257

## Proposed Changes

* Replace Reccommended stream API call to `/read/tags/cards` with `/read/streams/discover` behind the feature flag `reader/discover-stream`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Visit `/discover`
* You should see the usual Discover stream load, with API calls to `/read/tags/cards`.
* Visit `/discover?flags=reader/discover-stream` to enable the feature flag.
* You should see API requests to `read/streams/discover` in the Network tab of the inspector. The actual page contents will probably be broken until we've updated the API for better compatibility, see D123381-code

<img width="1021" alt="Screenshot 2023-09-27 at 12 15 15 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/0ece163b-0a23-42fb-90fb-b1e4f625031d">

* With the feature flag enabled, all other Discover pages (Latest, individual tags) should still work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?