### PR TITLE
Fix legal text on accepting domain transfers

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -166,7 +166,7 @@ function ContactInfo( {
 					<Gridicon icon="info-outline" size={ 18 } />
 					<p>
 						{ translate(
-							'By accepting this transfer, you agree to the {{agreementlink}}Domain Registration Agreement{{/agreementlink}} for %(domainName)s. You authorize the respective registrar to act as your {{agentlink}}Designated Agent{{/agentlink}}.',
+							'By clicking "Accept domain transfer", you agree to the {{agreementlink}}Domain Registration Agreement{{/agreementlink}} for %(domainName)s. You authorize the respective registrar to act as your {{agentlink}}Designated Agent{{/agentlink}}.',
 							{
 								args: {
 									domainName: domain ?? '',


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3999

## Proposed Changes

Replacing "By accepting this transfer"  text with "By clicking "Accept this transfer" based on https://github.com/Automattic/wp-calypso/pull/81541#issuecomment-1740034687. 

![Screenshot 2023-09-29 at 10-48-24 WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/7046eb2f-f02c-4fa8-b072-afe52db28384)


## Testing Instructions

https://wordpress.com/setup/domain-user-transfer/domain-contact-info?domain=test345678.blog