### PR TITLE
Jetpack Manage: Hide WordPress.com hosting products from the Issue License screen

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -41,7 +41,9 @@ export default function IssueMultipleLicensesForm( {
 
 	const { data, isLoading: isLoadingProducts } = useProductsQuery();
 
-	let allProducts = data;
+	// Filter out hosting products as they have their own dedicated UI.
+	let allProducts = ( data || [] ).filter( ( product ) => product.family_slug !== 'wpcom-hosting' );
+
 	const addedPlanAndProducts = useSelector( ( state ) =>
 		selectedSite ? getAssignedPlanAndProductIDsForSite( state, selectedSite.ID ) : null
 	);


### PR DESCRIPTION
## Proposed Changes

* Jetpack Manage: Hide WordPress.com hosting products from the Issue License screen. Hosting products have their own dedicated UI so they don't need to be mixed with the rest.

## Testing Instructions

* Checkout this PR and run Jetpack Cloud.
* Make sure you have Billing Scheme 871 assigned to your partner key - please reach out to team Avalon if you are not sure what this means.
* Open up https://cloud.jetpack.com/partner-portal/issue-license
* You should not see any WordPress.com hosting products in the list.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?