### PR TITLE
Jetpack Manage: Allow WordPress.com hosting in Manage Dashboard

### DIFF
--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -49,7 +49,7 @@
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": true,
 		"jetpack/pro-dashboard-monitor-paid-tier": true,
 		"jetpack/pro-dashboard-monitor-sms-notification": true,
-		"jetpack/pro-dashboard-wpcom-atomic-hosting": false,
+		"jetpack/pro-dashboard-wpcom-atomic-hosting": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,


### PR DESCRIPTION
## Proposed Changes

Enabled the feature flag for WordPress.com hosting in Jetpack Manage.

## Testing Instructions

* Code review.
* Tests pass.
* Do a quick check of provisioning a site in staging.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?