### PR TITLE
Launchpad: Add the progress icon to the Navigator

### DIFF
--- a/client/layout/masterbar/masterbar-launchpad-navigator.tsx
+++ b/client/layout/masterbar/masterbar-launchpad-navigator.tsx
@@ -24,7 +24,7 @@ const MasterbarLaunchpadNavigator = () => {
 					'is-active': launchpadIsVisible,
 				} ) }
 				tooltip={ translate( 'My tasks' ) }
-				icon={ <LaunchpadNavigatorIcon /> }
+				icon={ <LaunchpadNavigatorIcon siteSlug={ siteSlug } /> }
 			/>
 			{ launchpadIsVisible && (
 				<div className="masterbar__launchpad-navigator">

--- a/packages/components/src/circular-progress-bar/index.tsx
+++ b/packages/components/src/circular-progress-bar/index.tsx
@@ -6,15 +6,18 @@ const CircularProgressBar = ( {
 	numberOfSteps,
 	size,
 	enableDesktopScaling = false,
+	strokeWidth = 4,
+	showProgressText = true,
 }: {
 	currentStep: number | null;
 	numberOfSteps: number | null;
 	size: number;
 	enableDesktopScaling?: boolean;
+	strokeWidth?: number;
+	showProgressText?: boolean;
 } ) => {
 	const SIZE = size;
-	const STROKE_WIDTH = 4;
-	const RADIUS = SIZE / 2 - STROKE_WIDTH / 2;
+	const RADIUS = SIZE / 2 - strokeWidth / 2;
 	const FULL_ARC = 2 * Math.PI * RADIUS;
 
 	if ( currentStep === null || ! numberOfSteps ) {
@@ -41,7 +44,7 @@ const CircularProgressBar = ( {
 					cx={ SIZE / 2 }
 					cy={ SIZE / 2 }
 					r={ RADIUS }
-					strokeWidth={ STROKE_WIDTH }
+					strokeWidth={ strokeWidth }
 				/>
 				<circle
 					style={ {
@@ -53,12 +56,14 @@ const CircularProgressBar = ( {
 					cx={ SIZE / 2 }
 					cy={ SIZE / 2 }
 					r={ RADIUS }
-					strokeWidth={ STROKE_WIDTH }
+					strokeWidth={ strokeWidth }
 				/>
 			</svg>
-			<div className="circular__progress-bar-text">
-				{ currentStep }/{ numberOfSteps }
-			</div>
+			{ showProgressText && (
+				<div className="circular__progress-bar-text">
+					{ currentStep }/{ numberOfSteps }
+				</div>
+			) }
 		</div>
 	);
 };

--- a/packages/launchpad-navigator/src/icon/index.tsx
+++ b/packages/launchpad-navigator/src/icon/index.tsx
@@ -1,7 +1,34 @@
-import { Gridicon } from '@automattic/components';
+import { CircularProgressBar } from '@automattic/components';
+import { LaunchpadNavigator, useLaunchpad } from '@automattic/data-stores';
+import { select } from '@wordpress/data';
+import type { Task } from '@automattic/launchpad';
 
-const LaunchpadNavigatorIcon = () => {
-	return <Gridicon icon="checkmark-circle" />;
+import './style.scss';
+
+type LaunchpadNavigatorIconProps = {
+	siteSlug: string | null;
+};
+
+const LaunchpadNavigatorIcon = ( { siteSlug }: LaunchpadNavigatorIconProps ) => {
+	const currentNavigatorChecklistSlug =
+		select( LaunchpadNavigator.store ).getActiveChecklistSlug() || null;
+
+	const {
+		data: { checklist },
+	} = useLaunchpad( siteSlug, currentNavigatorChecklistSlug );
+
+	const numberOfSteps = checklist?.length || 0;
+	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
+	return (
+		<CircularProgressBar
+			size={ 15 }
+			strokeWidth={ 2 }
+			enableDesktopScaling
+			numberOfSteps={ numberOfSteps }
+			currentStep={ completedSteps }
+			showProgressText={ false }
+		/>
+	);
 };
 
 export default LaunchpadNavigatorIcon;

--- a/packages/launchpad-navigator/src/icon/style.scss
+++ b/packages/launchpad-navigator/src/icon/style.scss
@@ -1,0 +1,3 @@
+.masterbar__item-launchpad-navigator .circular__progress-bar svg {
+	display: flex;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #82520

## Proposed Changes

* We decided to use the progress ring as the icon for the Launchpad navigator. This will be the element that will open up the modal with the Launchpad info. The ring should reflect the progress(task completed against the total of tasks) of the current task list.
* Changes the Circular Progress Bar component to allow us to change the stroke width and allow us to disable the text that indicates the progress, e.g., 1/6. 

![Screen Shot 2023-10-03 at 15 02 26](https://github.com/Automattic/wp-calypso/assets/1234758/6aca7763-ceff-417b-951e-10a82158a9ab)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link or apply this PR to your local environment
* With a test site with some progress, go to the Customer Home and add the flag to the URL:
```
/home/:site?flags=launchpad/navigator
```
* Make sure you see the ring with the progress

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?