### PR TITLE
GF Signup: Enable custom domain on onboarding-pm

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-custom-domain-allowed-on-free-plan.ts
@@ -8,10 +8,18 @@ const useIsCustomDomainAllowedOnFreePlan = (
 	const EXPERIMENT_NAME =
 		flowName === 'onboarding'
 			? 'calypso_onboarding_plans_paid_domain_on_free_plan_confidence_check'
-			: 'calypso_onboardingpm_plans_paid_domain_on_free_plan';
+			: '';
 	const [ isLoading, assignment ] = useExperiment( EXPERIMENT_NAME, {
-		isEligible: [ 'onboarding', 'onboarding-pm' ].includes( flowName ?? '' ) && hasPaidDomainName,
+		isEligible: flowName === 'onboarding' && hasPaidDomainName,
 	} );
+
+	/** Ships experiment variant to onboarding-pm flow only  */
+	if ( flowName === 'onboarding-pm' ) {
+		return {
+			isLoading: false,
+			result: true,
+		};
+	}
 
 	return {
 		isLoading,


### PR DESCRIPTION
Related to 
- #82189

## Proposed Changes

* This change seems to have dropped when reverting the previous PR which ships all of the changes.
- Initial https://github.com/Automattic/wp-calypso/pull/82189
- Revert https://github.com/Automattic/wp-calypso/pull/82360
- Re merge https://github.com/Automattic/wp-calypso/pull/82361

| Current | The Change |
| - | - |
|  ![image](https://github.com/Automattic/wp-calypso/assets/3422709/1fcbc72b-7b30-42ad-9761-5fa9560da724) | ![image](https://github.com/Automattic/wp-calypso/assets/3422709/d7a9ae41-768d-41d6-907b-35290ffe2433) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go through /start/onboarding-pm
- Select paid domain
- Select a free plan
- The updated modal should appear on paid domain selections


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
