### PR TITLE
Site profiler: replace empty domain with new query string

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -202,15 +202,8 @@ const Domains: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 	const setNewDomainFromQueryArg = () => {
 		let duplicateDomain = false;
 		const newDomainsState = { ...domainsState };
-
-		// Check if the domain already exists in the state
-		Object.keys( newDomainsState ).forEach( ( domainData ) => {
-			if ( newDomainsState[ domainData ].domain === newDomainTransferQueryArg ) {
-				duplicateDomain = true;
-			}
-		} );
-
-		newDomainsState[ uuid() ] = {
+		const domainKeys = Object.keys( newDomainsState );
+		const domainTransferObj = {
 			domain: String( newDomainTransferQueryArg ),
 			auth: '',
 			valid: false,
@@ -218,6 +211,19 @@ const Domains: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 			saleCost: undefined,
 			currencyCode: undefined,
 		};
+
+		if ( domainKeys.length === 1 && newDomainsState[ domainKeys[ 0 ] ].domain === '' ) {
+			newDomainsState[ domainKeys[ 0 ] ] = { ...domainTransferObj };
+		} else {
+			// Check if the domain already exists in the state
+			Object.keys( newDomainsState ).forEach( ( domainData ) => {
+				if ( newDomainsState[ domainData ].domain === newDomainTransferQueryArg ) {
+					duplicateDomain = true;
+				}
+			} );
+
+			newDomainsState[ uuid() ] = { ...domainTransferObj };
+		}
 
 		if ( ! duplicateDomain ) {
 			setDomainsTransferData( newDomainsState );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82400

## Proposed Changes

* Currently, if you navigate to domains like `http://calypso.localhost:3000/setup/domain-transfer/domains?new=${testing.domain}&search=yes` it'll show up as a second item and the first item remains blank. It'll be great if it shows as the first item. For more context, please see the related issue above. In this PR, we check if the domain object has only one item and the domain is empty, if so, we replace it with the one provided  from the `new` query string.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to http://calypso.localhost:3000/site-profiler
* Type in testtt.com and click `Check site`
* Click `Transfer domain` 
* Check and see if you see the transfer domain page and click `Get started`
* Make sure `testtt.com` shows up as the first item.

Note: If you were on this page previously, make sure if you clear everything before testing, Otherwise there's cache on the add your domains page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?