### PR TITLE
Create cart for domains and update to actual cart when checkout

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Badge, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -43,6 +44,7 @@ class DomainRegistrationSuggestion extends Component {
 		isFeatured: PropTypes.bool,
 		buttonStyles: PropTypes.object,
 		cart: PropTypes.object,
+		domainCart: PropTypes.object,
 		suggestion: PropTypes.shape( {
 			domain_name: PropTypes.string.isRequired,
 			product_slug: PropTypes.string,
@@ -133,9 +135,15 @@ class DomainRegistrationSuggestion extends Component {
 			pendingCheckSuggestion,
 			premiumDomain,
 			isCartPendingUpdateDomain,
+			domainCart,
 		} = this.props;
 		const { domain_name: domain } = suggestion;
-		const isAdded = hasDomainInCart( cart, domain );
+		let isAdded;
+		if ( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ) {
+			isAdded = domainCart ? domainCart[ domain ] : false;
+		} else {
+			isAdded = hasDomainInCart( cart, domain );
+		}
 
 		let buttonContent;
 		let buttonStyles = this.props.buttonStyles;
@@ -212,7 +220,6 @@ class DomainRegistrationSuggestion extends Component {
 	 * becomes the tld. This is not very comprehensive since there can be
 	 * subdomains which would fail this test. However, for our purpose of
 	 * highlighting the TLD in domain suggestions, this is good enough.
-	 *
 	 * @param {string} domain The domain to be parsed
 	 */
 	getDomainParts( domain ) {

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -269,6 +269,7 @@ class DomainSearchResults extends Component {
 			featuredSuggestionElement = (
 				<FeaturedDomainSuggestions
 					cart={ this.props.cart }
+					domainCart={ this.props.domainCart }
 					isCartPendingUpdate={ this.props.isCartPendingUpdate }
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					isDomainOnly={ isDomainOnly }
@@ -302,6 +303,7 @@ class DomainSearchResults extends Component {
 						isDomainOnly={ isDomainOnly }
 						suggestion={ suggestion }
 						key={ suggestion.domain_name }
+						domainCart={ this.props.domainCart }
 						cart={ this.props.cart }
 						isSignupStep={ this.props.isSignupStep }
 						showStrikedOutPrice={ this.props.showStrikedOutPrice }

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -37,6 +37,7 @@ export class FeaturedDomainSuggestions extends Component {
 			'pendingCheckSuggestion',
 			'unavailableDomains',
 			'domainAndPlanUpsellFlow',
+			'domainCart',
 		];
 		return pick( this.props, childKeys );
 	}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1423,6 +1423,7 @@ class RegisterDomainStep extends Component {
 		return (
 			<DomainSearchResults
 				key="domain-search-results" // key is required for CSS transition of content/
+				domainCart={ this.props.domainCart }
 				availableDomain={ availableDomain }
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 				isDomainOnly={ this.props.isDomainOnly }

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -239,12 +239,15 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 		themeStyleVariation,
 		themeItem,
 		siteAccentColor,
+		domainCart,
 	} = stepData;
 
 	// flowName isn't always passed in
 	const flowToCheck = flowName || lastKnownFlow;
 
-	const newCartItems = [ domainItem, googleAppsCartItem, themeItem ].filter( ( item ) => item );
+	const newCartItems = [ ...Object.values( domainCart ), googleAppsCartItem, themeItem ].filter(
+		( item ) => item
+	);
 
 	const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' ) && ! themeItem;
 	const state = reduxStore.getState();
@@ -308,6 +311,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				domainItem,
 				themeItem,
 			};
+			// TODO: need to change here to support multiple domains
 
 			processItemCart( providedDependencies, newCartItems, callback, reduxStore, siteSlug, {
 				isFreeThemePreselected,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -445,6 +445,7 @@ export function generateSteps( {
 				'siteUrl',
 				'lastDomainSearched',
 				'useThemeHeadstart',
+				'domainCart',
 			],
 			optionalDependencies: [
 				'shouldHideFreePlan',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4032

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start?flags=domains/add-multiple-domains-to-cart`
* Select multiple domains
* Go through the entire flow
* Check checkout cart to see if it has the selected domains

Screencast: p1696322669962609/1696279559.896049-slack-CKZHG0QCR

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?