### PR TITLE
Plans 2023: Grid perf (part 2) - memoize inline data transformations and callbacks

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-filter-plans-for-plan-features.ts
+++ b/client/my-sites/plans-features-main/hooks/use-filter-plans-for-plan-features.ts
@@ -5,6 +5,7 @@ import {
 	isPersonalPlan,
 	isPremiumPlan,
 } from '@automattic/calypso-products';
+import { useMemo } from '@wordpress/element';
 import type { GridPlan } from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans';
 
 interface Props {
@@ -28,45 +29,56 @@ const useFilterPlansForPlanFeatures = ( {
 	hideBusinessPlan,
 	hideEcommercePlan,
 }: Props ) => {
-	const filteredPlans = isDisplayingPlansNeededForFeature
-		? plans.map( ( gridPlan ) => {
-				if ( selectedPlan && isEcommercePlan( selectedPlan ) ) {
-					return isEcommercePlan( gridPlan.planSlug )
-						? gridPlan
-						: { ...gridPlan, isVisible: false };
-				}
+	const filteredPlans = useMemo( () => {
+		return isDisplayingPlansNeededForFeature
+			? plans.map( ( gridPlan ) => {
+					if ( selectedPlan && isEcommercePlan( selectedPlan ) ) {
+						return isEcommercePlan( gridPlan.planSlug )
+							? gridPlan
+							: { ...gridPlan, isVisible: false };
+					}
 
-				if ( selectedPlan && isBusinessPlan( selectedPlan ) ) {
-					return isBusinessPlan( gridPlan.planSlug ) || isEcommercePlan( gridPlan.planSlug )
-						? gridPlan
-						: { ...gridPlan, isVisible: false };
-				}
+					if ( selectedPlan && isBusinessPlan( selectedPlan ) ) {
+						return isBusinessPlan( gridPlan.planSlug ) || isEcommercePlan( gridPlan.planSlug )
+							? gridPlan
+							: { ...gridPlan, isVisible: false };
+					}
 
-				if ( selectedPlan && isPremiumPlan( selectedPlan ) ) {
-					return isPremiumPlan( gridPlan.planSlug ) ||
-						isBusinessPlan( gridPlan.planSlug ) ||
-						isEcommercePlan( gridPlan.planSlug )
-						? gridPlan
-						: { ...gridPlan, isVisible: false };
-				}
+					if ( selectedPlan && isPremiumPlan( selectedPlan ) ) {
+						return isPremiumPlan( gridPlan.planSlug ) ||
+							isBusinessPlan( gridPlan.planSlug ) ||
+							isEcommercePlan( gridPlan.planSlug )
+							? gridPlan
+							: { ...gridPlan, isVisible: false };
+					}
 
-				return gridPlan;
-		  } )
-		: plans;
+					return gridPlan;
+			  } )
+			: plans;
+	}, [ isDisplayingPlansNeededForFeature, plans, selectedPlan ] );
 
-	return filteredPlans.map( ( gridPlan ) => {
-		if (
-			( hideFreePlan && isFreePlan( gridPlan.planSlug ) ) ||
-			( hidePersonalPlan && isPersonalPlan( gridPlan.planSlug ) ) ||
-			( hidePremiumPlan && isPremiumPlan( gridPlan.planSlug ) ) ||
-			( hideBusinessPlan && isBusinessPlan( gridPlan.planSlug ) ) ||
-			( hideEcommercePlan && isEcommercePlan( gridPlan.planSlug ) )
-		) {
-			return { ...gridPlan, isVisible: false };
-		}
+	return useMemo( () => {
+		return filteredPlans.map( ( gridPlan ) => {
+			if (
+				( hideFreePlan && isFreePlan( gridPlan.planSlug ) ) ||
+				( hidePersonalPlan && isPersonalPlan( gridPlan.planSlug ) ) ||
+				( hidePremiumPlan && isPremiumPlan( gridPlan.planSlug ) ) ||
+				( hideBusinessPlan && isBusinessPlan( gridPlan.planSlug ) ) ||
+				( hideEcommercePlan && isEcommercePlan( gridPlan.planSlug ) )
+			) {
+				return { ...gridPlan, isVisible: false };
+			}
 
-		return gridPlan;
-	} );
+			return gridPlan;
+		} );
+	}, [
+		filteredPlans,
+		hideFreePlan,
+		hidePersonalPlan,
+		hidePremiumPlan,
+		hideBusinessPlan,
+		hideEcommercePlan,
+	] );
 };
 
 export default useFilterPlansForPlanFeatures;

--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -1,3 +1,4 @@
+import { useMemo } from '@wordpress/element';
 import { useExperiment } from 'calypso/lib/explat';
 import type { DataResponse } from 'calypso/my-sites/plans-grid/types';
 
@@ -14,17 +15,19 @@ const useIsCustomDomainAllowedOnFreePlan = (
 	} );
 
 	/** Ships experiment variant to onboarding-pm flow only  */
