### PR TITLE
Site profiler: Show login link for the WordPress platform

### DIFF
--- a/client/data/site-profiler/use-analyze-url-query.ts
+++ b/client/data/site-profiler/use-analyze-url-query.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import type { UrlData } from 'calypso/blocks/import/types';
+
+export const useAnalyzeUrlQuery = ( domain: string, isValid?: boolean ) => {
+	return useQuery( {
+		queryKey: [ 'analyze-url-', domain ],
+		queryFn: (): Promise< UrlData > =>
+			wp.req.get( {
+				path: '/imports/analyze-url?site_url=' + encodeURIComponent( domain ),
+				apiNamespace: 'wpcom/v2',
+			} ),
+		meta: {
+			persist: false,
+		},
+		enabled: !! domain && isValid,
+		retry: false,
+		refetchOnWindowFocus: false,
+	} );
+};

--- a/client/data/site-profiler/use-domain-analyzer-query.ts
+++ b/client/data/site-profiler/use-domain-analyzer-query.ts
@@ -2,11 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 import { DomainAnalyzerQueryResponse } from 'calypso/data/site-profiler/types';
 import wp from 'calypso/lib/wp';
 
-export interface MigrationStatusError {
-	status: number;
-	message: string;
-}
-
 export const useDomainAnalyzerQuery = ( domain: string, isValid?: boolean ) => {
 	return useQuery( {
 		queryKey: [ 'domain-', domain ],

--- a/client/data/site-profiler/use-domain-whois-raw-data-query.ts
+++ b/client/data/site-profiler/use-domain-whois-raw-data-query.ts
@@ -2,11 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 import type { DomainAnalyzerWhoisRawDataQueryResponse } from 'calypso/data/site-profiler/types';
 
-export interface MigrationStatusError {
-	status: number;
-	message: string;
-}
-
 export const useDomainAnalyzerWhoisRawDataQuery = ( domain: string, enableFetch: boolean ) => {
 	return useQuery( {
 		queryKey: [ 'whois-domain-', domain ],

--- a/client/data/site-profiler/use-hosting-provider-query.ts
+++ b/client/data/site-profiler/use-hosting-provider-query.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { HostingProviderQueryResponse } from 'calypso/data/site-profiler/types';
 import wp from 'calypso/lib/wp';
+import type { HostingProviderQueryResponse } from 'calypso/data/site-profiler/types';
 
 export const useHostingProviderQuery = ( domain: string, isValid?: boolean ) => {
 	return useQuery( {

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -1,15 +1,17 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
+import { UrlData } from 'calypso/blocks/import/types';
 import VerifiedProvider from '../domain-information/verified-provider';
 import type { DNS, HostingProvider } from 'calypso/data/site-profiler/types';
 
 interface Props {
 	dns: DNS[];
+	urlData?: UrlData;
 	hostingProvider?: HostingProvider;
 }
 
 export default function HostingInformation( props: Props ) {
-	const { dns = [], hostingProvider } = props;
+	const { dns = [], urlData, hostingProvider } = props;
 	const aRecordIps = dns.filter( ( x ) => x.type === 'A' && x.ip );
 
 	return (
@@ -19,7 +21,23 @@ export default function HostingInformation( props: Props ) {
 				<li>
 					<div className="name">{ translate( 'Provider' ) }</div>
 					<div>
-						{ hostingProvider?.slug !== 'automattic' && <>{ hostingProvider?.name }</> }
+						{ hostingProvider?.slug !== 'automattic' && (
+							<>
+								{ hostingProvider?.name }
+								{ urlData?.platform === 'wordpress' && (
+									<>
+										&nbsp;&nbsp;
+										<a
+											href={ `${ urlData.url }wp-admin` }
+											target="_blank"
+											rel="nofollow noreferrer"
+										>
+											({ translate( 'login' ) })
+										</a>
+									</>
+								) }
+							</>
+						) }
 						{ hostingProvider?.slug === 'automattic' && <VerifiedProvider /> }
 					</div>
 				</li>

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
+import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useDomainAnalyzerQuery } from 'calypso/data/site-profiler/use-domain-analyzer-query';
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -32,8 +33,9 @@ export default function SiteProfiler() {
 		isError: isErrorSP,
 		errorUpdateCount: errorUpdateCountSP,
 	} = useDomainAnalyzerQuery( domain, isDomainValid );
-	const isBusyForWhile = useLongFetchingDetection( domain, isFetchingSP );
+	const { data: urlData } = useAnalyzeUrlQuery( domain, isDomainValid );
 	const { data: hostingProviderData } = useHostingProviderQuery( domain, isDomainValid );
+	const isBusyForWhile = useLongFetchingDetection( domain, isFetchingSP );
 	const conversionAction = useDefineConversionAction(
 		domain,
 		siteProfilerData?.whois,
@@ -99,6 +101,7 @@ export default function SiteProfiler() {
 								<LayoutBlockSection>
 									<HostingInformation
 										dns={ siteProfilerData.dns }
+										urlData={ urlData }
 										hostingProvider={ hostingProviderData?.hosting_provider }
 									/>
 								</LayoutBlockSection>


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3971

## Proposed Changes

* Added `(login)` link next to the `WordPress` hosting platform

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site-profiler`
* Enter any WP self hosted site (outside of the wpcom)
* Check if there is (login) link next to the Hosting platform
* Check if link redirect user to the `/wp-content` route in the new tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?