### PR TITLE
Improve display of existing plan purchased using an introductory offer

### DIFF
--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -182,6 +182,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 					billingPeriod: pricedAPIPlan?.bill_period,
 					currencyCode: pricedAPIPlan?.currency_code,
 					introOffer: sitePlan?.introOffer,
+					expiry: sitePlan?.expiry,
 				},
 			};
 		},

--- a/client/my-sites/plans-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plans-grid/components/billing-timeframe.tsx
@@ -38,7 +38,12 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 		storageAddOns: storageAddOnsForPlan,
 	} )?.[ yearlyVariantPlanSlug ];
 
-	if ( isMonthlyPlan && originalPrice?.monthly && yearlyVariantPricing && ! introOffer ) {
+	if (
+		isMonthlyPlan &&
+		originalPrice?.monthly &&
+		yearlyVariantPricing &&
+		( ! introOffer || introOffer.isOfferComplete )
+	) {
 		const yearlyVariantMaybeDiscountedPrice =
 			yearlyVariantPricing.discountedPrice?.monthly || yearlyVariantPricing.originalPrice?.monthly;
 
@@ -78,7 +83,7 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 	 * The introOffer billing should fall below into the next block once experiment with Woo plans is finalized.
 	 * We only expose introOffers to monthly & yearly plans for now (so no need to introduce more translations just yet).
 	 */
-	if ( introOffer?.intervalCount && introOffer.intervalUnit ) {
+	if ( introOffer?.intervalCount && introOffer.intervalUnit && ! introOffer.isOfferComplete ) {
 		if ( discountedPriceFullTermText ) {
 			if ( isMonthlyPlan ) {
 				return translate(
@@ -243,7 +248,11 @@ const PlanFeatures2023GridBillingTimeframe = ( { planSlug }: Props ) => {
 	const perMonthDescription = usePerMonthDescription( { planSlug } );
 	const description = perMonthDescription || billingTimeframe;
 
-	if ( isWooExpressPlan( planSlug ) && isMonthlyPlan && ! introOffer ) {
+	if (
+		isWooExpressPlan( planSlug ) &&
+		isMonthlyPlan &&
+		( ! introOffer || introOffer.isOfferComplete )
+	) {
 		return (
 			<div>
 				<div>{ billingTimeframe }</div>

--- a/client/my-sites/plans-grid/components/header-price.tsx
+++ b/client/my-sites/plans-grid/components/header-price.tsx
@@ -138,6 +138,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	} = gridPlansIndex[ planSlug ];
 	const shouldShowDiscountedPrice = Boolean( discountedPrice.monthly );
 	const isPricedPlan = null !== originalPrice.monthly;
+	const shouldShowIntroPricing = introOffer && ! introOffer.isOfferComplete;
 
 	if ( isWpcomEnterpriseGridPlan( planSlug ) ) {
 		return null;
@@ -147,7 +148,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 		<>
 			{ isPricedPlan ? (
 				<HeaderPriceContainer>
-					{ introOffer && (
+					{ shouldShowIntroPricing && (
 						<>
 							{ ! current && (
 								<Badge className="plan-features-2023-grid__badge" isForIntroOffer={ true }>
@@ -164,7 +165,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 							/>
 						</>
 					) }
-					{ ! introOffer && shouldShowDiscountedPrice && (
+					{ ! shouldShowIntroPricing && shouldShowDiscountedPrice && (
 						<>
 							<Badge className="plan-features-2023-grid__badge">
 								{ isPlanUpgradeCreditEligible
@@ -193,7 +194,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 							</PricesGroup>
 						</>
 					) }
-					{ ! introOffer && ! shouldShowDiscountedPrice && (
+					{ ! shouldShowIntroPricing && ! shouldShowDiscountedPrice && (
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ originalPrice.monthly }

--- a/client/my-sites/plans-grid/components/header-price.tsx
+++ b/client/my-sites/plans-grid/components/header-price.tsx
@@ -133,6 +133,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	const translate = useTranslate();
 	const { gridPlansIndex } = usePlansGridContext();
 	const {
+		current,
 		pricing: { currencyCode, originalPrice, discountedPrice, introOffer },
 	} = gridPlansIndex[ planSlug ];
 	const shouldShowDiscountedPrice = Boolean( discountedPrice.monthly );
@@ -148,9 +149,11 @@ const PlanFeatures2023GridHeaderPrice = ( {
 				<HeaderPriceContainer>
 					{ introOffer && (
 						<>
-							<Badge className="plan-features-2023-grid__badge" isForIntroOffer={ true }>
-								{ translate( 'Limited Time Offer' ) }
-							</Badge>
+							{ ! current && (
+								<Badge className="plan-features-2023-grid__badge" isForIntroOffer={ true }>
+									{ translate( 'Limited Time Offer' ) }
+								</Badge>
+							) }
 							<PlanPrice
 								currencyCode={ currencyCode }
 								rawPrice={ introOffer.rawPrice }

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -61,6 +61,8 @@ export interface PricingMetaForGridPlan {
 	// intro offers override billing and pricing shown in the UI
 	// they are currently defined off the site plans (so not defined when siteId is not available)
 	introOffer?: PlanIntroductoryOffer | null;
+	// Expiry date is only available from site plans and is the expiry date of an existing plan.
+	expiry?: string | null;
 }
 
 export type UsePricedAPIPlans = ( { planSlugs }: { planSlugs: PlanSlug[] } ) => {

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -24,11 +24,18 @@ const unpackIntroOffer = ( sitePlan: PricedAPISitePlan ): PlanIntroductoryOffer 
 		return null;
 	}
 
+	const isOfferComplete = Boolean(
+		sitePlan.expiry &&
+			sitePlan.introductory_offer_end_date &&
+			new Date( sitePlan.expiry ) > new Date( sitePlan.introductory_offer_end_date )
+	);
+
 	return {
 		formattedPrice: sitePlan.introductory_offer_formatted_price as string,
 		rawPrice: sitePlan.introductory_offer_raw_price as number,
 		intervalUnit: sitePlan.introductory_offer_interval_unit as string,
 		intervalCount: sitePlan.introductory_offer_interval_count as number,
+		isOfferComplete,
 	};
 };
 
@@ -55,6 +62,7 @@ function useSitePlans( { siteId }: Props ) {
 						planSlug: plan.product_slug,
 						productId: Number( productId ),
 						introOffer: unpackIntroOffer( plan ),
+						expiry: plan.expiry,
 					},
 				};
 			}, {} );

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -63,6 +63,8 @@ export interface SitePlan {
 	planSlug: PlanSlugFromProducts;
 	productId: number;
 	introOffer?: PlanIntroductoryOffer | null;
+	/* This value is only returned for the current plan on the site. */
+	expiry?: string;
 }
 
 export interface PricedAPIPlanIntroductoryOffer {

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -56,6 +56,7 @@ export interface PlanIntroductoryOffer {
 	rawPrice: number;
 	intervalUnit: string;
 	intervalCount: number;
+	isOfferComplete: boolean;
 }
 
 export interface SitePlan {
@@ -69,6 +70,7 @@ export interface PricedAPIPlanIntroductoryOffer {
 	introductory_offer_raw_price?: number;
 	introductory_offer_interval_unit?: string;
 	introductory_offer_interval_count?: number;
+	introductory_offer_end_date?: string;
 }
 
 /**
@@ -119,6 +121,8 @@ export interface PricedAPIPlan {
  */
 export interface PricedAPISitePlan extends PricedAPIPlanIntroductoryOffer {
 	/* product_id: number; // not included in the plan's payload */
+	current_plan?: boolean;
+	expiry?: string;
 	product_slug: StorePlanSlug;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81506

## Proposed Changes

While working on #81506, I discovered that we have a bug in our API and front-end code when displaying plan pricing for a plan that was purchased using an introductory offer. The two issues break down as follows:
  - The back end wasn't including the introductory offer that was used during the plan purchase, or indicating when that offer ends
  - The UI wasn't handling the case where we had an introductory offer applied to the current site plan, which has to do with showing the current/ongoing price for the plan while inside the introductory offer period and showing the ongoing price after the introductory period ends

I've worked on the back end changes in D123944-code, which we need for these changes to work correctly.

However, this PR tackles a few front-end changes to correctly handle the two states that may occur for a plan that was purchased with an introductory offer. The core change is to add a new `isOfferComplete` boolean to the `introOffer` object that reflects whether the offer period is complete, which we compute by determining whether the current plan's subscription expiry data is after the new `introductory_offer_end_date` timestamp added by D123944-code.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that D123944-code is applied to your development sandbox, and that you are routing requests for `public-api.wordpress.com` via your sandbox
* Set up sites to be in the following states:
  - A free Woo Express trial site that isn't expired yet (and where you haven't purchased a Woo Express plan before)
  - A site that was a Woo Express trial and where you purchased a Woo Express plan using the introductory offer, and the site is still in the introductory period
  - A site that was a Woo Express trial and where you purchased a Woo Express plan using the introductory offer, and the subscription has been renewed once - this means the introductory pricing is not the currently active pricing
  - A site where you purchased a Woo Express plan _not_ using the introductory offer
* Run the code in this branch via Calypso.live or locally
* For each of the sites above, navigate to _Upgrades_ -> _Plans_
* Verify that the following are true for each site:
  - For the site in a free trial, you should see the introductory offer terms as expected
<img width="1128" alt="Screenshot 2023-10-03 at 12 54 18" src="https://github.com/Automattic/wp-calypso/assets/3376401/554c9ff8-6a93-4b4d-8d88-9babefd1daae">
  - For the site where you have only purchased a Woo Express plan using the introductory offer, and the site is still in the introductory period, you should see the introductory pricing without the "Limited time offer" header
<img width="1128" alt="Screenshot 2023-10-03 at 12 46 03" src="https://github.com/Automattic/wp-calypso/assets/3376401/9627db9b-1d81-48f2-8743-dcc895742dab">
  - For the site with the Woo Express plan that was purchased with the introductory offer and then renewed, you should see the standard pricing apply (depending on timing, the amount shown in the upgrade banner will likely be different)
<img width="1128" alt="Screenshot 2023-10-03 at 12 53 15" src="https://github.com/Automattic/wp-calypso/assets/3376401/85753d72-9efd-413b-8b6d-b58b12245609">
  - For the site where you purchased a full-price Woo Express plan, you should see the standard pricing
<img width="1128" alt="Screenshot 2023-10-03 at 12 57 13" src="https://github.com/Automattic/wp-calypso/assets/3376401/2a79fa7d-c000-4c52-a3b5-3204713d3e84">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
