### PR TITLE
Add reader-join-conversation modal block

### DIFF
--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -22,6 +22,7 @@ const CommentActions = ( {
 	onReplyCancel,
 	showReadMore,
 	onReadMore,
+	onLoggedOut,
 } ) => {
 	const showReplyButton = post && post.discussion && post.discussion.comments_open === true;
 	const showCancelReplyButton = activeReplyCommentId === commentId;
@@ -73,6 +74,7 @@ const CommentActions = ( {
 				siteId={ post.site_ID }
 				postId={ post.ID }
 				commentId={ commentId }
+				onLoggedOut={ onLoggedOut }
 			/>
 		</div>
 	);
@@ -80,6 +82,7 @@ const CommentActions = ( {
 
 CommentActions.defaultProps = {
 	onReadMore: noop,
+	onLoggedOut: noop,
 };
 
 export default localize( CommentActions );

--- a/client/blocks/comments/comment-likes.jsx
+++ b/client/blocks/comments/comment-likes.jsx
@@ -8,8 +8,10 @@ import ReaderLikeIcon from 'calypso/reader/components/icons/like-icon';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { likeComment, unlikeComment } from 'calypso/state/comments/actions';
 import { getCommentLike } from 'calypso/state/comments/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
+const noop = () => {};
 class CommentLikeButtonContainer extends Component {
 	constructor() {
 		super();
@@ -17,6 +19,13 @@ class CommentLikeButtonContainer extends Component {
 	}
 
 	handleLikeToggle( liked ) {
+		if ( ! this.props.isLoggedIn && this.props.onLoggedOut !== noop ) {
+			return this.props.onLoggedOut();
+		}
+		this.recordLikeToggle( liked );
+	}
+
+	recordLikeToggle = ( liked ) => {
 		if ( liked ) {
 			this.props.likeComment( this.props.siteId, this.props.postId, this.props.commentId );
 		} else {
@@ -32,7 +41,7 @@ class CommentLikeButtonContainer extends Component {
 				comment_id: this.props.commentId,
 			}
 		);
-	}
+	};
 
 	render() {
 		const props = pick( this.props, [ 'showZeroCount', 'tagName' ] );
@@ -71,11 +80,13 @@ CommentLikeButtonContainer.propTypes = {
 	commentLike: PropTypes.object,
 	likeComment: PropTypes.func.isRequired,
 	unlikeComment: PropTypes.func.isRequired,
+	onLoggedOut: PropTypes.func.isRequired,
 };
 
 export default connect(
 	( state, props ) => ( {
 		commentLike: getCommentLike( state, props.siteId, props.postId, props.commentId ),
+		isLoggedIn: isUserLoggedIn( state ),
 	} ),
 	{ likeComment, recordReaderTracksEvent, unlikeComment }
 )( CommentLikeButtonContainer );

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -1,13 +1,8 @@
-import { getUrlParts } from '@automattic/calypso-url';
 import classNames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
 import { omitBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { createElement, PureComponent } from 'react';
-import { connect } from 'react-redux';
-import { navigate } from 'calypso/lib/navigate';
-import { createAccountUrl } from 'calypso/lib/paths';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import LikeIcons from './icons';
 import './style.scss';
 
@@ -49,13 +44,6 @@ class LikeButton extends PureComponent {
 	}
 
 	toggleLiked( event ) {
-		if ( ! this.props.isLoggedIn ) {
-			if ( this.props.onLoggedOut ) {
-				return this.props.onLoggedOut();
-			}
-			const { pathname } = getUrlParts( window.location.href );
-			return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
-		}
 		if ( event ) {
 			event.preventDefault();
 		}
@@ -120,6 +108,4 @@ class LikeButton extends PureComponent {
 	}
 }
 
-export default connect( ( state ) => ( {
-	isLoggedIn: isUserLoggedIn( state ),
-} ) )( localize( LikeButton ) );
+export default localize( LikeButton );

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -21,7 +21,6 @@ class LikeButton extends PureComponent {
 		slug: PropTypes.string,
 		icon: PropTypes.object,
 		defaultLabel: PropTypes.string,
-		onLoggedOut: PropTypes.func,
 	};
 
 	static defaultProps = {

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -26,6 +26,7 @@ class LikeButton extends PureComponent {
 		slug: PropTypes.string,
 		icon: PropTypes.object,
 		defaultLabel: PropTypes.string,
+		onLoggedOut: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -49,6 +50,9 @@ class LikeButton extends PureComponent {
 
 	toggleLiked( event ) {
 		if ( ! this.props.isLoggedIn ) {
+			if ( this.props.onLoggedOut ) {
+				return this.props.onLoggedOut();
+			}
 			const { pathname } = getUrlParts( window.location.href );
 			return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
 		}

--- a/client/blocks/like-button/index.jsx
+++ b/client/blocks/like-button/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import QueryPostLikes from 'calypso/components/data/query-post-likes';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { like, unlike } from 'calypso/state/posts/likes/actions';
 import { getPostLikeCount } from 'calypso/state/posts/selectors/get-post-like-count';
 import { isLikedPost } from 'calypso/state/posts/selectors/is-liked-post';
@@ -29,9 +30,11 @@ class LikeButtonContainer extends Component {
 	};
 
 	handleLikeToggle = ( liked ) => {
+		if ( ! this.props.isLoggedIn && this.props.onLoggedOut !== noop ) {
+			return this.props.onLoggedOut();
+		}
 		const toggler = liked ? this.props.like : this.props.unlike;
 		toggler( this.props.siteId, this.props.postId, { source: this.props.likeSource } );
-
 		this.props.onLikeToggle( liked );
 	};
 
@@ -65,6 +68,7 @@ export default connect(
 		return {
 			likeCount: getPostLikeCount( state, siteId, postId ),
 			iLike: isLikedPost( state, siteId, postId ),
+			isLoggedIn: isUserLoggedIn( state ),
 		};
 	},
 	{ like, unlike },

--- a/client/blocks/like-button/index.jsx
+++ b/client/blocks/like-button/index.jsx
@@ -21,7 +21,6 @@ class LikeButtonContainer extends Component {
 		iLike: PropTypes.bool,
 		likeSource: PropTypes.string,
 		icon: PropTypes.object,
-		onLoggedOut: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -55,7 +54,6 @@ class LikeButtonContainer extends Component {
 					animateLike={ true }
 					onLikeToggle={ this.handleLikeToggle }
 					icon={ this.props.icon }
-					onLoggedOut={ this.props.onLoggedOut }
 				/>
 			</Fragment>
 		);

--- a/client/blocks/like-button/index.jsx
+++ b/client/blocks/like-button/index.jsx
@@ -21,10 +21,12 @@ class LikeButtonContainer extends Component {
 		iLike: PropTypes.bool,
 		likeSource: PropTypes.string,
 		icon: PropTypes.object,
+		onLoggedOut: PropTypes.func,
 	};
 
 	static defaultProps = {
 		onLikeToggle: noop,
+		onLoggedOut: noop,
 	};
 
 	handleLikeToggle = ( liked ) => {
@@ -53,6 +55,7 @@ class LikeButtonContainer extends Component {
 					animateLike={ true }
 					onLikeToggle={ this.handleLikeToggle }
 					icon={ this.props.icon }
+					onLoggedOut={ this.props.onLoggedOut }
 				/>
 			</Fragment>
 		);

--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -1,18 +1,18 @@
 import { Dialog } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
-import LoginBlock from 'calypso/blocks/login';
-//import WPLogin from 'calypso/login/wp-login';
-
+import useLoginWindow from 'calypso/components/login-window';
 import './style.scss';
 
 const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
 	const translate = useTranslate();
-	const [ isLoginVisible, setIsLoginVisible ] = useState( false );
-	const showLogin = () => {
-		setIsLoginVisible( true );
-	};
+	//create function to handle when login is complete
+
+	const { login } = useLoginWindow( {
+		onLoginSuccess: () => window.location.reload(),
+		domain: 'wpcalypso.wordpress.com', //Need to use this while testing locally (also needs to be sandboxed)
+	} );
+
 	return (
 		<Dialog
 			additionalClassNames="reader-join-conversation-dialog"
@@ -23,25 +23,20 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
 			label={ translate( 'Join the conversation' ) }
 			shouldCloseOnEsc={ true }
 		>
-			{ ! isLoginVisible && (
-				<div className="reader-join-conversation-dialog__content">
-					<h1>{ translate( 'Join the conversation' ) }</h1>
-					<p>
-						{ translate( 'Sign in to like, comment, reblog, and follow your favorite blogs.' ) }
-					</p>
-					<Button
-						isTertiary
-						onClick={ showLogin }
-						className="reader-join-conversation-dialog__create-account-button"
-					>
-						{ translate( 'Create a new account' ) }
-					</Button>
-					<Button isLink onClick={ showLogin } className="reader-join-conversation-dialog__login">
-						{ translate( 'Log in' ) }
-					</Button>
-				</div>
-			) }
-			{ isLoginVisible && <LoginBlock disableAutoFocus /> }
+			<div className="reader-join-conversation-dialog__content">
+				<h1>{ translate( 'Join the conversation' ) }</h1>
+				<p>{ translate( 'Sign in to like, comment, reblog, and follow your favorite blogs.' ) }</p>
+				<Button
+					isPrimary
+					onClick={ login }
+					className="reader-join-conversation-dialog__create-account-button"
+				>
+					{ translate( 'Create a new account' ) }
+				</Button>
+				<Button isLink onClick={ login } className="reader-join-conversation-dialog__login">
+					{ translate( 'Log in' ) }
+				</Button>
+			</div>
 		</Dialog>
 	);
 };

--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import useLoginWindow from 'calypso/components/login-window';
 import './style.scss';
 import WordPressLogo from 'calypso/components/wordpress-logo';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
 	const translate = useTranslate();
@@ -11,6 +12,16 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
 	const { login, createAccount } = useLoginWindow( {
 		onLoginSuccess: () => window.location.reload(),
 	} );
+
+	const onLoginClick = () => {
+		recordTracksEvent( 'calypso_reader_dialog_login_clicked' );
+		login();
+	};
+
+	const onCreateAccountClick = () => {
+		recordTracksEvent( 'calypso_reader_dialog_create_account_clicked' );
+		createAccount();
+	};
 
 	return (
 		<Dialog
@@ -28,13 +39,13 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
 				<p>{ translate( 'Sign in to like, comment, reblog, and follow your favorite blogs.' ) }</p>
 				<Button
 					isPrimary
-					onClick={ createAccount }
+					onClick={ onCreateAccountClick }
 					className="reader-join-conversation-dialog__create-account-button"
 				>
 					{ translate( 'Create a new account' ) }
 				</Button>
 				<br />
-				<Button isLink onClick={ login } className="reader-join-conversation-dialog__login">
+				<Button isLink onClick={ onLoginClick } className="reader-join-conversation-dialog__login">
 					{ translate( 'Log in' ) }
 				</Button>
 			</div>

--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -9,7 +9,6 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
 
 	const { login, createAccount } = useLoginWindow( {
 		onLoginSuccess: () => window.location.reload(),
-		domain: 'wpcalypso.wordpress.com', //Need to use this while testing locally (also needs to be sandboxed)
 	} );
 
 	return (

--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -7,7 +7,7 @@ import './style.scss';
 const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
 	const translate = useTranslate();
 
-	const { login } = useLoginWindow( {
+	const { login, createAccount } = useLoginWindow( {
 		onLoginSuccess: () => window.location.reload(),
 		domain: 'wpcalypso.wordpress.com', //Need to use this while testing locally (also needs to be sandboxed)
 	} );
@@ -27,11 +27,12 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
 				<p>{ translate( 'Sign in to like, comment, reblog, and follow your favorite blogs.' ) }</p>
 				<Button
 					isPrimary
-					onClick={ login }
+					onClick={ createAccount }
 					className="reader-join-conversation-dialog__create-account-button"
 				>
 					{ translate( 'Create a new account' ) }
 				</Button>
+				<br />
 				<Button isLink onClick={ login } className="reader-join-conversation-dialog__login">
 					{ translate( 'Log in' ) }
 				</Button>

--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -3,22 +3,15 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import LoginBlock from 'calypso/blocks/login';
+//import WPLogin from 'calypso/login/wp-login';
 
 import './style.scss';
 
 const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
 	const translate = useTranslate();
-	// use state to track if button is clicked
-	// if button is clicked, show login form
-	// if login form is submitted, close dialog
-	// if login form is closed, close dialog
-	// if dialog is closed, reset state
 	const [ isLoginVisible, setIsLoginVisible ] = useState( false );
 	const showLogin = () => {
 		setIsLoginVisible( true );
-	};
-	const hideLogin = () => {
-		setIsLoginVisible( false );
 	};
 	return (
 		<Dialog
@@ -37,21 +30,18 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
 						{ translate( 'Sign in to like, comment, reblog, and follow your favorite blogs.' ) }
 					</p>
 					<Button
-						isPrimary
+						isTertiary
 						onClick={ showLogin }
 						className="reader-join-conversation-dialog__create-account-button"
 					>
 						{ translate( 'Create a new account' ) }
 					</Button>
+					<Button isLink onClick={ showLogin } className="reader-join-conversation-dialog__login">
+						{ translate( 'Log in' ) }
+					</Button>
 				</div>
 			) }
-			{ isLoginVisible && (
-				<LoginBlock
-					className="reader-join-conversation-dialog__login-block"
-					onClose={ hideLogin }
-					onSuccess={ hideLogin }
-				/>
-			) }
+			{ isLoginVisible && <LoginBlock disableAutoFocus /> }
 		</Dialog>
 	);
 };

--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -1,0 +1,59 @@
+import { Dialog } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import LoginBlock from 'calypso/blocks/login';
+
+import './style.scss';
+
+const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
+	const translate = useTranslate();
+	// use state to track if button is clicked
+	// if button is clicked, show login form
+	// if login form is submitted, close dialog
+	// if login form is closed, close dialog
+	// if dialog is closed, reset state
+	const [ isLoginVisible, setIsLoginVisible ] = useState( false );
+	const showLogin = () => {
+		setIsLoginVisible( true );
+	};
+	const hideLogin = () => {
+		setIsLoginVisible( false );
+	};
+	return (
+		<Dialog
+			additionalClassNames="reader-join-conversation-dialog"
+			isBackdropVisible={ true }
+			isVisible={ isVisible }
+			onClose={ onClose }
+			showCloseIcon={ true }
+			label={ translate( 'Join the conversation' ) }
+			shouldCloseOnEsc={ true }
+		>
+			{ ! isLoginVisible && (
+				<div className="reader-join-conversation-dialog__content">
+					<h1>{ translate( 'Join the conversation' ) }</h1>
+					<p>
+						{ translate( 'Sign in to like, comment, reblog, and follow your favorite blogs.' ) }
+					</p>
+					<Button
+						isPrimary
+						onClick={ showLogin }
+						className="reader-join-conversation-dialog__create-account-button"
+					>
+						{ translate( 'Create a new account' ) }
+					</Button>
+				</div>
+			) }
+			{ isLoginVisible && (
+				<LoginBlock
+					className="reader-join-conversation-dialog__login-block"
+					onClose={ hideLogin }
+					onSuccess={ hideLogin }
+				/>
+			) }
+		</Dialog>
+	);
+};
+
+export default ReaderJoinConversationDialog;

--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -3,6 +3,7 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import useLoginWindow from 'calypso/components/login-window';
 import './style.scss';
+import WordPressLogo from 'calypso/components/wordpress-logo';
 
 const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
 	const translate = useTranslate();
@@ -22,6 +23,7 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
 			shouldCloseOnEsc={ true }
 		>
 			<div className="reader-join-conversation-dialog__content">
+				<WordPressLogo size={ 32 } />
 				<h1>{ translate( 'Join the conversation' ) }</h1>
 				<p>{ translate( 'Sign in to like, comment, reblog, and follow your favorite blogs.' ) }</p>
 				<Button

--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -6,7 +6,6 @@ import './style.scss';
 
 const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
 	const translate = useTranslate();
-	//create function to handle when login is complete
 
 	const { login } = useLoginWindow( {
 		onLoginSuccess: () => window.location.reload(),

--- a/client/blocks/reader-join-conversation/style.scss
+++ b/client/blocks/reader-join-conversation/style.scss
@@ -1,0 +1,35 @@
+.reader-join-conversation-dialog {
+	border-radius: 6px; /* stylelint-disable scales/radii */
+
+	.dialog__action-buttons-close {
+		padding: 28px 28px 5px 5px;
+	}
+	.dialog__content {
+		padding: 24px 32px 8px;
+	}
+}
+
+.reader-join-conversation-dialog__content {
+	width: 534px;
+
+	.reader-join-conversation-dialog__header {
+		margin-bottom: 30px;
+
+		h2 {
+			color: var(--color-neutral-70);
+			font-size: $font-title-large;
+			font-weight: 600;
+			margin-bottom: 9px;
+		}
+	}
+}
+@media only screen and (max-width: 600px) {
+	.reader-join-conversation-dialog__content {
+		width: 100%;
+	}
+}
+
+.dialog__backdrop,
+.dialog__backdrop.card {
+	background-color: rgba(var(--color-neutral-70-rgb), 0.8) !important;
+}

--- a/client/blocks/reader-join-conversation/style.scss
+++ b/client/blocks/reader-join-conversation/style.scss
@@ -1,25 +1,54 @@
 .reader-join-conversation-dialog {
 	border-radius: 6px; /* stylelint-disable scales/radii */
+	width: 321px;
 
 	.dialog__action-buttons-close {
-		padding: 28px 28px 5px 5px;
+		padding: 24px;
 	}
 	.dialog__content {
-		padding: 24px 32px 8px;
+		padding: 24px 32px;
 	}
 }
 
 .reader-join-conversation-dialog__content {
-	width: 534px;
+	width: 257px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 
-	.reader-join-conversation-dialog__header {
-		margin-bottom: 30px;
+	h1 {
+		color: var(--color-neutral-70);
+		font-size: 1.25rem;
+		font-weight: 600;
+		margin-bottom: 9px;
+	}
 
-		h2 {
-			color: var(--color-neutral-70);
-			font-size: $font-title-large;
-			font-weight: 600;
-			margin-bottom: 9px;
+	p {
+		font-size: 1rem;
+		text-align: center;
+	}
+
+	svg.wordpress-logo {
+		fill: var(--color-neutral-70);
+	}
+
+	button.components-button.is-primary {
+		background-color: #117ac9;
+		border-color: #117ac9;
+
+		&:active:not(:disabled),
+		&:hover:not(:disabled),
+		&:focus:not(:disabled) {
+			background-color: #0e64a5;
+			border-color: #0e64a5;
+		}
+	}
+
+	button.components-button.is-link {
+		color: #1d2333;
+
+		&:hover:not(:disabled) {
+			color: var(--studio-blue-50);
 		}
 	}
 }

--- a/client/components/login-window/README.md
+++ b/client/components/login-window/README.md
@@ -1,0 +1,13 @@
+# LoginWindow
+
+This component is used to display a WordPress.com login form in a window.
+The component will track when the login is complete and notify the parent window.
+
+## How to use
+
+```js
+
+```
+
+## Props
+

--- a/client/components/login-window/README.md
+++ b/client/components/login-window/README.md
@@ -1,12 +1,31 @@
 # LoginWindow
 
-This component is used to display a WordPress.com login form in a window.
-The component will track when the login is complete and notify the parent window.
+This component is used to display a WordPress.com login or create account form in a popup window.
+When the user has successfully logged in or created an account, the window will send a postMessage confirming login has completed, then the window will close. 
+The component will listen for the postMessage from the window and call the onLoginSuccess callback.
 
 ## How to use
 
 ```js
+import { Button } from '@wordpress/components';
+import useLoginWindow from 'calypso/components/login-window';
+import WordPressLogo from 'calypso/components/wordpress-logo';
 
+const MyLoginForm = () => {
+	const { login, createAccount } = useLoginWindow( {
+		onLoginSuccess: () => window.location.reload(),
+	} );
+
+	return (
+		<div className="reader-join-conversation-dialog__content">
+			<WordPressLogo size={ 32 } />
+			<h1>You need to be logged in!</h1>
+			<Button	isPrimary onClick={ createAccount } >Create a new account</Button>
+			<br />
+			<Button isLink onClick={ login }>Log in</Button>
+		</div>
+	);
+};
 ```
 
 ## Props

--- a/client/components/login-window/docs/example.jsx
+++ b/client/components/login-window/docs/example.jsx
@@ -1,14 +1,16 @@
+import { Button } from '@wordpress/components';
 import useLoginWindow from 'calypso/components/login-window';
 
 const LoginWindowExample = () => {
-	const { login } = useLoginWindow();
-	const service = 'wordpress';
+	const { login } = useLoginWindow( {
+		onLoginSuccess: () => window.location.reload(),
+	} );
 	return (
 		<div className="design-assets__group">
-			<div className="verbum-logins__social-buttons">
-				<button type="button" key={ service } onClick={ login( service ) }>
-					{ service }
-				</button>
+			<div className="login-window__social-buttons">
+				<Button isLink onClick={ login }>
+					Log in
+				</Button>
 			</div>
 		</div>
 	);

--- a/client/components/login-window/docs/example.jsx
+++ b/client/components/login-window/docs/example.jsx
@@ -1,0 +1,17 @@
+import useLoginWindow from 'calypso/components/login-window';
+
+const LoginWindowExample = () => {
+	const { login } = useLoginWindow();
+	const service = 'wordpress';
+	return (
+		<div className="design-assets__group">
+			<div className="verbum-logins__social-buttons">
+				<button type="button" key={ service } onClick={ login( service ) }>
+					{ service }
+				</button>
+			</div>
+		</div>
+	);
+};
+
+export default LoginWindowExample;

--- a/client/components/login-window/index.jsx
+++ b/client/components/login-window/index.jsx
@@ -56,7 +56,7 @@ const setUserInfoCookie = ( userData ) => {
 export default function useLoginWindow() {
 	const [ userInfo, setUserInfo ] = useState();
 	const [ loginWindowRef, setLoginWindowRef ] = useState();
-	const WordPress = () => {
+	const WordPressIcon = () => {
 		return (
 			<svg
 				width="20"
@@ -80,7 +80,7 @@ export default function useLoginWindow() {
 			cookieName: 'wpc_wpc',
 			name: 'WordPress.com',
 			popup: ',height=980,width=500',
-			icon: WordPress,
+			icon: WordPressIcon,
 			class: 'wordpress-login',
 		},
 	};

--- a/client/components/login-window/index.jsx
+++ b/client/components/login-window/index.jsx
@@ -1,11 +1,10 @@
 import { useEffect } from 'react';
 
-export default function useLoginWindow( { onLoginSuccess, domain } ) {
+export default function useLoginWindow( { onLoginSuccess } ) {
 	const isBrowser = typeof window !== 'undefined';
-	const baseURL = `https://${ domain }`;
 
 	const waitForLogin = ( event ) => {
-		if ( event.origin !== baseURL ) {
+		if ( event.origin !== 'wordpress.com' ) {
 			return;
 		}
 
@@ -23,7 +22,7 @@ export default function useLoginWindow( { onLoginSuccess, domain } ) {
 		}
 
 		const loginWindow = window.open(
-			`${ baseURL }/public.api/connect/?action=request&domain=${ domain }&service=wordpress`,
+			`https://wordpress.com/public.api/connect/?action=request&service=wordpress`,
 			'CalyspoLogin',
 			'status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=0,height=980,width=500'
 		);
@@ -45,7 +44,7 @@ export default function useLoginWindow( { onLoginSuccess, domain } ) {
 		}
 
 		const createAccountWindow = window.open(
-			`https://wordpress.com/start/account/user?redirect_to=https%3A%2F%2Fwpcalypso.wordpress.com%2Fpublic.api%2Fconnect%2F%3Faction%3Dverify%26service%3Dwordpress%26domain%3D${ domain }`,
+			`https://wordpress.com/start/account/user?redirect_to=https%3A%2F%2Fwordpress.com%2Fpublic.api%2Fconnect%2F%3Faction%3Dverify%26service%3Dwordpress`,
 			'CalyspoLogin',
 			'status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=0,height=980,width=500'
 		);

--- a/client/components/login-window/index.jsx
+++ b/client/components/login-window/index.jsx
@@ -17,6 +17,11 @@ export default function useLoginWindow( { onLoginSuccess } ) {
 		);
 	}
 
+	const loginURL = `https://wordpress.com/log-in?redirect_to=${ redirectTo }`;
+	const createAccountURL = `https://wordpress.com${ createAccountUrl( {
+		redirectTo: redirectTo,
+		ref: 'reader-lw',
+	} ) }`;
 	const windowFeatures =
 		'status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=0,height=980,width=500';
 	const windowName = 'CalypsoLogin';
@@ -34,48 +39,30 @@ export default function useLoginWindow( { onLoginSuccess } ) {
 		}
 	};
 
-	const login = () => {
+	const openWindow = ( url ) => {
 		if ( ! isBrowser ) {
 			return;
 		}
 
-		const loginWindow = window.open(
-			`https://wordpress.com/log-in?redirect_to=${ redirectTo }`,
-			windowName,
-			windowFeatures
-		);
+		const loginWindow = window.open( url, windowName, windowFeatures );
 
 		// Listen for login data
 		window.addEventListener( 'message', waitForLogin );
 
 		// Clean up loginWindow
-		const loginClosed = setInterval( () => {
+		const loginWindowClosed = setInterval( () => {
 			if ( loginWindow?.closed ) {
-				clearInterval( loginClosed );
+				clearInterval( loginWindowClosed );
 			}
 		}, 100 );
 	};
 
+	const login = () => {
+		openWindow( loginURL );
+	};
+
 	const createAccount = () => {
-		if ( ! isBrowser ) {
-			return;
-		}
-
-		const createAccountWindow = window.open(
-			`https://wordpress.com${ createAccountUrl( { redirectTo: redirectTo, ref: 'reader-lw' } ) }`,
-			windowName,
-			windowFeatures
-		);
-
-		// Listen for login data
-		window.addEventListener( 'message', waitForLogin );
-
-		// Clean up loginWindow
-		const createAccountWindowClosed = setInterval( () => {
-			if ( createAccountWindow?.closed ) {
-				clearInterval( createAccountWindowClosed );
-			}
-		}, 100 );
+		openWindow( createAccountURL );
 	};
 
 	//Cleanup event listener when component unmounts

--- a/client/components/login-window/index.jsx
+++ b/client/components/login-window/index.jsx
@@ -1,10 +1,23 @@
+import config from '@automattic/calypso-config';
 import { useEffect } from 'react';
 
 export default function useLoginWindow( { onLoginSuccess } ) {
 	const isBrowser = typeof window !== 'undefined';
+	const environment = config( 'env_id' );
+	let domain = 'wordpress.com';
+	let redirectTo = encodeURIComponent(
+		`https://${ domain }/public.api/connect/?action=verify&service=wordpress`
+	);
+	if ( environment === 'development' ) {
+		// We need to redirect to a sandboxed domain in development to allow us to test the postMessage returned from public_api_connect_close_window()
+		domain = 'wpcalypso.wordpress.com';
+		redirectTo = encodeURIComponent(
+			`https://${ domain }/public.api/connect/?action=verify&service=wordpress&domain=${ domain }`
+		);
+	}
 
 	const waitForLogin = ( event ) => {
-		if ( event.origin !== 'wordpress.com' ) {
+		if ( event.origin !== `https://${ domain }` ) {
 			return;
 		}
 
@@ -22,7 +35,7 @@ export default function useLoginWindow( { onLoginSuccess } ) {
 		}
 
 		const loginWindow = window.open(
-			`https://wordpress.com/public.api/connect/?action=request&service=wordpress`,
+			`https://wordpress.com/log-in?redirect_to=${ redirectTo }`,
 			'CalyspoLogin',
 			'status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=0,height=980,width=500'
 		);
@@ -44,7 +57,7 @@ export default function useLoginWindow( { onLoginSuccess } ) {
 		}
 
 		const createAccountWindow = window.open(
-			`https://wordpress.com/start/account/user?redirect_to=https%3A%2F%2Fwordpress.com%2Fpublic.api%2Fconnect%2F%3Faction%3Dverify%26service%3Dwordpress`,
+			`https://wordpress.com/start/account/user?redirect_to=${ redirectTo }`,
 			'CalyspoLogin',
 			'status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=0,height=980,width=500'
 		);

--- a/client/components/login-window/index.jsx
+++ b/client/components/login-window/index.jsx
@@ -1,155 +1,38 @@
-import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
-import { getLogoutUrl } from 'calypso/lib/user/shared-utils';
-import wpcom from 'calypso/lib/wp';
 
-import './style.scss';
-
-const addWordPressDomain = window.location.hostname.endsWith( '.wordpress.com' )
-	? ' Domain=.wordpress.com'
-	: '';
-
-const getUserInfoCookie = () => {
-	let userData = { service: 'guest' };
-	const cookies = document.cookie.split( '; ' );
-
-	for ( let i = 0; i < cookies.length; i++ ) {
-		const cookie = cookies[ i ].trim();
-		if ( cookie.startsWith( 'wpc_' ) ) {
-			const service = cookie.slice( 0, 7 );
-			const serviceName = service === 'wpc_wpc' ? 'wordpress' : 'guest';
-			const data = cookie.slice( 8 );
-			userData = data && {
-				service: serviceName,
-				...Object.fromEntries( new URLSearchParams( decodeURIComponent( data ) ) ),
-			};
-
-			if ( serviceName === 'wordpress' ) {
-				const avatarUrl = new URL( userData.avatar );
-				userData.avatar = avatarUrl.origin + avatarUrl.pathname + '?s=64';
-				//TODO: add break here?
-			}
-		}
-	}
-	return userData;
-};
-
-const setUserInfoCookie = ( userData ) => {
-	let cookieName;
-	const { service } = userData;
-
-	if ( service === 'wordpress' ) {
-		cookieName = 'wpc_wpc';
-	}
-
-	const cookieData = new URLSearchParams( {
-		...userData,
-		avatar: encodeURIComponent( userData.avatar ),
-		email: encodeURIComponent( userData.email ),
-		logout_url: encodeURIComponent( userData.logout_url ),
-		uid: userData.uid.toString(),
-	} ).toString();
-
-	document.cookie = `${ cookieName }=${ cookieData }; path=/; SameSite=None; Secure=True;${ addWordPressDomain }`;
-};
-
-export default function useLoginWindow() {
-	const [ userInfo, setUserInfo ] = useState();
+export default function useLoginWindow( { onLoginSuccess, domain } ) {
+	const isBrowser = typeof window !== 'undefined';
 	const [ loginWindowRef, setLoginWindowRef ] = useState();
-	const WordPressIcon = () => {
-		return (
-			<svg
-				width="20"
-				height="20"
-				viewBox="0 0 20 20"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<path
-					fill-rule="evenodd"
-					clip-rule="evenodd"
-					d="M19.2308 9.99981C19.2308 4.91366 15.0862 0.769043 10.0001 0.769043C4.90467 0.769043 0.769287 4.91366 0.769287 9.99981C0.769287 15.0952 4.90467 19.2306 10.0001 19.2306C15.0862 19.2306 19.2308 15.0952 19.2308 9.99981ZM7.95083 14.9567L4.80313 6.51058C5.31083 6.49212 5.88313 6.43674 5.88313 6.43674C6.34467 6.38135 6.28929 5.39366 5.82775 5.41212C5.82775 5.41212 4.48929 5.51366 3.64006 5.51366C3.4739 5.51366 3.29852 5.51366 3.10467 5.50443C4.57236 3.25212 7.11083 1.79366 10.0001 1.79366C12.1508 1.79366 14.1077 2.59674 15.5847 3.95366C14.957 3.85212 14.0616 4.31366 14.0616 5.41212C14.0616 6.01026 14.3801 6.52347 14.7382 7.10048C14.7891 7.18242 14.8407 7.26565 14.8924 7.35058C15.2154 7.91366 15.4001 8.60597 15.4001 9.62135C15.4001 10.9967 14.1077 14.2367 14.1077 14.2367L11.3108 6.51058C11.8093 6.49212 12.0677 6.35366 12.0677 6.35366C12.5293 6.3075 12.4739 5.19981 12.0124 5.2275C12.0124 5.2275 10.6831 5.33827 9.81544 5.33827C9.01236 5.33827 7.66467 5.2275 7.66467 5.2275C7.20313 5.19981 7.14775 6.3352 7.60929 6.35366L8.45852 6.4275L9.62159 9.5752L7.95083 14.9567ZM16.8602 9.94619L16.8401 9.99981C16.1713 11.7605 15.5075 13.5364 14.8451 15.3087L14.845 15.309L14.8448 15.3093C14.6113 15.9341 14.378 16.5583 14.1447 17.1814C16.6093 15.7598 18.2062 13.0367 18.2062 9.99981C18.2062 8.57827 17.8831 7.2675 17.237 6.07674C17.5147 8.20894 17.0881 9.34123 16.8602 9.94617L16.8602 9.94619ZM6.40006 17.4675C3.64929 16.1383 1.7939 13.2583 1.7939 9.99981C1.7939 8.79981 2.00621 7.71058 2.45852 6.68597L3.28801 8.95912C4.32263 11.7949 5.35847 14.6341 6.40006 17.4675ZM12.5016 17.7906L10.1201 11.3475C9.68129 12.6419 9.23927 13.9362 8.79593 15.2344C8.4931 16.1212 8.18965 17.0097 7.88621 17.9014C8.55083 18.1044 9.27083 18.206 10.0001 18.206C10.877 18.206 11.7077 18.0583 12.5016 17.7906Z"
-					fill="white"
-				/>
-			</svg>
-		);
-	};
+	const baseURL = `https://${ domain }`;
 
-	const serviceData = {
-		wordpress: {
-			cookieName: 'wpc_wpc',
-			name: 'WordPress.com',
-			popup: ',height=980,width=500',
-			icon: WordPressIcon,
-			class: 'wordpress-login',
-		},
-	};
+	const waitForLogin = ( event ) => {
+		if ( event.origin !== baseURL ) {
+			return;
+		}
 
-	useEffect( () => {
-		setUserInfo( getUserInfoCookie() );
-	}, [] );
-
-	const logout = () => {
-		const logoutURL = getLogoutUrl( userInfo );
-		const serviceName = userInfo?.service;
-		const cookieName = serviceData[ serviceName ].cookieName;
-
-		const cookie = `${ cookieName }=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=None; Secure=True;${ addWordPressDomain }`;
-		document.cookie = cookie;
-
-		if ( serviceName === 'wordpress' ) {
-			// Atomic logging out
-			if ( window.location.host === 'jetpack.wordpress.com' ) {
-				const newURL =
-					logoutURL + '&redirect_to=' + window.location.hash.match( /#parent=(.*)/ )[ 1 ];
-				window.parent.location.href = newURL;
-			} else {
-				window.location.href = logoutURL + '&redirect_to=' + window.location.href;
+		if ( event?.data?.service === 'wordpress' ) {
+			onLoginSuccess();
+			if ( isBrowser ) {
+				window.removeEventListener( 'message', waitForLogin );
 			}
 		}
 	};
 
-	const { res } = useQuery( {
-		queryKey: [ 'verbum/auth' ],
-		queryFn: () =>
-			wpcom.req.get( {
-				path: `/verbum/auth`,
-				apiNamespace: 'wpcom/v2',
-			} ),
-		select: ( data ) => {
-			//console.log( data );
-			return data;
-		},
-	} );
-	//console.log( 'res: ', res );
-	setUserInfo( res );
-
-	const login = async ( service ) => {
-		const { connectURL } = 'https://wordpress.com/log-in';
+	const login = () => {
+		if ( ! isBrowser ) {
+			return;
+		}
 
 		const loginWindow = window.open(
-			`${ connectURL }&service=${ service }`,
-			'VerbumCommentsLogin',
-			`status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=0${ serviceData[ service ].popup }`
+			`${ baseURL }/public.api/connect/?action=request&domain=${ domain }&service=wordpress`,
+			'CalyspoLogin',
+			'status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=0,height=980,width=500'
 		);
 
 		// Listen for login data
-		window.addEventListener( 'message', function waitForLogin( event ) {
-			if ( event.origin !== document.location.origin ) {
-				return;
-			}
+		window.addEventListener( 'message', waitForLogin );
 
-			if ( event.data.service === service ) {
-				setUserInfo( event.data );
-
-				if ( ! document.cookie.includes( 'wpc_' ) ) {
-					setUserInfoCookie( event.data );
-				}
-				window.removeEventListener( 'message', waitForLogin );
-			}
-		} );
-
-		// Clean up loginWindow to reset activeService
+		// Clean up loginWindow
 		const loginClosed = setInterval( () => {
 			if ( loginWindow?.closed ) {
 				clearInterval( loginClosed );
@@ -160,5 +43,14 @@ export default function useLoginWindow() {
 		setLoginWindowRef( loginWindow );
 	};
 
-	return { userInfo, login, loginWindowRef, logout };
+	//Cleanup event listener when component unmounts
+	useEffect( () => {
+		return () => {
+			if ( isBrowser ) {
+				window.removeEventListener( 'message', waitForLogin );
+			}
+		};
+	}, [] );
+
+	return { login, loginWindowRef };
 }

--- a/client/components/login-window/index.jsx
+++ b/client/components/login-window/index.jsx
@@ -1,8 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 
 export default function useLoginWindow( { onLoginSuccess, domain } ) {
 	const isBrowser = typeof window !== 'undefined';
-	const [ loginWindowRef, setLoginWindowRef ] = useState();
 	const baseURL = `https://${ domain }`;
 
 	const waitForLogin = ( event ) => {
@@ -36,11 +35,30 @@ export default function useLoginWindow( { onLoginSuccess, domain } ) {
 		const loginClosed = setInterval( () => {
 			if ( loginWindow?.closed ) {
 				clearInterval( loginClosed );
-				setLoginWindowRef( undefined );
 			}
 		}, 100 );
+	};
 
-		setLoginWindowRef( loginWindow );
+	const createAccount = () => {
+		if ( ! isBrowser ) {
+			return;
+		}
+
+		const createAccountWindow = window.open(
+			`https://wordpress.com/start/account/user?redirect_to=https%3A%2F%2Fwpcalypso.wordpress.com%2Fpublic.api%2Fconnect%2F%3Faction%3Dverify%26service%3Dwordpress%26domain%3D${ domain }`,
+			'CalyspoLogin',
+			'status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=0,height=980,width=500'
+		);
+
+		// Listen for login data
+		window.addEventListener( 'message', waitForLogin );
+
+		// Clean up loginWindow
+		const createAccountWindowClosed = setInterval( () => {
+			if ( createAccountWindow?.closed ) {
+				clearInterval( createAccountWindowClosed );
+			}
+		}, 100 );
 	};
 
 	//Cleanup event listener when component unmounts
@@ -52,5 +70,5 @@ export default function useLoginWindow( { onLoginSuccess, domain } ) {
 		};
 	}, [] );
 
-	return { login, loginWindowRef };
+	return { login, createAccount };
 }

--- a/client/components/login-window/index.jsx
+++ b/client/components/login-window/index.jsx
@@ -17,6 +17,10 @@ export default function useLoginWindow( { onLoginSuccess } ) {
 		);
 	}
 
+	const windowFeatures =
+		'status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=0,height=980,width=500';
+	const windowName = 'CalypsoLogin';
+
 	const waitForLogin = ( event ) => {
 		if ( event.origin !== `https://${ domain }` ) {
 			return;
@@ -37,8 +41,8 @@ export default function useLoginWindow( { onLoginSuccess } ) {
 
 		const loginWindow = window.open(
 			`https://wordpress.com/log-in?redirect_to=${ redirectTo }`,
-			'CalyspoLogin',
-			'status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=0,height=980,width=500'
+			windowName,
+			windowFeatures
 		);
 
 		// Listen for login data
@@ -57,11 +61,10 @@ export default function useLoginWindow( { onLoginSuccess } ) {
 			return;
 		}
 
-		const url = createAccountUrl( { redirectTo: redirectTo, ref: 'reader-lw' } );
 		const createAccountWindow = window.open(
-			url,
-			'CalyspoLogin',
-			'status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=0,height=980,width=500'
+			`https://wordpress.com${ createAccountUrl( { redirectTo: redirectTo, ref: 'reader-lw' } ) }`,
+			windowName,
+			windowFeatures
 		);
 
 		// Listen for login data

--- a/client/components/login-window/index.jsx
+++ b/client/components/login-window/index.jsx
@@ -1,0 +1,164 @@
+import { useQuery } from '@tanstack/react-query';
+import { useState, useEffect } from 'react';
+import { getLogoutUrl } from 'calypso/lib/user/shared-utils';
+import wpcom from 'calypso/lib/wp';
+
+import './style.scss';
+
+const addWordPressDomain = window.location.hostname.endsWith( '.wordpress.com' )
+	? ' Domain=.wordpress.com'
+	: '';
+
+const getUserInfoCookie = () => {
+	let userData = { service: 'guest' };
+	const cookies = document.cookie.split( '; ' );
+
+	for ( let i = 0; i < cookies.length; i++ ) {
+		const cookie = cookies[ i ].trim();
+		if ( cookie.startsWith( 'wpc_' ) ) {
+			const service = cookie.slice( 0, 7 );
+			const serviceName = service === 'wpc_wpc' ? 'wordpress' : 'guest';
+			const data = cookie.slice( 8 );
+			userData = data && {
+				service: serviceName,
+				...Object.fromEntries( new URLSearchParams( decodeURIComponent( data ) ) ),
+			};
+
+			if ( serviceName === 'wordpress' ) {
+				const avatarUrl = new URL( userData.avatar );
+				userData.avatar = avatarUrl.origin + avatarUrl.pathname + '?s=64';
+				//TODO: add break here?
+			}
+		}
+	}
+	return userData;
+};
+
+const setUserInfoCookie = ( userData ) => {
+	let cookieName;
+	const { service } = userData;
+
+	if ( service === 'wordpress' ) {
+		cookieName = 'wpc_wpc';
+	}
+
+	const cookieData = new URLSearchParams( {
+		...userData,
+		avatar: encodeURIComponent( userData.avatar ),
+		email: encodeURIComponent( userData.email ),
+		logout_url: encodeURIComponent( userData.logout_url ),
+		uid: userData.uid.toString(),
+	} ).toString();
+
+	document.cookie = `${ cookieName }=${ cookieData }; path=/; SameSite=None; Secure=True;${ addWordPressDomain }`;
+};
+
+export default function useLoginWindow() {
+	const [ userInfo, setUserInfo ] = useState();
+	const [ loginWindowRef, setLoginWindowRef ] = useState();
+	const WordPress = () => {
+		return (
+			<svg
+				width="20"
+				height="20"
+				viewBox="0 0 20 20"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path
+					fill-rule="evenodd"
+					clip-rule="evenodd"
+					d="M19.2308 9.99981C19.2308 4.91366 15.0862 0.769043 10.0001 0.769043C4.90467 0.769043 0.769287 4.91366 0.769287 9.99981C0.769287 15.0952 4.90467 19.2306 10.0001 19.2306C15.0862 19.2306 19.2308 15.0952 19.2308 9.99981ZM7.95083 14.9567L4.80313 6.51058C5.31083 6.49212 5.88313 6.43674 5.88313 6.43674C6.34467 6.38135 6.28929 5.39366 5.82775 5.41212C5.82775 5.41212 4.48929 5.51366 3.64006 5.51366C3.4739 5.51366 3.29852 5.51366 3.10467 5.50443C4.57236 3.25212 7.11083 1.79366 10.0001 1.79366C12.1508 1.79366 14.1077 2.59674 15.5847 3.95366C14.957 3.85212 14.0616 4.31366 14.0616 5.41212C14.0616 6.01026 14.3801 6.52347 14.7382 7.10048C14.7891 7.18242 14.8407 7.26565 14.8924 7.35058C15.2154 7.91366 15.4001 8.60597 15.4001 9.62135C15.4001 10.9967 14.1077 14.2367 14.1077 14.2367L11.3108 6.51058C11.8093 6.49212 12.0677 6.35366 12.0677 6.35366C12.5293 6.3075 12.4739 5.19981 12.0124 5.2275C12.0124 5.2275 10.6831 5.33827 9.81544 5.33827C9.01236 5.33827 7.66467 5.2275 7.66467 5.2275C7.20313 5.19981 7.14775 6.3352 7.60929 6.35366L8.45852 6.4275L9.62159 9.5752L7.95083 14.9567ZM16.8602 9.94619L16.8401 9.99981C16.1713 11.7605 15.5075 13.5364 14.8451 15.3087L14.845 15.309L14.8448 15.3093C14.6113 15.9341 14.378 16.5583 14.1447 17.1814C16.6093 15.7598 18.2062 13.0367 18.2062 9.99981C18.2062 8.57827 17.8831 7.2675 17.237 6.07674C17.5147 8.20894 17.0881 9.34123 16.8602 9.94617L16.8602 9.94619ZM6.40006 17.4675C3.64929 16.1383 1.7939 13.2583 1.7939 9.99981C1.7939 8.79981 2.00621 7.71058 2.45852 6.68597L3.28801 8.95912C4.32263 11.7949 5.35847 14.6341 6.40006 17.4675ZM12.5016 17.7906L10.1201 11.3475C9.68129 12.6419 9.23927 13.9362 8.79593 15.2344C8.4931 16.1212 8.18965 17.0097 7.88621 17.9014C8.55083 18.1044 9.27083 18.206 10.0001 18.206C10.877 18.206 11.7077 18.0583 12.5016 17.7906Z"
+					fill="white"
+				/>
+			</svg>
+		);
+	};
+
+	const serviceData = {
+		wordpress: {
+			cookieName: 'wpc_wpc',
+			name: 'WordPress.com',
+			popup: ',height=980,width=500',
+			icon: WordPress,
+			class: 'wordpress-login',
+		},
+	};
+
+	useEffect( () => {
+		setUserInfo( getUserInfoCookie() );
+	}, [] );
+
+	const logout = () => {
+		const logoutURL = getLogoutUrl( userInfo );
+		const serviceName = userInfo?.service;
+		const cookieName = serviceData[ serviceName ].cookieName;
+
+		const cookie = `${ cookieName }=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=None; Secure=True;${ addWordPressDomain }`;
+		document.cookie = cookie;
+
+		if ( serviceName === 'wordpress' ) {
+			// Atomic logging out
+			if ( window.location.host === 'jetpack.wordpress.com' ) {
+				const newURL =
+					logoutURL + '&redirect_to=' + window.location.hash.match( /#parent=(.*)/ )[ 1 ];
+				window.parent.location.href = newURL;
+			} else {
+				window.location.href = logoutURL + '&redirect_to=' + window.location.href;
+			}
+		}
+	};
+
+	const { res } = useQuery( {
+		queryKey: [ 'verbum/auth' ],
+		queryFn: () =>
+			wpcom.req.get( {
+				path: `/verbum/auth`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		select: ( data ) => {
+			//console.log( data );
+			return data;
+		},
+	} );
+	//console.log( 'res: ', res );
+	setUserInfo( res );
+
+	const login = async ( service ) => {
+		const { connectURL } = 'https://wordpress.com/log-in';
+
+		const loginWindow = window.open(
+			`${ connectURL }&service=${ service }`,
+			'VerbumCommentsLogin',
+			`status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=0${ serviceData[ service ].popup }`
+		);
+
+		// Listen for login data
+		window.addEventListener( 'message', function waitForLogin( event ) {
+			if ( event.origin !== document.location.origin ) {
+				return;
+			}
+
+			if ( event.data.service === service ) {
+				setUserInfo( event.data );
+
+				if ( ! document.cookie.includes( 'wpc_' ) ) {
+					setUserInfoCookie( event.data );
+				}
+				window.removeEventListener( 'message', waitForLogin );
+			}
+		} );
+
+		// Clean up loginWindow to reset activeService
+		const loginClosed = setInterval( () => {
+			if ( loginWindow?.closed ) {
+				clearInterval( loginClosed );
+				setLoginWindowRef( undefined );
+			}
+		}, 100 );
+
+		setLoginWindowRef( loginWindow );
+	};
+
+	return { userInfo, login, loginWindowRef, logout };
+}

--- a/client/components/login-window/index.jsx
+++ b/client/components/login-window/index.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { useEffect } from 'react';
+import { createAccountUrl } from 'calypso/lib/paths';
 
 export default function useLoginWindow( { onLoginSuccess } ) {
 	const isBrowser = typeof window !== 'undefined';
@@ -56,8 +57,9 @@ export default function useLoginWindow( { onLoginSuccess } ) {
 			return;
 		}
 
+		const url = createAccountUrl( { redirectTo: redirectTo, ref: 'reader-lw' } );
 		const createAccountWindow = window.open(
-			`https://wordpress.com/start/account/user?redirect_to=${ redirectTo }`,
+			url,
 			'CalyspoLogin',
 			'status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=0,height=980,width=500'
 		);

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -2,6 +2,7 @@ import { createRef, Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import LikeButtonContainer from 'calypso/blocks/like-button';
 import PostLikesPopover from 'calypso/blocks/post-likes/popover';
+import ReaderJoinConversationDialog from 'calypso/blocks/reader-join-conversation/dialog';
 import QueryPostLikes from 'calypso/components/data/query-post-likes';
 import ReaderLikeIcon from 'calypso/reader/components/icons/like-icon';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
@@ -14,6 +15,7 @@ import './style.scss';
 class ReaderLikeButton extends Component {
 	state = {
 		showLikesPopover: false,
+		showJoinConversationModal: false,
 	};
 
 	hidePopoverTimeout = null;
@@ -38,6 +40,10 @@ class ReaderLikeButton extends Component {
 		}
 	};
 
+	showJoinConversationModal = () => {
+		this.setState( { showJoinConversationModal: true } );
+	};
+
 	showLikesPopover = () => {
 		clearTimeout( this.hidePopoverTimeout );
 		this.setState( { showLikesPopover: true } );
@@ -51,7 +57,7 @@ class ReaderLikeButton extends Component {
 
 	render() {
 		const { siteId, postId, likeCount, iLike, iconSize } = this.props;
-		const { showLikesPopover } = this.state;
+		const { showLikesPopover, showJoinConversationModal } = this.state;
 		const hasEnoughLikes = ( likeCount > 0 && ! iLike ) || ( likeCount > 1 && iLike );
 
 		const likeIcon = ReaderLikeIcon( {
@@ -70,6 +76,7 @@ class ReaderLikeButton extends Component {
 					onLikeToggle={ this.recordLikeToggle }
 					likeSource="reader"
 					icon={ likeIcon }
+					onLoggedOut={ this.showJoinConversationModal }
 				/>
 				{ showLikesPopover && siteId && postId && hasEnoughLikes && (
 					<PostLikesPopover
@@ -80,6 +87,12 @@ class ReaderLikeButton extends Component {
 						postId={ postId }
 						showDisplayNames={ true }
 						context={ this.likeButtonRef.current }
+					/>
+				) }
+				{ showJoinConversationModal && (
+					<ReaderJoinConversationDialog
+						onClose={ () => this.setState( { showJoinConversationModal: false } ) }
+						isVisible={ this.state.showJoinConversationModal }
 					/>
 				) }
 			</Fragment>

--- a/config/development.json
+++ b/config/development.json
@@ -161,6 +161,7 @@
 		"reader/first-posts-stream": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
+		"reader/login-window": true,
 		"reader/public-tag-pages": true,
 		"recommend-plugins": true,
 		"redirect-fallback-browsers": false,

--- a/config/production.json
+++ b/config/production.json
@@ -127,6 +127,7 @@
 		"reader/full-errors": false,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,
+		"reader/login-window": false,
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,


### PR DESCRIPTION
This PR will add a new dialog/modal when a logged out user clicks on a reader action (that requires the user to be logged in).

The modal will inform the user that they need to either create a new WordPress.com account or log in to an existing WordPress.com account to interact with the reader.

This PR adds tracks events;
`calypso_reader_dialog_login_clicked` - when user clicks the login link in the modal
`calypso_reader_dialog_create_account_clicked` - when the user clicks the create account button in the modal

Project thread - p2-pe7F0s-1gz

- [x] Create LoginWindow Component
- [x] Update Like button to use LoginWindow Component when clicked and user is logged out
- [x] Add feature flag to LoginWindow so we can merge without side affects
- [x] Add stats/tracks for login/create account actions from LoginWindow

### Testing (so far)

* Sandbox the domains `public-api.wordpress.com` and `wpcalypso.wordpress.com`
* Requires patch code-D124724 - this handles the postMessage to inform popup window of login event - without this, the page will not refresh after login is complete
* Open incognito window in browser and make sure you are logged out of WordPress.com
* Go to a tag page, i.e. http://calypso.localhost:3000/tag/writing
* Click the like icon  in the post stream and you should get the modal below
<img width="354" alt="Screenshot 2023-10-11 at 22 00 39" src="https://github.com/Automattic/wp-calypso/assets/5560595/14194ca4-69ec-435f-94d5-bb4e490fe24c">

* Click either the create and account button or login link
* You should see the login popup - login to your WordPress.com account
* The popup should automatically close and the reader page should refresh with you logged in

**Things to look out for**
* There has been a change to how we handle logged out likes - the functionality is now in a `onLoggedOut` function that is passed as a prop to the like container. There is a feature flag check in this function that checks to see if the loginWindow feature is enabled; if it is the new modal should show when logged out like event occurs, otherwise the user is redirected to the create account (as it happens without PR).