### PR TITLE
Site profiler: Update copy, reorder data to reflect design changes

### DIFF
--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -24,7 +24,7 @@ export default function DomainAnalyzer( props: Props ) {
 
 	return (
 		<div className="domain-analyzer">
-			<h1>{ translate( 'Who Hosts This Site?' ) }</h1>
+			<h1>{ translate( 'Site Profiler' ) }</h1>
 			<p>
 				{ translate(
 					'Access essential information about a site, such as hosting provider, domain details, and contact information.'

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -35,7 +35,7 @@ export default function HeadingInformation( props: Props ) {
 	return (
 		<div className="heading-information">
 			<summary>
-				<h5>{ translate( 'Who Hosts This Site?' ) }</h5>
+				<h5>{ translate( 'Site Profiler' ) }</h5>
 				<div className="domain">
 					<StatusIcon conversionAction={ conversionAction } />
 					{ domain }

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -44,8 +44,8 @@ export default function HostingInformation( props: Props ) {
 						<ul>
 							{ aRecordIps.map( ( x, i ) => (
 								<li key={ i }>
-									{ ! x.host && '-' }
-									{ x.host && `${ x.host }` }
+									{ ! x.ip && '-' }
+									{ x.ip && `${ x.ip }` }
 								</li>
 							) ) }
 						</ul>
@@ -54,8 +54,8 @@ export default function HostingInformation( props: Props ) {
 						<ul>
 							{ aRecordIps.map( ( x, i ) => (
 								<li key={ i }>
-									{ ! x.ip && '-' }
-									{ x.ip && `${ x.ip }` }
+									{ ! x.host && '-' }
+									{ x.host && `${ x.host }` }
 								</li>
 							) ) }
 						</ul>

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -84,7 +84,7 @@ export default function SiteProfiler() {
 				</LayoutBlock>
 			) }
 
-			<LayoutBlock isMonoBg>
+			<LayoutBlock isMonoBg={ !! data }>
 				<HostingIntro />
 			</LayoutBlock>
 		</>


### PR DESCRIPTION


Closes https://github.com/Automattic/wp-calypso/issues/82179

## Proposed Changes

* A Records raw: Reorder columns host <-> ip
* Update copy
* Update background

## Testing Instructions

* Go to `/site-profiler`
* Check the reflected changes

<img width="1728" alt="Screenshot 2023-09-26 at 19 22 07" src="https://github.com/Automattic/wp-calypso/assets/1241413/b76244cc-0220-42d5-9d6d-76277943fb21">
<img width="541" alt="Screenshot 2023-09-26 at 19 34 35" src="https://github.com/Automattic/wp-calypso/assets/1241413/e74acd9b-939d-4713-9e38-ac5f79ca9a40">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?