### PR TITLE
User content link tracking: do not count user content links under Other

### DIFF
--- a/client/state/stats/emails/utils.js
+++ b/client/state/stats/emails/utils.js
@@ -232,9 +232,9 @@ export function parseEmailLinksData( internalLinks = [], userContentLinks = [] )
 	// filter out links that are not in the stringMap
 	const filteredInternalLinks = validatedInternalLinks.filter( ( link ) => stringMap[ link[ 0 ] ] );
 
-	// Get count of all links where the first element is not a key of stringMap
+	// Get count of all links where the first element is not a key of stringMap and link_desc is not user_link
 	const otherInternalLinksCount = validatedInternalLinks.reduce( ( count, link ) => {
-		if ( ! stringMap[ link[ 0 ] ] ) {
+		if ( ! stringMap[ link[ 0 ] ] && link[ 0 ] !== 'user_link' ) {
 			count += parseInt( link[ 1 ], 10 );
 		}
 		return count;


### PR DESCRIPTION
## Proposed Changes

- We're currently storing information about email clicks in two places: Tracks & the user content link tracking tables. To show which links get clicked (both internal links such as Unsubscribe, & user content links), we query both sources and throw the data together.

This PR prevents the user content links from showing up twice: once as a total for the link (originating from the user content link tracking tables.) and once in the Other category (Tracks events with link_desc being `user_link`). 

## Testing Instructions

A code review will probably be fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?