### PR TITLE
Site profiler: Make hosting provider link and improve generating contact support link

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -61,7 +61,7 @@ export interface HostingProvider {
 	name: string;
 	is_cdn: boolean;
 	support_url?: string;
-	home_url?: string;
+	homepage_url?: string;
 }
 
 export interface DomainAnalyzerQueryResponse {

--- a/client/site-profiler/components/hosting-information/hosting-provider-name.tsx
+++ b/client/site-profiler/components/hosting-information/hosting-provider-name.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import { UrlData } from 'calypso/blocks/import/types';
 import InfoPopover from 'calypso/components/info-popover';
@@ -14,18 +13,16 @@ interface Props {
 export default function HostingProviderName( props: Props ) {
 	const { hostingProvider, urlData } = props;
 	const isPopularCdn = !! hostingProvider?.is_cdn;
-	const getNonAutomatticHostingElement = () => {
-		const nameComponent = hostingProvider?.home_url ? (
-			<Button
-				borderless={ true }
-				className="action-buttons__borderless hosting-provider-name__link"
-				href={ hostingProvider?.home_url }
-			>
-				{ hostingProvider?.name }
-			</Button>
+
+	const NonA8cHostingName = () => {
+		const nameComponent = hostingProvider?.homepage_url ? (
+			<a href={ hostingProvider.homepage_url } target="_blank" rel="nofollow noreferrer">
+				{ hostingProvider.name }
+			</a>
 		) : (
 			hostingProvider?.name
 		);
+
 		return (
 			<>
 				{ nameComponent }
@@ -48,7 +45,7 @@ export default function HostingProviderName( props: Props ) {
 
 	return (
 		<div className="hosting-provider-name__container">
-			{ hostingProvider?.slug !== 'automattic' && getNonAutomatticHostingElement() }
+			{ hostingProvider?.slug !== 'automattic' && <NonA8cHostingName /> }
 			{ hostingProvider?.slug === 'automattic' && <VerifiedProvider /> }
 		</div>
 	);

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -14,6 +14,10 @@ interface Props {
 export default function HostingInformation( props: Props ) {
 	const { dns = [], urlData, hostingProvider } = props;
 	const aRecordIps = dns.filter( ( x ) => x.type === 'A' && x.ip );
+	const supportUrl =
+		hostingProvider?.slug === 'automattic'
+			? localizeUrl( 'https://wordpress.com/help/contact' )
+			: hostingProvider?.support_url;
 
 	return (
 		<div className="hosting-information">
@@ -23,13 +27,11 @@ export default function HostingInformation( props: Props ) {
 					<div className="name">{ translate( 'Provider' ) }</div>
 					<HostingProviderName hostingProvider={ hostingProvider } urlData={ urlData } />
 				</li>
-				{ hostingProvider?.slug === 'automattic' && (
+				{ supportUrl && (
 					<li>
-						<div className="name">Support</div>
+						<div className="name">{ translate( 'Support' ) }</div>
 						<div>
-							<a href={ localizeUrl( 'https://wordpress.com/help/contact' ) }>
-								{ translate( 'Contact support' ) }
-							</a>
+							<a href={ supportUrl }>{ translate( 'Contact support' ) }</a>
 						</div>
 					</li>
 				) }

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -27,7 +27,7 @@ export default function HostingInformation( props: Props ) {
 					<div className="name">{ translate( 'Provider' ) }</div>
 					<HostingProviderName hostingProvider={ hostingProvider } urlData={ urlData } />
 				</li>
-				{ supportUrl && (
+				{ supportUrl && ! hostingProvider?.is_cdn && (
 					<li>
 						<div className="name">{ translate( 'Support' ) }</div>
 						<div>


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/3971

## Proposed Changes

* Made hosting provider home page link
* Improve the rendering logic of the contact support link

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site-profiler`
* Enter any domain (eg. blic.rs, wordpress.com, etc.)
* Check if the hosting provider name becomes a link
* Check if there is contact support link

Note: for the unknown hosts and CDN, there is no "contact support" row

<img width="588" alt="Screenshot 2023-10-02 at 11 04 54" src="https://github.com/Automattic/wp-calypso/assets/1241413/3aea1727-800f-4693-9ac6-72a38993bbbf">

<img width="676" alt="Screenshot 2023-10-02 at 11 04 41" src="https://github.com/Automattic/wp-calypso/assets/1241413/58e7ca81-37f3-4bb8-ad01-235538783360">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?