### PR TITLE
Jetpack Cloud: Add new feature flag 'jetpack/new-navigation'

### DIFF
--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -39,7 +39,7 @@
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
 		"jetpack-cloud": true,
-		"jetpack/new-navigation": true,
+		"jetpack/new-navigation": false,
 		"jetpack/activity-log-sharing": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -39,6 +39,7 @@
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
 		"jetpack-cloud": true,
+		"jetpack/new-navigation": true,
 		"jetpack/activity-log-sharing": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -34,6 +34,7 @@
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
 		"jetpack-cloud": true,
+		"jetpack/new-navigation": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -34,7 +34,7 @@
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
 		"jetpack-cloud": true,
-		"jetpack/new-navigation": true,
+		"jetpack/new-navigation": false,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/33.

## Proposed Changes

* Add a new feature flag `jetpack/new-navigation`, and ~~enable~~ disable it by default in Jetpack Cloud's development and horizon environments.

***NOTE:** This flag is off by default in all environments, because enabling it during early development will create significant difficulty navigating around Jetpack Cloud.*

## Testing Instructions

No behavior is changed as a result of this pull request. To review, verify the application builds successfully and the feature flag name is the same across both environment configurations where it is present.