### PR TITLE
Domains: Avoid negative lookbehind in regex due to issue in Safari 16.1

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -192,7 +192,7 @@ export default function DomainForwardingCard( { domain }: { domain: ResponseDoma
 		const subdomain = event.target.value;
 		setSubdomain( withoutHttp( subdomain ) );
 
-		const CAPTURE_SUBDOMAIN_RGX = /^(?!-)[a-zA-Z0-9-]{0,63}(?<!-)$/i;
+		const CAPTURE_SUBDOMAIN_RGX = /^(?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]$|^[a-zA-Z0-9]$/i;
 
 		if ( subdomain.length > 0 && ! CAPTURE_SUBDOMAIN_RGX.test( subdomain ) ) {
 			setIsValidUrl( false );


### PR DESCRIPTION
It seems that Safari 16.1 does not correctly support a negative lookbehind in regexes.  See: https://bugs.webkit.org/show_bug.cgi?id=174931

There was a negative lookbehind added in https://github.com/Automattic/wp-calypso/pull/81460


Related to #82430

## Proposed Changes

* This PR updates the regex to avoid the use of the negative lookbehind.

## Testing Instructions

Easiest test is to make sure that the /domains/manage/[site] page loads when using Safari 16.1.  (This problem seems to be resolved in Safari 17.)

Also try adding a subdomain redirect and make sure that works as well (as described in https://github.com/Automattic/wp-calypso/pull/81460)

Make sure that when adding a subdomain redirect, you get an error if the subdomain starts or ends with a hyphen (-).

<img width="668" alt="A8C_Test_Site_—_WordPress_com" src="https://github.com/Automattic/wp-calypso/assets/1379730/c13da497-528d-4b90-80f6-a2402ed0abaf">

