### PR TITLE
Checkout: Add Akismet and Jetpack groups to ChatButton

### DIFF
--- a/client/components/chat-button/index.tsx
+++ b/client/components/chat-button/index.tsx
@@ -8,10 +8,12 @@ import type { MessagingGroup } from '@automattic/help-center/src/hooks/use-messa
 import type { FC } from 'react';
 
 type ChatIntent = 'SUPPORT' | 'PRESALES' | 'PRECANCELLATION';
+export type KeyType = 'akismet' | 'jpAgency' | 'jpCheckout' | 'jpGeneral' | 'wpcom';
 
 type Props = {
 	borderless?: boolean;
 	chatIntent?: ChatIntent;
+	keyType?: KeyType;
 	className?: string;
 	initialMessage: string;
 	onClick?: () => void;
@@ -23,10 +25,23 @@ type Props = {
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
-function getMessagingGroupForIntent( chatIntent: ChatIntent ): MessagingGroup {
+function getGroupName( keyType: KeyType ) {
+	switch ( keyType ) {
+		case 'akismet':
+		case 'jpAgency':
+		case 'jpCheckout':
+		case 'jpGeneral':
+			return 'jp_presales';
+		case 'wpcom':
+		default:
+			return 'wpcom_presales';
+	}
+}
+
+function getMessagingGroupForIntent( chatIntent: ChatIntent, keyType: KeyType ): MessagingGroup {
 	switch ( chatIntent ) {
 		case 'PRESALES':
-			return 'wpcom_presales';
+			return getGroupName( keyType );
 
 		case 'PRECANCELLATION':
 		case 'SUPPORT':
@@ -38,6 +53,7 @@ function getMessagingGroupForIntent( chatIntent: ChatIntent ): MessagingGroup {
 const ChatButton: FC< Props > = ( {
 	borderless = true,
 	chatIntent = 'SUPPORT',
+	keyType = 'wpcom',
 	children,
 	className = '',
 	initialMessage,
@@ -48,7 +64,8 @@ const ChatButton: FC< Props > = ( {
 } ) => {
 	const { __ } = useI18n();
 
-	const messagingGroup = getMessagingGroupForIntent( chatIntent );
+	const messagingGroup = getMessagingGroupForIntent( chatIntent, keyType );
+
 	const {
 		canConnectToZendesk,
 		hasActiveChats,
@@ -57,13 +74,13 @@ const ChatButton: FC< Props > = ( {
 		isPrecancellationChatOpen,
 		isPresalesChatOpen,
 	} = useChatStatus( messagingGroup );
+
 	const { setShowHelpCenter, setInitialRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	function shouldShowChatButton() {
 		if ( isEligibleForChat && hasActiveChats ) {
 			return true;
 		}
-
 		switch ( chatIntent ) {
 			case 'PRESALES':
 				if ( ! isPresalesChatOpen ) {


### PR DESCRIPTION
This is largely a shim of the existing messaging group code found in `usePresalesChat()`. Before these changes the ChatButton component would set the messagingGroup for useChatStatus to wpcom_presales, regardless of what products are in the cart. This change will allow us to set the messaging group for Jetpack and Akismet products.

A sidenote for a future PR, we ought to move the `getPresalesChatKey` function used in `wp-checkout` into its own file (or another file) and make it more generic, i.e. `getChatKey` then we can update the logic in one place instead of duplicating it like I've done in this PR.

Related to #80724 

## Proposed Changes

* This PR changes the static messagingGroup assignment from `wp_presales` to use a function that checks for Jetpack and Akismet products in the cart.
* This PR allows us to dynamically set the messagingGroup depending on the cart's content

## Testing Instructions
WIP