### PR TITLE
Fix broken Jetpack Instant search E2E test

### DIFF
--- a/test/e2e/specs/search/search__jetpack-instant.ts
+++ b/test/e2e/specs/search/search__jetpack-instant.ts
@@ -105,11 +105,15 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Instant Search' ), function () {
 	it( 'Enter search term and launch search modal', async function () {
 		const inputLocator = page
 			.getByRole( 'search' )
-			.getByRole( 'searchbox', { name: 'Search' } )
+			// Sometimes the parent block on a homepage has a very high-up aria-hidden.
+			// TODO: figure out what is adding that, and remove the "includeHidden" here.
+			.getByRole( 'searchbox', { name: 'Search', includeHidden: true } )
 			.first();
 		const buttonLocator = page
 			.getByRole( 'search' )
-			.getByRole( 'button', { name: 'Search' } )
+			// Sometimes the parent block on a homepage has a very high-up aria-hidden.
+			// TODO: figure out what is adding that, and remove the "includeHidden" here.
+			.getByRole( 'button', { name: 'Search', includeHidden: true } )
 			.first();
 
 		// Adding a slightly longer timeout here because we can't fully wait for the "load" event above due to

--- a/test/e2e/specs/search/search__jetpack-instant.ts
+++ b/test/e2e/specs/search/search__jetpack-instant.ts
@@ -103,16 +103,14 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Instant Search' ), function () {
 	} );
 
 	it( 'Enter search term and launch search modal', async function () {
+		// Sometimes the parent block on a homepage has a very high-up aria-hidden.
+		// TODO: figure out what is adding that, and remove the "includeHidden" here.
 		const inputLocator = page
-			.getByRole( 'search' )
-			// Sometimes the parent block on a homepage has a very high-up aria-hidden.
-			// TODO: figure out what is adding that, and remove the "includeHidden" here.
+			.getByRole( 'search', { includeHidden: true } )
 			.getByRole( 'searchbox', { name: 'Search', includeHidden: true } )
 			.first();
 		const buttonLocator = page
-			.getByRole( 'search' )
-			// Sometimes the parent block on a homepage has a very high-up aria-hidden.
-			// TODO: figure out what is adding that, and remove the "includeHidden" here.
+			.getByRole( 'search', { includeHidden: true } )
 			.getByRole( 'button', { name: 'Search', includeHidden: true } )
 			.first();
 


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #81343 

## Proposed Changes

The Jetpack instant search test was permafailing on a few of the Atomic sites.

Under the hood, the top-level element with class `wp-site-blocks` is `aria-hidden` on some our test sites homepages. I am really struggling to figure out where that possibly could be coming from!

In the meantime, this allows matching on hidden elements for the home page search elements for now. 

## Testing Instructions

The search test should not long fail / flake-out in the atomic runs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?