### PR TITLE
Subscriptions Management: Add subscription's feed button in site subscription details page

### DIFF
--- a/client/blocks/reader-site-subscription/details.tsx
+++ b/client/blocks/reader-site-subscription/details.tsx
@@ -1,10 +1,9 @@
 import { SubscriptionManager, Reader } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
-import { useTranslate, numberFormat } from 'i18n-calypso';
-import { useEffect, useState, useMemo } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
 import { SiteIcon } from 'calypso/blocks/site-icon';
-import ExternalLink from 'calypso/components/external-link';
 import FormattedHeader from 'calypso/components/formatted-header';
 import TimeSince from 'calypso/components/time-since';
 import { Notice, NoticeState, NoticeType } from 'calypso/landing/subscriptions/components/notice';
@@ -18,6 +17,7 @@ import {
 	getPaymentInterval,
 } from './helpers';
 import SiteSubscriptionSettings from './settings';
+import SiteSubscriptionSubheader from './site-subscription-subheader';
 import SubscribeToNewsletterCategories from './subscribe-to-newsletter-categories';
 import './styles.scss';
 
@@ -28,6 +28,7 @@ const SiteSubscriptionDetails = ( {
 	siteIcon,
 	name,
 	blogId,
+	feedId,
 	deliveryMethods,
 	url,
 	paymentDetails,
@@ -84,7 +85,7 @@ const SiteSubscriptionDetails = ( {
 
 			setPaymentPlans( newPaymentPlans );
 		}
-	}, [ paymentDetails ] );
+	}, [ localeSlug, paymentDetails ] );
 
 	const onClickCancelSubscriptionButton = () => {
 		if ( paymentPlans && !! paymentPlans.length ) {
@@ -99,38 +100,6 @@ const SiteSubscriptionDetails = ( {
 		window.open( '/me/purchases', '_blank' );
 		setShowUnsubscribeModal( false );
 	};
-
-	const subscriberCountText = subscriberCount
-		? translate( '%s subscriber', '%s subscribers', {
-				count: subscriberCount,
-				args: [ numberFormat( subscriberCount, 0 ) ],
-				comment: '%s is the number of subscribers. For example: "12,000,000"',
-		  } )
-		: '';
-
-	const hostname = useMemo( () => {
-		try {
-			return new URL( url ).hostname;
-		} catch ( e ) {
-			return '';
-		}
-	}, [ url ] );
-
-	const urlLink = hostname ? (
-		<ExternalLink href={ url } rel="noreferrer noopener" target="_blank">
-			{ hostname }
-		</ExternalLink>
-	) : (
-		''
-	);
-
-	const subHeaderText = (
-		<>
-			{ subscriberCountText }
-			{ hostname ? ' · ' : '' }
-			{ urlLink }
-		</>
-	);
 
 	useEffect( () => {
 		// todo: style the button (underline, color?, etc.)
@@ -196,7 +165,18 @@ const SiteSubscriptionDetails = ( {
 		<>
 			<header className="site-subscription-page__header site-subscription-page__centered-content">
 				<SiteIcon iconUrl={ siteIcon } size={ 116 } alt={ name } />
-				<FormattedHeader brandFont headerText={ name } subHeaderText={ subHeaderText } />
+				<FormattedHeader
+					brandFont
+					headerText={ name }
+					subHeaderAs="div"
+					subHeaderText={
+						<SiteSubscriptionSubheader
+							feedId={ feedId }
+							subscriberCount={ subscriberCount }
+							url={ url }
+						/>
+					}
+				/>
 			</header>
 
 			<Notice

--- a/client/blocks/reader-site-subscription/helpers.tsx
+++ b/client/blocks/reader-site-subscription/helpers.tsx
@@ -9,6 +9,7 @@ export type SiteSubscriptionDetailsProps = {
 	siteIcon: string | null;
 	name: string;
 	blogId: number;
+	feedId: number;
 	deliveryMethods: Reader.SiteSubscriptionDeliveryMethods;
 	url: string;
 	paymentDetails: Reader.SiteSubscriptionPaymentDetails[];

--- a/client/blocks/reader-site-subscription/index.tsx
+++ b/client/blocks/reader-site-subscription/index.tsx
@@ -40,6 +40,7 @@ const ReaderSiteSubscription = () => {
 						<SiteSubscriptionDetails
 							subscriptionId={ data.ID }
 							blogId={ data.blog_ID }
+							feedId={ data.feed_ID }
 							name={ data.name }
 							subscriberCount={ data.subscriber_count }
 							dateSubscribed={ data.date_subscribed }

--- a/client/blocks/reader-site-subscription/site-subscription-subheader.tsx
+++ b/client/blocks/reader-site-subscription/site-subscription-subheader.tsx
@@ -1,0 +1,78 @@
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { numberFormat, useTranslate } from 'i18n-calypso';
+import React from 'react';
+import ExternalLink from 'calypso/components/external-link';
+import { FeedIcon } from 'calypso/landing/subscriptions/components/settings/icons';
+import { getFeedUrl } from 'calypso/reader/route';
+
+type SiteSubscriptionSubheaderProps = {
+	feedId: number;
+	subscriberCount: number;
+	url: string;
+};
+
+const getHostname = ( url: string ) => {
+	try {
+		return new URL( url ).hostname;
+	} catch ( e ) {
+		return '';
+	}
+};
+
+const withDotSeparators = ( items: React.ReactNode[] ) => {
+	const itemsWithSeparator: React.ReactNode[] = [];
+	items.forEach( ( item, index ) => {
+		itemsWithSeparator.push( item );
+		if ( index !== items.length - 1 ) {
+			itemsWithSeparator.push( <div key={ `dot-separator-${ index }` }>·</div> );
+		}
+	} );
+	return itemsWithSeparator;
+};
+
+const SiteSubscriptionSubheader = ( {
+	feedId,
+	subscriberCount,
+	url,
+}: SiteSubscriptionSubheaderProps ) => {
+	const translate = useTranslate();
+
+	const subheaderItems = [];
+
+	if ( subscriberCount > 0 ) {
+		subheaderItems.push(
+			<div key={ `subscriber-count-${ subscriberCount }` }>
+				{ translate( '%s subscriber', '%s subscribers', {
+					count: subscriberCount,
+					args: [ numberFormat( subscriberCount, 0 ) ],
+					comment: '%s is the number of subscribers. For example: "12,000,000"',
+				} ) }
+			</div>
+		);
+	}
+
+	const hostname = getHostname( url );
+	if ( hostname !== '' ) {
+		subheaderItems.push(
+			<ExternalLink key={ url } href={ url } rel="noreferrer noopener" target="_blank">
+				{ hostname }
+			</ExternalLink>
+		);
+	}
+
+	subheaderItems.push(
+		<Button
+			key={ `view-feed-button-${ feedId }` }
+			title={ translate( 'View feed' ) }
+			className="site-subscription-header__view-feed-button"
+			icon={ <FeedIcon /> }
+			href={ getFeedUrl( feedId ) }
+		/>
+	);
+
+	return (
+		<HStack className="site-subscription-header">{ withDotSeparators( subheaderItems ) }</HStack>
+	);
+};
+
+export default React.memo( SiteSubscriptionSubheader );

--- a/client/blocks/reader-site-subscription/styles.scss
+++ b/client/blocks/reader-site-subscription/styles.scss
@@ -43,18 +43,21 @@
 				color: $studio-gray-100;
 			}
 
-			&__subtitle {
+			&__subtitle .site-subscription-header {
 				font-family: "SF Pro Text", $sans;
 				font-weight: 400;
 				color: $studio-gray-40;
 
+				&__view-feed-button {
+					padding: 0;
+					height: auto;
+					min-width: unset;
+				}
+
 				.external-link {
 					color: $studio-gray-40;
 					white-space: nowrap;
-
-					&:hover {
-						text-decoration: underline;
-					}
+					text-decoration: underline;
 				}
 			}
 		}

--- a/client/blocks/reader-site-subscription/test/index.tsx
+++ b/client/blocks/reader-site-subscription/test/index.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment jsdom
  */
+import { Reader } from '@automattic/data-stores';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -13,6 +14,29 @@ import ReaderSiteSubscription, {
 
 const queryClient = new QueryClient();
 const mockStore = configureStore();
+
+const mockSiteSubscriptionContext = (
+	subscription: Partial< Reader.SiteSubscriptionDetails< string > > = {}
+): SiteSubscriptionContextProps => {
+	return {
+		data: {
+			ID: 123,
+			blog_ID: 123,
+			feed_ID: 987123654,
+			name: 'Test Site',
+			URL: 'https://example.com',
+			site_icon: 'site_icon_url',
+			date_subscribed: '2023-01-01',
+			delivery_methods: {},
+			subscriber_count: 100,
+			payment_details: [],
+			...subscription,
+		},
+		isLoading: false,
+		error: null,
+		navigate: jest.fn(),
+	};
+};
 
 const renderReaderSiteSubscription = (
 	siteSubscriptionContextValue: SiteSubscriptionContextProps,
@@ -25,44 +49,28 @@ const renderReaderSiteSubscription = (
 	}
 ) => {
 	const store = mockStore( storeValue );
-	render( <ReaderSiteSubscription />, {
-		wrapper: ( props ) => {
-			return (
-				<Provider store={ store }>
-					<QueryClientProvider client={ queryClient }>
-						<SiteSubscriptionContext.Provider value={ siteSubscriptionContextValue }>
-							{ props.children }
-						</SiteSubscriptionContext.Provider>
-					</QueryClientProvider>
-				</Provider>
-			);
-		},
+	act( () => {
+		render( <ReaderSiteSubscription />, {
+			wrapper: ( props ) => {
+				return (
+					<Provider store={ store }>
+						<QueryClientProvider client={ queryClient }>
+							<SiteSubscriptionContext.Provider value={ siteSubscriptionContextValue }>
+								{ props.children }
+							</SiteSubscriptionContext.Provider>
+						</QueryClientProvider>
+					</Provider>
+				);
+			},
+		} );
 	} );
 };
 
 describe( 'ReaderSiteSubscription', () => {
 	// Tests that the component renders with default props and no errors
 	it( 'should render with default props and no errors', () => {
-		const contextValue = {
-			blogId: '123',
-			data: {
-				ID: 123,
-				blog_ID: 123,
-				name: 'Test Site',
-				URL: 'https://example.com',
-				site_icon: 'site_icon_url',
-				date_subscribed: '2023-01-01',
-				delivery_methods: {},
-				subscriber_count: 100,
-				payment_details: [],
-			},
-			isLoading: false,
-			error: null,
-			navigate: jest.fn(),
-		};
-
 		// Render the component
-		renderReaderSiteSubscription( contextValue );
+		renderReaderSiteSubscription( mockSiteSubscriptionContext() );
 
 		// Assert that the back button is rendered
 		expect(
@@ -76,5 +84,14 @@ describe( 'ReaderSiteSubscription', () => {
 		expect( screen.getByAltText( 'Test Site' ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'link', { name: 'example.com' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Cancel subscription' } ) ).toBeEnabled();
+	} );
+
+	it( 'The "View feed" button should navigate to the expected path', async () => {
+		renderReaderSiteSubscription( mockSiteSubscriptionContext( { feed_ID: 123456789 } ) );
+
+		expect( screen.getByRole( 'link', { name: 'View feed' } ) ).toHaveAttribute(
+			'href',
+			'/read/feeds/123456789'
+		);
 	} );
 } );

--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -17,6 +17,7 @@ function FormattedHeader( {
 	subHeaderAlign,
 	isSecondary,
 	hasScreenOptions,
+	subHeaderAs: SubHeaderAs = 'p',
 	children,
 } ) {
 	const classes = classNames( 'formatted-header', className, {
@@ -51,7 +52,9 @@ function FormattedHeader( {
 					</h2>
 				) }
 				{ subHeaderText && (
-					<p className={ subtitleClasses }>{ preventWidows( subHeaderText, 2 ) }</p>
+					<SubHeaderAs className={ subtitleClasses }>
+						{ preventWidows( subHeaderText, 2 ) }
+					</SubHeaderAs>
 				) }
 			</div>
 			{ children }
@@ -64,6 +67,7 @@ FormattedHeader.propTypes = {
 	className: PropTypes.string,
 	brandFont: PropTypes.bool,
 	headerText: PropTypes.node,
+	subHeaderAs: PropTypes.elementType,
 	subHeaderText: PropTypes.node,
 	tooltipText: PropTypes.node,
 	compactOnMobile: PropTypes.bool,

--- a/client/landing/subscriptions/components/settings/icons/feed-icon.tsx
+++ b/client/landing/subscriptions/components/settings/icons/feed-icon.tsx
@@ -1,0 +1,13 @@
+const FeedIcon = ( props: { className?: string } ) => (
+	<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path
+			className={ props.className }
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M4 4.5H16V15C16 15.2761 15.7761 15.5 15.5 15.5H4.5C4.22386 15.5 4 15.2761 4 15V4.5ZM2.5 3H4H16H17.5V4.5V15C17.5 16.1046 16.6046 17 15.5 17H4.5C3.39543 17 2.5 16.1046 2.5 15V4.5V3ZM5.5 6.5H14.5V8H5.5V6.5ZM5.5 9.5H9.5V11H5.5V9.5ZM12 11H13V12H12V11ZM10.5 9.5H12H13H14.5V11V12V13.5H13H12H10.5V12V11V9.5ZM5.5 12H9.5V13.5H5.5V12Z"
+			fill="#3C434A"
+		/>
+	</svg>
+);
+
+export default FeedIcon;

--- a/client/landing/subscriptions/components/settings/icons/index.ts
+++ b/client/landing/subscriptions/components/settings/icons/index.ts
@@ -1,1 +1,2 @@
 export { default as UnsubscribeIcon } from './unsubscribe-icon';
+export { default as FeedIcon } from './feed-icon';

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -14,7 +14,7 @@ import { NextButton } from '@automattic/onboarding';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useRef, useState, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import FoldableFAQComponent from 'calypso/components/foldable-faq';
@@ -69,6 +69,7 @@ const ImageSection = styled.div`
 	}
 `;
 
+// @ts-expect-error FormattedHeader is not typed and it's causing issues with the styled component
 const Header = styled( FormattedHeader )`
 	.formatted-header__title {
 		line-height: 3rem;
@@ -324,6 +325,7 @@ export default function DIFMLanding( {
 			{ ! hasPriceDataLoaded && <QueryProductsList /> }
 			<Wrapper>
 				<ContentSection>
+					{ /* @ts-expect-error FormattedHeader is not typed and it's causing issues with the styled component */ }
 					<Header align="left" headerText={ headerText } subHeaderText={ subHeaderText } />
 					<VerticalStepProgress>
 						<Step

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -139,6 +139,7 @@ export type PendingPostSubscriptionsResult = {
 export type SiteSubscriptionDetails< DateT = Date > = {
 	ID: number;
 	blog_ID: number;
+	feed_ID: number;
 	name: string;
 	URL: string;
 	site_icon: string | null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/82270

![zbl2GF.png](https://github.com/Automattic/wp-calypso/assets/2019970/851b8cec-298f-4c0c-8b34-d316cafed5d5)

## Proposed Changes

* Add feed icon button in the site subscription details page that would take users to the reader feed of that site, i.e. `/read/feeds/$feedId`
* Make the subscription site's URL underlined as per the Figma design
  * pS3hHF3lIosnX0Mgc8WtYV-fi-4_7153
  * p1695823739476599/1695810424.438149-slack-C02TCEHP3HA

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/read/subscriptions`
* Click on a site title of any WPCOM site subscription that you have
* You should end up on the site subscription's page
* Ensure the feed icon is present. When clicked, the site's reader feed page should open up

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?