### PR TITLE
Prevent default form submission when clicking advanced settings

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -556,6 +556,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 				) }
 				<div>
 					<FormButton
+						onClick={ () => handleSubmit }
 						disabled={
 							! pointsToWpcom ||
 							! isValidUrl ||
@@ -586,7 +587,12 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 		<>
 			{ renderNotice() }
 			{ renderNoticeForPrimaryDomain() }
-			<form onSubmit={ handleSubmit }>
+			<form
+				onSubmit={ ( e ) => {
+					e.preventDefault();
+					return false;
+				} }
+			>
 				{ data?.map( ( item ) =>
 					shouldEdit( item ) ? FormRowEdditable( { child: item } ) : FormViewRow( { child: item } )
 				) }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4000

## Proposed Changes

* Prevent default form submission when clicking advanced settings

## Testing Instructions

* http://calypso.localhost:3000/domains/manage/all/test345678.blog/edit/test345678.blog
* Attempt to open advanced settings for a domain forwarding rule, it should not save the form early.
