### PR TITLE
Restore anonId to dedicated ExPlat anonId

### DIFF
--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -127,9 +127,11 @@ export const analyticsEvents: EventEmitter = new EventEmitter();
  * Returns the anoymous id stored in the `tk_ai` cookie
  * @returns The Tracks anonymous user id
  */
-export function getTracksAnonymousUserId(): string {
+export function getTracksAnonymousUserId( isExplat?: boolean ): string {
 	const cookies = cookie.parse( document.cookie );
-
+	if ( isExplat ) {
+		return cookies.tk_ai_explat || cookies.tk_ai;
+	}
 	return cookies.tk_ai;
 }
 
@@ -171,10 +173,13 @@ export function identifyUser( userData: any ): any {
 	// Tracks user identification.
 	debug( 'Tracks identifyUser.', currentUser );
 
-	const anonId = getTracksAnonymousUserId();
+	const anonId = getTracksAnonymousUserId( true );
 	pushEventToTracksQueue( [ 'identifyUser', currentUser.ID, currentUser.username ] );
 	if ( anonId ) {
-		document.cookie = cookie.serialize( 'tk_ai', anonId, { path: '/', domain: '.wordpress.com' } );
+		document.cookie = cookie.serialize( 'tk_ai_explat', anonId, {
+			path: '/',
+			domain: '.wordpress.com',
+		} );
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This is variation of the #82269 where instead of restoring the `tk_ai` we store it in `tk_ai_explat`. Together with the changes to the ExPlat assigner (D123644-code), the assignment should be persisted across the login barrier.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit a Logged Out Landing page, so that the `tk_ai` cookie is populated
* Go through the Log in flow and the Signup flow and make sure there's a `tk_ai_explat` cookie with the initial `tk_ai`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
