### PR TITLE
Enable TTL editing in DNS records

### DIFF
--- a/client/my-sites/domains/domain-management/dns/a-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/a-record.jsx
@@ -21,6 +21,7 @@ class ARecord extends Component {
 		const classes = classnames( { 'is-hidden': ! show } );
 		const isNameValid = isValid( 'name' );
 		const isDataValid = isValid( 'data' );
+		const isTTLValid = isValid( 'ttl' );
 		const isAaaaRecord = fieldValues.type === 'AAAA';
 
 		const label = translate( 'Name (optional)', { context: 'DNS record' } );
@@ -66,6 +67,24 @@ class ARecord extends Component {
 						placeholder={ dataPlaceholder }
 					/>
 					{ ! isDataValid && <FormInputValidation text={ translate( 'Invalid IP' ) } isError /> }
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel>TTL</FormLabel>
+					<FormTextInput
+						name="ttl"
+						isError={ ! isTTLValid }
+						onChange={ onChange }
+						value={ fieldValues.ttl }
+						defaultValue={ 3600 }
+						placeholder={ 3600 }
+					/>
+					{ ! isTTLValid && (
+						<FormInputValidation
+							text={ translate( 'Invalid TTL value - Use a value between 3600 and 86400' ) }
+							isError
+						/>
+					) }
 				</FormFieldset>
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/dns/a-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/a-record.jsx
@@ -81,7 +81,7 @@ class ARecord extends Component {
 					/>
 					{ ! isTTLValid && (
 						<FormInputValidation
-							text={ translate( 'Invalid TTL value - Use a value between 3600 and 86400' ) }
+							text={ translate( 'Invalid TTL value - Use a value between 300 and 86400' ) }
 							isError
 						/>
 					) }

--- a/client/my-sites/domains/domain-management/dns/a-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/a-record.jsx
@@ -70,7 +70,7 @@ class ARecord extends Component {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel>TTL</FormLabel>
+					<FormLabel>TTL (time to live)</FormLabel>
 					<FormTextInput
 						name="ttl"
 						isError={ ! isTTLValid }

--- a/client/my-sites/domains/domain-management/dns/cname-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/cname-record.jsx
@@ -56,7 +56,7 @@ class CnameRecord extends Component {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel>TTL</FormLabel>
+					<FormLabel>TTL (time to live)</FormLabel>
 					<FormTextInput
 						name="ttl"
 						isError={ ! isTTLValid }

--- a/client/my-sites/domains/domain-management/dns/cname-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/cname-record.jsx
@@ -21,6 +21,7 @@ class CnameRecord extends Component {
 		const classes = classnames( { 'is-hidden': ! show } );
 		const isNameValid = isValid( 'name' );
 		const isDataValid = isValid( 'data' );
+		const isTTLValid = isValid( 'ttl' );
 
 		return (
 			<div className={ classes }>
@@ -51,6 +52,24 @@ class CnameRecord extends Component {
 					/>
 					{ ! isDataValid && (
 						<FormInputValidation text={ translate( 'Invalid Target Host' ) } isError />
+					) }
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel>TTL</FormLabel>
+					<FormTextInput
+						name="ttl"
+						isError={ ! isTTLValid }
+						onChange={ onChange }
+						value={ fieldValues.ttl }
+						defaultValue={ 3600 }
+						placeholder={ 3600 }
+					/>
+					{ ! isTTLValid && (
+						<FormInputValidation
+							text={ translate( 'Invalid TTL value - Use a value between 3600 and 86400' ) }
+							isError
+						/>
 					) }
 				</FormFieldset>
 			</div>

--- a/client/my-sites/domains/domain-management/dns/cname-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/cname-record.jsx
@@ -67,7 +67,7 @@ class CnameRecord extends Component {
 					/>
 					{ ! isTTLValid && (
 						<FormInputValidation
-							text={ translate( 'Invalid TTL value - Use a value between 3600 and 86400' ) }
+							text={ translate( 'Invalid TTL value - Use a value between 300 and 86400' ) }
 							isError
 						/>
 					) }

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -49,6 +49,7 @@ class DnsAddNew extends React.Component {
 				),
 				initialFields: {
 					name: '',
+					ttl: 3600,
 					data: '',
 				},
 			},
@@ -60,6 +61,7 @@ class DnsAddNew extends React.Component {
 				),
 				initialFields: {
 					name: '',
+					ttl: 3600,
 					data: '',
 				},
 			},
@@ -71,6 +73,7 @@ class DnsAddNew extends React.Component {
 				),
 				initialFields: {
 					name: '',
+					ttl: 3600,
 					data: '',
 					aux: 10,
 				},
@@ -83,6 +86,7 @@ class DnsAddNew extends React.Component {
 				),
 				initialFields: {
 					name: '',
+					ttl: 3600,
 					data: '',
 				},
 			},
@@ -94,6 +98,7 @@ class DnsAddNew extends React.Component {
 				),
 				initialFields: {
 					name: '',
+					ttl: 3600,
 					service: '',
 					aux: 10,
 					weight: 10,

--- a/client/my-sites/domains/domain-management/dns/mx-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/mx-record.jsx
@@ -99,7 +99,7 @@ class MxRecord extends Component {
 					/>
 					{ ! isTTLValid && (
 						<FormInputValidation
-							text={ translate( 'Invalid TTL value - Use a value between 3600 and 86400' ) }
+							text={ translate( 'Invalid TTL value - Use a value between 300 and 86400' ) }
 							isError
 						/>
 					) }

--- a/client/my-sites/domains/domain-management/dns/mx-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/mx-record.jsx
@@ -23,6 +23,7 @@ class MxRecord extends Component {
 		const isNameValid = isValid( 'name' );
 		const isDataValid = isValid( 'data' );
 		const isAuxValid = isValid( 'aux' );
+		const isTTLValid = isValid( 'ttl' );
 
 		return (
 			<div className={ classes }>
@@ -83,6 +84,24 @@ class MxRecord extends Component {
 					/>
 					{ ! isAuxValid && (
 						<FormInputValidation text={ translate( 'Invalid Priority' ) } isError />
+					) }
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel>TTL</FormLabel>
+					<FormTextInput
+						name="ttl"
+						isError={ ! isTTLValid }
+						onChange={ onChange }
+						value={ fieldValues.ttl }
+						defaultValue={ 3600 }
+						placeholder={ 3600 }
+					/>
+					{ ! isTTLValid && (
+						<FormInputValidation
+							text={ translate( 'Invalid TTL value - Use a value between 3600 and 86400' ) }
+							isError
+						/>
 					) }
 				</FormFieldset>
 			</div>

--- a/client/my-sites/domains/domain-management/dns/mx-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/mx-record.jsx
@@ -88,7 +88,7 @@ class MxRecord extends Component {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel>TTL</FormLabel>
+					<FormLabel>TTL (time to live)</FormLabel>
 					<FormTextInput
 						name="ttl"
 						isError={ ! isTTLValid }

--- a/client/my-sites/domains/domain-management/dns/srv-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/srv-record.jsx
@@ -139,7 +139,7 @@ class SrvRecord extends Component {
 					/>
 					{ ! isTTLValid && (
 						<FormInputValidation
-							text={ translate( 'Invalid TTL value - Use a value between 3600 and 86400' ) }
+							text={ translate( 'Invalid TTL value - Use a value between 300 and 86400' ) }
 							isError
 						/>
 					) }

--- a/client/my-sites/domains/domain-management/dns/srv-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/srv-record.jsx
@@ -128,7 +128,7 @@ class SrvRecord extends Component {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel>TTL</FormLabel>
+					<FormLabel>TTL (time to live)</FormLabel>
 					<FormTextInput
 						name="ttl"
 						isError={ ! isTTLValid }

--- a/client/my-sites/domains/domain-management/dns/srv-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/srv-record.jsx
@@ -34,6 +34,7 @@ class SrvRecord extends Component {
 		const isWeightValid = isValid( 'weight' );
 		const isTargetValid = isValid( 'target' );
 		const isPortValid = isValid( 'port' );
+		const isTTLValid = isValid( 'ttl' );
 
 		return (
 			<div className={ classes }>
@@ -123,6 +124,24 @@ class SrvRecord extends Component {
 					/>
 					{ ! isPortValid && (
 						<FormInputValidation text={ translate( 'Invalid Target Port' ) } isError />
+					) }
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel>TTL</FormLabel>
+					<FormTextInput
+						name="ttl"
+						isError={ ! isTTLValid }
+						onChange={ onChange }
+						value={ fieldValues.ttl }
+						defaultValue={ 3600 }
+						placeholder={ 3600 }
+					/>
+					{ ! isTTLValid && (
+						<FormInputValidation
+							text={ translate( 'Invalid TTL value - Use a value between 3600 and 86400' ) }
+							isError
+						/>
 					) }
 				</FormFieldset>
 			</div>

--- a/client/my-sites/domains/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/txt-record.jsx
@@ -98,7 +98,7 @@ class TxtRecord extends Component {
 					/>
 					{ ! isTTLValid && (
 						<FormInputValidation
-							text={ translate( 'Invalid TTL value - Use a value between 3600 and 86400' ) }
+							text={ translate( 'Invalid TTL value - Use a value between 300 and 86400' ) }
 							isError
 						/>
 					) }

--- a/client/my-sites/domains/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/txt-record.jsx
@@ -87,7 +87,7 @@ class TxtRecord extends Component {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel>TTL</FormLabel>
+					<FormLabel>TTL (time to live)</FormLabel>
 					<FormTextInput
 						name="ttl"
 						isError={ ! isTTLValid }

--- a/client/my-sites/domains/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/txt-record.jsx
@@ -6,6 +6,7 @@ import { Component } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import { DNS_TXT_RECORD_CHAR_LIMIT } from 'calypso/lib/url/support';
@@ -44,6 +45,7 @@ class TxtRecord extends Component {
 		const classes = classnames( { 'is-hidden': ! show } );
 		const isNameValid = isValid( 'name' );
 		const isDataValid = isValid( 'data' );
+		const isTTLValid = isValid( 'ttl' );
 		// eslint-disable-next-line no-control-regex
 		const hasNonAsciiData = /[^\u0000-\u007f]/.test( fieldValues.data );
 		const validationError = this.getValidationErrorMessage( fieldValues.data );
@@ -81,6 +83,24 @@ class TxtRecord extends Component {
 					) }
 					{ ! isDataValid && validationError && (
 						<FormInputValidation text={ validationError } isError />
+					) }
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel>TTL</FormLabel>
+					<FormTextInput
+						name="ttl"
+						isError={ ! isTTLValid }
+						onChange={ onChange }
+						value={ fieldValues.ttl }
+						defaultValue={ 3600 }
+						placeholder={ 3600 }
+					/>
+					{ ! isTTLValid && (
+						<FormInputValidation
+							text={ translate( 'Invalid TTL value - Use a value between 3600 and 86400' ) }
+							isError
+						/>
 					) }
 				</FormFieldset>
 			</div>

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -31,7 +31,7 @@ function validateField( { name, value, type, domainName } ) {
 		}
 		case 'ttl': {
 			const intValue = parseInt( value, 10 );
-			return intValue >= 3600 && intValue <= 86400;
+			return intValue >= 300 && intValue <= 86400;
 		}
 		case 'service':
 			return value.match( /^[^\s.]+$/ );

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -29,6 +29,10 @@ function validateField( { name, value, type, domainName } ) {
 			const intValue = parseInt( value, 10 );
 			return intValue >= 0 && intValue <= 65535;
 		}
+		case 'ttl': {
+			const intValue = parseInt( value, 10 );
+			return intValue >= 3600 && intValue <= 86400;
+		}
 		case 'service':
 			return value.match( /^[^\s.]+$/ );
 		default:


### PR DESCRIPTION
## Proposed Changes

This PR enable TTL editing for all dns records (CNAME, A, AAAA, TXT, MX, SRV)

## Testing Instructions
Apply the patch locally or use the link below, the try to edit/dns records and verify that then new TTL field is available. 
Add some custom value and verify that the value is stored correctly.
The try invalid values and check that the error message is displayed.

![ttl-update](https://github.com/Automattic/wp-calypso/assets/2797601/599b280b-6a4f-4163-91d6-6d76fa2831ea)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?