### PR TITLE
Assembler: Remove reset toggle in the upsell screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
@@ -43,8 +43,6 @@ export const PATTERN_ASSEMBLER_EVENTS = {
 		'calypso_signup_pattern_assembler_screen_upsell_checkout_button_click',
 	SCREEN_UPSELL_UPGRADE_LATER_BUTTON_CLICK:
 		'calypso_signup_pattern_assembler_screen_upsell_upgrade_later_button_click',
-	SCREEN_UPSELL_EDIT_YOUR_CONTENT_BUTTON_CLICK:
-		'calypso_signup_pattern_assembler_screen_upsell_edit_your_content_button_click',
 
 	/**
 	 * Pattern Panels

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-custom-styles.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-custom-styles.tsx
@@ -1,4 +1,3 @@
-import { useSearchParams } from 'react-router-dom';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 
 interface Props {
@@ -8,33 +7,12 @@ interface Props {
 }
 
 const useCustomStyles = ( { siteID = 0, hasColor, hasFont }: Props ) => {
-	const [ searchParams, setSearchParams ] = useSearchParams();
-
 	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteID );
-
 	const numOfSelectedGlobalStyles = [ hasColor, hasFont ].filter( Boolean ).length;
-
-	const resetCustomStyles = !! searchParams.get( 'reset_custom_styles' );
-
-	const setResetCustomStyles = ( value: boolean ) => {
-		setSearchParams(
-			( currentSearchParams ) => {
-				if ( value ) {
-					currentSearchParams.set( 'reset_custom_styles', String( value ) );
-				} else {
-					currentSearchParams.delete( 'reset_custom_styles' );
-				}
-				return currentSearchParams;
-			},
-			{ replace: true }
-		);
-	};
 
 	return {
 		shouldUnlockGlobalStyles: numOfSelectedGlobalStyles > 0 && shouldLimitGlobalStyles,
 		numOfSelectedGlobalStyles,
-		resetCustomStyles,
-		setResetCustomStyles,
 	};
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-props.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-props.tsx
@@ -10,7 +10,6 @@ interface Props {
 	stepName: string;
 	nextScreenName: ScreenName;
 	onUpgradeLater?: () => void;
-	onContinue?: () => void;
 	recordTracksEvent: ( eventName: string, eventProps?: { [ key: string ]: unknown } ) => void;
 }
 
@@ -19,7 +18,6 @@ const useGlobalStylesUpgradeProps = ( {
 	stepName,
 	nextScreenName,
 	onUpgradeLater,
-	onContinue,
 	recordTracksEvent,
 }: Props ) => {
 	const site = useSite();
@@ -49,15 +47,9 @@ const useGlobalStylesUpgradeProps = ( {
 		onUpgradeLater?.();
 	};
 
-	const handleContinue = () => {
-		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_UPSELL_EDIT_YOUR_CONTENT_BUTTON_CLICK );
-		onContinue?.();
-	};
-
 	return {
 		onCheckout: handleCheckout,
 		onTryStyle: handleTryStyle,
-		onContinue: handleContinue,
 	};
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -118,12 +118,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		resetRecipe,
 	} = useRecipe( site?.ID, dotcomPatterns, categories );
 
-	const {
-		shouldUnlockGlobalStyles,
-		numOfSelectedGlobalStyles,
-		resetCustomStyles,
-		setResetCustomStyles,
-	} = useCustomStyles( {
+	const { shouldUnlockGlobalStyles, numOfSelectedGlobalStyles } = useCustomStyles( {
 		siteID: site?.ID,
 		hasColor: !! colorVariation,
 		hasFont: !! fontVariation,
@@ -150,11 +145,8 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	);
 
 	const selectedVariations = useMemo(
-		() =>
-			! resetCustomStyles
-				? ( [ colorVariation, fontVariation ].filter( Boolean ) as GlobalStylesObject[] )
-				: [],
-		[ colorVariation, fontVariation, resetCustomStyles ]
+		() => [ colorVariation, fontVariation ].filter( Boolean ) as GlobalStylesObject[],
+		[ colorVariation, fontVariation ]
 	);
 
 	const syncedGlobalStylesUserConfig = useSyncGlobalStylesUserConfig( selectedVariations );
@@ -214,7 +206,6 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 			pattern_categories: categories.join( ',' ),
 			category_count: categories.length,
 			pattern_count: patterns.length,
-			reset_custom_styles: resetCustomStyles,
 		} );
 		patterns.forEach( ( { ID, name, category } ) => {
 			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_FINAL_SELECT, {
@@ -234,7 +225,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 				pattern_ids: sections.filter( Boolean ).map( ( pattern ) => encodePatternId( pattern.ID ) ),
 				footer_pattern_ids: footer ? [ encodePatternId( footer.ID ) ] : undefined,
 			} as DesignRecipe,
-		} ) as Design;
+		} as Design );
 
 	const updateActivePatternPosition = ( position: number ) => {
 		const patternPosition = header ? position + 1 : position;
@@ -374,7 +365,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 						homeHtml: sections.map( ( pattern ) => pattern.html ).join( '' ),
 						headerHtml: header?.html,
 						footerHtml: footer?.html,
-						globalStyles: ! resetCustomStyles ? syncedGlobalStylesUserConfig : undefined,
+						globalStyles: syncedGlobalStylesUserConfig,
 						// Newly created sites with blog patterns reset the starter content created from the default Headstart annotation
 						// TODO: Ask users whether they want all their pages and posts to be replaced with the content from theme demo site
 						shouldResetContent: isNewSite && hasBlogPatterns,
@@ -413,7 +404,6 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		stepName,
 		nextScreenName: isNewSite ? 'confirmation' : 'activation',
 		onUpgradeLater: onContinue,
-		onContinue,
 		recordTracksEvent,
 	} );
 
@@ -430,11 +420,6 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	};
 
 	const onBack = () => {
-		// Turn off the resetting custom styles when going back from the upsell screen
-		if ( currentScreen.name === 'upsell' && resetCustomStyles ) {
-			setResetCustomStyles( false );
-		}
-
 		// Go back to the previous screen
 		if ( currentScreen.previousScreen ) {
 			if ( navigator.location.isInitial && currentScreen.name !== INITIAL_SCREEN ) {
@@ -581,8 +566,6 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 					<ScreenUpsell
 						{ ...globalStylesUpgradeProps }
 						numOfSelectedGlobalStyles={ numOfSelectedGlobalStyles }
-						resetCustomStyles={ resetCustomStyles }
-						setResetCustomStyles={ setResetCustomStyles }
 					/>
 				</NavigatorScreen>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -216,16 +216,15 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		} );
 	};
 
-	const getDesign = () =>
-		( {
-			...selectedDesign,
-			recipe: {
-				...selectedDesign?.recipe,
-				header_pattern_ids: header ? [ encodePatternId( header.ID ) ] : undefined,
-				pattern_ids: sections.filter( Boolean ).map( ( pattern ) => encodePatternId( pattern.ID ) ),
-				footer_pattern_ids: footer ? [ encodePatternId( footer.ID ) ] : undefined,
-			} as DesignRecipe,
-		} as Design );
+	const getDesign = () => ( {
+		...selectedDesign,
+		recipe: {
+			...selectedDesign?.recipe,
+			header_pattern_ids: header ? [ encodePatternId( header.ID ) ] : undefined,
+			pattern_ids: sections.filter( Boolean ).map( ( pattern ) => encodePatternId( pattern.ID ) ),
+			footer_pattern_ids: footer ? [ encodePatternId( footer.ID ) ] : undefined,
+		} as DesignRecipe,
+	} );
 
 	const updateActivePatternPosition = ( position: number ) => {
 		const patternPosition = header ? position + 1 : position;
@@ -336,7 +335,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	};
 
 	const onSubmit = () => {
-		const design = getDesign();
+		const design = getDesign() as Design;
 		const stylesheet = design.recipe?.stylesheet ?? '';
 		const themeId = getThemeIdFromStylesheet( stylesheet );
 		const hasBlogPatterns = !! sections.find(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -1,6 +1,5 @@
 import { Button, Gridicon, PremiumBadge } from '@automattic/components';
 import { NavigatorHeader } from '@automattic/onboarding';
-import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import useGlobalStylesUpgradeTranslations from 'calypso/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations';
 import { useScreen } from './hooks';
@@ -8,24 +7,14 @@ import NavigatorTitle from './navigator-title';
 import './screen-upsell.scss';
 
 interface Props {
-	resetCustomStyles: boolean;
 	numOfSelectedGlobalStyles?: number;
-	setResetCustomStyles: ( value: boolean ) => void;
 	onCheckout: () => void;
 	onTryStyle: () => void;
-	onContinue: () => void;
 }
 
-const ScreenUpsell = ( {
-	resetCustomStyles,
-	numOfSelectedGlobalStyles = 1,
-	setResetCustomStyles,
-	onCheckout,
-	onTryStyle,
-	onContinue,
-}: Props ) => {
+const ScreenUpsell = ( { numOfSelectedGlobalStyles = 1, onCheckout, onTryStyle }: Props ) => {
 	const translate = useTranslate();
-	const { title, description, continueLabel } = useScreen( 'upsell' );
+	const { title, description } = useScreen( 'upsell' );
 	const translations = useGlobalStylesUpgradeTranslations( { numOfSelectedGlobalStyles } );
 
 	return (
@@ -46,11 +35,6 @@ const ScreenUpsell = ( {
 				</strong>
 				<div className="screen-upsell__description">
 					<p>{ translations.description }</p>
-					<ToggleControl
-						label={ translate( 'Reset custom styles' ) }
-						checked={ resetCustomStyles }
-						onChange={ () => setResetCustomStyles( ! resetCustomStyles ) }
-					/>
 				</div>
 				<strong>{ translations.featuresTitle }</strong>
 				<ul className="screen-upsell__features">
@@ -63,17 +47,11 @@ const ScreenUpsell = ( {
 				</ul>
 			</div>
 			<div className="screen-container__footer">
-				{ ! resetCustomStyles && (
-					<Button className="pattern-assembler__button" onClick={ onTryStyle }>
-						{ translations.cancel }
-					</Button>
-				) }
-				<Button
-					className="pattern-assembler__button"
-					primary
-					onClick={ ! resetCustomStyles ? onCheckout : onContinue }
-				>
-					{ ! resetCustomStyles ? translations.upgradeWithPlan : continueLabel }
+				<Button className="pattern-assembler__button" onClick={ onTryStyle }>
+					{ translations.cancel }
+				</Button>
+				<Button className="pattern-assembler__button" primary onClick={ onCheckout }>
+					{ translations.upgradeWithPlan }
 				</Button>
 			</div>
 		</>


### PR DESCRIPTION
## Proposed Changes

This PR removes the "reset custom styles" toggle (and its related code) as discussed in pbxlJb-4yn-p2.

| Before | After | 
| --- | --- |
| ![Screenshot 2023-09-28 at 5 16 59 PM](https://github.com/Automattic/wp-calypso/assets/797888/4450f172-aaca-49eb-b4f3-8d5d5bc8c5c0) |  ![Screenshot 2023-09-28 at 5 17 29 PM](https://github.com/Automattic/wp-calypso/assets/797888/980ae209-f265-437b-a35b-271ba1e20122) | 

We have also received feedback that this screen is a bit verbose. Perhaps we can remove the subheading "You've chosen a custom style and action is required." WDYT @lucasmendes-design  @autumnfjeld  @Automattic/lego 

Alternatively, we can change the UI to the following:
![Screenshot 2023-09-28 at 5 21 26 PM](https://github.com/Automattic/wp-calypso/assets/797888/16795d13-9356-48bc-95ed-289fa21c112f)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler `/setup/with-theme-assembler/patternAssembler?siteSlug=${ SITE_SLUG }`.
* Select a custom style to land in the Upsell screen.
* Ensure that the Upsell screen is updated as described above, and that the buttons "Decide later" and "Get Premium" works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?