### PR TITLE
Stats: Fix for broken URLs in Tags & categories card

### DIFF
--- a/client/my-sites/stats/stats-list/action-link.jsx
+++ b/client/my-sites/stats/stats-list/action-link.jsx
@@ -21,10 +21,13 @@ class StatsActionLink extends PureComponent {
 
 	render() {
 		const { href, translate } = this.props;
+		// The following fix is to address encoding issues with the URLs
+		// as returned to us from the API. If we fix that, we can remove this.
+		const finalLink = href.includes( '&#038;term' ) ? href.replace( '&#038;term', '&term' ) : href;
 		return (
 			<li className="stats-list__item-action module-content-list-item-action">
 				<a
-					href={ href }
+					href={ finalLink }
 					onClick={ this.onClick }
 					target="_blank"
 					rel="noopener noreferrer"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82510.

## Proposed Changes

The API is returning URLs with an unnecessary URL-encoded ampersand in them for the Tags & categories card on the Insights page. This PR adds a local client-side fix until we can investigate on the API side.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this branch.
2. Build and run locally.
3. Follow steps listed here: pejTkB-VK-p2#comment-807
4. Confirm links are listed correctly and work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?