### PR TITLE
Multi-Domain: Center align the header

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -917,7 +917,7 @@ class DomainsStep extends Component {
 				backLabelText={ backLabelText }
 				hideSkip={ true }
 				goToNextStep={ this.handleSkip }
-				align={ isReskinned ? 'left' : 'center' }
+				align="center"
 				isWideLayout={ isReskinned }
 			/>
 		);

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -917,14 +917,6 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 		.is-wide-layout {
 			max-width: 1280px;
 		}
-
-		.formatted-header__subtitle {
-			text-align: start;
-		}
-
-		.formatted-header__title {
-			text-align: start;
-		}
 	}
 
 	.signup__step.is-design-setup-site,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4084

## Proposed Changes

* Centers the heading text for the domain selection step.

<img width="1535" alt="Screenshot 2023-10-03 at 6 38 00 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/642656f1-6434-45e0-82d2-dce06929e595">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Observer that the headline is centered and matches the design (p9Jlb4-94t-p2) for:
* http://calypso.localhost:3000/start/domain/domain-only
* http://calypso.localhost:3000/start/domain

Ensure other flows are not negatively affected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?