### PR TITLE
Fix the basic functionality of `discount` query param of `/plans`

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -32,6 +32,7 @@ import {
 import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { isValidFeatureKey, FEATURES_LIST } from 'calypso/lib/plans/features-list';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
+import { addQueryArgs } from 'calypso/lib/url';
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
 import PlanTypeSelector from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import PlansGrid from 'calypso/my-sites/plans-grid';
@@ -330,7 +331,10 @@ const PlansFeaturesMain = ( {
 		const planPath = cartItemForPlan?.product_slug
 			? getPlanPath( cartItemForPlan.product_slug )
 			: '';
-		const checkoutUrlWithArgs = `/checkout/${ siteSlug }/${ planPath }`;
+		const checkoutUrlWithArgs = addQueryArgs(
+			{ ...( withDiscount && { coupon: withDiscount } ) },
+			`/checkout/${ siteSlug }/${ planPath }`
+		);
 
 		page( checkoutUrlWithArgs );
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR fixes the functionality of passing the coupon code to 
Ideally I think we should also add a notice informing the user that the coupon will be applied upon checking out. However, it would require [cleanning up the PlanNotice code](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/plans-features-main/components/plan-notice.tsx#L86) and polishing the copy, which would better be follow-ups.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the public API
* Log in and visit `/plans/{selected site slug}`
* Append the coupon code by `?discount=SOUTHP_TEST` and click "upgrade" for any paid plan
* The coupon should be applied successfully.
* Upgrading without a coupon code should work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
