### PR TITLE
Update/theme collection desktop style

### DIFF
--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -76,10 +76,12 @@ export default function ThemeCollection( {
 	}, [ swiperContainerId, isSwiperLoaded ] );
 
 	return (
-		<div className="theme-collection__container ">
-			<h2 className="theme-collection__title">{ title }</h2>
-			<div className="theme-collection__description">{ description }</div>
-			<div className="swiper-container" id={ swiperContainerId }>
+		<div className="theme-collection__container swiper-container" id={ swiperContainerId }>
+			<div className="theme-collection__meta">
+				<div className="theme-collection__headings">
+					<h2 className="theme-collection__title">{ title }</h2>
+					<div className="theme-collection__description">{ description }</div>
+				</div>
 				<div className="theme-collection__carousel-controls">
 					<Button className="theme-collection__carousel-nav-button theme-collection__carousel-nav-button--previous">
 						<Icon icon={ chevronLeft } />
@@ -88,8 +90,8 @@ export default function ThemeCollection( {
 						<Icon icon={ chevronRight } />
 					</Button>
 				</div>
-				<div className="theme-collection__list-wrapper swiper-wrapper">{ children }</div>
 			</div>
+			<div className="theme-collection__list-wrapper swiper-wrapper">{ children }</div>
 		</div>
 	);
 }

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -1,3 +1,22 @@
+.theme-collection__meta {
+	display: flex;
+	justify-content: space-between;
+}
+
+.theme-collection__headings {
+	flex-basis: 45%;
+}
+
+.theme-collection__title {
+	font-size: 1.75rem;
+	line-height: 1;
+}
+
+.theme-collection__description * {
+	margin-bottom: 0;
+}
+
+
 .theme-collection__list-item.swiper-slide {
 	/* TODO: Needs a better solution. Testing on more screen widths etc */
 	width: 32%;
@@ -13,28 +32,24 @@
 	justify-content: flex-end;
 	/*!rtl:ignore*/
 	direction: ltr;
+	align-self: end;
 
 	button {
 		width: 40px;
 		height: 40px;
 		background: #eee;
 		border-radius: 50%;
-		align-items: center;
 		display: flex;
 		justify-content: center;
-		transition: opacity 0.3s ease-in-out;
+		margin: 0 1em;
+		transition: opacity 0.3s linear;
 		pointer-events: all;
-		z-index: 2;
-
-		cursor: pointer;
 
 		&:hover {
-			opacity: 1;
-			fill: var(--studio-blue-50);
+			filter: brightness(0.9);
 		}
 
 		&.swiper-button-disabled {
-			visibility: hidden;
 			pointer-events: none;
 		}
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -269,7 +269,7 @@
 		border: none;
 		box-shadow: none;
 		margin-top: 32px;
-		margin-bottom: 0;
+		margin-bottom: 32px;
 		padding: 24px 30px;
 		border-radius: 4px;
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -256,8 +256,12 @@
 		margin: 0;
 	}
 
+	.themes__showcase {
+		margin-top: 32px;
+	}
+
 	.themes__selection .themes-list {
-		margin: 32px -16px 0;
+		margin: 0 -16px;
 	}
 
 	.themes__content .upsell-nudge {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4072

## Proposed Changes

Theme collections: Improve desktop styling
    
 * Used font sizes from designs (but not font family until we're ready to do the whole page at once)
 * Removed unnecessary vertical space between headings and carousel
 * Limited width of subheading text
 * Removed some unnecessary divs
 * Tweaked navigation buttons

## Testing Instructions
 1. Use calypso live link
 2. In a logged-out window visit /themes?flags=themes/discovery-lots

Before | After
-------|------
<img width="1450" alt="Screenshot 2023-10-03 at 13 59 46" src="https://github.com/Automattic/wp-calypso/assets/93301/1253b373-78e9-4f7e-ae6b-881b255f37bb"> | <img width="1450" alt="Screenshot 2023-10-03 at 13 57 41" src="https://github.com/Automattic/wp-calypso/assets/93301/407eb526-e23f-4491-8404-684ba6a19c39">



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?