### PR TITLE
Site Profiler: improve host detection

### DIFF
--- a/client/blocks/import/types.ts
+++ b/client/blocks/import/types.ts
@@ -6,6 +6,11 @@ export type UrlData = {
 	platform: ImporterPlatform;
 	platform_data?: {
 		is_wpcom: boolean;
+		is_wpengine: boolean;
+		slug?: string;
+		name?: string;
+		support_url?: string;
+		homepage_url?: string;
 	};
 	meta: {
 		favicon: string | null;

--- a/client/site-profiler/components/hosting-information/hosting-provider-name.tsx
+++ b/client/site-profiler/components/hosting-information/hosting-provider-name.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export default function HostingProviderName( props: Props ) {
 	const { hostingProvider, urlData } = props;
-	const isPopularCdn = !! hostingProvider?.is_cdn;
+	const isPopularCdn = ! urlData?.platform_data?.name && !! hostingProvider?.is_cdn;
 	const hostingProviderName = urlData?.platform_data?.name ?? hostingProvider?.name;
 	const hostingProviderHomepage =
 		urlData?.platform_data?.homepage_url ?? hostingProvider?.homepage_url;
@@ -29,7 +29,7 @@ export default function HostingProviderName( props: Props ) {
 		return (
 			<>
 				{ nameComponent }
-				{ ( urlData?.platform === 'wordpress' || urlData?.platform_data?.is_wpengine ) && (
+				{ urlData?.platform === 'wordpress' && (
 					<>
 						&nbsp;&nbsp;
 						<a href={ `${ urlData.url }wp-admin` } target="_blank" rel="nofollow noreferrer">

--- a/client/site-profiler/components/hosting-information/hosting-provider-name.tsx
+++ b/client/site-profiler/components/hosting-information/hosting-provider-name.tsx
@@ -13,20 +13,23 @@ interface Props {
 export default function HostingProviderName( props: Props ) {
 	const { hostingProvider, urlData } = props;
 	const isPopularCdn = !! hostingProvider?.is_cdn;
+	const hostingProviderName = urlData?.platform_data?.name ?? hostingProvider?.name;
+	const hostingProviderHomepage =
+		urlData?.platform_data?.homepage_url ?? hostingProvider?.homepage_url;
 
 	const NonA8cHostingName = () => {
 		const nameComponent = hostingProvider?.homepage_url ? (
-			<a href={ hostingProvider.homepage_url } target="_blank" rel="nofollow noreferrer">
-				{ hostingProvider.name }
+			<a href={ hostingProviderHomepage } target="_blank" rel="nofollow noreferrer">
+				{ hostingProviderName }
 			</a>
 		) : (
-			hostingProvider?.name
+			hostingProviderName
 		);
 
 		return (
 			<>
 				{ nameComponent }
-				{ urlData?.platform === 'wordpress' && (
+				{ ( urlData?.platform === 'wordpress' || urlData?.platform_data?.is_wpengine ) && (
 					<>
 						&nbsp;&nbsp;
 						<a href={ `${ urlData.url }wp-admin` } target="_blank" rel="nofollow noreferrer">

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -20,7 +20,7 @@ export default function HostingInformation( props: Props ) {
 		supportUrl = localizeUrl( 'https://wordpress.com/help/contact' );
 	} else if ( urlData?.platform_data?.support_url ) {
 		supportUrl = urlData.platform_data.support_url;
-	} else if ( hostingProvider?.support_url && ! hostingProvider?.is_cdn ) {
+	} else if ( hostingProvider?.support_url ) {
 		supportUrl = hostingProvider?.support_url;
 	}
 

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -14,10 +14,15 @@ interface Props {
 export default function HostingInformation( props: Props ) {
 	const { dns = [], urlData, hostingProvider } = props;
 	const aRecordIps = dns.filter( ( x ) => x.type === 'A' && x.ip );
-	const supportUrl =
-		hostingProvider?.slug === 'automattic'
-			? localizeUrl( 'https://wordpress.com/help/contact' )
-			: hostingProvider?.support_url;
+	let supportUrl = null;
+
+	if ( hostingProvider?.slug === 'automattic' ) {
+		supportUrl = localizeUrl( 'https://wordpress.com/help/contact' );
+	} else if ( urlData?.platform_data?.support_url ) {
+		supportUrl = urlData.platform_data.support_url;
+	} else if ( hostingProvider?.support_url && ! hostingProvider?.is_cdn ) {
+		supportUrl = hostingProvider?.support_url;
+	}
 
 	return (
 		<div className="hosting-information">
@@ -27,7 +32,7 @@ export default function HostingInformation( props: Props ) {
 					<div className="name">{ translate( 'Provider' ) }</div>
 					<HostingProviderName hostingProvider={ hostingProvider } urlData={ urlData } />
 				</li>
-				{ supportUrl && ! hostingProvider?.is_cdn && (
+				{ supportUrl && (
 					<li>
 						<div className="name">{ translate( 'Support' ) }</div>
 						<div>

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -88,11 +88,9 @@ export default function SiteProfiler() {
 									/>
 								</LayoutBlockSection>
 							) }
-							{ siteProfilerData?.whois && (
-								<LayoutBlockSection>
-									<DomainInformation domain={ domain } whois={ siteProfilerData.whois } />
-								</LayoutBlockSection>
-							) }
+							<LayoutBlockSection>
+								<DomainInformation domain={ domain } whois={ siteProfilerData.whois } />
+							</LayoutBlockSection>
 						</>
 					) }
 				</LayoutBlock>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82395

## Proposed Changes

* Add check for WP Engine
* Add check for more detailed informations got from url-analyzer
* Add support for empty whois data. See D123868#2428368-code

## Testing Instructions

Apply D123905-code.

## WP Engine sites

1. http://calypso.localhost:3000/site-profiler?domain=paulocoelhoblog.com
2. http://calypso.localhost:3000/site-profiler?domain=theknoblenedev.wpengine.com

Should display:
1. `WP Engine` as "engine"
3. `/wp-admin` login URL
4. `WP Engine` as support URL

## Wix sites

1. http://calypso.localhost:3000/site-profiler?domain=karmico-indugio-0q.wixsite.com
2. http://calypso.localhost:3000/site-profiler?domain=wix.com

Should output:
1. Homepage URL
2. Support URL

## Other sites

They should not change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?