### PR TITLE
Social Signup: Pass correct social Handler

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1177,7 +1177,7 @@ class SignupForm extends Component {
 					flowName={ this.props.flowName }
 					goToNextStep={ this.props.goToNextStep }
 					logInUrl={ logInUrl }
-					handleResponse={ this.props.handleSocialResponse }
+					handleSocialResponse={ this.props.handleSocialResponse }
 					socialService={ this.props.socialService }
 					socialServiceResponse={ this.props.socialServiceResponse }
 					isReskinned={ this.props.isReskinned }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/82481

In the social first new signup, we were passing the wrong function handler to the sign up component, this PR fixes it