### PR TITLE
Domain Transfers: Fix recipient typo

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/transfer-domain-to-any-user.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-any-user/transfer-domain-to-any-user.tsx
@@ -211,7 +211,7 @@ export default function TransferDomainToAnyUser( {
 								</div>
 							</div>
 							<div className="transfer-domain-to-any-user__pending-detail">
-								<strong>{ translate( 'Transfer receipient' ) }</strong>
+								<strong>{ translate( 'Transfer recipient' ) }</strong>
 								<div>
 									<span>{ transferEmail }</span>
 								</div>


### PR DESCRIPTION
## Proposed Changes

* Fix recipient typo

## Testing Instructions

* Create a pending transfer: http://calypso.localhost:3000/domains/manage/all/test-345678.blog/transfer/any-user/test-345678.blog

Before
![Screenshot 2023-09-28 at 11-04-18 test-345678 blog — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/d1f7636a-09e0-4f5f-b317-53de59f915ad)

After

![Screenshot 2023-09-28 at 11-04-26 test-345678 blog — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/63d38f34-6063-4fcc-ba02-25abd344f0c4)
