### PR TITLE
Site Profiler: update copy and action for WordPress platform

### DIFF
--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -58,7 +58,10 @@ export default function HeadingInformation( props: Props ) {
 							{ translate( 'Transfer domain for free' ) }
 						</Button>
 					) }
-					{ conversionAction === 'transfer-hosting' && (
+					{ ( conversionAction === 'transfer-hosting' ||
+						conversionAction === 'transfer-hosting-wp' ||
+						conversionAction === 'transfer-domain-hosting-wp' ||
+						conversionAction === 'transfer-google-domain-hosting-wp' ) && (
 						<Button className="button-action" onClick={ onMigrateSite }>
 							{ translate( 'Migrate site' ) }
 						</Button>

--- a/client/site-profiler/components/heading-information/status-cta-info.tsx
+++ b/client/site-profiler/components/heading-information/status-cta-info.tsx
@@ -34,6 +34,7 @@ export default function StatusCtaInfo( props: Props ) {
 			);
 		case 'transfer-google-domain':
 		case 'transfer-google-domain-hosting':
+		case 'transfer-google-domain-hosting-wp':
 			return (
 				<p>
 					{ translate(
@@ -47,6 +48,7 @@ export default function StatusCtaInfo( props: Props ) {
 				</p>
 			);
 		case 'transfer-hosting':
+		case 'transfer-hosting-wp':
 			return (
 				<p>
 					{ translate(
@@ -59,6 +61,7 @@ export default function StatusCtaInfo( props: Props ) {
 				</p>
 			);
 		case 'transfer-domain-hosting':
+		case 'transfer-domain-hosting-wp':
 			return (
 				<p>
 					{ translate(

--- a/client/site-profiler/components/heading-information/status-info.tsx
+++ b/client/site-profiler/components/heading-information/status-info.tsx
@@ -37,6 +37,7 @@ export default function StatusInfo( props: Props ) {
 					) }
 				</p>
 			);
+
 		case 'transfer-domain-hosting':
 		case 'transfer-google-domain-hosting':
 			return (
@@ -47,6 +48,14 @@ export default function StatusInfo( props: Props ) {
 							components: { strong: <strong /> },
 						}
 					) }
+				</p>
+			);
+		case 'transfer-hosting-wp':
+		case 'transfer-domain-hosting-wp':
+		case 'transfer-google-domain-hosting-wp':
+			return (
+				<p>
+					{ translate( 'The owner of this site has great taste—this site runs on WordPress!' ) }
 				</p>
 			);
 		case 'idle':

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -30,12 +30,14 @@ export default function SiteProfiler() {
 	const { data: urlData } = useAnalyzeUrlQuery( domain, isDomainValid );
 	const { data: hostingProviderData } = useHostingProviderQuery( domain, isDomainValid );
 	const isBusyForWhile = useLongFetchingDetection( domain, isFetchingSP );
+	const isWordPressPlatForm = urlData?.platform === 'wordpress';
 	const conversionAction = useDefineConversionAction(
 		domain,
 		siteProfilerData?.whois,
 		siteProfilerData?.is_domain_available,
 		siteProfilerData?.eligible_google_transfer,
-		hostingProviderData?.hosting_provider
+		hostingProviderData?.hosting_provider,
+		isWordPressPlatForm
 	);
 
 	const updateDomainQueryParam = ( value: string ) => {

--- a/client/site-profiler/hooks/use-define-conversion-action.ts
+++ b/client/site-profiler/hooks/use-define-conversion-action.ts
@@ -5,8 +5,11 @@ export type CONVERSION_ACTION =
 	| 'transfer-domain'
 	| 'transfer-google-domain'
 	| 'transfer-google-domain-hosting'
+	| 'transfer-google-domain-hosting-wp'
 	| 'transfer-hosting'
+	| 'transfer-hosting-wp'
 	| 'transfer-domain-hosting'
+	| 'transfer-domain-hosting-wp'
 	| 'idle';
 
 export default function useDefineConversionAction(
@@ -14,7 +17,8 @@ export default function useDefineConversionAction(
 	whois?: WhoIs,
 	isDomainAvailable?: boolean,
 	isEligibleGoogleTransfer?: boolean,
-	hostingProvider?: HostingProvider
+	hostingProvider?: HostingProvider,
+	isWordPressPlatform?: boolean
 ): CONVERSION_ACTION | undefined {
 	const isWpDomain = domain.toLowerCase().includes( 'wordpress.com' );
 	const isWpAtomicDomain = domain.toLowerCase().includes( 'wpcomstaging.com' );
@@ -26,14 +30,23 @@ export default function useDefineConversionAction(
 	if ( isDomainAvailable ) {
 		return 'register-domain';
 	} else if ( isA8cDomain && ! isA8cHosting ) {
+		if ( isWordPressPlatform ) {
+			return 'transfer-hosting-wp';
+		}
 		return 'transfer-hosting';
 	} else if ( ! isA8cDomain && isEligibleGoogleTransfer && isA8cHosting ) {
 		return 'transfer-google-domain';
 	} else if ( ! isA8cDomain && isEligibleGoogleTransfer && ! isA8cHosting ) {
+		if ( isWordPressPlatform ) {
+			return 'transfer-google-domain-hosting-wp';
+		}
 		return 'transfer-google-domain-hosting';
 	} else if ( ! isA8cDomain && isA8cHosting ) {
 		return 'transfer-domain';
 	} else if ( ! isA8cDomain && ! isA8cHosting ) {
+		if ( isWordPressPlatform ) {
+			return 'transfer-domain-hosting-wp';
+		}
 		return 'transfer-domain-hosting';
 	}
 	return 'idle';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82439

## Proposed Changes

* When a user is using WordPress platform, we'd like to output something special and nice to the users. In the PR, we introduced three more types of site profiler conventions to target cases with WordPress platform, and outputting message for WordPress users. In addition, we'll also offer users to migrate their site to us if it's using WordPress as platform but hosting elsewhere.

![Screen Shot 2023-10-03 at 3 51 44 PM](https://github.com/Automattic/wp-calypso/assets/4074459/c9621617-694d-46e2-922d-ef247558afdc)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to http://calypso.localhost:3000/site-profiler
* Try out different domains that use WordPress as a platform but not hosting with WordPress.com, you can also test it with a JN site as well.
* Check if the status info shows as **The owner of this site has great taste—this site runs on WordPress!**
* Check if the CTA is "Migrate site"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?