### PR TITLE
First posts: add UI to Read > Discover

### DIFF
--- a/client/reader/discover/discover-navigation.js
+++ b/client/reader/discover/discover-navigation.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
@@ -107,19 +108,21 @@ const DiscoverNavigation = ( { recommendedTags, selectedTab, width } ) => {
 					>
 						{ translate( 'Recommended' ) }
 					</SegmentedControl.Item>
+					{ config.isEnabled( 'reader/first-posts-stream' ) && (
+						<SegmentedControl.Item
+							key={ FIRST_POSTS_TAB }
+							selected={ FIRST_POSTS_TAB === selectedTab }
+							onClick={ () => menuTabClick( FIRST_POSTS_TAB ) }
+						>
+							{ translate( 'First posts' ) }
+						</SegmentedControl.Item>
+					) }
 					<SegmentedControl.Item
 						key={ LATEST_TAB }
 						selected={ LATEST_TAB === selectedTab }
 						onClick={ () => menuTabClick( LATEST_TAB ) }
 					>
 						{ translate( 'Latest' ) }
-					</SegmentedControl.Item>
-					<SegmentedControl.Item
-						key={ FIRST_POSTS_TAB }
-						selected={ FIRST_POSTS_TAB === selectedTab }
-						onClick={ () => menuTabClick( FIRST_POSTS_TAB ) }
-					>
-						{ translate( 'First posts' ) }
 					</SegmentedControl.Item>
 					{ recommendedTags.map( ( tag ) => {
 						return (

--- a/client/reader/discover/discover-navigation.js
+++ b/client/reader/discover/discover-navigation.js
@@ -8,7 +8,7 @@ import SegmentedControl from 'calypso/components/segmented-control';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
-import { DEFAULT_TAB, LATEST_TAB } from './helper';
+import { DEFAULT_TAB, FIRST_POSTS_TAB, LATEST_TAB } from './helper';
 
 import './discover-navigation.scss';
 
@@ -113,6 +113,13 @@ const DiscoverNavigation = ( { recommendedTags, selectedTab, width } ) => {
 						onClick={ () => menuTabClick( LATEST_TAB ) }
 					>
 						{ translate( 'Latest' ) }
+					</SegmentedControl.Item>
+					<SegmentedControl.Item
+						key={ FIRST_POSTS_TAB }
+						selected={ FIRST_POSTS_TAB === selectedTab }
+						onClick={ () => menuTabClick( FIRST_POSTS_TAB ) }
+					>
+						{ translate( 'First posts' ) }
 					</SegmentedControl.Item>
 					{ recommendedTags.map( ( tag ) => {
 						return (

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -19,6 +19,7 @@ import {
 	DEFAULT_TAB,
 	getSelectedTabTitle,
 	buildDiscoverStreamKey,
+	FIRST_POSTS_TAB,
 } from './helper';
 
 const DiscoverStream = ( props ) => {
@@ -73,6 +74,10 @@ const DiscoverStream = ( props ) => {
 	);
 
 	const streamSidebar = () => {
+		if ( selectedTab === FIRST_POSTS_TAB ) {
+			return <></>;
+		}
+
 		if ( ( isDefaultTab || selectedTab === 'latest' ) && recommendedSites?.length ) {
 			return (
 				<>
@@ -94,6 +99,7 @@ const DiscoverStream = ( props ) => {
 		useCompactCards: true,
 		streamSidebar,
 		sidebarTabTitle: isDefaultTab ? translate( 'Sites' ) : translate( 'Related' ),
+		selectedStreamName: selectedTab,
 	};
 
 	return (

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -3,6 +3,7 @@ import moment from 'moment';
 const DEFAULT_DISCOVER_TAGS = [ 'dailyprompt', 'wordpress' ];
 export const DEFAULT_TAB = 'recommended';
 export const LATEST_TAB = 'latest';
+export const FIRST_POSTS_TAB = 'firstposts';
 
 /**
  * Filters tags data and returns the tags intended to be loaded by the discover pages recommended
@@ -29,6 +30,9 @@ export function getSelectedTabTitle( selectedTab ) {
 	}
 	if ( selectedTab === LATEST_TAB ) {
 		return 'new';
+	}
+	if ( selectedTab === FIRST_POSTS_TAB ) {
+		return 'firstposts';
 	}
 	return selectedTab;
 }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -78,6 +78,7 @@ class ReaderStream extends Component {
 		translate: PropTypes.func,
 		useCompactCards: PropTypes.bool,
 		fixedHeaderHeight: PropTypes.number,
+		selectedStreamName: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -502,8 +503,11 @@ class ReaderStream extends Component {
 			if ( ! sidebarContentFn || streamType === 'search' ) {
 				body = <div className="reader__content">{ bodyContent }</div>;
 			} else if ( wideDisplay ) {
+				const streamClassNames = classnames( {
+					'stream__two-column': this.props.selectedStreamName !== 'firstposts',
+				} );
 				body = (
-					<div className="stream__two-column">
+					<div className={ streamClassNames }>
 						<div className="reader__content">
 							{ streamHeader?.() }
 							{ bodyContent }
@@ -511,7 +515,12 @@ class ReaderStream extends Component {
 						<div className="stream__right-column">{ sidebarContentFn?.() }</div>
 					</div>
 				);
-				baseClassnames = classnames( 'reader-two-column', baseClassnames );
+				baseClassnames = classnames(
+					{
+						'reader-two-column': this.props.selectedStreamName !== 'firstposts',
+					},
+					baseClassnames
+				);
 			} else {
 				body = (
 					<>

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -209,6 +209,8 @@ const streamApis = {
 				return '/read/tags/cards';
 			} else if ( streamKeySuffix( streamKey ).includes( 'latest' ) ) {
 				return '/read/tags/posts';
+			} else if ( streamKeySuffix( streamKey ).includes( 'firstposts' ) ) {
+				return '/read/streams/first-posts';
 			}
 			return `/read/tags/${ streamKeySuffix( streamKey ) }/cards`;
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/82280

This PR adds a new First posts tab visible only behind a the `reader/first-posts-stream` feature flag.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local Calypso or navigate to the Calypso live link below.
* Go to `/discover`.
* Click on the `First posts` tab: 
<img width="264" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/a220ce81-b6e5-4d97-b85b-80be5ba97de6">

* Verify you get a list of first posts like this one: 
<img width="1009" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/1997c422-504e-4fde-895f-414d6ff873a4">
 * Verify you can scroll through the list and get new posts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?