### PR TITLE
Login: Magic Link: Logged in

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -124,6 +124,10 @@ export async function login( context, next ) {
 export function magicLogin( context, next ) {
 	const { path } = context;
 
+	if ( isUserLoggedIn( context.store.getState() ) ) {
+		return login( context, next );
+	}
+
 	context.primary = <MagicLogin path={ path } />;
 
 	next();

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -73,7 +73,6 @@ export default ( router ) => {
 
 		router(
 			[ `/log-in/link/${ lang }`, `/log-in/jetpack/link/${ lang }`, `/log-in/new/link/${ lang }` ],
-			redirectLoggedIn,
 			setLocaleMiddleware(),
 			setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 			magicLogin,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

When a user is already logged in, navigating to https://wordpress.com/log-in?redirect_to=http://jetpack.com works as expected. However, using https://wordpress.com/log-in/link?redirect_to=http://jetpack.com redirects the user to the root / page instead.

## Proposed Changes

**Solution:**
This PR harmonizes the behavior of the two URLs. Now, when a user is logged in and visits https://wordpress.com/log-in/link?redirect_to=http://nuevadecadencia.com, they will see the ContinueAsUser component and respect the `redirect_to`  query argument in the same manner as with https://wordpress.com/log-in?redirect_to=http://jetpack.com.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Make sure you are logged in to WPCOM
* Go to http://calypso.localhost:3000/log-in/link?redirect_to=https://jetpack.com
* Or go to (Live branch link: https://container-eloquent-chaplygin.calypso.live/log-in/link?redirect_to=https://jetpack.com)
* Confirm you get redirected to the desired url


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?