### PR TITLE
Assembler: Update navigation copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
@@ -26,17 +26,17 @@ const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ): Sc
 	const screens: Record< ScreenName, Screen > = {
 		main: {
 			name: 'main',
-			title: hasEnTranslation( 'Select your patterns' )
-				? translate( 'Select your patterns' )
-				: translate( 'Design your own' ),
+			title: hasEnTranslation( 'Select patterns' )
+				? translate( 'Select patterns' )
+				: translate( 'Select your patterns' ),
 			description: translate( 'Create your homepage from our library of patterns.' )
 				? translate( 'Create your homepage from our library of patterns.' )
 				: translate(
 						'Create your homepage by first adding patterns and then choosing a color palette and font style.'
 				  ),
-			continueLabel: hasEnTranslation( 'Pick your styles' )
-				? translate( 'Pick your styles' )
-				: translate( 'Pick your style' ),
+			continueLabel: hasEnTranslation( 'Select styles' )
+				? translate( 'Select styles' )
+				: translate( 'Pick your styles' ),
 			backLabel: hasEnTranslation( 'patterns' ) ? translate( 'patterns' ) : undefined,
 			initialPath: NAVIGATOR_PATHS.MAIN_HEADER,
 		},
@@ -50,14 +50,14 @@ const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ): Sc
 				: translate(
 						'Find the section patterns for your homepage by exploring the categories below.'
 				  ),
-			continueLabel: translate( 'Save and continue' ),
+			continueLabel: translate( 'Save sections' ),
 			initialPath: `${ NAVIGATOR_PATHS.SECTIONS }/${ INITIAL_CATEGORY }`,
 		},
 		styles: {
 			name: 'styles',
-			title: hasEnTranslation( 'Pick your styles' )
-				? translate( 'Pick your styles' )
-				: translate( 'Pick your style' ),
+			title: hasEnTranslation( 'Select styles' )
+				? translate( 'Select styles' )
+				: translate( 'Pick your styles' ),
 			description: hasEnTranslation(
 				'Add style to your page with our expertly curated color palettes and font pairings.'
 			)

--- a/test/e2e/specs/onboarding/onboarding__site-assembler.ts
+++ b/test/e2e/specs/onboarding/onboarding__site-assembler.ts
@@ -100,7 +100,7 @@ describe( 'Onboarding: Site Assembler', () => {
 		it( 'Select "Sections"', async function () {
 			await siteAssemblerFlow.clickLayoutComponentType( 'Sections' );
 			await siteAssemblerFlow.selectLayoutComponent( { index: 0 } );
-			await siteAssemblerFlow.clickButton( 'Save and continue' );
+			await siteAssemblerFlow.clickButton( 'Save sections' );
 
 			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 2 );
 		} );
@@ -113,7 +113,7 @@ describe( 'Onboarding: Site Assembler', () => {
 		} );
 
 		it( 'Pick default style', async function () {
-			await siteAssemblerFlow.clickButton( 'Pick your style' );
+			await siteAssemblerFlow.clickButton( 'Select styles' );
 			await siteAssemblerFlow.pickStyle( 'Color: Free style' );
 			await siteAssemblerFlow.clickButton( 'Save and continue' );
 		} );


### PR DESCRIPTION
## Proposed Changes

This PR is a copy update of the Patterns and Styles steps in the Assembler.

Patterns step: "Select your patterns" → "Select patterns"
| Before | After | 
| --- | --- |
| ![Screenshot 2023-10-02 at 2 47 40 PM](https://github.com/Automattic/wp-calypso/assets/797888/38f3b581-b9a5-4190-b651-b9723fd17d63) | ![Screenshot 2023-10-02 at 2 47 20 PM](https://github.com/Automattic/wp-calypso/assets/797888/e827c34b-a616-41cb-8a2c-e0ede8ad764a) |

Patterns step: "Pick your styles" → "Select styles"
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-02 at 2 50 47 PM](https://github.com/Automattic/wp-calypso/assets/797888/acbb07a7-2bd2-47bb-b4f1-e9cda4e95589) |  ![Screenshot 2023-10-02 at 2 50 41 PM](https://github.com/Automattic/wp-calypso/assets/797888/f25c401a-da5b-4c7d-8b64-97d6985dd37a) |

Sections sub-step:  "Save and continue" → "Save sections"
| Before | After | 
| --- | --- |
| ![Screenshot 2023-10-02 at 2 49 33 PM](https://github.com/Automattic/wp-calypso/assets/797888/271a5009-f953-4c45-b866-e3bf37f2f4ac) | ![Screenshot 2023-10-02 at 2 49 38 PM](https://github.com/Automattic/wp-calypso/assets/797888/33b9bb62-a5b5-46a4-9af2-9ac252f1905f) |

Styles step: "Pick your styles" → "Select styles"
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-02 at 2 51 47 PM](https://github.com/Automattic/wp-calypso/assets/797888/fb7f7d24-4c84-4000-8592-5ae9eb927258) | ![Screenshot 2023-10-02 at 2 51 54 PM](https://github.com/Automattic/wp-calypso/assets/797888/a37e1972-0fdd-4811-b1f8-d2f414fbfba1) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler `/setup/with-theme-assembler/patternAssembler?siteSlug=${ SITE_SLUG }`.
* Ensure that the sidebar heading and buttons are updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?