### PR TITLE
Site profiler: Improve google domain detection

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -69,6 +69,7 @@ export interface DomainAnalyzerQueryResponse {
 	whois: WhoIs;
 	dns: DNS[];
 	is_domain_available: boolean;
+	eligible_google_transfer: boolean;
 }
 
 export interface DomainAnalyzerWhoisRawDataQueryResponse {

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -40,6 +40,7 @@ export default function SiteProfiler() {
 		domain,
 		siteProfilerData?.whois,
 		siteProfilerData?.is_domain_available,
+		siteProfilerData?.eligible_google_transfer,
 		hostingProviderData?.hosting_provider
 	);
 

--- a/client/site-profiler/hooks/use-define-conversion-action.ts
+++ b/client/site-profiler/hooks/use-define-conversion-action.ts
@@ -13,15 +13,12 @@ export default function useDefineConversionAction(
 	domain: string,
 	whois?: WhoIs,
 	isDomainAvailable?: boolean,
+	isEligibleGoogleTransfer?: boolean,
 	hostingProvider?: HostingProvider
 ): CONVERSION_ACTION | undefined {
 	const isWpDomain = domain.toLowerCase().includes( 'wordpress.com' );
 	const isWpAtomicDomain = domain.toLowerCase().includes( 'wpcomstaging.com' );
 	const isA8cRegistrar = whois?.registrar?.toLowerCase().includes( 'automattic' );
-	const isGoogleRegistrar =
-		whois?.registrar?.toLowerCase().includes( 'google' ) ||
-		whois?.registrar_whois_server?.toLowerCase().includes( 'google' ) ||
-		whois?.registrant_organization?.toLowerCase().includes( 'google' );
 
 	const isA8cDomain = isA8cRegistrar || isWpDomain || isWpAtomicDomain;
 	const isA8cHosting = hostingProvider?.slug === 'automattic';
@@ -30,9 +27,9 @@ export default function useDefineConversionAction(
 		return 'register-domain';
 	} else if ( isA8cDomain && ! isA8cHosting ) {
 		return 'transfer-hosting';
-	} else if ( ! isA8cDomain && isGoogleRegistrar && isA8cHosting ) {
+	} else if ( ! isA8cDomain && isEligibleGoogleTransfer && isA8cHosting ) {
 		return 'transfer-google-domain';
-	} else if ( ! isA8cDomain && isGoogleRegistrar && ! isA8cHosting ) {
+	} else if ( ! isA8cDomain && isEligibleGoogleTransfer && ! isA8cHosting ) {
 		return 'transfer-google-domain-hosting';
 	} else if ( ! isA8cDomain && isA8cHosting ) {
 		return 'transfer-domain';


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82393

## Proposed Changes

* Improved google domain detection relying on the new field getting from the `/site-profiler` endpoint.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site-profiler`
* Enter any google domain
* Check the result in the main heading block

More context here: pdtkmj-1Rk-p2#comment-3349

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?