### PR TITLE
Earn: Update promo card buttons and links

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -320,7 +320,7 @@ const Home = () => {
 			return;
 		}
 		const cta = {
-			text: translate( 'Learn how to get started' ),
+			text: translate( 'Learn more' ),
 			action: () => {
 				trackCtaButton( 'learn-paid-newsletters' );
 				if ( window && window.location ) {

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -187,7 +187,6 @@ const Home = () => {
 			icon: 'credit-card',
 			actions: {
 				cta,
-				featureIncludedInPlan: hasSimplePayments,
 			},
 		};
 	};
@@ -229,7 +228,6 @@ const Home = () => {
 			icon: 'money',
 			actions: {
 				cta,
-				featureIncludedInPlan: true,
 			},
 		};
 	};
@@ -273,7 +271,6 @@ const Home = () => {
 			icon: 'heart-outline',
 			actions: {
 				cta,
-				featureIncludedInPlan: true,
 			},
 		};
 	};
@@ -311,7 +308,6 @@ const Home = () => {
 			icon: 'bookmark-outline',
 			actions: {
 				cta,
-				featureIncludedInPlan: true,
 			},
 		};
 	};
@@ -390,7 +386,6 @@ const Home = () => {
 			icon: 'user-add',
 			actions: {
 				cta,
-				featureIncludedInPlan: true,
 			},
 		};
 	};
