### PR TITLE
Plans 2023: Woo  promotional pricing - billing desc. updates

### DIFF
--- a/client/my-sites/plans-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plans-grid/components/billing-timeframe.tsx
@@ -92,6 +92,17 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 		if ( discountedPriceFullTermText ) {
 			if ( isMonthlyPlan ) {
 				if ( 'month' === introOffer.intervalUnit ) {
+					if ( 1 === introOffer.intervalCount ) {
+						return translate(
+							'for your first month,{{br/}}' + 'then %(rawPrice)s for the first month, excl. taxes',
+							{
+								args: { rawPrice: discountedPriceFullTermText },
+								components: { br: <br /> },
+								comment: 'excl. taxes is short for excluding taxes',
+							}
+						);
+					}
+
 					return translate(
 						'for your first %(introOfferIntervalCount)s month,{{br/}}' +
 							'then %(rawPrice)s for the first month, excl. taxes',
@@ -112,6 +123,17 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 
 			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
 				if ( 'month' === introOffer.intervalUnit ) {
+					if ( 1 === introOffer.intervalCount ) {
+						return translate(
+							'for your first month,{{br/}}' + 'then %(rawPrice)s for the first year, excl. taxes',
+							{
+								args: { rawPrice: discountedPriceFullTermText },
+								components: { br: <br /> },
+								comment: 'excl. taxes is short for excluding taxes',
+							}
+						);
+					}
+
 					return translate(
 						'for your first %(introOfferIntervalCount)s month,{{br/}}' +
 							'then %(rawPrice)s for the first year, excl. taxes',
@@ -132,6 +154,17 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 		} else if ( originalPriceFullTermText ) {
 			if ( isMonthlyPlan ) {
 				if ( 'month' === introOffer.intervalUnit ) {
+					if ( 1 === introOffer.intervalCount ) {
+						return translate(
+							'for your first month,{{br/}}' + 'then %(rawPrice)s billed monthly, excl. taxes',
+							{
+								args: { rawPrice: originalPriceFullTermText },
+								components: { br: <br /> },
+								comment: 'excl. taxes is short for excluding taxes',
+							}
+						);
+					}
+
 					return translate(
 						'for your first %(introOfferIntervalCount)s month,{{br/}}' +
 							'then %(rawPrice)s billed monthly, excl. taxes',
@@ -152,6 +185,17 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 
 			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
 				if ( 'month' === introOffer.intervalUnit ) {
+					if ( 1 === introOffer.intervalCount ) {
+						return translate(
+							'for your first month,{{br/}}' + 'then %(rawPrice)s billed annually, excl. taxes',
+							{
+								args: { rawPrice: originalPriceFullTermText },
+								components: { br: <br /> },
+								comment: 'excl. taxes is short for excluding taxes',
+							}
+						);
+					}
+
 					return translate(
 						'for your first %(introOfferIntervalCount)s month,{{br/}}' +
 							'then %(rawPrice)s billed annually, excl. taxes',

--- a/client/my-sites/plans-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plans-grid/components/billing-timeframe.tsx
@@ -91,82 +91,85 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 	if ( introOffer?.intervalCount && introOffer.intervalUnit && ! introOffer.isOfferComplete ) {
 		if ( discountedPriceFullTermText ) {
 			if ( isMonthlyPlan ) {
-				return translate(
-					'per month, for your first %(introOfferIntervalCount)s %(introOfferIntervalPeriod)s,{{br/}}' +
-						'then, %(rawPrice)s for the first month, Excl. Taxes',
-					'per month, for your first %(introOfferIntervalCount)s %(introOfferIntervalPeriod)ss,{{br/}}' +
-						'then, %(rawPrice)s for the first month, Excl. Taxes',
-					{
-						count: introOffer.intervalCount,
-						args: {
-							rawPrice: discountedPriceFullTermText,
-							introOfferIntervalCount: introOffer.intervalCount,
-							introOfferIntervalPeriod: introOffer.intervalUnit,
-						},
-						components: { br: <br /> },
-						comment: 'Excl. Taxes is short for excluding taxes',
-					}
-				);
+				if ( 'month' === introOffer.intervalUnit ) {
+					return translate(
+						'per month for your first %(introOfferIntervalCount)s month,{{br/}}' +
+							'then %(rawPrice)s for the first month, excl. taxes',
+						'per month for your first %(introOfferIntervalCount)s months,{{br/}}' +
+							'then %(rawPrice)s for the first month, excl. taxes',
+						{
+							count: introOffer.intervalCount,
+							args: {
+								rawPrice: discountedPriceFullTermText,
+								introOfferIntervalCount: introOffer.intervalCount,
+							},
+							components: { br: <br /> },
+							comment: 'excl. taxes is short for excluding taxes',
+						}
+					);
+				}
 			}
 
 			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-				return translate(
-					'per month, for your first %(introOfferIntervalCount)s %(introOfferIntervalPeriod)s,{{br/}}' +
-						'then, %(rawPrice)s for the first year, Excl. Taxes',
-					'per month, for your first %(introOfferIntervalCount)s %(introOfferIntervalPeriod)ss,{{br/}}' +
-						'then, %(rawPrice)s for the first year, Excl. Taxes',
-					{
-						count: introOffer.intervalCount,
-						args: {
-							rawPrice: discountedPriceFullTermText,
-							introOfferIntervalCount: introOffer.intervalCount,
-							introOfferIntervalPeriod: introOffer.intervalUnit,
-						},
-						components: { br: <br /> },
-						comment: 'Excl. Taxes is short for excluding taxes',
-					}
-				);
+				if ( 'month' === introOffer.intervalUnit ) {
+					return translate(
+						'per month for your first %(introOfferIntervalCount)s month,{{br/}}' +
+							'then %(rawPrice)s for the first year, excl. taxes',
+						'per month for your first %(introOfferIntervalCount)s months,{{br/}}' +
+							'then %(rawPrice)s for the first year, excl. taxes',
+						{
+							count: introOffer.intervalCount,
+							args: {
+								rawPrice: discountedPriceFullTermText,
+								introOfferIntervalCount: introOffer.intervalCount,
+							},
+							components: { br: <br /> },
+							comment: 'excl. taxes is short for excluding taxes',
+						}
+					);
+				}
 			}
 		} else if ( originalPriceFullTermText ) {
 			if ( isMonthlyPlan ) {
-				return translate(
-					'per month, for your first %(introOfferIntervalCount)s %(introOfferIntervalPeriod)s,{{br/}}' +
-						'then, %(rawPrice)s billed monthly, Excl. Taxes',
-					'per month, for your first %(introOfferIntervalCount)s %(introOfferIntervalPeriod)ss,{{br/}}' +
-						'then, %(rawPrice)s billed monthly, Excl. Taxes',
-					{
-						count: introOffer.intervalCount,
-						args: {
-							rawPrice: originalPriceFullTermText,
-							introOfferIntervalCount: introOffer.intervalCount,
-							introOfferIntervalPeriod: introOffer.intervalUnit,
-						},
-						components: { br: <br /> },
-						comment: 'Excl. Taxes is short for excluding taxes',
-					}
-				);
+				if ( 'month' === introOffer.intervalUnit ) {
+					return translate(
+						'per month for your first %(introOfferIntervalCount)s month,{{br/}}' +
+							'then %(rawPrice)s billed monthly, excl. taxes',
+						'per month for your first %(introOfferIntervalCount)s months,{{br/}}' +
+							'then %(rawPrice)s billed monthly, excl. taxes',
+						{
+							count: introOffer.intervalCount,
+							args: {
+								rawPrice: originalPriceFullTermText,
+								introOfferIntervalCount: introOffer.intervalCount,
+							},
+							components: { br: <br /> },
+							comment: 'excl. taxes is short for excluding taxes',
+						}
+					);
+				}
 			}
 
 			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-				return translate(
-					'per month, for your first %(introOfferIntervalCount)s %(introOfferIntervalPeriod)s,{{br/}}' +
-						'then, %(rawPrice)s billed annually, Excl. Taxes',
-					'per month, for your first %(introOfferIntervalCount)s %(introOfferIntervalPeriod)ss,{{br/}}' +
-						'then, %(rawPrice)s billed annually, Excl. Taxes',
-					{
-						count: introOffer.intervalCount,
-						args: {
-							rawPrice: originalPriceFullTermText,
-							introOfferIntervalCount: introOffer.intervalCount,
-							introOfferIntervalPeriod: introOffer.intervalUnit,
-						},
-						components: { br: <br /> },
-						comment: 'Excl. Taxes is short for excluding taxes',
-					}
-				);
+				if ( 'month' === introOffer.intervalUnit ) {
+					return translate(
+						'per month for your first %(introOfferIntervalCount)s month,{{br/}}' +
+							'then %(rawPrice)s billed annually, excl. taxes',
+						'per month for your first %(introOfferIntervalCount)s months,{{br/}}' +
+							'then %(rawPrice)s billed annually, excl. taxes',
+						{
+							count: introOffer.intervalCount,
+							args: {
+								rawPrice: originalPriceFullTermText,
+								introOfferIntervalCount: introOffer.intervalCount,
+							},
+							components: { br: <br /> },
+							comment: 'excl. taxes is short for excluding taxes',
+						}
+					);
+				}
 			}
 		}
-
 		/*
 		 * Early return here is for sanity. We don't want to show regular billing descriptions
 		 * if there is an introOffer (despite that will not be the case, unless some API-level bug happens)

--- a/client/my-sites/plans-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plans-grid/components/billing-timeframe.tsx
@@ -93,9 +93,9 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 			if ( isMonthlyPlan ) {
 				if ( 'month' === introOffer.intervalUnit ) {
 					return translate(
-						'per month for your first %(introOfferIntervalCount)s month,{{br/}}' +
+						'for your first %(introOfferIntervalCount)s month,{{br/}}' +
 							'then %(rawPrice)s for the first month, excl. taxes',
-						'per month for your first %(introOfferIntervalCount)s months,{{br/}}' +
+						'for your first %(introOfferIntervalCount)s months,{{br/}}' +
 							'then %(rawPrice)s for the first month, excl. taxes',
 						{
 							count: introOffer.intervalCount,
@@ -113,9 +113,9 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
 				if ( 'month' === introOffer.intervalUnit ) {
 					return translate(
-						'per month for your first %(introOfferIntervalCount)s month,{{br/}}' +
+						'for your first %(introOfferIntervalCount)s month,{{br/}}' +
 							'then %(rawPrice)s for the first year, excl. taxes',
-						'per month for your first %(introOfferIntervalCount)s months,{{br/}}' +
+						'for your first %(introOfferIntervalCount)s months,{{br/}}' +
 							'then %(rawPrice)s for the first year, excl. taxes',
 						{
 							count: introOffer.intervalCount,
@@ -133,9 +133,9 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 			if ( isMonthlyPlan ) {
 				if ( 'month' === introOffer.intervalUnit ) {
 					return translate(
-						'per month for your first %(introOfferIntervalCount)s month,{{br/}}' +
+						'for your first %(introOfferIntervalCount)s month,{{br/}}' +
 							'then %(rawPrice)s billed monthly, excl. taxes',
-						'per month for your first %(introOfferIntervalCount)s months,{{br/}}' +
+						'for your first %(introOfferIntervalCount)s months,{{br/}}' +
 							'then %(rawPrice)s billed monthly, excl. taxes',
 						{
 							count: introOffer.intervalCount,
@@ -153,9 +153,9 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
 				if ( 'month' === introOffer.intervalUnit ) {
 					return translate(
-						'per month for your first %(introOfferIntervalCount)s month,{{br/}}' +
+						'for your first %(introOfferIntervalCount)s month,{{br/}}' +
 							'then %(rawPrice)s billed annually, excl. taxes',
-						'per month for your first %(introOfferIntervalCount)s months,{{br/}}' +
+						'for your first %(introOfferIntervalCount)s months,{{br/}}' +
 							'then %(rawPrice)s billed annually, excl. taxes',
 						{
 							count: introOffer.intervalCount,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/81620 (not closing, as we may revisit once experiments are over to abstract / better implement)

## Proposed Changes

- Updates the billing descriptions for the intro offers to match copy - per discussion peapX7-3fa-p2#comment-4783
- Updates the plural/singular conditioning per suggestion by @emilyaudela https://github.com/Automattic/wp-calypso/pull/80430#discussion_r1321418356

```
for your first 3 months,
then €40 billed monthly, excl. taxes
```

```
for your first 3 months,
then €300 billed annually, excl. taxes
```

### Media

<img width="700" alt="Screenshot 2023-10-03 at 2 07 10 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/3502b69c-eded-4ec9-83e8-1c0cd8fb2a13">

<img width="700" alt="Screenshot 2023-10-03 at 2 07 16 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/502d88cd-2ce8-4f1d-99ad-d8869c89bb9c">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox public-api and disable store sandbox (more about this in phab diff D119416-code ) 
    * Go to `/setup/wooexpress` and create a Woo Express site
    * Go to `/plans/[woo-trial]` and confirm the billing descriptions are rendered correctly
    * Confirm `/start` renders as previously (no promo pricing)
    * Confirm `/plans/[paid | free site]` renders as previously (no promo pricing)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?