### PR TITLE
Site profiler: Unify the way of showing error messages

### DIFF
--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -10,12 +10,16 @@ interface Props {
 	isBusy?: boolean;
 	isBusyForWhile?: boolean;
 	isDomainValid?: boolean;
+	domainFetchingError?: Error;
 	onFormSubmit: ( domain: string ) => void;
 }
 
 export default function DomainAnalyzer( props: Props ) {
 	const translate = useTranslate();
-	const { domain, isBusy, isBusyForWhile, isDomainValid, onFormSubmit } = props;
+	const { domain, isBusy, isBusyForWhile, isDomainValid, domainFetchingError, onFormSubmit } =
+		props;
+
+	const showError = isDomainValid === false || domainFetchingError;
 
 	const onSubmit = ( e: FormEvent< HTMLFormElement > ) => {
 		e.preventDefault();
@@ -36,7 +40,7 @@ export default function DomainAnalyzer( props: Props ) {
 			</p>
 
 			<form
-				className={ classnames( 'domain-analyzer--form', { 'is-error': isDomainValid === false } ) }
+				className={ classnames( 'domain-analyzer--form', { 'is-error': showError } ) }
 				onSubmit={ onSubmit }
 			>
 				<div className="domain-analyzer--form-container">
@@ -63,11 +67,12 @@ export default function DomainAnalyzer( props: Props ) {
 				<div className="domain-analyzer--msg">
 					<p
 						className={ classnames( 'error', {
-							'vis-hidden': isDomainValid || isDomainValid === undefined,
+							'vis-hidden': ! showError,
 						} ) }
 					>
 						<Icon icon={ info } size={ 20 } />{ ' ' }
-						{ translate( 'Please enter a valid website address' ) }
+						{ isDomainValid === false && translate( 'Please enter a valid website address' ) }
+						{ domainFetchingError && domainFetchingError.message }
 					</p>
 				</div>
 			</form>

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -1,6 +1,4 @@
 import { translate } from 'i18n-calypso';
-import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
@@ -10,7 +8,6 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { LayoutBlock, LayoutBlockSection } from 'calypso/site-profiler/components/layout';
 import useDefineConversionAction from 'calypso/site-profiler/hooks/use-define-conversion-action';
 import useDomainQueryParam from 'calypso/site-profiler/hooks/use-domain-query-param';
-import { errorNotice } from 'calypso/state/notices/actions';
 import useLongFetchingDetection from '../hooks/use-long-fetching-detection';
 import DomainAnalyzer from './domain-analyzer';
 import DomainInformation from './domain-information';
@@ -21,17 +18,14 @@ import './styles.scss';
 
 export default function SiteProfiler() {
 	const location = useLocation();
-	const dispatch = useDispatch();
 	const navigate = useNavigate();
 	const queryParams = useQuery();
 	const { domain, isValid: isDomainValid } = useDomainQueryParam();
-	const noticeOptions = { duration: 3000 };
 
 	const {
 		data: siteProfilerData,
+		error: errorSP,
 		isFetching: isFetchingSP,
-		isError: isErrorSP,
-		errorUpdateCount: errorUpdateCountSP,
 	} = useDomainAnalyzerQuery( domain, isDomainValid );
 	const { data: urlData } = useAnalyzeUrlQuery( domain, isDomainValid );
 	const { data: hostingProviderData } = useHostingProviderQuery( domain, isDomainValid );
@@ -43,20 +37,6 @@ export default function SiteProfiler() {
 		siteProfilerData?.eligible_google_transfer,
 		hostingProviderData?.hosting_provider
 	);
-
-	// Handle errors from the domain analyzer query
-	useEffect( () => {
-		if ( ! isErrorSP ) {
-			return;
-		}
-
-		dispatch(
-			errorNotice(
-				translate( 'There was problem analyzing provided domain. Please try again.' ),
-				noticeOptions
-			)
-		);
-	}, [ errorUpdateCountSP ] );
 
 	const updateDomainQueryParam = ( value: string ) => {
 		// Update the domain query param;
@@ -74,9 +54,10 @@ export default function SiteProfiler() {
 					<DomainAnalyzer
 						domain={ domain }
 						isDomainValid={ isDomainValid }
-						onFormSubmit={ updateDomainQueryParam }
 						isBusy={ isFetchingSP }
 						isBusyForWhile={ isBusyForWhile }
+						domainFetchingError={ errorSP instanceof Error ? errorSP : undefined }
+						onFormSubmit={ updateDomainQueryParam }
 					/>
 				</LayoutBlock>
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/82415

## Proposed Changes

* Unified a way of showing error messages (see related ticket for more info)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site-profiler`
* Enter a wrong domain like `abcd.abcd`
* Check if there is error message below the input field

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?