@@ -444,7 +439,6 @@ const Home = () => {
 			actions: {
 				cta,
 				learnMoreLink,
-				featureIncludedInPlan: true,
 			},
 		};
 	};

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -149,15 +149,14 @@ const Home = () => {
 	 * Return the content to display in the Simple Payments card based on the current plan.
 	 */
 	const getSimplePaymentsCard = (): PromoSectionCardProps => {
-		const supportLink = localizeUrl(
-			'https://wordpress.com/support/wordpress-editor/blocks/pay-with-paypal/'
-		);
 		const cta = hasSimplePayments
 			? {
-					text: translate( 'Learn how to get started' ),
+					text: translate( 'Learn more' ),
 					action: () => {
 						trackCtaButton( 'simple-payments' );
-						page( supportLink );
+						window.location.href = localizeUrl(
+							'https://wordpress.com/support/wordpress-editor/blocks/pay-with-paypal/'
+						);
 					},
 			  }
 			: {
@@ -172,9 +171,6 @@ const Home = () => {
 						);
 					},
 			  };
-		const learnMoreLink = hasSimplePayments
-			? null
-			: { url: supportLink, onClick: () => trackLearnLink( 'simple-payments' ) };
 		const title = translate( 'Collect PayPal payments' );
 		const body = (
 			<>
@@ -191,7 +187,7 @@ const Home = () => {
 			icon: 'credit-card',
 			actions: {
 				cta,
-				learnMoreLink,
+				featureIncludedInPlan: hasSimplePayments,
 			},
 		};
 	};
@@ -200,14 +196,17 @@ const Home = () => {
 	 * Return the content to display in the Recurring Payments card based on the current plan.
 	 */
 	const getRecurringPaymentsCard = (): PromoSectionCardProps => {
-		const hasConnectionCtaTitle = translate( 'Manage Payment Button' );
-		const noConnectionCtaTitle = translate( 'Enable Payment Button' );
-		const ctaTitle = hasConnectedAccount ? hasConnectionCtaTitle : noConnectionCtaTitle;
 		const cta = {
-			text: ctaTitle,
+			text: translate( 'Learn more' ),
 			action: () => {
 				trackCtaButton( 'recurring-payments' );
-				page( `/earn/payments/${ site?.slug }` );
+				const learnMoreLink = ! hasConnectedAccount
+					? 'https://wordpress.com/payments-donations/'
+					: 'https://wordpress.com/support/wordpress-editor/blocks/payments/#payment-button-block';
+
+				if ( window && window.location ) {
+					window.location.href = localizeUrl( learnMoreLink );
+				}
 			},
 		};
 		const title = translate( 'Collect payments' );
@@ -224,25 +223,13 @@ const Home = () => {
 			</>
 		);
 
-		const learnMoreLink = ! hasConnectedAccount
-			? {
-					url: localizeUrl( 'https://wordpress.com/payments-donations/' ),
-					onClick: () => trackLearnLink( 'recurring-payments' ),
-			  }
-			: {
-					url: localizeUrl(
-						'https://wordpress.com/support/wordpress-editor/blocks/payments/#payment-button-block'
-					),
-					onClick: () => trackLearnLink( 'recurring-payments' ),
-					label: translate( 'Support documentation' ),
-			  };
 		return {
 			title,
 			body,
 			icon: 'money',
 			actions: {
 				cta,
-				learnMoreLink,
+				featureIncludedInPlan: true,
 			},
 		};
 	};
@@ -251,16 +238,20 @@ const Home = () => {
 	 * Return the content to display in the Donations card based on the current plan.
 	 */
 	const getDonationsCard = (): PromoSectionCardProps => {
-		const hasConnectionCtaTitle = translate( 'Manage Donations Form' );
-		const noConnectionCtaTitle = translate( 'Enable Donations Form' );
-		const ctaTitle = hasConnectedAccount ? hasConnectionCtaTitle : noConnectionCtaTitle;
 		const cta = {
-			text: ctaTitle,
+			text: translate( 'Learn more' ),
 			action: () => {
 				trackCtaButton( 'donations' );
-				page( `/earn/payments/${ site?.slug }` );
+				const learnMoreLink = ! hasConnectedAccount
+					? 'https://wordpress.com/payments-donations/'
+					: 'https://wordpress.com/support/wordpress-editor/blocks/donations/';
+
+				if ( window && window.location ) {
+					window.location.href = localizeUrl( learnMoreLink );
+				}
 			},
 		};
+
 		const title = translate( 'Accept donations and tips' );
 
 		const body = (
@@ -276,24 +267,13 @@ const Home = () => {
 			</>
 		);
 
-		const learnMoreLink = ! hasConnectedAccount
-			? {
-					url: localizeUrl( 'https://wordpress.com/payments-donations/' ),
-					onClick: () => trackLearnLink( 'donations' ),
-			  }
-			: {
-					url: localizeUrl( 'https://wordpress.com/support/wordpress-editor/blocks/donations/' ),
-					onClick: () => trackLearnLink( 'donations' ),
-					label: translate( 'Support documentation' ),
-			  };
-
 		return {
 			title,
 			body,
 			icon: 'heart-outline',
 			actions: {
 				cta,
-				learnMoreLink,
+				featureIncludedInPlan: true,
 			},
 		};
 	};
@@ -302,17 +282,18 @@ const Home = () => {
 	 * Return the content to display in the Premium Content Block card based on the current plan.
 	 */
 	const getPremiumContentCard = (): PromoSectionCardProps | undefined => {
-		const hasConnectionCtaTitle = translate( 'Manage Premium Content' );
-		const noConnectionCtaTitle = translate( 'Enable Premium Content' );
-		const ctaTitle = hasConnectedAccount ? hasConnectionCtaTitle : noConnectionCtaTitle;
 		if ( isNonAtomicJetpack ) {
 			return;
 		}
 		const cta = {
-			text: ctaTitle,
+			text: translate( 'Learn more' ),
 			action: () => {
-				trackCtaButton( 'premium-content' );
-				page( `/earn/payments/${ site?.slug }` );
+				trackLearnLink( 'premium-content' );
+				if ( window && window.location ) {
+					window.location.href = localizeUrl(
+						'https://wordpress.com/support/wordpress-editor/blocks/premium-content-block/'
+					);
+				}
 			},
 		};
 		const title = translate( 'Profit from subscriber-only content' );
@@ -323,13 +304,6 @@ const Home = () => {
 			'Create paid subscription options to share premium content like text, images, video, and any other content on your website.'
 		);
 		const body = <>{ hasConnectedAccount ? hasConnectionBodyText : noConnectionBodyText }</>;
-		const learnMoreLink = {
-			url: localizeUrl(
-				'https://wordpress.com/support/wordpress-editor/blocks/premium-content-block/'
-			),
-			onClick: () => trackLearnLink( 'premium-content' ),
-			label: hasConnectedAccount ? translate( 'Support documentation' ) : undefined,
-		};
 
 		return {
 			title,
@@ -337,7 +311,7 @@ const Home = () => {
 			icon: 'bookmark-outline',
 			actions: {
 				cta,
-				learnMoreLink,
+				featureIncludedInPlan: true,
 			},
 		};
 	};
@@ -416,6 +390,7 @@ const Home = () => {
 			icon: 'user-add',
 			actions: {
 				cta,
+				featureIncludedInPlan: true,
 			},
 		};
 	};
@@ -461,6 +436,7 @@ const Home = () => {
 		const learnMoreLink = ! ( hasWordAdsFeature || hasSetupAds )
 			? { url: 'https://wordads.co/', onClick: () => trackLearnLink( 'ads' ) }
 			: null;
+
 		return {
 			title,
 			body,
@@ -468,6 +444,7 @@ const Home = () => {
 			actions: {
 				cta,
 				learnMoreLink,
+				featureIncludedInPlan: true,
 			},
 		};
 	};


### PR DESCRIPTION
## Proposed Changes

Converts CTA buttons to Learn More, and adds notices for whether each feature is included in a users current plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Checkout this branch, go to http://calypso.localhost:3000/earn/YOURDOMAIN, and confirm cards have been updated as in screenshots above.
   - Buttons should now be Learn More buttons, and there should be notices about whether each feature is included in the user's current plan. 
   - For Ad Dashboard, if you haven't enabled ads, you'll still see the Unlock button and Learn more link. Once you do enable ads, you'll see a button to access the Ads dashboard and the feature availability notice (compare screenshots 2 and 3 above).
   - For Collect Paypal payments, you should see the Unlock button unless you are on a premium plans. Otherwise, you will see Learn More + included in your plan (compare screenshots 2 and 3 above). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?