### PR TITLE
Stats: Track selection state for shortcut list.

### DIFF
--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-shortcuts.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-shortcuts.tsx
@@ -1,17 +1,25 @@
 import { Button } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import React from 'react';
-import { DateControlPickerShortcutsProps } from './types';
+import { DateControlPickerShortcut, DateControlPickerShortcutsProps } from './types';
 
 const DateControlPickerShortcuts = ( {
 	shortcutList,
+	currentShortcut,
 	onClick,
 }: DateControlPickerShortcutsProps ) => {
+	// Apply selection state via CSS.
+	function classNameForShortcut( shortcut: DateControlPickerShortcut ): string {
+		const defaultClassName = 'date-control-picker-shortcuts__shortcut';
+		const selectedClassName = defaultClassName + ' is-selected';
+		return shortcut.id !== currentShortcut ? defaultClassName : selectedClassName;
+	}
+
 	return (
 		<div className="date-control-picker-shortcuts">
 			<ul className="date-control-picker-shortcuts__list">
 				{ shortcutList.map( ( shortcut, idx ) => (
-					<li className="date-control-picker-shortcuts__shortcut" key={ shortcut.id || idx }>
+					<li className={ classNameForShortcut( shortcut ) } key={ shortcut.id || idx }>
 						<Button
 							key={ shortcut.id || idx }
 							onClick={ () => {

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -20,6 +20,7 @@ const DateControlPicker = ( {
 	const [ inputEndDate, setInputEndDate ] = useState(
 		new Date( new Date().setMonth( new Date().getMonth() - 3 ) ).toISOString().slice( 0, 10 )
 	);
+	const [ currentShortcut, setCurrentShortcut ] = useState( 'today' );
 	const infoReferenceElement = useRef( null );
 	const [ popoverOpened, togglePopoverOpened ] = useState( false );
 
@@ -69,6 +70,8 @@ const DateControlPicker = ( {
 		// Calc new end date based on start date plus range as specified in shortcut.
 		const newEndDate = calcNewDateWithOffset( newStartDate, shortcut.range );
 		setInputEndDate( formattedDate( newEndDate ) );
+
+		setCurrentShortcut( shortcut.id || '' );
 	};
 
 	const formatDate = ( date: string ) => {
@@ -100,6 +103,7 @@ const DateControlPicker = ( {
 				/>
 				<DateControlPickerShortcuts
 					shortcutList={ shortcutList }
+					currentShortcut={ currentShortcut }
 					onClick={ handleShortcutSelected }
 				/>
 			</Popover>

--- a/client/my-sites/stats/stats-date-control/types.d.ts
+++ b/client/my-sites/stats/stats-date-control/types.d.ts
@@ -15,6 +15,7 @@ interface DateControlPickerProps {
 
 interface DateControlPickerShortcutsProps {
 	shortcutList: DateControlPickerShortcut[];
+	currentShortcut: string;
 	onClick: ( shortcut: DateControlPickerShortcut ) => void;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81939.

## Proposed Changes

Adds state to track the selected shortcut and applies correct class names as needed.

Screenshot with selection enabled:

![SCR-20231004-pflk](https://github.com/Automattic/wp-calypso/assets/40267301/d3420f2e-25e8-4022-8fa0-66b5fa3c2f80)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. View the Calypso Live branch.
2. Visit the **Stats → Traffic** page.
3. Enable the date picker: `?flags=stats/date-control`
4. Confirm that selection works in the pop-up.
5. Confirm selection persists when closing and opening the pop-up.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?