### PR TITLE
Stats: Add check for empty links

### DIFF
--- a/client/my-sites/stats/stats-list/action-link.jsx
+++ b/client/my-sites/stats/stats-list/action-link.jsx
@@ -23,7 +23,10 @@ class StatsActionLink extends PureComponent {
 		const { href, translate } = this.props;
 		// The following fix is to address encoding issues with the URLs
 		// as returned to us from the API. If we fix that, we can remove this.
-		const finalLink = href.includes( '&#038;term' ) ? href.replace( '&#038;term', '&term' ) : href;
+		const finalLink = href?.includes( '&#038;term' )
+			? href?.replace( '&#038;term', '&term' )
+			: href;
+
 		return (
 			<li className="stats-list__item-action module-content-list-item-action">
 				<a


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82510

## Proposed Changes

* fixing issue reported in p1696406900931659-slack-C04U5A26MJB (executing a function on an empty string)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the live branch and verify that both the Traffic and Insights pages load correctly 
* review the code in the PR (I couldn't reproduce the issue, but the new code adds a check preventing the problem)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?