### PR TITLE
Use pink buttons due to winning in the experiment

### DIFF
--- a/apps/blaze-dashboard/src/app.scss
+++ b/apps/blaze-dashboard/src/app.scss
@@ -102,20 +102,18 @@
 		}
 
 		// Post table
-		// the important rules below are to override the styles from the AB experiment that is running in calypso
-		// check history and remove when the experiment is over
 		.post-item__post-promote-button {
 			color: var(--color-accent) !important;
-			border: 1.5px solid var(--color-accent) !important;
+			border: 1.5px solid var(--color-accent);
 			border-radius: 4px;
 			font-weight: 600;
 			font-size: 0.75rem;
-			background-color: var(--color-surface) !important;
+			background-color: var(--color-surface);
 
 			&:hover {
 				text-decoration: underline;
-				color: var(--color-accent) !important;
-				background-color: var(--color-surface) !important;
+				color: var(--color-accent);
+				background-color: var(--color-surface);
 			}
 		}
 

--- a/client/my-sites/promote-post-i2/components/post-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/post-item/index.tsx
@@ -2,7 +2,6 @@ import { safeImageUrl } from '@automattic/calypso-url';
 import './style.scss';
 import { Button } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import classNames from 'classnames';
 import InfoPopover from 'calypso/components/info-popover';
 import { BlazablePost } from 'calypso/data/promote-post/types';
 import resizeImageUrl from 'calypso/lib/resize-image-url';
@@ -10,7 +9,7 @@ import useOpenPromoteWidget from '../../hooks/use-open-promote-widget';
 import { formatNumber, getPostType } from '../../utils';
 import RelativeTime from '../relative-time';
 
