### PR TITLE
Plans 2023: Grid perf (part 1) - avoid un-mounting comparison grid when hiding

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -570,6 +570,13 @@ const PlansFeaturesMain = ( {
 
 	const isLoadingGridPlans = Boolean( intentFromSiteMeta.processing || ! gridPlans );
 
+	const comparisonGridContainerClasses = classNames(
+		'plans-features-main__comparison-grid-container',
+		{
+			isHidden: ! showPlansComparisonGrid,
+		}
+	);
+
 	return (
 		<div
 			className={ classNames( 'plans-features-main', 'is-pricing-grid-2023-plans-features-main' ) }
@@ -719,58 +726,55 @@ const PlansFeaturesMain = ( {
 								}
 							/>
 							{ ! hidePlansFeatureComparison && (
-								<ComparisonGridToggle
-									onClick={ toggleShowPlansComparisonGrid }
-									label={
-										showPlansComparisonGrid
-											? translate( 'Hide comparison' )
-											: translate( 'Compare plans' )
-									}
-									ref={ observableForOdieRef }
-								/>
-							) }
-							{ ! hidePlansFeatureComparison && showPlansComparisonGrid ? (
-								<div
-									ref={ plansComparisonGridRef }
-									className="plans-features-main__comparison-grid-container"
-								>
-									<ComparisonGrid
-										gridPlans={ gridPlansForComparisonGrid }
-										gridPlanForSpotlight={ gridPlanForSpotlight }
-										paidDomainName={ paidDomainName }
-										wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
-										isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-										isInSignup={ isInSignup }
-										isLaunchPage={ isLaunchPage }
-										onUpgradeClick={ handleUpgradeClick }
-										flowName={ flowName }
-										selectedFeature={ selectedFeature }
-										selectedPlan={ selectedPlan }
-										siteId={ siteId }
-										isReskinned={ isReskinned }
-										intervalType={ intervalType }
-										hideUnavailableFeatures={ hideUnavailableFeatures }
-										currentSitePlanSlug={ sitePlanSlug }
-										planActionOverrides={ planActionOverrides }
-										intent={ intent }
-										showLegacyStorageFeature={ showLegacyStorageFeature }
-										showUpgradeableStorage={ showUpgradeableStorage }
-										stickyRowOffset={ masterbarHeight }
-										usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
-										allFeaturesList={ FEATURES_LIST }
-										planTypeSelectorProps={ planTypeSelectorProps }
-										onStorageAddOnClick={ ( addOnSlug ) =>
-											recordTracksEvent( 'calypso_signup_storage_add_on_dropdown_option_click', {
-												add_on_slug: addOnSlug,
-											} )
-										}
-									/>
+								<>
 									<ComparisonGridToggle
 										onClick={ toggleShowPlansComparisonGrid }
-										label={ translate( 'Hide comparison' ) }
+										label={
+											showPlansComparisonGrid
+												? translate( 'Hide comparison' )
+												: translate( 'Compare plans' )
+										}
+										ref={ observableForOdieRef }
 									/>
-								</div>
-							) : null }
+									<div ref={ plansComparisonGridRef } className={ comparisonGridContainerClasses }>
+										<ComparisonGrid
+											gridPlans={ gridPlansForComparisonGrid }
+											gridPlanForSpotlight={ gridPlanForSpotlight }
+											paidDomainName={ paidDomainName }
+											wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+											isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
+											isInSignup={ isInSignup }
+											isLaunchPage={ isLaunchPage }
+											onUpgradeClick={ handleUpgradeClick }
+											flowName={ flowName }
+											selectedFeature={ selectedFeature }
+											selectedPlan={ selectedPlan }
+											siteId={ siteId }
+											isReskinned={ isReskinned }
+											intervalType={ intervalType }
+											hideUnavailableFeatures={ hideUnavailableFeatures }
+											currentSitePlanSlug={ sitePlanSlug }
+											planActionOverrides={ planActionOverrides }
+											intent={ intent }
+											showLegacyStorageFeature={ showLegacyStorageFeature }
+											showUpgradeableStorage={ showUpgradeableStorage }
+											stickyRowOffset={ masterbarHeight }
+											usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+											allFeaturesList={ FEATURES_LIST }
+											planTypeSelectorProps={ planTypeSelectorProps }
+											onStorageAddOnClick={ ( addOnSlug ) =>
+												recordTracksEvent( 'calypso_signup_storage_add_on_dropdown_option_click', {
+													add_on_slug: addOnSlug,
+												} )
+											}
+										/>
+										<ComparisonGridToggle
+											onClick={ toggleShowPlansComparisonGrid }
+											label={ translate( 'Hide comparison' ) }
+										/>
+									</div>
+								</>
+							) }
 						</div>
 					</div>
 				</>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -573,7 +573,7 @@ const PlansFeaturesMain = ( {
 	const comparisonGridContainerClasses = classNames(
 		'plans-features-main__comparison-grid-container',
 		{
-			isHidden: ! showPlansComparisonGrid,
+			'is-hidden': ! showPlansComparisonGrid,
 		}
 	);
 

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -59,6 +59,12 @@
 	}
 }
 
+.plans-features-main__comparison-grid-container {
+	&.isHidden {
+		display: none;
+	}
+}
+
 // Content group
 .plans-features-main__group {
 	& + & {

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -60,7 +60,7 @@
 }
 
 .plans-features-main__comparison-grid-container {
-	&.isHidden {
+	&.is-hidden {
 		display: none;
 	}
 }

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -73,6 +73,7 @@ import PlansFeaturesMain from '../index';
 const props = {
 	selectedPlan: PLAN_FREE,
 	translate: ( x ) => x,
+	hidePlansFeatureComparison: true,
 };
 
 const emptyPlansIndexForMockedFeatures = {
@@ -272,6 +273,7 @@ describe( 'PlansFeaturesMain', () => {
 			hideFreePlan: true,
 			withWPPlanTabs: true,
 			planTypeSelector: null,
+			hidePlansFeatureComparison: true,
 		};
 
 		beforeEach( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78266

## Proposed Changes

Avoids conditional mounting of the comparison grid to improve performance when interacting with the grid toggle. This alone is enough to address a fairly noticeable degradation when clicking to show/hide the comparison grid. Previously, React would unmount and remount the component on every interaction. We now hide it via CSS instead and keep the component in the React tree, hence a slightly smoother / less clunky UI.

This is a follow-up from https://github.com/Automattic/wp-calypso/pull/82249 to address performance improvements. It is Part 1 of a series of enhancements happening across a few consecutive/linked PRs. It's also the only "necessary" optimization before shipping the component splits in https://github.com/Automattic/wp-calypso/issues/78266 

### Media

**Before**

| perf graph | snap |
| --- | --- |
| <img width="690" alt="Screenshot 2023-10-02 at 12 56 11 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/bafe2e8c-1d89-48fc-a9cc-3c5bb718e2ff"> | https://github.com/Automattic/wp-calypso/assets/1705499/de19800e-ed07-4fda-95d8-50515fffdaa6 |

**After**

| perf graph | snap |
| --- | --- |
| <img width="690" alt="Screenshot 2023-10-02 at 12 58 03 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/06b6247e-e6dc-4607-aa63-6cad80e88a1e"> | https://github.com/Automattic/wp-calypso/assets/1705499/c65ada45-55d7-4fb5-b02b-7d93bded97ed |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/plans/[site]` and `/start/plans`
- Click on "compare plans" and ensure the comparison grid scrolls smoothly into view (no jump or stoppage)
- Click on "hide comparison" and "compare plans" again to ensure the result is smooth

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?