### PR TITLE
Assembler - Categories - Reuse testimonials category slug for quotes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -118,6 +118,11 @@ class Block_Patterns_From_API {
 						'Blog Posts',
 						'full-site-editing'
 					);
+				} elseif ( 'testimonials' === $slug ) {
+					$category_properties['label'] = __(
+						'Quotes',
+						'full-site-editing'
+					);
 				}
 				register_block_pattern_category( $slug, $category_properties );
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -49,7 +49,7 @@ export const PATTERN_CATEGORIES = [
 	'newsletter',
 	//'podcast', -- Hidden
 	//'portfolio', -- Hidden
-	'quotes',
+	//'quotes', -- Not exist
 	'services',
 	'store',
 	//'team', -- Not exist

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -53,7 +53,7 @@ export const PATTERN_CATEGORIES = [
 	'services',
 	'store',
 	//'team', -- Not exist
-	//'testimonials', -- Not exist
+	'testimonials', // Reused as "Quotes"
 	//'text', -- Hidden
 ];
 
@@ -62,7 +62,7 @@ export const ORDERED_PATTERN_CATEGORIES = [
 	'about',
 	'services',
 	'store',
-	'quotes',
+	'testimonials',
 	'posts',
 	'newsletter',
 	'gallery',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1695707140881379-slack-C048CUFRGFQ

## Proposed Changes

* Reuse `testimonials` category slug for Quotes

This change will prevent the editor from showing the "Testimonials" category when theme patterns or core patterns are categorized as `testimonials`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I have created a temporary Testimonials category in the source site by duplicating Quotes. I will rename it to Quotes and remove the old Quotes after this PR is merged.

- Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }`
- Click Sections and verify you see "Testimonials" in the right position after "Store"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?