### PR TITLE
Domains Table: Update loading placeholder redesign

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -65,7 +65,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page' ] } />
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
 				<DomainsTable
-					isFetchingDomains={ isLoading }
+					isLoadingDomains={ isLoading }
 					domains={ domains }
 					isAllSitesView
 					shouldDisplayContactInfoBulkAction={ isEnabled(

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -90,7 +90,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page' ] } />
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
 				<DomainsTable
-					isFetchingDomains={ isLoading }
+					isLoadingDomains={ isLoading }
 					domains={ data?.domains }
 					isAllSitesView={ false }
 					siteSlug={ site?.slug ?? null }

--- a/packages/domains-table/src/domains-table-header/header-loading.tsx
+++ b/packages/domains-table/src/domains-table-header/header-loading.tsx
@@ -1,0 +1,34 @@
+import { useDomainsTable } from '../domains-table/domains-table';
+import { DomainsTablePlaceholder } from '../domains-table/domains-table-placeholder';
+
+export default function DomainsTableHeaderLoading() {
+	const { domainsTableColumns } = useDomainsTable();
+
+	return (
+		<tr className="domains-table-header-loading-placeholder">
+			<th className="domains-table-header-loading-placeholder-checkbox-column">
+				<DomainsTablePlaceholder isHeader delayMS={ 50 } />
+			</th>
+			<th>
+				<DomainsTablePlaceholder isHeader delayMS={ 50 } />
+			</th>
+			{ domainsTableColumns.some( ( column ) => column.name === 'owner' ) && (
+				<th>
+					<DomainsTablePlaceholder isHeader delayMS={ 50 } />
+				</th>
+			) }
+			<th>
+				<DomainsTablePlaceholder isHeader delayMS={ 50 } />
+			</th>
+			<th>
+				<DomainsTablePlaceholder isHeader delayMS={ 50 } />
+			</th>
+			<th>
+				<DomainsTablePlaceholder isHeader delayMS={ 50 } />
+			</th>
+			<th>
+				<DomainsTablePlaceholder isHeader delayMS={ 50 } />
+			</th>
+		</tr>
+	);
+}

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -4,7 +4,8 @@ import { CheckboxControl, Icon } from '@wordpress/components';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
-import { ReactNode } from 'react';
+import DomainsTableHeaderLoading from './header-loading';
+import type { ReactNode } from 'react';
 
 import './style.scss';
 
@@ -47,6 +48,7 @@ type DomainsTableHeaderProps = {
 	headerClasses?: string;
 	domainsRequiringAttention?: number;
 	canSelectAnyDomains?: boolean;
+	isLoadingDomains?: boolean;
 };
 
 export const DomainsTableHeader = ( {
@@ -61,6 +63,7 @@ export const DomainsTableHeader = ( {
 	headerClasses,
 	domainsRequiringAttention,
 	canSelectAnyDomains = true,
+	isLoadingDomains,
 }: DomainsTableHeaderProps ) => {
 	const { __ } = useI18n();
 	const listHeaderClasses = classNames( 'domains-table-header', headerClasses || '' );
@@ -81,6 +84,14 @@ export const DomainsTableHeader = ( {
 	};
 
 	const isBulkSelection = bulkSelectionStatus !== 'no-domains';
+
+	if ( isLoadingDomains ) {
+		return (
+			<thead className={ listHeaderClasses }>
+				<DomainsTableHeaderLoading />
+			</thead>
+		);
+	}
 
 	return (
 		<thead className={ listHeaderClasses }>

--- a/packages/domains-table/src/domains-table-header/style.scss
+++ b/packages/domains-table/src/domains-table-header/style.scss
@@ -80,3 +80,13 @@
 		line-height: 20px;
 	}
 }
+
+.domains-table-header-loading-placeholder {
+	th {
+		width: 77px;
+
+		&.domains-table-header-loading-placeholder-checkbox-column {
+			width: 20px;
+		}
+	}
+}

--- a/packages/domains-table/src/domains-table/domains-table-body.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-body.tsx
@@ -6,9 +6,9 @@ import DomainsTableRowLoading from './domains-table-row-loading';
 import './style.scss';
 
 export function DomainsTableBody() {
-	const { filteredData, isFetchingDomains } = useDomainsTable();
+	const { filteredData, isLoadingDomains } = useDomainsTable();
 
-	if ( isFetchingDomains ) {
+	if ( isLoadingDomains ) {
 		return (
 			<tbody>
 				<DomainsTableRowLoading />

--- a/packages/domains-table/src/domains-table/domains-table-header.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-header.tsx
@@ -13,6 +13,7 @@ export const DomainsTableHeader = () => {
 		filteredData,
 		domainsTableColumns,
 		selectedDomains,
+		isLoadingDomains,
 	} = useDomainsTable();
 
 	return (
@@ -27,6 +28,7 @@ export const DomainsTableHeader = () => {
 			canSelectAnyDomains={ canSelectAnyDomains }
 			domainCount={ filteredData.length }
 			selectedDomainsCount={ selectedDomains.size }
+			isLoadingDomains={ isLoadingDomains }
 		/>
 	);
 };

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card-loading.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card-loading.tsx
@@ -1,22 +1,22 @@
-import { LoadingPlaceholder } from '@automattic/components';
+import { DomainsTablePlaceholder } from './domains-table-placeholder';
 
 export default function DomainsTableMobileCardLoading() {
 	return (
 		<div className="domains-table-mobile-card-loading-placeholder">
 			<div>
-				<LoadingPlaceholder delayMS={ 50 } />
+				<DomainsTablePlaceholder delayMS={ 50 } />
 				<div className="domains-table-mobile-card-loading-placeholder-actions">
-					<LoadingPlaceholder delayMS={ 50 } />
+					<DomainsTablePlaceholder delayMS={ 50 } />
 				</div>
 			</div>
 			<div>
-				<LoadingPlaceholder delayMS={ 50 } />
-				<LoadingPlaceholder delayMS={ 50 } />
+				<DomainsTablePlaceholder delayMS={ 50 } />
+				<DomainsTablePlaceholder delayMS={ 50 } />
 			</div>
 			<div>
-				<LoadingPlaceholder delayMS={ 50 } />
+				<DomainsTablePlaceholder delayMS={ 50 } />
 				<div className="domains-table-mobile-card-loading-placeholder-status">
-					<LoadingPlaceholder delayMS={ 50 } />
+					<DomainsTablePlaceholder delayMS={ 50 } />
 				</div>
 			</div>
 		</div>

--- a/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-card.tsx
@@ -1,5 +1,4 @@
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
-import { LoadingPlaceholder } from '@automattic/components';
 import { PartialDomainData } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
@@ -9,6 +8,7 @@ import { useDomainRow } from '../use-domain-row';
 import { canBulkUpdate } from '../utils/can-bulk-update';
 import { DomainsTableEmailIndicator } from './domains-table-email-indicator';
 import { DomainsTableExpiresRewnewsOnCell } from './domains-table-expires-renew-cell';
+import { DomainsTablePlaceholder } from './domains-table-placeholder';
 import { DomainsTableRowActions } from './domains-table-row-actions';
 import { DomainsTableStatusCell } from './domains-table-status-cell';
 import { DomainsTableStatusCTA } from './domains-table-status-cta';
@@ -90,7 +90,7 @@ export const DomainsTableMobileCard = ( { domain }: Props ) => {
 			<div>
 				<span className="domains-table-mobile-card-label"> { __( 'Status' ) } </span>
 				{ ! currentDomainData || isLoadingSiteDomainsDetails ? (
-					<LoadingPlaceholder style={ { width: '30%' } } />
+					<DomainsTablePlaceholder style={ { width: '30%' } } />
 				) : (
 					<div className="domains-table-mobile-card-status">
 						<DomainsTableStatusCell

--- a/packages/domains-table/src/domains-table/domains-table-mobile-cards.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-mobile-cards.tsx
@@ -11,7 +11,7 @@ export const DomainsTableMobileCards = () => {
 		canSelectAnyDomains,
 		changeBulkSelection,
 		getBulkSelectionStatus,
-		isFetchingDomains,
+		isLoadingDomains,
 	} = useDomainsTable();
 
 	const bulkSelectionStatus = getBulkSelectionStatus();
@@ -48,7 +48,7 @@ export const DomainsTableMobileCards = () => {
 					</div>
 				) }
 			</div>
-			{ isFetchingDomains && (
+			{ isLoadingDomains && (
 				<>
 					<DomainsTableMobileCardLoading />
 					<DomainsTableMobileCardLoading />

--- a/packages/domains-table/src/domains-table/domains-table-placeholder/index.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-placeholder/index.tsx
@@ -1,0 +1,16 @@
+import { LoadingPlaceholder } from '@automattic/components';
+import classnames from 'classnames';
+import type { ComponentProps } from 'react';
+import './style.scss';
+
+export function DomainsTablePlaceholder( {
+	className,
+	...rest
+}: ComponentProps< typeof LoadingPlaceholder > ) {
+	return (
+		<LoadingPlaceholder
+			className={ classnames( 'domains-table-placeholder', className ) }
+			{ ...rest }
+		/>
+	);
+}

--- a/packages/domains-table/src/domains-table/domains-table-placeholder/index.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-placeholder/index.tsx
@@ -3,13 +3,18 @@ import classnames from 'classnames';
 import type { ComponentProps } from 'react';
 import './style.scss';
 
+interface DomainsTablePlaceholderProps extends ComponentProps< typeof LoadingPlaceholder > {
+	isHeader?: boolean;
+}
+
 export function DomainsTablePlaceholder( {
 	className,
+	isHeader,
 	...rest
-}: ComponentProps< typeof LoadingPlaceholder > ) {
+}: DomainsTablePlaceholderProps ) {
 	return (
 		<LoadingPlaceholder
-			className={ classnames( 'domains-table-placeholder', className ) }
+			className={ classnames( 'domains-table-placeholder', { 'is-header': isHeader }, className ) }
 			{ ...rest }
 		/>
 	);

--- a/packages/domains-table/src/domains-table/domains-table-placeholder/style.scss
+++ b/packages/domains-table/src/domains-table/domains-table-placeholder/style.scss
@@ -2,4 +2,8 @@
 	// Custom border radius used to create a pill shape
 	// stylelint-disable-next-line scales/radii
 	border-radius: 100px;
+
+	&.is-header {
+		background-color: var(--color-neutral-5);
+	}
 }

--- a/packages/domains-table/src/domains-table/domains-table-placeholder/style.scss
+++ b/packages/domains-table/src/domains-table/domains-table-placeholder/style.scss
@@ -1,0 +1,5 @@
+.domains-table-placeholder {
+	// Custom border radius used to create a pill shape
+	// stylelint-disable-next-line scales/radii
+	border-radius: 100px;
+}

--- a/packages/domains-table/src/domains-table/domains-table-row-loading.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-loading.tsx
@@ -1,32 +1,32 @@
-import { LoadingPlaceholder } from '@automattic/components';
 import { useDomainsTable } from './domains-table';
+import { DomainsTablePlaceholder } from './domains-table-placeholder';
 
 export default function DomainsTableRowLoading() {
 	const { domainsTableColumns } = useDomainsTable();
 	return (
-		<tr className="domains-table-row-loading-placeholder">
+		<tr>
 			<td className="domains-table-row-loading-placeholder-checkbox-column">
-				<LoadingPlaceholder delayMS={ 50 } />
+				<DomainsTablePlaceholder delayMS={ 50 } />
 			</td>
 			<td className="domains-table-row-loading-placeholder-domain-column">
-				<LoadingPlaceholder delayMS={ 50 } />
+				<DomainsTablePlaceholder delayMS={ 50 } />
 			</td>
 			{ domainsTableColumns.some( ( column ) => column.name === 'owner' ) && (
 				<td className="domains-table-row-loading-placeholder-owner-column">
-					<LoadingPlaceholder delayMS={ 50 } />
+					<DomainsTablePlaceholder delayMS={ 50 } />
 				</td>
 			) }
 			<td className="domains-table-row-loading-placeholder-site-column">
-				<LoadingPlaceholder delayMS={ 50 } />
+				<DomainsTablePlaceholder delayMS={ 50 } />
 			</td>
 			<td className="domains-table-row-loading-placeholder-expires-column">
-				<LoadingPlaceholder delayMS={ 50 } />
+				<DomainsTablePlaceholder delayMS={ 50 } />
 			</td>
 			<td className="domains-table-row-loading-placeholder-status-column">
-				<LoadingPlaceholder delayMS={ 50 } />
+				<DomainsTablePlaceholder delayMS={ 50 } />
 			</td>
 			<td className="domains-table-row-loading-placeholder-action-column">
-				<LoadingPlaceholder delayMS={ 50 } />
+				<DomainsTablePlaceholder delayMS={ 50 } />
 			</td>
 		</tr>
 	);

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,5 +1,4 @@
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
-import { LoadingPlaceholder } from '@automattic/components';
 import { PartialDomainData } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
@@ -13,6 +12,7 @@ import { domainManagementLink } from '../utils/paths';
 import { useDomainsTable } from './domains-table';
 import { DomainsTableEmailIndicator } from './domains-table-email-indicator';
 import { DomainsTableExpiresRewnewsOnCell } from './domains-table-expires-renew-cell';
+import { DomainsTablePlaceholder } from './domains-table-placeholder';
 import { DomainsTableRowActions } from './domains-table-row-actions';
 import { DomainsTableSiteCell } from './domains-table-site-cell';
 import { DomainsTableStatusCell } from './domains-table-status-cell';
@@ -57,7 +57,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 		}
 
 		if ( isLoadingRowDetails ) {
-			return <LoadingPlaceholder style={ { width: `${ placeholderWidth }%` } } />;
+			return <DomainsTablePlaceholder style={ { width: `${ placeholderWidth }%` } } />;
 		}
 
 		return null;
@@ -68,7 +68,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 
 	const renderOwnerCell = () => {
 		if ( isLoadingSiteDetails || isLoadingSiteDomainsDetails ) {
-			return <LoadingPlaceholder style={ { width: `${ placeholderWidth }%` } } />;
+			return <DomainsTablePlaceholder style={ { width: `${ placeholderWidth }%` } } />;
 		}
 
 		if ( ! currentDomainData?.owner ) {
@@ -145,7 +145,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 				if ( column.name === 'status' ) {
 					return isLoadingRowDetails ? (
 						<td key={ column.name }>
-							<LoadingPlaceholder style={ { width: `${ placeholderWidth }%` } } />
+							<DomainsTablePlaceholder style={ { width: `${ placeholderWidth }%` } } />
 						</td>
 					) : (
 						<DomainsTableStatusCell

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -53,7 +53,7 @@ interface BaseDomainsTableProps {
 	onDomainAction?: OnDomainAction;
 	userCanSetPrimaryDomains?: boolean;
 	shouldDisplayContactInfoBulkAction?: boolean;
-	isFetchingDomains?: boolean;
+	isLoadingDomains?: boolean;
 
 	// These props allow table users to provide their own fetching functions. This is used for
 	// testing and for Calypso to provide functions that handle authentication in a special way.
@@ -80,7 +80,7 @@ interface DomainsTableUpdatingDomain {
 }
 
 type Value = {
-	isFetchingDomains?: boolean;
+	isLoadingDomains?: boolean;
 	filter: DomainsTableFilter;
 	setFilter: (
 		value: ( ( prevState: DomainsTableFilter ) => DomainsTableFilter ) | DomainsTableFilter
@@ -142,7 +142,7 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		onDomainAction,
 		userCanSetPrimaryDomains,
 		shouldDisplayContactInfoBulkAction = false,
-		isFetchingDomains,
+		isLoadingDomains,
 		currentUserCanBulkUpdateContactInfo = false,
 	} = props;
 
@@ -424,7 +424,7 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		userCanSetPrimaryDomains,
 		shouldDisplayContactInfoBulkAction,
 		domainsTableColumns,
-		isFetchingDomains,
+		isLoadingDomains,
 		currentUserCanBulkUpdateContactInfo,
 		isCompact,
 	};

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -151,26 +151,23 @@ $domains-table-mobile-breakpoint: 480px;
 }
 
 .domains-table-row-loading-placeholder {
-	td {
-		padding-right: 16px;
-	}
 	&-checkbox-column {
-		width: 5%;
+		width: 20px;
 	}
 	&-domain-column {
-		width: 25%;
+		width: 170px;
 	}
 	&-owner-column {
-		width: 15%;
+		width: 107px;
 	}
 	&-site-column {
-		width: 25%;
+		width: 70px;
 	}
 	&-expires-column {
-		width: 25%;
+		width: 107px;
 	}
 	&-status-column {
-		width: 15%;
+		width: 107px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Implements the placeholder design described here p58i-fm0-p2#comment-59308

## Proposed Changes

* Renames the `isFetchingDomains` prop to `isLoadingDomains`. This matches the way React Query talks about "fetching" vs. "loading". "Loading" is a special word that means just the first time.
* Use rounded placeholders
* Show loading placeholders instead of column headers, but with a slightly lighter colour

![CleanShot 2023-09-28 at 19 13 51@2x](https://github.com/Automattic/wp-calypso/assets/1500769/8df61565-25ea-4a0e-8d0d-192dc4c53270)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Make sure to test on mobile and desktop

One easy way to test is to use the React dev tools. Find the `<DomainsTable>` component and toggle the `isLoadingDomains` prop

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?