### PR TITLE
Launchpad: Fixed preview border and remove top bar

### DIFF
--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -11,12 +11,12 @@
 		max-height: 235px;
 		cursor: pointer;
 		transition: all 200ms ease-in-out;
-		border: 1px solid var(--color-border-subtle);
-		border-radius: 4px;
+		box-shadow: 0 0 0 1px var(--color-border-subtle);
+		border-radius: 3px; /* stylelint-disable-line scales/radii */
 
 		&:hover,
 		&:focus {
-			box-shadow: rgba(0, 0, 0, 0.2) 0 7px 30px -10px;
+			box-shadow: 0 0 0 1px var(--color-border-subtle), rgba(0, 0, 0, 0.2) 0 7px 30px -10px;
 			.home-site-preview__thumbnail {
 				opacity: 0.8;
 			}
@@ -35,11 +35,12 @@
 				// The idea is to zoom-out the iframe to get most of the content
 				// into the thumbnail and then we scale it down so it remains the
 				// size of the parent component (357% * 0.28 ~= 100%)
-				height: 357%;
+				min-height: 375%;
 				width: 357%;
 				max-width: 357%;
 				transform: scale(0.28);
 				transform-origin: top left;
+				translate: 0 -10px;
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/81395

## Proposed Changes

* This PR changes the preview thumbnail border to box-shadow, so the 1px gap between the columns is fixed.
* The preview is also shifted a bit to hide the top bar.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site with build intent and launch it
* Go to the Customer home
* Check the preview

Before:
![image](https://github.com/Automattic/wp-calypso/assets/3801502/7446ac67-c93b-405e-a52d-79d88d6fd45d)

After:
![image](https://github.com/Automattic/wp-calypso/assets/3801502/7496975d-9644-4edb-a325-014d3d5d2a26)
