### PR TITLE
Update copy for transaction fee feature

### DIFF
--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -1696,34 +1696,43 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_10 ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_10,
 		getTitle: () =>
-			i18n.translate( '%(commission)d%% transaction fee for payments', {
-				args: { commission: 10 },
-			} ),
-		getDescription: () =>
-			i18n.translate( 'Credit card fees are applied in addition to commission fees for payments.' ),
-		getAlternativeTitle: () => '10%',
+			i18n.translate(
+				'%(commission)d%% commission fee (plus standard processing fee) for payments',
+				{
+					args: { commission: 10 },
+				}
+			),
+		get getAlternativeTitle() {
+			return this.getTitle();
+		},
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_8 ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_8,
 		getTitle: () =>
-			i18n.translate( '%(commission)d%% transaction fee for payments', {
-				args: { commission: 8 },
-			} ),
-		getDescription: () =>
-			i18n.translate( 'Credit card fees are applied in addition to commission fees for payments.' ),
-		getAlternativeTitle: () => '8%',
+			i18n.translate(
+				'%(commission)d%% commission fee (plus standard processing fee) for payments',
+				{
+					args: { commission: 8 },
+				}
+			),
+		get getAlternativeTitle() {
+			return this.getTitle();
+		},
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_4 ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_4,
 		getTitle: () =>
