### PR TITLE
Subscription Management: Add a “Manage Subscription” dropdown menu item on the Settings dropdown

### DIFF
--- a/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
@@ -1,5 +1,6 @@
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
+import { Icon, settings } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRecordViewFeedButtonClicked } from 'calypso/landing/subscriptions/tracks';
@@ -83,6 +84,7 @@ type SiteSettingsPopoverProps = SiteSettingsProps & {
 	unsubscribing: boolean;
 	blogId?: number;
 	feedId: number;
+	subscriptionId: number;
 };
 
 export const SiteSettingsPopover = ( {
@@ -90,6 +92,7 @@ export const SiteSettingsPopover = ( {
 	unsubscribing,
 	blogId,
 	feedId,
+	subscriptionId,
 	...props
 }: SiteSettingsPopoverProps ) => {
 	const translate = useTranslate();
@@ -102,7 +105,29 @@ export const SiteSettingsPopover = ( {
 		>
 			{ ( close: () => void ) => (
 				<>
-					{ isWpComSite && <SiteSettings { ...props } /> }
+					{ isWpComSite && (
+						<>
+							<SiteSettings { ...props } />
+
+							<Button
+								className="site-settings-popover__manage-subscription-button"
+								icon={
+									<Icon
+										className="subscriptions-ellipsis-menu__item-icon"
+										size={ 20 }
+										icon={ settings }
+									/>
+								}
+								href={ `/read/subscriptions/${ subscriptionId }` }
+								onClick={ () => {
+									onUnsubscribe();
+									close();
+								} }
+							>
+								{ translate( 'Manage subscription' ) }
+							</Button>
+						</>
+					) }
 
 					<Button
 						className={ classNames( 'site-settings-popover__unsubscribe-button', {

--- a/client/landing/subscriptions/components/settings/site-settings/styles.scss
+++ b/client/landing/subscriptions/components/settings/site-settings/styles.scss
@@ -14,7 +14,8 @@
 	}
 
 	&__unsubscribe-button.components-button.has-icon,
-	&__view-feed-button.components-button.has-icon {
+	&__view-feed-button.components-button.has-icon,
+	&__manage-subscription-button.components-button.has-icon {
 		display: flex;
 		width: 100%;
 		height: auto;
@@ -28,6 +29,11 @@
 
 		&:not(:last-child) {
 			margin-bottom: 24px;
+		}
+
+		.subscriptions-ellipsis-menu__item-icon {
+			width: 20px;
+			height: 20px;
 		}
 	}
 }

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -346,6 +346,7 @@ const SiteSubscriptionRow = ( {
 					unsubscribing={ unsubscribing }
 					blogId={ sanitizedBlogId }
 					feedId={ Number( feed_id ) }
+					subscriptionId={ Number( subscriptionId ) }
 				/>
 			</span>
 		</HStack>


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82369

## Proposed Changes

* Add a “Manage Subscription” dropdown menu item on the Settings dropdown

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/read/subscriptions
* Open the Settings dropdown on a subscription row
* You should see the "Manage subscription" button on the dropdown
* Click on the button and you should be redirected to the individual subscription page

<img width="356" alt="Screenshot 2023-09-28 at 19 47 10" src="https://github.com/Automattic/wp-calypso/assets/3113712/f8869372-1684-4fbe-b382-c3b8cda404d5">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?