### PR TITLE
Thank You: Use theme fetching status to verify if atomic is needed

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -73,7 +73,7 @@ const MarketplaceThankYou = ( {
 		themeSubtitle,
 	} );
 
-	const isAtomicNeeded = isAtomicNeededForPlugins || isAtomicNeededForThemes;
+	const isAtomicNeeded = isAtomicNeededForPlugins || isAtomicNeededForThemes || ! allThemesFetched;
 	const [ isAtomicTransferCheckComplete, currentStep, showProgressBar, setShowProgressBar ] =
 		useAtomicTransfer( isAtomicNeeded );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82110

## Proposed Changes

Add theme fetching condition to guarantee themes don't need an atomic transfer.
Before this change, it was considered an atomic transfer was not needed for themes in cases where the data was not available yet.

## Testing Instructions
* Apply the diff D118900-code to your sandbox and direct requests to the sandbox
* Go to the Design Picker page with a Marketplace theme selected `/setup/update-design/designSetup?siteSlug=:site&theme=:theme_slug`. Theme slugs such as `makoney` and `olsen-fse` can be used.
* Click on `Unlock Theme`
* You should see the upgrade modal.
* Click to proceed and complete the purchase.
* After completing the purchase you should be redirected to the Thank You page to activate the theme.
* You should see the loader for some time, and then see the purchased theme details.
* As soon as theme details are shown, click on `Activate this design`, and the theme should be activated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
