### PR TITLE
Site profiler: Fix styling issues

### DIFF
--- a/client/site-profiler/components/heading-information/styles.scss
+++ b/client/site-profiler/components/heading-information/styles.scss
@@ -2,7 +2,7 @@
 
 .heading-information {
 	background: #fff;
-	border: 1px solid var(--studio-gray-5);
+	border: 1px solid rgb(220 220 222 / 60%);
 	/* stylelint-disable-next-line */
 	border-radius: 3px;
 	box-shadow: 0 4px 10px 0 #0000000d;

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -176,6 +176,12 @@
 		margin-right: 0.25rem;
 	}
 
+	.domain-analyzer-block {
+		@media (max-width: $break-small ) {
+			padding-top: 4rem;
+		}
+	}
+
 	.hosting-intro-block {
 		h2 {
 			max-width: 400px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/82414
Closes https://github.com/Automattic/wp-calypso/issues/82402

## Proposed Changes

* Update border color style
* Fixed Domain analyzer block padding issue on mobile device for logged-in user

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site-profiler` as logged in user
* Check if the heading is visible on mobile device resolution
* Enter any domain
* Check if the heading information block border is lighter than it was before this change

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?