### PR TITLE
Added custom fields while receiving whois information on domain transfer flow

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -5,6 +5,7 @@ import {
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get, deburr, kebabCase, pick, includes, isEqual, isEmpty, camelCase } from 'lodash';
+import merge from 'lodash/merge';
 import PropTypes from 'prop-types';
 import { Component, createElement } from 'react';
 import { connect } from 'react-redux';
@@ -539,10 +540,17 @@ export class ContactDetailsFormFields extends Component {
 	}
 
 	updateDomainContactFields = ( data ) => {
-		const newContactDetails = Object.assign( {}, this.state.contactDetails, data );
+		if ( data.vatId ) {
+			data = {
+				extra: {
+					fr: {
+						registrantVatId: data.vatId,
+					},
+				},
+			};
+		}
+		const newContactDetails = merge( {}, this.state.contactDetails, data );
 		this.setState( { contactDetails: newContactDetails } );
-		// Object.keys( newContactDetails ).length > 0 &&
-		// 	this.debouncedValidateContactDetails( newContactDetails );
 	};
 
 	render() {
@@ -564,36 +572,43 @@ export class ContactDetailsFormFields extends Component {
 		const isFooterVisible = !! ( this.props.onSubmit || onCancel );
 
 		return (
-			<FormFieldset className="contact-details-form-fields">
-				<div className="contact-details-form-fields__row">
-					{ this.createField(
-						'first-name',
-						Input,
-						{
-							label: translate( 'First name' ),
-						},
-						{
-							customErrorMessage: contactDetailsErrors?.firstName,
-						}
+			<>
+				<FormFieldset className="contact-details-form-fields">
+					<div className="contact-details-form-fields__row">
+						{ this.createField(
+							'first-name',
+							Input,
+							{
+								label: translate( 'First name' ),
+							},
+							{
+								customErrorMessage: contactDetailsErrors?.firstName,
+							}
+						) }
+
+						{ this.createField(
+							'last-name',
+							Input,
+							{
+								label: translate( 'Last name' ),
+							},
+							{
+								customErrorMessage: contactDetailsErrors?.lastName,
+							}
+						) }
+					</div>
+					{ this.props.needsAlternateEmailForGSuite && this.renderAlternateEmailFieldForGSuite() }
+
+					{ this.props.needsOnlyGoogleAppsDetails
+						? this.renderGAppsFieldset()
+						: this.renderContactDetailsFields() }
+
+					{ this.props.children && (
+						<div className="contact-details-form-fields__extra-fields">{ this.props.children }</div>
 					) }
 
-					{ this.createField(
-						'last-name',
-						Input,
-						{
-							label: translate( 'Last name' ),
-						},
-						{
-							customErrorMessage: contactDetailsErrors?.lastName,
-						}
-					) }
-				</div>
-				{ this.props.needsAlternateEmailForGSuite && this.renderAlternateEmailFieldForGSuite() }
-
-				{ this.props.needsOnlyGoogleAppsDetails
-					? this.renderGAppsFieldset()
-					: this.renderContactDetailsFields() }
-
+					<QueryDomainCountries />
+				</FormFieldset>
 				<div className="contact-details-form-fields__extra-fields">
 					{
 						// TODO: connect contactDetailsErrors
@@ -607,11 +622,6 @@ export class ContactDetailsFormFields extends Component {
 						isLoggedOutCart={ false }
 					/>
 				</div>
-
-				{ this.props.children && (
-					<div className="contact-details-form-fields__extra-fields">{ this.props.children }</div>
-				) }
-
 				{ isFooterVisible && (
 					<div>
 						{ this.props.onSubmit && (
@@ -637,8 +647,7 @@ export class ContactDetailsFormFields extends Component {
 						) }
 					</div>
 				) }
-				<QueryDomainCountries />
-			</FormFieldset>
+			</>
 		);
 	}
 }

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -20,7 +20,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import NoticeErrorMessage from 'calypso/my-sites/checkout/checkout/notice-error-message';
-import DomainContactDetails from 'calypso/my-sites/checkout/src/components/domain-contact-details';
+import DomainContactDetailsTlds from 'calypso/my-sites/checkout/src/components/domain-contact-details-tlds';
 import { CountrySelect, Input, HiddenInput } from 'calypso/my-sites/domains/components/form';
 import { getCountryStates } from 'calypso/state/country-states/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -596,7 +596,7 @@ export class ContactDetailsFormFields extends Component {
 					: this.renderContactDetailsFields() }
 
 				<div className="contact-details-form-fields__extra-fields">
-					<DomainContactDetails
+					<DomainContactDetailsTlds
 						domainNames={ [] }
 						contactDetails={ this.state.contactDetails }
 						// contactDetailsErrors={  }

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -20,6 +20,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import NoticeErrorMessage from 'calypso/my-sites/checkout/checkout/notice-error-message';
+import DomainContactDetails from 'calypso/my-sites/checkout/src/components/domain-contact-details';
 import { CountrySelect, Input, HiddenInput } from 'calypso/my-sites/domains/components/form';
 import { getCountryStates } from 'calypso/state/country-states/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -105,6 +106,7 @@ export class ContactDetailsFormFields extends Component {
 			form: null,
 			submissionCount: 0,
 			updateWpcomEmail: false,
+			contactDetails: this.props.contactDetails || {},
 		};
 
 		this.inputRefs = {};
@@ -128,7 +130,8 @@ export class ContactDetailsFormFields extends Component {
 			nextProps.needsFax !== this.props.needsFax ||
 			nextProps.disableSubmitButton !== this.props.disableSubmitButton ||
 			nextProps.needsOnlyGoogleAppsDetails !== this.props.needsOnlyGoogleAppsDetails ||
-			nextState.updateWpcomEmail !== this.state.updateWpcomEmail
+			nextState.updateWpcomEmail !== this.state.updateWpcomEmail ||
+			nextState.contactDetails !== this.state.contactDetails
 		);
 	}
 
@@ -535,6 +538,13 @@ export class ContactDetailsFormFields extends Component {
 		);
 	}
 
+	updateDomainContactFields = ( data ) => {
+		const newContactDetails = Object.assign( {}, this.state.contactDetails, data );
+		this.setState( { contactDetails: newContactDetails } );
+		// Object.keys( newContactDetails ).length > 0 &&
+		// 	this.debouncedValidateContactDetails( newContactDetails );
+	};
+
 	render() {
 		const {
 			translate,
@@ -549,6 +559,7 @@ export class ContactDetailsFormFields extends Component {
 			return null;
 		}
 
+		const tlds = [ 'fr' ];
 		const countryCode = this.getCountryCode();
 
 		const isFooterVisible = !! ( this.props.onSubmit || onCancel );
@@ -583,6 +594,38 @@ export class ContactDetailsFormFields extends Component {
 				{ this.props.needsOnlyGoogleAppsDetails
 					? this.renderGAppsFieldset()
 					: this.renderContactDetailsFields() }
+
+				<div className="contact-details-form-fields__extra-fields">
+					<DomainContactDetails
+						domainNames={ [] }
+						contactDetails={ this.state.contactDetails }
+						// contactDetailsErrors={  }
+						updateDomainContactFields={ this.updateDomainContactFields }
+						shouldShowContactDetailsValidationErrors={ false }
+						isLoggedOutCart={ false }
+						// isDisabled={ isDisabled || isSubmitting }
+						// emailOnly={ emailOnly }
+					/>
+					{
+						//'uk', 'fr', 'ca', 'de', 'jp'
+					 }
+					{ /* { tlds.includes( 'fr' ) && (
+						<RegistrantExtraInfoForm
+							contactDetails={ this.props.contactDetails }
+							ccTldDetails="organization"
+							onContactDetailsChange={ ( item ) => {
+								console.log( 'updated: ', item );
+							} }
+							// contactDetailsValidationErrors={
+							// 	shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
+							// }
+							tld="fr"
+							getDomainNames={ () => [ 'something.de' ] }
+							translate={ translate }
+							isManaged={ true }
+						/>
+					) } */ }
+				</div>
 
 				{ this.props.children && (
 					<div className="contact-details-form-fields__extra-fields">{ this.props.children }</div>

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -559,7 +559,6 @@ export class ContactDetailsFormFields extends Component {
 			return null;
 		}
 
-		const tlds = [ 'fr' ];
 		const countryCode = this.getCountryCode();
 
 		const isFooterVisible = !! ( this.props.onSubmit || onCancel );
@@ -596,6 +595,9 @@ export class ContactDetailsFormFields extends Component {
 					: this.renderContactDetailsFields() }
 
 				<div className="contact-details-form-fields__extra-fields">
+					{
+						// TODO: connect contactDetailsErrors
+					 }
 					<DomainContactDetailsTlds
 						domainNames={ [] }
 						contactDetails={ this.state.contactDetails }
@@ -603,28 +605,7 @@ export class ContactDetailsFormFields extends Component {
 						updateDomainContactFields={ this.updateDomainContactFields }
 						shouldShowContactDetailsValidationErrors={ false }
 						isLoggedOutCart={ false }
-						// isDisabled={ isDisabled || isSubmitting }
-						// emailOnly={ emailOnly }
 					/>
-					{
-						//'uk', 'fr', 'ca', 'de', 'jp'
-					 }
-					{ /* { tlds.includes( 'fr' ) && (
-						<RegistrantExtraInfoForm
-							contactDetails={ this.props.contactDetails }
-							ccTldDetails="organization"
-							onContactDetailsChange={ ( item ) => {
-								console.log( 'updated: ', item );
-							} }
-							// contactDetailsValidationErrors={
-							// 	shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
-							// }
-							tld="fr"
-							getDomainNames={ () => [ 'something.de' ] }
-							translate={ translate }
-							isManaged={ true }
-						/>
-					) } */ }
 				</div>
 
 				{ this.props.children && (

--- a/client/my-sites/checkout/src/components/domain-contact-details-tlds.tsx
+++ b/client/my-sites/checkout/src/components/domain-contact-details-tlds.tsx
@@ -1,0 +1,81 @@
+import { useTranslate } from 'i18n-calypso';
+import RegistrantExtraInfoForm from 'calypso/components/domains/registrant-extra-info';
+import { getTopLevelOfTld } from 'calypso/lib/domains';
+import type { DomainContactDetails as DomainContactDetailsData } from '@automattic/shopping-cart';
+import type { DomainContactDetailsErrors } from '@automattic/wpcom-checkout';
+
+export default function DomainContactDetailsTlds( {
+	domainNames,
+	contactDetails,
+	contactDetailsErrors,
+	updateDomainContactFields,
+	shouldShowContactDetailsValidationErrors,
+}: {
+	domainNames: string[];
+	contactDetails: DomainContactDetailsData;
+	contactDetailsErrors: DomainContactDetailsErrors;
+	updateDomainContactFields: ( details: DomainContactDetailsData ) => void;
+	shouldShowContactDetailsValidationErrors: boolean;
+} ) {
+	const translate = useTranslate();
+	const tlds = getAllTopLevelTlds( domainNames );
+
+	// TODO: Remove this test code
+	tlds.push( 'fr' );
+	console.log( 'tlds: ', tlds );
+	console.log( 'contactDetails: ', contactDetails );
+
+	return (
+		<>
+			{ tlds.includes( 'ca' ) && (
+				<RegistrantExtraInfoForm
+					contactDetails={ contactDetails }
+					ccTldDetails={ contactDetails?.extra?.ca ?? {} }
+					onContactDetailsChange={ updateDomainContactFields }
+					contactDetailsValidationErrors={
+						shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
+					}
+					tld="ca"
+					getDomainNames={ () => domainNames }
+					translate={ translate }
+					isManaged={ true }
+				/>
+			) }
+			{ tlds.includes( 'uk' ) && (
+				<RegistrantExtraInfoForm
+					contactDetails={ contactDetails }
+					ccTldDetails={ contactDetails?.extra?.uk ?? {} }
+					onContactDetailsChange={ updateDomainContactFields }
+					contactDetailsValidationErrors={
+						shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
+					}
+					tld="uk"
+					getDomainNames={ () => domainNames }
+					translate={ translate }
+					isManaged={ true }
+				/>
+			) }
+			{ tlds.includes( 'fr' ) && (
+				<RegistrantExtraInfoForm
+					contactDetails={ contactDetails }
+					ccTldDetails={ contactDetails?.extra?.fr ?? {} }
+					onContactDetailsChange={ updateDomainContactFields }
+					contactDetailsValidationErrors={
+						shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
+					}
+					tld="fr"
+					getDomainNames={ () => domainNames }
+					translate={ translate }
+					isManaged={ true }
+				/>
+			) }
+			{
+				// TODO: add 'de' and 'jp' tlds here
+			 }
+		</>
+	);
+}
+
+function getAllTopLevelTlds( domainNames: string[] ): string[] {
+	return Array.from( new Set( domainNames.map( getTopLevelOfTld ) ) ).sort();
+}

--- a/client/my-sites/checkout/src/components/domain-contact-details.tsx
+++ b/client/my-sites/checkout/src/components/domain-contact-details.tsx
@@ -1,15 +1,13 @@
 import config from '@automattic/calypso-config';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import { useTranslate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import ManagedContactDetailsFormFields from 'calypso/components/domains/contact-details-form-fields/managed-contact-details-form-fields';
-import RegistrantExtraInfoForm from 'calypso/components/domains/registrant-extra-info';
 import {
 	hasGoogleApps,
 	hasDomainRegistration,
 	hasTransferProduct,
 } from 'calypso/lib/cart-values/cart-items';
-import { getTopLevelOfTld } from 'calypso/lib/domains';
+import DomainContactDetailsTlds from 'calypso/my-sites/checkout/src/components/domain-contact-details-tlds';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { VatForm } from './vat-form';
 import type { DomainContactDetails as DomainContactDetailsData } from '@automattic/shopping-cart';
@@ -34,26 +32,20 @@ export default function DomainContactDetails( {
 	isLoggedOutCart: boolean;
 	emailOnly?: boolean;
 } ) {
-	const translate = useTranslate();
-	// const cartKey = useCartKey();
-	// const { responseCart } = useShoppingCart( cartKey );
-	// const needsOnlyGoogleAppsDetails =
-	// 	hasGoogleApps( responseCart ) &&
-	// 	! hasDomainRegistration( responseCart ) &&
-	// 	! hasTransferProduct( responseCart );
-	// const getIsFieldDisabled = () => isDisabled;
-	// const needsAlternateEmailForGSuite = needsOnlyGoogleAppsDetails;
-	const tlds = getAllTopLevelTlds( domainNames );
-
-	tlds.push( 'fr' );
-	console.log( 'tlds: ', tlds );
-	console.log( 'contactDetails: ', contactDetails );
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
+	const needsOnlyGoogleAppsDetails =
+		hasGoogleApps( responseCart ) &&
+		! hasDomainRegistration( responseCart ) &&
+		! hasTransferProduct( responseCart );
+	const getIsFieldDisabled = () => isDisabled;
+	const needsAlternateEmailForGSuite = needsOnlyGoogleAppsDetails;
 
 	const isVatSupported = config.isEnabled( 'checkout/vat-form' );
 
 	return (
 		<Fragment>
-			{ /* <ManagedContactDetailsFormFields
+			<ManagedContactDetailsFormFields
 				needsOnlyGoogleAppsDetails={ needsOnlyGoogleAppsDetails }
 				needsAlternateEmailForGSuite={ needsAlternateEmailForGSuite }
 				contactDetails={ contactDetails }
@@ -64,49 +56,14 @@ export default function DomainContactDetails( {
 				getIsFieldDisabled={ getIsFieldDisabled }
 				isLoggedOutCart={ isLoggedOutCart }
 				emailOnly={ emailOnly }
-			/> */ }
-			{ tlds.includes( 'ca' ) && (
-				<RegistrantExtraInfoForm
-					contactDetails={ contactDetails }
-					ccTldDetails={ contactDetails?.extra?.ca ?? {} }
-					onContactDetailsChange={ updateDomainContactFields }
-					contactDetailsValidationErrors={
-						shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
-					}
-					tld="ca"
-					getDomainNames={ () => domainNames }
-					translate={ translate }
-					isManaged={ true }
-				/>
-			) }
-			{ tlds.includes( 'uk' ) && (
-				<RegistrantExtraInfoForm
-					contactDetails={ contactDetails }
-					ccTldDetails={ contactDetails?.extra?.uk ?? {} }
-					onContactDetailsChange={ updateDomainContactFields }
-					contactDetailsValidationErrors={
-						shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
-					}
-					tld="uk"
-					getDomainNames={ () => domainNames }
-					translate={ translate }
-					isManaged={ true }
-				/>
-			) }
-			{ tlds.includes( 'fr' ) && (
-				<RegistrantExtraInfoForm
-					contactDetails={ contactDetails }
-					ccTldDetails={ contactDetails?.extra?.fr ?? {} }
-					onContactDetailsChange={ updateDomainContactFields }
-					contactDetailsValidationErrors={
-						shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
-					}
-					tld="fr"
-					getDomainNames={ () => domainNames }
-					translate={ translate }
-					isManaged={ true }
-				/>
-			) }
+			/>
+			<DomainContactDetailsTlds
+				domainNames={ domainNames }
+				contactDetails={ contactDetails }
+				contactDetailsErrors={ contactDetailsErrors }
+				updateDomainContactFields={ updateDomainContactFields }
+				shouldShowContactDetailsValidationErrors={ shouldShowContactDetailsValidationErrors }
+			/>
 			{ isVatSupported && (
 				<VatForm
 					section="domain-contact-form"
@@ -119,7 +76,3 @@ export default function DomainContactDetails( {
 }
 
 DomainContactDetails.defaultProps = { emailOnly: false };
-
-function getAllTopLevelTlds( domainNames: string[] ): string[] {
-	return Array.from( new Set( domainNames.map( getTopLevelOfTld ) ) ).sort();
-}

--- a/client/my-sites/checkout/src/components/domain-contact-details.tsx
+++ b/client/my-sites/checkout/src/components/domain-contact-details.tsx
@@ -35,21 +35,25 @@ export default function DomainContactDetails( {
 	emailOnly?: boolean;
 } ) {
 	const translate = useTranslate();
-	const cartKey = useCartKey();
-	const { responseCart } = useShoppingCart( cartKey );
-	const needsOnlyGoogleAppsDetails =
-		hasGoogleApps( responseCart ) &&
-		! hasDomainRegistration( responseCart ) &&
-		! hasTransferProduct( responseCart );
-	const getIsFieldDisabled = () => isDisabled;
-	const needsAlternateEmailForGSuite = needsOnlyGoogleAppsDetails;
+	// const cartKey = useCartKey();
+	// const { responseCart } = useShoppingCart( cartKey );
+	// const needsOnlyGoogleAppsDetails =
+	// 	hasGoogleApps( responseCart ) &&
+	// 	! hasDomainRegistration( responseCart ) &&
+	// 	! hasTransferProduct( responseCart );
+	// const getIsFieldDisabled = () => isDisabled;
+	// const needsAlternateEmailForGSuite = needsOnlyGoogleAppsDetails;
 	const tlds = getAllTopLevelTlds( domainNames );
+
+	tlds.push( 'fr' );
+	console.log( 'tlds: ', tlds );
+	console.log( 'contactDetails: ', contactDetails );
 
 	const isVatSupported = config.isEnabled( 'checkout/vat-form' );
 
 	return (
 		<Fragment>
-			<ManagedContactDetailsFormFields
+			{ /* <ManagedContactDetailsFormFields
 				needsOnlyGoogleAppsDetails={ needsOnlyGoogleAppsDetails }
 				needsAlternateEmailForGSuite={ needsAlternateEmailForGSuite }
 				contactDetails={ contactDetails }
@@ -60,7 +64,7 @@ export default function DomainContactDetails( {
 				getIsFieldDisabled={ getIsFieldDisabled }
 				isLoggedOutCart={ isLoggedOutCart }
 				emailOnly={ emailOnly }
-			/>
+			/> */ }
 			{ tlds.includes( 'ca' ) && (
 				<RegistrantExtraInfoForm
 					contactDetails={ contactDetails }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 3835-gh-Automattic/dotcom-forge


## Proposed Changes

We're adding extra fields depending on the domain TLD. These are from `.fr`, for instance:

![image](https://github.com/Automattic/wp-calypso/assets/1044309/ecadc431-815d-4f5f-ab88-90beb5e49a9d)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?