### PR TITLE
Subscription Management: Center-align not found error message and use Powered by Jetpack footer

### DIFF
--- a/client/blocks/reader-site-subscription/index.tsx
+++ b/client/blocks/reader-site-subscription/index.tsx
@@ -34,7 +34,7 @@ const ReaderSiteSubscription = () => {
 							className="site-subscription-page__fetch-details-error"
 							type={ NoticeType.Error }
 						>
-							Subscription not found
+							{ translate( 'Subscription not found' ) }
 						</Notice>
 					) : (
 						<SiteSubscriptionDetails

--- a/client/blocks/reader-site-subscription/index.tsx
+++ b/client/blocks/reader-site-subscription/index.tsx
@@ -2,9 +2,9 @@ import { Gridicon } from '@automattic/components';
 import { Reader } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import JetpackColophon from 'calypso/components/jetpack-colophon';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { Notice, NoticeType } from 'calypso/landing/subscriptions/components/notice';
-import PoweredByWPFooter from 'calypso/layout/powered-by-wp-footer';
 import { Path, useSiteSubscription } from './context';
 import SiteSubscriptionDetails from './details';
 import './styles.scss';
@@ -52,7 +52,7 @@ const ReaderSiteSubscription = () => {
 				</div>
 			</div>
 
-			<PoweredByWPFooter />
+			<JetpackColophon />
 		</div>
 	);
 };

--- a/client/blocks/reader-site-subscription/styles.scss
+++ b/client/blocks/reader-site-subscription/styles.scss
@@ -148,6 +148,7 @@
 
 	&__fetch-details-error {
 		margin: 64px 0 32px;
+		justify-content: center;
 	}
 
 	.site-subscription-page__manage-button {

--- a/client/blocks/reader-site-subscription/styles.scss
+++ b/client/blocks/reader-site-subscription/styles.scss
@@ -25,7 +25,7 @@
 		color: $studio-gray-100;
 		font-size: $font-body-small;
 		font-weight: 500;
-		padding: 0 0 0 24px;
+		padding: 0 0 0 0;
 
 		svg {
 			margin-right: 0;
@@ -167,10 +167,12 @@
 			position: fixed;
 			height: $back-button-height;
 			bottom: 0;
+			left: 0;
 			width: 100%;
 			box-shadow: inset 0 1px 0 #e2e4e7;
 			background-color: $studio-white;
 			z-index: 999;
+			padding: 0 0 0 24px;
 		}
 
 		&__header {
@@ -195,8 +197,6 @@
 // Large screens
 @media screen and (min-width: $break-small) {
 	.site-subscription-page {
-		margin-top: 26px;
-
 		&__back-button.components-button.has-icon.has-text {
 			box-shadow: none;
 		}

--- a/client/blocks/reader-site-subscription/styles.scss
+++ b/client/blocks/reader-site-subscription/styles.scss
@@ -60,10 +60,6 @@
 		}
 	}
 
-	.powered-by-wp-footer {
-		position: relative;
-	}
-
 	.site-subscription-settings {
 		width: 100%;
 		@extend .settings;

--- a/client/reader/site-subscription/site-subscription.tsx
+++ b/client/reader/site-subscription/site-subscription.tsx
@@ -1,9 +1,13 @@
 import ReaderSiteSubscription from 'calypso/blocks/reader-site-subscription';
+import Main from 'calypso/components/main';
 import SiteSubscriptionProvider from './site-subscription-provider';
+
 const SiteSubscription = ( { subscriptionId }: { subscriptionId: number } ) => {
 	return (
 		<SiteSubscriptionProvider subscriptionId={ subscriptionId }>
-			<ReaderSiteSubscription />
+			<Main className="site-subscriptions-manager">
+				<ReaderSiteSubscription />
+			</Main>
 		</SiteSubscriptionProvider>
 	);
 };


### PR DESCRIPTION
Context p1695754718934089-slack-C02TCEHP3HA

## Proposed Changes

* Center-align `Subscription not found` error
* Fix `Subscription not found` translation
* Use Powered by Jetpack footer
* Fix back button alignment

## Testing Instructions

* Apply this PR to your local
* Go to https://wordpress.com/read/subscriptions and open a subscription
* You should see the Jetpack footer
* Replace the subscription ID on the URL for an invalid ID
* You should see the `Subscription not found` error center-aligned with the Jetpack footer

<img width="1053" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/daa3cde8-e65e-40ad-acfe-351467497175">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?