### PR TITLE
Update JP tooltip copy

### DIFF
--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -734,9 +734,7 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	const isEnglishLocale = useIsEnglishLocale();
 	const shouldShowNewJPTooltipCopy =
 		isEnglishLocale ||
-		i18n.hasTranslation(
-			'Security, performance and growth tools made by the WordPress experts. Powered by Jetpack.'
-		);
+		i18n.hasTranslation( 'Security, performance, and growth tools—powered by Jetpack.' );
 
 	return (
 		<Row
@@ -777,7 +775,7 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 											text={
 												shouldShowNewJPTooltipCopy
 													? translate(
-															'Security, performance and growth tools made by the WordPress experts. Powered by Jetpack. '
+															'Security, performance, and growth tools—powered by Jetpack.'
 													  )
 													: ''
 											}

--- a/client/my-sites/plans-grid/components/plan-features-container.tsx
+++ b/client/my-sites/plans-grid/components/plan-features-container.tsx
@@ -32,9 +32,7 @@ const PlanFeaturesContainer: React.FC< {
 	const isEnglishLocale = useIsEnglishLocale();
 	const shouldShowNewJPTooltipCopy =
 		isEnglishLocale ||
-		i18n.hasTranslation(
-			'Security, performance and growth tools made by the WordPress experts. Powered by Jetpack.'
-		);
+		i18n.hasTranslation( 'Security, performance, and growth tools—powered by Jetpack.' );
 
 	return plansWithFeatures.map(
 		( { planSlug, features: { wpcomFeatures, jetpackFeatures } }, mapIndex ) => {
@@ -60,9 +58,7 @@ const PlanFeaturesContainer: React.FC< {
 							<Plans2023Tooltip
 								text={
 									shouldShowNewJPTooltipCopy
-										? translate(
-												'Security, performance and growth tools made by the WordPress experts. Powered by Jetpack.'
-										  )
+										? translate( 'Security, performance, and growth tools—powered by Jetpack.' )
 										: translate(
 												'Security, performance and growth tools made by the WordPress experts.'
 										  )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

Follow up to https://github.com/Automattic/wp-calypso/pull/82457/, this PR modifies the tooltip copy as suggested in p1696272830097389?thread_ts=1689799108.082379&cid=C040UAN6TPS-slack-C040UAN6TPS.

#### Plans grid in `/start`: 
<img width="472" alt="Screenshot 2023-10-03 at 8 44 30 AM" src="https://github.com/Automattic/wp-calypso/assets/1269602/9029a1b5-b9db-47d8-bb59-9ae74e879b1e">

#### Comparison grid in `/start`
<img width="465" alt="Screenshot 2023-10-03 at 8 44 37 AM" src="https://github.com/Automattic/wp-calypso/assets/1269602/7c5ed205-5d27-4651-b45c-8e3b31277e5c">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Same instructions as in https://github.com/Automattic/wp-calypso/pull/82457/

