### PR TITLE
Plans 2023: Grid perf (part 3) - memoize useAddOns hook

### DIFF
--- a/client/my-sites/add-ons/hooks/use-add-on-display-cost.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-display-cost.ts
@@ -6,10 +6,10 @@ import useAddOnPrices from './use-add-on-prices';
 const useAddOnDisplayCost = ( productSlug: string, quantity?: number ) => {
 	const translate = useTranslate();
 	const prices = useAddOnPrices( productSlug, quantity );
-	const formattedCost = prices?.formattedMonthlyPrice || '';
 
 	return useSelector( ( state ) => {
 		const product = getProductBySlug( state, productSlug );
+		const formattedCost = prices?.formattedMonthlyPrice || '';
 
 		if ( product?.product_term === 'month' ) {
 			return translate( '%(formattedCost)s/month, billed monthly', {

--- a/client/my-sites/add-ons/hooks/use-add-on-display-cost.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-display-cost.ts
@@ -6,10 +6,10 @@ import useAddOnPrices from './use-add-on-prices';
 const useAddOnDisplayCost = ( productSlug: string, quantity?: number ) => {
 	const translate = useTranslate();
 	const prices = useAddOnPrices( productSlug, quantity );
+	const formattedCost = prices?.formattedMonthlyPrice || '';
 
 	return useSelector( ( state ) => {
 		const product = getProductBySlug( state, productSlug );
-		const formattedCost = prices?.formattedMonthlyPrice || '';
 
 		if ( product?.product_term === 'month' ) {
 			return translate( '%(formattedCost)s/month, billed monthly', {

--- a/client/my-sites/add-ons/hooks/use-add-on-feature-slugs.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-feature-slugs.ts
@@ -9,28 +9,31 @@ import {
 	FEATURE_100GB_STORAGE_ADD_ON,
 	PRODUCT_1GB_SPACE,
 } from '@automattic/calypso-products';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Returns any relevant feature slugs for a given add-on.
  * Add-ons are currently uniquely identified by their product slugs.
  */
 const useAddOnFeatureSlugs = ( addOnProductSlug: string, quantity?: number ) => {
-	switch ( addOnProductSlug ) {
-		case PRODUCT_WPCOM_UNLIMITED_THEMES:
-			return [ WPCOM_FEATURES_PREMIUM_THEMES ];
-		case PRODUCT_WPCOM_CUSTOM_DESIGN:
-			return [ WPCOM_FEATURES_CUSTOM_DESIGN ];
-		case PRODUCT_NO_ADS:
-			return [ WPCOM_FEATURES_NO_ADVERTS ];
-		case PRODUCT_1GB_SPACE:
-			if ( quantity === 50 ) {
-				return [ FEATURE_50GB_STORAGE_ADD_ON ];
-			} else if ( quantity === 100 ) {
-				return [ FEATURE_100GB_STORAGE_ADD_ON ];
-			}
-		default:
-			return null;
-	}
+	return useMemo( () => {
+		switch ( addOnProductSlug ) {
+			case PRODUCT_WPCOM_UNLIMITED_THEMES:
+				return [ WPCOM_FEATURES_PREMIUM_THEMES ];
+			case PRODUCT_WPCOM_CUSTOM_DESIGN:
+				return [ WPCOM_FEATURES_CUSTOM_DESIGN ];
+			case PRODUCT_NO_ADS:
+				return [ WPCOM_FEATURES_NO_ADVERTS ];
+			case PRODUCT_1GB_SPACE:
+				if ( quantity === 50 ) {
+					return [ FEATURE_50GB_STORAGE_ADD_ON ];
+				} else if ( quantity === 100 ) {
+					return [ FEATURE_100GB_STORAGE_ADD_ON ];
+				}
+			default:
+				return null;
+		}
+	}, [ addOnProductSlug, quantity ] ); // add dependencies
 };
 
 export default useAddOnFeatureSlugs;

--- a/client/my-sites/add-ons/hooks/use-add-on-prices.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-prices.ts
@@ -1,13 +1,14 @@
 import formatCurrency from '@automattic/format-currency';
+import { useMemo } from '@wordpress/element';
 import { useSelector } from 'calypso/state';
 import { getProductCurrencyCode, getProductBySlug } from 'calypso/state/products-list/selectors';
 
 const useAddOnPrices = ( productSlug: string, quantity?: number ) => {
-	return useSelector( ( state ) => {
-		const product = getProductBySlug( state, productSlug );
-		let cost = product?.cost_smallest_unit;
-		const currencyCode = getProductCurrencyCode( state, productSlug );
+	const product = useSelector( ( state ) => getProductBySlug( state, productSlug ) );
+	const currencyCode = useSelector( ( state ) => getProductCurrencyCode( state, productSlug ) );
 
+	return useMemo( () => {
+		let cost = product?.cost_smallest_unit;
 		if ( ! cost || ! currencyCode ) {
 			return null;
 		}
@@ -45,7 +46,7 @@ const useAddOnPrices = ( productSlug: string, quantity?: number ) => {
 				isSmallestUnit: true,
 			} ),
 		};
-	} );
+	}, [ product, currencyCode, quantity ] );
 };
 
 export default useAddOnPrices;

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -9,6 +9,7 @@ import {
 	PRODUCT_1GB_SPACE,
 	WPCOM_FEATURES_AI_ASSISTANT,
 } from '@automattic/calypso-products';
+import { useMemo } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import useMediaStorageQuery from 'calypso/data/media-storage/use-media-storage-query';
 import { filterTransactions } from 'calypso/me/purchases/billing-history/filter-transactions';
@@ -34,97 +35,144 @@ import useAddOnFeatureSlugs from './use-add-on-feature-slugs';
 import useAddOnPrices from './use-add-on-prices';
 import type { AddOnMeta } from '@automattic/data-stores';
 
-// some memoization. executes far too many times
 const useAddOns = ( siteId?: number, isInSignup = false ): ( AddOnMeta | null )[] => {
 	const translate = useTranslate();
-
-	const addOnsActive = [
-		{
-			productSlug: PRODUCT_JETPACK_AI_MONTHLY,
-			featureSlugs: useAddOnFeatureSlugs( PRODUCT_JETPACK_AI_MONTHLY ),
-			icon: jetpackAIIcon,
-			overrides: null,
-			displayCost: useAddOnDisplayCost( PRODUCT_JETPACK_AI_MONTHLY ),
-			featured: true,
-			description: translate(
-				'Elevate your content with Jetpack AI, your AI assistant in the WordPress Editor. Save time writing with effortless content crafting, tone adjustment, title generation, grammar checks, translation, and more.'
-			),
-		},
-		{
-			productSlug: PRODUCT_WPCOM_UNLIMITED_THEMES,
-			featureSlugs: useAddOnFeatureSlugs( PRODUCT_WPCOM_UNLIMITED_THEMES ),
-			icon: unlimitedThemesIcon,
-			overrides: null,
-			displayCost: useAddOnDisplayCost( PRODUCT_WPCOM_UNLIMITED_THEMES ),
-			featured: true,
-		},
-		{
-			productSlug: PRODUCT_WPCOM_CUSTOM_DESIGN,
-			featureSlugs: useAddOnFeatureSlugs( PRODUCT_WPCOM_CUSTOM_DESIGN ),
-			icon: customDesignIcon,
-			overrides: null,
-			displayCost: useAddOnDisplayCost( PRODUCT_WPCOM_CUSTOM_DESIGN ),
-			featured: false,
-		},
-		{
-			productSlug: PRODUCT_1GB_SPACE,
-			featureSlugs: useAddOnFeatureSlugs( PRODUCT_1GB_SPACE, 50 ),
-			icon: spaceUpgradeIcon,
-			quantity: 50,
-			name: translate( '50 GB Storage' ),
-			displayCost: useAddOnDisplayCost( PRODUCT_1GB_SPACE, 50 ),
-			prices: useAddOnPrices( PRODUCT_1GB_SPACE, 50 ),
-			description: translate(
-				'Make more space for high-quality photos, videos, and other media. '
-			),
-			featured: false,
-			purchased: false,
-		},
-		{
-			productSlug: PRODUCT_1GB_SPACE,
-			featureSlugs: useAddOnFeatureSlugs( PRODUCT_1GB_SPACE, 100 ),
-			icon: spaceUpgradeIcon,
-			quantity: 100,
-			name: translate( '100 GB Storage' ),
-			displayCost: useAddOnDisplayCost( PRODUCT_1GB_SPACE, 100 ),
-			prices: useAddOnPrices( PRODUCT_1GB_SPACE, 100 ),
-			description: translate(
-				'Take your site to the next level. Store all your media in one place without worrying about running out of space.'
-			),
-			featured: false,
-			purchased: false,
-		},
-		{
-			productSlug: PRODUCT_JETPACK_STATS_PWYW_YEARLY,
-			featureSlugs: useAddOnFeatureSlugs( PRODUCT_JETPACK_STATS_PWYW_YEARLY ),
-			icon: jetpackStatsIcon,
-			overrides: null,
-			displayCost: translate( 'Varies', {
-				comment:
-					'Used to describe price of Jetpack Stats, which can be either a pay-what-you-want product or fixed price product. In the future, it can also be a metered product.',
-			} ),
-			featured: true,
-			description: translate(
-				'Upgrade Jetpack Stats to unlock priority support and all upcoming premium features.'
-			),
-		},
-		{
-			productSlug: PRODUCT_JETPACK_STATS_YEARLY,
-			featureSlugs: useAddOnFeatureSlugs( PRODUCT_JETPACK_STATS_YEARLY ),
-			icon: jetpackStatsIcon,
-			overrides: null,
-			displayCost: useAddOnDisplayCost( PRODUCT_JETPACK_STATS_YEARLY ),
-			featured: true,
-			description: translate(
-				'Upgrade Jetpack Stats to unlock priority support and all upcoming premium features.'
-			),
-		},
-	];
-
 	// if upgrade is bought - show as manage
 	// if upgrade is not bought - only show it if available storage and if it's larger than previously bought upgrade
 	const { data: mediaStorage } = useMediaStorageQuery( siteId );
 	const { billingTransactions, isLoading } = usePastBillingTransactions( isInSignup );
+
+	/*
+	 * TODO: `useAddOnFeatureSlugs` be refactored instead to return an index of `{ [ slug ]: featureSlug[] }`
+	 */
+	const featureSlugsJetpackAIMonthly = useAddOnFeatureSlugs( PRODUCT_JETPACK_AI_MONTHLY );
+	const featureSlugsUnlimitedThemes = useAddOnFeatureSlugs( PRODUCT_WPCOM_UNLIMITED_THEMES );
+	const featureSlugsCustomDesign = useAddOnFeatureSlugs( PRODUCT_WPCOM_CUSTOM_DESIGN );
+	const featureSlugs1GBSpace50 = useAddOnFeatureSlugs( PRODUCT_1GB_SPACE, 50 );
+	const featureSlugs1GBSpace100 = useAddOnFeatureSlugs( PRODUCT_1GB_SPACE, 100 );
+	const featureSlugsJetpackStatsYearly = useAddOnFeatureSlugs( PRODUCT_JETPACK_STATS_YEARLY );
+	const featureSlugsJetpackStatsPWYWYearly = useAddOnFeatureSlugs(
+		PRODUCT_JETPACK_STATS_PWYW_YEARLY
+	);
+
+	/*
+	 * TODO: `useAddOnDisplayCost` be refactored instead to return an index of `{ [ slug ]: "display cost" }`
+	 */
+	const displayCostJetpackAIMonthly = useAddOnDisplayCost( PRODUCT_JETPACK_AI_MONTHLY );
+	const displayCostUnlimitedThemes = useAddOnDisplayCost( PRODUCT_WPCOM_UNLIMITED_THEMES );
+	const displayCostCustomDesign = useAddOnDisplayCost( PRODUCT_WPCOM_CUSTOM_DESIGN );
+	const displayCost1GBSpace50 = useAddOnDisplayCost( PRODUCT_1GB_SPACE, 50 );
+	const displayCost1GBSpace100 = useAddOnDisplayCost( PRODUCT_1GB_SPACE, 100 );
+	const displayCostJetpackStatsYearly = useAddOnDisplayCost( PRODUCT_JETPACK_STATS_YEARLY );
+
+	/*
+	 * TODO: `useAddOnPrices` be refactored instead to return an index of `{ [ slug ]: AddOnPrice }`
+	 */
+	const addOnPrices1GBSpace50 = useAddOnPrices( PRODUCT_1GB_SPACE, 50 );
+	const addOnPrices1GBSpace100 = useAddOnPrices( PRODUCT_1GB_SPACE, 100 );
+
+	const addOnsActive = useMemo(
+		() => [
+			{
+				productSlug: PRODUCT_JETPACK_AI_MONTHLY,
+				featureSlugs: featureSlugsJetpackAIMonthly,
+				icon: jetpackAIIcon,
+				overrides: null,
+				displayCost: displayCostJetpackAIMonthly,
+				featured: true,
+				description: translate(
+					'Elevate your content with Jetpack AI, your AI assistant in the WordPress Editor. Save time writing with effortless content crafting, tone adjustment, title generation, grammar checks, translation, and more.'
+				),
+			},
+			{
+				productSlug: PRODUCT_WPCOM_UNLIMITED_THEMES,
+				featureSlugs: featureSlugsUnlimitedThemes,
+				icon: unlimitedThemesIcon,
+				overrides: null,
+				displayCost: displayCostUnlimitedThemes,
+				featured: true,
+			},
+			{
+				productSlug: PRODUCT_WPCOM_CUSTOM_DESIGN,
+				featureSlugs: featureSlugsCustomDesign,
+				icon: customDesignIcon,
+				overrides: null,
+				displayCost: displayCostCustomDesign,
+				featured: false,
+			},
+			{
+				productSlug: PRODUCT_1GB_SPACE,
+				featureSlugs: featureSlugs1GBSpace50,
+				icon: spaceUpgradeIcon,
+				quantity: 50,
+				name: translate( '50 GB Storage' ),
+				displayCost: displayCost1GBSpace50,
+				prices: addOnPrices1GBSpace50,
+				description: translate(
+					'Make more space for high-quality photos, videos, and other media. '
+				),
+				featured: false,
+				purchased: false,
+			},
+			{
+				productSlug: PRODUCT_1GB_SPACE,
+				featureSlugs: featureSlugs1GBSpace100,
+				icon: spaceUpgradeIcon,
+				quantity: 100,
+				name: translate( '100 GB Storage' ),
+				displayCost: displayCost1GBSpace100,
+				prices: addOnPrices1GBSpace100,
+				description: translate(
+					'Take your site to the next level. Store all your media in one place without worrying about running out of space.'
+				),
+				featured: false,
+				purchased: false,
+			},
+			{
+				productSlug: PRODUCT_JETPACK_STATS_PWYW_YEARLY,
+				featureSlugs: featureSlugsJetpackStatsPWYWYearly,
+				icon: jetpackStatsIcon,
+				overrides: null,
+				displayCost: translate( 'Varies', {
+					comment:
+						'Used to describe price of Jetpack Stats, which can be either a pay-what-you-want product or fixed price product. In the future, it can also be a metered product.',
+				} ),
+				featured: true,
+				description: translate(
+					'Upgrade Jetpack Stats to unlock priority support and all upcoming premium features.'
+				),
+			},
+			{
+				productSlug: PRODUCT_JETPACK_STATS_YEARLY,
+				featureSlugs: featureSlugsJetpackStatsYearly,
+				icon: jetpackStatsIcon,
+				overrides: null,
+				displayCost: displayCostJetpackStatsYearly,
+				featured: true,
+				description: translate(
+					'Upgrade Jetpack Stats to unlock priority support and all upcoming premium features.'
+				),
+			},
+		],
+		[
+			addOnPrices1GBSpace100,
+			addOnPrices1GBSpace50,
+			displayCost1GBSpace100,
+			displayCost1GBSpace50,
+			displayCostCustomDesign,
+			displayCostJetpackAIMonthly,
+			displayCostJetpackStatsYearly,
+			displayCostUnlimitedThemes,
+			featureSlugs1GBSpace100,
+			featureSlugs1GBSpace50,
+			featureSlugsCustomDesign,
+			featureSlugsJetpackAIMonthly,
+			featureSlugsJetpackStatsPWYWYearly,
+			featureSlugsJetpackStatsYearly,
+			featureSlugsUnlimitedThemes,
+			translate,
+		]
+	);
 
 	return useSelector( ( state ): ( AddOnMeta | null )[] => {
 		// get the list of supported features

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -24,7 +24,7 @@ import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-tr
 import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import { usePastBillingTransactions } from 'calypso/state/sites/hooks/use-billing-history';
 import { getSiteOption } from 'calypso/state/sites/selectors';
-import { IAppState } from 'calypso/state/types';
+import { AppState } from 'calypso/types';
 import { STORAGE_LIMIT } from '../constants';
 import customDesignIcon from '../icons/custom-design';
 import jetpackAIIcon from '../icons/jetpack-ai';
@@ -206,7 +206,7 @@ const useActiveAddOnsDefs = () => {
 
 const getAddOnsTransformed = createSelector(
 	(
-		state: IAppState,
+		state: AppState,
 		activeAddOns,
 		spaceUpgradesPurchased,
 		siteId,
@@ -340,7 +340,9 @@ const getAddOnsTransformed = createSelector(
 		isLoadingBillingTransactions,
 		mediaStorage
 	) => [
-		state,
+		getFeaturesBySiteId( state, siteId ),
+		getSiteOption( state, siteId, 'is_commercial' ),
+		state.productsList,
 		activeAddOns,
 		spaceUpgradesPurchased,
 		siteId,

--- a/client/state/selectors/get-billing-transaction-filters.ts
+++ b/client/state/selectors/get-billing-transaction-filters.ts
@@ -1,24 +1,27 @@
+import { createSelector } from '@automattic/state-utils';
 import {
 	BillingTransactionsType,
 	BillingTransactionUiState,
 } from 'calypso/state/billing-transactions/types';
 import { IAppState } from '../types';
-
 import 'calypso/state/billing-transactions/init';
 
 /**
  * Returns filter for the billing transactions of the given type
  */
-export default function getBillingTransactionFilters(
-	state: IAppState,
-	transactionType: BillingTransactionsType
-): BillingTransactionUiState {
-	const filters = state.billingTransactions?.ui?.[ transactionType ] ?? {};
-	return {
-		app: '',
-		date: { month: null, operator: null },
-		page: 1,
-		query: '',
-		...filters,
-	};
-}
+export const getBillingTransactionFilters = createSelector(
+	( state: IAppState, transactionType: BillingTransactionsType ): BillingTransactionUiState => {
+		const filters = state.billingTransactions?.ui?.[ transactionType ] ?? {};
+
+		return {
+			app: '',
+			date: { month: null, operator: null },
+			page: 1,
+			query: '',
+			...filters,
+		};
+	},
+	( state ) => [ state.billingTransactions ]
+);
+
+export default getBillingTransactionFilters;

--- a/client/state/sites/hooks/use-billing-history.ts
+++ b/client/state/sites/hooks/use-billing-history.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useMemo } from '@wordpress/element';
 import wp from 'calypso/lib/wp';
 import { BillingTransaction } from 'calypso/state/billing-transactions/types';
 
@@ -21,10 +22,12 @@ export const usePastBillingTransactions = ( disabled: boolean ) => {
 		queryFn: () => fetchPastBillingTransactions(),
 	} );
 
-	return {
-		billingTransactions: data?.billing_history || null,
-		isLoading: disabled ? false : isLoading,
-		error: error?.message || null,
-		enabled: ! disabled,
-	};
+	return useMemo( () => {
+		return {
+			billingTransactions: data?.billing_history || null,
+			isLoading: disabled ? false : isLoading,
+			error: error?.message || null,
+			enabled: ! disabled,
+		};
+	}, [ data, isLoading, error, disabled ] );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78266

This is a follow-up from https://github.com/Automattic/wp-calypso/pull/82249 and https://github.com/Automattic/wp-calypso/pull/82403 to address performance improvements. It is part of a series of enhancements happening across a few consecutive/linked PRs. 

This is based on https://github.com/Automattic/wp-calypso/pull/82460 which is the second in the series of optimizations (and the first on memoizing). 

## Proposed Changes

Memoizes the result from `useAddOns` hook, to ensure the same object is returned when `state` stabilizes.

The add-ons data compilation is on the roadmap for a refactor (to compile from a data-store package), so the changes here could be indicative of what needs to happen in the refactored version. cc @jeyip

### Possible TODO

- Add a unit test to ensure the result from the hook is memoized when state doesn't change.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/plans/[site]` and `/start/plans` and try to smoke test as much as possible. 
- Ensure interacting with add-ons selector works as before (only available to `/start/plans`)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?