### PR TITLE
Domain transfers: Add designated agent terms and link

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -203,16 +203,25 @@ function ContactInfo( {
 					<Gridicon icon="info-outline" size={ 18 } />
 					<p>
 						{ translate(
-							'By accepting this transfer, you agree to the {{a}}Domain Registration Agreement{{/a}} for %(domainName)s.',
+							'By accepting this transfer, you agree to the {{agreementlink}}Domain Registration Agreement{{/agreementlink}} for %(domainName)s. You authorize the respective registrar to act as your {{agentlink}}Designated Agent{{/agentlink}}.',
 							{
 								args: {
 									domainName: domain ?? '',
 								},
 								components: {
-									a: (
+									agreementlink: (
 										<a
 											href={ localizeUrl(
 												'https://wordpress.com/automattic-domain-name-registration-agreement/'
+											) }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+									agentlink: (
+										<a
+											href={ localizeUrl(
+												'https://wordpress.com/support/domains/update-contact-information/#designated-agent'
 											) }
 											target="_blank"
 											rel="noopener noreferrer"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/styles.scss
@@ -31,22 +31,15 @@ $heading-font-family: "SF Pro Display", $sans;
 
 	.domain-contact-info-form {
 		&__terms {
-			padding-left: 24px;
-			position: relative;
 			font-size: $font-body-small;
-			margin-left: 0;
+			color: var(--color-text-subtle);
+			display: flex;
+			align-items: flex-start;
+			justify-content: space-between;
+			column-gap: 5px;
 
 			> svg {
-				position: absolute;
-				top: 0;
-				left: 0;
-				width: 16px;
-				height: 16px;
-
-				.rtl & {
-					left: auto;
-					right: 0;
-				}
+				flex-shrink: 0;
 			}
 
 			p {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3901

## Proposed Changes

* Adds link to designated agent terms to the information part of the domain transfer acceptance screen.
* Minor style fixes 

## Testing Instructions

* http://calypso.localhost:3000/setup/domain-user-transfer/domain-contact-info?domain=test345678.blog

Before

![Screenshot 2023-09-27 at 20-22-40 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/8aa57dac-e27e-4773-8125-3537083e3e8c)


After

![Screenshot 2023-09-27 at 20-22-52 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/de0c8183-f912-4a2a-9dff-4a22ac3076b8)
