### PR TITLE
Plans 2023: Grid perf (part 4) - memoize useGridPlans hook

### DIFF
--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -342,7 +342,7 @@ const getAddOnsTransformed = createSelector(
 	) => [
 		getFeaturesBySiteId( state, siteId ),
 		getSiteOption( state, siteId, 'is_commercial' ),
-		state.productsList,
+		state.productsList?.items,
 		activeAddOns,
 		spaceUpgradesPurchased,
 		siteId,

--- a/client/my-sites/add-ons/hooks/use-storage-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-storage-add-ons.ts
@@ -6,7 +6,6 @@ interface Props {
 	siteId?: number | null;
 	isInSignup?: boolean;
 }
-
 const useStorageAddOns = ( { siteId, isInSignup }: Props ) => {
 	const addOns = useAddOns( siteId ?? undefined, isInSignup );
 

--- a/client/my-sites/plans-features-main/hooks/use-plan-upgradeability-check.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-upgradeability-check.ts
@@ -1,4 +1,6 @@
+import { createSelector } from '@automattic/state-utils';
 import { useSelector } from 'react-redux';
+import { getSitePlan } from 'calypso/state/sites/plans/selectors';
 import isPlanAvailableForPurchase from 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { PlanSlug } from '@automattic/calypso-products';
@@ -11,9 +13,10 @@ type PlanUpgradeability = {
 	[ planSlug in PlanSlug ]: boolean;
 };
 
-const usePlanUpgradeabilityCheck = ( { planSlugs }: Props ): PlanUpgradeability => {
-	const selectedSiteId = useSelector( getSelectedSiteId );
-	const planUpgradeability = useSelector( ( state ) => {
+const getPlanUpgradeability = createSelector(
+	( state, planSlugs: PlanSlug[] ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+
 		return planSlugs.reduce( ( acc, planSlug ) => {
 			return {
 				...acc,
@@ -21,9 +24,16 @@ const usePlanUpgradeabilityCheck = ( { planSlugs }: Props ): PlanUpgradeability 
 					!! selectedSiteId && isPlanAvailableForPurchase( state, selectedSiteId, planSlug ),
 			};
 		}, {} as PlanUpgradeability );
-	} );
+	},
+	( state, planSlugs: PlanSlug[] ) => [
+		getSelectedSiteId( state ),
+		getSitePlan( state, getSelectedSiteId( state ) ),
+		planSlugs,
+	]
+);
 
-	return planUpgradeability;
+const usePlanUpgradeabilityCheck = ( { planSlugs }: Props ): PlanUpgradeability => {
+	return useSelector( ( state ) => getPlanUpgradeability( state, planSlugs ) );
 };
 
 export default usePlanUpgradeabilityCheck;

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -25,6 +25,7 @@ import {
 	isEcommercePlan,
 	TYPE_P2_PLUS,
 } from '@automattic/calypso-products';
+import { useMemo } from '@wordpress/element';
 import { isSamePlan } from '../../../lib/is-same-plan';
 import useHighlightLabels from './use-highlight-labels';
 import usePlansFromTypes from './use-plans-from-types';
@@ -173,95 +174,96 @@ const usePlanTypesWithIntent = ( {
 	Props,
 	'intent' | 'selectedPlan' | 'sitePlanSlug' | 'hideEnterprisePlan' | 'isSubdomainNotGenerated'
 > ): string[] => {
-	const isEnterpriseAvailable = ! hideEnterprisePlan;
-	const isBloggerAvailable =
-		( selectedPlan && isBloggerPlan( selectedPlan ) ) ||
-		( sitePlanSlug && isBloggerPlan( sitePlanSlug ) );
+	return useMemo( () => {
+		const isEnterpriseAvailable = ! hideEnterprisePlan;
+		const isBloggerAvailable =
+			( selectedPlan && isBloggerPlan( selectedPlan ) ) ||
+			( sitePlanSlug && isBloggerPlan( sitePlanSlug ) );
 
-	let currentSitePlanType = null;
-	if ( sitePlanSlug ) {
-		currentSitePlanType = getPlan( sitePlanSlug )?.type;
-	}
+		let currentSitePlanType = null;
+		if ( sitePlanSlug ) {
+			currentSitePlanType = getPlan( sitePlanSlug )?.type;
+		}
 
-	const availablePlanTypes = [
-		TYPE_FREE,
-		...( isBloggerAvailable ? [ TYPE_BLOGGER ] : [] ),
-		TYPE_PERSONAL,
-		TYPE_PREMIUM,
-		TYPE_BUSINESS,
-		TYPE_ECOMMERCE,
-		...( isEnterpriseAvailable ? [ TYPE_ENTERPRISE_GRID_WPCOM ] : [] ),
-		TYPE_WOOEXPRESS_SMALL,
-		TYPE_WOOEXPRESS_MEDIUM,
-		TYPE_P2_PLUS,
-	];
+		const availablePlanTypes = [
+			TYPE_FREE,
+			...( isBloggerAvailable ? [ TYPE_BLOGGER ] : [] ),
+			TYPE_PERSONAL,
+			TYPE_PREMIUM,
+			TYPE_BUSINESS,
+			TYPE_ECOMMERCE,
+			...( isEnterpriseAvailable ? [ TYPE_ENTERPRISE_GRID_WPCOM ] : [] ),
+			TYPE_WOOEXPRESS_SMALL,
+			TYPE_WOOEXPRESS_MEDIUM,
+		];
 
-	let planTypes;
-	switch ( intent ) {
-		case 'plans-woocommerce':
-			planTypes = [ TYPE_WOOEXPRESS_SMALL, TYPE_WOOEXPRESS_MEDIUM ];
-			break;
-		case 'plans-blog-onboarding':
-			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS ];
-			break;
-		case 'plans-newsletter':
-		case 'plans-link-in-bio':
-			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM ];
-			break;
-		case 'plans-new-hosted-site':
-			planTypes = [ TYPE_BUSINESS, TYPE_ECOMMERCE ];
-			break;
-		case 'plans-import':
-			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS ];
-			break;
-		case 'plans-plugins':
-			planTypes = [
-				...( currentSitePlanType ? [ currentSitePlanType ] : [] ),
-				TYPE_BUSINESS,
-				TYPE_ECOMMERCE,
-			];
-			break;
-		case 'plans-jetpack-app':
-			planTypes = [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
-			break;
-		case 'plans-jetpack-app-site-creation':
-			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
-			break;
-		case 'plans-paid-media':
-			planTypes = [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
-			break;
-		case 'plans-p2':
-			planTypes = [ TYPE_FREE, TYPE_P2_PLUS ];
-			break;
-		case 'plans-default-wpcom':
-			planTypes = [
-				TYPE_FREE,
-				...( isBloggerAvailable ? [ TYPE_BLOGGER ] : [] ),
-				TYPE_PERSONAL,
-				TYPE_PREMIUM,
-				TYPE_BUSINESS,
-				TYPE_ECOMMERCE,
-				...( isEnterpriseAvailable ? [ TYPE_ENTERPRISE_GRID_WPCOM ] : [] ),
-			];
-			break;
-		case 'plans-business-trial':
-			planTypes = [
-				TYPE_BUSINESS,
-				...( isEnterpriseAvailable ? [ TYPE_ENTERPRISE_GRID_WPCOM ] : [] ),
-			];
-			break;
-		default:
-			planTypes = availablePlanTypes;
-	}
+		let planTypes;
+		switch ( intent ) {
+			case 'plans-woocommerce':
+				planTypes = [ TYPE_WOOEXPRESS_SMALL, TYPE_WOOEXPRESS_MEDIUM ];
+				break;
+			case 'plans-blog-onboarding':
+				planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS ];
+				break;
+			case 'plans-newsletter':
+			case 'plans-link-in-bio':
+				planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM ];
+				break;
+			case 'plans-new-hosted-site':
+				planTypes = [ TYPE_BUSINESS, TYPE_ECOMMERCE ];
+				break;
+			case 'plans-import':
+				planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS ];
+				break;
+			case 'plans-plugins':
+				planTypes = [
+					...( currentSitePlanType ? [ currentSitePlanType ] : [] ),
+					TYPE_BUSINESS,
+					TYPE_ECOMMERCE,
+				];
+				break;
+			case 'plans-jetpack-app':
+				planTypes = [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
+				break;
+			case 'plans-jetpack-app-site-creation':
+				planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
+				break;
+			case 'plans-paid-media':
+				planTypes = [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
+				break;
+			case 'plans-p2':
+				planTypes = [ TYPE_FREE, TYPE_P2_PLUS ];
+				break;
+			case 'plans-default-wpcom':
+				planTypes = [
+					TYPE_FREE,
+					...( isBloggerAvailable ? [ TYPE_BLOGGER ] : [] ),
+					TYPE_PERSONAL,
+					TYPE_PREMIUM,
+					TYPE_BUSINESS,
+					TYPE_ECOMMERCE,
+					...( isEnterpriseAvailable ? [ TYPE_ENTERPRISE_GRID_WPCOM ] : [] ),
+				];
+				break;
+			case 'plans-business-trial':
+				planTypes = [
+					TYPE_BUSINESS,
+					...( isEnterpriseAvailable ? [ TYPE_ENTERPRISE_GRID_WPCOM ] : [] ),
+				];
+				break;
+			default:
+				planTypes = availablePlanTypes;
+		}
 
-	// Filters out the free plan  isSubdomainNotGenerated
-	// This is because, on a free plan,  a custom domain can only redirect to the hosted site.
-	// To effectively communicate this, a valid subdomain is necessary.
-	if ( isSubdomainNotGenerated ) {
-		planTypes = planTypes.filter( ( planType ) => planType !== TYPE_FREE );
-	}
+		// Filters out the free plan  isSubdomainNotGenerated
+		// This is because, on a free plan,  a custom domain can only redirect to the hosted site.
+		// To effectively communicate this, a valid subdomain is necessary.
+		if ( isSubdomainNotGenerated ) {
+			planTypes = planTypes.filter( ( planType ) => planType !== TYPE_FREE );
+		}
 
-	return planTypes;
+		return planTypes;
+	}, [ hideEnterprisePlan, selectedPlan, sitePlanSlug, intent, isSubdomainNotGenerated ] );
 };
 
 // TODO clk: move to plans data store
@@ -324,62 +326,76 @@ const useGridPlans = ( {
 		storageAddOns,
 	} );
 
-	// Null return would indicate that we are still loading the data. No grid without grid plans.
-	if ( ! pricingMeta || ! pricedAPIPlans ) {
-		return null;
-	}
-
-	return availablePlanSlugs.map( ( planSlug ) => {
-		const planConstantObj = applyTestFiltersToPlansList( planSlug, undefined );
-		const planObject = pricedAPIPlans[ planSlug ];
-		const isMonthlyPlan = isMonthly( planSlug );
-		const availableForPurchase = !! ( isInSignup || planUpgradeability?.[ planSlug ] );
-		const isCurrentPlan = sitePlanSlug ? isSamePlan( sitePlanSlug, planSlug ) : false;
-
-		let tagline: TranslateResult = '';
-		if ( 'plans-newsletter' === intent ) {
-			tagline = planConstantObj.getNewsletterTagLine?.() ?? '';
-		} else if ( 'plans-link-in-bio' === intent ) {
-			tagline = planConstantObj.getLinkInBioTagLine?.() ?? '';
-		} else if ( 'plans-blog-onboarding' === intent ) {
-			tagline = planConstantObj.getBlogOnboardingTagLine?.() ?? '';
-		} else {
-			tagline = planConstantObj.getPlanTagline?.() ?? '';
+	return useMemo( () => {
+		// Null return would indicate that we are still loading the data. No grid without grid plans.
+		if ( ! pricingMeta || ! pricedAPIPlans ) {
+			return null;
 		}
 
-		const productNameShort =
-			isWpcomEnterpriseGridPlan( planSlug ) && planConstantObj.getPathSlug
-				? planConstantObj.getPathSlug()
-				: planObject?.product_name_short ?? null;
+		return availablePlanSlugs.map( ( planSlug ) => {
+			const planConstantObj = applyTestFiltersToPlansList( planSlug, undefined );
+			const planObject = pricedAPIPlans[ planSlug ];
+			const isMonthlyPlan = isMonthly( planSlug );
+			const availableForPurchase = !! ( isInSignup || planUpgradeability?.[ planSlug ] );
+			const isCurrentPlan = sitePlanSlug ? isSamePlan( sitePlanSlug, planSlug ) : false;
 
-		// cartItemForPlan done in line here as it's a small piece of logic to pass another selector for
-		const cartItemForPlan =
-			isWpComFreePlan( planSlug ) || isWpcomEnterpriseGridPlan( planSlug )
-				? null
-				: {
-						product_slug: planSlug,
-				  };
+			let tagline: TranslateResult = '';
+			if ( 'plans-newsletter' === intent ) {
+				tagline = planConstantObj.getNewsletterTagLine?.() ?? '';
+			} else if ( 'plans-link-in-bio' === intent ) {
+				tagline = planConstantObj.getLinkInBioTagLine?.() ?? '';
+			} else if ( 'plans-blog-onboarding' === intent ) {
+				tagline = planConstantObj.getBlogOnboardingTagLine?.() ?? '';
+			} else {
+				tagline = planConstantObj.getPlanTagline?.() ?? '';
+			}
 
-		const storageAddOnsForPlan =
-			isBusinessPlan( planSlug ) || isEcommercePlan( planSlug ) ? storageAddOns : null;
+			const productNameShort =
+				isWpcomEnterpriseGridPlan( planSlug ) && planConstantObj.getPathSlug
+					? planConstantObj.getPathSlug()
+					: planObject?.product_name_short ?? null;
 
-		return {
-			planSlug,
-			freeTrialPlanSlug: freeTrialPlanSlugs?.[ planConstantObj.type ],
-			isVisible: planSlugsForIntent.includes( planSlug ),
-			tagline,
-			availableForPurchase,
-			productNameShort,
-			planTitle: planConstantObj.getTitle?.() ?? '',
-			billingTimeframe: planConstantObj.getBillingTimeFrame?.(),
-			current: isCurrentPlan,
-			isMonthlyPlan,
-			cartItemForPlan,
-			highlightLabel: highlightLabels[ planSlug ],
-			pricing: pricingMeta[ planSlug ],
-			storageAddOnsForPlan,
-		};
-	} );
+			// cartItemForPlan done in line here as it's a small piece of logic to pass another selector for
+			const cartItemForPlan =
+				isWpComFreePlan( planSlug ) || isWpcomEnterpriseGridPlan( planSlug )
+					? null
+					: {
+							product_slug: planSlug,
+					  };
+
+			const storageAddOnsForPlan =
+				isBusinessPlan( planSlug ) || isEcommercePlan( planSlug ) ? storageAddOns : null;
+
+			return {
+				planSlug,
+				freeTrialPlanSlug: freeTrialPlanSlugs?.[ planConstantObj.type ],
+				isVisible: planSlugsForIntent.includes( planSlug ),
+				tagline,
+				availableForPurchase,
+				productNameShort,
+				planTitle: planConstantObj.getTitle?.() ?? '',
+				billingTimeframe: planConstantObj.getBillingTimeFrame?.(),
+				current: isCurrentPlan,
+				isMonthlyPlan,
+				cartItemForPlan,
+				highlightLabel: highlightLabels[ planSlug ],
+				pricing: pricingMeta[ planSlug ],
+				storageAddOnsForPlan,
+			};
+		} );
+	}, [
+		pricingMeta,
+		pricedAPIPlans,
+		availablePlanSlugs,
+		isInSignup,
+		planUpgradeability,
+		sitePlanSlug,
+		intent,
+		storageAddOns,
+		freeTrialPlanSlugs,
+		planSlugsForIntent,
+		highlightLabels,
+	] );
 };
 
 export default useGridPlans;

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-highlight-labels.ts
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-highlight-labels.ts
@@ -5,6 +5,7 @@ import {
 	planLevelsMatch,
 	type PlanSlug,
 } from '@automattic/calypso-products';
+import { useMemo } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { isSamePlan } from '../../../lib/is-same-plan';
 import { isPopularPlan } from './is-popular-plan';
@@ -31,44 +32,48 @@ const useHighlightLabels = ( {
 }: Props ) => {
 	const translate = useTranslate();
 
-	return planSlugs.reduce(
-		( acc, planSlug ) => {
-			const isCurrentPlan = currentSitePlanSlug
-				? isSamePlan( currentSitePlanSlug, planSlug )
-				: false;
-			const isPlanAvailableForUpgrade = planUpgradeability?.[ planSlug ];
-			const isSuggestedPlan =
-				selectedPlan && planLevelsMatch( planSlug, selectedPlan ) && isPlanAvailableForUpgrade;
+	return useMemo(
+		() =>
+			planSlugs.reduce(
+				( acc, planSlug ) => {
+					const isCurrentPlan = currentSitePlanSlug
+						? isSamePlan( currentSitePlanSlug, planSlug )
+						: false;
+					const isPlanAvailableForUpgrade = planUpgradeability?.[ planSlug ];
+					const isSuggestedPlan =
+						selectedPlan && planLevelsMatch( planSlug, selectedPlan ) && isPlanAvailableForUpgrade;
 
-			let label;
-			if ( isCurrentPlan ) {
-				label = translate( 'Your plan' );
-			} else if ( isSuggestedPlan ) {
-				label = translate( 'Suggested' );
-			} else if ( 'plans-newsletter' === intent ) {
-				if ( isPersonalPlan( planSlug ) ) {
-					label = translate( 'Best for Newsletter' );
-				}
-			} else if ( 'plans-link-in-bio' === intent ) {
-				if ( isPremiumPlan( planSlug ) ) {
-					label = translate( 'Best for Link in Bio' );
-				}
-			} else if ( 'plans-blog-onboarding' === intent ) {
-				if ( isPremiumPlan( planSlug ) ) {
-					label = translate( 'Best for Blog' );
-				}
-			} else if ( isBusinessPlan( planSlug ) && ! selectedPlan ) {
-				label = translate( 'Best for devs' );
-			} else if ( isPopularPlan( planSlug ) && ! selectedPlan ) {
-				label = translate( 'Popular' );
-			}
+					let label;
+					if ( isCurrentPlan ) {
+						label = translate( 'Your plan' );
+					} else if ( isSuggestedPlan ) {
+						label = translate( 'Suggested' );
+					} else if ( 'plans-newsletter' === intent ) {
+						if ( isPersonalPlan( planSlug ) ) {
+							label = translate( 'Best for Newsletter' );
+						}
+					} else if ( 'plans-link-in-bio' === intent ) {
+						if ( isPremiumPlan( planSlug ) ) {
+							label = translate( 'Best for Link in Bio' );
+						}
+					} else if ( 'plans-blog-onboarding' === intent ) {
+						if ( isPremiumPlan( planSlug ) ) {
+							label = translate( 'Best for Blog' );
+						}
+					} else if ( isBusinessPlan( planSlug ) && ! selectedPlan ) {
+						label = translate( 'Best for devs' );
+					} else if ( isPopularPlan( planSlug ) && ! selectedPlan ) {
+						label = translate( 'Popular' );
+					}
 
-			return {
-				...acc,
-				[ planSlug ]: label ?? null,
-			};
-		},
-		{} as Record< PlanSlug, TranslateResult | null >
+					return {
+						...acc,
+						[ planSlug ]: label ?? null,
+					};
+				},
+				{} as Record< PlanSlug, TranslateResult | null >
+			),
+		[ planSlugs, currentSitePlanSlug, planUpgradeability, selectedPlan, intent, translate ]
 	);
 };
 

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-plans-from-types.ts
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-plans-from-types.ts
@@ -8,6 +8,7 @@ import {
 	TYPE_P2_PLUS,
 	GROUP_P2,
 } from '@automattic/calypso-products';
+import { useMemo } from '@wordpress/element';
 import warn from '@wordpress/warning';
 import type { PlansIntent } from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans';
 
@@ -18,34 +19,36 @@ interface Props {
 }
 
 const usePlansFromTypes = ( { planTypes, term, intent }: Props ): PlanSlug[] => {
-	const plans = planTypes.reduce( ( accum: PlanSlug[], type ) => {
-		// These plans don't have a term.
-		// We may consider to move this logic into the underlying `planMatches` function, but that would have wider implication so it's TBD
-		const planQuery: { type: string; term?: string; group?: string } = [
-			TYPE_FREE,
-			TYPE_ENTERPRISE_GRID_WPCOM,
-			TYPE_WOO_EXPRESS_PLUS,
-			TYPE_P2_PLUS,
-		].includes( type )
-			? { type }
-			: { type, term };
+	return useMemo(
+		() =>
+			planTypes.reduce( ( accum: PlanSlug[], type ) => {
+				// These plans don't have a term.
+				// We may consider to move this logic into the underlying `planMatches` function, but that would have wider implication so it's TBD
+				const planQuery: { type: string; term?: string; group?: string } = [
+					TYPE_FREE,
+					TYPE_ENTERPRISE_GRID_WPCOM,
+					TYPE_WOO_EXPRESS_PLUS,
+					TYPE_P2_PLUS,
+				].includes( type )
+					? { type }
+					: { type, term };
 
-		if ( intent === 'plans-p2' ) {
-			planQuery[ 'group' ] = GROUP_P2;
-		}
+				if ( intent === 'plans-p2' ) {
+					planQuery[ 'group' ] = GROUP_P2;
+				}
 
-		const plan = findPlansKeys( planQuery )[ 0 ];
+				const plan = findPlansKeys( planQuery )[ 0 ];
 
-		if ( ! plan ) {
-			warn(
-				`Invalid plan type, \`${ type }\`, provided to \`PlansFeaturesMain\` component. See plans constants for valid plan types.`
-			);
-		}
+				if ( ! plan ) {
+					warn(
+						`Invalid plan type, \`${ type }\`, provided to \`PlansFeaturesMain\` component. See plans constants for valid plan types.`
+					);
+				}
 
-		return plan ? [ ...accum, plan as PlanSlug ] : accum;
-	}, [] );
-
-	return plans;
+				return plan ? [ ...accum, plan as PlanSlug ] : accum;
+			}, [] ),
+		[ intent, planTypes, term ]
+	);
 };
 
 export default usePlansFromTypes;

--- a/client/state/purchases/selectors/get-by-purchase-id.js
+++ b/client/state/purchases/selectors/get-by-purchase-id.js
@@ -1,3 +1,4 @@
+import { createSelector } from '@automattic/state-utils';
 import { getPurchases } from './get-purchases';
 
 import 'calypso/state/purchases/init';
@@ -8,5 +9,7 @@ import 'calypso/state/purchases/init';
  * @param   {number} purchaseId  the purchase id
  * @returns {import('calypso/lib/purchases/types').Purchase|undefined} the matching purchase if there is one
  */
-export const getByPurchaseId = ( state, purchaseId ) =>
-	getPurchases( state ).find( ( purchase ) => purchase.id === purchaseId );
+export const getByPurchaseId = createSelector(
+	( state, purchaseId ) => getPurchases( state ).find( ( purchase ) => purchase.id === purchaseId ),
+	[ getPurchases ]
+);

--- a/client/state/purchases/selectors/get-by-purchase-id.js
+++ b/client/state/purchases/selectors/get-by-purchase-id.js
@@ -1,4 +1,3 @@
-import { createSelector } from '@automattic/state-utils';
 import { getPurchases } from './get-purchases';
 
 import 'calypso/state/purchases/init';
@@ -9,7 +8,5 @@ import 'calypso/state/purchases/init';
  * @param   {number} purchaseId  the purchase id
  * @returns {import('calypso/lib/purchases/types').Purchase|undefined} the matching purchase if there is one
  */
-export const getByPurchaseId = createSelector(
-	( state, purchaseId ) => getPurchases( state ).find( ( purchase ) => purchase.id === purchaseId ),
-	[ getPurchases ]
-);
+export const getByPurchaseId = ( state, purchaseId ) =>
+	getPurchases( state ).find( ( purchase ) => purchase.id === purchaseId );

--- a/client/state/sites/plans/selectors/get-current-plan.js
+++ b/client/state/sites/plans/selectors/get-current-plan.js
@@ -1,3 +1,4 @@
+import { createSelector } from '@automattic/state-utils';
 import debugFactory from 'debug';
 import { find } from 'lodash';
 import { createSitePlanObject } from 'calypso/state/sites/plans/assembler';
@@ -6,20 +7,24 @@ import { getSite } from 'calypso/state/sites/selectors';
 
 const debug = debugFactory( 'calypso:state:sites:plans:selectors' );
 
-export function getCurrentPlan( state, siteId ) {
-	const plans = getPlansBySiteId( state, siteId );
-	if ( plans.data ) {
-		const currentPlan = find( plans.data, 'currentPlan' );
+export const getCurrentPlan = createSelector(
+	( state, siteId ) => {
+		const plans = getPlansBySiteId( state, siteId );
 
-		if ( currentPlan ) {
-			debug( 'current plan: %o', currentPlan );
-			return currentPlan;
+		if ( plans.data ) {
+			const currentPlan = find( plans.data, 'currentPlan' );
+
+			if ( currentPlan ) {
+				debug( 'current plan: %o', currentPlan );
+				return currentPlan;
+			}
+
+			const site = getSite( state, siteId );
+			const plan = createSitePlanObject( site.plan );
+			debug( 'current plan: %o', plan );
+			return plan;
 		}
-
-		const site = getSite( state, siteId );
-		const plan = createSitePlanObject( site.plan );
-		debug( 'current plan: %o', plan );
-		return plan;
-	}
-	return null;
-}
+		return null;
+	},
+	( state, siteId ) => [ getPlansBySiteId( state, siteId ), getSite( state, siteId ) ]
+);

--- a/packages/state-utils/src/create-selector/index.ts
+++ b/packages/state-utils/src/create-selector/index.ts
@@ -21,7 +21,6 @@ type Dependant< TState, TProps extends any[], TDependency > = (
  * Default behavior for determining whether current state differs from previous
  * state, which is the basis upon which memoize cache is cleared. Should return
  * a value or array of values to be shallowly compared for strict equality.
- *
  * @param state Current state object
  * @returns Value(s) to be shallow compared
  */
@@ -55,7 +54,6 @@ const DEFAULT_GET_CACHE_KEY = ( () => {
 /**
  * Given an array of getDependants functions, returns a single function which,
  * when called, returns an array of mapped results from those functions.
- *
  * @param dependants Array of getDependants
  * @returns Function mapping getDependants results
  */
@@ -66,7 +64,6 @@ const makeSelectorFromArray =
 
 /**
  * Returns a memoized state selector for use with the global application state.
- *
  * @param selector      Function calculating cached result
  * @param getDependants Function(s) describing dependent
  *                                             state, or an array of dependent


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78266

This is a follow-up from https://github.com/Automattic/wp-calypso/pull/82249 and https://github.com/Automattic/wp-calypso/pull/82403 to address performance improvements. It is part of a series of enhancements happening across a few consecutive/linked PRs.

This is based on https://github.com/Automattic/wp-calypso/pull/82461 which is the third in the series of optimizations.

## Proposed Changes

Memoizes the result from `useGridPlans` hook. 

This is a slightly "deeper" refactor as `useGridPlans` is the main API for pulling in the data for the `plans-grid` components. This hook and its dependencies will also be subject to additional refactors as we progress with the NPM migration (e.g. no longer feeding the hook with state-dependent callbacks for fetching pricing and add-ons metadata). Changes happening here though could be indicative of what needs to happen in the refactored versions.

### Possible TODO

- Add a unit test to ensure the result from the hook is memoized when state doesn't change.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/[site]` and `/start/plans` and try to smoke test as much as possible.
* Ensure interacting with components outside the grid (e.g. toggle to show/hide comparison grid or to switch term) work as before (`plans-grid` components are updated as expected)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?