### PR TITLE
Domains: Remove specific status notices for VIP sites

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -133,11 +133,10 @@ export function resolveDomainStatus(
 				};
 			}
 
-			if ( getMappingErrors && siteSlug !== null ) {
+			if ( getMappingErrors && siteSlug !== null && ! isVipSite ) {
 				const registrationDatePlus3Days = moment.utc( domain.registrationDate ).add( 3, 'days' );
 
 				const hasMappingError =
-					! isVipSite &&
 					domain.type === domainTypes.MAPPED &&
 					! domain.pointsToWpcom &&
 					moment.utc().isAfter( registrationDatePlus3Days );

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -50,6 +50,7 @@ export type ResolveDomainStatusOptionsBag = {
 	currentRoute?: string | null;
 	getMappingErrors?: boolean | null;
 	dismissPreferences?: any;
+	isVipSite?: boolean | null;
 };
 
 export function resolveDomainStatus(
@@ -65,6 +66,7 @@ export function resolveDomainStatus(
 		getMappingErrors = false,
 		currentRoute = null,
 		dismissPreferences = null,
+		isVipSite = false,
 	}: ResolveDomainStatusOptionsBag = {}
 ): ResolveDomainStatusReturn {
 	const transferOptions = {
@@ -107,7 +109,7 @@ export function resolveDomainStatus(
 
 				let noticeText = null;
 
-				if ( ! domain.pointsToWpcom ) {
+				if ( ! isVipSite && ! domain.pointsToWpcom ) {
 					noticeText = translate(
 						"We noticed that something wasn't updated correctly. Please try {{a}}this setup{{/a}} again.",
 						{ components: mappingSetupComponents }
@@ -135,6 +137,7 @@ export function resolveDomainStatus(
 				const registrationDatePlus3Days = moment.utc( domain.registrationDate ).add( 3, 'days' );
 
 				const hasMappingError =
+					! isVipSite &&
 					domain.type === domainTypes.MAPPED &&
 					! domain.pointsToWpcom &&
 					moment.utc().isAfter( registrationDatePlus3Days );
@@ -154,7 +157,11 @@ export function resolveDomainStatus(
 				}
 			}
 
-			if ( ( ! isJetpackSite || isSiteAutomatedTransfer ) && ! domain.pointsToWpcom ) {
+			if (
+				! isVipSite &&
+				( ! isJetpackSite || isSiteAutomatedTransfer ) &&
+				! domain.pointsToWpcom
+			) {
 				return {
 					statusText: translate( 'Verifying' ),
 					statusClass: 'status-success',

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -149,6 +149,7 @@ class DomainRow extends PureComponent {
 			siteSlug: site?.slug,
 			getMappingErrors: true,
 			currentRoute,
+			isVipSite: site?.is_vip,
 		} );
 
 		const domainStatusClass = classnames( 'domain-row__status-cell', {
@@ -488,6 +489,7 @@ class DomainRow extends PureComponent {
 				siteSlug: site?.slug,
 				getMappingErrors: true,
 				currentRoute,
+				isVipSite: site?.is_vip,
 			}
 		);
 

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -156,6 +156,7 @@ export class SiteDomains extends Component {
 						resolveDomainStatus( domain, null, translate, dispatch, {
 							getMappingErrors: true,
 							siteSlug: selectedSite.slug,
+							isVipSite: selectedSite.is_vip,
 						} )
 					)
 				),

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -101,6 +101,7 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 	const renderStatusBadge = ( domain: ResponseDomain ) => {
 		const { status, statusClass } = resolveDomainStatus( domain, null, translate, dispatch, {
 			currentRoute,
+			isVipSite: site.is_vip,
 		} );
 
 		if ( status ) {
@@ -140,6 +141,7 @@ export default function SettingsHeader( { domain, site, purchase }: SettingsHead
 				getMappingErrors: true,
 				currentRoute,
 				dismissPreferences: hasNoticePreferences ? noticeDismissPreferences : null,
+				isVipSite: site.is_vip,
 			}
 		);
 

--- a/packages/domains-table/src/use-domain-row.ts
+++ b/packages/domains-table/src/use-domain-row.ts
@@ -76,6 +76,7 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 					isPurchasedDomain: domainStatusPurchaseActions?.isPurchasedDomain?.( currentDomainData ),
 					isCreditCardExpiring:
 						domainStatusPurchaseActions?.isCreditCardExpiring?.( currentDomainData ),
+					isVipSite: site?.is_vip,
 				} )
 			)
 			.filter( notNull );
@@ -137,6 +138,7 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 					domainStatusPurchaseActions?.onRenewNowClick?.( siteSlug ?? '', currentDomainData ),
 				monthsUtilCreditCardExpires:
 					domainStatusPurchaseActions?.monthsUtilCreditCardExpires?.( currentDomainData ),
+				isVipSite: site?.is_vip,
 		  } )
 		: null;
 

--- a/packages/domains-table/src/utils/resolve-domain-status.tsx
+++ b/packages/domains-table/src/utils/resolve-domain-status.tsx
@@ -53,6 +53,7 @@ export type ResolveDomainStatusOptionsBag = {
 	onRenewNowClick?(): void;
 	isCreditCardExpiring?: boolean | null;
 	monthsUtilCreditCardExpires?: number | null;
+	isVipSite?: boolean | null;
 };
 
 export type DomainStatusPurchaseActions = {
@@ -73,6 +74,7 @@ export function resolveDomainStatus(
 		onRenewNowClick,
 		isCreditCardExpiring = false,
 		monthsUtilCreditCardExpires = null,
+		isVipSite = false,
 	}: ResolveDomainStatusOptionsBag
 ): ResolveDomainStatusReturn | null {
 	const transferOptions = {
@@ -121,7 +123,7 @@ export function resolveDomainStatus(
 
 				let noticeText = null;
 
-				if ( ! domain.pointsToWpcom ) {
+				if ( ! isVipSite && ! domain.pointsToWpcom ) {
 					noticeText = translate( "We noticed that something wasn't updated correctly." );
 					callToAction = mappingSetupCallToAction;
 				}
@@ -148,6 +150,7 @@ export function resolveDomainStatus(
 				const registrationDatePlus3Days = moment.utc( domain.registrationDate ).add( 3, 'days' );
 
 				const hasMappingError =
+					! isVipSite &&
 					domain.type === domainTypes.MAPPED &&
 					! domain.pointsToWpcom &&
 					moment.utc().isAfter( registrationDatePlus3Days );

--- a/packages/domains-table/src/utils/resolve-domain-status.tsx
+++ b/packages/domains-table/src/utils/resolve-domain-status.tsx
@@ -146,11 +146,10 @@ export function resolveDomainStatus(
 				};
 			}
 
-			if ( getMappingErrors ) {
+			if ( getMappingErrors && ! isVipSite ) {
 				const registrationDatePlus3Days = moment.utc( domain.registrationDate ).add( 3, 'days' );
 
 				const hasMappingError =
-					! isVipSite &&
 					domain.type === domainTypes.MAPPED &&
 					! domain.pointsToWpcom &&
 					moment.utc().isAfter( registrationDatePlus3Days );


### PR DESCRIPTION
Removes the status notice - displayed on the domain management page - for mapped domains in VIP sites. 

## Testing Instructions
- With any VIP site with a mapped domain, go to /domains/manage/:sitePrimaryDomain
- Ensure you can't see any notice regarding the mapping - `We noticed that something wasn't updated correctly (...)` notice.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?