### PR TITLE
Allow multiple ThemeCollection on one page

### DIFF
--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -33,9 +33,11 @@ export default function ThemeCollection( {
 	isInstalling,
 }: ThemeCollectionProps ): ReactElement {
 	const swiperInstance = useRef< SwiperType | null >( null );
+	const swiperContainerId = `swiper-container-${ collectionSlug }`;
+
 	useEffect( () => {
 		if ( themes !== null && themes.length > 0 ) {
-			const el = document.querySelector( '.swiper-container' ) as HTMLElement;
+			const el = document.querySelector( `#${ swiperContainerId }` ) as HTMLElement;
 			if ( el ) {
 				/**
 				 * We have to import the swiper package dynamically because it doesn't offer a CommonJS version. Because of this, the SSR build will fail.
@@ -95,7 +97,7 @@ export default function ThemeCollection( {
 		<div className="theme-collection__container ">
 			<h2>{ heading }</h2>
 			{ subheading }
-			<div className="swiper-container">
+			<div className="swiper-container" id={ swiperContainerId }>
 				<div className="theme-collection__carousel-controls">
 					<Button className="theme-collection__carousel-nav-button theme-collection__carousel-nav-button--previous">
 						<Icon icon={ chevronLeft } />

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -283,7 +283,7 @@ class ThemesSelection extends Component {
 							heading="Premium themes"
 							subheading={ <p>Lorem ipsum nessum dorma</p> }
 							themes={ interlacedThemes.splice( 10 ) }
-							collectionSlug="premium-themes"
+							collectionSlug="some-themes"
 							getThemeDetailsUrl={ this.props.getThemeDetailsUrl }
 							getScreenshotUrl={ this.props.getScreenshotUrl }
 							bookmarkRef={ this.props.bookmarkRef }


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4070

## Proposed Changes

Previously only the first ThemeCollection on each page worked as a carousel. With this change all of the carousels are.

One behaviour which may be a little...surprising is that keyboard navigation will scroll all ThemeCollection that are in the current viewport, not just the one which has focus.

## Testing Instructions

1. Use the Calypso live link and go to /themes page in incognito.
2. Append the feature flag flags=themes/discovery-lots
3. Notice that we display three carousels, all of which work (albeit still a little rough)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?