### PR TITLE
Jetpack Manage: Show a notice on the dashboard when a new site is being provisioned

### DIFF
--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -56,6 +56,7 @@ const useFetchDashboardSites = (
 			),
 		select: ( data ) => {
 			return {
+				provisioningBlogIds: data.provisioning_blog_ids,
 				sites: data.sites.map( ( site: Site ) => {
 					// Since the "sites" API includes the "is_connected" property in the cache of the query set by
 					// the "useFetchTestConnection" hook, we are setting it here again since the "sites" API gets called

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -56,7 +56,6 @@ const useFetchDashboardSites = (
 			),
 		select: ( data ) => {
 			return {
-				provisioningBlogIds: data.provisioning_blog_ids,
 				sites: data.sites.map( ( site: Site ) => {
 					// Since the "sites" API includes the "is_connected" property in the cache of the query set by
 					// the "useFetchTestConnection" hook, we are setting it here again since the "sites" API gets called

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-query-provisioning-blog-ids.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-query-provisioning-blog-ids.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
+import { wpcomJetpackLicensing } from 'calypso/lib/wp';
+import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
+
+type QueryProvisioningBlogIdsApiResponse = {
+	provisioning_blog_ids: number[];
+};
+
+const useQueryProvisioningBlogIds = () => {
+	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
+
+	return useQuery< QueryProvisioningBlogIdsApiResponse, never, number[] >( {
+		queryKey: [ 'jetpack-agency-dashboard-provisioning-sites' ],
+		queryFn: () =>
+			wpcomJetpackLicensing.req.get( {
+				path: '/jetpack-agency/provisioning-sites',
+				apiNamespace: 'wpcom/v2',
+			} ),
+		select: ( data ) => data.provisioning_blog_ids,
+		enabled: isPartnerOAuthTokenLoaded,
+	} );
+};
+
+export default useQueryProvisioningBlogIds;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -8,6 +8,7 @@ import page from 'page';
 import { useContext, useEffect, useState, useMemo, createRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import Notice from 'calypso/components/notice';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -236,6 +237,8 @@ export default function SitesOverview() {
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
 
+	const isProvisioningSite = ! isLoading && data?.provisioningBlogIds?.length > 0;
+
 	return (
 		<div className="sites-overview">
 			<DocumentHead title={ pageTitle } />
@@ -245,6 +248,13 @@ export default function SitesOverview() {
 					<div className="sites-overview__content-wrapper">
 						<DashboardBanners />
 
+						{ isProvisioningSite && (
+							<Notice status="is-info">
+								{ translate(
+									"We're setting up your new WordPress.com site and will notify you once it's ready, which should only take a few minutes."
+								) }
+							</Notice>
+						) }
 						{ data?.sites && <SiteAddLicenseNotification /> }
 						<SiteContentHeader
 							content={

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -244,7 +244,8 @@ export default function SitesOverview() {
 	const [ hasDismissedProvisioningNotice, setHasDismissedProvisioningNotice ] =
 		useState< boolean >( false );
 	const isProvisioningSite =
-		! isLoadingProvisioningBlogIds && Number( provisioningBlogIds?.length ) > 0;
+		'true' === getQueryArg( window.location.href, 'provisioning' ) ||
+		( ! isLoadingProvisioningBlogIds && Number( provisioningBlogIds?.length ) > 0 );
 
 	return (
 		<div className="sites-overview">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -29,6 +29,7 @@ import OnboardingWidget from '../../partner-portal/primary/onboarding-widget';
 import SitesOverviewContext from './context';
 import DashboardBanners from './dashboard-banners';
 import DashboardDataContext from './dashboard-data-context';
+import useQueryProvisioningBlogIds from './hooks/use-query-provisioning-blog-ids';
 import { DASHBOARD_PRODUCT_SLUGS_BY_TYPE } from './lib/constants';
 import SiteAddLicenseNotification from './site-add-license-notification';
 import SiteContent from './site-content';
@@ -237,7 +238,10 @@ export default function SitesOverview() {
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
 
-	const isProvisioningSite = ! isLoading && data?.provisioningBlogIds?.length > 0;
+	const { data: provisioningBlogIds, isLoading: isLoadingProvisioningBlogIds } =
+		useQueryProvisioningBlogIds();
+	const isProvisioningSite =
+		! isLoadingProvisioningBlogIds && Number( provisioningBlogIds?.length ) > 0;
 
 	return (
 		<div className="sites-overview">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -240,6 +240,9 @@ export default function SitesOverview() {
 
 	const { data: provisioningBlogIds, isLoading: isLoadingProvisioningBlogIds } =
 		useQueryProvisioningBlogIds();
+
+	const [ hasDismissedProvisioningNotice, setHasDismissedProvisioningNotice ] =
+		useState< boolean >( false );
 	const isProvisioningSite =
 		! isLoadingProvisioningBlogIds && Number( provisioningBlogIds?.length ) > 0;
 
@@ -252,8 +255,11 @@ export default function SitesOverview() {
 					<div className="sites-overview__content-wrapper">
 						<DashboardBanners />
 
-						{ isProvisioningSite && (
-							<Notice status="is-info">
+						{ isProvisioningSite && ! hasDismissedProvisioningNotice && (
+							<Notice
+								status="is-info"
+								onDismissClick={ () => setHasDismissedProvisioningNotice( true ) }
+							>
 								{ translate(
 									"We're setting up your new WordPress.com site and will notify you once it's ready, which should only take a few minutes."
 								) }

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -132,7 +132,7 @@ export default function CardContent( {
 		issueLicenses( [ productSlug ] );
 
 		setIsRequesting( false );
-		page.redirect( `/partner-portal/licenses?provisioning=true` );
+		page.redirect( `/dashboard?provisioning=true` );
 	}, [ dispatch, planSlug, issueLicenses, translate, setIsRequesting ] );
 
 	if ( ! plan ) {


### PR DESCRIPTION
This pull request is meant to give customers more apparent feedback when a new site they've added is still being provisioned.

## Proposed Changes

* Expose `provisioning_blog_ids` in the API response payload for `/jetpack-agency/sites`.
* Add a `<Notice>` in the Sites Overview component that renders only if `provisioning_blog_ids` is a non-empty array.

## Testing Instructions

***Setup:** ensure you've sandboxed the WordPress.com API in your testing environment, and that in your sandbox, the patch ~~D123558-code~~ D123647-code is applied.*

1. Visit Jetpack Manage and either: (a) click **Add new site > Create new WordPress.com site** on the Dashboard; or (b), use the sidebar navigation to do the same by selecting **Switch site** and clicking the **Add new site** button at the bottom.
2. Select either **Business** or **eCommerce** to provision a new site.
3. Return to the Dashboard. Verify a new notice is displayed while your site is being provisioned; and, that once it's finished provisioning, the notice disappears. You may also dismiss the banner yourself using the X, but it should return if you revisit the page and your site is still being provisioned.

### Reference screenshots

<img height="250" src="https://github.com/Automattic/wp-calypso/assets/670067/7c163473-ca0f-4362-ac48-8ccecb679ae0">
<img height="250" src="https://github.com/Automattic/wp-calypso/assets/670067/0152d5a2-53d5-4e15-8158-d47b6b1e39c1">
<img height="250" src="https://github.com/Automattic/wp-calypso/assets/670067/f56a4623-928b-4db8-aa43-c5c06c487bb8">