### PR TITLE
Subscriptions Management: Fix confirm and delete pending subscriptions on Reader

### DIFF
--- a/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn } from '../hooks';
+import { postSubscriptionsQueryKeyPrefix } from '../queries/use-post-subscriptions-query';
+import { subscriptionsCountQueryKeyPrefix } from '../queries/use-subscriptions-count-query';
 import { PendingPostSubscriptionsResult, SubscriptionManagerSubscriptionsCount } from '../types';
 
 type PendingPostConfirmParams = {
@@ -14,7 +16,9 @@ type PendingPostConfirmResponse = {
 const usePendingPostConfirmMutation = () => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
-	const countCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
+	const subscriptionsCacheKey = useCacheKey( postSubscriptionsQueryKeyPrefix );
+	const countCacheKey = useCacheKey( subscriptionsCountQueryKeyPrefix );
+
 	return useMutation( {
 		mutationFn: async ( { id }: PendingPostConfirmParams ) => {
 			if ( ! id ) {
@@ -25,8 +29,10 @@ const usePendingPostConfirmMutation = () => {
 			}
 
 			const response = await callApi< PendingPostConfirmResponse >( {
+				apiNamespace: 'wpcom/v2',
 				path: `/post-comment-subscriptions/${ id }/confirm`,
 				method: 'POST',
+				isLoggedIn,
 				apiVersion: '2',
 			} );
 			if ( ! response.confirmed ) {
@@ -40,6 +46,7 @@ const usePendingPostConfirmMutation = () => {
 		},
 		onMutate: async ( { id } ) => {
 			await queryClient.cancelQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
+			await queryClient.cancelQueries( subscriptionsCacheKey );
 			await queryClient.cancelQueries( countCacheKey );
 
 			const previousPendingPostSubscriptions =
@@ -96,6 +103,7 @@ const usePendingPostConfirmMutation = () => {
 		},
 		onSettled: () => {
 			queryClient.invalidateQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
+			queryClient.invalidateQueries( subscriptionsCacheKey );
 			queryClient.invalidateQueries( countCacheKey );
 		},
 	} );

--- a/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn } from '../hooks';
+import { subscriptionsCountQueryKeyPrefix } from '../queries/use-subscriptions-count-query';
 import { PendingPostSubscriptionsResult, SubscriptionManagerSubscriptionsCount } from '../types';
 
 type PendingPostDeleteParams = {
@@ -14,7 +15,8 @@ type PendingPostDeleteResponse = {
 const usePendingPostDeleteMutation = () => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
-	const countCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
+	const countCacheKey = useCacheKey( subscriptionsCountQueryKeyPrefix );
+
 	return useMutation( {
 		mutationFn: async ( params: PendingPostDeleteParams ) => {
 			if ( ! params.id ) {
@@ -25,8 +27,10 @@ const usePendingPostDeleteMutation = () => {
 			}
 
 			const response = await callApi< PendingPostDeleteResponse >( {
+				apiNamespace: 'wpcom/v2',
 				path: `/post-comment-subscriptions/${ params.id }/delete`,
 				method: 'POST',
+				isLoggedIn,
 				apiVersion: '2',
 			} );
 			if ( ! response.deleted ) {

--- a/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn } from '../hooks';
+import { siteSubscriptionsQueryKeyPrefix } from '../queries';
+import { subscriptionsCountQueryKeyPrefix } from '../queries/use-subscriptions-count-query';
 import { PendingSiteSubscriptionsResult, SubscriptionManagerSubscriptionsCount } from '../types';
 
 type PendingSiteConfirmParams = {
@@ -15,7 +17,9 @@ type PendingSiteConfirmResponse = {
 const usePendingSiteConfirmMutation = () => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
-	const countCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
+	const subscriptionsCacheKey = useCacheKey( siteSubscriptionsQueryKeyPrefix );
+	const countCacheKey = useCacheKey( subscriptionsCountQueryKeyPrefix );
+
 	return useMutation( {
 		mutationFn: async ( params: PendingSiteConfirmParams ) => {
 			if ( ! params.activation_key ) {
@@ -26,8 +30,10 @@ const usePendingSiteConfirmMutation = () => {
 			}
 
 			const response = await callApi< PendingSiteConfirmResponse >( {
+				apiNamespace: 'wpcom/v2',
 				path: `/pending-blog-subscriptions/${ params.activation_key }/confirm`,
 				method: 'POST',
+				isLoggedIn,
 				apiVersion: '2',
 			} );
 			if ( ! response.confirmed ) {
@@ -41,6 +47,7 @@ const usePendingSiteConfirmMutation = () => {
 		},
 		onMutate: async ( params ) => {
 			await queryClient.cancelQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+			await queryClient.cancelQueries( subscriptionsCacheKey );
 			await queryClient.cancelQueries( countCacheKey );
 
 			const previousPendingSiteSubscriptions =
@@ -95,6 +102,7 @@ const usePendingSiteConfirmMutation = () => {
 		},
 		onSettled: () => {
 			queryClient.invalidateQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+			queryClient.invalidateQueries( subscriptionsCacheKey );
 			queryClient.invalidateQueries( countCacheKey );
 		},
 	} );

--- a/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn } from '../hooks';
+import { subscriptionsCountQueryKeyPrefix } from '../queries/use-subscriptions-count-query';
 import { PendingSiteSubscriptionsResult, SubscriptionManagerSubscriptionsCount } from '../types';
 
 type PendingSiteDeleteParams = {
@@ -14,7 +15,8 @@ type PendingSiteDeleteResponse = {
 const usePendingSiteDeleteMutation = () => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
-	const countCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
+	const countCacheKey = useCacheKey( subscriptionsCountQueryKeyPrefix );
+
 	return useMutation( {
 		mutationFn: async ( params: PendingSiteDeleteParams ) => {
 			if ( ! params.id ) {
@@ -25,8 +27,10 @@ const usePendingSiteDeleteMutation = () => {
 			}
 
 			const response = await callApi< PendingSiteDeleteResponse >( {
+				apiNamespace: 'wpcom/v2',
 				path: `/pending-blog-subscriptions/${ params.id }/delete`,
 				method: 'POST',
+				isLoggedIn,
 				apiVersion: '2',
 			} );
 			if ( ! response.deleted ) {

--- a/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
@@ -5,6 +5,8 @@ import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { PostSubscription } from '../types';
 
+export const postSubscriptionsQueryKeyPrefix = [ 'read', 'post-subscriptions' ];
+
 type SubscriptionManagerPostSubscriptions = {
 	comment_subscriptions: PostSubscription[];
 	total_comment_subscriptions_count: number;
@@ -41,7 +43,7 @@ const usePostSubscriptionsQuery = ( {
 }: PostSubscriptionsQueryProps = {} ) => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
-	const cacheKey = useCacheKey( [ 'read', 'post-subscriptions' ] );
+	const cacheKey = useCacheKey( postSubscriptionsQueryKeyPrefix );
 
 	const { data, isFetching, isFetchingNextPage, fetchNextPage, hasNextPage, ...rest } =
 		useInfiniteQuery< SubscriptionManagerPostSubscriptions >(

--- a/packages/data-stores/src/reader/queries/use-subscriptions-count-query.ts
+++ b/packages/data-stores/src/reader/queries/use-subscriptions-count-query.ts
@@ -3,10 +3,12 @@ import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { SubscriptionManagerSubscriptionsCount } from '../types';
 
+export const subscriptionsCountQueryKeyPrefix = [ 'read', 'subscriptions-count' ];
+
 const useSubscriptionsCountQuery = () => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
-	const cacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
+	const cacheKey = useCacheKey( subscriptionsCountQueryKeyPrefix );
 
 	return useQuery< SubscriptionManagerSubscriptionsCount >( {
 		queryKey: cacheKey,


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82429

## Proposed Changes

* Fixes confirm and delete pending subscriptions
* Invalidate subscriptions query after confirm

## Testing Instructions

* Apply this PR to your local
* Using an incognito window (logged-out)
  * Go to a site with the subscribe block
  * Subscribe to this site using an email from a valid wpcom account
* On a logged-in window:
  * Go to http://calypso.localhost:3000/read/subscriptions
  * Click on the Pending tab
  * You should see the site subscription listed
  * Confirm the subscription
  * The list/count should be updated with the expected behavior
* Repeat the same process to test deleting a pending subscription
* Perform regression tests with post subscriptions and non-wpcom accounts

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?