### PR TITLE
Stats: Date control - style new chart header button label formatting

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -252,12 +252,6 @@ class StatsSite extends Component {
 					<>
 						{ isDateControlEnabled ? (
 							<>
-								<StatsDateControl
-									slug={ slug }
-									queryParams={ context.query }
-									period={ period }
-									pathTemplate={ pathTemplate }
-								/>
 								<StatsPeriodHeader>
 									<StatsPeriodNavigation
 										date={ date }
@@ -275,7 +269,12 @@ class StatsSite extends Component {
 											isShort
 										/>
 									</StatsPeriodNavigation>
-									<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
+									<StatsDateControl
+										slug={ slug }
+										queryParams={ context.query }
+										period={ period }
+										pathTemplate={ pathTemplate }
+									/>
 								</StatsPeriodHeader>
 							</>
 						) : (

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -1,4 +1,5 @@
 import { Dropdown, Button } from '@wordpress/components';
+import moment from 'moment';
 import page from 'page';
 import qs from 'qs';
 import React, { useState } from 'react';
@@ -47,6 +48,10 @@ const DateControlPicker = ( { slug, queryParams }: DateControlPickerProps ) => {
 		page( href );
 	};
 
+	const formatDate = ( date: string ) => {
+		return moment( date ).format( 'MMM D, YYYY' );
+	};
+
 	const DateControlPickerContent = () => (
 		<div>
 			<DateControlPickerDate
@@ -66,7 +71,7 @@ const DateControlPicker = ( { slug, queryParams }: DateControlPickerProps ) => {
 			popoverProps={ { placement: 'bottom-end' } }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button variant="primary" onClick={ onToggle } aria-expanded={ isOpen }>
-					{ `${ inputStartDate } - ${ inputEndDate }` }
+					{ `${ formatDate( inputStartDate ) } - ${ formatDate( inputEndDate ) }` }
 				</Button>
 			) }
 			renderContent={ () => <DateControlPickerContent /> }

--- a/client/my-sites/stats/stats-interval-dropdown/index.jsx
+++ b/client/my-sites/stats/stats-interval-dropdown/index.jsx
@@ -1,18 +1,36 @@
 import { Button, Dropdown } from '@wordpress/components';
-import React from 'react';
+import React, { useState } from 'react';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 
 const IntervalDropdown = ( { period, pathTemplate } ) => {
+	const [ currentInterval, setCurrentInterval ] = useState( period );
+
+	const intervalLabels = {
+		day: 'Days',
+		week: 'Weeks',
+		month: 'Months',
+		year: 'Years',
+	};
+
+	const getCurrentIntervalLabel = ( intervalValue ) => {
+		return intervalLabels[ intervalValue ] || intervalValue;
+	};
+
 	return (
 		<Dropdown
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button onClick={ onToggle } aria-expanded={ isOpen }>
-					Toggle Dropdown
+					{ getCurrentIntervalLabel( currentInterval ) }
 				</Button>
 			) }
 			renderContent={ ( { onClose } ) => (
 				<div>
-					<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
+					<Intervals
+						selected={ currentInterval }
+						pathTemplate={ pathTemplate }
+						compact={ false }
+						onChange={ setCurrentInterval }
+					/>
 					<Button variant="secondary" onClick={ onClose }>
 						Close
 					</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82082

## Proposed Changes

* This PR relocates the `StatsDateControl` component (containing `IntervalDropdown` and `DateControlPicker`) across the header to replace the previous intervals buttons. 
* Additionally, it formats the labels on both drop down buttons to display the correct & formatted data
	- 	`Toggle dropdown` becomes `Days` , `Weeks`, `Years` etc and updates to reflect whichever period is currently selected
	- The unformatted date button (`2023-23-9 - 2023-26-9`) becomes a formatted date (`Sep 23, 2023 - Sep 26, 2023`) and corrects the order to show the `from` date before the `to` date on the button label. 
* Note: Additional styling and relocation of the Date Picker to come in followup PRs, along with moving the date drop down up and out of the interval selection buttons section, whilst leaving the intervals drop down in this location. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live branch
* Navigate to `/stats/day/{site URL}`
* Confirm that everything remains unchanged without the feature flag applied
* Append `?flags=stats/date-control` to the end of the URL
* Confirm that now that the date range button displays a formatted date, eg. `Sep 23, 2023 - Sep 26, 2023`
* Confirm that the Toggle Dropdown button becomes `Days` , `Weeks`, `Years` etc and updates to reflect whichever period is currently selected
* Confirm both buttons are now located on the right, replacing the Interval buttons. 

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/30754158/07b12fa6-e724-4de8-a0d5-c6f99fd9fd74)  | ![image](https://github.com/Automattic/wp-calypso/assets/30754158/2dc6baf6-f90b-4873-b56d-d14c664fb96a)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?