### PR TITLE
Composite Checkout: Fix Storybook examples

### DIFF
--- a/packages/composite-checkout/demo/index.stories.tsx
+++ b/packages/composite-checkout/demo/index.stories.tsx
@@ -6,7 +6,6 @@ import {
 	CheckoutStepGroup,
 	FormStatus,
 	PaymentMethodStep,
-	getDefaultOrderReviewStep,
 	makeSuccessResponse,
 	useFormStatus,
 	useIsStepActive,
@@ -14,6 +13,7 @@ import {
 } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useState, useEffect, useMemo, useRef } from 'react';
+import { getDefaultOrderReviewStep } from '../src/components/default-steps';
 import { createPayPalMethod } from './pay-pal';
 
 const initialItems = [

--- a/packages/composite-checkout/demo/pay-pal.tsx
+++ b/packages/composite-checkout/demo/pay-pal.tsx
@@ -2,13 +2,13 @@ import {
 	FormStatus,
 	TransactionStatus,
 	useTransactionStatus,
-	useLineItems,
 	useFormStatus,
 	Button,
 } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { Fragment } from 'react';
+import { useLineItems } from '../src/lib/line-items';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 
 const ButtonPayPalIcon = styled( PaypalLogo )`


### PR DESCRIPTION
## Proposed Changes

This PR fixes the `@automattic/composite-checkout` storybook examples. 

I discovered they're broken during testing of #80524.

Seems like they were broken in #81807 where we removed a bunch of unused exports from the package.

## Testing Instructions

* Checkout this branch
* Run a fresh `yarn install`
* Navigate to package dir: `cd packages/composite-checkout`
* Run `yarn run storybook`
* Verify the example works.