-	if ( flowName === 'onboarding-pm' ) {
-		return {
-			isLoading: false,
-			result: true,
-		};
-	}
+	return useMemo( () => {
+		if ( flowName === 'onboarding-pm' ) {
+			return {
+				isLoading: false,
+				result: true,
+			};
+		}
 
-	return {
-		isLoading,
-		result: assignment?.variationName === 'treatment',
-	};
+		return {
+			isLoading,
+			result: assignment?.variationName === 'treatment',
+		};
+	}, [ isLoading, assignment, flowName ] );
 };
 
 export default useIsCustomDomainAllowedOnFreePlan;

--- a/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
@@ -1,5 +1,6 @@
 import configApi from '@automattic/calypso-config';
 import { DomainSuggestions } from '@automattic/data-stores';
+import { useMemo } from '@wordpress/element';
 import { logToLogstash } from 'calypso/lib/logstash';
 import type { DataResponse } from 'calypso/my-sites/plans-grid/types';
 
@@ -27,13 +28,16 @@ export function useGetFreeSubdomainSuggestion( query: string ): {
 		} );
 	}
 
-	return {
-		wpcomFreeDomainSuggestion: {
-			isLoading,
-			result,
-		},
-		invalidateDomainSuggestionCache,
-	};
+	return useMemo(
+		() => ( {
+			wpcomFreeDomainSuggestion: {
+				isLoading,
+				result,
+			},
+			invalidateDomainSuggestionCache,
+		} ),
+		[ isLoading, result, invalidateDomainSuggestionCache ]
+	);
 }
 
 export default useGetFreeSubdomainSuggestion;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -486,38 +486,22 @@ const PlansFeaturesMain = ( {
 		_customerType = 'business';
 	}
 
-	const planTypeSelectorProps = useMemo( () => {
-		return {
-			basePlansPath,
-			isStepperUpgradeFlow,
-			isInSignup,
-			eligibleForWpcomMonthlyPlans,
-			isPlansInsideStepper,
-			intervalType,
-			customerType: _customerType,
-			siteSlug,
-			selectedPlan,
-			selectedFeature,
-			showBiennialToggle,
-			kind: planTypeSelector,
-			plans: gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ),
-		};
-	}, [
+	// These never reach the grid-components. Little/no need to memoize.
+	const planTypeSelectorProps = {
 		basePlansPath,
 		isStepperUpgradeFlow,
 		isInSignup,
 		eligibleForWpcomMonthlyPlans,
 		isPlansInsideStepper,
 		intervalType,
-		_customerType,
+		customerType: _customerType,
 		siteSlug,
 		selectedPlan,
 		selectedFeature,
 		showBiennialToggle,
-		planTypeSelector,
-		gridPlansForFeaturesGrid,
-	] );
-
+		kind: planTypeSelector,
+		plans: gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ),
+	};
 	/**
 	 * The effects on /plans page need to be checked if this variable is initialized
 	 */

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -15,7 +15,14 @@ import { Button, Spinner } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import styled from '@emotion/styled';
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -287,12 +294,14 @@ const PlansFeaturesMain = ( {
 		}
 	}, [] );
 
