### PR TITLE
Site Profiler: fix Pressable header informations

### DIFF
--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -1,6 +1,8 @@
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import page from 'page';
+import { UrlData } from 'calypso/blocks/import/types';
+import { HostingProvider } from 'calypso/data/site-profiler/types';
 import StatusCtaInfo from '../heading-information/status-cta-info';
 import StatusInfo from '../heading-information/status-info';
 import type { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
@@ -9,11 +11,13 @@ import './styles.scss';
 interface Props {
 	domain: string;
 	conversionAction?: CONVERSION_ACTION;
+	hostingProvider?: HostingProvider;
+	urlData?: UrlData;
 	onCheckAnotherSite?: () => void;
 }
 
 export default function HeadingInformation( props: Props ) {
-	const { domain, conversionAction, onCheckAnotherSite } = props;
+	const { domain, conversionAction, hostingProvider, urlData, onCheckAnotherSite } = props;
 
 	const onRegisterDomain = () => {
 		page( `/start/domain/domain-only?new=${ domain }&search=yes` );
@@ -36,7 +40,11 @@ export default function HeadingInformation( props: Props ) {
 			<summary>
 				<h5>{ translate( 'Site Profiler' ) }</h5>
 				<div className="domain">{ domain }</div>
-				<StatusInfo conversionAction={ conversionAction } />
+				<StatusInfo
+					conversionAction={ conversionAction }
+					hostingProvider={ hostingProvider }
+					urlData={ urlData }
+				/>
 			</summary>
 			<footer>
 				<StatusCtaInfo conversionAction={ conversionAction } />

--- a/client/site-profiler/components/heading-information/status-info.tsx
+++ b/client/site-profiler/components/heading-information/status-info.tsx
@@ -1,11 +1,17 @@
 import { translate } from 'i18n-calypso';
+import { UrlData } from 'calypso/blocks/import/types';
+import { HostingProvider } from 'calypso/data/site-profiler/types';
+import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
 import { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
 
 interface Props {
 	conversionAction?: CONVERSION_ACTION;
+	hostingProvider?: HostingProvider;
+	urlData?: UrlData;
 }
 export default function StatusInfo( props: Props ) {
-	const { conversionAction } = props;
+	const { conversionAction, hostingProvider, urlData } = props;
+	const hostingProviderName = useHostingProviderName( hostingProvider, urlData );
 
 	switch ( conversionAction ) {
 		case 'register-domain':
@@ -19,9 +25,10 @@ export default function StatusInfo( props: Props ) {
 			return (
 				<p>
 					{ translate(
-						'This site is hosted on {{strong}}WordPress.com{{/strong}} but the domain is registered elsewhere.',
+						'This site is hosted on {{strong}}%s{{/strong}} but the domain is registered elsewhere.',
 						{
 							components: { strong: <strong /> },
+							args: [ hostingProviderName ],
 						}
 					) }
 				</p>

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -76,6 +76,8 @@ export default function SiteProfiler() {
 								domain={ domain }
 								conversionAction={ conversionAction }
 								onCheckAnotherSite={ () => updateDomainQueryParam( '' ) }
+								hostingProvider={ hostingProviderData?.hosting_provider }
+								urlData={ urlData }
 							/>
 						</LayoutBlockSection>
 					) }

--- a/client/site-profiler/hooks/use-hosting-provider-name.ts
+++ b/client/site-profiler/hooks/use-hosting-provider-name.ts
@@ -6,10 +6,10 @@ import { HostingProvider } from 'calypso/data/site-profiler/types';
 export default function useHostingProviderName(
 	hostingProvider?: HostingProvider,
 	urlData?: UrlData
-): string | undefined {
+): string {
 	const translate = useTranslate();
 
-	return useMemo( (): string | undefined => {
+	return useMemo( (): string => {
 		// Translators: "Unknown" stands for "Unknown hosting provider"
 		const ret = urlData?.platform_data?.name ?? hostingProvider?.name ?? translate( 'Unknown' );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82518

## Proposed Changes

* Change the hardcoded string to a custom one.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
These should display "This site is hosted on Pressable but the domain is registered elsewhere."

* http://calypso.localhost:3000/site-profiler?domain=cagrimmett.com
* http://calypso.localhost:3000/site-profiler?domain=pressable.com

Other cases must stay the same. You can find a list of sites to test https://github.com/Automattic/wp-calypso/pull/82508.

![image](https://github.com/Automattic/wp-calypso/assets/167611/d75b464d-9593-457b-b1c9-d4dcea5f5ec6)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?