### PR TITLE
Stats: Remove Custom Range shortcut

### DIFF
--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -43,13 +43,8 @@ const StatsDateControl = ( { slug, queryParams, period, pathTemplate }: StatsDat
 			offset: 0,
 			range: 400, // TODO: Don't hard code this value.
 		},
-		{
-			id: 'custom-range',
-			label: 'Custom Range',
-			offset: 0,
-			range: 3, // TODO: Should nail down how this is expected to behave.
-		},
 	];
+
 	return (
 		<div className={ COMPONENT_CLASS_NAME }>
 			<IntervalDropdown period={ period } pathTemplate={ pathTemplate } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81938.

## Proposed Changes

Just removing the Custom Range shortcut per updated designs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Spin up the Live branch.
2. Visit **Stats → Traffic**.
3. Enable feature flag: `?flags=stats/date-control`
4. Open the date range picker and confirm "Custom Range" is no longer listed as a shortcut.

<img width="404" alt="SCR-20230927-oolg" src="https://github.com/Automattic/wp-calypso/assets/40267301/060c2a74-c95b-4cf8-99f9-7ded2de7b56f">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?