-	const resolvedSubdomainName: DataResponse< string > = {
-		isLoading: signupFlowSubdomain ? false : wpcomFreeDomainSuggestion.isLoading,
-		result: signupFlowSubdomain
-			? signupFlowSubdomain
-			: wpcomFreeDomainSuggestion.result?.domain_name,
-	};
+	const resolvedSubdomainName: DataResponse< string > = useMemo( () => {
+		return {
+			isLoading: signupFlowSubdomain ? false : wpcomFreeDomainSuggestion.isLoading,
+			result: signupFlowSubdomain
+				? signupFlowSubdomain
+				: wpcomFreeDomainSuggestion.result?.domain_name,
+		};
+	}, [ signupFlowSubdomain, wpcomFreeDomainSuggestion ] );
 
 	const isDisplayingPlansNeededForFeature = () => {
 		if (
@@ -309,53 +318,62 @@ const PlansFeaturesMain = ( {
 		return false;
 	};
 
-	const toggleIsFreePlanPaidDomainDialogOpen = () => {
+	const toggleIsFreePlanPaidDomainDialogOpen = useCallback( () => {
 		setIsFreePlanPaidDomainDialogOpen( ! isFreePlanPaidDomainDialogOpen );
-	};
+	}, [ isFreePlanPaidDomainDialogOpen ] );
 
-	const handleUpgradeClick = ( cartItems?: MinimalRequestCartProduct[] | null ) => {
-		const cartItemForPlan = getPlanCartItem( cartItems );
-		const cartItemForStorageAddOn = cartItems?.find(
-			( items ) => items.product_slug === PRODUCT_1GB_SPACE
-		);
+	const handleUpgradeClick = useCallback(
+		( cartItems?: MinimalRequestCartProduct[] | null ) => {
+			const cartItemForPlan = getPlanCartItem( cartItems );
+			const cartItemForStorageAddOn = cartItems?.find(
+				( items ) => items.product_slug === PRODUCT_1GB_SPACE
+			);
+			const planPath = cartItemForPlan?.product_slug
+				? getPlanPath( cartItemForPlan.product_slug )
+				: '';
+			const checkoutUrlWithArgs = addQueryArgs(
+				{ ...( withDiscount && { coupon: withDiscount } ) },
+				`/checkout/${ siteSlug }/${ planPath }`
+			);
 
-		// `cartItemForPlan` is empty if Free plan is selected. Show `FreePlanPaidDomainDialog`
-		// in that case and exit. `FreePlanPaidDomainDialog` takes over from there.
-		// It only applies to main onboarding flow and the paid media flow at the moment.
-		// Standardizing it or not is TBD; see Automattic/growth-foundations#63 and pdgrnI-2nV-p2#comment-4110 for relevant discussion.
-		if ( ! cartItemForPlan ) {
-			recordTracksEvent( 'calypso_signup_free_plan_click' );
-			if ( paidDomainName ) {
-				toggleIsFreePlanPaidDomainDialogOpen();
+			// `cartItemForPlan` is empty if Free plan is selected. Show `FreePlanPaidDomainDialog`
+			// in that case and exit. `FreePlanPaidDomainDialog` takes over from there.
+			// It only applies to main onboarding flow and the paid media flow at the moment.
+			// Standardizing it or not is TBD; see Automattic/growth-foundations#63 and pdgrnI-2nV-p2#comment-4110 for relevant discussion.
+			if ( ! cartItemForPlan ) {
+				recordTracksEvent( 'calypso_signup_free_plan_click' );
+				if ( paidDomainName ) {
+					toggleIsFreePlanPaidDomainDialogOpen();
+					return;
+				}
+				if ( isPlanUpsellEnabledOnFreeDomain.result ) {
+					setIsFreePlanFreeDomainDialogOpen( true );
+					return;
+				}
+			}
+
+			if ( cartItemForStorageAddOn?.extra ) {
+				recordTracksEvent( 'calypso_signup_storage_add_on_upgrade_click', {
+					add_on_slug: cartItemForStorageAddOn.extra.feature_slug,
+				} );
+			}
+
+			if ( onUpgradeClick ) {
+				onUpgradeClick( cartItems );
 				return;
 			}
-			if ( isPlanUpsellEnabledOnFreeDomain.result ) {
-				setIsFreePlanFreeDomainDialogOpen( true );
-				return;
-			}
-		}
 
-		if ( cartItemForStorageAddOn?.extra ) {
-			recordTracksEvent( 'calypso_signup_storage_add_on_upgrade_click', {
-				add_on_slug: cartItemForStorageAddOn.extra.feature_slug,
-			} );
-		}
-
-		if ( onUpgradeClick ) {
-			onUpgradeClick( cartItems );
-			return;
-		}
-
-		const planPath = cartItemForPlan?.product_slug
-			? getPlanPath( cartItemForPlan.product_slug )
-			: '';
-		const checkoutUrlWithArgs = addQueryArgs(
-			{ ...( withDiscount && { coupon: withDiscount } ) },
-			`/checkout/${ siteSlug }/${ planPath }`
-		);
-
-		page( checkoutUrlWithArgs );
-	};
+			page( checkoutUrlWithArgs );
+		},
+		[
+			isPlanUpsellEnabledOnFreeDomain.result,
+			onUpgradeClick,
+			paidDomainName,
+			siteSlug,
+			toggleIsFreePlanPaidDomainDialogOpen,
+			withDiscount,
+		]
+	);
 
 	const term = usePlanBillingPeriod( {
 		intervalType,
@@ -418,34 +436,37 @@ const PlansFeaturesMain = ( {
 	} );
 
 	// we neeed only the visible ones for comparison grid (these should extend into plans-ui data store selectors)
-	const gridPlansForComparisonGrid = filteredPlansForPlanFeatures.reduce( ( acc, gridPlan ) => {
-		if ( gridPlan.isVisible ) {
-			return [
-				...acc,
-				{
-					...gridPlan,
-					features: planFeaturesForComparisonGrid[ gridPlan.planSlug ],
-				},
-			];
-		}
+	const gridPlansForComparisonGrid = useMemo( () => {
+		return filteredPlansForPlanFeatures.reduce( ( acc, gridPlan ) => {
+			if ( gridPlan.isVisible ) {
+				return [
+					...acc,
+					{
+						...gridPlan,
+						features: planFeaturesForComparisonGrid[ gridPlan.planSlug ],
+					},
+				];
+			}
 
-		return acc;
-	}, [] as GridPlan[] );
+			return acc;
+		}, [] as GridPlan[] );
+	}, [ filteredPlansForPlanFeatures, planFeaturesForComparisonGrid ] );
 
 	// we neeed only the visible ones for features grid (these should extend into plans-ui data store selectors)
-	const gridPlansForFeaturesGrid = filteredPlansForPlanFeatures.reduce( ( acc, gridPlan ) => {
-		if ( gridPlan.isVisible ) {
-			return [
-				...acc,
-				{
-					...gridPlan,
-					features: planFeaturesForFeaturesGrid[ gridPlan.planSlug ],
-				},
-			];
-		}
-
-		return acc;
-	}, [] as GridPlan[] );
+	const gridPlansForFeaturesGrid = useMemo( () => {
+		return filteredPlansForPlanFeatures.reduce( ( acc, gridPlan ) => {
+			if ( gridPlan.isVisible ) {
+				return [
+					...acc,
+					{
+						...gridPlan,
+						features: planFeaturesForFeaturesGrid[ gridPlan.planSlug ],
+					},
+				];
+			}
+			return acc;
+		}, [] as GridPlan[] );
+	}, [ filteredPlansForPlanFeatures, planFeaturesForFeaturesGrid ] );
 
 	// If advertising plans for a certain feature, ensure user has pressed "View all plans" before they can see others
 	let hidePlanSelector = 'customer' === planTypeSelector && isDisplayingPlansNeededForFeature();
@@ -465,57 +486,89 @@ const PlansFeaturesMain = ( {
 		_customerType = 'business';
 	}
 
-	const planTypeSelectorProps = {
+	const planTypeSelectorProps = useMemo( () => {
+		return {
+			basePlansPath,
+			isStepperUpgradeFlow,
+			isInSignup,
+			eligibleForWpcomMonthlyPlans,
+			isPlansInsideStepper,
+			intervalType,
+			customerType: _customerType,
+			siteSlug,
+			selectedPlan,
+			selectedFeature,
+			showBiennialToggle,
+			kind: planTypeSelector,
+			plans: gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ),
+		};
+	}, [
 		basePlansPath,
 		isStepperUpgradeFlow,
 		isInSignup,
 		eligibleForWpcomMonthlyPlans,
 		isPlansInsideStepper,
 		intervalType,
-		customerType: _customerType,
+		_customerType,
 		siteSlug,
 		selectedPlan,
 		selectedFeature,
 		showBiennialToggle,
-		kind: planTypeSelector,
-		plans: gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ),
-	};
+		planTypeSelector,
+		gridPlansForFeaturesGrid,
+	] );
 
 	/**
 	 * The effects on /plans page need to be checked if this variable is initialized
 	 */
-	let planActionOverrides: PlanActionOverrides | undefined;
-	if ( isInSignup ) {
-		planActionOverrides = {
-			loggedInFreePlan: {
-				status:
-					isPlanUpsellEnabledOnFreeDomain.isLoading || wpcomFreeDomainSuggestion.isLoading
-						? 'blocked'
-						: 'enabled',
-			},
-		};
-	}
-	if ( sitePlanSlug && isFreePlan( sitePlanSlug ) ) {
-		planActionOverrides = {
-			loggedInFreePlan: {
-				status:
-					isPlanUpsellEnabledOnFreeDomain.isLoading || wpcomFreeDomainSuggestion.isLoading
-						? 'blocked'
-						: 'enabled',
-				callback: () => {
-					page.redirect( `/add-ons/${ siteSlug }` );
+	const planActionOverrides = useMemo( () => {
+		let actionOverrides: PlanActionOverrides | undefined;
+
+		if ( isInSignup ) {
+			actionOverrides = {
+				loggedInFreePlan: {
+					status:
+						isPlanUpsellEnabledOnFreeDomain.isLoading || wpcomFreeDomainSuggestion.isLoading
+							? 'blocked'
+							: 'enabled',
 				},
-				text: translate( 'Manage add-ons', { context: 'verb' } ),
-			},
-		};
-		if ( domainFromHomeUpsellFlow ) {
-			planActionOverrides.loggedInFreePlan = {
-				...planActionOverrides.loggedInFreePlan,
-				callback: showDomainUpsellDialog,
-				text: translate( 'Keep my plan', { context: 'verb' } ),
 			};
 		}
-	}
+
+		if ( sitePlanSlug && isFreePlan( sitePlanSlug ) ) {
+			actionOverrides = {
+				loggedInFreePlan: {
+					status:
+						isPlanUpsellEnabledOnFreeDomain.isLoading || wpcomFreeDomainSuggestion.isLoading
+							? 'blocked'
+							: 'enabled',
+					callback: () => {
+						page.redirect( `/add-ons/${ siteSlug }` );
+					},
+					text: translate( 'Manage add-ons', { context: 'verb' } ),
+				},
+			};
+
+			if ( domainFromHomeUpsellFlow ) {
+				actionOverrides.loggedInFreePlan = {
+					...actionOverrides.loggedInFreePlan,
+					callback: showDomainUpsellDialog,
+					text: translate( 'Keep my plan', { context: 'verb' } ),
+				};
+			}
+		}
+
+		return actionOverrides;
+	}, [
+		isInSignup,
+		sitePlanSlug,
+		isPlanUpsellEnabledOnFreeDomain.isLoading,
+		wpcomFreeDomainSuggestion.isLoading,
+		translate,
+		domainFromHomeUpsellFlow,
+		siteSlug,
+		showDomainUpsellDialog,
+	] );
 
 	/**
 	 * The spotlight in smaller grids looks broken.
@@ -525,12 +578,13 @@ const PlansFeaturesMain = ( {
 	 * Eventually once the spotlight card is made responsive this flag can be removed.
 	 * Check : https://github.com/Automattic/wp-calypso/pull/80232 for more details.
 	 */
-	const gridPlanForSpotlight =
-		sitePlanSlug && isSpotlightOnCurrentPlan && SPOTLIGHT_ENABLED_INTENTS.includes( intent )
+	const gridPlanForSpotlight = useMemo( () => {
+		return sitePlanSlug && isSpotlightOnCurrentPlan && SPOTLIGHT_ENABLED_INTENTS.includes( intent )
 			? gridPlansForFeaturesGrid.find(
 					( { planSlug } ) => getPlanClass( planSlug ) === getPlanClass( sitePlanSlug )
 			  )
 			: undefined;
+	}, [ sitePlanSlug, isSpotlightOnCurrentPlan, intent, gridPlansForFeaturesGrid ] );
 
 	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
 	/**

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-highlighted-features.ts
@@ -6,6 +6,7 @@ import {
 	FEATURE_PAYMENT_TRANSACTION_FEES_8,
 	FEATURE_PAYMENT_TRANSACTION_FEES_4,
 } from '@automattic/calypso-products';
+import { useMemo } from '@wordpress/element';
 import type { PlansIntent } from './use-grid-plans';
 
 export type UseHighlightedFeatures = ( {
@@ -31,18 +32,20 @@ export type UseHighlightedFeatures = ( {
  * TODO clk: move to plans data store
  */
 const useHighlightedFeatures: UseHighlightedFeatures = ( { intent, isInSignup } ) => {
-	if ( isInSignup && intent && 'plans-newsletter' === intent ) {
-		return [
-			FEATURE_CUSTOM_DOMAIN,
-			FEATURE_NEWSLETTER_IMPORT_SUBSCRIBERS_FREE,
-			FEATURE_UNLIMITED_SUBSCRIBERS,
-			FEATURE_PAYMENT_TRANSACTION_FEES_10,
-			FEATURE_PAYMENT_TRANSACTION_FEES_8,
-			FEATURE_PAYMENT_TRANSACTION_FEES_4,
-		];
-	}
+	return useMemo( () => {
+		if ( isInSignup && intent && 'plans-newsletter' === intent ) {
+			return [
+				FEATURE_CUSTOM_DOMAIN,
+				FEATURE_NEWSLETTER_IMPORT_SUBSCRIBERS_FREE,
+				FEATURE_UNLIMITED_SUBSCRIBERS,
+				FEATURE_PAYMENT_TRANSACTION_FEES_10,
+				FEATURE_PAYMENT_TRANSACTION_FEES_8,
+				FEATURE_PAYMENT_TRANSACTION_FEES_4,
+			];
+		}
 
-	return null;
+		return null;
+	}, [ intent, isInSignup ] );
 };
 
 export default useHighlightedFeatures;

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans.ts
@@ -3,6 +3,7 @@ import {
 	applyTestFiltersToPlansList,
 	isMonthly,
 } from '@automattic/calypso-products';
+import { useMemo } from '@wordpress/element';
 import getPlanFeaturesObject from '../../../lib/get-plan-features-object';
 import useHighlightedFeatures from './use-highlighted-features';
 import type { FeatureObject, FeatureList } from '@automattic/calypso-products';
@@ -30,7 +31,7 @@ export type UsePlanFeaturesForGridPlans = ( {
 	isInSignup?: boolean;
 } ) => { [ planSlug: string ]: PlanFeaturesForGridPlan };
 
-/*
+/**
  * usePlanFeaturesForGridPlans:
  * - these plan features are mainly relevannt to FeaturesGrid and Spotlight components
  * - this hook can migrate to data store once features definitions migrate to calypso-products
@@ -45,151 +46,167 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 } ) => {
 	const highlightedFeatures = useHighlightedFeatures( { intent: intent ?? null, isInSignup } );
 
-	return gridPlans.reduce(
-		( acc, gridPlan ) => {
-			const planSlug = gridPlan.planSlug;
-			const planConstantObj = applyTestFiltersToPlansList( planSlug, undefined );
-			const isMonthlyPlan = isMonthly( planSlug );
+	return useMemo(
+		() =>
+			gridPlans.reduce(
+				( acc, gridPlan ) => {
+					const planSlug = gridPlan.planSlug;
+					const planConstantObj = applyTestFiltersToPlansList( planSlug, undefined );
+					const isMonthlyPlan = isMonthly( planSlug );
 
-			let wpcomFeatures: FeatureObject[] = [];
-			let jetpackFeatures: FeatureObject[] = [];
+					let wpcomFeatures: FeatureObject[] = [];
+					let jetpackFeatures: FeatureObject[] = [];
 
-			if ( 'plans-newsletter' === intent ) {
-				wpcomFeatures = getPlanFeaturesObject(
-					allFeaturesList,
-					planConstantObj?.getNewsletterSignupFeatures?.() ?? []
-				);
-			} else if ( 'plans-link-in-bio' === intent ) {
-				wpcomFeatures = getPlanFeaturesObject(
-					allFeaturesList,
-					planConstantObj?.getLinkInBioSignupFeatures?.() ?? []
-				);
-			} else if ( 'plans-blog-onboarding' === intent ) {
-				wpcomFeatures = getPlanFeaturesObject(
-					allFeaturesList,
-					planConstantObj?.getBlogOnboardingSignupFeatures?.() ?? []
-				);
+					if ( 'plans-newsletter' === intent ) {
+						wpcomFeatures = getPlanFeaturesObject(
+							allFeaturesList,
+							planConstantObj?.getNewsletterSignupFeatures?.() ?? []
+						);
+					} else if ( 'plans-link-in-bio' === intent ) {
+						wpcomFeatures = getPlanFeaturesObject(
+							allFeaturesList,
+							planConstantObj?.getLinkInBioSignupFeatures?.() ?? []
+						);
+					} else if ( 'plans-blog-onboarding' === intent ) {
+						wpcomFeatures = getPlanFeaturesObject(
+							allFeaturesList,
+							planConstantObj?.getBlogOnboardingSignupFeatures?.() ?? []
+						);
 
-				jetpackFeatures = getPlanFeaturesObject(
-					allFeaturesList,
-					planConstantObj.getBlogOnboardingSignupJetpackFeatures?.() ?? []
-				);
-			} else if ( 'plans-woocommerce' === intent ) {
-				wpcomFeatures = getPlanFeaturesObject(
-					allFeaturesList,
-					planConstantObj?.get2023PricingGridSignupWpcomFeatures?.() ?? []
-				);
+						jetpackFeatures = getPlanFeaturesObject(
+							allFeaturesList,
+							planConstantObj.getBlogOnboardingSignupJetpackFeatures?.() ?? []
+						);
+					} else if ( 'plans-woocommerce' === intent ) {
+						wpcomFeatures = getPlanFeaturesObject(
+							allFeaturesList,
+							planConstantObj?.get2023PricingGridSignupWpcomFeatures?.() ?? []
+						);
 
-				jetpackFeatures = getPlanFeaturesObject(
-					allFeaturesList,
-					planConstantObj.get2023PricingGridSignupJetpackFeatures?.() ?? []
-				);
+						jetpackFeatures = getPlanFeaturesObject(
+							allFeaturesList,
+							planConstantObj.get2023PricingGridSignupJetpackFeatures?.() ?? []
+						);
 
-				/*
-				 * Woo Express plans with an introductory offer need some features removed:
-				 * - custom domain feature removed for all Woo Express plans
-				 */
-				if ( gridPlan.pricing.introOffer ) {
-					wpcomFeatures = wpcomFeatures.filter( ( feature ) => {
-						// Remove the custom domain feature for Woo Express plans with an introductory offer.
-						if ( FEATURE_CUSTOM_DOMAIN === feature.getSlug() ) {
-							return false;
+						/*
+						 * Woo Express plans with an introductory offer need some features removed:
+						 * - custom domain feature removed for all Woo Express plans
+						 */
+						if ( gridPlan.pricing.introOffer ) {
+							wpcomFeatures = wpcomFeatures.filter( ( feature ) => {
+								// Remove the custom domain feature for Woo Express plans with an introductory offer.
+								if ( FEATURE_CUSTOM_DOMAIN === feature.getSlug() ) {
+									return false;
+								}
+
+								return true;
+							} );
 						}
+					} else {
+						wpcomFeatures = getPlanFeaturesObject(
+							allFeaturesList,
+							planConstantObj?.get2023PricingGridSignupWpcomFeatures?.() ?? []
+						);
 
-						return true;
+						jetpackFeatures = getPlanFeaturesObject(
+							allFeaturesList,
+							planConstantObj.get2023PricingGridSignupJetpackFeatures?.() ?? []
+						);
+					}
+
+					const annualPlansOnlyFeatures = planConstantObj.getAnnualPlansOnlyFeatures?.() || [];
+					const wpcomFeaturesTransformed: TransformedFeatureObject[] = [];
+					const jetpackFeaturesTransformed = jetpackFeatures.map( ( feature ) => {
+						const availableOnlyForAnnualPlans = annualPlansOnlyFeatures.includes(
+							feature.getSlug()
+						);
+
+						return {
+							...feature,
+							availableOnlyForAnnualPlans,
+							availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
+						};
 					} );
-				}
-			} else {
-				wpcomFeatures = getPlanFeaturesObject(
-					allFeaturesList,
-					planConstantObj?.get2023PricingGridSignupWpcomFeatures?.() ?? []
-				);
 
-				jetpackFeatures = getPlanFeaturesObject(
-					allFeaturesList,
-					planConstantObj.get2023PricingGridSignupJetpackFeatures?.() ?? []
-				);
-			}
+					if ( highlightedFeatures ) {
+						// slice() and reverse() are needed to the preserve order of features
+						highlightedFeatures
+							.slice()
+							.reverse()
+							.forEach( ( slug ) => {
+								const feature = wpcomFeatures.find( ( feature ) => feature.getSlug() === slug );
+								if ( feature ) {
+									const availableOnlyForAnnualPlans = annualPlansOnlyFeatures.includes(
+										feature.getSlug()
+									);
+									wpcomFeaturesTransformed.unshift( {
+										...feature,
+										availableOnlyForAnnualPlans,
+										availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
+										isHighlighted: true,
+									} );
+								}
+							} );
+					}
 
-			const annualPlansOnlyFeatures = planConstantObj.getAnnualPlansOnlyFeatures?.() || [];
-			const wpcomFeaturesTransformed: TransformedFeatureObject[] = [];
-			const jetpackFeaturesTransformed = jetpackFeatures.map( ( feature ) => {
-				const availableOnlyForAnnualPlans = annualPlansOnlyFeatures.includes( feature.getSlug() );
+					const topFeature = selectedFeature
+						? wpcomFeatures.find( ( feature ) => feature.getSlug() === selectedFeature )
+						: undefined;
 
-				return {
-					...feature,
-					availableOnlyForAnnualPlans,
-					availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
-				};
-			} );
+					if ( topFeature ) {
+						const availableOnlyForAnnualPlans = annualPlansOnlyFeatures.includes(
+							topFeature.getSlug()
+						);
+						wpcomFeaturesTransformed.unshift( {
+							...topFeature,
+							availableOnlyForAnnualPlans,
+							availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
+						} );
+					}
 
-			if ( highlightedFeatures ) {
-				// slice() and reverse() are neede to the preserve order of features
-				highlightedFeatures
-					.slice()
-					.reverse()
-					.forEach( ( slug ) => {
-						const feature = wpcomFeatures.find( ( feature ) => feature.getSlug() === slug );
-						if ( feature ) {
+					if ( annualPlansOnlyFeatures.length > 0 ) {
+						wpcomFeatures.forEach( ( feature ) => {
+							// topFeature and highlightedFeatures are already added to the list above
+							const isHighlightedFeature =
+								highlightedFeatures && highlightedFeatures.includes( feature.getSlug() );
+							if ( feature === topFeature || isHighlightedFeature ) {
+								return;
+							}
+
 							const availableOnlyForAnnualPlans = annualPlansOnlyFeatures.includes(
 								feature.getSlug()
 							);
-							wpcomFeaturesTransformed.unshift( {
+
+							wpcomFeaturesTransformed.push( {
 								...feature,
 								availableOnlyForAnnualPlans,
 								availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
-								isHighlighted: true,
 							} );
-						}
-					} );
-			}
-
-			const topFeature = selectedFeature
-				? wpcomFeatures.find( ( feature ) => feature.getSlug() === selectedFeature )
-				: undefined;
-
-			if ( topFeature ) {
-				const availableOnlyForAnnualPlans = annualPlansOnlyFeatures.includes(
-					topFeature.getSlug()
-				);
-				wpcomFeaturesTransformed.unshift( {
-					...topFeature,
-					availableOnlyForAnnualPlans,
-					availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
-				} );
-			}
-
-			if ( annualPlansOnlyFeatures.length > 0 ) {
-				wpcomFeatures.forEach( ( feature ) => {
-					// topFeature and highlightedFeatures are already added to the list above
-					const isHighlightedFeature =
-						highlightedFeatures && highlightedFeatures.includes( feature.getSlug() );
-					if ( feature === topFeature || isHighlightedFeature ) {
-						return;
+						} );
 					}
 
-					const availableOnlyForAnnualPlans = annualPlansOnlyFeatures.includes( feature.getSlug() );
-
-					wpcomFeaturesTransformed.push( {
-						...feature,
-						availableOnlyForAnnualPlans,
-						availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
-					} );
-				} );
-			}
-
-			return {
-				...acc,
-				[ planSlug ]: {
-					wpcomFeatures: wpcomFeaturesTransformed,
-					jetpackFeatures: jetpackFeaturesTransformed,
-					storageOptions:
-						planConstantObj.get2023PricingGridSignupStorageOptions?.( showLegacyStorageFeature ) ??
-						[],
+					return {
+						...acc,
+						[ planSlug ]: {
+							wpcomFeatures: wpcomFeaturesTransformed,
+							jetpackFeatures: jetpackFeaturesTransformed,
+							storageOptions:
+								planConstantObj.get2023PricingGridSignupStorageOptions?.(
+									showLegacyStorageFeature
+								) ?? [],
+						},
+					};
 				},
-			};
-		},
-		{} as { [ planSlug: string ]: PlanFeaturesForGridPlan }
+				{} as { [ planSlug: string ]: PlanFeaturesForGridPlan }
+			),
+		[
+			gridPlans,
+			intent,
+			highlightedFeatures,
+			selectedFeature,
+			showLegacyStorageFeature,
+			allFeaturesList,
+		]
 	);
 };
 

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-restructured-plan-features-for-comparison-grid.ts
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-restructured-plan-features-for-comparison-grid.ts
@@ -39,7 +39,7 @@ const useRestructuredPlanFeaturesForComparisonGrid: UseRestructuredPlanFeaturesF
 			showLegacyStorageFeature,
 		} );
 
-		const restructuredFeatures = useMemo( () => {
+		return useMemo( () => {
 			let previousPlan = null;
 			const planFeatureMap: Record< string, PlanFeaturesForGridPlan > = {};
 
@@ -145,9 +145,7 @@ const useRestructuredPlanFeaturesForComparisonGrid: UseRestructuredPlanFeaturesF
 			}
 
 			return planFeatureMap;
-		}, [ gridPlans, allFeaturesList, intent, planFeaturesForGridPlans ] );
-
-		return restructuredFeatures;
+		}, [ gridPlans, allFeaturesList, planFeaturesForGridPlans, intent ] );
 	};
 
 export default useRestructuredPlanFeaturesForComparisonGrid;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78266

This is a follow-up from https://github.com/Automattic/wp-calypso/pull/82249 and https://github.com/Automattic/wp-calypso/pull/82403 to address performance improvements. It is part of a series of enhancements happening across a few consecutive/linked PRs. 

## Proposed Changes

Memoizes various callbacks and inline object data transformations/compilations happening in the plans-grid wrapper (`plans-features-main`) to make sure we feed the grid with the same objects when none of the concerned dependencies change. This would allow React to optimize component re-renders inside the plans-grid components. The following are now wrapped with `useMemo/Callback`:


- useIsCustomDomainAllowedOnFreePlan
- useGetFreeSubdomainSuggestion
- handleUpgradeClick
- planActionOverrides
- planTypeSelectorProps
- handleStorageAddOnClick
- gridPlanForSpotlight
- gridPlansForFeaturesGrid
- gridPlansForComparisonGrid
- useFilterPlansForPlanFeatures
- usePlanFeaturesForGridPlans
- useRestructuredPlanFeaturesForComparisonGrid
- resolvedSubdomainName

### Notes

I am not a big fan of "memorizing unconditionally" (as caching carries its own costs), but we've been memoizing things at places, just not uniformly/consistently. This brings more unity. These sorts of enhancements will likely become more vital as we progress with the NPM refactors - they are not immediately obvious right now either. The use of context in the `plans-grid` may potentially block such enhancement from taking effect, so that may need to be revisited soon (opt for the `wpcom-plans-ui` data store instead, as an alternative).

### Next

A good follow-up from here is https://github.com/Automattic/wp-calypso/issues/82409, which would bring some of these data transformations into a more accessible location for reuse (which will essentially be needed for easier package reuse).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/[site]` and `/start/plans` and try to smoke test as much as possible. Everything should behave like before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?