### PR TITLE
Fix the sticky nav value for signup step wrapper

### DIFF
--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -203,7 +203,7 @@ class StepWrapper extends Component {
 		if ( isSticky !== undefined ) {
 			sticky = isSticky;
 		} else {
-			sticky = isReskinnedFlow( flowName ) ? true : false;
+			sticky = isReskinnedFlow( flowName ) ? null : false;
 		}
 
 		return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/82481

## Proposed Changes

Noticed that the nav bar for the signup steps changed it's position to the bottom after this change (https://github.com/Automattic/wp-calypso/pull/82481/files#diff-4e9e90c87f37812dd56061274d576c3be0b7dad72318441eeaee22eb3cae07c6R206), this PR reverts it(https://github.com/Automattic/wp-calypso/pull/82481/files#diff-4e9e90c87f37812dd56061274d576c3be0b7dad72318441eeaee22eb3cae07c6L210) back to `null : false`

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/c02f7b72-9b5c-4763-9b32-d4438db8d390">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/35bdbf6e-aa31-42fc-96a3-c579fe9dcf5a">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/user` and see that the nav is back on the top

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?