### PR TITLE
Site Profiler: Add check for multiple dates

### DIFF
--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -50,6 +50,16 @@ export default function DomainInformation( props: Props ) {
 		} );
 	};
 
+	const formatDateTime = ( date?: string | string[] ) => {
+		if ( Array.isArray( date ) && date.length > 0 ) {
+			date = date[ 0 ];
+		}
+
+		const res = moment.utc( date );
+
+		return res.isValid() ? res.format( momentFormat ) : '';
+	};
+
 	return (
 		<div className="domain-information">
 			<h3>{ translate( 'Domain information' ) }</h3>
@@ -81,19 +91,19 @@ export default function DomainInformation( props: Props ) {
 				{ filteredWhois.creation_date && (
 					<li>
 						<div className="name">{ translate( 'Registered on' ) }</div>
-						<div>{ moment.utc( whois.creation_date ).format( momentFormat ) }</div>
+						<div>{ formatDateTime( whois.creation_date ) }</div>
 					</li>
 				) }
 				{ filteredWhois.registry_expiry_date && (
 					<li>
 						<div className="name">{ translate( 'Expires on' ) }</div>
-						<div>{ moment.utc( whois.registry_expiry_date ).format( momentFormat ) }</div>
+						<div>{ formatDateTime( whois.registry_expiry_date ) }</div>
 					</li>
 				) }
 				{ filteredWhois.updated_date && (
 					<li>
 						<div className="name">{ translate( 'Updated on' ) }</div>
-						<div>{ moment.utc( whois.updated_date ).format( momentFormat ) }</div>
+						<div>{ formatDateTime( whois.updated_date ) }</div>
 					</li>
 				) }
 				{ filteredWhois.name_server && whois.name_server && (


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/82456

## Proposed Changes

* Add check for multiple dates in `creation_date`, `registry_expiry_date` and `updated_date`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* http://calypso.localhost:3000/site-profiler?domain=google.it must output `1999-12-10 00:00:00 UTC` in "registered on" and not "Invalid date".
* http://calypso.localhost:3000/site-profiler?domain=amazon.it must output `2000-02-10 00:00:00 UTC` in "registered on" and not "Invalid date".
* Other domains already working should continue to work as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?