### PR TITLE
Jetpack Manage: Fix missing search field in assign license flow when searching for site

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -149,7 +149,7 @@ export default function AssignLicenseForm( {
 		return page.redirect( partnerPortalBasePath( '/licenses' ) );
 	}, [ assignLicensesToSite, dispatch, licenseKeysArray, selectedSite?.ID ] );
 
-	if ( ! results.length ) {
+	if ( ! results.length && search === '' ) {
 		return (
 			<div className="assign-license-form__empty-state">
 				<p>


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack-genesis/issues/43

## Proposed Changes

When the user searches for a site during the assign license flow, the search field will disappear if no sites are returned. It looks like this was introduced in https://github.com/Automattic/wp-calypso/pull/70703, but it needed to account that it should work as described only when no search was initiated.

This PR adds additional check to ensure that the empty state code will be rendered only when no search is initiated by hte user.

Before | After
--|--
![image](https://github.com/Automattic/wp-calypso/assets/1749918/c22e2fd4-a400-46fb-9c82-b2c4f076e500)|![image](https://github.com/Automattic/wp-calypso/assets/1749918/db42fb91-0acb-46aa-b4b6-e1c6645b5b17)

## Testing Instructions
- Use the Jetpack Cloud Live link below.
- Visit `/partner-portal/licenses` and click Assign on any unassigned license (_if you don't have one, you can issue a new one_)
- Search for any site not part of the sites list and verify that the search field is still visible.
- Follow the testing instructions on https://github.com/Automattic/wp-calypso/pull/70703 and verify everything works as described.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?