### PR TITLE
Earn: Fix document title on some screens

### DIFF
--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -40,7 +40,9 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 	const layoutTitles = {
 		earnings: translate( '%(wordads)s Earnings', { args: { wordads: adsProgramName } } ),
 		settings: translate( '%(wordads)s Settings', { args: { wordads: adsProgramName } } ),
-		payments: translate( 'Recurring Payments' ),
+		payments: translate( 'Payment Settings' ),
+		customers: translate( 'Customers', { args: { wordads: adsProgramName } } ),
+		stats: translate( 'Stats' ),
 		'payments-plans': translate( 'Recurring Payments plans' ),
 		'refer-a-friend': translate( 'Refer-a-Friend Program' ),
 	};
@@ -226,7 +228,9 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				path={ section ? `/earn/${ section }/:site` : `/earn/:site` }
 				title={ `${ adsProgramName } ${ capitalize( section ) }` }
 			/>
-			<DocumentHead title={ layoutTitles[ section as keyof typeof layoutTitles ] } />
+			<DocumentHead
+				title={ layoutTitles[ section as keyof typeof layoutTitles ] ?? translate( 'Earn' ) }
+			/>
 			<FormattedHeader
 				brandFont
 				className="earn__page-header"

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -38,8 +38,9 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 	const adsProgramName = isJetpack ? 'Ads' : 'WordAds';
 
 	const layoutTitles = {
-		earnings: translate( '%(wordads)s Earnings', { args: { wordads: adsProgramName } } ),
-		settings: translate( '%(wordads)s Settings', { args: { wordads: adsProgramName } } ),
+		'ads-earnings': translate( '%(wordads)s Earnings', { args: { wordads: adsProgramName } } ),
+		'ads-settings': translate( '%(wordads)s Settings', { args: { wordads: adsProgramName } } ),
+		'ads-payments': translate( '%(wordads)s Payments', { args: { wordads: adsProgramName } } ),
 		payments: translate( 'Payment Settings' ),
 		customers: translate( 'Customers' ),
 		stats: translate( 'Stats' ),

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -41,7 +41,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		earnings: translate( '%(wordads)s Earnings', { args: { wordads: adsProgramName } } ),
 		settings: translate( '%(wordads)s Settings', { args: { wordads: adsProgramName } } ),
 		payments: translate( 'Payment Settings' ),
-		customers: translate( 'Customers', { args: { wordads: adsProgramName } } ),
+		customers: translate( 'Customers' ),
 		stats: translate( 'Stats' ),
 		'payments-plans': translate( 'Recurring Payments plans' ),
 		'refer-a-friend': translate( 'Refer-a-Friend Program' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fixes html document title not being set correctly for several Earn screens.

**Example + Screenshot for Translations**
<img width="1411" alt="earn-doc-title" src="https://github.com/Automattic/wp-calypso/assets/21228350/f362d24d-3c0f-4d12-a981-299ad9819de3">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Check out this branch and go to http://calypso.localhost:3000/earn/YOURDOMAIN. Confirm doc title visible in browser tab is 'Earn'
2) Click different tabs and confirm that document title visible in browser tab updates accurately for each tab. 
3) Click to the Tools > Marketing section on dashboard menu, then return to Earn, and confirm that doc title visible in browser tab is 'Earn' again (this had not been updating correctly in this specific situation). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?