### PR TITLE
Jetpack Manage: Update 'Boost' expandable block CTA button rendering logic.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -67,7 +67,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 				},
 				{
 					label: translate( 'Settings' ),
-					href: `${ siteUrlWithScheme }/wp-admin/admin.php`,
+					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`,
 					onClick: () => trackEvent( 'expandable_block_settings_click' ),
 				},
 			];
@@ -77,7 +77,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 			return [
 				{
 					label: translate( 'Boost Settings' ),
-					href: `${ siteUrlWithScheme }/wp-admin/admin.php`,
+					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`,
 					onClick: () => trackEvent( 'expandable_block_settings_click' ),
 				},
 			];

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -188,6 +188,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 					onClose={ () => setShowBoostModal( false ) }
 					siteId={ siteId }
 					siteUrl={ siteUrl }
+					upgradeOnly
 				/>
 			) }
 		</ExpandedCard>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -86,7 +86,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 		return [
 			{
 				label: translate( 'Optimize performance' ),
-				href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#:~:text=Inactive-,Boost,-The%20easiest%20speedt`,
+				href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#:~:text=Inactive-,Boost,-The%20easiest%20speed`,
 				onClick: () => trackEvent( 'expandable_block_optimize_performance_click' ),
 				primary: true,
 			},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -22,7 +22,10 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 
 	const helpIconRef = useRef< HTMLElement | null >( null );
 	const [ showTooltip, setShowTooltip ] = useState( false );
-	const [ showBoostModal, setShowBoostModal ] = useState( false );
+	const [ boostModalState, setBoostModalState ] = useState< {
+		show: boolean;
+		upgradeOnly?: boolean;
+	} >( { show: false } );
 
 	const {
 		blog_id: siteId,
@@ -31,6 +34,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 		has_boost: hasBoost,
 		jetpack_boost_scores: boostData,
 		has_pending_boost_one_time_score: hasPendingScore,
+		has_paid_boost: hasPaidLicense,
 	} = site;
 
 	const { overall: overallScore, mobile: mobileScore, desktop: desktopScore } = boostData;
@@ -43,12 +47,8 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 		'Your Overall Score is a summary of your website performance across both mobile and desktop devices.'
 	);
 
