### PR TITLE
Assembler - Patterns - Randomize order of blog posts with CSS

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/index.ts
@@ -9,3 +9,4 @@ export { default as usePatternsMapByCategory } from './use-patterns-map-by-categ
 export { default as useRecipe } from './use-recipe';
 export { default as useScreen } from './use-screen';
 export { default as useSyncNavigatorScreen } from './use-sync-navigator-screen';
+export { default as useIsNewSite } from './use-is-new-site';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-is-new-site.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-is-new-site.ts
@@ -1,0 +1,11 @@
+import { isSiteSetupFlow } from '@automattic/onboarding';
+import { useQuery } from '../../../../../hooks/use-query';
+
+const useIsNewSite = ( flow: string ) => {
+	// New sites are created from:
+	// - 'site-setup' flow
+	// - 'with-theme-assembler' from LoTS, which has isNewSite: true
+	return !! useQuery().get( 'isNewSite' ) || isSiteSetupFlow( flow );
+};
+
+export default useIsNewSite;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -5,12 +5,7 @@ import {
 	getVariationType,
 } from '@automattic/global-styles';
 import { useLocale } from '@automattic/i18n-utils';
-import {
-	StepContainer,
-	isSiteAssemblerFlow,
-	isSiteSetupFlow,
-	NavigatorScreen,
-} from '@automattic/onboarding';
+import { StepContainer, isSiteAssemblerFlow, NavigatorScreen } from '@automattic/onboarding';
 import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalUseNavigator as useNavigator,
