### PR TITLE
Reader/First posts: add new sites sidebar

### DIFF
--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -26,10 +26,12 @@ const DiscoverStream = ( props ) => {
 	const locale = useLocale();
 	const followedTags = useSelector( getReaderFollowedTags );
 	const isLoggedIn = useSelector( isUserLoggedIn );
-	const recommendedSites = useSelector(
-		( state ) => getReaderRecommendedSites( state, 'discover-recommendations' ) || []
-	);
 	const selectedTab = props.selectedTab;
+	const recommendedSitesSeed =
+		selectedTab === FIRST_POSTS_TAB ? 'discover-new-sites' : 'discover-recommendations';
+	const recommendedSites = useSelector(
+		( state ) => getReaderRecommendedSites( state, recommendedSitesSeed ) || []
+	);
 	const { data: interestTags = [] } = useQuery( {
 		queryKey: [ 'read/interests', locale ],
 		queryFn: () =>
@@ -80,8 +82,16 @@ const DiscoverStream = ( props ) => {
 	);
 
 	const streamSidebar = () => {
-		if ( selectedTab === FIRST_POSTS_TAB ) {
-			return <></>;
+		if ( selectedTab === FIRST_POSTS_TAB && recommendedSites?.length ) {
+			return (
+				<>
+					<h2>{ translate( 'New Sites' ) }</h2>
+					<ReaderPopularSitesSidebar
+						items={ recommendedSites }
+						followSource={ READER_DISCOVER_POPULAR_SITES }
+					/>
+				</>
+			);
 		}
 
 		if ( ( isDefaultTab || selectedTab === 'latest' ) && recommendedSites?.length ) {

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -85,7 +85,7 @@ const DiscoverStream = ( props ) => {
 		if ( selectedTab === FIRST_POSTS_TAB && recommendedSites?.length ) {
 			return (
 				<>
-					<h2>{ translate( 'New Sites' ) }</h2>
+					<h2>{ translate( 'New sites' ) }</h2>
 					<ReaderPopularSitesSidebar
 						items={ recommendedSites }
 						followSource={ READER_DISCOVER_POPULAR_SITES }
@@ -97,7 +97,7 @@ const DiscoverStream = ( props ) => {
 		if ( ( isDefaultTab || selectedTab === 'latest' ) && recommendedSites?.length ) {
 			return (
 				<>
-					<h2>{ translate( 'Popular Sites' ) }</h2>
+					<h2>{ translate( 'Popular sites' ) }</h2>
 					<ReaderPopularSitesSidebar
 						items={ recommendedSites }
 						followSource={ READER_DISCOVER_POPULAR_SITES }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -512,11 +512,8 @@ class ReaderStream extends Component {
 			if ( ! sidebarContentFn || streamType === 'search' ) {
 				body = <div className="reader__content">{ bodyContent }</div>;
 			} else if ( wideDisplay ) {
-				const streamClassNames = classnames( {
-					'stream__two-column': this.props.selectedStreamName !== 'firstposts',
-				} );
 				body = (
-					<div className={ streamClassNames }>
+					<div className="stream__two-column">
 						<div className="reader__content">
 							{ streamHeader?.() }
 							{ bodyContent }
@@ -524,12 +521,7 @@ class ReaderStream extends Component {
 						<div className="stream__right-column">{ sidebarContentFn?.() }</div>
 					</div>
 				);
-				baseClassnames = classnames(
-					{
-						'reader-two-column': this.props.selectedStreamName !== 'firstposts',
-					},
-					baseClassnames
-				);
+				baseClassnames = classnames( 'reader-two-column', baseClassnames );
 			} else {
 				body = (
 					<>

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -103,15 +103,20 @@ function createStreamDataFromCards( cards, dateProperty ) {
 	// TODO: We may want to extract the related tags and update related tags stream too
 	const cardPosts = [];
 	let cardRecommendedSites = [];
+	let newSites = [];
 	cards.forEach( ( card ) => {
 		if ( card.type === 'post' ) {
 			cardPosts.push( card.data );
 		} else if ( card.type === 'recommended_blogs' ) {
 			cardRecommendedSites = card.data;
+		} else if ( card.type === 'new_sites' ) {
+			newSites = card.data;
 		}
 	} );
+
 	const streamSites = createStreamSitesFromRecommendedSites( cardRecommendedSites );
-	return { ...createStreamDataFromPosts( cardPosts, dateProperty ), streamSites };
+	const streamNewSites = createStreamSitesFromRecommendedSites( newSites );
+	return { ...createStreamDataFromPosts( cardPosts, dateProperty ), streamSites, streamNewSites };
 }
 
 function createStreamDataFromSites( sites, dateProperty ) {
@@ -394,6 +399,7 @@ export function handlePage( action, data ) {
 	let streamItems = [];
 	let streamPosts = [];
 	let streamSites = [];
+	let streamNewSites = [];
 
 	// If the payload has posts, then this stream is intended to be a post stream
 	// If the payload has sites, then we need to extract the posts from the sites and update the post stream
@@ -413,6 +419,7 @@ export function handlePage( action, data ) {
 		streamItems = streamData.streamItems;
 		streamPosts = streamData.streamPosts;
 		streamSites = streamData.streamSites;
+		streamNewSites = streamData.streamNewSites;
 	}
 
 	const actions = analyticsForStream( {
@@ -430,6 +437,11 @@ export function handlePage( action, data ) {
 		if ( streamSites.length > 0 ) {
 			actions.push(
 				receiveRecommendedSites( { seed: 'discover-recommendations', sites: streamSites } )
+			);
+		}
+		if ( streamNewSites.length > 0 ) {
+			actions.push(
+				receiveRecommendedSites( { seed: 'discover-new-sites', sites: streamNewSites } )
 			);
 		}
 		actions.push( receivePage( { streamKey, query, streamItems, pageHandle, gap } ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/82474

## Proposed Changes

Adds a new sites sidebar to the First posts tab. The approach I took here was to play nice with existing code and try to avoid refactoring.

<img width="1016" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/9882175c-34b4-4d7d-b180-3903af6acf4e">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR or go to Calypso.live.
* Go to http://calypso.localhost:3000/discover?selectedTab=firstposts
* Verify you see a list of new sites in the sidebar.
* Navigate to other tabs.
* Verify the sidebar gets populated with different results according to the current UI tab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?