### PR TITLE
Domain transfers: Explain why contact information can't be modified during transfer

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
@@ -191,6 +191,13 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 							</Button>
 						) }
 					</div>
+					{ disableEdit && (
+						<p className="contact-information__transfer-warn">
+							{ translate(
+								'Contact modifications are disabled while domain transfers are pending.'
+							) }
+						</p>
+					) }
 				</div>
 				<div className="contact-information__toggle-container">
 					{ getPrivacyProtection() }

--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/style.scss
@@ -23,6 +23,13 @@
 				}
 			}
 		}
+
+		.contact-information__transfer-warn {
+			margin-top: 1em;
+			margin-bottom: 0;
+			color: var(--studio-red-50);
+			font-size: $font-body-small;
+		}
 	}
 
 	&__toggle {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3902
Follow up from https://github.com/Automattic/wp-calypso/pull/82307

## Proposed Changes

* Adds an explanation why editing contact details has been disabled

## Testing Instructions

* Create a pending transfer on a domain
* Try to edit contact information:

![Screenshot(16)](https://github.com/Automattic/wp-calypso/assets/811776/e8ed937c-ed4f-49be-82ac-466490106088)
