### PR TITLE
Partner Themes on Onboarding: Support custom domains

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -112,6 +112,7 @@ const renderComponent = ( component, initialState = {} ) => {
 	const queryClient = new QueryClient();
 	const store = mockStore( {
 		purchases: {},
+		sites: {},
 		...initialState,
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -1,9 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import {
-	PLAN_BUSINESS,
-	WPCOM_FEATURES_PREMIUM_THEMES,
-	isDomainRegistration,
-} from '@automattic/calypso-products';
+import { PLAN_BUSINESS, WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import {
 	Onboard,
@@ -43,7 +39,7 @@ import { marketplaceThemeBillingProductSlug } from 'calypso/my-sites/themes/help
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
 import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { hasPurchasedDomain } from 'calypso/state/purchases/selectors/has-purchased-domain';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { setActiveTheme, activateOrInstallThenActivate } from 'calypso/state/themes/actions';
@@ -109,8 +105,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		flow === DESIGN_FIRST_FLOW || queryParams.get( 'flowToReturnTo' ) === DESIGN_FIRST_FLOW;
 
 	const wpcomSiteSlug = useSelector( ( state ) => getSiteSlug( state, site?.ID ) );
-	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, site?.ID ) );
-	const isDomainPurchased = !! sitePurchases.find( isDomainRegistration );
+	const didPurchaseDomain = useSelector(
+		( state ) => site?.ID && hasPurchasedDomain( state, site.ID )
+	);
 
 	// The design-first flow put the checkout at the last step, so we cannot show any upsell modal.
 	// Therefore, we need to hide any feature that needs to check out right away, e.g.: Premium theme.
@@ -495,7 +492,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			if (
 				selectedDesign?.is_externally_managed &&
 				hasEligibilityMessages &&
-				! isDomainPurchased
+				! didPurchaseDomain
 			) {
 				setShowEligibility( true );
 			} else {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -40,6 +40,7 @@ import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
 import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { setActiveTheme, activateOrInstallThenActivate } from 'calypso/state/themes/actions';
 import {
 	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
@@ -96,6 +97,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	);
 
 	const { site, siteSlug, siteSlugOrId } = useSiteData();
+	const wpcomSiteSlug = useSelector( ( state ) => getSiteSlug( state, site?.ID ) );
 	const siteTitle = site?.name;
 	const siteDescription = site?.description;
 	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
@@ -455,7 +457,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		// When the user is done with checkout, send them back to the current url
 		// If the theme is externally managed, send them to the marketplace thank you page
 		const destination = selectedDesign?.is_externally_managed
-			? addQueryArgs( `/marketplace/thank-you/${ siteSlug }?onboarding`, {
+			? addQueryArgs( `/marketplace/thank-you/${ wpcomSiteSlug }?onboarding`, {
 					themes: selectedDesign?.slug,
 			  } )
 			: window.location.href.replace( window.location.origin, '' );

--- a/client/state/purchases/selectors/has-purchased-domain.ts
+++ b/client/state/purchases/selectors/has-purchased-domain.ts
@@ -1,0 +1,11 @@
+import { isDomainRegistration } from '@automattic/calypso-products';
+import { getSitePurchases } from './get-site-purchases';
+import type { AppState } from 'calypso/types';
+
+import 'calypso/state/purchases/init';
+
+export function hasPurchasedDomain( state: AppState, siteId: number | null ): boolean {
+	const sitePurchases = getSitePurchases( state, siteId );
+
+	return !! sitePurchases.find( isDomainRegistration );
+}


### PR DESCRIPTION
Fix https://github.com/Automattic/wp-calypso/issues/82279

## Proposed Changes

* Allow the usage of site slug from site data, instead of from  URL
* Avoid showing the Eligibility Modal when a domain is purchased as the actual domain shouldn't change.

## Testing Instructions

* Apply the diff D118900-code to your sandbox and direct requests to the sandbox
* Use the getting started flow from `/start/free` or `/start/business`
* Select a custom domain (non `.wordpress.com` ended)
* On the Desing Picker, select a Partner Theme
* Click on `Unlock Theme` and after the upgrade modal, you shouldn't see the Eligibility Modal
* The flow should proceed until the Thank You page, and you should be able to activate the theme

**Regression test**
* Select a wordpress.com domain
* The flow should proceed normally, including the Eligibility Modal displaying

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
