### PR TITLE
Ignore empty behaviours when nudging for global styles

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -301,8 +301,18 @@ function wpcom_global_styles_in_use_by_wp_global_styles_post( array $wp_global_s
 		return false;
 	}
 
-	$global_style_keys    = array_keys( json_decode( $wp_global_styles_post['post_content'], true ) ?? array() );
-	$global_styles_in_use = count( array_diff( $global_style_keys, array( 'version', 'isGlobalStylesUserThemeJSON' ) ) ) > 0;
+	$global_styles_content = json_decode( $wp_global_styles_post['post_content'], true ) ?? array();
+
+	// Some keys are ignored because they are not relevant to a custom style
+	// behaviours are not relevant if blank - as they where when included during GB16.4 and later removed.
+	$ignored_keys = array( 'version', 'isGlobalStylesUserThemeJSON' );
+	if ( isset( $global_styles_content['behaviors'] ) && empty( $global_styles_content['behaviors'] ) ) {
+		$ignored_keys[] = 'behaviors';
+	}
+
+	$global_style_keys    = array_keys( $global_styles_content );
+	$global_styles_in_use = count( array_diff( $global_style_keys, $ignored_keys ) ) > 0;
+
 	return $global_styles_in_use;
 }
 


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81628

## Proposed Changes

This change fixes a problem where the front-end of sites displayed an upgrade nudge for global styles in the front-end of a site but did not display a nudge in the editor. This happened because some sites had an empty 'behaviours' key in the custom styles. Behaviours was in an earlier Gutenberg release but has been removed (and a migration path provided) while it is worked upon further.

The fix works by ignoring the 'behaviours' key if the value is empty.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. SU to the owner of one of the sites mentioned in 81628
 2. Go to the front-end of the site, note that you get a GS upgrade nudge in the launchbar
 3. Open the editor, note that you don't
 4. Apply this patch to the sandbox via ETK magic from comment below
 5. Sandbox the site you're testing
 6. Go to the front-end of the site, note that you no longer get a GS upgrade nudge in the launchbar
 7. Ditto for the editor
 8. Open up another site that is on a non-GS plan and has GS and note you still get the upgrade nudge as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?