### PR TITLE
Update Jetpack tooltip copy

### DIFF
--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -12,11 +12,12 @@ import {
 	getPlans,
 } from '@automattic/calypso-products';
 import { Gridicon, JetpackLogo } from '@automattic/components';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useMemo } from '@wordpress/element';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useState, useCallback, useEffect, ChangeEvent, Dispatch, SetStateAction } from 'react';
 import PlanTypeSelector from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plans-grid/hooks/use-is-plan-upgrade-credit-visible';
@@ -730,6 +731,12 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	const featureSlug = feature?.getSlug() ?? '';
 	const footnote = planFeatureFootnotes?.footnotesByFeature?.[ featureSlug ];
 	const tooltipId = `${ feature?.getSlug() }-comparison-grid`;
+	const isEnglishLocale = useIsEnglishLocale();
+	const shouldShowNewJPTooltipCopy =
+		isEnglishLocale ||
+		i18n.hasTranslation(
+			'Security, performance and growth tools made by the WordPress experts. Powered by Jetpack.'
+		);
 
 	return (
 		<Row
@@ -766,7 +773,20 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 								</Plans2023Tooltip>
 								{ allJetpackFeatures.has( feature.getSlug() ) ? (
 									<JetpackIconContainer>
-										<JetpackLogo size={ 16 } />
+										<Plans2023Tooltip
+											text={
+												shouldShowNewJPTooltipCopy
+													? translate(
+															'Security, performance and growth tools made by the WordPress experts. Powered by Jetpack. '
+													  )
+													: ''
+											}
+											setActiveTooltipId={ setActiveTooltipId }
+											activeTooltipId={ activeTooltipId }
+											id={ `jp-${ tooltipId }` }
+										>
+											<JetpackLogo size={ 16 } />
+										</Plans2023Tooltip>
 									</JetpackIconContainer>
 								) : null }
 							</>

--- a/client/my-sites/plans-grid/components/plan-features-container.tsx
+++ b/client/my-sites/plans-grid/components/plan-features-container.tsx
@@ -1,5 +1,6 @@
 import { JetpackLogo } from '@automattic/components';
-import { LocalizeProps } from 'i18n-calypso';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import i18n, { LocalizeProps } from 'i18n-calypso';
 import { useManageTooltipToggle } from 'calypso/my-sites/plans-grid/hooks/use-manage-tooltip-toggle';
 import { DataResponse } from '../types';
 import PlanFeatures2023GridFeatures from './features';
@@ -28,6 +29,12 @@ const PlanFeaturesContainer: React.FC< {
 	isTableCell,
 } ) => {
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
+	const isEnglishLocale = useIsEnglishLocale();
+	const shouldShowNewJPTooltipCopy =
+		isEnglishLocale ||
+		i18n.hasTranslation(
+			'Security, performance and growth tools made by the WordPress experts. Powered by Jetpack.'
+		);
 
 	return plansWithFeatures.map(
 		( { planSlug, features: { wpcomFeatures, jetpackFeatures } }, mapIndex ) => {
@@ -51,9 +58,15 @@ const PlanFeaturesContainer: React.FC< {
 					{ jetpackFeatures.length !== 0 && (
 						<div className="plan-features-2023-grid__jp-logo" key="jp-logo">
 							<Plans2023Tooltip
-								text={ translate(
-									'Security, performance and growth tools made by the WordPress experts.'
-								) }
+								text={
+									shouldShowNewJPTooltipCopy
+										? translate(
+												'Security, performance and growth tools made by the WordPress experts. Powered by Jetpack.'
+										  )
+										: translate(
+												'Security, performance and growth tools made by the WordPress experts.'
+										  )
+								}
 								setActiveTooltipId={ setActiveTooltipId }
 								activeTooltipId={ activeTooltipId }
 								id={ `${ planSlug }-jp-logo-${ mapIndex }` }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* As requested in p1689799108082379-slack-C040UAN6TPS, update the Jetpack tooltip copy to add a "Powered by Jetpack." line in the end.

<img width="520" alt="Screenshot 2023-10-02 at 4 05 41 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/2dd1e506-0288-47ad-8dbd-b8e6cbe29063">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/start/plans` and hover mouse over the Jetpack icon. Verify that the tooltip includes "Powered by Jetpack." in the end.
* Verify that in non-EN, untranslated content is not shown.
* Verify in the plan comparison grid that the JP logo tooltip shows the new copy in `en`. This PR also fixes a bug that the tooltip wouldn't show for the JP logo in the comparison grid. 

