### PR TITLE
Site profiler: Improve routing and adjust initial height

### DIFF
--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -7,6 +7,7 @@
 .is-section-site-profiler .layout__content {
 	background: #fff;
 	padding: 0;
+	min-height: 100vh;
 
 	h1 {
 		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;

--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -4,6 +4,11 @@ import { BrowserRouter } from 'react-router-dom';
 import Main from 'calypso/components/main';
 import SiteProfiler from 'calypso/site-profiler/components/site-profiler';
 
+export function redirectSiteProfilerRoot( domain?: string ) {
+	const queryParam = domain ? `?domain=${ domain }` : '';
+	page.redirect( `/site-profiler${ queryParam }` );
+}
+
 export function siteProfilerContext( context: PageJS.Context, next: () => void ): void {
 	if ( ! config.isEnabled( 'site-profiler' ) ) {
 		page.redirect( '/' );

--- a/client/site-profiler/index.web.ts
+++ b/client/site-profiler/index.web.ts
@@ -1,7 +1,9 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
-import { siteProfilerContext } from 'calypso/site-profiler/controller';
+import { siteProfilerContext, redirectSiteProfilerRoot } from 'calypso/site-profiler/controller';
 
 export default function () {
 	page( '/site-profiler', siteProfilerContext, makeLayout, clientRender );
+	page( '/site-profiler/:domain', ( { params } ) => redirectSiteProfilerRoot( params.domain ) );
+	page( '/site-profiler/:domain/*', ( { params } ) => redirectSiteProfilerRoot( params.domain ) );
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82441
Closes https://github.com/Automattic/wp-calypso/issues/82443

## Proposed Changes

* Improved site-profiler routing; allow setting domain value as route param such as `/site-profiler/bbc.com`
* CSS: Add min-height value for the layout content

## Testing Instructions

* Go to route `/site-profiler/{DOMAIN}`
* Check if the page is rendered correctly
* Go to route `/site-profiler/{DOMAIN}/something-random`
* Check if the page is correctly rendered
* Check the initial page height

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?