### PR TITLE
Subscription Management: Add RSS in the filter dropdown

### DIFF
--- a/client/landing/subscriptions/hooks/use-site-subscriptions-filter-options.ts
+++ b/client/landing/subscriptions/hooks/use-site-subscriptions-filter-options.ts
@@ -11,6 +11,7 @@ const useSiteSubscriptionsFilterOptions = () => {
 			{ value: FilterBy.All, label: translate( 'All' ) },
 			{ value: FilterBy.Paid, label: translate( 'Paid' ) },
 			{ value: FilterBy.P2, label: translate( 'P2' ) },
+			{ value: FilterBy.RSS, label: translate( 'RSS' ) },
 		],
 		[ translate ]
 	);

--- a/packages/data-stores/src/reader/constants.ts
+++ b/packages/data-stores/src/reader/constants.ts
@@ -14,6 +14,7 @@ export enum SiteSubscriptionsFilterBy {
 	All = 'all',
 	Paid = 'paid',
 	P2 = 'p2',
+	RSS = 'rss',
 }
 
 export enum SiteSubscriptionsSortBy {

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -102,6 +102,8 @@ const useSiteSubscriptionsQuery = ( {
 					return item.is_paid_subscription;
 				case SiteSubscriptionsFilterBy.P2:
 					return item.is_wpforteams_site;
+				case SiteSubscriptionsFilterBy.RSS:
+					return item.is_rss;
 				case SiteSubscriptionsFilterBy.All:
 				default:
 					return true;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82341
**Depends on D123498-code**

## Proposed Changes

* Add RSS in the filter dropdown

<img width="645" alt="Screenshot 2023-09-28 at 11 02 09" src="https://github.com/Automattic/wp-calypso/assets/3113712/4fedcf6e-2f55-4028-8a36-b42d4234b0e6">

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/read/subscriptions
* Check if the RSS option is available on the filter dropdown
* Click on RSS and check if the subscription list updates with only RSS subscriptions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?