### PR TITLE
Jetpack Manage: Fix the toggle favorite notification issue

### DIFF
--- a/client/data/agency-dashboard/use-toggle-favourite-site-mutation.ts
+++ b/client/data/agency-dashboard/use-toggle-favourite-site-mutation.ts
@@ -2,13 +2,9 @@ import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/re
 import {
 	APIError,
 	APIToggleFavorite,
+	ToggleFavoriteOptions,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
-
-interface ToggleFavoriteOptions {
-	siteId: number;
-	isFavorite: boolean;
-}
 
 function mutationToggleFavoriteSite( {
 	siteId,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
@@ -10,7 +10,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
 import SitesOverviewContext from '../context';
-import type { APIError, Site } from '../types';
+import type { APIError, Site, APIToggleFavorite, ToggleFavoriteOptions } from '../types';
 
 import './style.scss';
 
@@ -41,7 +41,7 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 		page.redirect( '/dashboard/favorites?highlight=favorite-tab' );
 	};
 
-	const handleOnChangeFavoriteSuccess = () => {
+	const handleOnChangeFavoriteSuccess = ( isFavorite: boolean ) => {
 		const text = (
 			<span>
 				{ ! isFavorite
@@ -114,8 +114,8 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 				// Store previous settings in case of failure
 				return { previousSites };
 			},
-			onSuccess: () => {
-				handleOnChangeFavoriteSuccess();
+			onSuccess: ( _data: APIToggleFavorite, options: ToggleFavoriteOptions ) => {
+				handleOnChangeFavoriteSuccess( options.isFavorite );
 			},
 			onError: ( error: APIError, options: any, context: any ) => {
 				queryClient.setQueryData( queryKey, context?.previousSites );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -264,6 +264,11 @@ export interface APIToggleFavorite {
 	[ key: string ]: any;
 }
 
+export interface ToggleFavoriteOptions {
+	siteId: number;
+	isFavorite: boolean;
+}
+
 interface MonitorURLS {
 	monitor_url: string;
 	options: Array< string >;


### PR DESCRIPTION
## Proposed Changes

* This PR fixes the issue with the toggle favorite functionality on the Sites Dashboard in Jetpack Manage that shows incorrect notification text.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud link
2. Visit the Dashboard 
3. Set any site as a favorite and also remove a site from favorites > Verify the message shown is accurate.

Verify this message is shown when a site is set as a favorite instead of `<site> has been removed from your favorites` 

<img width="720" alt="Screenshot 2023-09-27 at 10 45 21 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/7eae04e4-9148-4245-be81-f8aaa414b69a">

Verify this message is shown when a site is removed from favorites instead of `<site> has been added to your favorites`

<img width="698" alt="Screenshot 2023-09-27 at 10 43 01 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c6778600-5387-4957-9136-76c1010ec1f8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?