### PR TITLE
Plugins: Display the page for the user without any site

### DIFF
--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -13,7 +13,7 @@ const Header = styled.header`
 	border-bottom: 1px solid var( --studio-gray-5 );
 	background-color: var( --studio-white );
 
-	.layout__secondary ~ .layout__primary & {
+	.layout__secondary:not( :empty ) ~ .layout__primary & {
 		left: calc( var( --sidebar-width-max ) + 1px ); // 1px is the sidebar border.
 		width: calc( 100% - var( --sidebar-width-max ) - 1px ); // 1px is the sidebar border.
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -31,6 +31,7 @@ import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
 import { OdieAssistantProvider } from 'calypso/odie/context';
 import { isOffline } from 'calypso/state/application/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
@@ -233,6 +234,7 @@ class Layout extends Component {
 			'is-support-session': this.props.isSupportSession,
 			'has-no-sidebar': this.props.sidebarIsHidden,
 			'has-no-masterbar': this.props.masterbarIsHidden,
+			'is-logged-in': this.props.isLoggedIn,
 			'is-jetpack-login': this.props.isJetpackLogin,
 			'is-jetpack-site': this.props.isJetpack,
 			'is-jetpack-mobile-flow': this.props.isJetpackMobileFlow,
@@ -401,6 +403,7 @@ export default withCurrentRoute(
 			isEligibleForJITM,
 			oauth2Client,
 			wccomFrom,
+			isLoggedIn: isUserLoggedIn( state ),
 			isSupportSession: isSupportSession( state ),
 			sectionGroup,
 			sectionName,

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -494,15 +494,17 @@ export function siteSelection( context, next ) {
 	const isUnlinkedCheckout =
 		'1' === context.query?.unlinked && context.pathname.match( /^\/checkout\/[^/]+\/jetpack_/i );
 
+	const shouldRenderNoSites = ! context.section.enableNoSites && ! isUnlinkedCheckout;
+
 	// The user doesn't have any sites: render `NoSitesMessage`
-	if ( currentUser && currentUser.site_count === 0 && ! isUnlinkedCheckout ) {
+	if ( currentUser && currentUser.site_count === 0 && shouldRenderNoSites ) {
 		renderEmptySites( context );
 		recordNoSitesPageView( context, siteFragment );
 		return;
 	}
 
 	// The user has all sites set as hidden: render help message with how to make them visible
-	if ( currentUser && currentUser.visible_site_count === 0 && ! isUnlinkedCheckout ) {
+	if ( currentUser && currentUser.visible_site_count === 0 && shouldRenderNoSites ) {
 		renderNoVisibleSites( context );
 		recordNoVisibleSitesPageView( context, siteFragment );
 		return;

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -5,7 +5,7 @@ import { redirectLoggedOut } from 'calypso/controller';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { getSiteFragment, sectionify } from 'calypso/lib/route';
 import { navigation } from 'calypso/my-sites/controller';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn, getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import { fetchSitePlans } from 'calypso/state/sites/plans/actions';
 import { isSiteOnECommerceTrial, getCurrentPlan } from 'calypso/state/sites/plans/selectors';
@@ -217,7 +217,8 @@ export function scrollTopIfNoHash( context, next ) {
 }
 
 export function navigationIfLoggedIn( context, next ) {
-	if ( isUserLoggedIn( context.store.getState() ) ) {
+	const state = context.store.getState();
+	if ( isUserLoggedIn( state ) && getCurrentUserSiteCount( state ) > 0 ) {
 		navigation( context, next );
 		return;
 	}

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -10,7 +10,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 import { addQueryArgs } from 'calypso/lib/route';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn, getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { getSectionName } from 'calypso/state/ui/selectors';
 
 const ThreeColumnContainer = styled.div`
