### PR TITLE
Make form AI e2e mobile-safe

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
@@ -1,3 +1,5 @@
+import { Locator } from 'playwright';
+import { envVariables } from '../../..';
 import { makeSelectorFromBlockName, validatePublishedFormFields } from './shared';
 import { BlockFlow, EditorContext, PublishedPostContext } from '.';
 
@@ -35,14 +37,23 @@ export class FormAiFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		const aiInputReadyLocator = context.addedBlockLocator.getByRole( 'textbox', {
+		let aiInputParentLocator: Locator;
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// On mobile, it's attached to the editor block toolbar, which is apart from the block DOM.
+			aiInputParentLocator = await context.editorPage.getEditorCanvas();
+		} else {
+			// On desktop, it's within the block DOM node.
+			aiInputParentLocator = context.addedBlockLocator;
+		}
+
+		const aiInputReadyLocator = aiInputParentLocator.getByRole( 'textbox', {
 			name: 'Ask Jetpack AI to create your form',
 		} );
-		const aiInputBusyLocator = context.addedBlockLocator.getByRole( 'textbox', {
+		const aiInputBusyLocator = aiInputParentLocator.getByRole( 'textbox', {
 			name: 'Creating your form. Please wait a few moments.',
 			disabled: true,
 		} );
-		const sendButtonLocator = context.addedBlockLocator.getByRole( 'button', {
+		const sendButtonLocator = aiInputParentLocator.getByRole( 'button', {
 			name: 'Send request',
 		} );
 

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
@@ -101,7 +101,7 @@ export class FormPatternsFlow implements BlockFlow {
 			.locator( `[aria-label="${ this.configurationData.patternName }"]` )
 			.getByRole( 'option' )
 			// These patterns can load in quite slowly, messing with animation wait checks, so let's give extra time.
-			.click( { timeout: 20 * 1000 } );
+			.click( { timeout: 30 * 1000 } );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #82530

## Proposed Changes

The form AI input moved to the top toolbar on mobile, but our E2E tests didn't account for that, as they try to look within the Form Block DOM Node for the input (which is where it is on desktop).

Now, we handle both cases

## Testing Instructions

- [x] Jetpack mobile and desktop tests pass
- [x] Gutenberg mobile and desktop tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?