### PR TITLE
Thank You page: Check the transition for needed atomic transfer

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
@@ -1,3 +1,4 @@
+import { usePrevious } from '@wordpress/compose';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -32,6 +33,8 @@ export function useAtomicTransfer(
 	const [ isAtomicTransferCheckComplete, setIsAtomicTransferCheckComplete ] = useState(
 		! isAtomicNeeded
 	);
+	const previousIsAtomicNeeded = usePrevious( isAtomicNeeded );
+	const isAtomicNeededTransition = ! previousIsAtomicNeeded && isAtomicNeeded;
 	const [ showProgressBar, setShowProgressBar ] = useState(
 		! new URLSearchParams( document.location.search ).has( 'hide-progress-bar' )
 	);
@@ -96,5 +99,10 @@ export function useAtomicTransfer(
 		}
 	}, [ transferStatus, showProgressBar, isJetpack ] );
 
-	return [ isAtomicTransferCheckComplete, currentStep, showProgressBar, setShowProgressBar ];
+	return [
+		isAtomicNeededTransition ? false : isAtomicTransferCheckComplete,
+		currentStep,
+		showProgressBar,
+		setShowProgressBar,
+	];
 }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
@@ -34,7 +34,7 @@ export function useAtomicTransfer(
 		! isAtomicNeeded
 	);
 	const previousIsAtomicNeeded = usePrevious( isAtomicNeeded );
-	const isAtomicNeededTransition = ! previousIsAtomicNeeded && isAtomicNeeded;
+	const isAtomicNeededActivated = ! previousIsAtomicNeeded && isAtomicNeeded;
 	const [ showProgressBar, setShowProgressBar ] = useState(
 		! new URLSearchParams( document.location.search ).has( 'hide-progress-bar' )
 	);
@@ -100,7 +100,7 @@ export function useAtomicTransfer(
 	}, [ transferStatus, showProgressBar, isJetpack ] );
 
 	return [
-		isAtomicNeededTransition ? false : isAtomicTransferCheckComplete,
+		isAtomicNeededActivated ? false : isAtomicTransferCheckComplete,
 		currentStep,
 		showProgressBar,
 		setShowProgressBar,


### PR DESCRIPTION
Fixes #82110

## Proposed Changes

Catch the transition for needed atomic transfer and return `false` at for atomic completion at this point. 
Details about why this is need and the investigation around the issue can be found at #82110.

## Testing Instructions

* Apply the diff D118900-code to your sandbox and direct requests to the sandbox
* Go to the Design Picker page with a Marketplace theme selected `/setup/update-design/designSetup?siteSlug=:site&theme=:theme_slug`. Theme slugs such as `makoney` and `olsen-fse` can be used.
* Click on `Unlock Theme`
* You should see the modal with the updated layout.
* Click to proceed and complete the purchase
* After completing the purchase you should be redirected to the Thank You page to activate the theme.
* You should see the loader for some time, and then see the purchased theme details.
* As soon as theme details are shown, click on `Activate this design`, and the theme should be activated.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
