### PR TITLE
Launchpad: Fixed Editor Launchpad redirect

### DIFF
--- a/client/state/selectors/get-editor-close-config.js
+++ b/client/state/selectors/get-editor-close-config.js
@@ -24,8 +24,11 @@ export default function getEditorCloseConfig( state, siteId, postType ) {
 	const currentSiteId = state?.ui?.selectedSiteId;
 	const currentSite = state?.sites?.items[ currentSiteId ];
 
-	// Redirect user to Launchpad screen if launchpad is enabled
-	if ( currentSite?.options?.launchpad_screen === 'full' ) {
+	// Redirect user to Launchpad screen if launchpad is enabled and site is not launched.
+	if (
+		currentSite?.options?.launchpad_screen === 'full' &&
+		! currentSite?.options?.launchpad_checklist_tasks_statuses?.site_launched
+	) {
 		const siteSlug = getSiteSlug( state, currentSiteId );
 		const flow = currentSite?.options?.site_intent;
 		return {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/81404

## Proposed Changes

* With this PR, the link to the fullscreen launchpad label "Next steps" is only shown if the fullscreen pre-launch Launchpad is enabled. If it's not, the default buttons are shown.

## Testing Instructions
- Create a new `build` site.
- In the fullscreen Launchpad, don't skip it, and don't launch it.
- Access `/page/<new-site-slug>`
- In the left bar, check the "back" button. It should read "Next steps"
![image](https://github.com/Automattic/wp-calypso/assets/3801502/188e445d-bd10-466a-af71-3220dc74e339)
- Clicking in the button should take you to the Launchpad page
- Launch the site
- In Customer home, click on "Add new page"
- Again, in the left bar, check the "back" button. It should read "Dashboard"

Before this PR:
![image](https://github.com/Automattic/wp-calypso/assets/3801502/188e445d-bd10-466a-af71-3220dc74e339)

After:
![image](https://github.com/Automattic/wp-calypso/assets/3801502/8b2b4156-ccae-4879-94cb-a666456a2b1c)
