### PR TITLE
Subscription Management: Clicking on site title and site icon on individual subscription page should go to Reader feed page.

### DIFF
--- a/client/blocks/reader-site-subscription/details.tsx
+++ b/client/blocks/reader-site-subscription/details.tsx
@@ -7,7 +7,9 @@ import { SiteIcon } from 'calypso/blocks/site-icon';
 import FormattedHeader from 'calypso/components/formatted-header';
 import TimeSince from 'calypso/components/time-since';
 import { Notice, NoticeState, NoticeType } from 'calypso/landing/subscriptions/components/notice';
+import { useRecordViewFeedButtonClicked } from 'calypso/landing/subscriptions/tracks';
 import { getQueryArgs } from 'calypso/lib/query-args';
+import { getFeedUrl } from 'calypso/reader/route';
 import CancelPaidSubscriptionModal from './cancel-paid-subscription-modal';
 import {
 	PaymentPlan,
@@ -161,16 +163,50 @@ const SiteSubscriptionDetails = ( {
 		name,
 	] );
 
+	const feedUrl = getFeedUrl( feedId );
+
+	const recordViewFeedButtonClicked = useRecordViewFeedButtonClicked();
+
+	const handleViewFeedButtonClicked = ( source: string ) => {
+		recordViewFeedButtonClicked( {
+			blogId: blogId ? String( blogId ) : null,
+			feedId: String( feedId ),
+			source,
+		} );
+	};
+
+	const siteTitle = (
+		<a
+			href={ feedUrl }
+			title={ translate( 'View feed' ) }
+			onClick={ () => {
+				handleViewFeedButtonClicked( 'subscription-site-title' );
+			} }
+		>
+			{ name }
+		</a>
+	);
+
 	return (
 		<>
 			<header className="site-subscription-page__header site-subscription-page__centered-content">
-				<SiteIcon iconUrl={ siteIcon } size={ 116 } alt={ name } />
+				<SiteIcon
+					iconUrl={ siteIcon }
+					size={ 116 }
+					alt={ name }
+					href={ feedUrl }
+					title={ translate( 'View feed' ) }
+					onClick={ () => {
+						handleViewFeedButtonClicked( 'subscription-site-icon' );
+					} }
+				/>
 				<FormattedHeader
 					brandFont
-					headerText={ name }
+					headerText={ siteTitle }
 					subHeaderAs="div"
 					subHeaderText={
 						<SiteSubscriptionSubheader
+							blogId={ blogId }
 							feedId={ feedId }
 							subscriberCount={ subscriberCount }
 							url={ url }

--- a/client/blocks/reader-site-subscription/site-subscription-subheader.tsx
+++ b/client/blocks/reader-site-subscription/site-subscription-subheader.tsx
@@ -3,9 +3,11 @@ import { numberFormat, useTranslate } from 'i18n-calypso';
 import React from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import { FeedIcon } from 'calypso/landing/subscriptions/components/settings/icons';
+import { useRecordViewFeedButtonClicked } from 'calypso/landing/subscriptions/tracks';
 import { getFeedUrl } from 'calypso/reader/route';
 
 type SiteSubscriptionSubheaderProps = {
+	blogId: number;
 	feedId: number;
 	subscriberCount: number;
 	url: string;
@@ -31,6 +33,7 @@ const withDotSeparators = ( items: React.ReactNode[] ) => {
 };
 
 const SiteSubscriptionSubheader = ( {
+	blogId,
 	feedId,
 	subscriberCount,
 	url,
@@ -60,6 +63,8 @@ const SiteSubscriptionSubheader = ( {
 		);
 	}
 
+	const recordViewFeedButtonClicked = useRecordViewFeedButtonClicked();
+
 	subheaderItems.push(
 		<Button
 			key={ `view-feed-button-${ feedId }` }
@@ -67,11 +72,20 @@ const SiteSubscriptionSubheader = ( {
 			className="site-subscription-header__view-feed-button"
 			icon={ <FeedIcon /> }
 			href={ getFeedUrl( feedId ) }
+			onClick={ () => {
+				recordViewFeedButtonClicked( {
+					blogId: blogId ? String( blogId ) : null,
+					feedId: String( feedId ),
+					source: 'subscription-feed-icon',
+				} );
+			} }
 		/>
 	);
 
 	return (
-		<HStack className="site-subscription-header">{ withDotSeparators( subheaderItems ) }</HStack>
+		<HStack className="site-subscription-header" alignment="center" spacing={ 1 }>
+			{ withDotSeparators( subheaderItems ) }
+		</HStack>
 	);
 };
 

--- a/client/blocks/reader-site-subscription/styles.scss
+++ b/client/blocks/reader-site-subscription/styles.scss
@@ -38,7 +38,7 @@
 		align-items: center;
 
 		.formatted-header {
-			&__title {
+			&__title a {
 				font-weight: 600;
 				color: $studio-gray-100;
 			}

--- a/client/blocks/reader-site-subscription/test/index.tsx
+++ b/client/blocks/reader-site-subscription/test/index.tsx
@@ -7,6 +7,10 @@ import { act, render, screen } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
+import {
+	SubscriptionManagerContextProvider,
+	SubscriptionsPortal,
+} from 'calypso/landing/subscriptions/components/subscription-manager-context';
 import ReaderSiteSubscription, {
 	SiteSubscriptionContext,
 	SiteSubscriptionContextProps,
@@ -55,9 +59,11 @@ const renderReaderSiteSubscription = (
 				return (
 					<Provider store={ store }>
 						<QueryClientProvider client={ queryClient }>
-							<SiteSubscriptionContext.Provider value={ siteSubscriptionContextValue }>
-								{ props.children }
-							</SiteSubscriptionContext.Provider>
+							<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Reader }>
+								<SiteSubscriptionContext.Provider value={ siteSubscriptionContextValue }>
+									{ props.children }
+								</SiteSubscriptionContext.Provider>
+							</SubscriptionManagerContextProvider>
 						</QueryClientProvider>
 					</Provider>
 				);

--- a/client/blocks/reader-site-subscription/test/index.tsx
+++ b/client/blocks/reader-site-subscription/test/index.tsx
@@ -84,7 +84,7 @@ describe( 'ReaderSiteSubscription', () => {
 		).toBeInTheDocument();
 
 		// Assert that the site subscription details are rendered
-		expect( screen.getByRole( 'heading', { name: 'Test Site' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'View feed' } ) ).toBeInTheDocument();
 		expect( screen.getByText( /100 subscribers/i ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Jan 1, 2023' ) ).toBeInTheDocument();
 		expect( screen.getByAltText( 'Test Site' ) ).toBeInTheDocument();
@@ -95,7 +95,7 @@ describe( 'ReaderSiteSubscription', () => {
 	it( 'The "View feed" button should navigate to the expected path', async () => {
 		renderReaderSiteSubscription( mockSiteSubscriptionContext( { feed_ID: 123456789 } ) );
 
-		expect( screen.getByRole( 'link', { name: 'View feed' } ) ).toHaveAttribute(
+		expect( screen.getAllByTitle( 'View feed' )[ 0 ] ).toHaveAttribute(
 			'href',
 			'/read/feeds/123456789'
 		);

--- a/client/blocks/site-icon/index.tsx
+++ b/client/blocks/site-icon/index.tsx
@@ -1,7 +1,6 @@
 import { Gridicon, Spinner } from '@automattic/components';
 import classNames from 'classnames';
 import { get } from 'lodash';
-import React from 'react';
 import { connect } from 'react-redux';
 import QuerySites from 'calypso/components/data/query-sites';
 import Image from 'calypso/components/image';

--- a/client/blocks/site-icon/index.tsx
+++ b/client/blocks/site-icon/index.tsx
@@ -1,6 +1,7 @@
 import { Gridicon, Spinner } from '@automattic/components';
 import classNames from 'classnames';
 import { get } from 'lodash';
+import React from 'react';
 import { connect } from 'react-redux';
 import QuerySites from 'calypso/components/data/query-sites';
 import Image from 'calypso/components/image';
@@ -29,6 +30,9 @@ type SiteIconProps = {
 	isTransientIcon?: boolean;
 	defaultIcon?: JSX.Element | null;
 	alt?: string;
+	href?: string;
+	title?: string;
+	onClick?: () => void;
 };
 
 export function SiteIcon( {
@@ -40,6 +44,9 @@ export function SiteIcon( {
 	isTransientIcon,
 	defaultIcon = null,
 	alt = '',
+	href = '',
+	title = '',
+	onClick = () => {},
 }: SiteIconProps ) {
 	const iconSrc = resizeImageUrl( iconUrl, imgSize, null );
 
@@ -57,8 +64,8 @@ export function SiteIcon( {
 
 	const icon = defaultIcon || <Gridicon icon="globe" size={ Math.round( size / 1.8 ) } />;
 
-	return (
-		<div className={ classes } style={ style }>
+	const children = (
+		<>
 			{ ! site && typeof siteId === 'number' && siteId > 0 && <QuerySites siteId={ siteId } /> }
 			{ iconSrc ? (
 				<MediaImage component={ Image } className="site-icon__img" src={ iconSrc } alt={ alt } />
@@ -66,6 +73,18 @@ export function SiteIcon( {
 				icon
 			) }
 			{ isTransientIcon && <Spinner /> }
+		</>
+	);
+
+	return (
+		<div className={ classes } style={ style }>
+			{ href ? (
+				<a href={ href } title={ title } onClick={ onClick }>
+					{ children }
+				</a>
+			) : (
+				children
+			) }
 		</div>
 	);
 }

--- a/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
@@ -155,6 +155,7 @@ export const SiteSettingsPopover = ( {
 									recordViewFeedButtonClicked( {
 										blogId: blogId ? String( blogId ) : null,
 										feedId: String( feedId ),
+										source: 'subscription-settings-dropdown',
 									} );
 								} }
 							>

--- a/client/landing/subscriptions/tracks/use-record-view-feed-button-clicked.tsx
+++ b/client/landing/subscriptions/tracks/use-record-view-feed-button-clicked.tsx
@@ -6,6 +6,7 @@ const useRecordViewFeedButtonClicked = () => {
 	const recordViewFeedButtonClicked = ( tracksProps: {
 		blogId: string | null;
 		feedId: string;
+		source?: string;
 	} ) => {
 		recordSubscriptionsTracksEvent( 'calypso_subscriptions_view_feed_button_clicked', tracksProps );
 	};

--- a/client/reader/site-subscription/site-subscription.tsx
+++ b/client/reader/site-subscription/site-subscription.tsx
@@ -1,14 +1,20 @@
 import ReaderSiteSubscription from 'calypso/blocks/reader-site-subscription';
 import Main from 'calypso/components/main';
+import {
+	SubscriptionManagerContextProvider,
+	SubscriptionsPortal,
+} from 'calypso/landing/subscriptions/components/subscription-manager-context';
 import SiteSubscriptionProvider from './site-subscription-provider';
 
 const SiteSubscription = ( { subscriptionId }: { subscriptionId: number } ) => {
 	return (
-		<SiteSubscriptionProvider subscriptionId={ subscriptionId }>
-			<Main className="site-subscriptions-manager">
-				<ReaderSiteSubscription />
-			</Main>
-		</SiteSubscriptionProvider>
+		<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Reader }>
+			<SiteSubscriptionProvider subscriptionId={ subscriptionId }>
+				<Main className="site-subscriptions-manager">
+					<ReaderSiteSubscription />
+				</Main>
+			</SiteSubscriptionProvider>
+		</SubscriptionManagerContextProvider>
 	);
 };
 


### PR DESCRIPTION
## Proposed Changes

* Clicking on site title and site icon on individual subscription page should go to Reader feed page.
* Added tracks event when clicking on those links.

## Testing Instructions

* Go to `/read/subscriptions`.
* Click on any of the subscriptiosn (that is not RSS).
* Click on the site title, site icon and feed icon.
* You should be redirected to the reader feed page.
* Inspect `*.gif` in the network panel.
* You should see tracks event recorded for the clicks from different sources.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?