@@ -22,7 +17,6 @@ import { useState, useRef, useMemo } from 'react';
 import { createRecordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { activateOrInstallThenActivate } from 'calypso/state/themes/actions';
-import { useQuery } from '../../../../hooks/use-query';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
@@ -40,6 +34,7 @@ import {
 	usePatternsMapByCategory,
 	useRecipe,
 	useSyncNavigatorScreen,
+	useIsNewSite,
 } from './hooks';
 import withNotices, { NoticesProps } from './notices/notices';
 import PatternAssemblerContainer from './pattern-assembler-container';
@@ -91,9 +86,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	const siteId = useSiteIdParam();
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 	const locale = useLocale();
-
-	// New sites are created from 'site-setup' and 'with-site-assembler' flows
-	const isNewSite = !! useQuery().get( 'isNewSite' ) || isSiteSetupFlow( flow );
+	const isNewSite = useIsNewSite( flow );
 
 	// The categories api triggers the ETK plugin before the PTK api request
 	const categories = usePatternCategories( site?.ID );
@@ -581,6 +574,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 						patternsMapByCategory={ patternsMapByCategory }
 						onSelect={ onSelect }
 						recordTracksEvent={ recordTracksEvent }
+						isNewSite={ isNewSite }
 					/>
 				</NavigatorScreen>
 
@@ -593,6 +587,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 						patternsMapByCategory={ patternsMapByCategory }
 						onSelect={ onSelect }
 						recordTracksEvent={ recordTracksEvent }
+						isNewSite={ isNewSite }
 					/>
 				</NavigatorScreen>
 
@@ -625,6 +620,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 				onDeleteFooter={ onDeleteFooter }
 				onShuffle={ onShuffle }
 				recordTracksEvent={ recordTracksEvent }
+				isNewSite={ isNewSite }
 			/>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -22,6 +22,7 @@ interface Props {
 	onDeleteFooter: () => void;
 	onShuffle: ( type: string, pattern: Pattern, position?: number ) => void;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
+	isNewSite: boolean;
 }
 
 // The pattern renderer element has 1px min height before the pattern is loaded
@@ -39,6 +40,7 @@ const PatternLargePreview = ( {
 	onDeleteFooter,
 	onShuffle,
 	recordTracksEvent,
+	isNewSite,
 }: Props ) => {
 	const translate = useTranslate();
 	const hasSelectedPattern = header || sections.length || footer;
@@ -88,6 +90,7 @@ const PatternLargePreview = ( {
 						viewportHeight={ viewportHeight }
 						// Disable default max-height
 						maxHeight="none"
+						isNewSite={ isNewSite }
 					/>
 				) }
 				<PatternActionBar

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -90,7 +90,7 @@ const PatternLargePreview = ( {
 						viewportHeight={ viewportHeight }
 						// Disable default max-height
 						maxHeight="none"
-						isNewSite={ isNewSite }
+						shouldShufflePosts={ isNewSite }
 					/>
 				) }
 				<PatternActionBar

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
@@ -18,6 +18,7 @@ type PatternListPanelProps = {
 	label?: string;
 	description?: string;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
+	isNewSite: boolean;
 };
 
 const PatternListPanel = ( {
@@ -30,6 +31,7 @@ const PatternListPanel = ( {
 	description,
 	onSelect,
 	recordTracksEvent,
+	isNewSite,
 }: PatternListPanelProps ) => {
 	const translate = useTranslate();
 	const [ isShowMorePatterns, setIsShowMorePatterns ] = useState( false );
@@ -59,6 +61,7 @@ const PatternListPanel = ( {
 				selectedPattern={ selectedPattern }
 				selectedPatterns={ selectedPatterns }
 				isShowMorePatterns={ isShowMorePatterns }
+				isNewSite={ isNewSite }
 			/>
 			{ ! isShowMorePatterns && hasNonPriorityPatterns && (
 				<div className="pattern-list-panel__show-more">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -85,7 +85,7 @@ const PatternListItem = ( {
 						viewportWidth={ DEFAULT_VIEWPORT_WIDTH }
 						viewportHeight={ DEFAULT_VIEWPORT_HEIGHT }
 						minHeight={ PLACEHOLDER_HEIGHT }
-						isNewSite={ isNewSite }
+						shouldShufflePosts={ isNewSite }
 					/>
 				) : (
 					<div key={ pattern.ID } style={ { height: PLACEHOLDER_HEIGHT } } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -15,6 +15,7 @@ interface PatternListItemProps {
 	isSelected?: boolean;
 	composite?: Record< string, unknown >;
 	onSelect: ( selectedPattern: Pattern | null ) => void;
+	isNewSite: boolean;
 }
 
 interface PatternListRendererProps {
@@ -26,6 +27,7 @@ interface PatternListRendererProps {
 	composite?: Record< string, unknown >;
 	onSelect: ( selectedPattern: Pattern | null ) => void;
 	isShowMorePatterns?: boolean;
+	isNewSite: boolean;
 }
 
 const DEFAULT_VIEWPORT_WIDTH = 1060;
@@ -40,6 +42,7 @@ const PatternListItem = ( {
 	isSelected,
 	composite,
 	onSelect,
+	isNewSite,
 }: PatternListItemProps ) => {
 	const ref = useRef< HTMLButtonElement >();
 	const { ref: inViewRef, inView: inViewOnce } = useInView( {
@@ -82,6 +85,7 @@ const PatternListItem = ( {
 						viewportWidth={ DEFAULT_VIEWPORT_WIDTH }
 						viewportHeight={ DEFAULT_VIEWPORT_HEIGHT }
 						minHeight={ PLACEHOLDER_HEIGHT }
+						isNewSite={ isNewSite }
 					/>
 				) : (
 					<div key={ pattern.ID } style={ { height: PLACEHOLDER_HEIGHT } } />
@@ -100,6 +104,7 @@ const PatternListRenderer = ( {
 	composite,
 	onSelect,
 	isShowMorePatterns,
+	isNewSite,
 }: PatternListRendererProps ) => {
 	const filterPriorityPatterns = ( pattern: Pattern ) =>
 		isShowMorePatterns || isPriorityPattern( pattern );
@@ -120,6 +125,7 @@ const PatternListRenderer = ( {
 					isSelected={ pattern.ID === selectedPattern?.ID }
 					composite={ composite }
 					onSelect={ onSelect }
+					isNewSite={ isNewSite }
 				/>
 			) ) }
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -13,6 +13,7 @@ type PatternSelectorProps = {
 	selectedPattern: Pattern | null;
 	selectedPatterns?: Pattern[];
 	isShowMorePatterns?: boolean;
+	isNewSite: boolean;
 };
 
 const PatternSelector = ( {
@@ -21,6 +22,7 @@ const PatternSelector = ( {
 	selectedPattern,
 	selectedPatterns,
 	isShowMorePatterns,
+	isNewSite,
 }: PatternSelectorProps ) => {
 	const translate = useTranslate();
 	const shownPatterns = useAsyncList( patterns );
@@ -44,6 +46,7 @@ const PatternSelector = ( {
 						composite={ composite }
 						onSelect={ onSelect }
 						isShowMorePatterns={ isShowMorePatterns }
+						isNewSite={ isNewSite }
 					/>
 				</Composite>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pattern-list-panel.tsx
@@ -15,6 +15,7 @@ interface Props {
 		selectedCategory: string | null
 	) => void;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
+	isNewSite: boolean;
 }
 
 const ScreenPatternListPanel = ( {

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -2,6 +2,7 @@ import usePatternInlineCss from '../hooks/use-pattern-inline-css';
 import usePatternMinHeightVh from '../hooks/use-pattern-min-height-vh';
 import BlockRendererContainer from './block-renderer-container';
 import { usePatternsRendererContext } from './patterns-renderer-context';
+
 interface Props {
 	patternId: string;
 	viewportWidth?: number;
@@ -9,6 +10,7 @@ interface Props {
 	minHeight?: number;
 	maxHeight?: 'none' | number;
 	placeholder?: JSX.Element;
+	isNewSite: boolean;
 }
 
 const PatternRenderer = ( {
@@ -17,11 +19,12 @@ const PatternRenderer = ( {
 	viewportHeight,
 	minHeight,
 	maxHeight,
+	isNewSite,
 }: Props ) => {
 	const renderedPatterns = usePatternsRendererContext();
 	const pattern = renderedPatterns[ patternId ];
 	const patternHtml = usePatternMinHeightVh( pattern?.html, viewportHeight );
-	const inlineCss = usePatternInlineCss( patternId );
+	const inlineCss = usePatternInlineCss( patternId, isNewSite );
 
 	return (
 		<BlockRendererContainer

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -10,7 +10,7 @@ interface Props {
 	minHeight?: number;
 	maxHeight?: 'none' | number;
 	placeholder?: JSX.Element;
-	isNewSite: boolean;
+	shouldShufflePosts: boolean;
 }
 
 const PatternRenderer = ( {
@@ -19,12 +19,12 @@ const PatternRenderer = ( {
 	viewportHeight,
 	minHeight,
 	maxHeight,
-	isNewSite,
+	shouldShufflePosts,
 }: Props ) => {
 	const renderedPatterns = usePatternsRendererContext();
 	const pattern = renderedPatterns[ patternId ];
 	const patternHtml = usePatternMinHeightVh( pattern?.html, viewportHeight );
-	const inlineCss = usePatternInlineCss( patternId, patternHtml, isNewSite );
+	const inlineCss = usePatternInlineCss( patternId, patternHtml, shouldShufflePosts );
 
 	return (
 		<BlockRendererContainer

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -24,7 +24,7 @@ const PatternRenderer = ( {
 	const renderedPatterns = usePatternsRendererContext();
 	const pattern = renderedPatterns[ patternId ];
 	const patternHtml = usePatternMinHeightVh( pattern?.html, viewportHeight );
-	const inlineCss = usePatternInlineCss( patternId, isNewSite );
+	const inlineCss = usePatternInlineCss( patternId, patternHtml, isNewSite );
 
 	return (
 		<BlockRendererContainer

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -1,3 +1,4 @@
+import usePatternInlineCss from '../hooks/use-pattern-inline-css';
 import usePatternMinHeightVh from '../hooks/use-pattern-min-height-vh';
 import BlockRendererContainer from './block-renderer-container';
 import { usePatternsRendererContext } from './patterns-renderer-context';
@@ -20,6 +21,7 @@ const PatternRenderer = ( {
 	const renderedPatterns = usePatternsRendererContext();
 	const pattern = renderedPatterns[ patternId ];
 	const patternHtml = usePatternMinHeightVh( pattern?.html, viewportHeight );
+	const inlineCss = usePatternInlineCss( patternId );
 
 	return (
 		<BlockRendererContainer
@@ -28,6 +30,7 @@ const PatternRenderer = ( {
 			viewportWidth={ viewportWidth }
 			maxHeight={ maxHeight }
 			minHeight={ minHeight }
+			inlineCss={ inlineCss }
 		>
 			<div
 				// eslint-disable-next-line react/no-danger

--- a/packages/block-renderer/src/constants.ts
+++ b/packages/block-renderer/src/constants.ts
@@ -1,2 +1,1 @@
 export const BLOCK_MAX_HEIGHT = 2000;
-export const MAX_BLOG_POSTS = 6;

--- a/packages/block-renderer/src/constants.ts
+++ b/packages/block-renderer/src/constants.ts
@@ -1,1 +1,2 @@
 export const BLOCK_MAX_HEIGHT = 2000;
+export const MAX_BLOG_POSTS = 6;

--- a/packages/block-renderer/src/hooks/use-pattern-inline-css.tsx
+++ b/packages/block-renderer/src/hooks/use-pattern-inline-css.tsx
@@ -17,7 +17,7 @@ const usePatternInlineCss = ( patternId: string, patternHtml: string, isNewSite:
 		const blogPostCount = patternHtml?.match( /wp-block-post /g )?.length ?? 0;
 
 		// Only for patterns with a grid of posts in newly created sites
-		if ( ! isNewSite || ! hasGrid || blogPostCount === 1 ) {
+		if ( ! isNewSite || ! hasGrid || blogPostCount <= 1 ) {
 			return undefined;
 		}
 

--- a/packages/block-renderer/src/hooks/use-pattern-inline-css.tsx
+++ b/packages/block-renderer/src/hooks/use-pattern-inline-css.tsx
@@ -2,15 +2,15 @@ import { shuffle } from '@automattic/js-utils';
 import { useMemo } from 'react';
 import { MAX_BLOG_POSTS } from '../constants';
 
-// Using this object to memoize the pattern as a workaround
+// Memoize the order per pattern to show the same order in previews
 const memoPatternOrder: { [ key: string ]: string } = {};
 
-const usePatternInlineCss = ( patternId: string ) => {
-	// FIXME: Why this useMemo is not working?
+const usePatternInlineCss = ( patternId: string, isNewSite: boolean ) => {
 	return useMemo( () => {
 		let inlineCss = memoPatternOrder[ patternId ] || '';
 
-		if ( inlineCss ) {
+		// Only newly created sites use this css
+		if ( ! isNewSite || inlineCss ) {
 			return inlineCss;
 		}
 

--- a/packages/block-renderer/src/hooks/use-pattern-inline-css.tsx
+++ b/packages/block-renderer/src/hooks/use-pattern-inline-css.tsx
@@ -17,7 +17,7 @@ const usePatternInlineCss = ( patternId: string, patternHtml: string, isNewSite:
 		const blogPostCount = patternHtml?.match( /wp-block-post /g )?.length ?? 0;
 
 		// Only for patterns with a grid of posts in newly created sites
-		if ( ! isNewSite || ! hasGrid ) {
+		if ( ! isNewSite || ! hasGrid || blogPostCount === 1 ) {
 			return undefined;
 		}
 
@@ -30,8 +30,8 @@ const usePatternInlineCss = ( patternId: string, patternHtml: string, isNewSite:
 		// Shuffle post order
 		let postOrder = shufflePostOrder( blogPostCount );
 
-		// Avoid repeating the last order
-		while ( lastPostOrder.toString() === postOrder.toString() ) {
+		// Prevent repeating the last order shuffling once more
+		if ( lastPostOrder.toString() === postOrder.toString() ) {
 			postOrder = shufflePostOrder( blogPostCount );
 		}
 

--- a/packages/block-renderer/src/hooks/use-pattern-inline-css.tsx
+++ b/packages/block-renderer/src/hooks/use-pattern-inline-css.tsx
@@ -1,0 +1,29 @@
+import { shuffle } from '@automattic/js-utils';
+import { useMemo } from 'react';
+import { MAX_BLOG_POSTS } from '../constants';
+
+// Using this object to memoize the pattern as a workaround
+const memoPatternOrder: { [ key: string ]: string } = {};
+
+const usePatternInlineCss = ( patternId: string ) => {
+	// FIXME: Why this useMemo is not working?
+	return useMemo( () => {
+		let inlineCss = memoPatternOrder[ patternId ] || '';
+
+		if ( inlineCss ) {
+			return inlineCss;
+		}
+
+		shuffle( [ ...Array( MAX_BLOG_POSTS ).keys() ] ).forEach( ( order, index ) => {
+			const childIndex = index + 1;
+			const shuffledOrder = order + 1;
+			inlineCss += `.is-layout-grid .wp-block-post:nth-child(${ childIndex }) { order: ${ shuffledOrder }; }`;
+		} );
+
+		memoPatternOrder[ patternId ] = inlineCss;
+
+		return inlineCss;
+	}, [ patternId ] );
+};
+
+export default usePatternInlineCss;

--- a/packages/block-renderer/src/hooks/use-pattern-inline-css.tsx
+++ b/packages/block-renderer/src/hooks/use-pattern-inline-css.tsx
@@ -1,5 +1,4 @@
 import { shuffle } from '@automattic/js-utils';
-import { useMemo } from 'react';
 
 // Shuffle order of blog posts to avoid repetition in previews
 const shufflePostOrder = ( blogPostCount: number ) =>
@@ -11,43 +10,45 @@ const inlineCssByPatternId: { [ key: string ]: string } = {};
 // Memoize last order
 let lastPostOrder: number[] = [];
 
-const usePatternInlineCss = ( patternId: string, patternHtml: string, isNewSite: boolean ) => {
-	return useMemo( () => {
-		const hasGrid = patternHtml?.includes( 'is-layout-grid' );
-		const blogPostCount = patternHtml?.match( /wp-block-post /g )?.length ?? 0;
+const usePatternInlineCss = (
+	patternId: string,
+	patternHtml: string,
+	shouldShufflePosts: boolean
+) => {
+	const hasGrid = patternHtml?.includes( 'is-layout-grid' );
+	const blogPostCount = patternHtml?.match( /wp-block-post /g )?.length ?? 0;
 
-		// Only for patterns with a grid of posts in newly created sites
-		if ( ! isNewSite || ! hasGrid || blogPostCount <= 1 ) {
-			return undefined;
-		}
+	// Only for patterns with a grid of posts in newly created sites
+	if ( ! shouldShufflePosts || ! hasGrid || blogPostCount <= 1 ) {
+		return undefined;
+	}
 
-		// Return memoized order
-		let inlineCss = inlineCssByPatternId[ patternId ] || '';
-		if ( inlineCss ) {
-			return inlineCss;
-		}
-
-		// Shuffle post order
-		let postOrder = shufflePostOrder( blogPostCount );
-
-		// Prevent repeating the last order shuffling once more
-		if ( lastPostOrder.toString() === postOrder.toString() ) {
-			postOrder = shufflePostOrder( blogPostCount );
-		}
-
-		// Create CSS rules
-		postOrder.forEach( ( order, index ) => {
-			const childIndex = index + 1;
-			const shuffledOrder = order + 1;
-			inlineCss += `.is-layout-grid > .wp-block-post:nth-child(${ childIndex }) { order: ${ shuffledOrder }; }`;
-		} );
-
-		// Memoize
-		inlineCssByPatternId[ patternId ] = inlineCss;
-		lastPostOrder = postOrder;
-
+	// Return memoized order
+	let inlineCss = inlineCssByPatternId[ patternId ] || '';
+	if ( inlineCss ) {
 		return inlineCss;
-	}, [ patternId, patternHtml ] );
+	}
+
+	// Shuffle post order
+	let postOrder = shufflePostOrder( blogPostCount );
+
+	// Prevent repeating the last order shuffling once more
+	if ( lastPostOrder.toString() === postOrder.toString() ) {
+		postOrder = shufflePostOrder( blogPostCount );
+	}
+
+	// Create CSS rules
+	postOrder.forEach( ( order, index ) => {
+		const childIndex = index + 1;
+		const shuffledOrder = order + 1;
+		inlineCss += `.is-layout-grid > .wp-block-post:nth-child(${ childIndex }) { order: ${ shuffledOrder }; }`;
+	} );
+
+	// Memoize
+	inlineCssByPatternId[ patternId ] = inlineCss;
+	lastPostOrder = postOrder;
+
+	return inlineCss;
 };
 
 export default usePatternInlineCss;

--- a/packages/block-renderer/src/hooks/use-pattern-inline-css.tsx
+++ b/packages/block-renderer/src/hooks/use-pattern-inline-css.tsx
@@ -27,7 +27,8 @@ const usePatternInlineCss = (
 	[ ...Array( blogPostCount ).keys() ].forEach( ( order, index ) => {
 		const childIndex = index + 1;
 		// Offset order of blog posts to avoid repetition in previews
-		const orderWithOffset = ( ( order - lastOffset + blogPostCount ) % blogPostCount ) + 1;
+		const offset = lastOffset % blogPostCount;
+		const orderWithOffset = ( order - offset + blogPostCount ) % blogPostCount;
 		inlineCss += `.is-layout-grid > .wp-block-post:nth-child(${ childIndex }) { order: ${ orderWithOffset }; }`;
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/82039

## Proposed Changes

* Show blog posts in a grid in random order
* Avoid repeating the order in the previous pattern
* Exclude patterns without a grid of posts and not newly created sites
* Use the real blog post count in the pattern to shuffle the order more precisely 

Note: I have also changed the date of two posts in the Creatio demo site to move them to the top of the list because their images have different colors and perspectives.

|BEFORE|AFTER|
|--|--|
|<img width="335" alt="Screenshot 2566-10-05 at 17 35 55" src="https://github.com/Automattic/wp-calypso/assets/1881481/d59a1f67-5aec-4a11-9cc5-238e67f57ad2">|<img width="360" alt="Screenshot 2566-10-05 at 17 37 53" src="https://github.com/Automattic/wp-calypso/assets/1881481/7138387e-3eac-42bb-a164-6a017e683140">|

|BEFORE|AFTER|
|--|--|
|<img width="703" alt="Screenshot 2566-10-05 at 17 42 42" src="https://github.com/Automattic/wp-calypso/assets/1881481/3756d598-466b-4cb1-8b89-15e56433e3b8">|<img width="696" alt="Screenshot 2566-10-12 at 10 12 06" src="https://github.com/Automattic/wp-calypso/assets/1881481/3271f1ee-5642-4cc3-901b-527028ce368f">|

### Follow-up tasks:

- For the patterns using a vertical list of posts, we could also randomize them by using the same hook but targeting the elements with `.is-layout-flow > .wp-block-post`. See p1696482022328099-slack-CRWCHQGUB

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site - Required because only newly created sites use the posts from creatiodemo.wordpress.com
* Click "Sections" > "Blog Posts"
* Add a pattern
* Verify the order of posts in the pattern inserter and the canvas is the same
* Verify the order is random every time you refresh the browser. You can compare with the version on production

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?