### PR TITLE
Site Profiler: add support for Pressable domains

### DIFF
--- a/client/blocks/import/types.ts
+++ b/client/blocks/import/types.ts
@@ -7,6 +7,7 @@ export type UrlData = {
 	platform_data?: {
 		is_wpcom: boolean;
 		is_wpengine: boolean;
+		is_pressable: boolean;
 		slug?: string;
 		name?: string;
 		support_url?: string;

--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -2,20 +2,23 @@ import { Button } from '@wordpress/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { TranslateOptions, translate } from 'i18n-calypso';
 import { useState } from 'react';
+import { UrlData } from 'calypso/blocks/import/types';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useDomainAnalyzerWhoisRawDataQuery } from 'calypso/data/site-profiler/use-domain-whois-raw-data-query';
 import { useFilteredWhoisData } from 'calypso/site-profiler/hooks/use-filtered-whois-data';
 import VerifiedProvider from './verified-provider';
-import type { WhoIs } from 'calypso/data/site-profiler/types';
+import type { HostingProvider, WhoIs } from 'calypso/data/site-profiler/types';
 import './styles.scss';
 
 interface Props {
 	domain: string;
 	whois: WhoIs;
+	hostingProvider?: HostingProvider;
+	urlData?: UrlData;
 }
 
 export default function DomainInformation( props: Props ) {
-	const { domain, whois } = props;
+	const { domain, whois, hostingProvider, urlData } = props;
 	const moment = useLocalizedMoment();
 	const momentFormat = 'YYYY-MM-DD HH:mm:ss UTC';
 	const urlRegex = /https?:\/\/[^\s/$.?#].[^\s]*/g;
@@ -76,7 +79,7 @@ export default function DomainInformation( props: Props ) {
 						<div className="name">{ translate( 'Registrar' ) }</div>
 						<div>
 							{ whois.registrar_url?.toLowerCase().includes( 'automattic' ) && (
-								<VerifiedProvider />
+								<VerifiedProvider hostingProvider={ hostingProvider } urlData={ urlData } />
 							) }
 							{ whois.registrar_url &&
 								! whois.registrar_url?.toLowerCase().includes( 'automattic' ) && (

--- a/client/site-profiler/components/domain-information/verified-provider.tsx
+++ b/client/site-profiler/components/domain-information/verified-provider.tsx
@@ -1,17 +1,30 @@
 import { Gridicon } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
+import { UrlData } from 'calypso/blocks/import/types';
+import { HostingProvider } from 'calypso/data/site-profiler/types';
+import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
+import useHostingProviderURL from 'calypso/site-profiler/hooks/use-hosting-provider-url';
 
-export default function VerifiedProvider() {
+interface Props {
+	hostingProvider?: HostingProvider;
+	urlData?: UrlData;
+}
+
+export default function VerifiedProvider( props: Props ) {
+	const { hostingProvider, urlData } = props;
+	const hostingProviderName = useHostingProviderName( hostingProvider, urlData );
+	const hostingProviderHomepage = useHostingProviderURL( 'homepage', hostingProvider, urlData );
+	const hostingProviderLogin = useHostingProviderURL( 'login', hostingProvider, urlData );
+
 	return (
 		<>
 			<span className="status-icon status-icon--small blue">
 				{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 				<Gridicon icon="checkmark" size={ 10 } />
 			</span>
-			<a href="https://wordpress.com">WordPress.com</a>
+			<a href={ hostingProviderHomepage }>{ hostingProviderName }</a>
 			&nbsp;&nbsp;
-			<a href={ localizeUrl( 'https://wordpress.com/login' ) }>({ translate( 'login' ) })</a>
+			<a href={ hostingProviderLogin }>({ translate( 'login' ) })</a>
 		</>
 	);
 }

--- a/client/site-profiler/components/hosting-information/hosting-provider-name.tsx
+++ b/client/site-profiler/components/hosting-information/hosting-provider-name.tsx
@@ -1,6 +1,8 @@
 import { translate } from 'i18n-calypso';
 import { UrlData } from 'calypso/blocks/import/types';
 import InfoPopover from 'calypso/components/info-popover';
+import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
+import useHostingProviderURL from 'calypso/site-profiler/hooks/use-hosting-provider-url';
 import VerifiedProvider from '../domain-information/verified-provider';
 import HostingPopupContent from './popup-inline-content';
 import type { HostingProvider } from 'calypso/data/site-profiler/types';
@@ -13,9 +15,9 @@ interface Props {
 export default function HostingProviderName( props: Props ) {
 	const { hostingProvider, urlData } = props;
 	const isPopularCdn = ! urlData?.platform_data?.name && !! hostingProvider?.is_cdn;
-	const hostingProviderName = urlData?.platform_data?.name ?? hostingProvider?.name;
-	const hostingProviderHomepage =
-		urlData?.platform_data?.homepage_url ?? hostingProvider?.homepage_url;
+	const hostingProviderName = useHostingProviderName( hostingProvider, urlData );
+	const hostingProviderHomepage = useHostingProviderURL( 'homepage', hostingProvider, urlData );
+	const hostingProviderLogin = useHostingProviderURL( 'login', hostingProvider, urlData );
 
 	const NonA8cHostingName = () => {
 		const nameComponent = hostingProvider?.homepage_url ? (
@@ -32,7 +34,7 @@ export default function HostingProviderName( props: Props ) {
 				{ urlData?.platform === 'wordpress' && (
 					<>
 						&nbsp;&nbsp;
-						<a href={ `${ urlData.url }wp-admin` } target="_blank" rel="nofollow noreferrer">
+						<a href={ hostingProviderLogin } target="_blank" rel="nofollow noreferrer">
 							({ translate( 'login' ) })
 						</a>
 					</>
@@ -49,7 +51,9 @@ export default function HostingProviderName( props: Props ) {
 	return (
 		<div className="hosting-provider-name__container">
 			{ hostingProvider?.slug !== 'automattic' && <NonA8cHostingName /> }
-			{ hostingProvider?.slug === 'automattic' && <VerifiedProvider /> }
+			{ hostingProvider?.slug === 'automattic' && (
+				<VerifiedProvider hostingProvider={ hostingProvider } urlData={ urlData } />
+			) }
 		</div>
 	);
 }

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -1,6 +1,6 @@
-import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import { UrlData } from 'calypso/blocks/import/types';
+import useHostingProviderURL from 'calypso/site-profiler/hooks/use-hosting-provider-url';
 import HostingProviderName from './hosting-provider-name';
 import type { DNS, HostingProvider } from 'calypso/data/site-profiler/types';
 import './style.scss';
@@ -14,15 +14,7 @@ interface Props {
 export default function HostingInformation( props: Props ) {
 	const { dns = [], urlData, hostingProvider } = props;
 	const aRecordIps = dns.filter( ( x ) => x.type === 'A' && x.ip );
-	let supportUrl = null;
-
-	if ( hostingProvider?.slug === 'automattic' ) {
-		supportUrl = localizeUrl( 'https://wordpress.com/help/contact' );
-	} else if ( urlData?.platform_data?.support_url ) {
-		supportUrl = urlData.platform_data.support_url;
-	} else if ( hostingProvider?.support_url ) {
-		supportUrl = hostingProvider?.support_url;
-	}
+	const supportUrl = useHostingProviderURL( 'support', hostingProvider, urlData );
 
 	return (
 		<div className="hosting-information">

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -91,7 +91,12 @@ export default function SiteProfiler() {
 								</LayoutBlockSection>
 							) }
 							<LayoutBlockSection>
-								<DomainInformation domain={ domain } whois={ siteProfilerData.whois } />
+								<DomainInformation
+									domain={ domain }
+									whois={ siteProfilerData.whois }
+									hostingProvider={ hostingProviderData?.hosting_provider }
+									urlData={ urlData }
+								/>
 							</LayoutBlockSection>
 						</>
 					) }

--- a/client/site-profiler/hooks/use-hosting-provider-name.ts
+++ b/client/site-profiler/hooks/use-hosting-provider-name.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+import { UrlData } from 'calypso/blocks/import/types';
+import { HostingProvider } from 'calypso/data/site-profiler/types';
+
+export default function useHostingProviderName(
+	hostingProvider?: HostingProvider,
+	urlData?: UrlData
+): string | undefined {
+	return useMemo( (): string | undefined => {
+		const ret = urlData?.platform_data?.name ?? hostingProvider?.name ?? '';
+
+		return ret === 'Automattic' ? 'WordPress.com' : ret;
+	}, [ hostingProvider, urlData ] );
+}

--- a/client/site-profiler/hooks/use-hosting-provider-name.ts
+++ b/client/site-profiler/hooks/use-hosting-provider-name.ts
@@ -1,3 +1,4 @@
+import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
 import { HostingProvider } from 'calypso/data/site-profiler/types';
@@ -6,9 +7,12 @@ export default function useHostingProviderName(
 	hostingProvider?: HostingProvider,
 	urlData?: UrlData
 ): string | undefined {
+	const translate = useTranslate();
+
 	return useMemo( (): string | undefined => {
-		const ret = urlData?.platform_data?.name ?? hostingProvider?.name ?? '';
+		// Translators: "Unknown" stands for "Unknown hosting provider"
+		const ret = urlData?.platform_data?.name ?? hostingProvider?.name ?? translate( 'Unknown' );
 
 		return ret === 'Automattic' ? 'WordPress.com' : ret;
-	}, [ hostingProvider, urlData ] );
+	}, [ translate, hostingProvider, urlData ] );
 }

--- a/client/site-profiler/hooks/use-hosting-provider-url.ts
+++ b/client/site-profiler/hooks/use-hosting-provider-url.ts
@@ -1,0 +1,19 @@
+import { useMemo } from 'react';
+import { UrlData } from 'calypso/blocks/import/types';
+import { HostingProvider } from 'calypso/data/site-profiler/types';
+
+export default function useHostingProviderURL(
+	type: 'support' | 'homepage' | 'login',
+	hostingProvider?: HostingProvider,
+	urlData?: UrlData
+): string | undefined {
+	return useMemo( (): string | undefined => {
+		if ( type === 'support' ) {
+			return urlData?.platform_data?.support_url ?? hostingProvider?.support_url ?? '';
+		} else if ( type === 'homepage' ) {
+			return urlData?.platform_data?.homepage_url ?? hostingProvider?.homepage_url ?? '';
+		}
+
+		return urlData?.platform === 'wordpress' && urlData?.url ? `${ urlData.url }wp-admin` : '';
+	}, [ type, hostingProvider, urlData ] );
+}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/82395
Related to pdtkmj-1Rk-p2#comment-3349
Related to https://github.com/Automattic/wp-calypso/issues/82396

This PR adds support for Pressable domain detection.

## Proposed Changes

* Add support for Pressable domains
* Accept BE support and homepage URLs for `automattic` domains (WP Engine, Pressable, WoA, Simple)
* Move data transform to separate hooks

> [!NOTE]
> Domains with "Automattic" as `registrar_url` are considered "verified" and so are Pressable domains

## Testing Instructions

Apply D123980-code.

All these sites must have the right provider. And other sites must work as before.

| URL | Provider | URLs |
| ---- | ---- | ---- |
| [site-profiler?domain=cagrimmett.com](http://calypso.localhost:3000/site-profiler?domain=cagrimmett.com) | Pressable | https://pressable.com/<br>https://pressable.com/resources/ |
| [site-profiler?domain=zaerl.wpcomstaging.com](http://calypso.localhost:3000/site-profiler?domain=zaerl.wpcomstaging.com) | WordPress.com | https://wordpress.com/<br>https://wordpress.com/help/contact/ |
| [site-profiler?domain=zaerl.wordpress.com](http://calypso.localhost:3000/site-profiler?domain=zaerl.wordpress.com) | WordPress.com | https://wordpress.com/<br>https://wordpress.com/help/contact/ |
| [site-profiler?domain=home.blog](http://calypso.localhost:3000/site-profiler?domain=home.blog) | WordPress.com | https://wordpress.com/<br>https://wordpress.com/help/contact/ |
| [site-profiler?domain=paulocoelhoblog.com](http://calypso.localhost:3000/site-profiler?domain=paulocoelhoblog.com) | WP Engine | https://wpengine.com/<br>https://wpengine.com/support/ |
| [site-profiler?domain=theknoblenedev.wpengine.com](http://calypso.localhost:3000/site-profiler?domain=theknoblenedev.wpengine.com) | WP Engine | https://wpengine.com/<br>https://wpengine.com/support/ |
| [site-profiler?domain=news.ycombinator.com](http://calypso.localhost:3000/site-profiler?domain=news.ycombinator.com) | Unknown | |
| [site-profiler?domain=zaerl.com](http://calypso.localhost:3000/site-profiler?domain=zaerl.com) | Amazon | https://www.amazon.com/<br>https://aws.amazon.com/contact-us/ |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?