### PR TITLE
Rename track event to a more sensical name

### DIFF
--- a/packages/help-center/src/components/help-center-survey/help-center-survey.tsx
+++ b/packages/help-center/src/components/help-center-survey/help-center-survey.tsx
@@ -29,7 +29,7 @@ export function Survey() {
 
 	const mutation = useMutation( {
 		mutationFn: ( { type = 'dismiss' }: { type?: 'dismiss' | 'remind' | 'take' } ) => {
-			recordTracksEvent( 'calypso_helpcenter-survey-skipped', {
+			recordTracksEvent( 'calypso_helpcenter-survey-interaction', {
 				location: 'help-center',
 				action: type,
 			} );


### PR DESCRIPTION
Tiny follow up to https://github.com/Automattic/wp-calypso/pull/82194