### PR TITLE
Signup Flow: Social First signup 

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -49,7 +49,7 @@ import {
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
-import { isP2Flow } from 'calypso/signup/utils';
+import { isP2Flow, isVideoPressFlow } from 'calypso/signup/utils';
 import { recordTracksEventWithClientId } from 'calypso/state/analytics/actions';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -60,7 +60,7 @@ import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerc
 import { getSectionName } from 'calypso/state/ui/selectors';
 import CrowdsignalSignupForm from './crowdsignal';
 import P2SignupForm from './p2';
-import PasswordlessSignupForm from './passwordless';
+import SignupFormSocialFirst from './signup-form-social-first';
 import SocialSignupForm from './social';
 
 import './style.scss';
@@ -1164,59 +1164,26 @@ class SignupForm extends Component {
 		const showSeparator =
 			! config.isEnabled( 'desktop' ) && this.isHorizontal() && ! this.userCreationComplete();
 
-		if ( ( this.props.isPasswordless && 'wpcc' !== this.props.flowName ) || isGravatar ) {
-			const logInUrl = this.getLoginLink();
-			const gravatarProps = isGravatar
-				? {
-						inputPlaceholder: this.props.translate( 'Enter your email address' ),
-						submitButtonLabel: this.props.translate( 'Continue' ),
-						submitButtonLoadingLabel: this.props.translate( 'Continue' ),
-				  }
-				: {};
+		const logInUrl = this.getLoginLink();
 
+		if (
+			( ! isVideoPressFlow( this.props.flowName ) && 'wpcc' !== this.props.flowName ) ||
+			isGravatar
+		) {
 			return (
-				<div
-					className={ classNames( 'signup-form', this.props.className, {
-						'is-horizontal': this.isHorizontal(),
-					} ) }
-				>
-					{ this.getNotice() }
-					<PasswordlessSignupForm
-						step={ this.props.step }
-						stepName={ this.props.stepName }
-						flowName={ this.props.flowName }
-						goToNextStep={ this.props.goToNextStep }
-						renderTerms={ this.termsOfServiceLink }
-						logInUrl={ logInUrl }
-						disabled={ this.props.disabled }
-						disableSubmitButton={ this.props.disableSubmitButton }
-						queryArgs={ this.props.queryArgs }
-						{ ...gravatarProps }
-					/>
-
-					{ ! isGravatar && (
-						<>
-							{ showSeparator && (
-								<div className="signup-form__separator">
-									<div className="signup-form__separator-text">
-										{ this.props.translate( 'or' ) }
-									</div>
-								</div>
-							) }
-
-							{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
-								<SocialSignupForm
-									handleResponse={ this.props.handleSocialResponse }
-									socialService={ this.props.socialService }
-									socialServiceResponse={ this.props.socialServiceResponse }
-									isReskinned={ this.props.isReskinned }
-									redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
-								/>
-							) }
-							{ this.props.footerLink || this.footerLink() }
-						</>
-					) }
-				</div>
+				<SignupFormSocialFirst
+					step={ this.props.step }
+					stepName={ this.props.stepName }
+					flowName={ this.props.flowName }
+					goToNextStep={ this.props.goToNextStep }
+					logInUrl={ logInUrl }
+					handleResponse={ this.props.handleSocialResponse }
+					socialService={ this.props.socialService }
+					socialServiceResponse={ this.props.socialServiceResponse }
+					isReskinned={ this.props.isReskinned }
+					redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
+					queryArgs={ this.props.queryArgs }
+				/>
 			);
 		}
 

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -241,15 +241,18 @@ class PasswordlessSignupForm extends Component {
 		);
 	}
 
+	getLabelText() {
+		return this.props.labelText ?? this.props.translate( 'Enter your email address' );
+	}
+
 	render() {
-		const { inputPlaceholder, translate } = this.props;
 		const { errorMessages, isSubmitting } = this.state;
 
 		return (
 			<div className="signup-form__passwordless-form-wrapper">
 				<LoggedOutForm onSubmit={ this.onFormSubmit } noValidate>
 					<ValidationFieldset errorMessages={ errorMessages }>
-						<FormLabel htmlFor="email">{ translate( 'Enter your email address' ) }</FormLabel>
+						<FormLabel htmlFor="email">{ this.getLabelText() }</FormLabel>
 						<FormTextInput
 							autoCapitalize="off"
 							className="signup-form__passwordless-email"
@@ -258,10 +261,10 @@ class PasswordlessSignupForm extends Component {
 							value={ this.state.email }
 							onChange={ this.onInputChange }
 							disabled={ isSubmitting || !! this.props.disabled }
-							placeholder={ inputPlaceholder }
+							placeholder={ this.props.inputPlaceholder }
 						/>
 					</ValidationFieldset>
-					{ this.props.renderTerms() }
+					{ this.props.renderTerms?.() }
 					{ this.formFooter() }
 				</LoggedOutForm>
 			</div>

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -1,0 +1,180 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { Button } from '@wordpress/components';
+import { useState, createInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
+import MailIcon from 'calypso/components/social-icons/mail';
+import { isGravatarOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { useSelector } from 'calypso/state';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
+import PasswordlessSignupForm from './passwordless';
+import SocialSignupForm from './social';
+import './style.scss';
+
+interface SignupFormSocialFirst {
+	goToNextStep: () => void;
+	step: string;
+	stepName: string;
+	flowName: string;
+	redirectToAfterLoginUrl: string;
+	logInUrl: string;
+	socialService: string;
+	socialServiceResponse: string;
+	handleSocialResponse: () => void;
+	isReskinned: boolean;
+	queryArgs: object;
+}
+
+const SignupFormSocialFirst = ( {
+	goToNextStep,
+	step,
+	stepName,
+	flowName,
+	redirectToAfterLoginUrl,
+	logInUrl,
+	socialService,
+	socialServiceResponse,
+	handleSocialResponse,
+	isReskinned,
+	queryArgs,
+}: SignupFormSocialFirst ) => {
+	const [ currentStep, setCurrentStep ] = useState( 'initial' );
+	const { __ } = useI18n();
+
+	const { isWoo, isGravatar } = useSelector( ( state ) => {
+		const oauth2Client = getCurrentOAuth2Client( state );
+		const isWooCoreProfilerFlow = isWooCommerceCoreProfilerFlow( state );
+
+		return {
+			isWoo: isWooOAuth2Client( oauth2Client ) || isWooCoreProfilerFlow,
+			isGravatar: isGravatarOAuth2Client( oauth2Client ),
+		};
+	} );
+
+	const renderContent = () => {
+		if ( currentStep === 'initial' ) {
+			return (
+				<SocialSignupForm
+					handleResponse={ handleSocialResponse }
+					socialService={ socialService }
+					socialServiceResponse={ socialServiceResponse }
+					isReskinned={ isReskinned }
+					redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
+					disableTosText={ true }
+					compact={ true }
+				>
+					<Button
+						className="social-buttons__button button"
+						onClick={ () => setCurrentStep( 'email' ) }
+					>
+						<MailIcon width="20" height="20" />
+						<span className="social-buttons__service-name">{ __( 'Continue with Email' ) }</span>
+					</Button>
+				</SocialSignupForm>
+			);
+		} else if ( currentStep === 'email' ) {
+			const gravatarProps = isGravatar
+				? {
+						inputPlaceholder: __( 'Enter your email address' ),
+						submitButtonLoadingLabel: __( 'Continue' ),
+				  }
+				: {};
+
+			return (
+				<div className="signup-form-social-first-email">
+					<PasswordlessSignupForm
+						step={ step }
+						stepName={ stepName }
+						flowName={ flowName }
+						goToNextStep={ goToNextStep }
+						logInUrl={ logInUrl }
+						queryArgs={ queryArgs }
+						labelText={ __( 'Your email' ) }
+						submitButtonLabel={ __( 'Continue' ) }
+						{ ...gravatarProps }
+					/>
+					<Button
+						onClick={ () => setCurrentStep( 'initial' ) }
+						className="back-button"
+						variant="link"
+					>
+						<span>{ __( 'Back' ) }</span>
+					</Button>
+				</div>
+			);
+		}
+	};
+
+	const renderTermsOfService = () => {
+		const options = {
+			tosLink: (
+				<a
+					href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+					onClick={ () => recordTracksEvent( 'calypso_signup_tos_link_click' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+				/>
+			),
+			privacyLink: (
+				<a
+					href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+					onClick={ () => recordTracksEvent( 'calypso_signup_privacy_link_click' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+				/>
+			),
+		};
+
+		if ( isWoo ) {
+			return (
+				<p className="signup-form-social-first__tos-link">
+					{ createInterpolateElement(
+						__( 'By continuing, you agree to our <tosLink>Terms of Service</tosLink>.' ),
+						options
+					) }
+				</p>
+			);
+		} else if ( isGravatar ) {
+			return (
+				<p className="signup-form-social-first__tos-link">
+					{ createInterpolateElement(
+						__(
+							'By entering your email address, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+						),
+						options
+					) }
+				</p>
+			);
+		}
+
+		let tosText;
+
+		if ( currentStep === 'initial' ) {
+			tosText = createInterpolateElement(
+				__(
+					'If you continue with Google or Apple, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+				),
+				options
+			);
+		} else if ( currentStep === 'email' ) {
+			tosText = createInterpolateElement(
+				__(
+					'By creating an account you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+				),
+				options
+			);
+		}
+
+		return <p className="signup-form-social-first__tos-link">{ tosText }</p>;
+	};
+
+	return (
+		<div className="signup-form signup-form-social-first">
+			{ renderContent() }
+			{ renderTermsOfService() }
+		</div>
+	);
+};
+
+export default SignupFormSocialFirst;

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -154,6 +154,7 @@ class SocialSignupForm extends Component {
 								isWpccFlow( this.props.flowName ) ? window.location.search.slice( 1 ) : null
 							}
 						/>
+						{ this.props.children }
 						{ ! this.props.isWoo && ! this.props.disableTosText && <SocialSignupToS /> }
 					</div>
 					{ this.props.isWoo && ! this.props.disableTosText && <SocialSignupToS /> }

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -28,7 +28,7 @@
 	text-align: center;
 
 	a {
-		@include breakpoint-deprecated( ">480px" ) {
+		@include breakpoint-deprecated(">480px") {
 			white-space: pre;
 		}
 	}
@@ -117,7 +117,7 @@
 
 // Replace recaptcha badge with ToS text and space
 // everything out a little more.
-@media ( max-width: 660px ) {
+@media (max-width: 660px) {
 	.signup-form__recaptcha-tos {
 		display: block;
 	}
@@ -133,6 +133,98 @@
 
 		.logged-out-form__links::before {
 			margin-bottom: 16px;
+		}
+	}
+}
+
+body.is-section-signup {
+
+	.signup__step.is-user {
+
+		.signup-form-social-first {
+			width: 327px;
+			margin: 0 auto;
+
+			.signup-form__social {
+				padding: 0 !important;
+			}
+
+			.signup-form-social-first__tos-link {
+				color: var(--studio-gray-50, #646970);
+				text-align: center;
+				font-family: "SF Pro Text", sans-serif;
+				font-size: 0.75rem;
+				font-style: normal;
+				font-weight: 400;
+				line-height: 18px;
+				margin-top: 32px;
+
+				a {
+					color: var(--studio-gray-50, #646970);
+					text-decoration-line: underline;
+				}
+			}
+		}
+
+		.signup-form-social-first-email {
+			.card {
+				box-shadow: none;
+				padding-left: 0;
+				padding-right: 0;
+
+				button {
+					display: block;
+					max-width: 327px;
+					margin: 0 auto;
+				}
+			}
+
+			.form-label {
+				color: var(--studio-gray-60, #50575e);
+				font-family: "SF Pro Text", sans-serif;
+				font-size: 0.875rem;
+				font-style: normal;
+				font-weight: 500;
+				line-height: 20px;
+			}
+
+			.logged-out-form__footer {
+				margin-top: 16px;
+			}
+
+			button.back-button {
+				color: #1d2327;
+				text-align: center;
+				font-family: "SF Pro Text", sans-serif;
+				font-size: 0.875rem;
+				font-style: normal;
+				font-weight: 500;
+				line-height: 20px;
+				display: block;
+				margin: 0 auto;
+				text-underline-offset: 5px;
+
+				&:hover {
+					color: var(--studio-blue-50, #0675c4);
+				}
+
+				&:focus {
+					outline: 1px dashed var(--studio-blue-50, #0675c4);
+					outline-offset: 3px;
+					box-shadow: none;
+					border-radius: 0;
+				}
+			}
+
+			button.button {
+				border-radius: 4px;
+
+				&:focus {
+					box-shadow: none;
+					outline: 2px solid var(--studio-blue-60, #055d9c);
+					outline-offset: 1px;
+				}
+			}
 		}
 	}
 }

--- a/client/components/social-icons/mail.jsx
+++ b/client/components/social-icons/mail.jsx
@@ -1,0 +1,56 @@
+import classNames from 'classnames';
+import { omit } from 'lodash';
+import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import './style.scss';
+
+export default class AppleIcon extends PureComponent {
+	static propTypes = {
+		isDisabled: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		isDisabled: false,
+	};
+
+	render() {
+		const props = omit( this.props, [ 'isDisabled' ] );
+
+		return (
+			<svg
+				className={ classNames( 'social-icons social-icons__google', {
+					'social-icons--enabled': ! this.props.isDisabled,
+					'social-icons--disabled': !! this.props.isDisabled,
+				} ) }
+				width="18"
+				height="14"
+				viewBox="0 0 18 14"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+				{ ...props }
+			>
+				<g>
+					<rect
+						id="Rectangle 710"
+						x="0.75"
+						y="0.75"
+						width="16.5"
+						height="12.5"
+						rx="1.25"
+						stroke="#1D2327"
+						fill="none"
+						strokeWidth="1.5"
+					/>
+					<path
+						id="Vector 107"
+						d="M1 3.5L9 9.5L17 3.5"
+						stroke="#1D2327"
+						strokeWidth="1.5"
+						fill="none"
+					/>
+				</g>
+			</svg>
+		);
+	}
+}

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -114,177 +114,78 @@ exports[`JetpackSignup should render 1`] = `
         </div>
       </div>
       <div
-        class="signup-form"
+        class="signup-form signup-form-social-first"
       >
-        <div
-          class="card logged-out-form"
-        >
-          <form
-            novalidate=""
-          >
-            <div>
-              <label
-                class="form-label"
-                for="email"
-              >
-                Your email address
-              </label>
-              <input
-                autocapitalize="off"
-                autocorrect="off"
-                class="form-text-input signup-form__input"
-                id="email"
-                name="email"
-                type="email"
-                value="email@an.example.site"
-              />
-              <label
-                class="form-label"
-                for="username"
-              >
-                Choose a username
-              </label>
-              <input
-                autocapitalize="off"
-                autocorrect="off"
-                class="form-text-input signup-form__input"
-                id="username"
-                name="username"
-                type="text"
-                value=""
-              />
-              <label
-                class="form-label"
-                for="password"
-              >
-                Choose a password
-              </label>
-              <div
-                class="form-password-input"
-              >
-                <input
-                  autocomplete="off"
-                  class="form-text-input signup-form__input"
-                  id="password"
-                  name="password"
-                  type="password"
-                  value=""
-                />
-                <span
-                  class="form-password-input__toggle form-password-input__toggle-visibility"
-                >
-                  <svg
-                    class="gridicon gridicons-not-visible"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <use
-                      xlink:href="gridicons.svg#gridicons-not-visible"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </div>
-            <div
-              class="card logged-out-form__footer is-blended"
-            >
-              <p
-                class="signup-form__terms-of-service-link"
-              >
-                By creating an account you agree to our 
-                <a
-                  href="https://wordpress.com/tos/"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Terms of Service
-                </a>
-                 and have read our 
-                <a
-                  href="https://automattic.com/privacy/"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Privacy Policy
-                </a>
-                .
-              </p>
-              <button
-                class="button signup-form__submit form-button is-primary"
-                locale="en"
-                type="submit"
-              >
-                Create your account
-              </button>
-            </div>
-          </form>
-        </div>
         <div
           class="signup-form__social"
         >
-          <p>
-            Or create an account using:
-          </p>
           <div
             class="signup-form__social-buttons"
           >
             GoogleSocialButton
             AppleLoginButton
-            <p
-              class="signup-form__social-buttons-tos"
+            <button
+              class="components-button social-buttons__button button"
+              type="button"
             >
-              If you continue with Google or Apple, you agree to our 
-              <a
-                href="https://wordpress.com/tos/"
-                rel="noopener noreferrer"
-                target="_blank"
+              <svg
+                class="social-icons social-icons__google social-icons--enabled"
+                fill="none"
+                height="20"
+                viewBox="0 0 18 14"
+                width="20"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                Terms of Service
-              </a>
-              , and have read our 
-              <a
-                href="https://automattic.com/privacy/"
-                rel="noopener noreferrer"
-                target="_blank"
+                <g>
+                  <rect
+                    fill="none"
+                    height="12.5"
+                    id="Rectangle 710"
+                    rx="1.25"
+                    stroke="#1D2327"
+                    stroke-width="1.5"
+                    width="16.5"
+                    x="0.75"
+                    y="0.75"
+                  />
+                  <path
+                    d="M1 3.5L9 9.5L17 3.5"
+                    fill="none"
+                    id="Vector 107"
+                    stroke="#1D2327"
+                    stroke-width="1.5"
+                  />
+                </g>
+              </svg>
+              <span
+                class="social-buttons__service-name"
               >
-                Privacy Policy
-              </a>
-              .
-            </p>
+                Continue with Email
+              </span>
+            </button>
           </div>
         </div>
-        <div
-          class="logged-out-form__links"
+        <p
+          class="signup-form-social-first__tos-link"
         >
+          If you continue with Google or Apple, you agree to our 
           <a
-            class="logged-out-form__link-item"
-            href="/log-in/jetpack?site=http%3A%2F%2Fan.example.site&redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site&from=banner-44-slide-1-dashboard"
-          >
-            Already have an account? Sign in
-          </a>
-          <a
-            class="logged-out-form__link-item jetpack-connect__help-button"
-            href="https://jetpack.com/contact-support?hpi=1"
+            href="https://wordpress.com/tos/"
             rel="noopener noreferrer"
             target="_blank"
           >
-            <svg
-              class="gridicon gridicons-help-outline needs-offset"
-              height="18"
-              viewBox="0 0 24 24"
-              width="18"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <use
-                xlink:href="gridicons.svg#gridicons-help-outline"
-              />
-            </svg>
-             
-            Get help setting up Jetpack
+            Terms of Service
           </a>
-        </div>
+           and have read our 
+          <a
+            href="https://automattic.com/privacy/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Privacy Policy
+          </a>
+          .
+        </p>
       </div>
     </div>
   </main>
@@ -405,177 +306,78 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
         </div>
       </div>
       <div
-        class="signup-form"
+        class="signup-form signup-form-social-first"
       >
-        <div
-          class="card logged-out-form"
-        >
-          <form
-            novalidate=""
-          >
-            <div>
-              <label
-                class="form-label"
-                for="email"
-              >
-                Your email address
-              </label>
-              <input
-                autocapitalize="off"
-                autocorrect="off"
-                class="form-text-input signup-form__input"
-                id="email"
-                name="email"
-                type="email"
-                value="email@an.example.site"
-              />
-              <label
-                class="form-label"
-                for="username"
-              >
-                Choose a username
-              </label>
-              <input
-                autocapitalize="off"
-                autocorrect="off"
-                class="form-text-input signup-form__input"
-                id="username"
-                name="username"
-                type="text"
-                value=""
-              />
-              <label
-                class="form-label"
-                for="password"
-              >
-                Choose a password
-              </label>
-              <div
-                class="form-password-input"
-              >
-                <input
-                  autocomplete="off"
-                  class="form-text-input signup-form__input"
-                  id="password"
-                  name="password"
-                  type="password"
-                  value=""
-                />
-                <span
-                  class="form-password-input__toggle form-password-input__toggle-visibility"
-                >
-                  <svg
-                    class="gridicon gridicons-not-visible"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <use
-                      xlink:href="gridicons.svg#gridicons-not-visible"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </div>
-            <div
-              class="card logged-out-form__footer is-blended"
-            >
-              <p
-                class="signup-form__terms-of-service-link"
-              >
-                By creating an account you agree to our 
-                <a
-                  href="https://wordpress.com/tos/"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Terms of Service
-                </a>
-                 and have read our 
-                <a
-                  href="https://automattic.com/privacy/"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Privacy Policy
-                </a>
-                .
-              </p>
-              <button
-                class="button signup-form__submit form-button is-primary"
-                locale="en"
-                type="submit"
-              >
-                Create your account
-              </button>
-            </div>
-          </form>
-        </div>
         <div
           class="signup-form__social"
         >
-          <p>
-            Or create an account using:
-          </p>
           <div
             class="signup-form__social-buttons"
           >
             GoogleSocialButton
             AppleLoginButton
-            <p
-              class="signup-form__social-buttons-tos"
+            <button
+              class="components-button social-buttons__button button"
+              type="button"
             >
-              If you continue with Google or Apple, you agree to our 
-              <a
-                href="https://wordpress.com/tos/"
-                rel="noopener noreferrer"
-                target="_blank"
+              <svg
+                class="social-icons social-icons__google social-icons--enabled"
+                fill="none"
+                height="20"
+                viewBox="0 0 18 14"
+                width="20"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                Terms of Service
-              </a>
-              , and have read our 
-              <a
-                href="https://automattic.com/privacy/"
-                rel="noopener noreferrer"
-                target="_blank"
+                <g>
+                  <rect
+                    fill="none"
+                    height="12.5"
+                    id="Rectangle 710"
+                    rx="1.25"
+                    stroke="#1D2327"
+                    stroke-width="1.5"
+                    width="16.5"
+                    x="0.75"
+                    y="0.75"
+                  />
+                  <path
+                    d="M1 3.5L9 9.5L17 3.5"
+                    fill="none"
+                    id="Vector 107"
+                    stroke="#1D2327"
+                    stroke-width="1.5"
+                  />
+                </g>
+              </svg>
+              <span
+                class="social-buttons__service-name"
               >
-                Privacy Policy
-              </a>
-              .
-            </p>
+                Continue with Email
+              </span>
+            </button>
           </div>
         </div>
-        <div
-          class="logged-out-form__links"
+        <p
+          class="signup-form-social-first__tos-link"
         >
+          If you continue with Google or Apple, you agree to our 
           <a
-            class="logged-out-form__link-item"
-            href="/log-in/jetpack/es?site=http%3A%2F%2Fan.example.site&redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site&from=banner-44-slide-1-dashboard"
-          >
-            Already have an account? Sign in
-          </a>
-          <a
-            class="logged-out-form__link-item jetpack-connect__help-button"
-            href="https://jetpack.com/contact-support?hpi=1"
+            href="https://wordpress.com/tos/"
             rel="noopener noreferrer"
             target="_blank"
           >
-            <svg
-              class="gridicon gridicons-help-outline needs-offset"
-              height="18"
-              viewBox="0 0 24 24"
-              width="18"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <use
-                xlink:href="gridicons.svg#gridicons-help-outline"
-              />
-            </svg>
-             
-            Get help setting up Jetpack
+            Terms of Service
           </a>
-        </div>
+           and have read our 
+          <a
+            href="https://automattic.com/privacy/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Privacy Policy
+          </a>
+          .
+        </p>
       </div>
     </div>
   </main>

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -1,4 +1,4 @@
-import { ActionButtons, NEWSLETTER_FLOW } from '@automattic/onboarding';
+import { ActionButtons } from '@automattic/onboarding';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -17,6 +17,7 @@ class StepWrapper extends Component {
 		hideBack: PropTypes.bool,
 		hideSkip: PropTypes.bool,
 		hideNext: PropTypes.bool,
+		isSticky: PropTypes.bool,
 		// Allows to force a back button in the first step for example.
 		// You should only force this when you're passing a backUrl.
 		allowBackFirstStep: PropTypes.bool,
@@ -138,11 +139,6 @@ class StepWrapper extends Component {
 				return this.props.headerText;
 			}
 
-			const params = new URLSearchParams( window.location.search );
-			if ( params.get( 'variationName' ) === NEWSLETTER_FLOW ) {
-				return this.props.translate( 'Let’s get you signed up.' );
-			}
-
 			return this.props.translate( 'Let’s get started' );
 		}
 
@@ -184,6 +180,7 @@ class StepWrapper extends Component {
 			isHorizontalLayout,
 			customizedActionButtons,
 			isExtraWideLayout,
+			isSticky,
 		} = this.props;
 
 		const backButton = ! hideBack && this.renderBack();
@@ -202,13 +199,17 @@ class StepWrapper extends Component {
 			'has-navigation': hasNavigation,
 		} );
 
+		let sticky = false;
+		if ( isSticky !== undefined ) {
+			sticky = isSticky;
+		} else {
+			sticky = isReskinnedFlow( flowName ) ? true : false;
+		}
+
 		return (
 			<>
 				<div className={ classes }>
-					<ActionButtons
-						className="step-wrapper__navigation"
-						sticky={ isReskinnedFlow( flowName ) ? null : false }
-					>
+					<ActionButtons className="step-wrapper__navigation" sticky={ sticky }>
 						{ backButton }
 						{ skipButton }
 						{ nextButton }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { isNewsletterFlow } from '@automattic/onboarding';
-import { isMobile } from '@automattic/viewport';
+import { Button } from '@wordpress/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { isEmpty, omit, get } from 'lodash';
@@ -259,20 +259,7 @@ export class UserStep extends Component {
 		}
 
 		if ( isReskinned && 0 === positionInFlow ) {
-			const { queryObject } = this.props;
-
-			if ( queryObject?.variationName && isNewsletterFlow( queryObject.variationName ) ) {
-				subHeaderText = translate( 'Already have a WordPress.com account? {{a}}Log in{{/a}}', {
-					components: { a: <a href={ loginUrl } rel="noopener noreferrer" /> },
-				} );
-			} else {
-				subHeaderText = translate(
-					'First, create your WordPress.com account. Have an account? {{a}}Log in{{/a}}',
-					{
-						components: { a: <a href={ loginUrl } rel="noopener noreferrer" /> },
-					}
-				);
-			}
+			subHeaderText = '';
 		}
 
 		if ( this.props.userLoggedIn ) {
@@ -458,6 +445,15 @@ export class UserStep extends Component {
 			} );
 		}
 
+		const params = new URLSearchParams( window.location.search );
+		if ( isNewsletterFlow( params.get( 'variationName' ) ) ) {
+			return this.props.translate( 'Let’s get you signed up.' );
+		}
+
+		if ( ! headerText ) {
+			return translate( 'Create your account' );
+		}
+
 		return headerText;
 	}
 
@@ -489,10 +485,6 @@ export class UserStep extends Component {
 
 	renderSignupForm() {
 		const { oauth2Client, isReskinned } = this.props;
-		const isPasswordless =
-			isMobile() ||
-			this.props.isPasswordless ||
-			isNewsletterFlow( this.props?.queryObject?.variationName );
 		let socialService;
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
@@ -523,7 +515,6 @@ export class UserStep extends Component {
 					submitButtonText={ this.submitButtonText() }
 					suggestedUsername={ this.props.suggestedUsername }
 					handleSocialResponse={ this.handleSocialResponse }
-					isPasswordless={ isPasswordless }
 					queryArgs={ this.props.initialContext?.query || {} }
 					isSocialSignupEnabled={ isSocialSignupEnabled }
 					socialService={ socialService }
@@ -620,6 +611,8 @@ export class UserStep extends Component {
 			return null; // return nothing so that we don't see the error message and the sign up form.
 		}
 
+		const loginUrl = this.getLoginUrl();
+
 		// TODO: decouple hideBack flag from the flow name.
 		return (
 			<StepWrapper
@@ -630,6 +623,16 @@ export class UserStep extends Component {
 				positionInFlow={ this.props.positionInFlow }
 				fallbackHeaderText={ this.props.translate( 'Create your account.' ) }
 				stepContent={ this.renderSignupForm() }
+				isSticky={ false }
+				customizedActionButtons={
+					<Button
+						className="step-wrapper__navigation-link forward"
+						href={ loginUrl }
+						variant="link"
+					>
+						<span>{ this.props.translate( 'Log in' ) }</span>
+					</Button>
+				}
 			/>
 		);
 	}

--- a/client/signup/steps/user/style.scss
+++ b/client/signup/steps/user/style.scss
@@ -23,4 +23,8 @@ body.is-section-signup.is-white-signup .signup {
 			text-decoration: underline;
 		}
 	}
+
+	.step-wrapper__navigation.action-buttons {
+		height: 60px;
+	}
 }

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -19,17 +19,19 @@ body.is-section-signup {
 				opacity: 1;
 			}
 		}
+
 		/**
 		* Removed the navigation back button step from mobile viewports.
 		* This is done because the there is usally already a back button displayed to the user (Browser back button)
 		* and the current back button is redundent.
 		*/
 		.signup__step .plans.plans-step .step-wrapper__navigation {
-			@include breakpoint-deprecated( "<660px" ) {
+			@include breakpoint-deprecated("<660px") {
 				display: none;
 			}
 		}
 	}
+
 	&.is-videopress-signup,
 	&.is-videopress-tv-signup {
 		background: var(--videopress-color-background-dark);
@@ -38,6 +40,7 @@ body.is-section-signup {
 		&.has-loading-screen-signup {
 			background: var(--videopress-color-background-dark);
 			color: var(--videopress-color-text);
+
 			&::before {
 				content: "";
 				position: absolute;
@@ -72,9 +75,10 @@ body.is-section-signup {
 			max-width: none;
 		}
 
-		@include breakpoint-deprecated( "<480px" ) {
+		@include breakpoint-deprecated("<480px") {
 			.locale-suggestions {
 				margin-top: 0;
+
 				.notice {
 					border-radius: 0;
 				}
@@ -90,6 +94,7 @@ body.is-section-signup {
 		&.has-loading-screen-signup {
 			background: var(--p2-color-text);
 			color: var(--p2-color-white);
+
 			&::before {
 				content: "";
 				position: absolute;
@@ -122,9 +127,10 @@ body.is-section-signup {
 			max-width: none;
 		}
 
-		@include breakpoint-deprecated( "<480px" ) {
+		@include breakpoint-deprecated("<480px") {
 			.locale-suggestions {
 				margin-top: 0;
+
 				.notice {
 					border-radius: 0;
 				}
@@ -163,6 +169,7 @@ body.is-section-signup {
 // Notice the :not(.dops) selector. I've added this to try and
 // avoid stepping on the toes of our oauth users, like Crowdsignal.
 body.is-section-signup .layout:not(.dops) {
+
 	// Update the logo that appears when loading Calypso
 	// to match the homepage, using primary-dark with opacity.
 	.wpcom-site__logo {
@@ -178,8 +185,8 @@ body.is-section-signup .layout:not(.dops) {
 			background: var(--color-surface);
 			padding-bottom: 16px;
 			margin-bottom: 24px;
-			border-radius: 6px; /* stylelint-disable-line scales/radii */
-			@include elevation( 3dp );
+			border-radius: 4px;
+			@include elevation(3dp);
 		}
 
 		.empty-content__title {
@@ -208,10 +215,10 @@ body.is-section-signup .layout:not(.dops) {
 		right: 0;
 		max-height: 350px;
 		overflow: auto;
-		@include elevation( 2dp );
+		@include elevation(2dp);
 	}
 
-	@include breakpoint-deprecated( "<660px" ) {
+	@include breakpoint-deprecated("<660px") {
 		.layout:not(.is-horizontal-layout) button:not(.is-compact):not(.is-primary) {
 			font-size: $font-body;
 			padding-top: 12px;
@@ -354,6 +361,7 @@ body.is-section-signup .layout:not(.dops):not(.is-wccom-oauth-flow) .formatted-h
 	.signup-form__social {
 		padding-bottom: 0;
 		margin-top: 16px;
+
 		p {
 			font-size: $font-body-extra-small;
 			color: var(--studio-gray-60);
@@ -370,6 +378,7 @@ body.is-section-signup .layout:not(.dops):not(.is-wccom-oauth-flow) .formatted-h
 
 	.logged-out-form__footer {
 		text-align: center;
+
 		.button.is-primary {
 			border: 0;
 			box-shadow: none;
@@ -401,6 +410,7 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 			fill: var(--color-text);
 			transform-origin: 0 0;
 		}
+
 		.signup-header__right {
 			inset-block-start: 22px;
 			inset-inline-end: 20px;
@@ -464,14 +474,14 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 		.step-wrapper__header {
 			margin: 24px 20px 38px;
 
-			@media ( min-width: 880px ) {
+			@media (min-width: 880px) {
 				margin: 24px 20px;
 			}
 		}
 	}
 
 	.step-wrapper__header-button {
-		@include breakpoint-deprecated( "<660px" ) {
+		@include breakpoint-deprecated("<660px") {
 			margin-top: 16px;
 			margin-bottom: -16px;
 		}
@@ -484,7 +494,7 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 			@include onboarding-font-recoleta;
 			color: $gray-100;
 			letter-spacing: 0.2px;
-			font-size: 2.15rem; /* stylelint-disable-line scales/font-sizes */
+			font-size: 2.25rem;
 
 			@include break-xlarge {
 				font-size: 2.75rem;
@@ -495,7 +505,7 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 			color: $gray-60;
 			font-size: 1rem;
 
-			@include breakpoint-deprecated( "<660px" ) {
+			@include breakpoint-deprecated("<660px") {
 				margin-top: 16px;
 			}
 		}
@@ -511,6 +521,7 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 		}
 
 		&.is-left-align {
+
 			.formatted-header__title,
 			.formatted-header__subtitle {
 				padding: 0;
@@ -519,6 +530,7 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 		}
 
 		&.is-right-align {
+
 			.formatted-header__title,
 			.formatted-header__subtitle {
 				padding: 0;
@@ -528,15 +540,23 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 	}
 
 	.signup__step.is-user {
+		margin-top: 25vh;
+
+		.step-wrapper__header {
+			margin-bottom: 24px !important;
+		}
+
 		.formatted-header {
 			.formatted-header__title {
 				text-align: center;
+				font-size: rem(30px);
+				line-height: 2.5;
 
 				@include break-small {
 					max-width: inherit;
-					font-size: 3.25rem; /* stylelint-disable-line scales/font-sizes */
+					font-size: 2rem;
 					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-					line-height: 3.5rem;
+					line-height: 3.25rem;
 				}
 			}
 
@@ -552,11 +572,32 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 
 				@include break-small {
 					max-width: inherit;
-					font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
+					font-size: rem(18px);
 					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 					line-height: 1.625rem;
 					letter-spacing: 0.24px;
 				}
+			}
+		}
+
+		a.step-wrapper__navigation-link {
+			color: #1d2327;
+			font-family: "SF Pro Text", sans-serif;
+			font-size: 0.875rem;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 20px;
+			text-underline-offset: 5px;
+
+			&:hover {
+				color: var(--studio-blue-50, #0675c4);
+			}
+
+			&:focus {
+				outline: 1px dashed var(--studio-blue-50, #0675c4);
+				outline-offset: 3px;
+				box-shadow: none;
+				border-radius: 0;
 			}
 		}
 
@@ -587,29 +628,60 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 			flex-direction: column;
 			height: 100%;
 			justify-content: center;
+			gap: 16px;
 		}
 
 		.social-buttons__button {
+			display: flex;
+			height: 48px;
+			padding: 4px 16px !important;
+			justify-content: center;
+			align-items: center;
+			align-self: stretch;
+			border-radius: 4px;
+			border: 1px solid var(--studio-gray-50, #646970) !important;
+			background: var(--black-white-white, #fff);
+			margin-bottom: 0;
+
 			text-align: start;
 			padding-left: 0;
 			padding-bottom: 0;
-			border: 0;
 			box-shadow: none;
 			background-color: transparent;
 
+			&:hover {
+				background: var(--studio-gray-0, #f6f7f7);
+			}
+
+			&:focus {
+				background: var(--studio-gray-0, #f6f7f7);
+				outline: 2px solid var(--studio-gray-90, #1d2327);
+				outline-offset: 1px;
+			}
+
 			@include break-small {
 				text-align: center;
-				margin-bottom: 5px;
 			}
 
 			@include break-medium {
 				text-align: start;
 			}
 
-			> svg {
-				border: 1px solid var(--studio-gray-10);
-				padding: 12px;
-				border-radius: 24px; /* stylelint-disable-line scales/radii */
+			>svg {
+				margin-right: auto;
+			}
+
+			span {
+				color: var(--studio-gray-80, #2c3338);
+				font-feature-settings: "clig" off, "liga" off;
+				font-family: "SF Pro Text", sans-serif;
+				font-size: 0.875rem;
+				font-style: normal;
+				font-weight: 500;
+				line-height: normal;
+				letter-spacing: 0.32px;
+				margin-right: auto;
+				margin-left: -20px;
 			}
 		}
 
@@ -655,11 +727,11 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 				margin: 0;
 			}
 
-			> .logged-out-form__links {
+			>.logged-out-form__links {
 				max-width: 100%;
 				margin-top: 30px;
 
-				@media screen and ( max-width: $breakpoint-mobile ) {
+				@media screen and (max-width: $breakpoint-mobile ) {
 					margin-top: 0;
 
 					&::before,
@@ -764,7 +836,7 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 				z-index: 1;
 				color: var(--studio-gray-50);
 
-				@media screen and ( max-width: $breakpoint-mobile ) {
+				@media screen and (max-width: $breakpoint-mobile ) {
 					padding: 0 24px;
 				}
 			}
@@ -798,6 +870,7 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 				line-height: 2.5rem;
 				font-weight: 500;
+
 				@include break-mobile {
 					font-size: 2.75rem;
 					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
@@ -820,7 +893,7 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 				line-height: 2.5rem;
 				font-weight: 400;
 
-				@media ( min-width: 880px ) {
+				@media (min-width: 880px) {
 					font-size: 2.75rem;
 					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 					line-height: 3rem;
@@ -840,6 +913,7 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 		@include break-wide {
 			padding-inline-start: 20px;
 		}
+
 		.is-wide-layout {
 			max-width: 1280px;
 		}
@@ -856,7 +930,7 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 	.signup__step.is-design-setup-site,
 	.signup__step.is-difm-design-setup-site {
 		.step-wrapper__header {
-			@include breakpoint-deprecated( "<660px" ) {
+			@include breakpoint-deprecated("<660px") {
 				margin-left: 0;
 				margin-right: 0;
 			}

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -28,7 +28,7 @@ const selectors = {
 	lastNameInput: `input[aria-describedby="validation-field-last-name"]`,
 	phoneInput: `input[name="phone"]`,
 	phoneSelect: 'select.phone-input__country-select',
-	countrySelect: 'select[aria-describedby="validation-field-country-code"]',
+	countrySelect: 'select[aria-describedby="country-selector-description"]',
 	addressInput: 'input[aria-describedby="validation-field-address-1"]',
 	cityInput: 'input[aria-describedby="validation-field-city"]',
 	stateSelect: 'select[aria-describedby="validation-field-state"]',

--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -81,6 +81,35 @@ export class UserSignupPage {
 	}
 
 	/**
+	 * Choose Email sign-up method, then fill out required information and then submit the form to complete the signup.
+	 *
+	 * @param {string} email Email address of the new user.
+	 * @returns Response from the REST API.
+	 */
+	async signupSocialFirstWithEmail( email: string ): Promise< NewUserResponse > {
+		await this.page.click( 'button.components-button' );
+
+		await this.page.fill( selectors.emailInput, email );
+
+		// Use CSS selector instead of text.
+		// Text displayed on button changes depending on the link directing
+		// user to this page.
+		const [ , response ] = await Promise.all( [
+			this.page.waitForNavigation(),
+			this.page.waitForResponse( /.*new\?.*/ ),
+			this.page.click( selectors.submitButton ),
+		] );
+
+		if ( ! response ) {
+			throw new Error( 'Failed to create new user at signup.' );
+		}
+
+		const responseBody: NewUserResponse = await response.json();
+
+		return responseBody;
+	}
+
+	/**
 	 * Signup form that is used by WordPress.com Connect (WPCC) endpoint.
 	 *
 	 * WPCC is a single sign-on service. For more information, please see

--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -81,13 +81,16 @@ export class UserSignupPage {
 	}
 
 	/**
-	 * Choose Email sign-up method, then fill out required information and then submit the form to complete the signup.
+	 * Using the Social First signup, selects the Email option, then fill out required information
+	 * and then submit the form to complete the signup.
+	 *
+	 * @see https://github.com/Automattic/wp-calypso/pull/82481
 	 *
 	 * @param {string} email Email address of the new user.
 	 * @returns Response from the REST API.
 	 */
 	async signupSocialFirstWithEmail( email: string ): Promise< NewUserResponse > {
-		await this.page.click( 'button.components-button' );
+		await this.page.getByRole( 'button', { name: 'Continue with Email' } ).click();
 
 		await this.page.fill( selectors.emailInput, email );
 

--- a/test/e2e/specs/onboarding/ftme__sell.ts
+++ b/test/e2e/specs/onboarding/ftme__sell.ts
@@ -168,14 +168,8 @@ describe( 'FTME: Sell', function () {
 			);
 		} );
 
-		it( 'Site URL matches selected domain', async function () {
-			// The username is too long, and it is not entirely used to generate the site slug
-			const expectedUsername = testUser.username.substring( 0, 40 );
-
-			// If domain selection is skipped during onboarding, the first (default) site
-			// is created with the user's username.
-			// See https://github.com/Automattic/wp-calypso/pull/67517.
-			expect( newSiteDetails.blog_details.site_slug ).toContain( expectedUsername );
+		it( 'Site slug exists', async function () {
+			expect( newSiteDetails.blog_details.site_slug ).toBeDefined();
 		} );
 	} );
 

--- a/test/e2e/specs/onboarding/ftme__sell.ts
+++ b/test/e2e/specs/onboarding/ftme__sell.ts
@@ -164,7 +164,7 @@ describe( 'FTME: Sell', function () {
 		it( 'Land in Home dashboard', async function () {
 			await page.waitForURL(
 				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.blogid }` ),
-				{ timeout: 20 * 1000 }
+				{ timeout: 30 * 1000 }
 			);
 		} );
 
@@ -209,10 +209,13 @@ describe( 'FTME: Sell', function () {
 			return;
 		}
 
-		const restAPIClient = new RestAPIClient( {
-			username: testUser.username,
-			password: testUser.password,
-		} );
+		const restAPIClient = new RestAPIClient(
+			{
+				username: testUser.username,
+				password: testUser.password,
+			},
+			newUserDetails.body.bearer_token
+		);
 
 		await apiCloseAccount( restAPIClient, {
 			userID: newUserDetails.body.user_id,

--- a/test/e2e/specs/onboarding/ftme__sell.ts
+++ b/test/e2e/specs/onboarding/ftme__sell.ts
@@ -57,11 +57,7 @@ describe( 'FTME: Sell', function () {
 
 		it( 'Sign up as new user', async function () {
 			const userSignupPage = new UserSignupPage( page );
-			newUserDetails = await userSignupPage.signup(
-				testUser.email,
-				testUser.username,
-				testUser.password
-			);
+			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
 		} );
 
 		it( 'Skip domain selection', async function () {

--- a/test/e2e/specs/onboarding/ftme__sell.ts
+++ b/test/e2e/specs/onboarding/ftme__sell.ts
@@ -169,10 +169,13 @@ describe( 'FTME: Sell', function () {
 		} );
 
 		it( 'Site URL matches selected domain', async function () {
+			// The username is too long, and it is not entirely used to generate the site slug
+			const expectedUsername = testUser.username.substring( 0, 40 );
+
 			// If domain selection is skipped during onboarding, the first (default) site
 			// is created with the user's username.
 			// See https://github.com/Automattic/wp-calypso/pull/67517.
-			expect( newSiteDetails.blog_details.site_slug ).toContain( testUser.username );
+			expect( newSiteDetails.blog_details.site_slug ).toContain( expectedUsername );
 		} );
 	} );
 

--- a/test/e2e/specs/onboarding/setup__start-writing.ts
+++ b/test/e2e/specs/onboarding/setup__start-writing.ts
@@ -39,11 +39,7 @@ describe( 'Start Writing Tailored Onboarding', () => {
 		it( 'Enter account details', async function () {
 			await page.waitForURL( /.*start-writing.*/ );
 			const userSignupPage = new UserSignupPage( page );
-			newUserDetails = await userSignupPage.signup(
-				testUser.email,
-				testUser.username,
-				testUser.password
-			);
+			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
 		} );
 
 		it( "Start user's first post", async function () {

--- a/test/e2e/specs/onboarding/signup__domain.ts
+++ b/test/e2e/specs/onboarding/signup__domain.ts
@@ -49,12 +49,12 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com Domain Only' ), fu
 		} );
 
 		it( 'Select to buy just the domain', async function () {
-			await page.click( 'button:text("Just buy a domain")' );
+			await page.click( 'button:text("Get domain")' );
 		} );
 
 		it( 'Sign up for a WordPress.com account', async function () {
 			const userSignupPage = new UserSignupPage( page );
-			await userSignupPage.signup( testUser.email, testUser.username, testUser.password );
+			await userSignupPage.signupSocialFirstWithEmail( testUser.email );
 		} );
 
 		it( 'Land in checkout cart', async function () {

--- a/test/e2e/specs/onboarding/signup__free.ts
+++ b/test/e2e/specs/onboarding/signup__free.ts
@@ -35,11 +35,7 @@ describe( 'Signup: Create a WordPress.com Free site as a new user', function () 
 
 		it( 'Sign up as new user', async function () {
 			const userSignupPage = new UserSignupPage( page );
-			userDetails = await userSignupPage.signup(
-				testUser.email,
-				testUser.username,
-				testUser.password
-			);
+			userDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
 
 			userCreatedFlag = true;
 		} );


### PR DESCRIPTION
More details in this issue: https://github.com/Automattic/dotcom-forge/issues/3893#issuecomment-1731924438

This is the 3rd PR, as the first (merged and reverted) needed work on VideoPress and on E2E tests

## Before

<img width="757" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/e071ad33-ab7d-44b2-bf8a-76de2c2f3547">


## After

<img width="1021" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/ba8ea7ab-c498-4fd3-bb83-8e488b625b04">

## Next iteration
VideoPress flow: https://github.com/Automattic/wp-calypso/issues/82449

## Testing
1. Live Link
2. Go through some flows like[ Link In Bio](http://calypso.localhost:3000/setup/link-in-bio) and reach user signup
3. Try Social Logins and email passwordless registration