### PR TITLE
Allow removing default A records

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
@@ -62,7 +62,7 @@ const emailProviderKeys: EmailProviderKey[] = [ EmailProvider.TITAN, EmailProvid
 
 function DnsMenuOptionsButton( {
 	domain,
-	pointsToWpcom,
+	hasDefaultARecords,
 	hasDefaultCnameRecord,
 	dns,
 	dispatchApplyDnsTemplate,
@@ -291,7 +291,7 @@ function DnsMenuOptionsButton( {
 			>
 				<PopoverMenuItem
 					onClick={ showRestoreARecordsDialog }
-					disabled={ pointsToWpcom || ! domain }
+					disabled={ hasDefaultARecords || ! domain }
 				>
 					<Icon icon={ redo } size={ 14 } className="gridicon" viewBox="2 2 20 20" />
 					{ __( 'Restore default A records' ) }

--- a/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
@@ -148,7 +148,7 @@ function DnsMenuOptionsButton( {
 	);
 
 	const restoreDefaultARecords = useCallback( async () => {
-		dispatchUpdateDns( domainName, [], getARecordsToRemove() )
+		dispatchUpdateDns( domainName, [], getARecordsToRemove(), true )
 			.then( () => dispatchSuccessNotice( __( 'Default A records restored' ) ) )
 			.catch( () => dispatchErrorNotice( __( 'Failed to restore the default A records' ) ) );
 	}, [

--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -202,7 +202,7 @@ class DnsRecordsList extends Component {
 		if ( ! record.protected_field ) {
 			actions.push( { ...this.editRecordAction } );
 		}
-		if ( ! ( record.protected_field && 'MX' !== record.type ) ) {
+		if ( ! ( record.protected_field && 'MX' !== record.type ) || record.type === 'A' ) {
 			actions.push( { ...this.deleteRecordAction } );
 		}
 		return actions;

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -52,10 +52,14 @@ class DnsRecords extends Component {
 		);
 	};
 
+	hasDefaultARecords = () => {
+		const { dns } = this.props;
+		return dns?.records?.some( ( record ) => record?.type === 'A' && record?.protected_field );
+	};
+
 	renderHeader = () => {
 		const { domains, translate, selectedSite, currentRoute, selectedDomainName, dns } = this.props;
 		const selectedDomain = domains?.find( ( domain ) => domain?.name === selectedDomainName );
-		const pointsToWpcom = selectedDomain?.pointsToWpcom ?? false;
 
 		const items = [
 			{
@@ -87,7 +91,7 @@ class DnsRecords extends Component {
 				key="menu-options-button"
 				domain={ selectedDomain }
 				dns={ dns }
-				pointsToWpcom={ pointsToWpcom }
+				hasDefaultARecords={ this.hasDefaultARecords() }
 				hasDefaultCnameRecord={ this.hasDefaultCnameRecord() }
 			/>
 		);

--- a/client/my-sites/domains/domain-management/dns/types.ts
+++ b/client/my-sites/domains/domain-management/dns/types.ts
@@ -30,7 +30,7 @@ type UnpackPromisedValue< T > = T extends ( ...args: unknown[] ) => infer R
 
 export type DnsMenuOptionsButtonProps = {
 	domain: ResponseDomain | undefined;
-	pointsToWpcom: boolean;
+	hasDefaultARecords: boolean;
 	hasDefaultCnameRecord: boolean;
 	dns: Dns;
 	dispatchApplyDnsTemplate: UnpackPromisedValue< typeof applyDnsTemplate >;

--- a/client/state/domains/dns/actions.js
+++ b/client/state/domains/dns/actions.js
@@ -83,18 +83,21 @@ export const applyDnsTemplate = ( domainName, provider, service, variables ) => 
 	return applyResult;
 };
 
-export const updateDns = ( domainName, recordsToAdd, recordsToRemove ) => ( dispatch ) => {
-	dispatch( { type: DOMAINS_DNS_UPDATE, recordsToAdd, recordsToRemove } );
+export const updateDns =
+	( domainName, recordsToAdd, recordsToRemove, restoreDefaultARecords = false ) =>
+	( dispatch ) => {
+		dispatch( { type: DOMAINS_DNS_UPDATE, recordsToAdd, recordsToRemove } );
 
-	const updateResult = updateDnsRequest( domainName, {
-		records_to_add: recordsToAdd,
-		records_to_remove: recordsToRemove,
-	} );
+		const updateResult = updateDnsRequest( domainName, {
+			records_to_add: recordsToAdd,
+			records_to_remove: recordsToRemove,
+			restore_default_a_records: restoreDefaultARecords,
+		} );
 
-	updateResult.then(
-		( { records } ) => dispatch( { type: DOMAINS_DNS_UPDATE_COMPLETED, domainName, records } ),
-		() => dispatch( { type: DOMAINS_DNS_UPDATE_FAILED, domainName } )
-	);
+		updateResult.then(
+			( { records } ) => dispatch( { type: DOMAINS_DNS_UPDATE_COMPLETED, domainName, records } ),
+			() => dispatch( { type: DOMAINS_DNS_UPDATE_FAILED, domainName } )
+		);
 
-	return updateResult;
-};
+		return updateResult;
+	};

--- a/client/state/domains/dns/actions.js
+++ b/client/state/domains/dns/actions.js
@@ -84,8 +84,7 @@ export const applyDnsTemplate = ( domainName, provider, service, variables ) => 
 };
 
 export const updateDns =
-	( domainName, recordsToAdd, recordsToRemove, restoreDefaultARecords = false ) =>
-	( dispatch ) => {
+	( domainName, recordsToAdd, recordsToRemove, restoreDefaultARecords ) => ( dispatch ) => {
 		dispatch( { type: DOMAINS_DNS_UPDATE, recordsToAdd, recordsToRemove } );
 
 		const updateResult = updateDnsRequest( domainName, {


### PR DESCRIPTION
## Proposed Changes

This PR extends DNS features to allow removing default DNS records.

Depends on D123550-code.

## Testing Instructions

Run this patch locally or open the Calypso build link below.
- Select a custom domain and visit the dns management page.
- Delete the default DNS A records and verify that the records are correctly deleted
- Restore the default DNS A records and verify that the records are correctly restored

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?