@@ -87,7 +87,7 @@ const CardText = styled.span< { color: string } >`
 export const MarketplaceFooter = () => {
 	const { __ } = useI18n();
 	const isLoggedIn = useSelector( isUserLoggedIn );
-
+	const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
 	const sectionName = useSelector( getSectionName );
 
 	const startUrl = addQueryArgs(
@@ -103,7 +103,7 @@ export const MarketplaceFooter = () => {
 				header={ preventWidows( __( 'You pick the plugin. We’ll take care of the rest.' ) ) }
 			>
 				<>
-					{ ! isLoggedIn && (
+					{ ( ! isLoggedIn || currentUserSiteCount === 0 ) && (
 						<Button className="is-primary marketplace-cta" href={ startUrl }>
 							{ __( 'Get Started' ) }
 						</Button>

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -70,8 +70,8 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	const currentPurchase = getPluginPurchased( plugin, purchases );
 
 	// Site type
-	const sites = useSelector( getSelectedOrAllSitesWithPlugins );
-	const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
+	const sitesWithPlugins = useSelector( getSelectedOrAllSitesWithPlugins );
+	const siteIds = [ ...new Set( siteObjectsToSiteIds( sitesWithPlugins ) ) ];
 
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
@@ -87,7 +87,6 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	const sitePlugin = useSelector( ( state ) =>
 		getPluginOnSite( state, selectedSite?.ID, softwareSlug )
 	);
-	const sitesWithPlugins = useSelector( getSelectedOrAllSitesWithPlugins );
 
 	const shouldUpgrade =
 		useSelector( ( state ) => ! siteHasFeature( state, selectedSite?.ID, pluginFeature ) ) &&
@@ -333,6 +332,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 						plugin={ plugin }
 						saasRedirectHRef={ saasRedirectHRef }
 						isWpcomStaging={ isWpcomStaging }
+						sitesWithPlugins={ sitesWithPlugins }
 						installedOnSitesQuantity={ installedOnSitesQuantity }
 					/>
 				</div>
@@ -395,6 +395,7 @@ function PrimaryButton( {
 	plugin,
 	saasRedirectHRef,
 	isWpcomStaging,
+	sitesWithPlugins,
 	installedOnSitesQuantity,
 } ) {
 	const dispatch = useDispatch();
@@ -414,7 +415,7 @@ function PrimaryButton( {
 		);
 	}, [ dispatch, plugin, isLoggedIn ] );
 
-	if ( isLoggedIn && currentUserSiteCount > 0 && ! selectedSite ) {
+	if ( isLoggedIn && currentUserSiteCount > 0 && sitesWithPlugins.length > 0 && ! selectedSite ) {
 		return (
 			<ManageSitesButton plugin={ plugin } installedOnSitesQuantity={ installedOnSitesQuantity } />
 		);

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -65,6 +65,10 @@
 			margin: 0 0 0 5px;
 		}
 	}
+
+	.plugin-details-cta__manage-button {
+		width: 100%;
+	}
 }
 
 .plugin-details-cta__t-and-c {

--- a/client/sections.js
+++ b/client/sections.js
@@ -109,6 +109,7 @@ const sections = [
 		module: 'calypso/my-sites/plugins',
 		group: 'sites',
 		enableLoggedOut: true,
+		enableNoSites: true,
 		isomorphic: true,
 		title: 'Plugins',
 	},

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -869,6 +869,9 @@ class DomainsStep extends Component {
 		} else if ( ! previousStepBackUrl && 'domain-transfer' === this.props.flowName ) {
 			backUrl = null;
 			backLabelText = null;
+		} else if ( 'with-plugin' === this.props.flowName ) {
+			backUrl = '/plugins';
+			backLabelText = translate( 'Back to plugins' );
 		} else {
 			backUrl = getStepUrl( this.props.flowName, this.props.stepName, null, this.getLocale() );
 

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -17,7 +17,7 @@ $studio-blue-30: #0675c4;
 	width: 1px;
 }
 
-.is-section-plugins.has-no-sidebar {
+.is-section-plugins.has-no-sidebar:not(.is-logged-in) {
 	.masterbar {
 		height: 56px;
 		position: relative;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/82549

## Proposed Changes

* Introduce the `enableNoSites` flag defined by the section to control whether to render no sites
* Display the price of the plugin for the account with multiple sites instead of just showing the “Manage sites” button
* Display the text, `on Business plan`, for no selected site or the site that requires an upgrade
* Display the upsell text only for the site that requires an upgrade so we won't display it for no selected site

| | The account without any site | The account with multiple sites but no selected site | The account with multiple sites and the one of them is selected |
| - | - | - | - |
| email-address-encoder | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/51c42fbe-17dd-4722-88fa-f2518c874dab) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/ff4a94aa-32e2-42f0-b4a0-10623e97589c) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/a059d169-2725-48c0-8e07-9db9fba74bde) |
| woocommerce-subscriptions | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/aeceb472-f858-44ed-94ee-2cf0b76ac0fe) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/7f9e20d3-79c1-4252-a951-b3d1194909e4) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/6ef78257-632b-48c1-8b15-d993d3b59fcc) |
| Gutenberg | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/dd297aa3-cbc5-43b3-8d5c-b461ab8b43d5) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/6e101a65-46e6-449e-b843-529a5afb8d6b) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/ba10d48f-d8c1-460e-8c61-9e165ab48759) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to the `/plugins` page with the account below, and ensure the plugins page and plugins detail page display correctly

* The account without any site
* The account with multiple sites

You can also browse the specific plugins directly, e.g.:
* /plugins/email-address-encoder (The free plugin on Business plan)
* /plugins/woocommerce-subscriptions (The paid plugin)
* /plugins/gutenberg (The preinstalled plugin)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?