### PR TITLE
Subscriptions Management: Display RSS tag beside RSS site subscription title

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -65,9 +65,9 @@ const SelectedNewPostDeliveryMethods = ( {
 	return <>{ selectedNewPostDeliveryMethods }</>;
 };
 
-type SiteRowProps = Reader.SiteSubscription;
+type SiteRowProps = Reader.SiteSubscriptionsResponseItem;
 
-const SiteRow = ( {
+const SiteSubscriptionRow = ( {
 	ID: subscriptionId,
 	blog_ID: blog_id,
 	feed_ID: feed_id,
@@ -79,6 +79,7 @@ const SiteRow = ( {
 	is_wpforteams_site,
 	is_paid_subscription,
 	isDeleted,
+	is_rss,
 }: SiteRowProps ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -236,11 +237,14 @@ const SiteRow = ( {
 					>
 						{ name }
 						{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
+
 						{ !! is_paid_subscription && (
 							<span className="paid-label">
 								{ translate( 'Paid', { context: 'Label for a paid subscription plan' } ) }
 							</span>
 						) }
+
+						{ !! is_rss && <span className="rss-label">RSS</span> }
 					</Link>
 					<ExternalLink
 						className="title-url"
@@ -348,4 +352,4 @@ const SiteRow = ( {
 	) : null;
 };
 
-export default SiteRow;
+export default SiteSubscriptionRow;

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscriptions-list.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscriptions-list.tsx
@@ -2,7 +2,7 @@ import { SubscriptionManager } from '@automattic/data-stores';
 import { Spinner, __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { Notice, NoticeType } from '../notice';
-import SiteRow from './site-row';
+import SiteSubscriptionRow from './site-subscription-row';
 import './styles/site-subscriptions-list.scss';
 
 type SiteSubscriptionsListProps = {
@@ -88,7 +88,10 @@ const SiteSubscriptionsList: React.FC< SiteSubscriptionsListProps > = ( {
 				<span className="actions-cell" role="columnheader" />
 			</HStack>
 			{ subscriptions.map( ( siteSubscription ) => (
-				<SiteRow key={ `sites.siteRow.${ siteSubscription.ID }` } { ...siteSubscription } />
+				<SiteSubscriptionRow
+					key={ `sites.siteRow.${ siteSubscription.ID }` }
+					{ ...siteSubscription }
+				/>
 			) ) }
 		</ul>
 	);

--- a/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
@@ -59,6 +59,10 @@
 			.paid-label {
 				@extend %paid-label;
 			}
+
+			.rss-label {
+				@extend %rss-label;
+			}
 		}
 
 		.title-url {

--- a/client/landing/subscriptions/styles/row-title-label.scss
+++ b/client/landing/subscriptions/styles/row-title-label.scss
@@ -21,3 +21,9 @@
 	@extend %row-title-label;
 	background: $studio-green-50;
 }
+
+%rss-label {
+	@extend %row-title-label;
+	color: $studio-gray-0;
+	background: $studio-orange-20;
+}

--- a/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
@@ -2,7 +2,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { EmailDeliveryFrequency } from '../constants';
 import { callApi, applyCallbackToPages, buildQueryKey } from '../helpers';
 import { useIsLoggedIn } from '../hooks';
-import type { PagedQueryResult, SiteSubscription, SiteSubscriptionDetails } from '../types';
+import type {
+	PagedQueryResult,
+	SiteSubscriptionsResponseItem,
+	SiteSubscriptionDetails,
+} from '../types';
 
 type SiteSubscriptionDeliveryFrequencyParams = {
 	delivery_frequency: EmailDeliveryFrequency;
@@ -78,30 +82,30 @@ const useSiteDeliveryFrequencyMutation = () => {
 			await queryClient.cancelQueries( siteSubscriptionDetailsCacheKey );
 
 			const previousSiteSubscriptions =
-				queryClient.getQueryData< PagedQueryResult< SiteSubscription, 'subscriptions' > >(
-					siteSubscriptionsCacheKey
-				);
-			const mutatedSiteSubscriptions = applyCallbackToPages< 'subscriptions', SiteSubscription >(
-				previousSiteSubscriptions,
-				( page ) => ( {
-					...page,
-					subscriptions: page.subscriptions.map( ( siteSubscription ) => {
-						if ( siteSubscription.blog_ID === blog_id ) {
-							return {
-								...siteSubscription,
-								delivery_methods: {
-									...siteSubscription.delivery_methods,
-									email: {
-										...( siteSubscription.delivery_methods?.email ?? { send_posts: false } ),
-										post_delivery_frequency: delivery_frequency,
-									},
+				queryClient.getQueryData<
+					PagedQueryResult< SiteSubscriptionsResponseItem, 'subscriptions' >
+				>( siteSubscriptionsCacheKey );
+			const mutatedSiteSubscriptions = applyCallbackToPages<
+				'subscriptions',
+				SiteSubscriptionsResponseItem
+			>( previousSiteSubscriptions, ( page ) => ( {
+				...page,
+				subscriptions: page.subscriptions.map( ( siteSubscription ) => {
+					if ( siteSubscription.blog_ID === blog_id ) {
+						return {
+							...siteSubscription,
+							delivery_methods: {
+								...siteSubscription.delivery_methods,
+								email: {
+									...( siteSubscription.delivery_methods?.email ?? { send_posts: false } ),
+									post_delivery_frequency: delivery_frequency,
 								},
-							};
-						}
-						return siteSubscription;
-					} ),
-				} )
-			);
+							},
+						};
+					}
+					return siteSubscription;
+				} ),
+			} ) );
 			queryClient.setQueryData( siteSubscriptionsCacheKey, mutatedSiteSubscriptions );
 
 			const previousSiteSubscriptionDetailsByBlogId =

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -4,12 +4,12 @@ import { SiteSubscriptionsFilterBy, SiteSubscriptionsSortBy } from '../constants
 import { useSiteSubscriptionsQueryProps } from '../contexts';
 import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
-import type { SiteSubscription } from '../types';
+import type { SiteSubscriptionsResponseItem } from '../types';
 
 export const siteSubscriptionsQueryKeyPrefix = [ 'read', 'site-subscriptions' ];
 
 type SubscriptionManagerSiteSubscriptions = {
-	subscriptions: SiteSubscription[];
+	subscriptions: SiteSubscriptionsResponseItem[];
 	page: number;
 	total_subscriptions: number;
 };
@@ -18,17 +18,20 @@ type SubscriptionManagerSiteSubscriptionsQueryProps = {
 	number?: number;
 };
 
-const sortByDateSubscribed = ( a: SiteSubscription, b: SiteSubscription ) =>
+const sortByDateSubscribed = (
+	a: SiteSubscriptionsResponseItem,
+	b: SiteSubscriptionsResponseItem
+) =>
 	a.date_subscribed instanceof Date && b.date_subscribed instanceof Date
 		? b.date_subscribed.getTime() - a.date_subscribed.getTime()
 		: 0;
 
-const sortByLastUpdated = ( a: SiteSubscription, b: SiteSubscription ) =>
+const sortByLastUpdated = ( a: SiteSubscriptionsResponseItem, b: SiteSubscriptionsResponseItem ) =>
 	a.last_updated instanceof Date && b.last_updated instanceof Date
 		? b.last_updated.getTime() - a.last_updated.getTime()
 		: 0;
 
-const sortBySiteName = ( a: SiteSubscription, b: SiteSubscription ) =>
+const sortBySiteName = ( a: SiteSubscriptionsResponseItem, b: SiteSubscriptionsResponseItem ) =>
 	a.name.localeCompare( b.name );
 
 const getSortFunction = ( sortTerm: SiteSubscriptionsSortBy ) => {
@@ -93,7 +96,7 @@ const useSiteSubscriptionsQuery = ( {
 	}, [ nextPage, fetchNextPage ] );
 
 	const filterFunction = useCallback(
-		( item: SiteSubscription ) => {
+		( item: SiteSubscriptionsResponseItem ) => {
 			switch ( filterOption ) {
 				case SiteSubscriptionsFilterBy.Paid:
 					return item.is_paid_subscription;
@@ -112,7 +115,7 @@ const useSiteSubscriptionsQuery = ( {
 		const flattenedData = data?.pages?.map( ( page ) => page.subscriptions ).flat();
 
 		const searchTermLowerCase = searchTerm.toLowerCase();
-		const searchFilter = ( item: SiteSubscription ) => {
+		const searchFilter = ( item: SiteSubscriptionsResponseItem ) => {
 			if ( searchTerm === '' ) {
 				return true;
 			}

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -53,7 +53,7 @@ export type PagedQueryResult< TDataType, TKey extends string > = {
 	pageParams: number;
 };
 
-export type SiteSubscription = {
+export type SiteSubscriptionsResponseItem = {
 	ID: string;
 	blog_ID: string;
 	feed_ID: string;
@@ -70,10 +70,11 @@ export type SiteSubscription = {
 	is_wpforteams_site: boolean;
 	is_paid_subscription: boolean;
 	isDeleted: boolean;
+	is_rss: boolean;
 };
 
 export type SiteSubscriptionPage = {
-	subscriptions: SiteSubscription[];
+	subscriptions: SiteSubscriptionsResponseItem[];
 	total_subscriptions: number;
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/82338

![LCh7kU.png](https://github.com/Automattic/wp-calypso/assets/2019970/b66c73af-b63a-4c88-9663-55260393d6b6)

## Proposed Changes

* Display RSS tag beside site subscriptions to non-WPCOM and non-Jetpack connected feeds
* Rename `SiteRow` component to `SiteSubscriptionRow` for clarity, the misleading compoentn name caught out me few times already
* Similarly rename the `Reader.SiteSubscription` type to ` Reader.SiteSubscriptionsResponseItem`. Otherwise it introduces confusion between the `SiteSubscriptions` type and `SiteSubscriptionDetails` for example. They are not very descriptive, and introduce ambiguity in my opinion. Similary the `SiteSubscriptionDetails` should be renamed to `SiteSubscriptionDetailsResponse` in my opinion.  In my opinion, it should be clear from the looking at the type name that types which use snake case syntax are associated with an API response.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Many RSS feeds do not work properly with Reader ATM, due to an issue with domain mapping which is being worked on elsewhere. The site I recommend testing with: https://www.dailymail.co.uk
* Go to `/read/subscriptions`
* Search for an RSS feed site and subscribe to it, e.g.: https://www.dailymail.co.uk
* Notice how the RSS tag is displayed beside the title of your new subscription's site 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?