### PR TITLE
Reader: Add Manage Subscription button to the Feed's page

### DIFF
--- a/client/blocks/reader-feed-header/follow.jsx
+++ b/client/blocks/reader-feed-header/follow.jsx
@@ -24,8 +24,8 @@ export default function ReaderFeedHeaderFollow( props ) {
 	const siteId = site?.ID;
 	const siteUrl = getSiteUrl( { feed, site } );
 
-	const { following, hasOrganization, isEmailBlocked, isWPForTeamsItem } = useSelector(
-		( state ) => {
+	const { following, hasOrganization, isEmailBlocked, isWPForTeamsItem, subscriptionId } =
+		useSelector( ( state ) => {
 			let _siteId = siteId;
 			let _feedId = feed?.feed_ID;
 			let _feed = _feedId ? getFeed( state, _feedId ) : undefined;
@@ -46,9 +46,9 @@ export default function ReaderFeedHeaderFollow( props ) {
 				hasOrganization: hasReaderFollowOrganization( state, _feedId, _siteId ),
 				isEmailBlocked: getUserSetting( state, 'subscription_delivery_email_blocked' ),
 				isWPForTeamsItem: isSiteWPForTeams( state, _siteId ) || isFeedWPForTeams( state, _feedId ),
+				subscriptionId: _feed?.subscription_id,
 			};
-		}
-	);
+		} );
 
 	const openSuggestedFollowsModal = ( followClicked ) => {
 		setIsSuggestedFollowsModalOpen( followClicked );
@@ -86,7 +86,12 @@ export default function ReaderFeedHeaderFollow( props ) {
 
 				{ site && following && ! isEmailBlocked && (
 					<div className="reader-feed-header__email-settings">
-						<ReaderSiteNotificationSettings iconSize={ 24 } showLabel={ false } siteId={ siteId } />
+						<ReaderSiteNotificationSettings
+							iconSize={ 24 }
+							showLabel={ false }
+							siteId={ siteId }
+							subscriptionId={ subscriptionId }
+						/>
 					</div>
 				) }
 			</div>

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -1,4 +1,5 @@
-import { ToggleControl } from '@wordpress/components';
+import { Button, ToggleControl } from '@wordpress/components';
+import { Icon, settings } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { find, get } from 'lodash';
 import PropTypes from 'prop-types';
@@ -30,6 +31,7 @@ class ReaderSiteNotificationSettings extends Component {
 		iconSize: PropTypes.number,
 		showLabel: PropTypes.bool,
 		siteId: PropTypes.number,
+		subscriptionId: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -110,6 +112,7 @@ class ReaderSiteNotificationSettings extends Component {
 			sendNewPostsByEmail,
 			sendNewPostsByNotification,
 			isEmailBlocked,
+			subscriptionId,
 		} = this.props;
 
 		if ( ! this.props.siteId ) {
@@ -225,6 +228,22 @@ class ReaderSiteNotificationSettings extends Component {
 								label={ translate( 'Email me new comments' ) }
 							/>
 						</div>
+					) }
+
+					{ subscriptionId && (
+						<Button
+							className="reader-site-notification-settings__manage-subscription-button"
+							icon={
+								<Icon
+									className="subscriptions-ellipsis-menu__item-icon"
+									size={ 20 }
+									icon={ settings }
+								/>
+							}
+							href={ `/read/subscriptions/${ subscriptionId }` }
+						>
+							{ translate( 'Manage subscription' ) }
+						</Button>
 					) }
 				</ReaderPopover>
 			</div>

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -112,3 +112,9 @@
 	margin-top: 4px;
 	width: 250px;
 }
+
+.reader-site-notification-settings__manage-subscription-button.has-icon.has-text {
+	padding: 10px 15px;
+	margin-bottom: 12px;
+	color: var(--color-neutral-70);
+}

--- a/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
@@ -1,6 +1,5 @@
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
-import { Icon, settings } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRecordViewFeedButtonClicked } from 'calypso/landing/subscriptions/tracks';
@@ -105,25 +104,7 @@ export const SiteSettingsPopover = ( {
 		>
 			{ ( close: () => void ) => (
 				<>
-					{ isWpComSite && (
-						<>
-							<SiteSettings { ...props } />
-
-							<Button
-								className="site-settings-popover__manage-subscription-button"
-								icon={
-									<Icon
-										className="subscriptions-ellipsis-menu__item-icon"
-										size={ 20 }
-										icon={ settings }
-									/>
-								}
-								href={ `/read/subscriptions/${ subscriptionId }` }
-							>
-								{ translate( 'Manage subscription' ) }
-							</Button>
-						</>
-					) }
+					{ isWpComSite && <SiteSettings { ...props } /> }
 
 					<Button
 						className={ classNames( 'site-settings-popover__unsubscribe-button', {

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -37,6 +37,7 @@ function adaptFeed( feed ) {
 		image: feed.image,
 		organization_id: feed.organization_id,
 		unseen_count: feed.unseen_count,
+		subscription_id: feed.subscription_id,
 	};
 }
 

--- a/client/state/reader/feeds/schema.js
+++ b/client/state/reader/feeds/schema.js
@@ -18,6 +18,7 @@ export const itemsSchema = {
 				image: { type: [ 'string', 'null' ] },
 				organization_id: { type: [ 'integer', 'null' ] },
 				unseen_count: { type: [ 'integer', 'null' ] },
+				subscription_id: { type: [ 'integer', 'null' ] },
 			},
 		},
 	},


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/82369

## Proposed Changes

* Add Manage Subscription button to the Feed's page
* Remove Manage Subscription button from the Subscriptions list

<img width="285" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/da185b08-9856-4dba-90d3-422d28a28134">

## Testing Instructions

* Apply this PR to your local
* Test together with D123723-code
* Go to http://calypso.localhost:3000/read/subscriptions
* Click on the ellipsis button for a subscription
* Check if the Manage subscription button is gone
* Click on View feed
* On the feed page, click on the Settings icon
* You should see the Manage subscription button
* Click on the Manage subscription button
* You should be redirected to the individual subscription page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?