### PR TITLE
Site profiler: Increase heading padding to match design

### DIFF
--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -182,6 +182,7 @@
 	}
 
 	.domain-analyzer-block {
+		padding-top: 10rem;
 		@media (max-width: $break-small ) {
 			padding-top: 4rem;
 		}
@@ -248,7 +249,7 @@
 		height: 100%;
 
 		@media (min-width: $break-medium) {
-			height: 280px;
+			height: 365px;
 		}
 	}
 	.domain-result-block::after {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82512

## Proposed Changes

* Increased heading padding to match design

## Testing Instructions

* Go to `/site-profiler`
* Check heading block

**Before:**
<img width="1728" alt="Screenshot 2023-10-04 at 11 16 43" src="https://github.com/Automattic/wp-calypso/assets/1241413/8ff451aa-5b5a-4075-a257-f6624680bb31">

**After:**
<img width="1728" alt="Screenshot 2023-10-04 at 11 16 52" src="https://github.com/Automattic/wp-calypso/assets/1241413/6794444a-ad49-4d6e-b5cc-0115e5eb047f">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?