### PR TITLE
ActivityLog: Add tracking when user searches by text

### DIFF
--- a/client/my-sites/activity/filterbar/text-selector.tsx
+++ b/client/my-sites/activity/filterbar/text-selector.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import React, { FunctionComponent } from 'react';
 import { useDispatch } from 'react-redux';
 import { updateFilter } from 'calypso/state/activity-log/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { CalypsoDispatch } from 'calypso/state/types';
 
 interface Props {
@@ -25,6 +26,11 @@ const TextSelector: FunctionComponent< Props > = ( { siteId, filter } ) => {
 
 		if ( event.key === 'Enter' ) {
 			dispatch( updateFilter( siteId, { textSearch: value } ) );
+			dispatch(
+				recordTracksEvent( 'calypso_activitylog_filterbar_text_search', {
+					characters: value.length,
+				} )
+			);
 		}
 	};
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/82355

## Proposed Changes

* Add `calypso_activitylog_filterbar_text_search` Tracks event when a user searches by text in the Activity Log with an additional `characters` parameter with the number of characters the user used. This could give us an idea if they are trying to search by post title, or else.

![CleanShot 2023-09-28 at 16 12 21](https://github.com/Automattic/wp-calypso/assets/1488641/273a309f-d25d-4424-8fb8-335c055fa597)

## Testing Instructions
* Start a Jetpack Cloud or Calypso Live branch.
* Spin up a Calypso live branch
* Navigate to the Activity Log
* Ensure the search box is visible and try searching your posts and play around with the filters. You must enter data and press ENTER to start filtering.
* On each search, validate that you see a `t.gif` call with the event `calypso_activitylog_filterbar_text_search` when starts searching.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?