### PR TITLE
Subscriptions Management: Add back button to Notification Settings page when arriving from Subscription Management

### DIFF
--- a/client/me/notification-settings/blogs-settings/style.scss
+++ b/client/me/notification-settings/blogs-settings/style.scss
@@ -124,7 +124,7 @@
 	}
 }
 
-.notification-settings__back-button {
-	padding: 0 !important;
+.notification-settings .notification-settings__back-button.has-icon.has-text {
+	padding: 0;
 	margin-bottom: 24px;
 }

--- a/client/me/notification-settings/blogs-settings/style.scss
+++ b/client/me/notification-settings/blogs-settings/style.scss
@@ -123,3 +123,8 @@
 		height: 22px;
 	}
 }
+
+.notification-settings__back-button {
+	padding: 0 !important;
+	margin-bottom: 24px;
+}

--- a/client/me/notification-settings/main.jsx
+++ b/client/me/notification-settings/main.jsx
@@ -1,5 +1,8 @@
+import { Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
+import page from 'page';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -53,6 +56,16 @@ class NotificationSettings extends Component {
 			<Main wideLayout className="notification-settings">
 				<PageViewTracker path="/me/notifications" title="Me > Notifications" />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+
+				{ page.current.includes( 'referrer=management' ) && (
+					<Button
+						className="notification-settings__back-button"
+						onClick={ () => page( '/read/subscriptions' ) }
+						icon={ <Gridicon icon="chevron-left" size={ 12 } /> }
+					>
+						{ this.props.translate( 'Manage all subscriptions' ) }
+					</Button>
+				) }
 				<FormattedHeader
 					brandFont
 					headerText={ this.props.translate( 'Notification Settings' ) }

--- a/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
+++ b/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
@@ -81,7 +81,7 @@ const SubscriptionsManagerWrapper = ( {
 								<Button
 									className="site-subscriptions-manager__manage-notifications-button"
 									variant="link"
-									href="/me/notifications"
+									href="/me/notifications?referrer=management"
 								>
 									{ translate( 'Manage notification settings' ) }
 								</Button>


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82266

## Proposed Changes

* Add back button to Notification Settings page when arriving from Subscription Management
* Update "Manage notification settings" link to include a referrer on the URL

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/read/subscriptions
* Click on "Manage notification settings"
* You should see the back button on top of the Notification Settings page
* Click on the back button, and you should be back to the Subscriptions Management
* Open the Notification Settings page by going through your profile
* You shouldn't see the back button

<img width="1074" alt="Screenshot 2023-09-27 at 13 53 07" src="https://github.com/Automattic/wp-calypso/assets/3113712/a546abb4-4ad1-45b2-9bd2-157d3d551fd4">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?