### PR TITLE
Newsletter Categories: Ship to Atomic

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -78,7 +78,13 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 }: NewsletterSettingsFormProps ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const isSimpleSite = useSelector( isSimpleSiteSelector );
-	const isAtomicSite = useSelector( isAtomicSiteSelector );
+	const isAtomicSite = useSelector( ( state ) => {
+		if ( ! siteId ) {
+			return null;
+		}
+
+		return isAtomicSiteSelector( state, siteId );
+	} );
 	const hasNewsletterCategoriesBlogSticker = useNewsletterCategoriesBlogSticker( { siteId } );
 
 	const isSubscriptionModuleInactive = useSelector( ( state ) => {

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -7,6 +7,7 @@ import Main from 'calypso/components/main';
 import { useNewsletterCategoriesBlogSticker } from 'calypso/data/newsletter-categories';
 import { useSelector } from 'calypso/state';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
+import isAtomicSiteSelector from 'calypso/state/selectors/is-site-automated-transfer';
 import {
 	isJetpackSite as isJetpackSiteSelector,
 	isSimpleSite as isSimpleSiteSelector,
@@ -77,6 +78,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 }: NewsletterSettingsFormProps ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const isSimpleSite = useSelector( isSimpleSiteSelector );
+	const isAtomicSite = useSelector( isAtomicSiteSelector );
 	const hasNewsletterCategoriesBlogSticker = useNewsletterCategoriesBlogSticker( { siteId } );
 
 	const isSubscriptionModuleInactive = useSelector( ( state ) => {
@@ -99,7 +101,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 	return (
 		<>
 			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
-			{ ( isSimpleSite || hasNewsletterCategoriesBlogSticker ) && (
+			{ ( isSimpleSite || isAtomicSite || hasNewsletterCategoriesBlogSticker ) && (
 				<form onSubmit={ handleSubmitForm }>
 					<NewsletterCategoriesSection
 						disabled={ disabled }


### PR DESCRIPTION
## Proposed Changes

* Enables the Newsletter Categories settings for Atomic site.

## Testing Instructions

* Go to `/settings/newsletter/YOUR_ATOMIC_SITE.wpcomstaging.com`, you should see Newsletter Categories settings.
* Go to `/settings/newsletter/YOUR_JETPACK_SITE.jurassic.tube`, you should NOT see Newsletter Categories settings.

(Just double-check make sure you have the `newsletter-categories` blog sticker **disabled** as that would override the logic.)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?