### PR TITLE
Remove the 'design-picker/query-marketplace-themes' flag

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -342,7 +342,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	useQueryThemes( 'wpcom', {
 		number: 1000,
-		...( ! isEnabled( 'design-picker/query-marketplace-themes' ) ? { tier: '-marketplace' } : {} ),
 	} );
 	useQueryProductsList();
 	useQuerySitePurchases( site ? site.ID : -1 );

--- a/config/development.json
+++ b/config/development.json
@@ -43,7 +43,6 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
-		"design-picker/query-marketplace-themes": true,
 		"desktop-promo": true,
 		"dev/auth-helper": true,
 		"dev/account-settings-helper": true,

--- a/config/production.json
+++ b/config/production.json
@@ -34,7 +34,6 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
-		"design-picker/query-marketplace-themes": true,
 		"desktop-promo": true,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -31,7 +31,6 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
-		"design-picker/query-marketplace-themes": true,
 		"desktop-promo": true,
 		"dev/preferences-helper": true,
 		"domains/gdpr-consent-page": true,

--- a/config/test.json
+++ b/config/test.json
@@ -33,7 +33,6 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
-		"design-picker/query-marketplace-themes": true,
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -31,7 +31,6 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
-		"design-picker/query-marketplace-themes": true,
 		"desktop-promo": true,
 		"dev/auth-helper": true,
 		"dev/account-settings-helper": true,


### PR DESCRIPTION
Follow up https://github.com/Automattic/wp-calypso/pull/82140

## Proposed Changes

Remove the 'design-picker/query-marketplace-themes' flag as the value is `true` in all environments.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test the partner themes on Onboarding flow and check if everything behaves normally, with the Partner badge on the Design Picker.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
