### PR TITLE
Earn: Remove header card

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -1,7 +1,6 @@
 import {
 	FEATURE_SIMPLE_PAYMENTS,
 	FEATURE_WORDADS_INSTANT,
-	PLAN_100_YEARS,
 	PLAN_JETPACK_SECURITY_DAILY,
 	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
@@ -11,7 +10,6 @@ import { useTranslate } from 'i18n-calypso';
 import { compact } from 'lodash';
 import page from 'page';
 import { useState, useEffect } from 'react';
-import earnSectionImage from 'calypso/assets/images/earn/earn-section.svg';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import QueryMembershipsEarnings from 'calypso/components/data/query-memberships-earnings';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
@@ -25,7 +23,6 @@ import wp from 'calypso/lib/wp';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { useDispatch, useSelector } from 'calypso/state';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getEarningsWithDefaultsForSiteId } from 'calypso/state/memberships/earnings/selectors';
 import { getConnectedAccountIdForSiteId } from 'calypso/state/memberships/settings/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -35,8 +32,6 @@ import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { isRequestingWordAdsApprovalForSite } from 'calypso/state/wordads/approve/selectors';
-import CommissionFees from './components/commission-fees';
-import type { Image } from 'calypso/components/promo-section/promo-card/index';
 
 import './style.scss';
 
@@ -45,9 +40,6 @@ const Home = () => {
 	const dispatch = useDispatch();
 	const [ peerReferralLink, setPeerReferralLink ] = useState( '' );
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
-	const { commission } = useSelector( ( state ) =>
-		getEarningsWithDefaultsForSiteId( state, site?.ID )
-	);
 	const sitePlanSlug = useSelector( ( state ) => getSitePlanSlug( state, site?.ID ?? 0 ) );
 	const hasWordAdsFeature = useSelector( ( state ) => siteHasWordAds( state, site?.ID ?? null ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
@@ -65,8 +57,6 @@ const Home = () => {
 	const isRequestingWordAds = useSelector( ( state ) =>
 		isRequestingWordAdsApprovalForSite( state, site )
 	);
-
-	const isPlan100YearPlan = sitePlanSlug === PLAN_100_YEARS;
 
 	const hasConnectedAccount = Boolean( connectedAccountId );
 	const isNonAtomicJetpack = Boolean( isJetpack && ! isSiteTransfer );
@@ -468,49 +458,11 @@ const Home = () => {
 		};
 	};
 
-	const getHeaderCard = () => ( {
-		title: translate( 'Start earning money now' ),
-		image: {
-			path: earnSectionImage,
-			align: 'right' as Image[ 'align' ],
-		},
-		body: (
-			<>
-				{ translate(
-					'Accept credit card payments today for just about anything – physical and digital goods, services, donations and tips, or access to your exclusive content. {{a}}Watch our tutorial videos to get started{{/a}}.',
-					{
-						components: {
-							a: (
-								<a
-									href={ localizeUrl(
-										'https://wordpress.com/support/video-tutorials-add-payments-features-to-your-site-with-our-guides/'
-									) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					}
-				) }
-				<br />
-				<br />
-				<CommissionFees
-					className="earn__notes"
-					commission={ commission }
-					iconSize={ 14 }
-					siteSlug={ site?.slug }
-					isPlan100YearPlan={ isPlan100YearPlan }
-				/>
-			</>
-		),
-	} );
-
 	const getPlaceholderPromoCard = () => {
 		return { title: '', body: '', image: <div /> };
 	};
 
 	const promos: PromoSectionProps = {
-		header: getHeaderCard(),
 		promos: compact( [
 			getRecurringPaymentsCard(),
 			getDonationsCard(),
@@ -537,10 +489,7 @@ const Home = () => {
 			<QueryMembershipsSettings siteId={ site?.ID ?? 0 } />
 			{ isLoading && (
 				<div className="earn__placeholder-promo-card">
-					<PromoSection
-						header={ getHeaderCard() }
-						promos={ [ getPlaceholderPromoCard(), getPlaceholderPromoCard() ] }
-					/>
+					<PromoSection promos={ [ getPlaceholderPromoCard(), getPlaceholderPromoCard() ] } />
 				</div>
 			) }
 			{ ! isLoading && <PromoSection { ...promos } /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Removes the header card from the Earn page. This paves the way for adding the Launchpad / Stats section which will appear where the header card currently does (see figma designs here: DqXCQr1dEWpF3P2dIEwiwd-fi-791_90231).

<img width="931" alt="earn-header" src="https://github.com/Automattic/wp-calypso/assets/21228350/5a58740c-f4ae-4069-92da-8f4c33daacf8">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Checkout this branch, go to http://calypso.localhost:3000/earn/YOURDOMAIN, and confirm the header card no longer appears. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.


Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?