### PR TITLE
Allow http protocol for domain forwarding

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -53,10 +53,10 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 	const [ forwardPaths, setForwardPaths ] = useState( false );
 	const [ isPermanent, setIsPermanent ] = useState( false );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
+	const [ protocol, setProtocol ] = useState( 'https' );
 	const pointsToWpcom = domain.pointsToWpcom;
 	const isDomainOnly = useSelector( ( state ) => isDomainOnlySite( state, domain.blogId ) );
 	const isPrimaryDomain = domain?.isPrimary && ! isDomainOnly;
-	const protocol = 'https';
 
 	// Display success notices when the forwarding is updated
 	const { updateDomainForwarding } = useUpdateDomainForwardingMutation( domain.name, {
@@ -145,9 +145,20 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 
 	const handleForwardToChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		const inputUrl = event.target.value;
-		setTargetUrl( withoutHttp( inputUrl ) );
+		const hasProtocol = inputUrl.startsWith( 'http://' ) || inputUrl.startsWith( 'https://' );
+		setProtocol( hasProtocol ? inputUrl.split( '://' )[ 0 ] : 'https' );
+		setTargetUrl( inputUrl );
+	};
 
-		if ( inputUrl.length > 0 && ! CAPTURE_URL_RGX_SOFT.test( protocol + '://' + inputUrl ) ) {
+	const forwardValidation = () => {
+		let inputUrl = targetUrl;
+
+		const hasProtocol = inputUrl.startsWith( 'http://' ) || inputUrl.startsWith( 'https://' );
+		if ( ! hasProtocol ) {
+			inputUrl = protocol + '://' + inputUrl;
+		}
+
+		if ( inputUrl.length > 0 && ! CAPTURE_URL_RGX_SOFT.test( inputUrl ) ) {
 			setIsValidUrl( false );
 			setErrorMessage( translate( 'Please enter a valid URL.' ) );
 			return;
@@ -221,9 +232,15 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 			return false;
 		}
 
+		let target = targetUrl;
+		const hasProtocol = target.startsWith( 'http://' ) || target.startsWith( 'https://' );
+		if ( ! hasProtocol ) {
+			target = protocol + '://' + targetUrl;
+		}
+
 		// Validate we have a valid url from the user
 		try {
-			const url = new URL( protocol + '://' + targetUrl, 'https://_domain_.invalid' );
+			const url = new URL( target, 'https://_domain_.invalid' );
 			if ( url.origin !== 'https://_domain_.invalid' ) {
 				targetHost = url.hostname;
 				targetPath = url.pathname + url.search + url.hash;
@@ -393,7 +410,9 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 					{ translate( 'Destination URL' ) }:
 				</div>
 				<div className="domain-forwarding-card__fields-column destination">
-					<strong>{ child.target_host + child.target_path }</strong>
+					<strong>
+						{ ( child.is_secure ? 'https://' : 'http://' ) + child.target_host + child.target_path }
+					</strong>
 				</div>
 			</div>
 		</FormFieldset>
@@ -445,6 +464,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 						name="destination"
 						noWrap
 						onChange={ handleForwardToChange }
+						onBlur={ forwardValidation }
 						value={ targetUrl }
 						className={ classNames( { 'is-error': ! isValidUrl } ) }
 						maxLength={ 1000 }

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -109,7 +109,9 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 			( child.is_secure ? 'http://' : 'https://' ) + ( child.target_host ?? '_invalid_.domain' );
 		const url = new URL( child.target_path, origin );
 		if ( url.hostname !== '_invalid_.domain' ) {
-			setTargetUrl( url.hostname + url.pathname + url.search + url.hash );
+			setTargetUrl(
+				( child.is_secure ? '' : 'http://' ) + url.hostname + url.pathname + url.search + url.hash
+			);
 			setIsPermanent( child.is_permanent );
 			setForwardPaths( child.forward_paths );
 			setSubdomain( child.subdomain );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3665
Fixes https://github.com/Automattic/dotcom-forge/issues/3680

## Proposed Changes

* Don't erase what the user has typed, see video

https://github.com/Automattic/wp-calypso/assets/6586048/9908d6e9-0257-4e73-b4f0-2e93aa3007e0

Expected behavior after this PR
* User can type http:// and https:// without getting erased
* If user doesn't specify a protocol, default to https

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/domains/manage/all/:domain/edit/:domain`
* Test input https://example.com
* Test input http://example.com
* Test input example.com
* Try to break it

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?