### PR TITLE
Update swiper

### DIFF
--- a/packages/design-carousel/package.json
+++ b/packages/design-carousel/package.json
@@ -34,7 +34,7 @@
 		"@automattic/onboarding": "workspace:^",
 		"@tanstack/react-query": "^4.29.1",
 		"classnames": "^2.3.1",
-		"swiper": "^10.1.0",
+		"swiper": "10.3.1",
 		"tslib": "^2.3.0",
 		"utility-types": "^3.10.0",
 		"wpcom-proxy-request": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -658,7 +658,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     redux: ^4.2.1
-    swiper: ^10.1.0
+    swiper: 10.3.1
     tslib: ^2.3.0
     typescript: ^5.1.6
     utility-types: ^3.10.0
@@ -29173,19 +29173,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"swiper@npm:10.3.1":
+  version: 10.3.1
+  resolution: "swiper@npm:10.3.1"
+  checksum: 1e9ad5480cbf451d99fab280553d5105eb314f381d98610771f0808cac03962d87967a190696686d62bce8e4ebcbf34962c369f9d502b34fef1582ced17f6f98
+  languageName: node
+  linkType: hard
+
 "swiper@npm:9.3.2":
   version: 9.3.2
   resolution: "swiper@npm:9.3.2"
   dependencies:
     ssr-window: ^4.0.2
   checksum: 8ed77b641d7620f92100a6fde39df7948be7932e56e31852946216ff7eef721bfc803c9a4e38bbdfa0674fbc46f5dfdd02ea1da4f0711d0fb7b69b2937bf001a
-  languageName: node
-  linkType: hard
-
-"swiper@npm:^10.1.0":
-  version: 10.1.0
-  resolution: "swiper@npm:10.1.0"
-  checksum: 88bdb25c960f5fce81d7e09909338ca5ac3eb6f2f4b65924565d1f8fe47365f7d5eb7458694befe27f52a651db88dcddc14c4d85609d41e18aad1676a656599e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Swiper is used in the link-in-bio picker, updating to the latest version while we work on theme collections which will also use swiper.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82254 - it is a soft prereq

## Proposed Changes

Updating the version, according to the [changelog](https://swiperjs.com/changelog) it's mainly bugfixes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to w.link and click 'Choose my design' 
* When it sends you to wordpress.com open it up on the test url below
* Ensure the l-i-b design picker works exactly as it did before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?