### PR TITLE
Revert "Ships free/free and partial paid/free experiment variants"

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -8,18 +8,10 @@ const useIsCustomDomainAllowedOnFreePlan = (
 	const EXPERIMENT_NAME =
 		flowName === 'onboarding'
 			? 'calypso_onboarding_plans_paid_domain_on_free_plan_confidence_check'
-			: '';
+			: 'calypso_onboardingpm_plans_paid_domain_on_free_plan';
 	const [ isLoading, assignment ] = useExperiment( EXPERIMENT_NAME, {
-		isEligible: flowName === 'onboarding' && hasPaidDomainName,
+		isEligible: [ 'onboarding', 'onboarding-pm' ].includes( flowName ?? '' ) && hasPaidDomainName,
 	} );
-
-	/** Ships experiment variant to onboarding-pm flow only  */
-	if ( flowName === 'onboarding-pm' ) {
-		return {
-			isLoading: false,
-			result: true,
-		};
-	}
 
 	return {
 		isLoading,

--- a/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
@@ -1,17 +1,21 @@
+import { useExperiment } from 'calypso/lib/explat';
 import type { DataResponse } from 'calypso/my-sites/plans-grid/types';
 
-/**
- * TODO: Cleanup pending, this condition needs to be removed
- */
 const useIsPlanUpsellEnabledOnFreeDomain = (
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	flowName?: string | null,
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	hasPaidDomain?: boolean
 ): DataResponse< boolean > => {
+	const ONBOARDING_EXPERIMENT = 'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3';
+	const ONBOARDING_PM_EXPERIMENT =
+		'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3';
+	const relevantExperiment =
+		flowName === 'onboarding' ? ONBOARDING_EXPERIMENT : ONBOARDING_PM_EXPERIMENT;
+	const [ isLoading, experimentAssignment ] = useExperiment( relevantExperiment, {
+		isEligible: [ 'onboarding', 'onboarding-pm' ].includes( flowName ?? '' ) && ! hasPaidDomain,
+	} );
 	return {
-		isLoading: false,
-		result: true,
+		isLoading,
+		result: experimentAssignment?.variationName === 'treatment',
 	};
 };
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#82189

There is an E2E test that needs to be fixed. Reverting for now to release deploy Queue