### PR TITLE
Update domain transfer init succeed congrats page

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-user-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-user-transfer.ts
@@ -25,7 +25,12 @@ const domainUserTransfer: Flow = {
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, currentStep );
-
+			switch ( currentStep ) {
+				case 'domain-contact-info':
+					return window.location.assign(
+						`/checkout/domain-transfer-to-any-user/thank-you/${ providedDependencies.domain }`
+					);
+			}
 			return providedDependencies;
 		}
 
@@ -34,10 +39,7 @@ const domainUserTransfer: Flow = {
 		};
 
 		const goNext = () => {
-			switch ( currentStep ) {
-				case 'contact-info':
-					return navigate( '/manage/domains' );
-			}
+			return;
 		};
 
 		const goToStep = ( step: string ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -1,9 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Gridicon, Button, ConfettiAnimation } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { camelToSnakeCase, mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/js-utils';
 import { useTranslate } from 'i18n-calypso';
-import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import ContactDetailsFormFields from 'calypso/components/domains/contact-details-form-fields';
@@ -16,7 +15,6 @@ import {
 } from 'calypso/data/domains/transfers/use-domain-transfer-receive';
 import { useDomainParams } from 'calypso/landing/stepper/hooks/use-domain-params';
 import wp from 'calypso/lib/wp';
-import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
 import { errorNotice } from 'calypso/state/notices/actions';
 import type { StepProps, ProvidedDependencies } from '../../types';
 import './styles.scss';
@@ -24,7 +22,6 @@ import './styles.scss';
 export default function DomainContactInfo( { navigation }: StepProps ) {
 	const { submit } = navigation;
 	const translate = useTranslate();
-	const [ success, setSuccess ] = useState( false );
 
 	return (
 		<StepContainer
@@ -34,57 +31,24 @@ export default function DomainContactInfo( { navigation }: StepProps ) {
 			formattedHeader={
 				<FormattedHeader
 					className="domain-contact-info-header"
-					headerText={
-						success
-							? translate( 'Your domain transfer is underway!' )
-							: translate( 'Your contact details are needed' )
-					}
-					subHeaderText={
-						success
-							? translate(
-									'Domain transfers can take a few minutes, we’ll email you once it’s set up.'
-							  )
-							: translate(
-									'To accept a domain transfer we are required to collect your contact information.'
-							  )
-					}
+					headerText={ translate( 'Your contact details are needed' ) }
+					subHeaderText={ translate(
+						'To accept a domain transfer we are required to collect your contact information.'
+					) }
 				/>
 			}
-			stepContent={
-				<>
-					{ success && <SuccessContent /> }
-					{ ! success && <ContactInfo onSubmit={ submit } setSuccess={ setSuccess } /> }
-				</>
-			}
+			stepContent={ <ContactInfo onSubmit={ submit } /> }
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);
 }
 
-function SuccessContent() {
-	const translate = useTranslate();
-	useEffect( () => {
-		recordTracksEvent( 'calypso_domain_transfer_start_success' );
-	}, [] );
-
-	return (
-		<div className="domain-contact-info__success">
-			<ConfettiAnimation />
-			<Button className="domain-contact-info__success-cta" href={ domainManagementRoot() } primary>
-				{ translate( 'Manage domains' ) }
-			</Button>
-		</div>
-	);
-}
-
 function ContactInfo( {
 	onSubmit,
-	setSuccess,
 }: {
 	onSubmit:
 		| ( ( providedDependencies?: ProvidedDependencies | undefined, ...params: string[] ) => void )
 		| undefined;
-	setSuccess: React.Dispatch< React.SetStateAction< boolean > >;
 } ) {
 	const translate = useTranslate();
 	const localizeUrl = useLocalizeUrl();
@@ -93,9 +57,7 @@ function ContactInfo( {
 
 	const { domainTransferReceive } = useDomainTransferReceive( domain ?? '', {
 		onSuccess( data ) {
-			if ( data.success ) {
-				setSuccess( true );
-			} else {
+			if ( ! data.success ) {
 				dispatch(
 					errorNotice(
 						translate( 'Domain transfers are currently unavailable, please try again later.' ),
@@ -168,7 +130,7 @@ function ContactInfo( {
 
 	function submitForm( contactInfo: TransferInfo ) {
 		domainTransferReceive( contactInfo );
-		onSubmit?.( contactInfo );
+		onSubmit?.( { contactInfo, domain } );
 	}
 
 	const renderContent = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -57,7 +57,9 @@ function ContactInfo( {
 
 	const { domainTransferReceive } = useDomainTransferReceive( domain ?? '', {
 		onSuccess( data ) {
-			if ( ! data.success ) {
+			if ( data.success ) {
+				onSubmit?.( { domain } );
+			} else {
 				dispatch(
 					errorNotice(
 						translate( 'Domain transfers are currently unavailable, please try again later.' ),
@@ -130,7 +132,6 @@ function ContactInfo( {
 
 	function submitForm( contactInfo: TransferInfo ) {
 		domainTransferReceive( contactInfo );
-		onSubmit?.( { contactInfo, domain } );
 	}
 
 	const renderContent = () => {

--- a/client/my-sites/checkout/checkout-thank-you/domain-transfer-to-any-user/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-transfer-to-any-user/index.tsx
@@ -1,0 +1,31 @@
+import { translate } from 'i18n-calypso';
+import ThankYouLayout from '../redesign-v2/ThankYouLayout';
+import DomainTransferToAnyUserFooter from '../redesign-v2/sections/footer/DomainTransferToAnyUserFooter';
+import DefaultThankYouHeader from '../redesign-v2/sections/header/Default';
+import ProductDomain from '../redesign-v2/sections/product/ProductDomain';
+import DefaultSubHeader from '../redesign-v2/sections/subheader/Default';
+
+interface DomainTransferToAnyUserContainerProps {
+	domain: string;
+}
+
+const DomainTransferToAnyUser: React.FC< DomainTransferToAnyUserContainerProps > = ( {
+	domain,
+} ) => {
+	return (
+		<ThankYouLayout>
+			<DefaultThankYouHeader>
+				{ translate( 'Your domain transfer is underway' ) }
+			</DefaultThankYouHeader>
+			<DefaultSubHeader>
+				{ translate(
+					'Domain transfers can take a few minutes, we’ll email you once it’s set up.'
+				) }
+			</DefaultSubHeader>
+			<ProductDomain domain={ domain } />
+			<DomainTransferToAnyUserFooter />
+		</ThankYouLayout>
+	);
+};
+
+export default DomainTransferToAnyUser;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/ThankYouLayout.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/ThankYouLayout.tsx
@@ -1,0 +1,21 @@
+import { ConfettiAnimation } from '@automattic/components';
+import Main from 'calypso/components/main';
+import CheckoutMasterbar from './sections/CheckoutMasterbar';
+
+import './style.scss';
+
+interface ThankYouLayoutContainerProps {
+	children: React.ReactNode;
+}
+
+const ThankYouLayout: React.FC< ThankYouLayoutContainerProps > = ( { children } ) => {
+	return (
+		<Main className="is-redesign-v2">
+			<ConfettiAnimation />
+			<CheckoutMasterbar />
+			{ children }
+		</Main>
+	);
+};
+
+export default ThankYouLayout;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/ThankYouLayout.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/ThankYouLayout.tsx
@@ -1,4 +1,3 @@
-import { ConfettiAnimation } from '@automattic/components';
 import Main from 'calypso/components/main';
 import CheckoutMasterbar from './sections/CheckoutMasterbar';
 
@@ -11,7 +10,6 @@ interface ThankYouLayoutContainerProps {
 const ThankYouLayout: React.FC< ThankYouLayoutContainerProps > = ( { children } ) => {
 	return (
 		<Main className="is-redesign-v2">
-			<ConfettiAnimation />
 			<CheckoutMasterbar />
 			{ children }
 		</Main>

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/CheckoutMasterbar.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/CheckoutMasterbar.tsx
@@ -5,7 +5,7 @@ import MasterbarStyled from '../masterbar-styled';
 
 type HeaderProps = {
 	siteId?: number;
-	siteSlug: string | null;
+	siteSlug?: string | null;
 };
 
 const CheckoutMasterbar = ( { siteId, siteSlug }: HeaderProps ) => {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/Product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/Product.tsx
@@ -13,7 +13,6 @@ const Product = ( {
 	if ( isBulkDomainTransfer( purchases ) ) {
 		return <DomainsTransferredList purchases={ purchases } currency={ currency } />;
 	}
-
 	return (
 		<ProductPlan siteSlug={ siteSlug } primaryPurchase={ primaryPurchase } siteID={ siteID } />
 	);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/DomainTransferToAnyUserFooter.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/DomainTransferToAnyUserFooter.tsx
@@ -1,0 +1,33 @@
+import { translate } from 'i18n-calypso';
+import PurchaseDetail from 'calypso/components/purchase-detail';
+
+import './style.scss';
+
+const DomainTransferToAnyUserFooter = () => {
+	return (
+		<div className="checkout-thank-you__purchase-details-list">
+			<div>
+				<PurchaseDetail
+					title={ translate( 'Dive into domain essentials' ) }
+					description={ translate(
+						'Check out our support documentation for step-by-step instructions and expert guidance on your domain set up.'
+					) }
+					buttonText={ translate( 'Master the domain basics' ) }
+					href="/support/domains"
+					onClick={ null }
+				/>
+				<PurchaseDetail
+					title={ translate( 'Your go-to domain resource' ) }
+					description={ translate(
+						'Dive into our comprehensive support documentation to learn the basics of domains, from registration to management.'
+					) }
+					buttonText="Domain support resources"
+					href="/support/category/domains-and-email"
+					onClick={ null }
+				/>
+			</div>
+		</div>
+	);
+};
+
+export default DomainTransferToAnyUserFooter;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/style.scss
@@ -1,0 +1,132 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.is-redesign-v2 {
+	.checkout-thank-you__purchase-details-list {
+		text-align: initial;
+		margin-top: 40px;
+		margin-bottom: 80px;
+		display: flex;
+		justify-content: center;
+
+		// Each of the checkout thank you pages "details" component sections specifically wrap
+		// all purchase details in a single unclassed div, so we need to target it for the
+		// flexbox styles instead of .checkout-thank-you__purchase-details-list directly.
+		> div {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 30px;
+		}
+
+		@include break-mobile {
+			margin-top: 50px;
+			padding-bottom: 0;
+		}
+
+		.purchase-detail {
+			margin: 0;
+			box-shadow: none;
+			height: auto;
+			min-width: auto;
+			max-width: 280px;
+			@include break-mobile {
+				width: 600px;
+			}
+		}
+
+		.purchase-detail__content {
+			padding: 0;
+		}
+
+
+		.purchase-detail__image {
+			display: none;
+		}
+
+		.purchase-detail__title {
+			font-size: $font-body-small;
+			line-height: 20px;
+			font-weight: 500;
+			color: var(--studio-gray-100);
+		}
+
+		.purchase-detail__description {
+			font-size: $font-body-small;
+			line-height: 20px;
+			font-weight: 400;
+			color: var(--color-text-subtle);
+		}
+
+		// Undo a.button styles
+		a.purchase-detail__button {
+			border: none;
+			display: inline;
+			margin: inherit;
+			outline: inherit;
+			overflow: inherit;
+			text-align: left;
+			text-overflow: inherit;
+			text-decoration: underline;
+			vertical-align: inherit;
+			box-sizing: border-box;
+			padding: 0;
+			appearance: none;
+			background-color: var(--color-surface);
+			font-size: $font-body-small;
+			line-height: 20px;
+			font-weight: 500;
+			color: var(--studio-blue-50);
+		}
+	}
+
+	div.checkout-thank-you__purchase-details-list {
+		margin-left: 0;
+		margin-right: 0;
+		display: block;
+
+		>div {
+			padding: 0 25px;
+			margin-bottom: 50px;
+			justify-content: space-between;
+			flex-wrap: nowrap;
+
+			@media (max-width: $break-medium ) {
+				flex-direction: column;
+				padding: 0;
+				flex-wrap: wrap;
+			}
+
+			div.purchase-detail {
+				flex: 1;
+				width: unset;
+				max-width: unset;
+			}
+
+			h3 {
+				font-size: 1rem;
+				font-weight: 500;
+			}
+
+			p {
+				font-size: 0.875rem;
+				margin-top: 5px;
+				margin-bottom: 16px;
+			}
+
+			a {
+				text-decoration: underline;
+				font-size: 0.875rem;
+				font-weight: 500;
+			}
+
+			.purchase-detail__button {
+				svg {
+					display: none;
+				}
+			}
+
+			display: flex;
+			gap: 40px;
+		}
+	}
+}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/header/Default.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/header/Default.tsx
@@ -1,0 +1,13 @@
+import preventWidows from 'calypso/lib/post-normalizer/rule-prevent-widows';
+
+import './style.scss';
+
+interface DefaultThankYouHeaderContainerProps {
+	children: string;
+}
+
+const DefaultThankYouHeader: React.FC< DefaultThankYouHeaderContainerProps > = ( { children } ) => {
+	return <h1 className="checkout-thank-you__header-heading">{ preventWidows( children ) }</h1>;
+};
+
+export default DefaultThankYouHeader;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/header/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/header/style.scss
@@ -1,0 +1,20 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.is-redesign-v2 {
+	.checkout-thank-you__header-heading {
+		@extend .wp-brand-font;
+		font-size: $font-headline-small;
+		color: var(--color-text);
+		margin: 30px 0 8px 0;
+		line-height: 40px;
+		text-align: left;
+
+		@include break-mobile {
+			font-size: $font-headline-medium;
+			margin: 60px 0 8px 0;
+			line-height: 60px;
+			text-align: center;
+		}
+	}
+}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/ProductDomain.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/ProductDomain.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@wordpress/components';
+import { translate } from 'i18n-calypso';
+import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
+
+import './style.scss';
+
+type ProductDomainProps = {
+	domain: string;
+};
+
+const ProductDomain = ( { domain }: ProductDomainProps ) => {
+	return (
+		<div className="checkout-thank-you__header-details">
+			<div className="checkout-thank-you__header-details-content">
+				<>
+					<div className="checkout-thank-you__header-details-content-name">{ domain }</div>
+				</>
+			</div>
+			<div className="checkout-thank-you__header-details-buttons">
+				<Button variant="primary" href={ domainManagementRoot() }>
+					{ translate( 'Manage domains' ) }
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+export default ProductDomain;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/style.scss
@@ -175,3 +175,59 @@
 		}
 	}
 }
+
+.is-redesign-v2 {
+	.checkout-thank-you__header-details {
+		margin: 40px 0 0;
+		display: flex;
+		flex-direction: row;
+		box-sizing: border-box;
+		align-items: center;
+		gap: 16px;
+		padding: 24px;
+		border-radius: 2px;
+		border: 1px solid var(--color-border-subtle);
+		flex-wrap: wrap;
+
+		div {
+			min-width: auto;
+		}
+
+		@media ( min-width: 480px ) {
+			padding: 20px 25px;
+			margin: 50px 0 0;
+		}
+	}
+
+	.checkout-thank-you__header-details-content {
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
+		flex-basis: 100%;
+		text-align: left;
+		@media ( min-width: 480px ) {
+			flex-basis: initial;
+		}
+	}
+
+	.checkout-thank-you__header-details-content-name {
+		font-size: $font-body;
+		font-weight: 500;
+		line-height: 24px;
+		color: var(--studio-gray-100);
+		flex-grow: 1;
+	}
+
+	.checkout-thank-you__header-details-content-expiry {
+		font-size: $font-body-small;
+		line-height: 22px;
+		color: var(--studio-gray-60);
+	}
+
+	.checkout-thank-you__header-details-buttons {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 16px;
+		min-width: auto;
+	}
+}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/subheader/Default.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/subheader/Default.tsx
@@ -1,0 +1,13 @@
+import preventWidows from 'calypso/lib/post-normalizer/rule-prevent-widows';
+
+import './style.scss';
+
+interface DefaultSubHeaderContainerProps {
+	children: string;
+}
+
+const DefaultSubHeader: React.FC< DefaultSubHeaderContainerProps > = ( { children } ) => {
+	return <h1 className="checkout-thank-you__header-text">{ preventWidows( children ) }</h1>;
+};
+
+export default DefaultSubHeader;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/subheader/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/subheader/style.scss
@@ -1,0 +1,15 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.is-redesign-v2 {
+	.checkout-thank-you__header-text {
+		color: var(--color-text-subtle);
+		font-size: initial;
+		margin: initial;
+		text-align: left;
+
+		@include break-mobile {
+			text-align: center;
+		}
+	}
+}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/style.scss
@@ -2,7 +2,8 @@
 @import "@wordpress/base-styles/mixins";
 
 // Design i2 overrides, the purchase-detail component is also used by the /plans/my-plan page to render plan features.
-.is-redesign-v2.checkout-thank-you {
+.is-redesign-v2.checkout-thank-you,
+.is-redesign-v2 {
 	&.main {
 		max-width: 750px;
 		padding: 0 24px 0;

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -31,6 +31,7 @@ import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import CheckoutMainWrapper from './checkout-main-wrapper';
 import CheckoutThankYouComponent from './checkout-thank-you';
 import AkismetCheckoutThankYou from './checkout-thank-you/akismet-checkout-thank-you';
+import DomainTransferToAnyUser from './checkout-thank-you/domain-transfer-to-any-user';
 import GiftThankYou from './checkout-thank-you/gift/gift-thank-you';
 import HundredYearPlanThankYou from './checkout-thank-you/hundred-year-plan-thank-you';
 import JetpackCheckoutThankYou from './checkout-thank-you/jetpack-checkout-thank-you';
@@ -511,6 +512,14 @@ export function giftThankYou( context, next ) {
 	// background via .is-section-checkout-gift-thank-you
 	context.section.name = 'checkout-gift-thank-you';
 	context.primary = <GiftThankYou site={ context.params.site } />;
+	next( context );
+}
+
+export function transferDomainToAnyUser( context, next ) {
+	// Overriding section name here in order to apply a top level
+	// background via .is-section-checkout-thank-you
+	context.section.name = 'checkout-thank-you';
+	context.primary = <DomainTransferToAnyUser domain={ context.params.domain } />;
 	next( context );
 }
 

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -26,6 +26,7 @@ import {
 	upsellRedirect,
 	akismetCheckoutThankYou,
 	hundredYearCheckoutThankYou,
+	transferDomainToAnyUser,
 } from './controller';
 
 export default function () {
@@ -140,6 +141,14 @@ export default function () {
 	// The no-site post-checkout route is for purchases not tied to a site so do
 	// not include the `siteSelection` middleware.
 	page( '/checkout/gift/thank-you/:site', giftThankYou, makeLayout, clientRender );
+
+	page(
+		'/checkout/domain-transfer-to-any-user/thank-you/:domain',
+		redirectLoggedOut,
+		transferDomainToAnyUser,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		'/checkout/thank-you/no-site/pending/:orderId',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3903

## Proposed Changes

* Built on the redesign-v2 structure of the congrats page

![congrats](https://github.com/Automattic/wp-calypso/assets/6586048/fb5c5883-11ac-4952-8753-d9e87b9e9017)
![mobile](https://github.com/Automattic/wp-calypso/assets/6586048/cb574756-b908-43f4-924b-a1d82ed3d751)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The congrats page is at http://calypso.localhost:3000/checkout/domain-transfer-to-any-user/thank-you/:domain
* To test the whole flow, go to /domains/manage and transfer a domain to another wp.com user
* Fill out the contact info form and submit to see the congrats page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?