### PR TITLE
Site Profiler: remove form hint

### DIFF
--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -55,9 +55,6 @@ export default function DomainAnalyzer( props: Props ) {
 					</div>
 				</div>
 				<div className="domain-analyzer--msg">
-					{ ( isDomainValid || isDomainValid === undefined ) && (
-						<p className="center">{ translate( 'Enter the URL of the site you want to check' ) }</p>
-					) }
 					{ isDomainValid === false && (
 						<p className="error">
 							<Icon icon={ info } size={ 20 } />{ ' ' }

--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -55,12 +55,14 @@ export default function DomainAnalyzer( props: Props ) {
 					</div>
 				</div>
 				<div className="domain-analyzer--msg">
-					{ isDomainValid === false && (
-						<p className="error">
-							<Icon icon={ info } size={ 20 } />{ ' ' }
-							{ translate( 'Please enter a valid website address' ) }
-						</p>
-					) }
+					<p
+						className={ classnames( 'error', {
+							'vis-hidden': isDomainValid || isDomainValid === undefined,
+						} ) }
+					>
+						<Icon icon={ info } size={ 20 } />{ ' ' }
+						{ translate( 'Please enter a valid website address' ) }
+					</p>
 				</div>
 			</form>
 		</div>

--- a/client/site-profiler/components/domain-analyzer/styles.scss
+++ b/client/site-profiler/components/domain-analyzer/styles.scss
@@ -64,6 +64,10 @@
 		text-align: center;
 	}
 
+	.vis-hidden {
+		visibility: hidden;
+	}
+
 	.error {
 		color: var(--studio-red-50) !important;
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82289

## Proposed Changes

* Remove form hint

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/site-profiler
* Check that the text has been removed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?