### PR TITLE
Earn: Move stats to home

### DIFF
--- a/client/my-sites/earn/components/stats/index.tsx
+++ b/client/my-sites/earn/components/stats/index.tsx
@@ -7,7 +7,7 @@ import SectionHeader from 'calypso/components/section-header';
 import { useSelector } from 'calypso/state';
 import { getEarningsWithDefaultsForSiteId } from 'calypso/state/memberships/earnings/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import CommissionFees from '../components/commission-fees';
+import CommissionFees from '../commission-fees';
 
 function StatsSection() {
 	const translate = useTranslate();

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -32,6 +32,7 @@ import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { isRequestingWordAdsApprovalForSite } from 'calypso/state/wordads/approve/selectors';
+import StatsSection from './components/stats';
 
 import './style.scss';
 
@@ -492,7 +493,12 @@ const Home = () => {
 					<PromoSection promos={ [ getPlaceholderPromoCard(), getPlaceholderPromoCard() ] } />
 				</div>
 			) }
-			{ ! isLoading && <PromoSection { ...promos } /> }
+			{ ! isLoading && (
+				<>
+					<StatsSection />
+					<PromoSection { ...promos } />
+				</>
+			) }
 		</>
 	);
 };

--- a/client/my-sites/earn/index.ts
+++ b/client/my-sites/earn/index.ts
@@ -5,7 +5,6 @@ import earnController from './controller';
 
 export default function () {
 	page( '/earn', siteSelection, sites, makeLayout, clientRender );
-	page( '/earn/stats', siteSelection, sites, makeLayout, clientRender );
 	page( '/earn/supporters', siteSelection, sites, makeLayout, clientRender );
 	page( '/earn/payments', siteSelection, sites, makeLayout, clientRender );
 	// This is legacy, we are leaving it here because it may have been public

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -21,7 +21,6 @@ import Home from './home';
 import MembershipsSection from './memberships';
 import MembershipsProductsSection from './memberships/products';
 import ReferAFriendSection from './refer-a-friend';
-import StatsSection from './stats';
 import { Query } from './types';
 
 type EarningsMainProps = {
@@ -43,7 +42,6 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		'ads-payments': translate( '%(wordads)s Payments', { args: { wordads: adsProgramName } } ),
 		payments: translate( 'Payment Settings' ),
 		supporters: translate( 'Supporters' ),
-		stats: translate( 'Stats' ),
 		'payments-plans': translate( 'Recurring Payments plans' ),
 		'refer-a-friend': translate( 'Refer-a-Friend Program' ),
 	};
@@ -60,11 +58,6 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				title: translate( 'Supporters' ),
 				path: '/earn/supporters' + pathSuffix,
 				id: 'supporters',
-			},
-			{
-				title: translate( 'Stats' ),
-				path: '/earn/stats' + pathSuffix,
-				id: 'stats',
 			},
 			{
 				title: translate( 'Payment Settings' ),
@@ -145,9 +138,6 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				return <MembershipsSection query={ query } />;
 			case 'payments-plans':
 				return <MembershipsProductsSection />;
-
-			case 'stats':
-				return <StatsSection />;
 
 			case 'supporters':
 				return <CustomerSection />;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Removes the separate tab/screen for stats, and adds the stats component to the top of Earn home.

In subsequent PR, we'll show Launchpad where this Earn component is until users have connected Stripe.
See figma here: DqXCQr1dEWpF3P2dIEwiwd-fi-791_90231

**Before**
<img width="1090" alt="stats-before" src="https://github.com/Automattic/wp-calypso/assets/21228350/758f6dd2-441d-467c-91cc-10a9a696e69f">

**After**
<img width="1100" alt="stats-after" src="https://github.com/Automattic/wp-calypso/assets/21228350/7a45badd-b754-41b2-a1ff-cb95ed191716">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to http://calypso.localhost:3000/earn/YOURDOMAIN, and confirm that stats tab is gone, that stats section loads at top of Earn home (the Monetization Options tab), and that the actual stats still load as expected. 
