### PR TITLE
Add Google Domains nudge to new bulk domains lists

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -18,6 +18,7 @@ import {
 	fetchSite,
 	fetchSiteDomains,
 } from '../domains-table-fetch-functions';
+import GoogleDomainOwnerBanner from './google-domain-owner-banner';
 import OptionsDomainButton from './options-domain-button';
 import { usePurchaseActions } from './use-purchase-actions';
 
@@ -64,6 +65,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			<Main>
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page' ] } />
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
+				{ ! isLoading && <GoogleDomainOwnerBanner /> }
 				<DomainsTable
 					isLoadingDomains={ isLoading }
 					domains={ domains }

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -33,6 +33,7 @@ import {
 	fetchSiteDomains,
 } from '../domains-table-fetch-functions';
 import EmptyDomainsListCard from './empty-domains-list-card';
+import GoogleDomainOwnerBanner from './google-domain-owner-banner';
 import { filterDomainsByOwner } from './helpers';
 import { ManageAllDomainsCTA } from './manage-domains-cta';
 import OptionsDomainButton from './options-domain-button';
@@ -89,6 +90,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 			<Main>
 				<BodySectionCssClass bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page' ] } />
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
+				{ ! isLoading && <GoogleDomainOwnerBanner /> }
 				<DomainsTable
 					isLoadingDomains={ isLoading }
 					domains={ data?.domains }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

This Google Domains banner was added to the old domains table before we shipped the new domains table.

![CleanShot 2023-09-29 at 20 42 01@2x](https://github.com/Automattic/wp-calypso/assets/1500769/e721005a-2098-40dd-a01e-fe3577f405fc)

This simply adds that banner to the new domains table pages once the table has finished it's initial load (this matches the old behaviour)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Easiest way I found was to manually edit `google-domain-owner-banner.tsx` to hardcode the logic for whether to show the banner.

Confirm mobile layout works too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?