### PR TITLE
Site profiler: Update copy

### DIFF
--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -31,7 +31,7 @@ export default function DomainAnalyzer( props: Props ) {
 			<h1>{ translate( 'Site Profiler' ) }</h1>
 			<p>
 				{ translate(
-					'Access essential information about a site, such as hosting provider, domain details, and contact information.'
+					'Access the essential information about any site, including hosting provider, domain details, and contact information.'
 				) }
 			</p>
 
@@ -46,7 +46,7 @@ export default function DomainAnalyzer( props: Props ) {
 							name="domain"
 							autoComplete="off"
 							defaultValue={ domain }
-							placeholder={ translate( 'Enter a website URL' ) }
+							placeholder={ translate( 'Enter a site URL' ) }
 						/>
 					</div>
 					<div className="col-2">

--- a/client/site-profiler/components/heading-information/status-cta-info.tsx
+++ b/client/site-profiler/components/heading-information/status-cta-info.tsx
@@ -13,7 +13,7 @@ export default function StatusCtaInfo( props: Props ) {
 				<p>
 					{ translate(
 						'Register your domain with {{strong}}WordPress.com{{/strong}} ' +
-							'and benefit from one of the best hosting platforms in the world.',
+							'and benefit from one of the best platforms in the world.',
 						{
 							components: { strong: <strong /> },
 						}
@@ -24,8 +24,8 @@ export default function StatusCtaInfo( props: Props ) {
 			return (
 				<p>
 					{ translate(
-						'If you own this domain, transfer it to {{strong}}WordPress.com{{/strong}} ' +
-							'and benefit from the best-performing, most reliable registrar in the business.',
+						'If you own this domain, consider transferring it to {{strong}}WordPress.com{{/strong}} ' +
+							'and benefiting from the best-performing, most reliable registrar in business.',
 						{
 							components: { strong: <strong /> },
 						}
@@ -37,10 +37,9 @@ export default function StatusCtaInfo( props: Props ) {
 			return (
 				<p>
 					{ translate(
-						'If you own this domain, transfer it to {{strong}}WordPress.com{{/strong}} ' +
-							'and benefit from the best-performing, most reliable registrar in the business.' +
-							'{{br/}}And because it’s registered with Google Domains ' +
-							'{{strong}}we’ll pay for an extra year of registration{{/strong}} when you transfer it.',
+						'If you own this domain, consider transferring it to {{strong}}WordPress.com{{/strong}} ' +
+							'to benefit from the best-performing, most reliable registrar in the business. ' +
+							'And—because it’s registered with Google Domains—{{strong}}you’ll get an extra year of registration on us!{{/strong}}',
 						{
 							components: { br: <br />, strong: <strong /> },
 						}
@@ -51,8 +50,8 @@ export default function StatusCtaInfo( props: Props ) {
 			return (
 				<p>
 					{ translate(
-						'If you own this site, host it with {{strong}}WordPress.com{{/strong}} and ' +
-							'benefit from one of the best hosting platforms in the world.',
+						'If you own this site, consider hosting it with {{strong}}WordPress.com{{/strong}} and ' +
+							'benefiting from one of the best platforms in the world.',
 						{
 							components: { strong: <strong /> },
 						}

--- a/client/site-profiler/components/heading-information/status-info.tsx
+++ b/client/site-profiler/components/heading-information/status-info.tsx
@@ -9,7 +9,11 @@ export default function StatusInfo( props: Props ) {
 
 	switch ( conversionAction ) {
 		case 'register-domain':
-			return <p>{ translate( 'Nice find! This site is available and could be yours today!' ) }</p>;
+			return (
+				<p>
+					{ translate( 'What a great domain! This site is available and could be yours today!' ) }
+				</p>
+			);
 		case 'transfer-domain':
 		case 'transfer-google-domain':
 			return (
@@ -26,7 +30,7 @@ export default function StatusInfo( props: Props ) {
 			return (
 				<p>
 					{ translate(
-						'This site is using {{strong}}WordPress.com{{/strong}} to manage the domain, but the site is hosted elsewhere.',
+						'This site is using {{strong}}WordPress.com{{/strong}} to manage the domain, but it’s hosted elsewhere',
 						{
 							components: { strong: <strong /> },
 						}
@@ -49,7 +53,7 @@ export default function StatusInfo( props: Props ) {
 			return (
 				<p>
 					{ translate(
-						'Nice! This site and its domain are fully hosted on {{strong}}WordPress.com{{/strong}}!',
+						'Looks like the owner of this site has great taste. The site and domain are both hosted on {{strong}}WordPress.com{{/strong}}!',
 						{
 							components: { strong: <strong /> },
 						}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/82321

## Proposed Changes

* Updated copy

## Testing Instructions

Compare it with Figma: LhioRMwirFL3WNKErGOzvy-fi-807_15466

<img width="1256" alt="Screenshot 2023-09-29 at 15 32 57" src="https://github.com/Automattic/wp-calypso/assets/1241413/da87319a-0783-4e6b-9280-b53f732cc692">

<img width="1275" alt="Screenshot 2023-09-29 at 15 33 07" src="https://github.com/Automattic/wp-calypso/assets/1241413/1f4e92d8-bd7f-4371-bc71-0152dc964889">

<img width="1256" alt="Screenshot 2023-09-29 at 15 33 55" src="https://github.com/Automattic/wp-calypso/assets/1241413/09c9e8ec-c063-4fa2-b847-90f009838cfb">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?