### PR TITLE
Site profiler: Handle BE error showing Notice

### DIFF
--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -27,7 +27,7 @@ export default function SiteProfiler() {
 
 	const {
 		data: siteProfilerData,
-		isFetching,
+		isFetching: isFetchingSP,
 		isError: isErrorSP,
 		errorUpdateCount: errorUpdateCountSP,
 	} = useDomainAnalyzerQuery( domain, isDomainValid );
@@ -41,13 +41,16 @@ export default function SiteProfiler() {
 
 	// Handle errors from the domain analyzer query
 	useEffect( () => {
-		isErrorSP &&
-			dispatch(
-				errorNotice(
-					translate( 'There was problem analyzing provided domain. Please try again.' ),
-					noticeOptions
-				)
-			);
+		if ( ! isErrorSP ) {
+			return;
+		}
+
+		dispatch(
+			errorNotice(
+				translate( 'There was problem analyzing provided domain. Please try again.' ),
+				noticeOptions
+			)
+		);
 	}, [ errorUpdateCountSP ] );
 
 	const updateDomainQueryParam = ( value: string ) => {
@@ -67,7 +70,7 @@ export default function SiteProfiler() {
 						domain={ domain }
 						isDomainValid={ isDomainValid }
 						onFormSubmit={ updateDomainQueryParam }
-						isBusy={ isFetching }
+						isBusy={ isFetchingSP }
 					/>
 				</LayoutBlock>
 			) }

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -23,11 +23,11 @@ export default function SiteProfiler() {
 	const navigate = useNavigate();
 	const queryParams = useQuery();
 	const { domain, isValid: isDomainValid } = useDomainQueryParam();
+	const noticeOptions = { duration: 3000 };
 
 	const {
 		data: siteProfilerData,
 		isFetching,
-		error: errorSP,
 		isError: isErrorSP,
 		errorUpdateCount: errorUpdateCountSP,
 	} = useDomainAnalyzerQuery( domain, isDomainValid );
@@ -41,7 +41,13 @@ export default function SiteProfiler() {
 
 	// Handle errors from the domain analyzer query
 	useEffect( () => {
-		isErrorSP && errorSP instanceof Error && dispatch( errorNotice( errorSP.message ) );
+		isErrorSP &&
+			dispatch(
+				errorNotice(
+					translate( 'There was problem analyzing provided domain. Please try again.' ),
+					noticeOptions
+				)
+			);
 	}, [ errorUpdateCountSP ] );
 
 	const updateDomainQueryParam = ( value: string ) => {

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -20,12 +20,12 @@ export default function SiteProfiler() {
 	const queryParams = useQuery();
 	const { domain, isValid: isDomainValid } = useDomainQueryParam();
 
-	const { data, isFetching } = useDomainAnalyzerQuery( domain, isDomainValid );
+	const { data: siteProfilerData, isFetching } = useDomainAnalyzerQuery( domain, isDomainValid );
 	const { data: hostingProviderData } = useHostingProviderQuery( domain, isDomainValid );
 	const conversionAction = useDefineConversionAction(
 		domain,
-		data?.whois,
-		data?.is_domain_available,
+		siteProfilerData?.whois,
+		siteProfilerData?.is_domain_available,
 		hostingProviderData?.hosting_provider
 	);
 
@@ -39,7 +39,7 @@ export default function SiteProfiler() {
 
 	return (
 		<>
-			{ ! data && (
+			{ ! siteProfilerData && (
 				<LayoutBlock className="domain-analyzer-block" width="medium">
 					<DocumentHead title={ translate( 'Site Profiler' ) } />
 					<DomainAnalyzer
@@ -51,13 +51,13 @@ export default function SiteProfiler() {
 				</LayoutBlock>
 			) }
 
-			{ data && (
+			{ siteProfilerData && (
 				<LayoutBlock className="domain-result-block">
 					{
 						// Translators: %s is the domain name searched
 						<DocumentHead title={ translate( '%s ‹ Site Profiler', { args: [ domain ] } ) } />
 					}
-					{ data && (
+					{ siteProfilerData && (
 						<LayoutBlockSection>
 							<HeadingInformation
 								domain={ domain }
@@ -66,19 +66,19 @@ export default function SiteProfiler() {
 							/>
 						</LayoutBlockSection>
 					) }
-					{ ! data.is_domain_available && (
+					{ ! siteProfilerData.is_domain_available && (
 						<>
-							{ data && (
+							{ siteProfilerData && (
 								<LayoutBlockSection>
 									<HostingInformation
-										dns={ data.dns }
+										dns={ siteProfilerData.dns }
 										hostingProvider={ hostingProviderData?.hosting_provider }
 									/>
 								</LayoutBlockSection>
 							) }
-							{ data?.whois && (
+							{ siteProfilerData?.whois && (
 								<LayoutBlockSection>
-									<DomainInformation domain={ domain } whois={ data.whois } />
+									<DomainInformation domain={ domain } whois={ siteProfilerData.whois } />
 								</LayoutBlockSection>
 							) }
 						</>
@@ -86,7 +86,7 @@ export default function SiteProfiler() {
 				</LayoutBlock>
 			) }
 
-			<LayoutBlock isMonoBg={ !! data }>
+			<LayoutBlock isMonoBg={ !! siteProfilerData }>
 				<HostingIntro />
 			</LayoutBlock>
 		</>


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82244

## Proposed Changes

* Handled error message from the site profiler endpoint showing general message "There was problem analyzing provided domain. Please try again."

## Testing Instructions

* Locally change the path of `site-profiler` endpoint to something wrong
* Go to `/site-profiler`
* Enter any valid url
* Check if there is Notice in the right top corner

<img width="610" alt="Screenshot 2023-09-27 at 14 56 42" src="https://github.com/Automattic/wp-calypso/assets/1241413/d913f0e6-4602-4f33-8528-e782f6b3660c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?