### PR TITLE
Global Styles: Change the word "custom" to "premium"

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -484,7 +484,7 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 					$message = sprintf(
 						/* translators: %s - documentation URL. */
 						__(
-							'Your site includes <a href="%s" target="_blank">customized styles</a> that are only visible to visitors after upgrading to the Premium plan or higher.',
+							'Your site includes <a href="%s" target="_blank">premium styles</a> that are only visible to visitors after upgrading to the Premium plan or higher.',
 							'full-site-editing'
 						),
 						'https://wordpress.com/support/using-styles/'
@@ -516,12 +516,12 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 					<svg width="15" height="14" viewBox="0 0 15 14" fill="none" xmlns="http://www.w3.org/2000/svg">
 						<path d="M5.8125 5.6875C5.8125 4.75552 6.56802 4 7.5 4C8.43198 4 9.1875 4.75552 9.1875 5.6875C9.1875 6.55621 8.53108 7.2716 7.6872 7.36473C7.58427 7.37609 7.5 7.45895 7.5 7.5625V8.5M7.5 9.25V10.375M13.5 7C13.5 10.3137 10.8137 13 7.5 13C4.18629 13 1.5 10.3137 1.5 7C1.5 3.68629 4.18629 1 7.5 1C10.8137 1 13.5 3.68629 13.5 7Z" stroke="#1E1E1E" stroke-width="1.5"/>
 					</svg>
-					<?php echo esc_html__( 'Remove custom styles', 'full-site-editing' ); ?>
+					<?php echo esc_html__( 'Remove premium styles', 'full-site-editing' ); ?>
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="15" height="15" aria-hidden="true" focusable="false"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg>
 				</a>
 				<a class="launch-bar-global-styles-preview" href="<?php echo esc_url( $preview_location ); ?>">
 					<label><input type="checkbox" <?php echo wpcom_is_previewing_global_styles() ? 'checked' : ''; ?>><span></span></label>
-					<?php echo esc_html__( 'Preview custom styles', 'full-site-editing' ); ?>
+					<?php echo esc_html__( 'Preview premium styles', 'full-site-editing' ); ?>
 				</a>
 			</div>
 			<a class="launch-bar-global-styles-toggle" href="#">

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
@@ -35,7 +35,7 @@ function GlobalStylesWarningNotice() {
 	}
 
 	const upgradeTranslation = __(
-		'Your site includes customized styles that are only visible to visitors after <a>upgrading to the Premium plan or higher</a>.',
+		'Your site includes premium styles that are only visible to visitors after <a>upgrading to the Premium plan or higher</a>.',
 		'full-site-editing'
 	);
 
@@ -143,7 +143,7 @@ function GlobalStylesEditNotice() {
 
 		if ( isPostEditor && canPreviewPost ) {
 			actions.push( {
-				label: __( 'Preview without custom styles', 'full-site-editing' ),
+				label: __( 'Preview without premium styles', 'full-site-editing' ),
 				onClick: previewPost,
 				variant: 'secondary',
 				noDefaultClasses: true,
@@ -152,7 +152,7 @@ function GlobalStylesEditNotice() {
 		}
 
 		actions.push( {
-			label: __( 'Remove custom styles', 'full-site-editing' ),
+			label: __( 'Remove premium styles', 'full-site-editing' ),
 			onClick: isSiteEditor ? resetGlobalStyles : openResetGlobalStylesSupport,
 			variant: isSiteEditor ? 'secondary' : 'link',
 			noDefaultClasses: true,
@@ -163,7 +163,7 @@ function GlobalStylesEditNotice() {
 
 		createWarningNotice(
 			__(
-				'Your site includes customized styles that are only visible to visitors after upgrading to the Premium plan or higher.',
+				'Your site includes premium styles that are only visible to visitors after upgrading to the Premium plan or higher.',
 				'full-site-editing'
 			),
 			{

--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -61,7 +61,7 @@ export default function PremiumGlobalStylesUpgradeModal( {
 				{ ! isLoading && (
 					<>
 						<div className="upgrade-modal__col">
-							<h1 className="upgrade-modal__heading">{ translate( 'Unlock custom styles' ) }</h1>
+							<h1 className="upgrade-modal__heading">{ translate( 'Unlock premium styles' ) }</h1>
 							{ description ?? (
 								<>
 									<p>{ translations.description }</p>

--- a/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
@@ -22,16 +22,16 @@ const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: 
 		featuresTitle: translate( 'Included with your Premium plan' ),
 		features: features,
 		description: translate(
-			'You’ve selected a custom style that will only be visible to visitors after upgrading to the %(planTitle)s plan or higher.',
-			'You’ve selected custom styles that will only be visible to visitors after upgrading to the %(planTitle)s plan or higher.',
+			'You’ve selected a premium style that will only be visible to visitors after upgrading to the %(planTitle)s plan or higher.',
+			'You’ve selected premium styles that will only be visible to visitors after upgrading to the %(planTitle)s plan or higher.',
 			{
 				count: numOfSelectedGlobalStyles,
 				args: { planTitle },
 			}
 		),
 		promotion: translate(
-			'Upgrade now to unlock your custom style and get access to tons of other features. Or you can decide later and try it out first.',
-			'Upgrade now to unlock your custom styles and get access to tons of other features. Or you can decide later and try them out first.',
+			'Upgrade now to unlock your premium style and get access to tons of other features. Or you can decide later and try it out first.',
+			'Upgrade now to unlock your premium styles and get access to tons of other features. Or you can decide later and try them out first.',
 			{ count: numOfSelectedGlobalStyles }
 		),
 		cancel: translate( 'Decide later' ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -59,7 +59,7 @@ export function getEnhancedTasks(
 	planCartItem?: MinimalRequestCartProduct | null,
 	domainCartItem?: MinimalRequestCartProduct | null,
 	stripeConnectUrl?: string,
-	setShowConfirmModal: () => void = () => {},
+	setShowConfirmModal: () => void = () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
 	isDomainEmailUnverified = false
 ) {
 	if ( ! tasks ) {
@@ -202,7 +202,7 @@ export function getEnhancedTasks(
 					let subtitle = task.subtitle;
 
 					if ( displayGlobalStylesWarning ) {
-						const removeCustomStyles = translate( 'Or, {{a}}remove your custom styles{{/a}}.', {
+						const removeCustomStyles = translate( 'Or, {{a}}remove your premium styles{{/a}}.', {
 							components: {
 								a: (
 									<ExternalLink

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
@@ -73,10 +73,10 @@ const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ): Sc
 		},
 		upsell: {
 			name: 'upsell',
-			title: translate( 'Custom styles' ),
-			description: translate( "You've chosen a custom style and action is required." ),
+			title: translate( 'Premium styles' ),
+			description: translate( "You've chosen a premium style and action is required." ),
 			continueLabel: translate( 'Continue' ),
-			backLabel: hasEnTranslation( 'custom styles' ) ? translate( 'custom styles' ) : undefined,
+			backLabel: hasEnTranslation( 'premium styles' ) ? translate( 'premium styles' ) : undefined,
 			initialPath: NAVIGATOR_PATHS.UPSELL,
 		},
 		activation: {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
@@ -24,7 +24,7 @@ const ScreenColorPalettes = ( {
 		<Panel
 			label={ translate( 'Colors' ) }
 			description={ translate(
-				'Find your perfect color style. Change the look and feel of your site in one click with our custom colors.'
+				'Find your perfect color style. Change the look and feel of your site in one click with our premium colors.'
 			) }
 		>
 			<ColorPaletteVariations

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -26,7 +26,7 @@ const ScreenUpsell = ( { numOfSelectedGlobalStyles = 1, onCheckout, onTryStyle }
 			/>
 			<div className="screen-container__body">
 				<strong className="screen-upsell__heading">
-					{ translate( 'Custom styles' ) }
+					{ translate( 'Premium styles' ) }
 					<PremiumBadge
 						shouldHideTooltip
 						shouldCompactWithAnimation

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -1024,7 +1024,7 @@ export class SiteSettingsFormGeneral extends Component {
 						<Gridicon icon="info-outline" />
 						<span>
 							{ translate(
-								'Your site contains customized styles that will only be visible once you upgrade to a Premium plan.'
+								'Your site contains premium styles that will only be visible once you upgrade to a Premium plan.'
 							) }
 						</span>
 					</div>

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -28,7 +28,7 @@ export function usePatternAssemblerCtaData(): PatternAssemblerCtaData {
 		subtitle: shouldGoToAssemblerStep ? (
 			<ul>
 				<li>{ translate( 'Select patterns to create your homepage layout.' ) }</li>
-				<li>{ translate( 'Style it up with custom colors and font pairings.' ) }</li>
+				<li>{ translate( 'Style it up with premium colors and font pairings.' ) }</li>
 				<li>{ translate( 'Bring your site to life with your own content.' ) }</li>
 			</ul>
 		) : (

--- a/packages/design-preview/src/hooks/use-screens.tsx
+++ b/packages/design-preview/src/hooks/use-screens.tsx
@@ -96,7 +96,7 @@ const useScreens = ( {
 						path: '/color-palettes',
 						title: translate( 'Colors' ),
 						description: translate(
-							'Discover your ideal color blend, from free to custom styles.'
+							'Discover your ideal color blend, from free to premium styles.'
 						),
 						content: (
 							<div className="design-preview__sidebar-variations">

--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -114,7 +114,7 @@ const ColorPaletteVariations = ( {
 			<div className="global-styles-variations__group">
 				<h3 className="global-styles-variations__group-title">
 					<span className="global-styles-variations__group-title-actual">
-						{ translate( 'Custom styles' ) }
+						{ translate( 'Premium styles' ) }
 					</span>
 					<PremiumBadge
 						shouldHideTooltip

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -115,7 +115,7 @@ const FontPairingVariations = ( {
 			<div className="global-styles-variations__group">
 				<h3 className="global-styles-variations__group-title">
 					<span className="global-styles-variations__group-title-actual">
-						{ translate( 'Custom fonts' ) }
+						{ translate( 'Premium fonts' ) }
 					</span>
 					<PremiumBadge
 						shouldHideTooltip

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -101,7 +101,7 @@ const GlobalStylesVariations = ( {
 }: GlobalStylesVariationsProps ) => {
 	const isRegisteredCoreBlocks = useRegisterCoreBlocks();
 	const premiumStylesDescription = translate(
-		'Unlock custom styles and tons of other features with the Premium plan, or try them out now for free.'
+		'Unlock premium styles and tons of other features with the Premium plan, or try them out now for free.'
 	);
 
 	const baseGlobalStyles = useMemo(
@@ -172,7 +172,7 @@ const GlobalStylesVariations = ( {
 						<div className="global-styles-variations__header">
 							<h2>
 								<span>
-									{ translate( 'Custom Style', 'Custom Styles', {
+									{ translate( 'Premium Style', 'Premium Styles', {
 										count: nonDefaultStyles.length,
 									} ) }
 								</span>


### PR DESCRIPTION
## Proposed Changes

This PR changes the copy "custom" to "premium" in the context of global styles. Note that some of the changes will need a separate ETK and Jetpack deploy. See the affected UI below:

Theme details page
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-04 at 11 55 06 AM](https://github.com/Automattic/wp-calypso/assets/797888/ae9575fa-b4f0-4cf4-a5c2-b4ef60308468) | ![Screenshot 2023-10-04 at 11 54 38 AM](https://github.com/Automattic/wp-calypso/assets/797888/a462abc5-eee5-45eb-b352-ad4eed3aac97) |

Design picker - theme preview
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-04 at 12 45 44 PM](https://github.com/Automattic/wp-calypso/assets/797888/6f3347f5-2ea5-4b3f-b853-1d69ece49152) |  ![Screenshot 2023-10-04 at 12 45 51 PM](https://github.com/Automattic/wp-calypso/assets/797888/59f5b992-1f13-47e8-ab9b-814dd276513a) |

Design picker - theme preview - colors
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-05 at 3 19 58 PM](https://github.com/Automattic/wp-calypso/assets/797888/775053cd-0eb8-4e10-baa0-c07ffb52e1bc)| ![272814179-9bc51fc1-cdc7-4ebb-b6b5-7453d35ea1de](https://github.com/Automattic/wp-calypso/assets/797888/d9024335-8c6e-47a4-bc61-aec83f26f3d6)|

Global styles upsell modal
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-04 at 12 54 07 PM](https://github.com/Automattic/wp-calypso/assets/797888/66a95f21-4005-4045-bb77-2cb629720150) | ![Screenshot 2023-10-04 at 12 54 11 PM](https://github.com/Automattic/wp-calypso/assets/797888/53ae44cb-98d7-4c11-95de-12db57801baa)|

Assembler CTA
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-04 at 12 53 15 PM](https://github.com/Automattic/wp-calypso/assets/797888/34544db2-5dbc-4f7a-b08f-110b277230c6) | ![Screenshot 2023-10-04 at 12 52 54 PM](https://github.com/Automattic/wp-calypso/assets/797888/2618b786-157c-4cff-8d80-21409bf72e8d) |

Assembler - colors
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-04 at 12 48 47 PM](https://github.com/Automattic/wp-calypso/assets/797888/c751b9b6-67a5-4a33-95f8-2ec394160107) | ![Screenshot 2023-10-04 at 12 48 35 PM](https://github.com/Automattic/wp-calypso/assets/797888/e4be84b9-e620-45fe-a7c5-8ef0de17f618) |

Assembler - fonts
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-04 at 12 48 55 PM](https://github.com/Automattic/wp-calypso/assets/797888/859e77c3-b661-4ce8-bcef-e21759df9392) | ![Screenshot 2023-10-04 at 12 48 40 PM](https://github.com/Automattic/wp-calypso/assets/797888/6ac0076f-10da-4137-b335-d5a67824062f) |

Assembler - upsell step
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-04 at 12 51 41 PM](https://github.com/Automattic/wp-calypso/assets/797888/b1280622-244f-4454-8883-57764a9c4b54) | ![Screenshot 2023-10-04 at 12 51 37 PM](https://github.com/Automattic/wp-calypso/assets/797888/d1af4d26-6f21-49be-9f35-d027e84dae14) |

Site settings
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-04 at 1 23 24 PM](https://github.com/Automattic/wp-calypso/assets/797888/de70f7e9-dec3-41cc-b30b-6b0256d504c8) | ![Screenshot 2023-10-04 at 1 24 28 PM](https://github.com/Automattic/wp-calypso/assets/797888/57407934-a60a-4ea7-9b39-432d9ae94592) |

Frontend (ETK)
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-04 at 1 05 18 PM](https://github.com/Automattic/wp-calypso/assets/797888/a8504c07-d3b6-4eb1-9718-100bff162762) | ![Screenshot 2023-10-04 at 1 08 44 PM](https://github.com/Automattic/wp-calypso/assets/797888/c8d7ba9f-230d-4ac9-b352-dc353e81b17e)|

Site editor - sidebar (ETK) 
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-04 at 1 11 30 PM](https://github.com/Automattic/wp-calypso/assets/797888/0f135ab3-9a9b-4adc-9d35-7ddce919d4aa) |  ![Screenshot 2023-10-04 at 1 10 43 PM](https://github.com/Automattic/wp-calypso/assets/797888/1c25d745-7107-4736-9b4f-89399e540a70) |

Site editor - canvas (ETK)
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-04 at 1 11 37 PM](https://github.com/Automattic/wp-calypso/assets/797888/26df26e9-9266-4a2e-8df6-a41c4686cbc0) | ![Screenshot 2023-10-04 at 1 12 28 PM](https://github.com/Automattic/wp-calypso/assets/797888/be83a744-9950-4309-8edb-2592af86aa4d) |

Post editor - canvas (ETK)
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-04 at 1 15 55 PM](https://github.com/Automattic/wp-calypso/assets/797888/22bb1e43-7e83-479d-bb0b-2b69a707f09b) |  ![Screenshot 2023-10-04 at 1 15 15 PM](https://github.com/Automattic/wp-calypso/assets/797888/4c12472b-1782-43f6-b249-113cf4f33516) |

Launchpad (Jetpack)
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-04 at 1 03 02 PM](https://github.com/Automattic/wp-calypso/assets/797888/810aa509-5edb-4d14-ac02-05ea61ef10a8) |  ![Screenshot 2023-10-04 at 1 02 58 PM](https://github.com/Automattic/wp-calypso/assets/797888/a0c4926a-65fa-4d22-93a6-3116106a7ff1) |

cc: @autumnfjeld  @ianstewart 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that the UI are updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?