-			i18n.translate( '%(commission)d%% transaction fee for payments', {
-				args: { commission: 4 },
-			} ),
-		getDescription: () =>
-			i18n.translate( 'Credit card fees are applied in addition to commission fees for payments.' ),
-		getAlternativeTitle: () => '4%',
+			i18n.translate(
+				'%(commission)d%% commission fee (plus standard processing fee) for payments',
+				{
+					args: { commission: 4 },
+				}
+			),
+		get getAlternativeTitle() {
+			return this.getTitle();
+		},
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_2 ]: {
@@ -1732,8 +1741,6 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate( '%(commission)d%% transaction fee for payments', {
 				args: { commission: 2 },
 			} ),
-		getDescription: () =>
-			i18n.translate( 'Credit card fees are applied in addition to commission fees for payments.' ),
 		getAlternativeTitle: () => '2%',
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
@@ -1743,41 +1750,54 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate( '%(commission)d%% transaction fee for payments', {
 				args: { commission: 0 },
 			} ),
-		getDescription: () =>
-			i18n.translate( 'Credit card fees are applied in addition to commission fees for payments.' ),
 		getAlternativeTitle: () => '0%',
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_0_WOO ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_0_WOO,
 		getTitle: () =>
-			i18n.translate( '%(commission)d%% transaction fee for WooCommerce payment features', {
-				args: { commission: 0 },
-			} ),
-		getDescription: () =>
-			i18n.translate( 'Credit card fees are applied in addition to commission fees for payments.' ),
+			i18n.translate(
+				'%(commission)d%% commission fee (plus standard processing fee) for standard WooCommerce payment features',
+				{
+					args: { commission: 0 },
+				}
+			),
 		getAlternativeTitle: () => '0%',
+		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_0_ALL ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_0_ALL,
 		getTitle: () =>
-			i18n.translate( '%(commission)d%% transaction fee for all payment features', {
-				args: { commission: 0 },
-			} ),
-		getDescription: () =>
-			i18n.translate( 'Credit card fees are applied in addition to commission fees for payments.' ),
-		getAlternativeTitle: () => '0%',
+			i18n.translate(
+				'%(commission)d%% commission fee (plus standard processing fee) for all payment features',
+				{
+					args: { commission: 0 },
+				}
+			),
+		get getAlternativeTitle() {
+			return this.getTitle();
+		},
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_2_REGULAR ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_2_REGULAR,
 		getTitle: () =>
-			i18n.translate( '%(commission)d%% transaction fee for regular payment features', {
-				args: { commission: 2 },
-			} ),
-		getDescription: () =>
-			i18n.translate( 'Credit card fees are applied in addition to commission fees for payments.' ),
-		getAlternativeTitle: () => '2%',
+			i18n.translate(
+				'%(commission)d%% commission fee (plus standard processing fee) for standard payment features',
+				{
+					args: { commission: 2 },
+				}
+			),
+		get getAlternativeTitle() {
+			return i18n.translate(
+				'%(stdcommission)d%% commission fee (plus standard processing fee) for standard payment features.{{br /}} %(woocommission)d%% commission fee (plus standard processing fee) for standard WooCommerce payment features',
+				{
+					args: { stdcommission: 2, woocommission: 0 },
+					components: { br: <br /> },
+				}
+			);
+		},
+
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_UNLIMITED_TRAFFIC ]: {

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -318,6 +318,42 @@ export type FeatureObject = FeatureObjectPackaged;
 
 export type FeatureList = FeatureListPackaged;
 
+const getTransactionFeeCopy = ( commission = 0, variation = '' ) => {
+	switch ( variation ) {
+		case 'woo':
+			return i18n.translate(
+				'%(commission)d%% commission fee (plus standard processing fee) for standard WooCommerce payment features',
+				{
+					args: { commission },
+				}
+			);
+
+		case 'all':
+			return i18n.translate(
+				'%(commission)d%% commission fee (plus standard processing fee) for all payment features',
+				{
+					args: { commission },
+				}
+			);
+
+		case 'regular':
+			return i18n.translate(
+				'%(commission)d%% commission fee (plus standard processing fee) for standard payment features',
+				{
+					args: { commission },
+				}
+			);
+
+		default:
+			return i18n.translate(
+				'%(commission)d%% commission fee (plus standard processing fee) for payments',
+				{
+					args: { commission },
+				}
+			);
+	}
+};
+
 export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_BLANK ]: {
 		getSlug: () => FEATURE_BLANK,
@@ -1690,49 +1726,23 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_GROUP_PAYMENT_TRANSACTION_FEES ]: {
 		getSlug: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 		getTitle: () => i18n.translate( 'Transaction fees for payments' ),
-		getDescription: () =>
-			i18n.translate( 'Credit card fees are applied in addition to commission fees for payments.' ),
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_10 ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_10,
-		getTitle: () =>
-			i18n.translate(
-				'%(commission)d%% commission fee (plus standard processing fee) for payments',
-				{
-					args: { commission: 10 },
-				}
-			),
-		get getAlternativeTitle() {
-			return this.getTitle();
-		},
+		getTitle: () => getTransactionFeeCopy( 10 ),
+		getAlternativeTitle: () => getTransactionFeeCopy( 10 ),
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_8 ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_8,
-		getTitle: () =>
-			i18n.translate(
-				'%(commission)d%% commission fee (plus standard processing fee) for payments',
-				{
-					args: { commission: 8 },
-				}
-			),
-		get getAlternativeTitle() {
-			return this.getTitle();
-		},
+		getTitle: () => getTransactionFeeCopy( 8 ),
+		getAlternativeTitle: () => getTransactionFeeCopy( 8 ),
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_4 ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_4,
-		getTitle: () =>
-			i18n.translate(
-				'%(commission)d%% commission fee (plus standard processing fee) for payments',
-				{
-					args: { commission: 4 },
-				}
-			),
-		get getAlternativeTitle() {
-			return this.getTitle();
-		},
+		getTitle: () => getTransactionFeeCopy( 4 ),
+		getAlternativeTitle: () => getTransactionFeeCopy( 4 ),
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_2 ]: {
@@ -1755,49 +1765,28 @@ export const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_0_WOO ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_0_WOO,
-		getTitle: () =>
-			i18n.translate(
-				'%(commission)d%% commission fee (plus standard processing fee) for standard WooCommerce payment features',
-				{
-					args: { commission: 0 },
-				}
-			),
+		getTitle: () => getTransactionFeeCopy( 0, 'woo' ),
 		getAlternativeTitle: () => '0%',
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_0_ALL ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_0_ALL,
-		getTitle: () =>
-			i18n.translate(
-				'%(commission)d%% commission fee (plus standard processing fee) for all payment features',
-				{
-					args: { commission: 0 },
-				}
-			),
-		get getAlternativeTitle() {
-			return this.getTitle();
-		},
+		getTitle: () => getTransactionFeeCopy( 0, 'all' ),
+		getAlternativeTitle: () => getTransactionFeeCopy( 0, 'all' ),
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_2_REGULAR ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_2_REGULAR,
-		getTitle: () =>
-			i18n.translate(
-				'%(commission)d%% commission fee (plus standard processing fee) for standard payment features',
-				{
-					args: { commission: 2 },
-				}
-			),
-		get getAlternativeTitle() {
-			return i18n.translate(
-				'%(stdcommission)d%% commission fee (plus standard processing fee) for standard payment features.{{br /}} %(woocommission)d%% commission fee (plus standard processing fee) for standard WooCommerce payment features',
-				{
-					args: { stdcommission: 2, woocommission: 0 },
-					components: { br: <br /> },
-				}
+		getTitle: () => getTransactionFeeCopy( 2, 'regular' ),
+		getAlternativeTitle: () => {
+			return (
+				<>
+					{ getTransactionFeeCopy( 2, 'regular' ) }
+					<br />
+					{ getTransactionFeeCopy( 0, 'woo' ) }
+				</>
 			);
 		},
-
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_UNLIMITED_TRAFFIC ]: {

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -644,7 +644,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 										</span>
 									</Plans2023Tooltip>
 									<span className="plan-comparison-grid__plan-conditional-title">
-										{ planPaymentTransactionFees?.getAlternativeTitle }
+										{ planPaymentTransactionFees?.getAlternativeTitle?.() }
 									</span>
 								</>
 							) : (

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -121,6 +121,7 @@ const Row = styled.div< {
 
 	${ plansBreakSmall( css`
 		display: flex;
+		align-items: center;
 		margin: 0 20px;
 		padding: 12px 0;
 		border-bottom: 1px solid #eee;
@@ -631,9 +632,21 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 					{ FEATURE_GROUP_PAYMENT_TRANSACTION_FEES === featureSlug ? (
 						<>
 							{ planPaymentTransactionFees ? (
-								<span className="plan-comparison-grid__plan-conditional-title">
-									{ planPaymentTransactionFees?.getAlternativeTitle?.() }
-								</span>
+								<>
+									<Plans2023Tooltip
+										text={ feature?.getDescription?.() }
+										setActiveTooltipId={ setActiveTooltipId }
+										activeTooltipId={ activeTooltipId }
+										id={ `${ planSlug }-${ featureSlug }` }
+									>
+										<span className="plan-comparison-grid__plan-title">
+											{ feature?.getAlternativeTitle?.() || feature?.getTitle() }
+										</span>
+									</Plans2023Tooltip>
+									<span className="plan-comparison-grid__plan-conditional-title">
+										{ planPaymentTransactionFees?.getAlternativeTitle }
+									</span>
+								</>
 							) : (
 								<Gridicon icon="minus-small" color="#C3C4C7" />
 							) }

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -426,6 +426,7 @@ import {
 	FEATURE_PAYMENT_TRANSACTION_FEES_0_ALL,
 	FEATURE_PAYMENT_TRANSACTION_FEES_2_REGULAR,
 	FEATURE_PAYMENT_TRANSACTION_FEES_0_WOO,
+	FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	PRODUCT_JETPACK_STATS_MONTHLY,
 	PRODUCT_JETPACK_STATS_YEARLY,
 	TERM_CENTENNIALLY,
@@ -589,6 +590,7 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_SECURITY_MALWARE,
 		FEATURE_SECURITY_DDOS,
 		FEATURE_PAYMENT_TRANSACTION_FEES_10,
+		FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	],
 	get2023PricingGridSignupJetpackFeatures: () => [
 		FEATURE_PAID_SUBSCRIBERS_JP,
@@ -838,6 +840,13 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_EMAIL_SUPPORT_SIGNUP,
 	],
 	get2023PricingGridSignupWpcomFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_AD_FREE_EXPERIENCE,
+		FEATURE_FAST_DNS,
+		FEATURE_SUPPORT_EMAIL,
+		FEATURE_PAYMENT_TRANSACTION_FEES_8,
+	],
+	get2023PlanComparisonFeatureOverride: () => [
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_AD_FREE_EXPERIENCE,
 		FEATURE_FAST_DNS,
@@ -1646,13 +1655,8 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_SITE_STAGING_SITES,
 		FEATURE_WP_UPDATES,
 		FEATURE_MULTI_SITE,
-		...( ( i18n.hasTranslation(
-			'%(commission)d%% transaction fee for WooCommerce payment features'
-		) &&
-			i18n.hasTranslation( '%(commission)d%% transaction fee for regular payment features' ) ) ||
-		[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
-			? [ FEATURE_PAYMENT_TRANSACTION_FEES_0_WOO, FEATURE_PAYMENT_TRANSACTION_FEES_2_REGULAR ]
-			: [ FEATURE_PAYMENT_TRANSACTION_FEES_2 ] ),
+		FEATURE_PAYMENT_TRANSACTION_FEES_2_REGULAR,
+		FEATURE_PAYMENT_TRANSACTION_FEES_0_WOO,
 	],
 	getCheckoutFeatures: () => [
 		FEATURE_CUSTOM_DOMAIN,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

As per the request in pau2Xa-598-p2, update transaction fee copy. There are two changes in this PR:

* Removes the hover tooltip for the transaction fee feature as mentioned in pau2Xa-598#comment-14155
* Updates the copy as mentioned in the comment pau2Xa-598#comment-14153:

> I’d be fine with lines like:

> Personal plan
Old: “8% transaction fee on payments”
NEW: “8% commission fee (plus standard processing fee) for payments”
Commerce plan
Old: “0% transaction fee for all payment features”
NEW: “0% commission fee (plus standard processing fee) for all payment features”

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/start/plans` and verify that you see the new copy both in top-of-the-fold grid and below-the-fold comparison grid.
<img width="1307" alt="Screenshot 2023-09-27 at 7 14 04 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/3084c247-09e4-4b08-9e25-f62f10cdb8d8">

<img width="1254" alt="Screenshot 2023-09-27 at 7 13 53 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/ca00d68b-5b56-4cb2-b502-7f2e69e1d63f">

Also verify that the changes are visible in mobile view under "Growth and monetisation features"
<img width="313" alt="Screenshot 2023-09-27 at 7 16 22 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/2f299e6c-7742-42d6-866b-75f855d07539">

* Similar to above, verify all these changes are visible in above-the-fold, below-the-fold, and mobile in Calypso's Upgrades > Plans page.
