### PR TITLE
Domain thank you page: add resend email verification step

### DIFF
--- a/client/data/domains/use-domain-email-verfication.ts
+++ b/client/data/domains/use-domain-email-verfication.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect } from 'react';
+import { useSiteDomains } from 'calypso/landing/stepper/hooks/use-site-domains';
+import { verifyIcannEmail } from 'calypso/state/domains/management/actions';
+import { useDispatch } from 'calypso/state/index';
+import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
+import { isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
+
+const request = ( siteId ) => ( dispatch, getState ) => {
+	if ( siteId && ! isRequestingSiteDomains( getState(), siteId ) ) {
+		dispatch( fetchSiteDomains( siteId ) );
+	}
+};
+
+export const useDomainEmailVerification = (
+	siteId: number | undefined,
+	selectedSiteSlug: string,
+	domain: string
+) => {
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		dispatch( request( siteId ) );
+	}, [ dispatch, siteId ] );
+
+	const siteDomains = useSiteDomains( selectedSiteSlug ) ?? [];
+	const siteDomain = siteDomains.find( ( siteDomain ) => siteDomain.domain === domain );
+
+	const isEmailUnverified = siteDomain?.is_pending_icann_verification;
+
+	const onResendVerificationEmail = useCallback( () => {
+		if ( isEmailUnverified ) {
+			dispatch( verifyIcannEmail( domain ) );
+		}
+	}, [ dispatch, domain, isEmailUnverified ] );
+
+	return { isEmailUnverified, onResendVerificationEmail };
+};

--- a/client/data/domains/use-domain-email-verfication.ts
+++ b/client/data/domains/use-domain-email-verfication.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react';
-import { useSiteDomains } from 'calypso/landing/stepper/hooks/use-site-domains';
+import { useSiteDomainsForSlug } from 'calypso/landing/stepper/hooks/use-site-domains';
 import { verifyIcannEmail } from 'calypso/state/domains/management/actions';
 import { useDispatch } from 'calypso/state/index';
 import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
@@ -22,7 +22,7 @@ export const useDomainEmailVerification = (
 		dispatch( request( siteId ) );
 	}, [ dispatch, siteId ] );
 
-	const siteDomains = useSiteDomains( selectedSiteSlug ) ?? [];
+	const siteDomains = useSiteDomainsForSlug( selectedSiteSlug ) ?? [];
 	const siteDomain = siteDomains.find( ( siteDomain ) => siteDomain.domain === domain );
 
 	const isEmailUnverified = siteDomain?.is_pending_icann_verification;

--- a/client/data/domains/use-domain-email-verfication.ts
+++ b/client/data/domains/use-domain-email-verfication.ts
@@ -1,15 +1,19 @@
 import { useCallback, useEffect } from 'react';
