### PR TITLE
Launchpad: Enabled `setup_general` task on customer home

### DIFF
--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -48,6 +48,11 @@ export const setUpActionsForTasks = ( {
 				targetPath = addQueryArgs( targetPath, { tour: 'marketingConnectionsTour' } );
 			}
 
+			// Enable task in 'calypso' context
+			if ( task.id === 'setup_general' ) {
+				task.disabled = false;
+			}
+
 			action = () => {
 				if ( siteSlug && TASKS_TO_COMPLETE_ON_CLICK.includes( task.id ) ) {
 					updateLaunchpadSettings( siteSlug, {


### PR DESCRIPTION
Context: p9Jlb4-8Tq-p2

Related to https://github.com/Automattic/wp-calypso/issues/82276
Related to https://github.com/Automattic/jetpack/pull/33355

## Proposed Changes

* This PR enables the `setup_general` task in Customer Home

## Testing Instructions

* Apply https://github.com/Automattic/jetpack/pull/33355 to your sandbox
   *  `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/calypso_path_to_task`
* Create a site with build intent
* When you get to the fullscreen Launchpad, check that the 'Set up your site' is disabled
* Skip Launchpad
* When in Customer Home, click on the 'Set up your site' task
* Confirm you are redirected to the settings page