### PR TITLE
Stats: Minor updates to plan summary copy.

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
@@ -38,10 +38,10 @@ const StatsCommercialOwned = ( { siteSlug } ) => {
 
 	return (
 		<>
-			<h1>{ translate( 'You have already purchased Jetpack Stats!' ) }</h1>
+			<h1>{ translate( 'You already have a commercial license for Jetpack Stats.' ) }</h1>
 			<p>
 				{ translate(
-					'You have already purchased a commercial license or a plan that supports this product, and it has been successfully activated. You now have access to:'
+					'You already have a license for this product and it has been successfully activated. You currently have access to:'
 				) }
 			</p>
 			<StatsBenefitsCommercial />
@@ -67,10 +67,10 @@ const StatsPWYWOwnedNotice = ( { siteId, siteSlug } ) => {
 
 	return (
 		<StatsSingleItemPagePurchaseFrame>
-			<h1>{ translate( 'You have already purchased Jetpack Stats!' ) }</h1>
+			<h1>{ translate( 'You already have a license for Jetpack Stats.' ) }</h1>
 			<p>
 				{ translate(
-					'You have already purchased a personal license for this product, and it has been successfully activated. You now have access to:'
+					'You already have a license for this product and it has been successfully activated. You currently have access to:'
 				) }
 			</p>
 			<StatsBenefitsPersonal />
@@ -107,7 +107,7 @@ const StatsFreeOwnedNotice = ( { siteId, siteSlug } ) => {
 			<h1>{ translate( 'You already have a free license for Jetpack Stats.' ) }</h1>
 			<p>
 				{ translate(
-					'You already have a free license for this product, and it has been successfully activated. Currently have access to:'
+					'You already have a license for this product and it has been successfully activated. You currently have access to:'
 				) }
 			</p>
 			<StatsBenefitsFree />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81745. Some of this feedback was addressed here: https://github.com/Automattic/wp-calypso/pull/82093#pullrequestreview-1641447500

## Proposed Changes

Updates the copy on the `/stats/purchase/DOMAIN` page to read a little smoother.

- Makes titles consistent across plan types.
- Fixes a few grammar issues.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up Live branch.
* Visit a site that has a Stats license (free, PWYW, or commercial).
* Visit `/stats/purchase/DOMAIN` and confirm the copy shows correctly.

![SCR-20231002-ofss](https://github.com/Automattic/wp-calypso/assets/40267301/d455bd2a-35c3-4e80-b1fe-3bf845b744f1)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?