+import { ThunkDispatch } from 'redux-thunk';
 import { useSiteDomainsForSlug } from 'calypso/landing/stepper/hooks/use-site-domains';
 import { verifyIcannEmail } from 'calypso/state/domains/management/actions';
 import { useDispatch } from 'calypso/state/index';
 import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
 import { isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
+import { IAppState } from 'calypso/state/types';
 
-const request = ( siteId ) => ( dispatch, getState ) => {
-	if ( siteId && ! isRequestingSiteDomains( getState(), siteId ) ) {
-		dispatch( fetchSiteDomains( siteId ) );
-	}
-};
+const request =
+	( siteId: number | undefined ) =>
+	( dispatch: ThunkDispatch< IAppState, unknown, any >, getState: () => IAppState ) => {
+		if ( siteId && ! isRequestingSiteDomains( getState(), siteId ) ) {
+			dispatch( fetchSiteDomains( siteId ) );
+		}
+	};
 
 export const useDomainEmailVerification = (
 	siteId: number | undefined,

--- a/client/landing/stepper/hooks/use-site-domains.ts
+++ b/client/landing/stepper/hooks/use-site-domains.ts
@@ -3,9 +3,7 @@ import { SITE_STORE } from '../stores';
 import { useQuery } from './use-query';
 import type { SiteSelect } from '@automattic/data-stores';
 
-export function useSiteDomains( selectedSiteSlug = null ) {
-	const querySlug = useQuery().get( 'siteSlug' );
-	const siteSlug = selectedSiteSlug ?? querySlug;
+export function useSiteDomainsForSlug( siteSlug: string | null = null ) {
 	const siteId = useSelect(
 		( select ) => siteSlug && ( select( SITE_STORE ) as SiteSelect ).getSiteIdBySlug( siteSlug ),
 		[ siteSlug ]
@@ -20,4 +18,9 @@ export function useSiteDomains( selectedSiteSlug = null ) {
 	}
 
 	return null;
+}
+
+export function useSiteDomains() {
+	const querySlug = useQuery().get( 'siteSlug' );
+	return useSiteDomainsForSlug( querySlug );
 }

--- a/client/landing/stepper/hooks/use-site-domains.ts
+++ b/client/landing/stepper/hooks/use-site-domains.ts
@@ -3,8 +3,9 @@ import { SITE_STORE } from '../stores';
 import { useQuery } from './use-query';
 import type { SiteSelect } from '@automattic/data-stores';
 
-export function useSiteDomains() {
-	const siteSlug = useQuery().get( 'siteSlug' );
+export function useSiteDomains( selectedSiteSlug = null ) {
+	const querySlug = useQuery().get( 'siteSlug' );
+	const siteSlug = selectedSiteSlug ?? querySlug;
 	const siteId = useSelect(
 		( select ) => siteSlug && ( select( SITE_STORE ) as SiteSelect ).getSiteIdBySlug( siteSlug ),
 		[ siteSlug ]

--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
@@ -14,6 +14,11 @@ import {
 import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { useActivityPubStatus } from 'calypso/state/activitypub/use-activitypub-status';
+import { verifyEmail } from 'calypso/state/current-user/email-verification/actions';
+import {
+	getCurrentUserEmail,
+	isCurrentUserEmailVerified,
+} from 'calypso/state/current-user/selectors';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import { useSiteOption } from 'calypso/state/sites/hooks';
 import { hideMasterbar, showMasterbar } from 'calypso/state/ui/masterbar-visibility/actions';
@@ -41,6 +46,7 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 	isDomainOnly,
 	selectedSiteId,
 } ) => {
+	const dispatch = useDispatch();
 	const {
 		data: { is_enabled: isLaunchpadIntentBuildEnabled },
 	} = useLaunchpad( selectedSiteSlug, 'intent-build' );
@@ -48,6 +54,21 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 	const redirectTo = isLaunchpadIntentBuildEnabled ? 'home' : 'setup';
 	const siteIntent = useSiteOption( 'site_intent' );
 	const { isEnabled: isActivityPubEnabled } = useActivityPubStatus( selectedSiteSlug );
+
+	const shouldDisplayVerifyEmailStep = useSelector( ( state ) => {
+		/**
+		 * We don't want to display the verify e-mail address action
+		 * if the email passed in the domain registration step differs
+		 * from the email used in account creation.
+		 *
+		 * See https://wp.me/pet6gk-Ht#rabbit-holes-no-gos
+		 */
+		if ( getCurrentUserEmail( state ) !== email ) {
+			return false;
+		}
+
+		return ! isCurrentUserEmailVerified( state );
+	} );
 
 	const isDomainOnlySiteOption = useSelector(
 		( state ) =>
@@ -59,6 +80,8 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 			selectedSiteSlug,
 			domain,
 			email,
+			shouldDisplayVerifyEmailStep,
+			onResendEmailVerificationClick: () => dispatch( verifyEmail( { showGlobalNotices: true } ) ),
 			hasProfessionalEmail,
 			hideProfessionalEmailStep,
 			siteIntent,
@@ -73,6 +96,8 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 		domain,
 		selectedSiteSlug,
 		email,
+		shouldDisplayVerifyEmailStep,
+		dispatch,
 		hasProfessionalEmail,
 		hideProfessionalEmailStep,
 		siteIntent,
@@ -83,7 +108,7 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 		isDomainOnlySiteOption,
 		isActivityPubEnabled,
 	] );
-	const dispatch = useDispatch();
+
 	const isLaunchpadEnabled = launchpadScreen === 'full';
 
 	useEffect( () => {

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -52,7 +52,7 @@ const domainRegistrationThankYouProps = ( {
 		stepKey: 'domain_registration_whats_next_confirm-email',
 		stepTitle: translate( 'Confirm email address' ),
 		stepDescription: translate(
-			'You must confirm your email address before your domain can be used.'
+			'You must confirm your email address to avoid your domain getting suspended.'
 		),
 		stepCta: (
 			<FullWidthButton onClick={ onResendEmailVerificationClick } busy={ false } disabled={ false }>

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -17,6 +17,8 @@ const domainRegistrationThankYouProps = ( {
 	email,
 	hasProfessionalEmail,
 	hideProfessionalEmailStep,
+	shouldDisplayVerifyEmailStep,
+	onResendEmailVerificationClick,
 	selectedSiteSlug,
 	siteIntent,
 	launchpadScreen,
@@ -45,6 +47,19 @@ const domainRegistrationThankYouProps = ( {
 		redirectTo,
 		true
 	);
+
+	const confirmEmailStep = {
+		stepKey: 'domain_registration_whats_next_confirm-email',
+		stepTitle: translate( 'Confirm email address' ),
+		stepDescription: translate(
+			'You must confirm your email address before your domain can be used.'
+		),
+		stepCta: (
+			<FullWidthButton onClick={ onResendEmailVerificationClick } busy={ false } disabled={ false }>
+				{ translate( 'Resend email' ) }
+			</FullWidthButton>
+		),
+	};
 
 	const createSiteStep = {
 		stepKey: 'domain_registration_whats_next_create-site',
@@ -111,6 +126,7 @@ const domainRegistrationThankYouProps = ( {
 				nextSteps: launchpadNextSteps
 					? [ launchpadNextSteps ]
 					: [
+							...( shouldDisplayVerifyEmailStep ? [ confirmEmailStep ] : [] ),
 							...( professionalEmail ? [ professionalEmail ] : [] ),
 							...( isDomainOnly && selectedSiteId ? [ createSiteStep ] : [] ),
 							...( isActivityPubEnabled ? [ fediverseSettingsStep ] : [ viewDomainsStep ] ),

--- a/client/my-sites/checkout/checkout-thank-you/domains/types.ts
+++ b/client/my-sites/checkout/checkout-thank-you/domains/types.ts
@@ -11,6 +11,8 @@ export type DomainThankYouProps = Required<
 export type DomainThankYouParams = {
 	domain: string;
 	email?: string;
+	shouldDisplayVerifyEmailStep?: boolean;
+	onResendEmailVerificationClick?(): void;
 	hasProfessionalEmail: boolean;
 	hideProfessionalEmailStep: boolean;
 	launchpadScreen: ReturnType< typeof useSiteOption >;

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -664,6 +664,7 @@ export class CheckoutThankYou extends Component<
 					isDomainOnly={ this.props.domainOnlySiteFlow }
 					selectedSiteId={ this.props.domainOnlySiteFlow ? domainPurchase?.blogId : undefined }
 					type={ purchaseType as DomainThankYouType }
+					isUserEmailVerified={ this.props.isEmailVerified }
 				/>
 			);
 		} else if ( wasTitanEmailOnlyProduct ) {

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -664,7 +664,6 @@ export class CheckoutThankYou extends Component<
 					isDomainOnly={ this.props.domainOnlySiteFlow }
 					selectedSiteId={ this.props.domainOnlySiteFlow ? domainPurchase?.blogId : undefined }
 					type={ purchaseType as DomainThankYouType }
-					isUserEmailVerified={ this.props.isEmailVerified }
 				/>
 			);
 		} else if ( wasTitanEmailOnlyProduct ) {

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/icann-verification.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/icann-verification.jsx
@@ -3,32 +3,20 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { resendIcannVerification } from 'calypso/lib/domains';
 import { TRANSFER_DOMAIN_REGISTRATION } from 'calypso/lib/url/support';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { verifyIcannEmail } from 'calypso/state/domains/management/actions';
 
 class IcannVerification extends Component {
 	state = {
 		submitting: false,
 	};
 
-	handleClick = () => {
+	handleClick = async () => {
 		this.setState( { submitting: true } );
 
-		resendIcannVerification( this.props.selectedDomainName, ( error ) => {
-			if ( error ) {
-				this.props.errorNotice( error.message );
-			} else {
-				this.props.successNotice(
-					this.props.translate(
-						'We sent the ICANN verification email to your ' +
-							'email address. Please check your inbox and click the link in the email.'
-					)
-				);
-			}
+		await this.props.verifyIcannEmail( this.props.selectedDomainName );
 
-			this.setState( { submitting: false } );
-		} );
+		this.setState( { submitting: false } );
 	};
 
 	render() {
@@ -69,6 +57,5 @@ class IcannVerification extends Component {
 }
 
 export default connect( null, {
-	errorNotice,
-	successNotice,
+	verifyIcannEmail,
 } )( localize( IcannVerification ) );

--- a/client/state/domains/management/actions.tsx
+++ b/client/state/domains/management/actions.tsx
@@ -17,7 +17,12 @@ import {
 	DOMAIN_MANAGEMENT_WHOIS_SAVE_SUCCESS,
 	DOMAIN_MANAGEMENT_WHOIS_UPDATE,
 } from 'calypso/state/action-types';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import {
+	errorNotice,
+	infoNotice,
+	removeNotice,
+	successNotice,
+} from 'calypso/state/notices/actions';
 import type { WhoisData } from './types';
 import type {
 	ContactValidationResponseMessages,
@@ -154,7 +159,6 @@ export function requestWhois( domain: string ) {
 /**
  * Sends a network request to the server to save updated WHOIS details
  * at the domain's registrar.
- *
  * @param   {string}   domain		domain to query
  * @param   {Object}   whoisData	whois details object
  * @param	  {boolean}  transferLock set 60-day transfer lock after update
@@ -226,8 +230,16 @@ export const showUpdatePrimaryDomainErrorNotice = ( errorMessage: string ) => {
 
 export const verifyIcannEmail = ( domain: string ) => {
 	return ( dispatch: CalypsoDispatch ) => {
+		const noticeId = 'icann-email-notice';
+
+		dispatch( removeNotice( noticeId ) );
+
+		dispatch( infoNotice( translate( 'Sending email…' ), { id: noticeId, duration: 4000 } ) );
+
 		resendIcannVerification( domain )
 			.then( () => {
+				dispatch( removeNotice( noticeId ) );
+
 				dispatch(
 					successNotice(
 						translate(
@@ -238,6 +250,8 @@ export const verifyIcannEmail = ( domain: string ) => {
 				);
 			} )
 			.catch( ( error: Error ) => {
+				dispatch( removeNotice( noticeId ) );
+
 				dispatch( errorNotice( error.message ) );
 			} );
 	};

--- a/client/state/domains/management/actions.tsx
+++ b/client/state/domains/management/actions.tsx
@@ -1,5 +1,6 @@
 import { mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/js-utils';
 import { translate } from 'i18n-calypso';
+import { resendIcannVerification } from 'calypso/lib/domains';
 import wpcom from 'calypso/lib/wp';
 import {
 	DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_RECEIVE,
@@ -220,5 +221,24 @@ export const showUpdatePrimaryDomainErrorNotice = ( errorMessage: string ) => {
 				{ duration: 10000, isPersistent: true }
 			)
 		);
+	};
+};
+
+export const verifyIcannEmail = ( domain: string ) => {
+	return ( dispatch: CalypsoDispatch ) => {
+		resendIcannVerification( domain )
+			.then( () => {
+				dispatch(
+					successNotice(
+						translate(
+							'We sent the ICANN verification email to your ' +
+								'email address. Please check your inbox and click the link in the email.'
+						)
+					)
+				);
+			} )
+			.catch( ( error: Error ) => {
+				dispatch( errorNotice( error.message ) );
+			} );
 	};
 };

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -336,6 +336,7 @@ export interface Domain {
 	bundled_plan_subscription_id?: any;
 	product_slug?: any;
 	owner: string;
+	is_pending_icann_verification?: boolean;
 }
 
 export interface SiteSettings {


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3952.

## Proposed Changes

Domain-only purchases that either have an unverified user email or a different e-mail address than the one associated with the account should receive a nudge about its verification.

<img width="681" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/8ba8b86e-c4c5-46ca-bce3-e82220787d23">

## Testing Instructions

Make sure you're using the test store: PCYsg-IA-p2

In an account with an unverified email address, buy a domain through the http://calypso.localhost:3000/start/domain/domain-only flow.

After the checkout, in the thank you step, verify that you see the "Confirm email step" as shown above. Clicking it should resend the email and you should see a top-right corner notice saying that the confirmation email was resent:

![image](https://github.com/Automattic/wp-calypso/assets/26530524/dc50a046-8f82-496a-8a6d-e163aa77efef)

Verify the email and buy another domain, but this time edit the contact info so that the owner is actually a different e-mail (tip: add `+something` to your email so that you can use the same inbox).

After the checkout, in the thank you step, verify that you see the "Confirm email step" as shown above. Clicking it should resend the email and you should see a top-right corner notice saying that the ICANN confirmation email was resent:

![image](https://github.com/Automattic/wp-calypso/assets/26530524/9a9eac3e-6fcb-4abc-b8dc-8a3fd0d76264)

The domain verification e-mail itself won't work for test purchases, so you might buy an actual domain an ask for a refund. But honestly, it's not needed, we are already using the same logic elsewhere and it's working. You can assert it's the same logic by changing the contact info for an actually purchased domain from the domains table.