### PR TITLE
Live Preview -> Preview & Customize

### DIFF
--- a/client/my-sites/theme/live-preview-button/index.tsx
+++ b/client/my-sites/theme/live-preview-button/index.tsx
@@ -12,7 +12,6 @@ interface Props {
 
 /**
  * Live Preview leveraging Gutenberg's Block Theme Previews
- *
  * @see pbxlJb-3Uv-p2
  */
 export const LivePreviewButton: FC< Props > = ( { themeId, siteId } ) => {
@@ -28,7 +27,7 @@ export const LivePreviewButton: FC< Props > = ( { themeId, siteId } ) => {
 
 	return (
 		<Button onClick={ () => dispatch( livePreview( themeId, siteId, 'detail' ) ) }>
-			{ translate( 'Live preview' ) }
+			{ translate( 'Preview & Customize' ) }
 		</Button>
 	);
 };

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -245,7 +245,7 @@ class ThanksModal extends Component {
 		const { isLivePreviewStarted } = this.props;
 
 		if ( isLivePreviewStarted ) {
-			return this.props.translate( 'Preparing the live preview…' );
+			return this.props.translate( 'Preparing the Preview & Customize…' );
 		}
 
 		return this.props.translate( 'Activating theme…' );

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -240,7 +240,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 	};
 
 	const livePreview = {
-		label: translate( 'Live preview', {
+		label: translate( 'Preview & Customize', {
 			comment: 'label for previewing a block theme',
 		} ),
 		action: ( themeId, siteId ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* This PR changes the copy "Live Preview" to "Preview & Customize" that was suggested in pekYwv-2Qw-p2#comment-2276. (I used `&` to align with "Try & Customize").
* Note that I did not change the codebase, which uses "Live Preview" for variables/functions, since we will iterate the copy going forward. Let's hold off on it until we stabilize the domain language for the Live Preview feature. 

![Screenshot 2023-10-05 at 8 36 15 AM](https://github.com/Automattic/wp-calypso/assets/797888/0f1fe92f-d856-4149-87f9-230b5b3b35eb)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Verify that "Previre & Customize" are shown in the following places;
	- On the three-dots menu on the Theme Card on the Theme Showcase page
	- On the Theme Detail page
- Verify that "Preparing the Previre & Customize" is shown when you click the "Previre & Customize" on the Theme Detail page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?