### PR TITLE
Update CIRA registration agreement URL

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -12,7 +12,7 @@ import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { updateContactDetailsCache } from 'calypso/state/domains/management/actions';
 import getContactDetailsCache from 'calypso/state/selectors/get-contact-details-cache';
 
-const ciraAgreementUrl = 'https://cira.ca/agree';
+const ciraAgreementUrl = 'https://www.cira.ca/en/resources/documents/about/registrant-agreement/';
 const defaultValues = {
 	lang: 'EN',
 	legalType: 'CCT',


### PR DESCRIPTION
The URL for the link to the CIRA agreement that we are required to link to when registering a .ca domain is incorrect now and needs to be updated.  

<img width="894" alt="Checkout_—_WordPress_com" src="https://github.com/Automattic/wp-calypso/assets/1379730/06defba0-5e1e-4c42-9c06-dce8febe37ce">


This PR changes the URL to the correct one: https://www.cira.ca/en/resources/documents/about/registrant-agreement/

To test, add a .ca domain to the cart and make sure that the URL in the image above links to the URL above.