### PR TITLE
Reader byline - Move author field to secondary area with timestamp, show on compact cards

### DIFF
--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -50,7 +50,6 @@ class PostByline extends Component {
 		const hasMatchingAuthorAndSiteNames =
 			hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, post.author.name );
 		const shouldDisplayAuthor =
-			! compact &&
 			hasAuthorName &&
 			! isAuthorNameBlocked( post.author.name ) &&
 			( ! hasMatchingAuthorAndSiteNames || ! showSiteName );
@@ -71,54 +70,61 @@ class PostByline extends Component {
 					/>
 				) }
 				<div className="reader-post-card__byline-details">
-					{ ( shouldDisplayAuthor || showSiteName ) && ! compact && (
-						<div className="reader-post-card__byline-author-site">
-							{ shouldDisplayAuthor && (
-								<ReaderAuthorLink
-									className="reader-post-card__link"
-									author={ post.author }
-									siteUrl={ streamUrl }
-									post={ post }
-								>
-									{ post.author.name }
-								</ReaderAuthorLink>
-							) }
-							{ shouldDisplayAuthor && showSiteName ? ', ' : '' }
-							{ showSiteName && (
-								<ReaderSiteStreamLink
-									className="reader-post-card__site reader-post-card__link"
-									feedId={ feedId }
-									siteId={ siteId }
-									post={ post }
-								>
-									{ siteName }
-								</ReaderSiteStreamLink>
-							) }
+					{ showSiteName && ! compact && (
+						<div className="reader-post-card__byline-site">
+							<ReaderSiteStreamLink
+								className="reader-post-card__site reader-post-card__link"
+								feedId={ feedId }
+								siteId={ siteId }
+								post={ post }
+							>
+								{ siteName }
+							</ReaderSiteStreamLink>
 						</div>
 					) }
-					<div className="reader-post-card__timestamp-and-tag">
-						{ post.date && post.URL && (
-							<span className="reader-post-card__timestamp">
-								<a
-									className="reader-post-card__timestamp-slug"
-									onClick={ this.recordStubClick }
-									href={ siteUrl }
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									{ /* Use the siteName if not showing it above, otherwise use the slug */ }
-									{ ! showSiteName ? siteName : siteSlug }
-								</a>
-								<span className="reader-post-card__timestamp-bullet">·</span>
-								<a
-									className="reader-post-card__timestamp-link"
-									onClick={ this.recordDateClick }
-									href={ post.URL }
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									<TimeSince date={ post.date } />
-								</a>
+					<div className="reader-post-card__author-and-timestamp">
+						{ ( shouldDisplayAuthor || ( post.date && post.URL ) ) && (
+							<span className="reader-post-card__byline-secondary">
+								{ shouldDisplayAuthor && (
+									<>
+										<ReaderAuthorLink
+											// className="reader-post-card__link"
+											className="reader-post-card__byline-secondary-item"
+											author={ post.author }
+											siteUrl={ streamUrl }
+											post={ post }
+										>
+											{ post.author.name }
+										</ReaderAuthorLink>
+										{ post.date && post.URL && (
+											<span className="reader-post-card__byline-secondary-bullet">·</span>
+										) }
+									</>
+								) }
+								{ post.date && post.URL && (
+									<>
+										<a
+											className="reader-post-card__byline-secondary-item"
+											onClick={ this.recordStubClick }
+											href={ siteUrl }
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											{ /* Use the siteName if not showing it above, otherwise use the slug */ }
+											{ ! showSiteName ? siteName : siteSlug }
+										</a>
+										<span className="reader-post-card__byline-secondary-bullet">·</span>
+										<a
+											className="reader-post-card__byline-secondary-item"
+											onClick={ this.recordDateClick }
+											href={ post.URL }
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											<TimeSince date={ post.date } />
+										</a>
+									</>
+								) }
 							</span>
 						) }
 					</div>

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -56,6 +56,10 @@ class PostByline extends Component {
 		const streamUrl = getStreamUrl( feedId, siteId );
 		const siteIcon = get( site, 'icon.img' );
 
+		// Use the siteName if not showing it elsewhere, otherwise use the slug.
+		const bylineSiteName = ! showSiteName ? siteName : siteSlug;
+		const showDate = post.date && post.URL;
+
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		return (
 			<div className="reader-post-card__byline ignore-click">
@@ -83,7 +87,7 @@ class PostByline extends Component {
 						</div>
 					) }
 					<div className="reader-post-card__author-and-timestamp">
-						{ ( shouldDisplayAuthor || ( post.date && post.URL ) ) && (
+						{ ( shouldDisplayAuthor || bylineSiteName || showDate ) && (
 							<span className="reader-post-card__byline-secondary">
 								{ shouldDisplayAuthor && (
 									<>
@@ -96,12 +100,12 @@ class PostByline extends Component {
 										>
 											{ post.author.name }
 										</ReaderAuthorLink>
-										{ post.date && post.URL && (
+										{ ( bylineSiteName || showDate ) && (
 											<span className="reader-post-card__byline-secondary-bullet">·</span>
 										) }
 									</>
 								) }
-								{ post.date && post.URL && (
+								{ bylineSiteName && (
 									<>
 										<a
 											className="reader-post-card__byline-secondary-item"
@@ -110,20 +114,23 @@ class PostByline extends Component {
 											target="_blank"
 											rel="noopener noreferrer"
 										>
-											{ /* Use the siteName if not showing it above, otherwise use the slug */ }
-											{ ! showSiteName ? siteName : siteSlug }
+											{ bylineSiteName }
 										</a>
-										<span className="reader-post-card__byline-secondary-bullet">·</span>
-										<a
-											className="reader-post-card__byline-secondary-item"
-											onClick={ this.recordDateClick }
-											href={ post.URL }
-											target="_blank"
-											rel="noopener noreferrer"
-										>
-											<TimeSince date={ post.date } />
-										</a>
+										{ showDate && (
+											<span className="reader-post-card__byline-secondary-bullet">·</span>
+										) }
 									</>
+								) }
+								{ showDate && (
+									<a
+										className="reader-post-card__byline-secondary-item"
+										onClick={ this.recordDateClick }
+										href={ post.URL }
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										<TimeSince date={ post.date } />
+									</a>
 								) }
 							</span>
 						) }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -347,8 +347,7 @@
 }
 
 // Need .reader__content to override .reader__content a
-.reader__content .reader-post-card__timestamp-link,
-.reader__content .reader-post-card__timestamp-slug,
+.reader__content .reader-post-card__byline-secondary-item,
 .reader__content .reader-post-card__tag-link {
 	color: var(--color-neutral-40);
 	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
@@ -371,7 +370,7 @@
 	outline: dotted 1px;
 }
 
-.reader-post-card__timestamp-bullet {
+.reader-post-card__byline-secondary-bullet {
 	color: var(--color-text-subtle);
 	display: inline-block;
 	margin: 0 4px;
@@ -390,7 +389,7 @@
 	flex: inherit;
 }
 
-.reader-post-card__byline-author-site {
+.reader-post-card__byline-site {
 	font-family: $sans;
 	font-weight: 600;
 	margin-bottom: 2px;
@@ -404,7 +403,7 @@
 	}
 }
 
-.reader-post-card__timestamp-and-tag {
+.reader-post-card__author-and-timestamp {
 	align-items: flex-start;
 	display: flex;
 	flex-direction: row;
@@ -412,7 +411,7 @@
 	margin-top: -2px;
 }
 
-.reader-post-card__timestamp {
+.reader-post-card__byline-secondary {
 	display: inline-table;
 }
 

--- a/client/components/seo-preview-pane/style.scss
+++ b/client/components/seo-preview-pane/style.scss
@@ -106,7 +106,7 @@
 			cursor: default;
 		}
 
-		.reader-post-card__timestamp-and-tag a {
+		.reader-post-card__author-and-timestamp a {
 			color: var(--color-neutral-light);
 		}
 

--- a/client/reader/conversations/stream.scss
+++ b/client/reader/conversations/stream.scss
@@ -24,12 +24,12 @@
 		max-height: none;
 	}
 
-	.reader-post-card__byline-author-site {
+	.reader-post-card__byline-site {
 		font-weight: 600;
 		margin-right: 5px;
 	}
 
-	.reader-post-card__timestamp-and-tag {
+	.reader-post-card__author-and-timestamp {
 		margin-left: 0;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-1kb-p2#comment-1560

## Proposed Changes

* Follows the above suggestions to update where the reader cards show the author and show this on compact cards as well.
* We aim to keep the same dom structure and styles, but rename some classnames to make them more fitting.

NOT HANDLED - smart code to hide bullets on wrap as mentioned in the post above.[ I opened this separate PR](https://github.com/Automattic/wp-calypso/pull/82523) trying this, but it seems to have quite a few challenges in our design and context and present some odd edge cases currently that don't look good (worse than having the bullets in the first place). Given we were not having smart bullet hiding logic before this, I don't think we should hold up this change on that item. I may explore this further but want to move onto more impactful items for the time being and get this change live.


**Standard cards**
Before:
<img width="666" alt="Screenshot 2023-10-02 at 2 46 35 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/2a70f554-6a91-4fc3-9230-aa13f2dd4599">

After:
<img width="639" alt="Screenshot 2023-10-02 at 2 48 39 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/b3b6d94b-fdb8-499b-8058-417ae4609a80">

**Compact cards**
Before:
<img width="626" alt="Screenshot 2023-10-02 at 2 46 04 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/692ed839-ca99-4a8a-9198-2c06ad3b4b3f">

After:
<img width="635" alt="Screenshot 2023-10-02 at 2 46 11 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/8512e983-c05c-4e9c-82b1-8f557cf521a7">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test cards in the reader. Both full and compact.
* Verify the name on full cards has been moved to the secondary section of the byline.
* Verify the name in compact cards is now visible in the byline.
* Smoke test for regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?