### PR TITLE
Plans 2023: Uncouple grid from QueryActivePromotions call

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -20,6 +20,7 @@ import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useSelector } from 'react-redux';
+import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
 import QueryPlans from 'calypso/components/data/query-plans';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
@@ -599,6 +600,7 @@ const PlansFeaturesMain = ( {
 			<QueryPlans />
 			<QuerySites siteId={ siteId } />
 			<QuerySitePlans siteId={ siteId } />
+			<QueryActivePromotions />
 			{ paidDomainName && isFreePlanPaidDomainDialogOpen && (
 				<FreePlanPaidDomainDialog
 					paidDomainName={ paidDomainName }

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -43,6 +43,7 @@ jest.mock(
 jest.mock( 'calypso/my-sites/plans-features-main/hooks/data-store/use-priced-api-plans', () =>
 	jest.fn()
 );
+jest.mock( 'calypso/components/data/query-active-promotions', () => jest.fn() );
 
 import {
 	PLAN_FREE,

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -1,6 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors/is-current-user-current-plan-owner';
 import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
@@ -118,7 +117,6 @@ const WrappedComparisonGrid = ( {
 				usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 				allFeaturesList={ allFeaturesList }
 			>
-				<QueryActivePromotions />
 				<ComparisonGrid
 					planTypeSelectorProps={ planTypeSelectorProps }
 					intervalType={ intervalType }
@@ -149,7 +147,6 @@ const WrappedComparisonGrid = ( {
 			allFeaturesList={ allFeaturesList }
 		>
 			<CalypsoShoppingCartProvider>
-				<QueryActivePromotions />
 				<ComparisonGrid
 					planTypeSelectorProps={ planTypeSelectorProps }
 					intervalType={ intervalType }
@@ -219,7 +216,6 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 				usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 				allFeaturesList={ allFeaturesList }
 			>
-				<QueryActivePromotions />
 				<FeaturesGrid
 					{ ...props }
 					isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
@@ -242,7 +238,6 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 			allFeaturesList={ allFeaturesList }
 		>
 			<CalypsoShoppingCartProvider>
-				<QueryActivePromotions />
 				<FeaturesGrid
 					{ ...props }
 					isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/78991

## Proposed Changes

Moves `<QueryActivePromotions />` data query to `plans-features-main`.

I'm actually not sure how this is needed or used, so I'm blindly just moving it into the wrapper. 🤔 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/plans/[ site ]` and `/start/plans`, ensure things render like before
- Confirm active promotions are shown/displayed.  (?)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?