### PR TITLE
Indiciate critical css premium feature

### DIFF
--- a/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
@@ -59,7 +59,7 @@ function getFeatureStrings(
 			];
 		case 'boost':
 			return [
-				translate( 'Automated critical CSS' ),
+				translate( 'Automated critical CSS (Premium)' ),
 				translate( 'Site performance scores' ),
 				translate( 'One-click optimization' ),
 				translate( 'Deferred non-essential JavaScript' ),

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1075,7 +1075,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Quick and accurate spelling correction' ),
 	];
 	const boostIncludesInfo = [
-		translate( '{{strong}}Automated critical CSS{{/strong}}', {
+		translate( '{{strong}}Automated critical CSS (Premium){{/strong}}', {
 			components: {
 				strong: <strong />,
 			},


### PR DESCRIPTION
Add an indicator on Jetpack Boost features that critical css is a premium feature

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Update the text for boost descriptions to indicate that Critical CSS is a premium feature

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR and got to the dashboard in Jetpack Cloud. 
* Verify that when Get Score is clicked on a site that does not have Boost scores the text `Automated critical CSS` now reads as `Automated critical CSS (Premium)`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
