### PR TITLE
Site profiler: Responsive mobile design support

### DIFF
--- a/client/site-profiler/components/domain-analyzer/styles.scss
+++ b/client/site-profiler/components/domain-analyzer/styles.scss
@@ -1,3 +1,15 @@
+@import "@wordpress/base-styles/breakpoints";
+
+@mixin input-style {
+	background: #fff;
+	box-sizing: border-box;
+	box-shadow: 0 5px 10px 0 #0000000d;
+	border: 1px solid transparent;
+	/* stylelint-disable-next-line */
+	border-radius: 8px;
+	padding: 0.625rem 1.5rem;
+}
+
 .domain-analyzer {
 	p + .domain-analyzer--form {
 		margin-top: 2.5rem;
@@ -5,23 +17,32 @@
 }
 
 .domain-analyzer--form-container {
-	background: #fff;
-	box-shadow: 0 5px 10px 0 #0000000d;
-	border: 1px solid transparent;
-	/* stylelint-disable-next-line */
-	border-radius: 8px;
-	padding: 0.625rem 1.5rem;
 	display: flex;
-	gap: 1rem;
 
-	.col-1 {
-		flex: 1;
+	@media (min-width: $break-small + 1px) {
+		@include input-style;
+		gap: 1rem;
+
+		.col-1 {
+			flex: 1;
+		}
+
+		.col-2 {
+			display: flex;
+			align-items: center;
+			width: fit-content;
+		}
 	}
 
-	.col-2 {
-		display: flex;
-		align-items: center;
-		width: fit-content;
+	@media (max-width: $break-small) {
+		flex-direction: column;
+		justify-content: space-between;
+		gap: 1.5rem;
+
+		.button-action {
+			width: 100%;
+			justify-content: center;
+		}
 	}
 
 	input {
@@ -41,13 +62,27 @@
 		&:focus {
 			outline: none;
 		}
+
+		@media (max-width: $break-small) {
+			@include input-style;
+			font-size: 1.5rem;
+			line-height: 2;
+		}
 	}
 }
 
 .domain-analyzer--form {
 	&.is-error {
-		.domain-analyzer--form-container {
-			border: 1px solid var(--studio-red-50);
+		@media (min-width: $break-small + 1px) {
+			.domain-analyzer--form-container {
+				border: 1px solid var(--studio-red-50);
+			}
+		}
+
+		@media (max-width: $break-small ) {
+			input {
+				border: 1px solid var(--studio-red-50);
+			}
 		}
 	}
 }

--- a/client/site-profiler/components/domain-analyzer/styles.scss
+++ b/client/site-profiler/components/domain-analyzer/styles.scss
@@ -18,6 +18,9 @@
 			margin-top: 2.25rem;
 		}
 	}
+
+	// subtract the height of the domain-analyzer--msg hidden element
+	margin-bottom: -1.5rem;
 }
 
 .domain-analyzer--form-container {
@@ -90,6 +93,7 @@
 		}
 	}
 }
+
 
 .domain-analyzer--msg {
 	margin-top: 1rem;

--- a/client/site-profiler/components/domain-analyzer/styles.scss
+++ b/client/site-profiler/components/domain-analyzer/styles.scss
@@ -13,6 +13,10 @@
 .domain-analyzer {
 	p + .domain-analyzer--form {
 		margin-top: 2.5rem;
+
+		@media (max-width: $break-small) {
+			margin-top: 2.25rem;
+		}
 	}
 }
 

--- a/client/site-profiler/components/heading-information/styles.scss
+++ b/client/site-profiler/components/heading-information/styles.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .heading-information {
 	background: #fff;
 	border: 1px solid var(--studio-gray-5);
@@ -18,7 +20,10 @@
 	.domain {
 		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
 		font-size: 3rem;
+		line-height: 1;
 		color: var(--studio-gray-100);
+		word-break: break-all;
+		margin: 0.5rem 0 1rem 0;
 	}
 
 	summary {
@@ -38,5 +43,18 @@
 	.cta-wrapper {
 		display: flex;
 		gap: 1rem;
+	}
+
+	@media (max-width: $break-small ) {
+		.domain {
+			font-size: 2rem;
+			line-height: 1;
+			margin: 0.5rem 0;
+		}
+
+		.status-icon {
+			padding: 4px !important;
+			top: -3px !important;
+		}
 	}
 }

--- a/client/site-profiler/components/layout/styles.scss
+++ b/client/site-profiler/components/layout/styles.scss
@@ -3,6 +3,10 @@
 .l-block {
 	padding: 5rem 0;
 
+	@media (max-width: $break-small) {
+		padding: 2.5rem 0;
+	}
+
 	&.is-mono-bg {
 		background-color: #e9eff5;
 	}
@@ -53,6 +57,10 @@
 
 .l-block-section {
 	padding: 1.5rem 0;
+
+	@media (max-width: $break-small) {
+		padding: 1rem 0;
+	}
 }
 
 @keyframes l-block-fade-in {

--- a/client/site-profiler/components/layout/styles.scss
+++ b/client/site-profiler/components/layout/styles.scss
@@ -37,6 +37,10 @@
 		gap: 5rem;
 		display: flex;
 		justify-content: space-between;
+
+		@media (max-width: $break-small) {
+			gap: 2.5rem;
+		}
 	}
 
 	.l-block-col-2 .l-block-content {

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -180,6 +180,10 @@
 		h2 {
 			max-width: 400px;
 		}
+
+		@media (max-width: $break-medium) {
+			flex-direction: column-reverse;
+		}
 	}
 
 	.domain-analyzer-block,

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -15,6 +15,10 @@
 		line-height: 1;
 		margin-bottom: 1rem;
 		color: var(--studio-gray-100);
+
+		@media (max-width: $break-small ) {
+			font-size: 3rem;
+		}
 	}
 
 	h2 {

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -199,17 +199,18 @@
 			left: 0;
 			background: #e5f4ff;
 			z-index: -1;
-			height: 100%;
 		}
 	}
 
-	@media (min-width: $break-medium) {
-		.domain-analyzer-block::after {
+	.domain-analyzer-block::after {
+		height: 100%;
+
+		@media (min-width: $break-medium) {
 			height: 280px;
 		}
-
-		.domain-result-block::after {
-			height: 210px;
-		}
 	}
+	.domain-result-block::after {
+		height: 210px;
+	}
+
 }

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -191,14 +191,17 @@
 			left: 0;
 			background: #e5f4ff;
 			z-index: -1;
+			height: 100%;
 		}
 	}
 
-	.domain-analyzer-block::after {
-		height: 280px;
-	}
+	@media (min-width: $break-medium) {
+		.domain-analyzer-block::after {
+			height: 280px;
+		}
 
-	.domain-result-block::after {
-		height: 210px;
+		.domain-result-block::after {
+			height: 210px;
+		}
 	}
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/81812

## Proposed Changes

* Add mobile device styles support matching provided Figma design

## Testing Instructions

* Go to `/site-profiler`
* Test the product on the smaller resolutions
* Compare it with the Figma design

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?