### PR TITLE
Subscription management: fix white screen of death for non-WPCOM users

### DIFF
--- a/client/landing/subscriptions/components/site-subscription-page/index.tsx
+++ b/client/landing/subscriptions/components/site-subscription-page/index.tsx
@@ -1,8 +1,14 @@
 import SiteSubscription from 'calypso/blocks/reader-site-subscription';
+import {
+	SubscriptionManagerContextProvider,
+	SubscriptionsPortal,
+} from 'calypso/landing/subscriptions/components/subscription-manager-context';
 import { SiteSubscriptionProvider } from './site-subscription-provider';
 
 export const SiteSubscriptionPage = () => (
-	<SiteSubscriptionProvider>
-		<SiteSubscription />
-	</SiteSubscriptionProvider>
+	<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Subscriptions }>
+		<SiteSubscriptionProvider>
+			<SiteSubscription />
+		</SiteSubscriptionProvider>
+	</SubscriptionManagerContextProvider>
 );

--- a/client/landing/subscriptions/index.tsx
+++ b/client/landing/subscriptions/index.tsx
@@ -15,6 +15,10 @@ import GlobalNotices from 'calypso/components/global-notices';
 import MomentProvider from 'calypso/components/localized-moment/provider';
 import { WindowLocaleEffectManager } from 'calypso/landing/stepper/utils/window-locale-effect-manager';
 import { SiteSubscriptionPage } from 'calypso/landing/subscriptions/components/site-subscription-page';
+import {
+	SubscriptionManagerContextProvider,
+	SubscriptionsPortal,
+} from 'calypso/landing/subscriptions/components/subscription-manager-context';
 import { SubscriptionManagerPage } from 'calypso/landing/subscriptions/components/subscription-manager-page';
 import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
 import { createReduxStore } from 'calypso/state';
@@ -63,7 +67,16 @@ window.AppBoot = async () => {
 						<BrowserRouter>
 							<RecordPageView />
 							<Routes>
-								<Route path="/subscriptions/site/:blogId/*" element={ <SiteSubscriptionPage /> } />
+								<Route
+									path="/subscriptions/site/:blogId/*"
+									element={
+										<SubscriptionManagerContextProvider
+											portal={ SubscriptionsPortal.Subscriptions }
+										>
+											<SiteSubscriptionPage />
+										</SubscriptionManagerContextProvider>
+									}
+								/>
 								<Route path="/subscriptions/*" element={ <SubscriptionManagerPage /> } />
 							</Routes>
 						</BrowserRouter>


### PR DESCRIPTION
Context: p1696311995362819-slack-C02TCEHP3HA

## Proposed Changes

The subscription detail page for logged-out users was not loading because the `useRecordSubscriptionsTracksEvent ` was missing a `SubscriptionManagerContextProvider`.

This PR wraps `<SiteSubscription />` with a `<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Subscriptions } />`. 

## Testing Instructions

- Apply this PR
- Find a new post email or "Welcome to " email send out to non-WPCOM user
- Click the unsubscribe email
- You will get a white screen of death
- Copy the `subkey` cookie value
- Change `https://wordpress.com` to `http://calypso.localhost`
- Apply the cookie to the calypso.localhost domain by typing this in your console: `document.cookie = 'subkey=xxx'`
- Refresh the page
- The subscription details should now show


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?