### PR TITLE
Redirect back to edit page if there is a pending transfer

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -1,9 +1,12 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layout';
 import ExternalLink from 'calypso/components/external-link';
 import Main from 'calypso/components/main';
+import useDomainTransferRequestQuery from 'calypso/data/domains/transfers/use-domain-transfer-request-query';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import InfoNotice from 'calypso/my-sites/domains/domain-management/components/domain/info-notice';
@@ -34,6 +37,15 @@ const EditContactInfoPage = ( {
 	selectedSite,
 }: EditContactInfoPageProps ) => {
 	const translate = useTranslate();
+
+	const { data } = useDomainTransferRequestQuery( selectedSite?.slug ?? '', selectedDomainName );
+	const transferPending = !! data?.email;
+
+	useEffect( () => {
+		if ( transferPending ) {
+			page( domainManagementEdit( selectedSite?.slug ?? '', selectedDomainName, currentRoute ) );
+		}
+	}, [ transferPending, selectedSite, selectedDomainName, currentRoute ] );
 
 	const isDataLoading = () => {
 		return ! getSelectedDomain( { domains, selectedDomainName } ) || isRequestingWhois;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3902
Follow up from https://github.com/Automattic/wp-calypso/pull/82307

## Proposed Changes

* Redirects users back to the domain management screen if they try to edit contact information while a domain transfer is pending

## Testing Instructions

* Create a pending transfer on a domain
* Try to edit contact information directly via url https://wordpress.com/domains/manage/all/test-345678.blog/edit-contact-info/test-345678.blog
* You should be redirected back to the domain management screen