### PR TITLE
Assembler: Update the action bar UI

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.scss
@@ -23,16 +23,14 @@
 
 			svg {
 				fill: var(--studio-gray-80);
-
-				&:hover {
-					transform: scale(1.05);
-					transition: transform 0.1s ease-in;
-					transform-origin: center;
-				}
 			}
 
-			&:not(:disabled):hover svg {
-				fill: var(--studio-blue-50);
+			&:not(:disabled):hover {
+				color: var(--studio-blue-50);
+
+				svg {
+					fill: var(--studio-blue-50);
+				}
 			}
 
 			&--move-up,
@@ -40,6 +38,16 @@
 				height: 13px;
 				display: flex;
 				align-items: center;
+			}
+
+			&--shuffle {
+				&.has-icon {
+					flex-direction: row;
+					gap: 4px;
+					line-height: 40px;
+					max-width: none;
+					padding: 0 12px;
+				}
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.scss
@@ -4,7 +4,7 @@
 		opacity: 0;
 		align-items: center;
 		position: absolute;
-		height: 27px;
+		height: 40px;
 		right: 0;
 
 		.pattern-action-bar__block {
@@ -16,8 +16,8 @@
 
 		.pattern-action-bar__action {
 			&.has-icon {
-				min-width: 30px;
-				max-width: 30px;
+				min-width: 40px;
+				max-width: 40px;
 				padding: 0;
 			}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
@@ -16,7 +16,6 @@ type PatternActionBarProps = {
 	disableMoveDown?: boolean;
 	patternType: string;
 	category?: Category;
-	isRemoveButtonTextOnly?: boolean;
 	source: 'list' | 'large_preview';
 };
 
@@ -30,7 +29,6 @@ const PatternActionBar = ( {
 	disableMoveDown,
 	patternType,
 	category,
-	isRemoveButtonTextOnly,
 	source,
 }: PatternActionBarProps ) => {
 	const translate = useTranslate();
@@ -106,11 +104,9 @@ const PatternActionBar = ( {
 					recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_DELETE_CLICK, eventProps );
 					onDelete();
 				} }
-				icon={ ! isRemoveButtonTextOnly ? close : null }
+				icon={ close }
 				iconSize={ 23 }
-			>
-				{ isRemoveButtonTextOnly ? translate( 'Remove' ) : null }
-			</Button>
+			/>
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { chevronUp, chevronDown, close, edit, shuffle } from '@wordpress/icons';
+import { chevronUp, chevronDown, edit, shuffle, trash } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
@@ -73,7 +73,7 @@ const PatternActionBar = ( {
 				</div>
 			) }
 			<Button
-				className="pattern-action-bar__block pattern-action-bar__action"
+				className="pattern-action-bar__block pattern-action-bar__action pattern-action-bar__action--shuffle"
 				role="menuitem"
 				label={ translate( 'Shuffle' ) }
 				onClick={ () => {
@@ -82,6 +82,7 @@ const PatternActionBar = ( {
 				} }
 				icon={ shuffle }
 				iconSize={ 23 }
+				text={ translate( 'Shuffle' ) }
 			/>
 			{ onReplace && (
 				<Button
@@ -104,7 +105,7 @@ const PatternActionBar = ( {
 					recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_DELETE_CLICK, eventProps );
 					onDelete();
 				} }
-				icon={ close }
+				icon={ trash }
 				iconSize={ 23 }
 			/>
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -38,14 +38,15 @@
 	position: relative;
 
 	.pattern-action-bar {
+		box-sizing: border-box;
 		position: absolute;
 		top: 16px;
 		left: 16px;
 		right: unset;
-		padding: 6px;
+		padding: 0;
 		border: 1px solid #1e1e1e;
 		border-radius: 2px;
-		gap: 6px;
+		gap: 0;
 		background-color: #fff;
 		opacity: 0;
 		z-index: 1;
@@ -55,21 +56,22 @@
 
 		> .pattern-action-bar__action {
 			position: relative;
-			min-width: 28px;
-			height: 28px;
+			min-height: 40px;
+			min-width: 40px;
 			padding: 2px;
 
-			&:last-child:not(:only-child):not(.has-icon) {
-				padding-right: 6px;
+			&:first-child::after {
+				content: none;
 			}
 
-			&::before {
+			&::after {
+				background-color: #1e1e1e;
+				bottom: 0;
 				content: "";
+				left: 0;
 				position: absolute;
-				left: -6px;
-				right: -6px;
-				top: -6px;
-				bottom: -6px;
+				top: 0;
+				width: 1px;
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -93,7 +93,6 @@ const PatternLargePreview = ( {
 				<PatternActionBar
 					patternType={ type }
 					category={ pattern.category }
-					isRemoveButtonTextOnly
 					source="large_preview"
 					{ ...getActionBarProps() }
 				/>


### PR DESCRIPTION
## Proposed Changes

This PR updates the action bar UI in two areas: 

- Adding a separator between action buttons.
- For the Remove button, show an icon instead of the text "remove".
- Add emphasis to the shuffle button by adding the copy "Shuffle" next to the icon

| Before | After |
| --- | --- |
| ![Screenshot 2023-09-28 at 3 08 04 PM](https://github.com/Automattic/wp-calypso/assets/797888/1b5e0000-bee6-4a0d-bbad-155355693fd2) | ![Screenshot 2023-09-28 at 2 59 28 PM](https://github.com/Automattic/wp-calypso/assets/797888/27719cf8-b393-4af4-bf44-d81a8ac3c426) |

Since the cross icon might be mistaken with a Close action, we can also use the trash icon:
![Screenshot 2023-09-28 at 3 00 36 PM](https://github.com/Automattic/wp-calypso/assets/797888/940f3fb6-608b-4ce0-8524-f937ea310bef)

WDYD @lucasmendes-design @autumnfjeld @Automattic/lego?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler `/setup/with-theme-assembler/patternAssembler?siteSlug=${ SITE_SLUG }`.
* Ensure that the action bar UI is updated as described above, and works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?