-	const isEnabled = hasBoost || Boolean( overallScore ) || hasPendingScore;
-
-	const hasPaidLicense = false;
-
-	const handleOnClick = () => {
-		setShowBoostModal( true );
+	const showBoostModal = ( upgradeOnly: boolean ) => {
+		setBoostModalState( { show: true, upgradeOnly } );
 	};
 
 	const ScoreRating = getBoostRating( overallScore );
@@ -58,7 +58,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 			return [
 				{
 					label: translate( 'Auto-optimize' ),
-					onClick: handleOnClick,
+					onClick: () => showBoostModal( true ),
 					primary: true,
 				},
 				{
@@ -90,107 +90,114 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 	}, [ hasPaidLicense, ScoreRating, translate, siteUrlWithScheme, trackEvent ] );
 
 	return (
-		<ExpandedCard
-			header={ translate( 'Boost site performance' ) }
-			isEnabled={ isEnabled }
-			emptyContent={ translate(
-				'{{strong}}Get Score{{/strong}} to see your site performance scores',
-				{
-					components,
-				}
-			) }
-			hasError={ hasError }
-			// Allow to click on the card only if Boost is not active
-			onClick={ ! isEnabled ? handleOnClick : undefined }
-		>
-			<div className="site-expanded-content__card-content-container">
-				<div className="site-expanded-content__card-content">
-					<div className="site-expanded-content__card-content-column">
-						{ hasPendingScore ? (
-							<InProgressIcon />
-						) : (
-							<div
-								className={ classNames(
-									'site-expanded-content__card-content-score',
-									getBoostRatingClass( overallScore )
-								) }
-							>
-								{ ScoreRating }
+		<>
+			<ExpandedCard
+				header={ translate( 'Boost site performance' ) }
+				isEnabled={ hasBoost }
+				emptyContent={ translate(
+					'{{strong}}Get Score{{/strong}} to see your site performance scores',
+					{
+						components,
+					}
+				) }
+				hasError={ hasError }
+				// Allow to click on the card only if Boost is not active
+				onClick={ () => {
+					if ( ! hasBoost ) {
+						showBoostModal( false );
+					}
+				} }
+			>
+				<div className="site-expanded-content__card-content-container">
+					<div className="site-expanded-content__card-content">
+						<div className="site-expanded-content__card-content-column">
+							{ hasPendingScore ? (
+								<InProgressIcon />
+							) : (
+								<div
+									className={ classNames(
+										'site-expanded-content__card-content-score',
+										getBoostRatingClass( overallScore )
+									) }
+								>
+									{ ScoreRating }
 
-								<span
-									ref={ helpIconRef }
-									onMouseEnter={ () => setShowTooltip( true ) }
-									onMouseLeave={ () => setShowTooltip( false ) }
-								>
-									<Icon size={ 20 } className="site-expanded-content__help-icon" icon={ help } />
-								</span>
-								<Tooltip
-									id={ `${ siteId }-boost-help-text` }
-									context={ helpIconRef.current }
-									isVisible={ showTooltip }
-									position="bottom"
-									className="site-expanded-content__tooltip"
-								>
-									{ tooltip }
-								</Tooltip>
+									<span
+										ref={ helpIconRef }
+										onMouseEnter={ () => setShowTooltip( true ) }
+										onMouseLeave={ () => setShowTooltip( false ) }
+									>
+										<Icon size={ 20 } className="site-expanded-content__help-icon" icon={ help } />
+									</span>
+									<Tooltip
+										id={ `${ siteId }-boost-help-text` }
+										context={ helpIconRef.current }
+										isVisible={ showTooltip }
+										position="bottom"
+										className="site-expanded-content__tooltip"
+									>
+										{ tooltip }
+									</Tooltip>
+								</div>
+							) }
+							<div className="site-expanded-content__card-content-score-title">
+								{ translate( 'Overall' ) }
 							</div>
-						) }
-						<div className="site-expanded-content__card-content-score-title">
-							{ translate( 'Overall' ) }
+						</div>
+						<div className="site-expanded-content__card-content-column">
+							{ hasPendingScore ? (
+								<InProgressIcon />
+							) : (
+								<div className="site-expanded-content__device-score-container">
+									<div className="site-expanded-content__card-content-column">
+										<Icon
+											size={ 24 }
+											className="site-expanded-content__device-icon"
+											icon={ jetpackBoostDesktopIcon }
+										/>
+										<span className="site-expanded-content__device-score">{ desktopScore }</span>
+									</div>
+									<div className="site-expanded-content__card-content-column site-expanded-content__card-content-column-mobile">
+										<Icon
+											className="site-expanded-content__device-icon"
+											size={ 24 }
+											icon={ jetpackBoostMobileIcon }
+										/>
+										<span className="site-expanded-content__device-score">{ mobileScore }</span>
+									</div>
+								</div>
+							) }
+							<div className="site-expanded-content__card-content-score-title">
+								{ translate( 'Devices' ) }
+							</div>
 						</div>
 					</div>
-					<div className="site-expanded-content__card-content-column">
-						{ hasPendingScore ? (
-							<InProgressIcon />
-						) : (
-							<div className="site-expanded-content__device-score-container">
-								<div className="site-expanded-content__card-content-column">
-									<Icon
-										size={ 24 }
-										className="site-expanded-content__device-icon"
-										icon={ jetpackBoostDesktopIcon }
-									/>
-									<span className="site-expanded-content__device-score">{ desktopScore }</span>
-								</div>
-								<div className="site-expanded-content__card-content-column site-expanded-content__card-content-column-mobile">
-									<Icon
-										className="site-expanded-content__device-icon"
-										size={ 24 }
-										icon={ jetpackBoostMobileIcon }
-									/>
-									<span className="site-expanded-content__device-score">{ mobileScore }</span>
-								</div>
-							</div>
-						) }
-						<div className="site-expanded-content__card-content-score-title">
-							{ translate( 'Devices' ) }
-						</div>
+					<div className="site-expanded-content__card-footer">
+						{ ctaButtons.map( ( ctaButton ) => (
+							<Button
+								key={ ctaButton.label }
+								href={ ctaButton.href }
+								target="_blank"
+								onClick={ ctaButton.onClick }
+								className="site-expanded-content__card-button"
+								primary={ ctaButton.primary }
+								compact
+							>
+								{ ctaButton.label } { !! ctaButton.href && <Gridicon icon="external" /> }
+							</Button>
+						) ) }
 					</div>
 				</div>
-				<div className="site-expanded-content__card-footer">
-					{ ctaButtons.map( ( ctaButton ) => (
-						<Button
-							key={ ctaButton.label }
-							href={ ctaButton.href }
-							target="_blank"
-							onClick={ ctaButton.onClick }
-							className="site-expanded-content__card-button"
-							primary={ ctaButton.primary }
-							compact
-						>
-							{ ctaButton.label } { !! ctaButton.href && <Gridicon icon="external" /> }
-						</Button>
-					) ) }
-				</div>
-			</div>
-			{ showBoostModal && (
+			</ExpandedCard>
+
+			{ boostModalState.show && (
 				<BoostLicenseInfoModal
-					onClose={ () => setShowBoostModal( false ) }
+					onClose={ () => setBoostModalState( { show: false } ) }
 					siteId={ siteId }
 					siteUrl={ siteUrl }
-					upgradeOnly
+					upgradeOnly={ boostModalState.upgradeOnly }
 				/>
 			) }
-		</ExpandedCard>
+		</>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -67,7 +67,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 				},
 				{
 					label: translate( 'Settings' ),
-					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`,
+					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#:~:text=Inactive-,Boost,-The%20easiest%20speed`,
 					onClick: () => trackEvent( 'expandable_block_settings_click' ),
 				},
 			];
@@ -77,7 +77,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 			return [
 				{
 					label: translate( 'Boost Settings' ),
-					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`,
+					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#:~:text=Inactive-,Boost,-The%20easiest%20speed`,
 					onClick: () => trackEvent( 'expandable_block_settings_click' ),
 				},
 			];
@@ -86,7 +86,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 		return [
 			{
 				label: translate( 'Optimize performance' ),
-				href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`,
+				href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#:~:text=Inactive-,Boost,-The%20easiest%20speedt`,
 				onClick: () => trackEvent( 'expandable_block_optimize_performance_click' ),
 				primary: true,
 			},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { Icon, help } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -45,25 +45,49 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 
 	const isEnabled = hasBoost || Boolean( overallScore ) || hasPendingScore;
 
-	const buttonProps = useMemo(
-		() =>
-			hasBoost && overallScore
-				? {
-						label: translate( 'Optimize CSS' ),
-						href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`,
-						onClick: () => trackEvent( 'expandable_block_optimize_css_click' ),
-				  }
-				: {
-						label: translate( 'Configure Boost' ),
-						href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#/add-boost`,
-						onClick: () => trackEvent( 'expandable_block_configure_boost_click' ),
-				  },
-		[ hasBoost, siteUrlWithScheme, trackEvent, translate, overallScore ]
-	);
+	const hasPaidLicense = false;
 
 	const handleOnClick = () => {
 		setShowBoostModal( true );
 	};
+
+	const ScoreRating = getBoostRating( overallScore );
+
+	const ctaButtons = useMemo( () => {
+		if ( ! hasPaidLicense ) {
+			return [
+				{
+					label: translate( 'Auto-optimize' ),
+					onClick: handleOnClick,
+					primary: true,
+				},
+				{
+					label: translate( 'Settings' ),
+					href: `${ siteUrlWithScheme }/wp-admin/admin.php`,
+					onClick: () => trackEvent( 'expandable_block_settings_click' ),
+				},
+			];
+		}
+
+		if ( ScoreRating === 'A' ) {
+			return [
+				{
+					label: translate( 'Boost Settings' ),
+					href: `${ siteUrlWithScheme }/wp-admin/admin.php`,
+					onClick: () => trackEvent( 'expandable_block_settings_click' ),
+				},
+			];
+		}
+
+		return [
+			{
+				label: translate( 'Optimize performance' ),
+				href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`,
+				onClick: () => trackEvent( 'expandable_block_optimize_performance_click' ),
+				primary: true,
+			},
+		];
+	}, [ hasPaidLicense, ScoreRating, translate, siteUrlWithScheme, trackEvent ] );
 
 	return (
 		<ExpandedCard
@@ -91,7 +115,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 									getBoostRatingClass( overallScore )
 								) }
 							>
-								{ getBoostRating( overallScore ) }
+								{ ScoreRating }
 
 								<span
 									ref={ helpIconRef }
@@ -144,15 +168,19 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 					</div>
 				</div>
 				<div className="site-expanded-content__card-footer">
-					<Button
-						href={ buttonProps.href }
-						target="_blank"
-						onClick={ buttonProps.onClick }
-						className="site-expanded-content__card-button"
-						compact
-					>
-						{ buttonProps.label }
-					</Button>
+					{ ctaButtons.map( ( ctaButton ) => (
+						<Button
+							key={ ctaButton.label }
+							href={ ctaButton.href }
+							target="_blank"
+							onClick={ ctaButton.onClick }
+							className="site-expanded-content__card-button"
+							primary={ ctaButton.primary }
+							compact
+						>
+							{ ctaButton.label } { !! ctaButton.href && <Gridicon icon="external" /> }
+						</Button>
+					) ) }
 				</div>
 			</div>
 			{ showBoostModal && (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -34,7 +34,6 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 		has_boost: hasBoost,
 		jetpack_boost_scores: boostData,
 		has_pending_boost_one_time_score: hasPendingScore,
-		has_paid_boost: hasPaidLicense,
 	} = site;
 
 	const { overall: overallScore, mobile: mobileScore, desktop: desktopScore } = boostData;
@@ -47,6 +46,8 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 		'Your Overall Score is a summary of your website performance across both mobile and desktop devices.'
 	);
 
+	const isEnabled = hasBoost || Boolean( overallScore ) || hasPendingScore;
+
 	const showBoostModal = ( upgradeOnly: boolean ) => {
 		setBoostModalState( { show: true, upgradeOnly } );
 	};
@@ -54,11 +55,14 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 	const ScoreRating = getBoostRating( overallScore );
 
 	const ctaButtons = useMemo( () => {
-		if ( ! hasPaidLicense ) {
+		if ( ! hasBoost ) {
 			return [
 				{
 					label: translate( 'Auto-optimize' ),
-					onClick: () => showBoostModal( true ),
+					onClick: () => {
+						trackEvent( 'expandable_block_auto_optimize_click' );
+						showBoostModal( true );
+					},
 					primary: true,
 				},
 				{
@@ -87,13 +91,13 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 				primary: true,
 			},
 		];
-	}, [ hasPaidLicense, ScoreRating, translate, siteUrlWithScheme, trackEvent ] );
+	}, [ hasBoost, ScoreRating, translate, siteUrlWithScheme, trackEvent ] );
 
 	return (
 		<>
 			<ExpandedCard
 				header={ translate( 'Boost site performance' ) }
-				isEnabled={ hasBoost }
+				isEnabled={ isEnabled }
 				emptyContent={ translate(
 					'{{strong}}Get Score{{/strong}} to see your site performance scores',
 					{
@@ -103,7 +107,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 				hasError={ hasError }
 				// Allow to click on the card only if Boost is not active
 				onClick={ () => {
-					if ( ! hasBoost ) {
+					if ( ! isEnabled ) {
 						showBoostModal( false );
 					}
 				} }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -85,6 +85,12 @@ $color-yellow: var(--studio-yellow-50);
 	}
 }
 
+.site-expanded-content__card-footer {
+	display: flex;
+	flex-direction: row;
+	gap: 8px;
+}
+
 @mixin svg-color($color, $fill, $stroke) {
 	color: $color;
 
@@ -112,9 +118,23 @@ $color-yellow: var(--studio-yellow-50);
 	text-overflow: ellipsis;
 }
 
-.site-expanded-content__card-button {
-	color: var(--studio-black) !important;
+.button.site-expanded-content__card-button {
+	color: var(--studio-black);
 	width: fit-content;
+
+	&.is-primary {
+		color: var(--studio-white);
+
+		.gridicon {
+			fill: var(--studio-white);
+		}
+	}
+
+	.gridicon {
+		width: 18px;
+		height: 18px;
+		margin-inline-start: 4px;
+	}
 }
 
 .is-small-screen {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
@@ -63,7 +63,7 @@ describe( 'BoostSitePerformance', () => {
 		expect( settingsButton ).toBeInTheDocument();
 		expect( settingsButton ).toHaveAttribute(
 			'href',
-			`${ site.url_with_scheme }/wp-admin/admin.php`
+			`${ site.url_with_scheme }/wp-admin/admin.php?page=my-jetpack#:~:text=Inactive-,Boost,-The%20easiest%20speed`
 		);
 
 		fireEvent.click( settingsButton );
@@ -84,7 +84,10 @@ describe( 'BoostSitePerformance', () => {
 
 		const button = screen.getByRole( 'link', { name: /boost settings/i } );
 		expect( button ).toBeInTheDocument();
-		expect( button ).toHaveAttribute( 'href', `${ site.url_with_scheme }/wp-admin/admin.php` );
+		expect( button ).toHaveAttribute(
+			'href',
+			`${ site.url_with_scheme }/wp-admin/admin.php?page=my-jetpack#:~:text=Inactive-,Boost,-The%20easiest%20speed`
+		);
 
 		fireEvent.click( button );
 		expect( trackEventMock ).toHaveBeenCalledWith( 'expandable_block_settings_click' );
@@ -106,7 +109,7 @@ describe( 'BoostSitePerformance', () => {
 		expect( button ).toBeInTheDocument();
 		expect( button ).toHaveAttribute(
 			'href',
-			`${ site.url_with_scheme }/wp-admin/admin.php?page=jetpack-boost`
+			`${ site.url_with_scheme }/wp-admin/admin.php?page=my-jetpack#:~:text=Inactive-,Boost,-The%20easiest%20speed`
 		);
 
 		fireEvent.click( button );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
@@ -43,12 +43,66 @@ describe( 'BoostSitePerformance', () => {
 		expect( strongTag ).toHaveStyle( 'font-weight: bold' );
 	} );
 
-	test( 'renders the Optimize css button when there is a score and has boost', () => {
-		render(
-			<BoostSitePerformance site={ site } trackEvent={ trackEventMock } hasError={ false } />
+	test( "renders the 'Auto-optimize' and 'Settings' buttons when there is a score and has no boost", () => {
+		const props = {
+			site: {
+				...site,
+				has_boost: false,
+				jetpack_boost_scores: { overall: 90, mobile: 90, desktop: 90 },
+			},
+			trackEvent: trackEventMock,
+			hasError: false,
+		};
+
+		render( <BoostSitePerformance { ...props } /> );
+
+		const autoOptimizeButton = screen.getByText( /Auto-optimize/i );
+		expect( autoOptimizeButton ).toBeInTheDocument();
+
+		const settingsButton = screen.getByRole( 'link', { name: /settings/i } );
+		expect( settingsButton ).toBeInTheDocument();
+		expect( settingsButton ).toHaveAttribute(
+			'href',
+			`${ site.url_with_scheme }/wp-admin/admin.php`
 		);
 
-		const button = screen.getByRole( 'link', { name: /optimize css/i } );
+		fireEvent.click( settingsButton );
+		expect( trackEventMock ).toHaveBeenCalledWith( 'expandable_block_settings_click' );
+	} );
+
+	test( 'renders the Boost settings button when there is a high score and has boost', () => {
+		const props = {
+			site: {
+				...site,
+				has_boost: true,
+				jetpack_boost_scores: { overall: 95, mobile: 95, desktop: 95 },
+			},
+			trackEvent: trackEventMock,
+			hasError: false,
+		};
+		render( <BoostSitePerformance { ...props } /> );
+
+		const button = screen.getByRole( 'link', { name: /boost settings/i } );
+		expect( button ).toBeInTheDocument();
+		expect( button ).toHaveAttribute( 'href', `${ site.url_with_scheme }/wp-admin/admin.php` );
+
+		fireEvent.click( button );
+		expect( trackEventMock ).toHaveBeenCalledWith( 'expandable_block_settings_click' );
+	} );
+
+	test( 'renders the Boost settings button when there is a low score and has boost', () => {
+		const props = {
+			site: {
+				...site,
+				has_boost: true,
+				jetpack_boost_scores: { overall: 50, mobile: 50, desktop: 50 },
+			},
+			trackEvent: trackEventMock,
+			hasError: false,
+		};
+		render( <BoostSitePerformance { ...props } /> );
+
+		const button = screen.getByRole( 'link', { name: /optimize performance/i } );
 		expect( button ).toBeInTheDocument();
 		expect( button ).toHaveAttribute(
 			'href',
@@ -56,28 +110,6 @@ describe( 'BoostSitePerformance', () => {
 		);
 
 		fireEvent.click( button );
-		expect( trackEventMock ).toHaveBeenCalledWith( 'expandable_block_optimize_css_click' );
-	} );
-
-	test( 'renders the Configure Boost button when there is a score and has no boost', () => {
-		const props = {
-			site: {
-				...site,
-				has_boost: false,
-			},
-			trackEvent: trackEventMock,
-			hasError: false,
-		};
-		render( <BoostSitePerformance { ...props } /> );
-
-		const button = screen.getByRole( 'link', { name: /configure boost/i } );
-		expect( button ).toBeInTheDocument();
-		expect( button ).toHaveAttribute(
-			'href',
-			`${ site.url_with_scheme }/wp-admin/admin.php?page=my-jetpack#/add-boost`
-		);
-
-		fireEvent.click( button );
-		expect( trackEventMock ).toHaveBeenCalledWith( 'expandable_block_configure_boost_click' );
+		expect( trackEventMock ).toHaveBeenCalledWith( 'expandable_block_optimize_performance_click' );
 	} );
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
@@ -12,9 +12,10 @@ interface Props {
 	onClose: () => void;
 	siteId: number;
 	siteUrl: string;
+	upgradeOnly?: boolean;
 }
 
-export default function BoostLicenseInfoModal( { onClose, siteId, siteUrl }: Props ) {
+export default function BoostLicenseInfoModal( { onClose, siteId, siteUrl, upgradeOnly }: Props ) {
 	const translate = useTranslate();
 
 	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
@@ -50,36 +51,45 @@ export default function BoostLicenseInfoModal( { onClose, siteId, siteUrl }: Pro
 	return (
 		<LicenseInfoModal
 			currentLicenseInfo="boost"
-			label={ translate( 'Purchase Boost License' ) }
+			label={
+				upgradeOnly
+					? translate( 'Upgrade to Auto-optimize' )
+					: translate( 'Purchase Boost License' )
+			}
 			onClose={ onClose }
 			siteId={ siteId }
 			onCtaClick={ handlePurchaseBoost }
 			extraAsideContent={
 				<>
-					<Button
-						disabled={ inProgress }
-						className="site-boost-column__extra-button"
-						onClick={ handleInstallBoost }
-					>
-						{ translate( 'Start Free' ) }
-					</Button>
-					<div className="site-boost-column__notice">
-						{ translate( 'Proceeding installs {{jetpackBoostLink/}} on your website.', {
-							args: { siteUrl },
-							comment: '%(siteUrl)s is the site url. Eg: example.com',
-							components: {
-								jetpackBoostLink: (
-									<ExternalLink
-										href="https://wordpress.org/plugins/jetpack-boost/"
-										onClick={ onJetpackBoostClick }
-										icon={ true }
-									>
-										{ translate( 'Jetpack Boost' ) }
-									</ExternalLink>
-								),
-							},
-						} ) }
-					</div>
+					{ ! upgradeOnly && (
+						<Button
+							disabled={ inProgress }
+							className="site-boost-column__extra-button"
+							onClick={ handleInstallBoost }
+						>
+							{ translate( 'Start Free' ) }
+						</Button>
+					) }
+
+					{ ! upgradeOnly && (
+						<div className="site-boost-column__notice">
+							{ translate( 'Proceeding installs {{jetpackBoostLink/}} on your website.', {
+								args: { siteUrl },
+								comment: '%(siteUrl)s is the site url. Eg: example.com',
+								components: {
+									jetpackBoostLink: (
+										<ExternalLink
+											href="https://wordpress.org/plugins/jetpack-boost/"
+											onClick={ onJetpackBoostClick }
+											icon={ true }
+										>
+											{ translate( 'Jetpack Boost' ) }
+										</ExternalLink>
+									),
+								},
+							} ) }
+						</div>
+					) }
 				</>
 			}
 			isDisabled={ inProgress }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -83,6 +83,7 @@ export interface Site {
 	has_scan: boolean;
 	has_backup: boolean;
 	has_boost: boolean;
+	has_paid_boost?: boolean;
 	latest_scan_threats_found: Array< string >;
 	latest_backup_status: string;
 	is_connection_healthy: boolean;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -83,7 +83,6 @@ export interface Site {
 	has_scan: boolean;
 	has_backup: boolean;
 	has_boost: boolean;
-	has_paid_boost?: boolean;
 	latest_scan_threats_found: Array< string >;
 	latest_backup_status: string;
 	is_connection_healthy: boolean;


### PR DESCRIPTION
This PR updates the rendering logic of CTAs in the 'Boost' expandable block.


Closes https://github.com/Automattic/jetpack-genesis/issues/37

## Proposed Changes

* The 'Boost' expandable block will be updated to show **'Auto-optimize'** and **'Settings'** buttons if the site has no boost (paid license) and we have a score. Clicking the **Auto-optimize** button will show the Boost modal with the upgrade path only (No **'Start free'** button). Clicking the Settings will redirect the user to WP-Admin.
<img width="300" alt="Screen Shot 2023-09-28 at 4 15 15 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/6d90d007-b6ec-41a3-872a-5d33626b7112">
<img width="1103" alt="Screen Shot 2023-09-29 at 9 48 33 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/98d8ce81-5d0d-4be3-ae35-42a3b16c7864">


* If the site has a boost (paid license) and an 'A' boost rating, we display the **'Boost settings'** button. Otherwise, we display the **'Optimize performance'** button. 
<img width="300" alt="Screen Shot 2023-09-28 at 4 17 03 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b368b544-fccf-4a0d-8400-6ecde7efa9ff">
<img width="300" alt="Screen Shot 2023-09-28 at 4 18 02 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7a5ca65b-f9e9-4cf3-bfc5-e06e16f6b2e5">

* Additionally, this PR fixes an issue with the empty card not displaying the Boost modal when clicked. The modal is only available when the `ExpandedCard` component.
<img width="339" alt="Screen Shot 2023-09-29 at 9 45 51 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d967e209-446a-471e-9d90-6cf930830b8a">


## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

### (Free version)
* Spin up a JN site (Make sure to have Jetpack Boost enabled and generate a score)
* Use the Jetpack cloud live link below and go `/dashboard?flags=jetpack/pro-dashboard-jetpack-boost`
* Find your site in the table and expand it.
* Confirm that the 'Boost' expandable block displays the **'Auto-optimize'** and **'Settings'** button. Clicking the **'Auto-optimize'** button will display the Boost modal with an upgrade-only path (No 'Start Free' button). Clicking the **'Settings'** button will redirect the user to `wp-admin`.

### (Paid version)
* Using the JN site you created, purchase a Boost license.
* Return to the dashboard and confirm that the **'Boost settings'** button is visible when site has a boost rating **'A'**. clicking this button will redirect the user to `wp-admin`.
* To test flow with a boost rating below **'A'**, you will need to modify the JN site so it will slow down. Or you can run Calypso locally and modify the following **line** so `const ScoreRating = 'B';`
* With a boost rating below **'A'**, confirm that the **'Optimize performance'** button is visible. Clicking this will redirect the user to the boost page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?