### PR TITLE
Suspended Domains i1: Should Launchpad task for unverified email when site has custom domain

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -555,7 +555,7 @@ export function getEnhancedTasks(
 						completed: ! isDomainEmailUnverified,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.replace( task.calypso_path || '/me/account' );
+							window.location.replace( task.calypso_path || `/domains/manage/${ siteSlug }` );
 						},
 					};
 					break;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -550,9 +550,14 @@ export function getEnhancedTasks(
 								: translate( 'Upgrade plan' ),
 					};
 					break;
+				case 'verify_domain_email':
 				case 'verify_email':
 					taskData = {
 						completed: isEmailVerified,
+						actionDispatch: () => {
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
+							window.location.replace( task.calypso_path || '/me/account' );
+						},
 					};
 					break;
 				case 'set_up_payments':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -551,6 +551,14 @@ export function getEnhancedTasks(
 					};
 					break;
 				case 'verify_domain_email':
+					taskData = {
+						completed: ! isDomainEmailUnverified,
+						actionDispatch: () => {
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
+							window.location.replace( task.calypso_path || '/me/account' );
+						},
+					};
+					break;
 				case 'verify_email':
 					taskData = {
 						completed: isEmailVerified,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -7,6 +7,7 @@ export interface Task {
 	badge_text?: string;
 	actionDispatch?: ( force?: boolean ) => void;
 	isLaunchTask?: boolean;
+	calypso_path?: string;
 }
 
 export type LaunchpadChecklist = Task[];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3948
Related D123297-code
Related https://github.com/Automattic/jetpack/pull/33373

## Proposed Changes

* If the user bought a custom domain and their email address has not been verified, show a Launchpad task to get them to confirm their email. 

![image](https://github.com/Automattic/wp-calypso/assets/6851384/5309d281-6eed-4a4e-a50f-acb8b92ffd6d)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the https://github.com/Automattic/jetpack/pull/33373 to your sandbox using `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/task_for_email_verification_when_custom_domain_present`
* Checkout this branch
* Buy a domain with an account that has an unverified email address
* Confirm you see a Launchpad task. 
* Confirm that clicking it takes you to `/domains/manage/:site` 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?