-export default function PostItem( { post, className }: { post: BlazablePost; className: string } ) {
+export default function PostItem( { post }: { post: BlazablePost } ) {
 	const onClickPromote = useOpenPromoteWidget( {
 		keyValue: 'post-' + post.ID,
 		entrypoint: 'promoted_posts-post_item',
@@ -34,7 +33,7 @@ export default function PostItem( { post, className }: { post: BlazablePost; cla
 	const titleShortened = titleIsLong ? post?.title.slice( 0, 55 ) + '...' : post?.title;
 
 	return (
-		<tr className={ classNames( 'post-item__row', className ) }>
+		<tr className="post-item__row">
 			<td className="post-item__post-data">
 				<div className="post-item__post-data-row">
 					{ featuredImage && (
@@ -85,12 +84,7 @@ export default function PostItem( { post, className }: { post: BlazablePost; cla
 						</div>
 					</div>
 				</div>
-				<div
-					className={ classNames(
-						'post-item__post-data-row post-item__post-data-row-mobile',
-						className
-					) }
-				>
+				<div className="post-item__post-data-row post-item__post-data-row-mobile">
 					<div className="post-item__stats-mobile">
 						{ sprintf(
 							// translators: %s is number of post's views

--- a/client/my-sites/promote-post-i2/components/post-item/style.scss
+++ b/client/my-sites/promote-post-i2/components/post-item/style.scss
@@ -17,20 +17,6 @@ body.is-section-promote-post-i2 {
 
 	.post-item__row {
 		width: 100%;
-
-		&_experimental { // A/B testing "dsp_blaze_open_widget_button_202308"
-			.post-item__post-promote .components-button.is-primary {
-				color: var(--studio-gray-80);
-				background-color: var(--color-surface);
-				border-radius: 4px;
-				border: 1px solid var(--studio-gray-10);
-
-				&:hover {
-					border-color: var(--color-neutral-20);
-				}
-			}
-		}
-
 	}
 
 	.post-item__post {
@@ -240,15 +226,6 @@ body.is-section-promote-post-i2 {
 			text-decoration: none;
 		}
 
-		// A/B testing "dsp_blaze_open_widget_button_202308"
-		// experimental changes in view button mobile
-		.post-item__row_experimental .post-item__post-data .post-item__post-data-row-mobile .post-item__actions-mobile a.post-item__view-link,
-		.post-item__row_experimental .post-item__post-data .post-item__post-data-row-mobile .post-item__actions-mobile a.post-item__view-link:visited {
-			color: var(--studio-gray-80);
-			background-color: var(--studio-gray-0);
-			border: 1px solid var(--studio-gray-0);
-		}
-
 		// Promote link
 		.post-item__post-data .post-item__post-data-row-mobile .post-item__actions-mobile button.post-item__post-promote-button {
 			display: inline-block;
@@ -256,20 +233,6 @@ body.is-section-promote-post-i2 {
 			height: 40px;
 			margin-left: 8px;
 		}
-
-		// A/B testing "dsp_blaze_open_widget_button_202308"
-		// experimental changes in promote button mobile
-		.post-item__post-data .post-item__row_experimental .post-item__actions-mobile button.post-item__post-promote-button {
-			color: var(--studio-gray-80);
-			background-color: var(--color-surface);
-			border: 1px solid var(--studio-gray-10);
-
-			&:hover {
-				border-color: var(--color-neutral-20);
-			}
-		}
-
-
 	}
 }
 

--- a/client/my-sites/promote-post-i2/components/posts-table/index.tsx
+++ b/client/my-sites/promote-post-i2/components/posts-table/index.tsx
@@ -1,7 +1,5 @@
 import '../campaigns-table/style.scss';
-import { useState, useEffect } from 'react';
 import { BlazablePost } from 'calypso/data/promote-post/types';
-import { useExperiment } from 'calypso/lib/explat';
 import PostItem from 'calypso/my-sites/promote-post-i2/components/post-item';
 import { ItemsLoading, SingleItemLoading } from '../campaigns-table';
 import PostsListHeader from '../posts-list/header';
@@ -15,36 +13,17 @@ interface Props {
 export default function PostsTable( props: Props ) {
 	const { posts, isLoading, isFetchingPageResults } = props;
 
-	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'dsp_blaze_open_widget_button_202308'
-	);
-
-	const [ postClassName, setPostClassName ] = useState( '' );
-
-	useEffect( () => {
-		if ( isLoadingExperimentAssignment ) {
-			return;
-		}
-		if ( undefined !== experimentAssignment?.variationName ) {
-			const className =
-				experimentAssignment?.variationName === 'treatment' ? 'post-item__row_experimental' : '';
-			setPostClassName( className );
-		}
-	}, [ isLoadingExperimentAssignment, experimentAssignment ] );
-
 	return (
 		<table className="promote-post-i2__table">
 			<PostsListHeader />
 
 			<tbody>
-				{ ( isLoading && ! isFetchingPageResults ) || isLoadingExperimentAssignment ? (
+				{ isLoading && ! isFetchingPageResults ? (
 					<ItemsLoading />
 				) : (
 					<>
 						{ posts.map( ( post: BlazablePost ) => {
-							return (
-								<PostItem key={ `post-id${ post.ID }` } post={ post } className={ postClassName } />
-							);
+							return <PostItem key={ `post-id${ post.ID }` } post={ post } />;
 						} ) }
 						{ isFetchingPageResults && <SingleItemLoading /> }
 					</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/80275
pbxNRc-2RP-p2#comment-4912
21342-explat-experiment

## Proposed Changes
* Revert code to the state as it was before the experiment,
* The only change that will still be Calypso is highlighting a border of the Learn More button at the top onHover.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch on your local environment
* Go Tools > Advertising
* Clear Local Storage for "calypso.localhost:3000"
* Make sure there's no requests for
```
https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/calypso?_envelope=1&experiment_name=dsp_blaze_open_widget_button_202308
```

* Also, the buttons next to posts should be pink colored:
<img width="743" alt="Screenshot 2023-10-02 at 13 40 20" src="https://github.com/Automattic/wp-calypso/assets/115007291/fc0e4c60-fc37-4d8e-9f04-ccdba2fe89ef">

* Check that onHover changing of a border color for the "Learn More" button (at the top) still works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
