### PR TITLE
Domain Forwarding: Improve error handling

### DIFF
--- a/client/data/domains/forwarding/use-update-domain-forwarding-mutation.ts
+++ b/client/data/domains/forwarding/use-update-domain-forwarding-mutation.ts
@@ -21,6 +21,9 @@ export default function useUpdateDomainForwardingMutation(
 			queryClient.invalidateQueries( domainForwardingQueryKey( domainName ) );
 			queryOptions.onSuccess?.();
 		},
+		onError( error: DomainsApiError ) {
+			queryOptions.onError?.( error );
+		},
 	} );
 
 	const { mutate } = mutation;

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -64,14 +64,11 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 			dispatch(
 				successNotice( translate( 'Domain forward updated and enabled.' ), noticeOptions )
 			);
+			// TODO: open the edition of the new forwarding we just created
+			setEditingId( 0 );
 		},
-		onError() {
-			dispatch(
-				errorNotice(
-					translate( 'An error occurred while updating the domain forward.' ),
-					noticeOptions
-				)
-			);
+		onError( error ) {
+			dispatch( errorNotice( error.message, noticeOptions ) );
 		},
 	} );
 
@@ -246,9 +243,6 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 			forward_paths: forwardPaths,
 			is_permanent: isPermanent,
 		} );
-
-		// TODO: open the edition of the new forwarding we just created
-		setEditingId( 0 );
 
 		return false;
 	};


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3611

## Proposed Changes

Show the backend error messages instead of a generic error message

### TO DO
- [x] Fix E2E tests
- [x] Check all type of errors on add/edit.
- [x] Check all type of errors on delete.

## Testing Instructions

* Apply D123099-code
* Create a domain forward with an error, like `goggle.co123$#@$@34423` as a Destination URL.
* Check error messages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?