### PR TITLE
Attempt 2 - Ships free/free and partial paid/free experiment variants

### DIFF
--- a/client/my-sites/plans-features-main/components/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-free-domain-dialog.tsx
@@ -292,7 +292,7 @@ export function FreePlanFreeDomainDialog( {
 
 				<ButtonRow>
 					<StyledButton
-						className="free-plan-free-domain-dialog__plan-button is-upsell-modal-free-plan"
+						className="free-plan-free-domain-dialog__plan-button is-upsell-modal-personal-plan"
 						disabled={ freeSubdomain.isLoading || ! freeSubdomain.result }
 						primary
 						onClick={ () => {
@@ -308,7 +308,7 @@ export function FreePlanFreeDomainDialog( {
 					</StyledButton>
 
 					<StyledButton
-						className="free-plan-free-domain-dialog__plan-button is-upsell-modal-personal-plan"
+						className="free-plan-free-domain-dialog__plan-button is-upsell-modal-free-plan"
 						disabled={ freeSubdomain.isLoading || ! freeSubdomain.result }
 						onClick={ () => {
 							onFreePlanSelected();

--- a/client/my-sites/plans-features-main/components/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/free-plan-free-domain-dialog.tsx
@@ -292,6 +292,7 @@ export function FreePlanFreeDomainDialog( {
 
 				<ButtonRow>
 					<StyledButton
+						className="free-plan-free-domain-dialog__plan-button is-upsell-modal-free-plan"
 						disabled={ freeSubdomain.isLoading || ! freeSubdomain.result }
 						primary
 						onClick={ () => {
@@ -307,6 +308,7 @@ export function FreePlanFreeDomainDialog( {
 					</StyledButton>
 
 					<StyledButton
+						className="free-plan-free-domain-dialog__plan-button is-upsell-modal-personal-plan"
 						disabled={ freeSubdomain.isLoading || ! freeSubdomain.result }
 						onClick={ () => {
 							onFreePlanSelected();

--- a/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
@@ -1,9 +1,7 @@
-import { useExperiment } from 'calypso/lib/explat';
 import type { DataResponse } from 'calypso/my-sites/plans-grid/types';
 
 const useIsPlanUpsellEnabledOnFreeDomain = (
-	flowName?: string | null,
-	hasPaidDomain?: boolean
+	flowName?: string | null
 ): DataResponse< boolean > => {
 	if ( flowName === 'onboarding' || flowName === 'onboarding-pm' ) {
 		return {

--- a/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts
@@ -5,17 +5,15 @@ const useIsPlanUpsellEnabledOnFreeDomain = (
 	flowName?: string | null,
 	hasPaidDomain?: boolean
 ): DataResponse< boolean > => {
-	const ONBOARDING_EXPERIMENT = 'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3';
-	const ONBOARDING_PM_EXPERIMENT =
-		'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3';
-	const relevantExperiment =
-		flowName === 'onboarding' ? ONBOARDING_EXPERIMENT : ONBOARDING_PM_EXPERIMENT;
-	const [ isLoading, experimentAssignment ] = useExperiment( relevantExperiment, {
-		isEligible: [ 'onboarding', 'onboarding-pm' ].includes( flowName ?? '' ) && ! hasPaidDomain,
-	} );
+	if ( flowName === 'onboarding' || flowName === 'onboarding-pm' ) {
+		return {
+			isLoading: false,
+			result: true,
+		};
+	}
 	return {
-		isLoading,
-		result: experimentAssignment?.variationName === 'treatment',
+		isLoading: false,
+		result: false,
 	};
 };
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -235,10 +235,7 @@ const PlansFeaturesMain = ( {
 		flowName,
 		!! paidDomainName
 	);
-	const isPlanUpsellEnabledOnFreeDomain = useIsPlanUpsellEnabledOnFreeDomain(
-		flowName,
-		!! paidDomainName
-	);
+	const isPlanUpsellEnabledOnFreeDomain = useIsPlanUpsellEnabledOnFreeDomain( flowName );
 	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
 	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -20,6 +20,12 @@ const selectors = {
 		}
 		return `button.is-${ name.toLowerCase() }-plan:visible`;
 	},
+	selectModalUpsellPlanButton: ( name: 'Free' | 'Personal' ) => {
+		if ( name === 'Free' ) {
+			return `button.is-upsell-modal-free-plan:visible`;
+		}
+		return `button.is-upsell-modal-${ name.toLowerCase() }-plan:visible`;
+	},
 
 	// Navigation
 	mobileNavTabsToggle: `button.section-nav__mobile-header`,
@@ -86,6 +92,21 @@ export class PlansPage {
 		const locator = this.page.locator( selectors.selectPlanButton( plan ) );
 		// In the `/plans` view, there are two buttons for "Upgrade" on the
 		// plan comparison chart. Select the first one.
+		await locator.first().click();
+	}
+
+	/**
+	 * Selects the plan on the modal upsell.
+	 *
+	 * @param {Plans} plan Plan to select.
+	 */
+	async selectModalUpsellPlan( plan: Plans ): Promise< void > {
+		if ( plan !== 'Free' && plan !== 'Personal' ) {
+			throw Error( `Unsupported plan to be selected in modal upsell: ${ plan }` );
+		}
+
+		const locator = this.page.locator( selectors.selectModalUpsellPlanButton( plan ) );
+
 		await locator.first().click();
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -45,7 +45,7 @@ export class SignupPickPlanPage {
 			url = new RegExp( '.*setup/site-setup.*' );
 		}
 
-		if ( name !== 'Free' ) {
+		if ( name === 'Free' ) {
 			if ( this.selectedDomain?.includes( 'wordpress.com' ) ) {
 				/** Shows a modal */
 				await this.plansPage.selectPlan( name );

--- a/test/e2e/specs/onboarding/ftme__site-assembler.ts
+++ b/test/e2e/specs/onboarding/ftme__site-assembler.ts
@@ -42,7 +42,7 @@ describe( 'Site Assembler', () => {
 		} );
 
 		it( `Select WordPress.com Free plan`, async function () {
-			const signupPickPlanPage = new SignupPickPlanPage( page );
+			const signupPickPlanPage = new SignupPickPlanPage( page, selectedFreeDomain );
 			newSiteDetails = await signupPickPlanPage.selectPlan( 'Free' );
 		} );
 	} );

--- a/test/e2e/specs/onboarding/ftme__write.ts
+++ b/test/e2e/specs/onboarding/ftme__write.ts
@@ -46,7 +46,7 @@ describe( DataHelper.createSuiteTitle( 'FTME: Write' ), function () {
 		} );
 
 		it( `Select WordPress.com Free plan`, async function () {
-			const signupPickPlanPage = new SignupPickPlanPage( page );
+			const signupPickPlanPage = new SignupPickPlanPage( page, selectedFreeDomain );
 			newSiteDetails = await signupPickPlanPage.selectPlan( 'Free' );
 
 			siteCreatedFlag = true;


### PR DESCRIPTION
Related to #

## Proposed Changes
This was an approved PR which was reverted due to E2E test failures. This PR also adds those E2E changes

- Initial https://github.com/Automattic/wp-calypso/pull/82189
- Revert https://github.com/Automattic/wp-calypso/pull/82360

---
### Feature Additions 

One key change I did related to the initial feature implementation was further restricting the free/free modal to only 2 flows.
https://github.com/Automattic/wp-calypso/blob/5ebeaba1daa5893d52206639a64757ecaafbddbf/client/my-sites/plans-features-main/hooks/use-is-plan-upsell-enabled-on-free-domain.ts#L11-L16

### Test Fixes

Adds a modal check when someone selects Free Plan/Free Domain

https://github.com/Automattic/wp-calypso/blob/bb93403616c6131277707cf1602f4b8fe99c0164/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts#L48-L49

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run E2E Tests
    * PCYsg-JGn-p2

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?