### PR TITLE
Assembler: Update device switcher CSS outline

### DIFF
--- a/packages/components/src/device-switcher/toolbar.scss
+++ b/packages/components/src/device-switcher/toolbar.scss
@@ -5,16 +5,17 @@
 	display: none;
 
 	.device-switcher__toolbar-devices {
+		align-items: center;
 		display: flex;
 		height: 58px;
+		gap: 18px;
 		margin-bottom: 13px;
 		justify-content: center;
 
 		> button {
 			border-radius: 2px;
 			color: var(--studio-gray-10);
-			height: auto;
-			margin: 0 9px;
+			height: 28px;
 			padding: 0;
 			transition: color 0.1s ease-in-out;
 


### PR DESCRIPTION
## Proposed Changes

This PR updates the device switcher focus/active outline so that it's not so tall.

| Before | After |
| --- | --- |
| ![Screenshot 2023-10-03 at 4 06 12 PM](https://github.com/Automattic/wp-calypso/assets/797888/5f3c00c9-8a6c-4364-ad19-567cc41c2a05) |![Screenshot 2023-10-03 at 4 06 03 PM](https://github.com/Automattic/wp-calypso/assets/797888/af34c6eb-4e5f-4d69-8564-84fc9dc59ded) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler `/setup/with-theme-assembler/patternAssembler?siteSlug=${ SITE_SLUG }`.
* Ensure that the device switcher CSS outline is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2