### PR TITLE
Gravatar: Move the `.is-grav-powered-login-page` setup logic to the same place for enhanced maintainability

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -25,6 +25,7 @@ import {
 	isGravPoweredOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getRedirectToOriginal } from 'calypso/state/login/selectors';
 import { isPartnerSignupQuery } from 'calypso/state/login/utils';
 import {
 	getCurrentOAuth2Client,
@@ -258,7 +259,12 @@ export default withCurrentRoute(
 		const oauth2Client = getCurrentOAuth2Client( state );
 		const isGravatar = isGravatarOAuth2Client( oauth2Client );
 		const isWPJobManager = isWPJobManagerOAuth2Client( oauth2Client );
-		const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
+		const redirectToOriginal = getRedirectToOriginal( state ) || '';
+		const clientId = new URLSearchParams( redirectToOriginal.split( '?' )[ 1 ] ).get( 'client_id' );
+		const isGravPoweredClient =
+			isGravPoweredOAuth2Client( oauth2Client ) ||
+			// To support the case of a login URL without the "client_id" parameter, e.g. /log-in/link/use
+			isGravPoweredOAuth2Client( { id: Number( clientId ) } );
 		const isReskinLoginRoute =
 			currentRoute.startsWith( '/log-in' ) &&
 			! isJetpackLogin &&

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -263,7 +263,7 @@ export default withCurrentRoute(
 		const clientId = new URLSearchParams( redirectToOriginal.split( '?' )[ 1 ] ).get( 'client_id' );
 		const isGravPoweredClient =
 			isGravPoweredOAuth2Client( oauth2Client ) ||
-			// To support the case of a login URL without the "client_id" parameter, e.g. /log-in/link/use
+			// To cover the case of a login URL without the "client_id" parameter, e.g. /log-in/link/use
 			isGravPoweredOAuth2Client( { id: Number( clientId ) } );
 		const isReskinLoginRoute =
 			currentRoute.startsWith( '/log-in' ) &&

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -85,12 +85,6 @@ class HandleEmailedLinkForm extends Component {
 		) {
 			this.handleSubmit();
 		}
-
-		if ( isGravPoweredOAuth2Client( this.props.oauth2Client ) ) {
-			document
-				.querySelector( '.layout.is-section-login' )
-				?.classList.add( 'is-grav-powered-login-page' );
-		}
 	}
 
 	handleSubmit = ( event ) => {
@@ -250,10 +244,8 @@ class HandleEmailedLinkForm extends Component {
 }
 
 const mapState = ( state ) => {
-	const redirectToOriginal = getRedirectToOriginal( state );
-	const redirectToOriginalParams =
-		typeof redirectToOriginal === 'string' && redirectToOriginal.split( '?' )[ 1 ];
-	const clientId = new URLSearchParams( redirectToOriginalParams ).get( 'client_id' );
+	const redirectToOriginal = getRedirectToOriginal( state ) || '';
+	const clientId = new URLSearchParams( redirectToOriginal.split( '?' )[ 1 ] ).get( 'client_id' );
 	const oauth2Client = state.oauth2Clients?.clients?.[ clientId ] || {};
 
 	return {

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -109,7 +109,7 @@ export const getRequestNotice = ( state ) => state.login.requestNotice;
  * @returns {?string}         Url to redirect the user to upon successful login
  * @see getRedirectToSanitized for the sanitized version
  */
-export const getRedirectToOriginal = ( state ) => state.login.redirectTo.original ?? null;
+export const getRedirectToOriginal = ( state ) => state.login?.redirectTo?.original ?? null;
 
 /**
  * Retrieves the last redirect url provided in the query parameters of any login page that was sanitized by the API


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: Moving the `.is-grav-powered-login-page` setup logic to the `logged-out.jsx` for enhanced maintainability

## Proposed Changes

* Move the `.is-grav-powered-login-page` setup logic to the same place, i.e. the `logged-out.jsx` file
* Make the `clientId` related logic of the `handle-emailed-link-form.jsx` shorter
* Add `?.` for the `getRedirectToOriginal()` to ensure it won't throw an error

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `public-api.wordpress.com`, and then apply this diff: `arc patch D123169`
* Setup Calypso, and run `yarn start`
* Log out of your account. Go to the login page of [Gravatar](http://calypso.localhost:3000/log-in/link?client_id=1854&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3Dbfa7ea95b0a07d39e3f23e1d923ce77b35016295d986b51361d4334a6e571206%26redirect_uri%3Dhttps%253A%252F%252Fen.gravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1) and [WPJM](http://calypso.localhost:3000/log-in/link/?client_id=90057&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthenticate%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3D01b7d7bfcfd126450053529ce09fefb5%26redirect_uri%3Dhttp%253A%252F%252Fwpjobmanagercom.vipdev.lndo.site%253A8000%252Fwp-json%252Fwpjmcom-auth%252Fv1%252Fcallback&create_account=1). The flow should work the same
* Log out of your account. Login via WP.com's [magic login page](http://calypso.localhost:3000/log-in/link). The flow should work the same

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
