### PR TITLE
Subscription Management: Fix manage subscription button

### DIFF
--- a/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
@@ -119,10 +119,6 @@ export const SiteSettingsPopover = ( {
 									/>
 								}
 								href={ `/read/subscriptions/${ subscriptionId }` }
-								onClick={ () => {
-									onUnsubscribe();
-									close();
-								} }
 							>
 								{ translate( 'Manage subscription' ) }
 							</Button>


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/82369

## Proposed Changes

* Fix manage subscription button, removing onClick callback

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/read/subscriptions
* Open the Settings dropdown on a subscription row
* You should see the "Manage subscription" button on the dropdown
* Click on the button and you should be redirected to the individual subscription page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?