### PR TITLE
Restore anonId after Login and Signup

### DIFF
--- a/client/lib/analytics/test/index.js
+++ b/client/lib/analytics/test/index.js
@@ -147,7 +147,7 @@ describe( 'Analytics', () => {
 		} );
 
 		test( 'should not call recordAliasInFloodlight when anonymousUserId does not exist', () => {
-			cookie.parse.mockImplementationOnce( () => ( {} ) );
+			cookie.parse.mockImplementation( () => ( {} ) );
 			identifyUser( { ID: 8, username: 'eight', email: 'eight@example.com' } );
 			expect( recordAliasInFloodlight ).not.toHaveBeenCalled();
 			expect( window._tkq.push ).toHaveBeenCalledWith( [ 'identifyUser', 8, 'eight' ] );

--- a/client/lib/analytics/test/index.js
+++ b/client/lib/analytics/test/index.js
@@ -146,10 +146,10 @@ describe( 'Analytics', () => {
 			expect( window._tkq.push ).toHaveBeenCalledWith( [ 'identifyUser', 8, 'eight' ] );
 		} );
 
-		test( 'should call recordAliasInFloodlight when anonymousUserId exists', () => {
+		test( 'should not call recordAliasInFloodlight when anonymousUserId does not exist', () => {
 			cookie.parse.mockImplementationOnce( () => ( {} ) );
 			identifyUser( { ID: 8, username: 'eight', email: 'eight@example.com' } );
-			expect( recordAliasInFloodlight ).toHaveBeenCalled();
+			expect( recordAliasInFloodlight ).not.toHaveBeenCalled();
 			expect( window._tkq.push ).toHaveBeenCalledWith( [ 'identifyUser', 8, 'eight' ] );
 		} );
 	} );

--- a/client/lib/analytics/test/index.js
+++ b/client/lib/analytics/test/index.js
@@ -146,10 +146,10 @@ describe( 'Analytics', () => {
 			expect( window._tkq.push ).toHaveBeenCalledWith( [ 'identifyUser', 8, 'eight' ] );
 		} );
 
-		test( 'should not call recordAliasInFloodlight when anonymousUserId does not exist', () => {
+		test( 'should call recordAliasInFloodlight when anonymousUserId exists', () => {
 			cookie.parse.mockImplementationOnce( () => ( {} ) );
 			identifyUser( { ID: 8, username: 'eight', email: 'eight@example.com' } );
-			expect( recordAliasInFloodlight ).not.toHaveBeenCalled();
+			expect( recordAliasInFloodlight ).toHaveBeenCalled();
 			expect( window._tkq.push ).toHaveBeenCalledWith( [ 'identifyUser', 8, 'eight' ] );
 		} );
 	} );

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -127,9 +127,11 @@ export const analyticsEvents: EventEmitter = new EventEmitter();
  * Returns the anoymous id stored in the `tk_ai` cookie
  * @returns The Tracks anonymous user id
  */
-export function getTracksAnonymousUserId(): string {
+export function getTracksAnonymousUserId( isExplat?: boolean ): string {
 	const cookies = cookie.parse( document.cookie );
-
+	if ( isExplat ) {
+		return cookies.tk_ai_explat || cookies.tk_ai;
+	}
 	return cookies.tk_ai;
 }
 
@@ -171,10 +173,13 @@ export function identifyUser( userData: any ): any {
 	// Tracks user identification.
 	debug( 'Tracks identifyUser.', currentUser );
 
-	const anonId = getTracksAnonymousUserId();
+	const anonId = getTracksAnonymousUserId( true );
 	pushEventToTracksQueue( [ 'identifyUser', currentUser.ID, currentUser.username ] );
 	if ( anonId ) {
-		document.cookie = cookie.serialize( 'tk_ai', anonId, { path: '/', domain: '.wordpress.com' } );
+		document.cookie = cookie.serialize( 'tk_ai_explat', anonId, {
+			path: '/',
+			domain: '.wordpress.com',
+		} );
 	}
 }
 

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -125,7 +125,6 @@ export const analyticsEvents: EventEmitter = new EventEmitter();
 
 /**
  * Returns the anoymous id stored in the `tk_ai` cookie
- *
  * @returns The Tracks anonymous user id
  */
 export function getTracksAnonymousUserId(): string {
@@ -171,7 +170,12 @@ export function identifyUser( userData: any ): any {
 
 	// Tracks user identification.
 	debug( 'Tracks identifyUser.', currentUser );
+
+	const anonId = getTracksAnonymousUserId();
 	pushEventToTracksQueue( [ 'identifyUser', currentUser.ID, currentUser.username ] );
+	if ( anonId ) {
+		document.cookie = cookie.serialize( 'tk_ai', anonId, { path: '/', domain: '.wordpress.com' } );
+	}
 }
 
 export function recordTracksEvent( eventName: string, eventProperties?: any ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

After login and signup, a `identifyUser` tracks event is recorded. This removes `tk_ai`  cookie (anonId) which breaks continuity between ExPlat assignments.
This PR attempts to fix this by restoring a `tk_ai_explat` cookie after the `tk_ai` is removed. This allows us to continue to apply the same test assignment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit a Logged Out Landing page, so that the `tk_ai` cookie is populated
* Go through the Log in flow and the Signup flow and make sure the `tk_ai` is the same

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
