### PR TITLE
Domain forwarding: Prevent react key warning

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -359,7 +359,11 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 	};
 
 	const FormViewRow = ( { child: child }: { child: DomainForwardingObject } ) => (
-		<FormFieldset disabled={ ! pointsToWpcom } className="domain-forwarding-card__fields">
+		<FormFieldset
+			disabled={ ! pointsToWpcom }
+			className="domain-forwarding-card__fields"
+			key={ `view-${ child.domain_redirect_id }` }
+		>
 			<div className="domain-forwarding-card__fields-row">
 				<div className="domain-forwarding-card__fields-column">
 					<Badge type={ child.subdomain === '' ? 'warning' : 'info' }>
@@ -402,9 +406,9 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 	const FormRowEdditable = ( { child }: { child: DomainForwardingObject } ) => (
 		<>
 			<FormFieldset
-				key={ child.domain_redirect_id }
 				disabled={ ! pointsToWpcom }
 				className="domain-forwarding-card__fields"
+				key={ `edit-${ child.domain_redirect_id }` }
 			>
 				<FormLabel>{ translate( 'Source URL' ) }</FormLabel>
 				<div


### PR DESCRIPTION
Related to #

## Proposed Changes

* Adds react keys for FormViewRow in the domain forwarding form to avoid React console warnings in development.

## Testing Instructions

http://calypso.localhost:3000/domains/manage/test1324123.blog/edit/test1233213.blog

![Screenshot_2023-09-29_15-23-32](https://github.com/Automattic/wp-calypso/assets/811776/c32cce28-f0e3-4c2d-93ea-18da70505fdb)
