### PR TITLE
Jetpack Manage: Account for active subscription/hosting in Boost links

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -56,9 +56,9 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 	const ScoreRating = getBoostRating( overallScore );
 
 	const ctaButtons = useMemo( () => {
-		const jetpackDashboardPage = isAtomicSite ? 'jetpack' : 'my-jetpack';
-
 		if ( ! hasBoost ) {
+			const jetpackDashboardPage = isAtomicSite ? 'jetpack' : 'my-jetpack';
+
 			return [
 				{
 					label: translate( 'Auto-optimize' ),
@@ -80,7 +80,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 			return [
 				{
 					label: translate( 'Boost Settings' ),
-					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=${ jetpackDashboardPage }`,
+					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`,
 					onClick: () => trackEvent( 'expandable_block_settings_click' ),
 				},
 			];
@@ -89,7 +89,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 		return [
 			{
 				label: translate( 'Optimize performance' ),
-				href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=${ jetpackDashboardPage }`,
+				href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`,
 				onClick: () => trackEvent( 'expandable_block_optimize_performance_click' ),
 				primary: true,
 			},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -31,6 +31,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 		blog_id: siteId,
 		url_with_scheme: siteUrlWithScheme,
 		url: siteUrl,
+		is_atomic: isAtomicSite,
 		has_boost: hasBoost,
 		jetpack_boost_scores: boostData,
 		has_pending_boost_one_time_score: hasPendingScore,
@@ -55,6 +56,8 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 	const ScoreRating = getBoostRating( overallScore );
 
 	const ctaButtons = useMemo( () => {
+		const jetpackDashboardPage = isAtomicSite ? 'jetpack' : 'my-jetpack';
+
 		if ( ! hasBoost ) {
 			return [
 				{
@@ -67,7 +70,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 				},
 				{
 					label: translate( 'Settings' ),
-					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack`,
+					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=${ jetpackDashboardPage }`,
 					onClick: () => trackEvent( 'expandable_block_settings_click' ),
 				},
 			];
@@ -77,7 +80,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 			return [
 				{
 					label: translate( 'Boost Settings' ),
-					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack`,
+					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=${ jetpackDashboardPage }`,
 					onClick: () => trackEvent( 'expandable_block_settings_click' ),
 				},
 			];
@@ -86,12 +89,12 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 		return [
 			{
 				label: translate( 'Optimize performance' ),
-				href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=my-jetpack`,
+				href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=${ jetpackDashboardPage }`,
 				onClick: () => trackEvent( 'expandable_block_optimize_performance_click' ),
 				primary: true,
 			},
 		];
-	}, [ hasBoost, ScoreRating, translate, siteUrlWithScheme, trackEvent ] );
+	}, [ isAtomicSite, hasBoost, ScoreRating, translate, siteUrlWithScheme, trackEvent ] );
 
 	return (
 		<>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
@@ -86,7 +86,7 @@ describe( 'BoostSitePerformance', () => {
 		expect( button ).toBeInTheDocument();
 		expect( button ).toHaveAttribute(
 			'href',
-			`${ site.url_with_scheme }/wp-admin/admin.php?page=my-jetpack`
+			`${ site.url_with_scheme }/wp-admin/admin.php?page=jetpack-boost`
 		);
 
 		fireEvent.click( button );
@@ -109,7 +109,7 @@ describe( 'BoostSitePerformance', () => {
 		expect( button ).toBeInTheDocument();
 		expect( button ).toHaveAttribute(
 			'href',
-			`${ site.url_with_scheme }/wp-admin/admin.php?page=my-jetpack`
+			`${ site.url_with_scheme }/wp-admin/admin.php?page=jetpack-boost`
 		);
 
 		fireEvent.click( button );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
@@ -45,7 +45,7 @@ export default function SiteBoostColumn( { site }: Props ) {
 				className="sites-overview__column-action-button is-link"
 				href={
 					adminUrl
-						? `${ origin }${ pathname }?page=my-jetpack#/add-boost`
+						? `${ origin }${ pathname }?page=jetpack-boost`
 						: `https://${ site.url }/wp-admin/admin.php?page=jetpack`
 				}
 				target="_blank"


### PR DESCRIPTION
This PR updates the **Configure Boost**, **Optimize performance**, **Settings**, and **Boost Settings** links in Jetpack Manage to account for whether or not a site is running on Atomic infrastructure, and if it has an active Boost subscription.

## Proposed Changes

* Direct paid Boost subscribers to their site's `?page=jetpack-boost` admin page when they click on **Configure Boost** in the expanded site overview card.
* Direct Atomic-hosted customers to their site's `?page=jetpack` admin page when they click any of the other aforementioned links in the expanded site overview card. (Self-hosted sites continue to go to `?page=my-jetpack`.)

## Testing Instructions

1. Visit the Jetpack Manage Dashboard. Follow these instructions with both a self-hosted and an Atomic-hosted site:
  1. Without expanding the site's details, verify that clicking the **Configure Boost** link directs you to the main Boost settings page for your site.
  2. Click the down arrow on the right to expand your site's details. Focus on the Boost card.
    * If you have a paid Boost subscription, verify that when you click **Boost Settings** or the **Optimize performance** button, you are directed to your site's main Jetpack dashboard. Likewise, if you do not have a paid Boost subscription and click on **Settings**, you should be directed to the same page.

<img width="519" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/3a8bdd44-d956-4fdd-8b34-223f23fec54b">

<img width="689" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/c324a29d-3436-4545-828c-80fd18e969a0">