### PR TITLE
Jetpack E2E: update locator used for Paid Content block spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
@@ -32,11 +32,10 @@ export class PaidContentBlockFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		const editorCanvas = await context.editorPage.getEditorCanvas();
-		const block = editorCanvas.getByRole( 'document', { name: 'Block: Paid Content' } );
-
 		// The Guest View will load by default. Wait for this view to fully render.
-		await block.getByRole( 'document', { name: 'Block: Guest View' } ).waitFor();
+		await context.addedBlockLocator
+			.getByRole( 'document', { name: 'Block: Guest View' } )
+			.waitFor();
 
 		// Using the Block Toolbar, change to the Subscriber view.
 		// The exact steps differ between the viewports.
@@ -50,13 +49,15 @@ export class PaidContentBlockFlow implements BlockFlow {
 		}
 
 		// Verify the Subscriber version of the block is now loaded.
-		await block.getByRole( 'document', { name: 'Block: Subscriber View' } ).waitFor();
+		await context.addedBlockLocator
+			.getByRole( 'document', { name: 'Block: Subscriber View' } )
+			.waitFor();
 
 		// Fill the title and text for Subscriber view.
-		await block
+		await context.addedBlockLocator
 			.getByRole( 'document', { name: 'Block: Heading' } )
 			.fill( this.configurationData.subscriberTitle );
-		await block
+		await context.addedBlockLocator
 			.getByRole( 'document', { name: /Paragraph/ } )
 			.fill( this.configurationData.subscriberText );
 	}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
@@ -52,12 +52,12 @@ export class PaidContentBlockFlow implements BlockFlow {
 		// Verify the Subscriber version of the block is now loaded.
 		await block.getByRole( 'document', { name: 'Block: Subscriber View' } ).waitFor();
 
-		// Fill the title and text for subscribers.
+		// Fill the title and text for Subscriber view.
 		await block
 			.getByRole( 'document', { name: 'Block: Heading' } )
 			.fill( this.configurationData.subscriberTitle );
 		await block
-			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.getByRole( 'document', { name: /Paragraph/ } )
 			.fill( this.configurationData.subscriberText );
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82495.

## Proposed Changes

This PR updates the locator used for the Paid Content block smoke flow to fix a permafail.

|  Before  |  After  |
|-------------|--------------|
|  ```getByRole( 'document', { name: 'Block: Paragraph' } )```   |   ```.getByRole( 'document', { name: /Paragraph/ } )```    |


## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?