### PR TITLE
Remove exclamation point from heading on My Mailboxes page

### DIFF
--- a/client/my-sites/email/mailboxes/mailbox-selection-list/index.tsx
+++ b/client/my-sites/email/mailboxes/mailbox-selection-list/index.tsx
@@ -144,7 +144,7 @@ const MailboxItems = ( { mailboxes }: { mailboxes: Mailbox[] } ) => {
 				align="center"
 				brandFont
 				className="mailbox-selection-list__header"
-				headerText={ translate( 'My Mailboxes!' ) }
+				headerText={ translate( 'My Mailboxes' ) }
 				subHeaderText={ translate( 'Choose the mailbox you’d like to open.' ) }
 			/>
 


### PR DESCRIPTION
Follow up to #81666

## Proposed Changes

* Remove a leftover exclamation point from the `My Mailboxes` heading on `/mailboxes`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a domain with at least one mailbox
2. Navigate to `/mailboxes/:site_slug`
3. Ensure that there is no exclamation point in the heading

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
