### PR TITLE
Launchpad: Clicking the Back button on the Domain page should redirect to My Home

### DIFF
--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -238,6 +238,17 @@ class DomainSearch extends Component {
 		return strippedHostname ?? selectedSite.domain.split( '.' )[ 0 ];
 	}
 
+	getBackButtonHref() {
+		const { selectedSiteSlug, currentRoute, isFromMyHome } = this.props;
+
+		// If we have the from query param, we should use that as the back button href
+		if ( isFromMyHome ) {
+			return `/home/${ selectedSiteSlug }`;
+		}
+
+		return domainManagementList( selectedSiteSlug, currentRoute );
+	}
+
 	render() {
 		const {
 			selectedSite,
@@ -248,7 +259,6 @@ class DomainSearch extends Component {
 			isDomainAndPlanPackageFlow,
 			isDomainUpsell,
 			isEcommerceSite,
-			currentRoute,
 		} = this.props;
 
 		if ( ! selectedSite ) {
@@ -309,10 +319,7 @@ class DomainSearch extends Component {
 				<span>
 					<div className="domain-search__content">
 						{ ! isDomainAndPlanPackageFlow && (
-							<BackButton
-								className="domain-search__go-back"
-								href={ domainManagementList( selectedSiteSlug, currentRoute ) }
-							>
+							<BackButton className="domain-search__go-back" href={ this.getBackButtonHref() }>
 								<Gridicon icon="arrow-left" size={ 18 } />
 								{ translate( 'Back' ) }
 							</BackButton>
@@ -430,6 +437,7 @@ export default connect(
 				isSiteOnECommerceTrial( state, siteId ) ||
 				isSiteOnWooExpress( state, siteId ) ||
 				isSiteOnEcommerce( state, siteId ),
+			isFromMyHome: getCurrentQueryArguments( state )?.from === 'my-home',
 		};
 	},
 	{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81219

## Proposed Changes

* The Back button on the Domain Search page would not take the user back to the Customer Home if the user navigated to it through the Launchpad. Instead, it took the user to the Domain Management page.
* This PR adds the ability to receive the from param in the URL, which will change the behavior of the Back button and redirect the User back to the Customer Home.
* For now, the test should be made manually introducing the `?from=my-home` in the URL, but this will added to the task definition in Jetpack.

More context: pdtkmj-1G6-p2#comment-3159

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below
* Navigate to `/domains/add/:siteSlug?from=my-home` on a site with the Build intent.
* Click on the `<- Back` button 
![Screen Shot 2023-09-29 at 08 09 09](https://github.com/Automattic/wp-calypso/assets/1234758/0d74fe0c-6203-44ec-8e38-c18ba5738a9f)
* You should be redirected to the Customer Home

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?