### PR TITLE
Avoid triggering the inline cache image rebuild

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -239,20 +239,25 @@ object BuildDockerImage : BuildType({
 			"""
 		}
 
+		// TODO: Cache rebuilding is currently disabled. It takes a long time and
+		// causes timeouts on trunk. It needs to run more quickly to be worth it.
+		// For now, the cache will be rebuilt a couple times a day by the dedicated
+		// cache build.
+
 		// Conditions don't seem to support and/or, so we do this in a separate step.
 		// Essentially, UPDATE_BASE_IMAGE_CACHE will remain false by default, but
 		// if we're on trunk and get WEBPACK_CACHE_INVALIDATED set by the docker build,
 		// then we can flip it to true to trigger the cache rebuild.
-		script {
-			name = "Set cache update"
-			conditions {
-				equals("env.WEBPACK_CACHE_INVALIDATED", "true")
-				equals("teamcity.build.branch.is_default", "true")
-			}
-			scriptContent = """
-				echo "##teamcity[setParameter name='UPDATE_BASE_IMAGE_CACHE' value='true']"
-			"""
-		}
+		// script {
+		// 	name = "Set cache update"
+		// 	conditions {
+		// 		equals("env.WEBPACK_CACHE_INVALIDATED", "true")
+		// 		equals("teamcity.build.branch.is_default", "true")
+		// 	}
+		// 	scriptContent = """
+		// 		echo "##teamcity[setParameter name='UPDATE_BASE_IMAGE_CACHE' value='true']"
+		// 	"""
+		// }
 
 		// This updates the base docker image when the webpack cache invalidates.
 		// It does so by re-using the layers already generated above, and simply


### PR DESCRIPTION
Disable the cache image rebuild. This only happens in the main docker image build on trunk. It was originally added in #72975. Having a recently-updated cache image improves docker image build times by up to 2min. So updating it as needed from the docker image build meant more builds would have a fresh cache.

The problem is that the cache rebuild is now taking quite a bit longer than it was originally. The result now is a lot of timeouts on docker image builds. These mostly waste time in the build system and cause extra noise. (see p1695829797182319-slack-C02DQP0FP)

For now, we'll disable this unless we can make it happen without timing out the build. Theoretically this is possible with local docker layer caches, but those were tricky to work with.

The cache image will still exist; it will just be rebuilt on a cron (currently twice a day). 
