### PR TITLE
Site profiler: Handle globe background edge cases

### DIFF
--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -105,7 +105,10 @@ export default function SiteProfiler() {
 				</LayoutBlock>
 			) }
 
-			<LayoutBlock className="hosting-intro-block globe-bg" isMonoBg={ !! siteProfilerData }>
+			<LayoutBlock
+				className="hosting-intro-block globe-bg"
+				isMonoBg={ !! siteProfilerData && conversionAction !== 'register-domain' }
+			>
 				<HostingIntro />
 			</LayoutBlock>
 		</>

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -1,5 +1,9 @@
 @import "@wordpress/base-styles/breakpoints";
 
+.is-section-site-profiler > #wpcom {
+	background: #fff;
+}
+
 .layout__primary .main {
 	padding-bottom: 0;
 }
@@ -7,7 +11,7 @@
 .is-section-site-profiler .layout__content {
 	background: #fff;
 	padding: 0;
-	min-height: 100vh;
+	min-height: calc(100vh - 3.5rem);
 
 	h1 {
 		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
@@ -195,7 +199,7 @@
 		&.globe-bg {
 			background-image: url(calypso/assets/images/illustrations/globe.svg);
 			background-repeat: no-repeat;
-			background-position: right top;
+			background-position: right top 60px;
 
 			.img-container {
 				min-height: 300px;


### PR DESCRIPTION
## Proposed Changes

* Fine-tune CSS around the globe background
* Hide mono background when domain is available for registration (design match)

## Testing Instructions

* Go to `/site-profiler`
* Enter a domain available for registration
* Check if the globe background acts correctly

**Before:**
<img width="1306" alt="Screenshot 2023-10-04 at 10 09 37" src="https://github.com/Automattic/wp-calypso/assets/1241413/c310a338-9ad6-4e17-89e1-bfd4e49130bb">
**After:**
<img width="1285" alt="Screenshot 2023-10-04 at 10 09 56" src="https://github.com/Automattic/wp-calypso/assets/1241413/ddf5ce2a-e102-4d24-a55c-cae5c2e44f3b">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?