### PR TITLE
Site Profiler: fix support for IDN URLs

### DIFF
--- a/client/site-profiler/hooks/use-domain-query-param.ts
+++ b/client/site-profiler/hooks/use-domain-query-param.ts
@@ -8,10 +8,34 @@ export default function useDomainQueryParam( sanitize = true ) {
 	const queryParams = useQuery();
 
 	useEffect( () => {
-		const _domain = queryParams.get( 'domain' ) || '';
-		const urlPattern = /^(https?:\/\/)?([a-z0-9-]+(\.[a-z0-9-]+)+(:\d{2,5})?(\/[^\s]*)?)$/i;
+		const _domain = ( queryParams.get( 'domain' ) || '' ).trim();
 
-		setIsValid( _domain ? urlPattern.test( _domain ) : undefined );
+		try {
+			if ( _domain ) {
+				// Only allow domains with a dot in them (not localhost, for example).
+				if ( ! _domain.includes( '.' ) ) {
+					throw new Error( 'Invalid domain' );
+				}
+
+				let normalised = _domain;
+
+				// If the domain doesn't start with http:// or https://, add https://
+				if ( ! normalised.startsWith( 'http://' ) && ! normalised.startsWith( 'https://' ) ) {
+					normalised = 'https://' + normalised;
+				}
+
+				// Test if we can parse the URL. If we can't, it's invalid.
+				const url = new URL( normalised );
+
+				// Check if the protocol is 'http' or 'https'.
+				setIsValid( url.protocol === 'http:' || url.protocol === 'https:' );
+			} else {
+				setIsValid( undefined );
+			}
+		} catch ( e ) {
+			setIsValid( false );
+		}
+
 		setDomain( sanitize ? getFixedDomainSearch( extractDomainFromInput( _domain ) ) : _domain );
 	}, [ queryParams ] );
 

--- a/client/site-profiler/hooks/use-domain-query-param.ts
+++ b/client/site-profiler/hooks/use-domain-query-param.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
+import { CAPTURE_URL_RGX_SOFT } from 'calypso/blocks/import/util';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { extractDomainFromInput, getFixedDomainSearch } from 'calypso/lib/domains';
 
@@ -11,7 +11,7 @@ export default function useDomainQueryParam( sanitize = true ) {
 	useEffect( () => {
 		const _domain = queryParams.get( 'domain' ) || '';
 
-		setIsValid( _domain ? CAPTURE_URL_RGX.test( _domain ) : undefined );
+		setIsValid( _domain ? CAPTURE_URL_RGX_SOFT.test( _domain ) : undefined );
 
 		setDomain( sanitize ? getFixedDomainSearch( extractDomainFromInput( _domain ) ) : _domain );
 	}, [ queryParams ] );

--- a/client/site-profiler/hooks/use-domain-query-param.ts
+++ b/client/site-profiler/hooks/use-domain-query-param.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { CAPTURE_URL_RGX_SOFT } from 'calypso/blocks/import/util';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { extractDomainFromInput, getFixedDomainSearch } from 'calypso/lib/domains';
 
@@ -10,9 +9,9 @@ export default function useDomainQueryParam( sanitize = true ) {
 
 	useEffect( () => {
 		const _domain = queryParams.get( 'domain' ) || '';
+		const urlPattern = /^(https?:\/\/)?([a-z0-9-]+(\.[a-z0-9-]+)+(:\d{2,5})?(\/[^\s]*)?)$/i;
 
-		setIsValid( _domain ? CAPTURE_URL_RGX_SOFT.test( _domain ) : undefined );
-
+		setIsValid( _domain ? urlPattern.test( _domain ) : undefined );
 		setDomain( sanitize ? getFixedDomainSearch( extractDomainFromInput( _domain ) ) : _domain );
 	}, [ queryParams ] );
 


### PR DESCRIPTION
After https://github.com/Automattic/wp-calypso/pull/82178 the IDN URLs like `https://xn--rksmrgs-5wao1o.josefsson.org/` are not accepted anymore by the Site Profiler. This PR fixes this.
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Replace URL regex with the soft version

## Testing Instructions

* Open http://calypso.localhost:3000/site-profiler
* Try `xn--rksmrgs-5wao1o.josefsson.org`
* Try other not IDN URLs
* Try invalid URLs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?