### PR TITLE
Jetpack Manage: Exclude hosting products from showing on the license issue screen

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -9,6 +9,7 @@ import TotalCost from 'calypso/jetpack-cloud/sections/partner-portal/primary/tot
 import {
 	isJetpackBundle,
 	isWooCommerceProduct,
+	isWpcomHostingProduct,
 } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -68,7 +69,8 @@ export default function IssueMultipleLicensesForm( {
 			( { family_slug }: { family_slug: string } ) =>
 				family_slug !== 'jetpack-packs' &&
 				family_slug !== 'jetpack-backup-storage' &&
-				! isWooCommerceProduct( family_slug )
+				! isWooCommerceProduct( family_slug ) &&
+				! isWpcomHostingProduct( family_slug )
 		) || [];
 	const wooExtensions =
 		allProducts?.filter( ( { family_slug }: { family_slug: string } ) =>

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -239,6 +239,16 @@ export function isWooCommerceProduct( keyOrSlug: string ) {
 }
 
 /**
+ * Provided a license key or a product slug, can we trust that the product is a WordPress.com hosting product
+ *
+ * @param keyOrSlug string
+ * @returns boolean True if wpcom hosting product, false if not
+ */
+export function isWpcomHostingProduct( keyOrSlug: string ) {
+	return keyOrSlug.startsWith( 'wpcom-hosting' );
+}
+
+/**
  * Provided a license key, return the product slug
  *
  * @param licenseKey string


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR removes the license cards from the license issue screen in Jetpack Manage > Licensing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure you are on billing scheme 871 and go to the license issue screen. You should no longer see cards for WordPress.com Business and WordPress.com Commerce plans.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?