### PR TITLE
Domain Forwarding: Sync DNS records on Forwarding save

### DIFF
--- a/client/components/data/query-domain-dns/index.jsx
+++ b/client/components/data/query-domain-dns/index.jsx
@@ -2,10 +2,10 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { fetchDns } from 'calypso/state/domains/dns/actions';
 
-export default function QueryDomainDns( { domain } ) {
+export default function QueryDomainDns( { domain, forceReload = false } ) {
 	const dispatch = useDispatch();
 	useEffect( () => {
-		dispatch( fetchDns( domain ) );
+		dispatch( fetchDns( domain, forceReload ) );
 	}, [ dispatch, domain ] );
 
 	return null;

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -7,6 +7,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { CAPTURE_URL_RGX_SOFT } from 'calypso/blocks/import/util';
+import QueryDomainDns from 'calypso/components/data/query-domain-dns';
 import Accordion from 'calypso/components/domains/accordion';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -27,6 +28,7 @@ import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import { validateDomainForwarding } from './utils/domain-forwarding';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
+
 import './style.scss';
 
 const noticeOptions = {
@@ -53,9 +55,14 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 	const [ forwardPaths, setForwardPaths ] = useState( false );
 	const [ isPermanent, setIsPermanent ] = useState( false );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
+<<<<<<< HEAD
 	const [ protocol, setProtocol ] = useState( 'https' );
+=======
+	const [ forceReloadDns, setForceReloadDns ] = useState( false );
+>>>>>>> 1cce51f1a1 (Rebase)
 	const pointsToWpcom = domain.pointsToWpcom;
 	const isDomainOnly = useSelector( ( state ) => isDomainOnlySite( state, domain.blogId ) );
+
 	const isPrimaryDomain = domain?.isPrimary && ! isDomainOnly;
 
 	// Display success notices when the forwarding is updated
@@ -66,6 +73,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 			);
 			// TODO: open the edition of the new forwarding we just created
 			setEditingId( 0 );
+			setForceReloadDns( true );
 		},
 		onError( error ) {
 			dispatch( errorNotice( error.message, noticeOptions ) );
@@ -79,6 +87,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 			dispatch(
 				successNotice( translate( 'Domain forward deleted successfully.' ), noticeOptions )
 			);
+			setForceReloadDns( true );
 		},
 		onError() {
 			dispatch(
@@ -128,6 +137,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 			return;
 		}
 
+		setForceReloadDns( false );
 		// By default, the interface already opens with domain forwarding addition
 		if ( data?.length === 0 ) {
 			setEditingId( -1 );
@@ -609,6 +619,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 		<>
 			{ renderNotice() }
 			{ renderNoticeForPrimaryDomain() }
+			{ forceReloadDns && <QueryDomainDns domain={ domain.name } forceReload={ true } /> }
 			<form
 				onSubmit={ ( e ) => {
 					e.preventDefault();
@@ -618,7 +629,6 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 				{ data?.map( ( item ) =>
 					shouldEdit( item ) ? FormRowEdditable( { child: item } ) : FormViewRow( { child: item } )
 				) }
-
 				{ editingId === -1 &&
 					FormRowEdditable( {
 						child: {

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -55,11 +55,8 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 	const [ forwardPaths, setForwardPaths ] = useState( false );
 	const [ isPermanent, setIsPermanent ] = useState( false );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
-<<<<<<< HEAD
 	const [ protocol, setProtocol ] = useState( 'https' );
-=======
 	const [ forceReloadDns, setForceReloadDns ] = useState( false );
->>>>>>> 1cce51f1a1 (Rebase)
 	const pointsToWpcom = domain.pointsToWpcom;
 	const isDomainOnly = useSelector( ( state ) => isDomainOnlySite( state, domain.blogId ) );
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3684

## Proposed Changes

Sync DNS records after saving a new domain forwarding because Domain Forwarding creates new A records

## Testing Instructions

- Click on "DNS records" of a domain
- Add a new subdomain forwarding in the Domain Forwarding card
- Click on "DNS records" and check the new subdomain exists
- Same but clicking on "manage"
- Check if the "DNS record" is deleted when delete a Subdomain Forwarding.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?