### PR TITLE
Replace Advanced Options title for domain transfer off platform

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Card, Spinner } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -80,7 +80,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 	const [ isRequestingTransferCode, setIsRequestingTransferCode ] = useState( false );
 	const [ isLockingOrUnlockingDomain, setIsLockingOrUnlockingDomain ] = useState( false );
 	const domain = getSelectedDomain( props );
-
+	const hasEnTranslation = useHasEnTranslation();
 	const renderHeader = () => {
 		const items = [
 			{
@@ -356,7 +356,11 @@ const TransferPage = ( props: TransferPageProps ) => {
 
 		return (
 			<Card className="transfer-page__advanced-transfer-options">
-				<CardHeading size={ 16 }>{ __( 'Transfer to another registrar' ) }</CardHeading>
+				<CardHeading size={ 16 }>
+					{ hasEnTranslation( 'Transfer to another registrar' )
+						? __( 'Transfer to another registrar' )
+						: __( 'Advanced Options' ) }
+				</CardHeading>
 				{ topLevelOfTld !== 'uk' ? renderCommonTldTransferOptions() : renderUkTransferOptions() }
 			</Card>
 		);

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -356,7 +356,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 
 		return (
 			<Card className="transfer-page__advanced-transfer-options">
-				<CardHeading size={ 16 }>{ __( 'Advanced Options' ) }</CardHeading>
+				<CardHeading size={ 16 }>{ __( 'Transfer to another registrar' ) }</CardHeading>
 				{ topLevelOfTld !== 'uk' ? renderCommonTldTransferOptions() : renderUkTransferOptions() }
 			</Card>
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3998

## Proposed Changes

* Replace "Advanced Options" title with "Transfer to another registrar"

## Testing Instructions

* http://calypso.localhost:3000/domains/manage/all/test1514123123.co.uk/transfer/test1514123123.co.uk

Before

![Screenshot 2023-09-29 at 10-40-25 My Home ‹ test-345678 blog — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/5ae53ad4-8362-4aa3-b3fc-cb6ad5c7829d)

After

![Screenshot 2023-09-29 at 10-40-50 test1514123123 co uk — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/2057d067-6032-44ec-9ad6-4dd793f81530)

Non UK
![Screenshot 2023-09-29 at 10-40-36 test-345678 blog — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/7f2fc25a-17c8-44c9-b68c-b9ec74036c16)

