### PR TITLE
Social Sign Up: Fallback for not English locales

### DIFF
--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -1,8 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useState, createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
+import { useTranslate } from 'i18n-calypso';
 import MailIcon from 'calypso/components/social-icons/mail';
 import { isGravatarOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { useSelector } from 'calypso/state';
@@ -40,7 +41,9 @@ const SignupFormSocialFirst = ( {
 	queryArgs,
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState( 'initial' );
-	const { __ } = useI18n();
+	const { __, hasTranslation } = useI18n();
+	const isEnglishLocale = useIsEnglishLocale();
+	const translate = useTranslate();
 
 	const { isWoo, isGravatar } = useSelector( ( state ) => {
 		const oauth2Client = getCurrentOAuth2Client( state );
@@ -54,6 +57,11 @@ const SignupFormSocialFirst = ( {
 
 	const renderContent = () => {
 		if ( currentStep === 'initial' ) {
+			const buttonEmailText =
+				hasTranslation( 'Continue with Email' ) || isEnglishLocale
+					? __( 'Continue with Email' )
+					: __( 'Email' );
+
 			return (
 				<SocialSignupForm
 					handleResponse={ handleSocialResponse }
@@ -69,7 +77,7 @@ const SignupFormSocialFirst = ( {
 						onClick={ () => setCurrentStep( 'email' ) }
 					>
 						<MailIcon width="20" height="20" />
-						<span className="social-buttons__service-name">{ __( 'Continue with Email' ) }</span>
+						<span className="social-buttons__service-name">{ buttonEmailText }</span>
 					</Button>
 				</SocialSignupForm>
 			);
@@ -81,6 +89,11 @@ const SignupFormSocialFirst = ( {
 				  }
 				: {};
 
+			const labelEmailText =
+				hasTranslation( 'Your email' ) || isEnglishLocale
+					? __( 'Your email' )
+					: __( 'Your email address' );
+
 			return (
 				<div className="signup-form-social-first-email">
 					<PasswordlessSignupForm
@@ -90,7 +103,7 @@ const SignupFormSocialFirst = ( {
 						goToNextStep={ goToNextStep }
 						logInUrl={ logInUrl }
 						queryArgs={ queryArgs }
-						labelText={ __( 'Your email' ) }
+						labelText={ labelEmailText }
 						submitButtonLabel={ __( 'Continue' ) }
 						{ ...gravatarProps }
 					/>
@@ -126,24 +139,55 @@ const SignupFormSocialFirst = ( {
 			),
 		};
 
+		const oldTranslationOptions = {
+			components: {
+				tosLink: (
+					<a
+						href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+						onClick={ () => recordTracksEvent( 'calypso_signup_tos_link_click' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+				privacyLink: (
+					<a
+						href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+						onClick={ () => recordTracksEvent( 'calypso_signup_privacy_link_click' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			},
+		};
+
 		if ( isWoo ) {
 			return (
 				<p className="signup-form-social-first__tos-link">
-					{ createInterpolateElement(
-						__( 'By continuing, you agree to our <tosLink>Terms of Service</tosLink>.' ),
-						options
-					) }
+					{ isEnglishLocale
+						? createInterpolateElement(
+								__( 'By continuing, you agree to our <tosLink>Terms of Service</tosLink>.' ),
+								options
+						  )
+						: translate(
+								'By continuing, you agree to our {{tosLink}}Terms of Service{{/tosLink}}',
+								oldTranslationOptions
+						  ) }
 				</p>
 			);
 		} else if ( isGravatar ) {
 			return (
 				<p className="signup-form-social-first__tos-link">
-					{ createInterpolateElement(
-						__(
-							'By entering your email address, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
-						),
-						options
-					) }
+					{ isEnglishLocale
+						? createInterpolateElement(
+								__(
+									'By entering your email address, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+								),
+								options
+						  )
+						: translate(
+								'By entering your email address, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+								oldTranslationOptions
+						  ) }
 				</p>
 			);
 		}
@@ -151,19 +195,38 @@ const SignupFormSocialFirst = ( {
 		let tosText;
 
 		if ( currentStep === 'initial' ) {
-			tosText = createInterpolateElement(
-				__(
+			if (
+				hasTranslation(
 					'If you continue with Google or Apple, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
-				),
-				options
-			);
+				) ||
+				isEnglishLocale
+			) {
+				tosText = createInterpolateElement(
+					__(
+						'If you continue with Google or Apple, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+					),
+					options
+				);
+			} else {
+				tosText = translate(
+					'By creating an account you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+					oldTranslationOptions
+				);
+			}
 		} else if ( currentStep === 'email' ) {
-			tosText = createInterpolateElement(
-				__(
-					'By creating an account you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
-				),
-				options
-			);
+			if ( isEnglishLocale ) {
+				tosText = createInterpolateElement(
+					__(
+						'By creating an account you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+					),
+					options
+				);
+			} else {
+				tosText = translate(
+					'By entering your email address, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+					oldTranslationOptions
+				);
+			}
 		}
 
 		return <p className="signup-form-social-first__tos-link">{ tosText }</p>;


### PR DESCRIPTION
The new Social first signup introduced new strings that are being translated.

This PR adds the machinery to handle not translated strings, and it will be cleaned after they are translated.

## Testing
1. Live Link
2. Visit a not English locale, like `/start/user/it` and check that all is translated
3. Check that English page works