### PR TITLE
Multiple domains: Select & show it in the side bar

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -239,12 +239,16 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 		themeStyleVariation,
 		themeItem,
 		siteAccentColor,
+		domainCart,
 	} = stepData;
 
 	// flowName isn't always passed in
 	const flowToCheck = flowName || lastKnownFlow;
 
-	const newCartItems = [ domainItem, googleAppsCartItem, themeItem ].filter( ( item ) => item );
+	const newCartItems =
+		domainCart && domainCart.length > 0
+			? [ ...Object.values( domainCart ), googleAppsCartItem, themeItem ].filter( ( item ) => item )
+			: [ domainItem, googleAppsCartItem, themeItem ].filter( ( item ) => item );
 
 	const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' ) && ! themeItem;
 	const state = reduxStore.getState();

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -445,6 +445,7 @@ export function generateSteps( {
 				'siteUrl',
 				'lastDomainSearched',
 				'useThemeHeadstart',
+				'domainCart',
 			],
 			optionalDependencies: [
 				'shouldHideFreePlan',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -76,6 +76,7 @@ export function generateSteps( {
 				'siteSlug',
 				'themeItem',
 				'useThemeHeadstart',
+				'domainCart',
 			],
 			optionalDependencies: [
 				'shouldHideFreePlan',
@@ -491,6 +492,7 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'themeItem',
 				'useThemeHeadstart',
+				'domainCart',
 			], // note: siteId, siteSlug are not provided when used in domain flow
 			optionalDependencies: [
 				'signupDomainOrigin',
@@ -521,6 +523,7 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'signupDomainOrigin',
 				'useThemeHeadstart',
+				'domainCart',
 			],
 			optionalDependencies: [
 				'siteUrl',
@@ -551,6 +554,7 @@ export function generateSteps( {
 				'siteUrl',
 				'lastDomainSearched',
 				'isManageSiteFlow',
+				'domainCart',
 			],
 			optionalDependencies: [
 				'shouldHideFreePlan',
@@ -580,6 +584,7 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'siteUrl',
 				'useThemeHeadstart',
+				'domainCart',
 			],
 			optionalDependencies: [
 				'signupDomainOrigin',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -446,7 +446,7 @@ export function generateSteps( {
 				'siteUrl',
 				'lastDomainSearched',
 				'useThemeHeadstart',
-				'domainCart',
+				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
 			],
 			optionalDependencies: [
 				'shouldHideFreePlan',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -76,7 +76,7 @@ export function generateSteps( {
 				'siteSlug',
 				'themeItem',
 				'useThemeHeadstart',
-				'domainCart',
+				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
 			],
 			optionalDependencies: [
 				'shouldHideFreePlan',
@@ -492,7 +492,7 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'themeItem',
 				'useThemeHeadstart',
-				'domainCart',
+				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
 			], // note: siteId, siteSlug are not provided when used in domain flow
 			optionalDependencies: [
 				'signupDomainOrigin',
@@ -523,7 +523,7 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'signupDomainOrigin',
 				'useThemeHeadstart',
-				'domainCart',
+				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
 			],
 			optionalDependencies: [
 				'siteUrl',
@@ -554,7 +554,7 @@ export function generateSteps( {
 				'siteUrl',
 				'lastDomainSearched',
 				'isManageSiteFlow',
-				'domainCart',
+				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
 			],
 			optionalDependencies: [
 				'shouldHideFreePlan',
@@ -584,7 +584,7 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'siteUrl',
 				'useThemeHeadstart',
-				'domainCart',
+				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
 			],
 			optionalDependencies: [
 				'signupDomainOrigin',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -76,7 +76,7 @@ export function generateSteps( {
 				'siteSlug',
 				'themeItem',
 				'useThemeHeadstart',
-				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
+				'domainCart',
 			],
 			optionalDependencies: [
 				'shouldHideFreePlan',
@@ -446,7 +446,7 @@ export function generateSteps( {
 				'siteUrl',
 				'lastDomainSearched',
 				'useThemeHeadstart',
-				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
+				'domainCart',
 			],
 			optionalDependencies: [
 				'shouldHideFreePlan',
@@ -492,7 +492,7 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'themeItem',
 				'useThemeHeadstart',
-				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
+				'domainCart',
 			], // note: siteId, siteSlug are not provided when used in domain flow
 			optionalDependencies: [
 				'signupDomainOrigin',
@@ -523,7 +523,7 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'signupDomainOrigin',
 				'useThemeHeadstart',
-				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
+				'domainCart',
 			],
 			optionalDependencies: [
 				'siteUrl',
@@ -554,7 +554,7 @@ export function generateSteps( {
 				'siteUrl',
 				'lastDomainSearched',
 				'isManageSiteFlow',
-				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
+				'domainCart',
 			],
 			optionalDependencies: [
 				'shouldHideFreePlan',
@@ -584,7 +584,7 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'siteUrl',
 				'useThemeHeadstart',
-				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
+				'domainCart',
 			],
 			optionalDependencies: [
 				'signupDomainOrigin',

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1169,7 +1169,7 @@ export class RenderDomainsStep extends Component {
 				backLabelText={ backLabelText }
 				hideSkip={ true }
 				goToNextStep={ this.handleSkip }
-				align={ isReskinned ? 'left' : 'center' }
+				align="center"
 				isWideLayout={ isReskinned }
 			/>
 		);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -659,7 +659,10 @@ export class RenderDomainsStep extends Component {
 			: [];
 		const cartIsLoading = this.props.shoppingCartManager.isLoading;
 
-		if ( cartIsLoading || this.shouldHideUseYourDomain() ) {
+		if (
+			this.shouldHideUseYourDomain() ||
+			( this.shouldUseMultipleDomainsInCart() && cartIsLoading )
+		) {
 			return null;
 		}
 		const useYourDomain = ! this.shouldHideUseYourDomain() ? (

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -681,7 +681,7 @@ export class RenderDomainsStep extends Component {
 		const cartIsLoading = this.props.shoppingCartManager.isLoading;
 
 		if ( cartIsLoading || this.shouldHideUseYourDomain() ) {
-			return null;
+			return <div className="domains__domain-side-content-container"></div>;
 		}
 		const useYourDomain = ! this.shouldHideUseYourDomain() ? (
 			<div className="domains__domain-side-content">

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -659,12 +659,6 @@ export class RenderDomainsStep extends Component {
 			: [];
 		const cartIsLoading = this.props.shoppingCartManager.isLoading;
 
-		if (
-			this.shouldHideUseYourDomain() ||
-			( this.shouldUseMultipleDomainsInCart() && cartIsLoading )
-		) {
-			return null;
-		}
 		const useYourDomain = ! this.shouldHideUseYourDomain() ? (
 			<div className="domains__domain-side-content">
 				<ReskinSideExplainer onClick={ this.handleUseYourDomainClick } type="use-your-domain" />
@@ -723,49 +717,52 @@ export class RenderDomainsStep extends Component {
 			);
 		};
 
+		const DomainsInCart =
+			this.shouldUseMultipleDomainsInCart() && ! cartIsLoading ? (
+				<div className="domains__domain-side-content domains__domain-cart">
+					<div className="domains__domain-cart-title">
+						{ this.props.translate( 'Your domains' ) }
+					</div>
+					<div className="domains__domain-cart-rows">
+						{ domainsInCart.map( ( domain, i ) => (
+							<div key={ `row${ i }` } className="domains__domain-cart-row">
+								<DomainNameAndCost domain={ domain } />
+							</div>
+						) ) }
+					</div>
+					<div key="rowtotal" className="domains__domain-cart-total">
+						{ this.props.translate( '%d domain', '%d domains', {
+							count: domainsInCart.length,
+							args: [ domainsInCart.length ],
+						} ) }
+					</div>
+					<Button primary className="domains__domain-cart-continue" onClick={ this.goToNext() }>
+						{ this.props.translate( 'Continue' ) }
+					</Button>
+					<Button
+						borderless
+						className="domains__domain-cart-choose-later"
+						onClick={ this.handleUseYourDomainClick }
+					>
+						{ this.props.translate( 'Choose my domain later' ) }
+					</Button>
+				</div>
+			) : null;
+
 		return (
 			<div className="domains__domain-side-content-container">
-				{ domainsInCart.length > 0 ? (
-					<div className="domains__domain-side-content domains__domain-cart">
-						<div className="domains__domain-cart-title">
-							{ this.props.translate( 'Your domains' ) }
-						</div>
-						<div className="domains__domain-cart-rows">
-							{ domainsInCart.map( ( domain, i ) => (
-								<div key={ `row${ i }` } className="domains__domain-cart-row">
-									<DomainNameAndCost domain={ domain } />
-								</div>
-							) ) }
-						</div>
-						<div key="rowtotal" className="domains__domain-cart-total">
-							{ this.props.translate( '%d domain', '%d domains', {
-								count: domainsInCart.length,
-								args: [ domainsInCart.length ],
-							} ) }
-						</div>
-						<Button primary className="domains__domain-cart-continue" onClick={ this.goToNext() }>
-							{ this.props.translate( 'Continue' ) }
-						</Button>
-						<Button
-							borderless
-							className="domains__domain-cart-choose-later"
-							onClick={ this.handleUseYourDomainClick }
-						>
-							{ this.props.translate( 'Choose my domain later' ) }
-						</Button>
-					</div>
-				) : (
-					! this.shouldHideDomainExplainer() &&
-					this.props.isPlanSelectionAvailableLaterInFlow && (
-						<div className="domains__domain-side-content domains__free-domain">
-							<ReskinSideExplainer
-								onClick={ this.handleDomainExplainerClick }
-								type="free-domain-explainer"
-								flowName={ this.props.flowName }
-							/>
-						</div>
-					)
-				) }
+				{ domainsInCart.length > 0
+					? DomainsInCart
+					: ! this.shouldHideDomainExplainer() &&
+					  this.props.isPlanSelectionAvailableLaterInFlow && (
+							<div className="domains__domain-side-content domains__free-domain">
+								<ReskinSideExplainer
+									onClick={ this.handleDomainExplainerClick }
+									type="free-domain-explainer"
+									flowName={ this.props.flowName }
+								/>
+							</div>
+					  ) }
 				{ useYourDomain }
 				{ this.shouldDisplayDomainOnlyExplainer() && (
 					<div className="domains__domain-side-content">

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -178,7 +178,7 @@ export class RenderDomainsStep extends Component {
 		);
 	};
 
-	handleAddDomain = async ( suggestion, position ) => {
+	handleAddDomain = ( suggestion, position ) => {
 		const signupDomainOrigin = suggestion?.is_free
 			? SIGNUP_DOMAIN_ORIGIN.FREE
 			: SIGNUP_DOMAIN_ORIGIN.CUSTOM;
@@ -573,12 +573,9 @@ export class RenderDomainsStep extends Component {
 			registration = updatePrivacyForDomain( registration, true );
 		}
 
-		try {
-			await this.props.shoppingCartManager.addProductsToCart( [ registration ] );
-		} catch {
-			return;
-		}
-		this.setState( { isCartPendingUpdateDomain: null } );
+		await this.props.shoppingCartManager.addProductsToCart( [ registration ] ).then( () => {
+			this.setState( { isCartPendingUpdateDomain: null } );
+		} );
 	}
 
 	removeDomainClickHandler = ( domain ) => {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -382,7 +382,11 @@ export class RenderDomainsStep extends Component {
 		const { step } = this.props;
 		const { suggestion } = step;
 
-		if ( suggestion && isEnabled( 'domains/add-multiple-domains-to-cart' ) ) {
+		if (
+			suggestion &&
+			! suggestion.is_free &&
+			isEnabled( 'domains/add-multiple-domains-to-cart' )
+		) {
 			return this.handleDomainToDomainCart( {
 				googleAppsCartItem,
 				shouldHideFreePlan,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -987,6 +987,9 @@ export class RenderDomainsStep extends Component {
 		}
 
 		if ( isReskinned ) {
+			if ( this.shouldUseMultipleDomainsInCart() ) {
+				return ! stepSectionName && translate( 'Choose your domains' );
+			}
 			return ! stepSectionName && translate( 'Choose a domain' );
 		}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -309,7 +309,7 @@ export class RenderDomainsStep extends Component {
 		}
 		const { suggestion } = step;
 
-		const enabledFlows = [ 'onboarding', 'onboarding-pm' ];
+		const enabledFlows = [ 'onboarding' ];
 
 		return (
 			isEnabled( 'domains/add-multiple-domains-to-cart' ) &&

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -61,6 +61,92 @@
 			border-radius: 0;
 		}
 	}
+
+
+	.domains__domain-cart {
+		.domains__domain-cart-title {
+			font-size: $font-body;
+			color: var(--studio-gray-90);
+			margin-bottom: 10px;
+		}
+
+		.domains__domain-cart-rows {
+			.domains__domain-cart-row {
+				padding-bottom: 6px;
+				padding-top: 6px;
+			}
+
+			.domains__domain-cart-row > div {
+				display: flex;
+				justify-content: space-between;
+			}
+
+			.savings-message {
+				color: var(--studio-green);
+				display: flex;
+				align-items: center;
+				font-size: 0.875rem;
+			}
+
+			.domains__domain-cart-domain {
+				display: flex;
+				align-items: center;
+				color: var(--studio-gray-50);
+				font-size: $font-body-small;
+
+				span {
+					overflow: hidden;
+					white-space: nowrap;
+					text-overflow: ellipsis;
+				}
+
+				&.limit-width {
+					width: 45%;
+				}
+			}
+
+			.domains__domain-cart-remove {
+				color: var(--studio-gray-50);
+				font-size: $font-body-extra-small;
+			}
+
+			.domain-product-price__price {
+				display: flex;
+				align-items: center;
+				font-size: 0.875rem;
+
+				del {
+					font-size: 0.75rem;
+					margin-right: 5px;
+				}
+			}
+		}
+
+		.domains__domain-cart-total {
+			border-top: 1px solid;
+			border-top-color: var(--studio-gray-5);
+			padding-top: 10px;
+			margin-bottom: 10px;
+			margin-top: 12px;
+			color: var(--studio-gray-60);
+			font-size: $font-body-small;
+		}
+
+		.domains__domain-cart-continue {
+			width: 100%;
+			height: 40px;
+			padding-left: 24px;
+			padding-right: 24px;
+			border-radius: 4px;
+		}
+
+		.domains__domain-cart-choose-later {
+			width: 100%;
+			height: 40px;
+			color: var(--studio-gray-100);
+			text-decoration: underline;
+		}
+	}
 }
 
 /**

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -26,7 +26,13 @@ function addProvidedDependencies( step, providedDependencies ) {
 }
 
 // These properties are never recorded in the tracks event for security reasons.
-const EXCLUDED_DEPENDENCIES = [ 'bearer_token', 'token', 'password', 'password_confirm' ];
+const EXCLUDED_DEPENDENCIES = [
+	'bearer_token',
+	'token',
+	'password',
+	'password_confirm',
+	'domainCart',
+];
 
 function recordSubmitStep( flow, stepName, providedDependencies, optionalProps ) {
 	// Transform the keys since tracks events only accept snaked prop names.
@@ -44,6 +50,7 @@ function recordSubmitStep( flow, stepName, providedDependencies, optionalProps )
 				/**
 				 * There's no need to include a resource ID in our event.
 				 * Just record that a preview was fetched
+				 *
 				 * @see the `sitePreviewImageBlob` dependency
 				 */
 				propName = 'site_preview_image_fetched';

--- a/config/development.json
+++ b/config/development.json
@@ -53,7 +53,7 @@
 		"devdocs": true,
 		"devdocs/color-scheme-picker": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"domains/add-multiple-domains-to-cart": false,
+		"domains/add-multiple-domains-to-cart": true,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/dashes-filter": false,
 		"domains/kracken-ui/exact-match-filter": true,

--- a/config/development.json
+++ b/config/development.json
@@ -53,7 +53,7 @@
 		"devdocs": true,
 		"devdocs/color-scheme-picker": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"domains/add-multiple-domains-to-cart": true,
+		"domains/add-multiple-domains-to-cart": false,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/dashes-filter": false,
 		"domains/kracken-ui/exact-match-filter": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -39,7 +39,7 @@
 		"devdocs": true,
 		"devdocs/color-scheme-picker": true,
 		"devdocs/redirect-loggedout-homepage": false,
-		"domains/add-multiple-domains-to-cart": true,
+		"domains/add-multiple-domains-to-cart": false,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4033, https://github.com/Automattic/dotcom-forge/issues/4032

## Proposed Changes

On the domain selection screen of the hero flow https://wordpress.com/start/user we want to allow the user to select and purchase multiple domains. The selected domains should be listed in the right-hand column.

## TO DO
- [x] Rebuild & add styles `Your domains` sidebar: https://github.com/Automattic/wp-calypso/pull/82579
- [x] Add filter to show only on selected flows.

## Testing Instructions

> [!IMPORTANT]  
> By default, in the development environment, the flag `domains/add-multiple-domains-to-cart` is enabled. You can disable it by changing `/config/development.json` and re-run `yarn start`

* Go to `/start/domains` (onboarding flow)
* Check if you can select multiple domains
* Check if the sidebar shows the selected domains (still WIP)
* Check if you can delete the domains from the sidebar
* Check if `Your Domains` sidebar disappears when no domains are selected
* Check selecting one or more domains
* Continue to checkout (selecting a paid plan) and check if all domains shows.
* Check without the flag if it works as expected
* Test other flows with and without the flag, it should work as usual, without multiple domains enabled.
