### PR TITLE
Earn: Update tab names

### DIFF
--- a/client/my-sites/earn/index.ts
+++ b/client/my-sites/earn/index.ts
@@ -6,7 +6,7 @@ import earnController from './controller';
 export default function () {
 	page( '/earn', siteSelection, sites, makeLayout, clientRender );
 	page( '/earn/stats', siteSelection, sites, makeLayout, clientRender );
-	page( '/earn/customers', siteSelection, sites, makeLayout, clientRender );
+	page( '/earn/supporters', siteSelection, sites, makeLayout, clientRender );
 	page( '/earn/payments', siteSelection, sites, makeLayout, clientRender );
 	// This is legacy, we are leaving it here because it may have been public
 	page(

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -42,7 +42,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		'ads-settings': translate( '%(wordads)s Settings', { args: { wordads: adsProgramName } } ),
 		'ads-payments': translate( '%(wordads)s Payments', { args: { wordads: adsProgramName } } ),
 		payments: translate( 'Payment Settings' ),
-		customers: translate( 'Customers' ),
+		supporters: translate( 'Customers' ),
 		stats: translate( 'Stats' ),
 		'payments-plans': translate( 'Recurring Payments plans' ),
 		'refer-a-friend': translate( 'Refer-a-Friend Program' ),
@@ -52,13 +52,13 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		const pathSuffix = site?.slug ? '/' + site?.slug : '';
 		return [
 			{
-				title: translate( 'Tools' ),
+				title: translate( 'Monetization Options' ),
 				path: '/earn' + pathSuffix,
 				id: 'earn',
 			},
 			{
-				title: translate( 'Customers' ),
-				path: '/earn/customers' + pathSuffix,
+				title: translate( 'Supporters' ),
+				path: '/earn/supporters' + pathSuffix,
 				id: 'customers',
 			},
 			{
@@ -67,7 +67,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				id: 'stats',
 			},
 			{
-				title: translate( 'Settings' ),
+				title: translate( 'Payment Settings' ),
 				path: '/earn/payments' + pathSuffix,
 				id: 'payments',
 			},
@@ -149,7 +149,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 			case 'stats':
 				return <StatsSection />;
 
-			case 'customers':
+			case 'supporters':
 				return <CustomerSection />;
 
 			case 'refer-a-friend':

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -59,7 +59,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 			{
 				title: translate( 'Supporters' ),
 				path: '/earn/supporters' + pathSuffix,
-				id: 'customers',
+				id: 'supporters',
 			},
 			{
 				title: translate( 'Stats' ),

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -42,7 +42,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		'ads-settings': translate( '%(wordads)s Settings', { args: { wordads: adsProgramName } } ),
 		'ads-payments': translate( '%(wordads)s Payments', { args: { wordads: adsProgramName } } ),
 		payments: translate( 'Payment Settings' ),
-		supporters: translate( 'Customers' ),
+		supporters: translate( 'Supporters' ),
 		stats: translate( 'Stats' ),
 		'payments-plans': translate( 'Recurring Payments plans' ),
 		'refer-a-friend': translate( 'Refer-a-Friend Program' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Updates two tab names on Earn page (Tools -> Monetization Options, Customers -> Supporters). 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Checkout this branch go to http://calypso.localhost:3000/earn/YOURDOMAIN and confirm that tab names are updated and that tab navigations works as epxected.  
