### PR TITLE
Assembler: Fix the selected patterns cannot be shuffled

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -4,6 +4,7 @@ import { useSelect } from '@wordpress/data';
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { ONBOARD_STORE } from '../../../../../stores';
+import { PATTERN_CATEGORIES } from '../constants';
 import { decodePatternId } from '../utils';
 import type { Pattern, Category } from '../types';
 import type { OnboardSelect } from '@automattic/data-stores';
@@ -40,22 +41,26 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 	   we first initialize the sections from the search params.
 	*/
 	const initialSections = useMemo(
-		() =>
-			section_pattern_ids
+		() => {
+			const categoriesSet = new Set( PATTERN_CATEGORIES );
+			return section_pattern_ids
 				.map( ( patternId ) => patternsById[ decodePatternId( patternId ) ] )
 				.filter( Boolean )
 				.map( ( pattern: Pattern ) => {
-					const [ firstCategory ] = Object.keys( pattern.categories );
-					const category = categoriesByName[ firstCategory ];
+					const availableCategory = Object.keys( pattern.categories ).find( ( category ) =>
+						categoriesSet.has( category )
+					);
+					const category = availableCategory ? categoriesByName[ availableCategory ] : undefined;
 					return {
 						...pattern,
 						category,
 					};
-				} ),
+				} );
+		},
 		/* We are ignoring the changes from the search params (section_pattern_ids),
 	       since after this point, the changes will be handled by setSections().
 	    */
-		[ patternsById, categoriesByName ] // eslint-disable-line react-hooks/exhaustive-deps
+		[ patternsById, categoriesByName, PATTERN_CATEGORIES ] // eslint-disable-line react-hooks/exhaustive-deps
 	);
 
 	const uniqueSectionPatternKeyRef = useRef( 0 );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -499,8 +499,10 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	const onDeleteFooter = () => onSelect( 'footer', null );
 
 	const onShuffle = ( type: string, pattern: Pattern, position?: number ) => {
-		const [ firstCategory ] = Object.keys( pattern.categories );
-		const selectedCategory = pattern.category?.name || firstCategory;
+		const availableCategory = Object.keys( pattern.categories ).find(
+			( category ) => patternsMapByCategory[ category ]
+		);
+		const selectedCategory = pattern.category?.name || availableCategory || '';
 		const patterns = patternsMapByCategory[ selectedCategory ];
 		const shuffledPattern = getShuffledPattern( patterns, pattern );
 		injectCategoryToPattern( shuffledPattern, categories, selectedCategory );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword andinstead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/82326

## Proposed Changes

* The pattern cannot be shuffled after the curated category. We pick the first category of the pattern when initializing the section patterns but the first category might be unavailable.
* This PR is proposing to use the available category as the selected one instead of the first to avoid shuffling a pattern with the unavailable category.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Theme Showcase
* Scroll down to select the Assembler CTA
* Select a pattern from "Sections > Intro" like below
  ![image](https://github.com/Automattic/wp-calypso/assets/13596067/7c4c8f65-9892-46b3-93a2-aec2e0b92d2d)
* Refresh the page
* Hover on the pattern on the large preview, and ensure the pattern can be shuffled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?