### PR TITLE
Update CTA links for Boost

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -67,7 +67,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 				},
 				{
 					label: translate( 'Settings' ),
-					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#:~:text=Inactive-,Boost,-The%20easiest%20speed`,
+					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack`,
 					onClick: () => trackEvent( 'expandable_block_settings_click' ),
 				},
 			];
@@ -77,7 +77,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 			return [
 				{
 					label: translate( 'Boost Settings' ),
-					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#:~:text=Inactive-,Boost,-The%20easiest%20speed`,
+					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack`,
 					onClick: () => trackEvent( 'expandable_block_settings_click' ),
 				},
 			];
@@ -86,7 +86,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 		return [
 			{
 				label: translate( 'Optimize performance' ),
-				href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack#:~:text=Inactive-,Boost,-The%20easiest%20speed`,
+				href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack`,
 				onClick: () => trackEvent( 'expandable_block_optimize_performance_click' ),
 				primary: true,
 			},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
@@ -63,7 +63,7 @@ describe( 'BoostSitePerformance', () => {
 		expect( settingsButton ).toBeInTheDocument();
 		expect( settingsButton ).toHaveAttribute(
 			'href',
-			`${ site.url_with_scheme }/wp-admin/admin.php?page=my-jetpack#:~:text=Inactive-,Boost,-The%20easiest%20speed`
+			`${ site.url_with_scheme }/wp-admin/admin.php?page=my-jetpack`
 		);
 
 		fireEvent.click( settingsButton );
@@ -86,7 +86,7 @@ describe( 'BoostSitePerformance', () => {
 		expect( button ).toBeInTheDocument();
 		expect( button ).toHaveAttribute(
 			'href',
-			`${ site.url_with_scheme }/wp-admin/admin.php?page=my-jetpack#:~:text=Inactive-,Boost,-The%20easiest%20speed`
+			`${ site.url_with_scheme }/wp-admin/admin.php?page=my-jetpack`
 		);
 
 		fireEvent.click( button );
@@ -109,7 +109,7 @@ describe( 'BoostSitePerformance', () => {
 		expect( button ).toBeInTheDocument();
 		expect( button ).toHaveAttribute(
 			'href',
-			`${ site.url_with_scheme }/wp-admin/admin.php?page=my-jetpack#:~:text=Inactive-,Boost,-The%20easiest%20speed`
+			`${ site.url_with_scheme }/wp-admin/admin.php?page=my-jetpack`
 		);
 
 		fireEvent.click( button );


### PR DESCRIPTION
Update the CTA links for Boost in the dashboard to link to My Jetpack page without Boost hightlight

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR builds on changes made in t[he updates to the Boost CTAs ](https://github.com/Automattic/wp-calypso/pull/82331)in the expandable block. It updates the links in the CTAs to link to the My Jetpack page without the Boost hightlight

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the testing instructions in the original PR, ensure that the links in the CTAs all function the same way and redirect the user to the My Jetpack page. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
