### PR TITLE
Domain Transfers: Disable contact edit screen when transfer is pending

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
@@ -3,6 +3,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import useDomainTransferRequestQuery from 'calypso/data/domains/transfers/use-domain-transfer-request-query';
 import { PRIVACY_PROTECTION, PUBLIC_VS_PRIVATE } from 'calypso/lib/url/support';
 import ContactDisplay from 'calypso/my-sites/domains/domain-management/contacts-privacy/contact-display';
 import {
@@ -22,6 +23,13 @@ import type { ContactsCardPassedProps, ContactsCardProps } from './types';
 
 const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 	const translate = useTranslate();
+
+	const { data, isLoading } = useDomainTransferRequestQuery(
+		props.selectedSite.slug,
+		props.selectedDomainName
+	);
+	const disableEdit = !! ( isLoading || data?.email );
+
 	const togglePrivacy = () => {
 		const { selectedSite, privateDomain, selectedDomainName: name } = props;
 
@@ -157,14 +165,20 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 					<ContactDisplay selectedDomainName={ selectedDomainName } />
 					<div className="contact-information__button-container">
 						<Button
-							href={ domainManagementEditContactInfo(
-								props.selectedSite.slug,
-								props.selectedDomainName,
-								currentRoute
-							) }
+							disabled={ disableEdit }
+							href={
+								disableEdit
+									? ''
+									: domainManagementEditContactInfo(
+											props.selectedSite.slug,
+											props.selectedDomainName,
+											currentRoute
+									  )
+							}
 						>
 							{ translate( 'Edit' ) }
 						</Button>
+
 						{ canManageConsent && (
 							<Button
 								href={ domainManagementManageConsent(


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3902

## Proposed Changes

* Disables the contact info edit link on domains while a domain transfer between users is pending

## Testing Instructions

* With a domain only site
* http://calypso.localhost:3000/domains/manage/all/test-345678.blog/edit/test-345678.blog
* Click transfer on the right
* Set up a pending transfer
* Go back to the domain screen
* Attempt to edit the contact details for the domain, the edit button should be disabled.

Before
![Screenshot 2023-09-28 at 13-38-15 test-345678 blog — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/582f47ba-f381-4813-9f55-752e1de02685)

After
![Screenshot 2023-09-28 at 13-37-50 test-345678 blog — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/0d737b37-386c-4499-8aec-ed378b08a968)
