### PR TITLE
Plans 2023: Stop propagating selectedSiteSlug through props

### DIFF
--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -42,7 +42,6 @@ type PlanFeaturesActionsButtonProps = {
 	buttonText?: string;
 	isWpcomEnterpriseGridPlan: boolean;
 	isWooExpressPlusPlan?: boolean;
-	selectedSiteSlug: string | null;
 	planActionOverrides?: PlanActionOverrides;
 	showMonthlyPrice: boolean;
 	siteId?: number | null;
@@ -214,7 +213,6 @@ const LoggedInPlansFeatureActionButton = ( {
 	canUserPurchasePlan?: boolean | null;
 	currentSitePlanSlug?: string | null;
 	buttonText?: string;
-	selectedSiteSlug: string | null;
 	planActionOverrides?: PlanActionOverrides;
 } ) => {
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
@@ -376,7 +374,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	buttonText,
 	isWpcomEnterpriseGridPlan = false,
 	isWooExpressPlusPlan = false,
-	selectedSiteSlug,
 	planActionOverrides,
 	isStuck,
 	isLargeCurrency,
@@ -501,7 +498,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			canUserPurchasePlan={ canUserPurchasePlan }
 			currentSitePlanSlug={ currentSitePlanSlug }
 			buttonText={ buttonText }
-			selectedSiteSlug={ selectedSiteSlug }
 			planActionOverrides={ planActionOverrides }
 			priceString={ priceString }
 			isStuck={ isStuck }

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -322,7 +322,6 @@ type ComparisonGridProps = {
 	currentSitePlanSlug?: string | null;
 	manageHref: string;
 	canUserPurchasePlan?: boolean | null;
-	selectedSiteSlug: string | null;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
 	siteId?: number | null;
 	planActionOverrides?: PlanActionOverrides;
@@ -344,7 +343,6 @@ type ComparisonGridHeaderProps = {
 	currentSitePlanSlug?: string | null;
 	manageHref: string;
 	canUserPurchasePlan?: boolean | null;
-	selectedSiteSlug: string | null;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
 	siteId?: number | null;
 	planActionOverrides?: PlanActionOverrides;
@@ -378,7 +376,6 @@ const ComparisonGridHeaderCell = ( {
 	canUserPurchasePlan,
 	isLaunchPage,
 	flowName,
-	selectedSiteSlug,
 	isLargeCurrency,
 	onUpgradeClick,
 	planActionOverrides,
@@ -469,7 +466,6 @@ const ComparisonGridHeaderCell = ( {
 				isLaunchPage={ isLaunchPage }
 				planSlug={ planSlug }
 				flowName={ flowName }
-				selectedSiteSlug={ selectedSiteSlug }
 				onUpgradeClick={ () => onUpgradeClick( planSlug ) }
 				planActionOverrides={ planActionOverrides }
 				showMonthlyPrice={ false }
@@ -490,7 +486,6 @@ const ComparisonGridHeader = ( {
 	currentSitePlanSlug,
 	manageHref,
 	canUserPurchasePlan,
-	selectedSiteSlug,
 	onUpgradeClick,
 	siteId,
 	planActionOverrides,
@@ -531,7 +526,6 @@ const ComparisonGridHeader = ( {
 					manageHref={ manageHref }
 					canUserPurchasePlan={ canUserPurchasePlan }
 					flowName={ flowName }
-					selectedSiteSlug={ selectedSiteSlug }
 					onUpgradeClick={ onUpgradeClick }
 					isLaunchPage={ isLaunchPage }
 					isLargeCurrency={ isLargeCurrency }
@@ -832,7 +826,6 @@ const ComparisonGrid = ( {
 	currentSitePlanSlug,
 	manageHref,
 	canUserPurchasePlan,
-	selectedSiteSlug,
 	onUpgradeClick,
 	siteId,
 	planActionOverrides,
@@ -1027,7 +1020,6 @@ const ComparisonGrid = ( {
 					currentSitePlanSlug={ currentSitePlanSlug }
 					manageHref={ manageHref }
 					canUserPurchasePlan={ canUserPurchasePlan }
-					selectedSiteSlug={ selectedSiteSlug }
 					onUpgradeClick={ onUpgradeClick }
 					planActionOverrides={ planActionOverrides }
 					selectedPlan={ selectedPlan }
@@ -1099,7 +1091,6 @@ const ComparisonGrid = ( {
 					currentSitePlanSlug={ currentSitePlanSlug }
 					manageHref={ manageHref }
 					canUserPurchasePlan={ canUserPurchasePlan }
-					selectedSiteSlug={ selectedSiteSlug }
 					onUpgradeClick={ onUpgradeClick }
 					siteId={ siteId }
 					planActionOverrides={ planActionOverrides }

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -48,7 +48,6 @@ interface FeaturesGridType extends PlansGridProps {
 	translate: LocalizeProps[ 'translate' ];
 	canUserPurchasePlan: boolean | null;
 	manageHref: string;
-	selectedSiteSlug: string | null;
 	isPlanUpgradeCreditEligible: boolean;
 	handleUpgradeClick: ( planSlug: PlanSlug ) => void;
 }
@@ -361,7 +360,6 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 			canUserPurchasePlan,
 			manageHref,
 			currentSitePlanSlug,
-			selectedSiteSlug,
 			translate,
 			planActionOverrides,
 			siteId,
@@ -412,7 +410,6 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 						planSlug={ planSlug }
 						flowName={ flowName }
 						currentSitePlanSlug={ currentSitePlanSlug }
-						selectedSiteSlug={ selectedSiteSlug }
 						buttonText={ buttonText }
 						planActionOverrides={ planActionOverrides }
 						showMonthlyPrice={ true }

--- a/client/my-sites/plans-grid/components/test/actions.tsx
+++ b/client/my-sites/plans-grid/components/test/actions.tsx
@@ -79,7 +79,6 @@ describe( 'PlanFeatures2023GridActions', () => {
 			onUpgradeClick: jest.fn(),
 			flowName: 'foo-flow',
 			isWpcomEnterpriseGridPlan: false,
-			selectedSiteSlug: 'foo.wordpress.com',
 			isStuck: false,
 			showMonthlyPrice: true,
 		};

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -126,7 +126,6 @@ const WrappedComparisonGrid = ( {
 					currentSitePlanSlug={ currentSitePlanSlug }
 					manageHref={ manageHref }
 					canUserPurchasePlan={ canUserPurchasePlan }
-					selectedSiteSlug={ selectedSiteSlug }
 					onUpgradeClick={ handleUpgradeClick }
 					siteId={ siteId }
 					selectedPlan={ selectedPlan }
@@ -156,7 +155,6 @@ const WrappedComparisonGrid = ( {
 					currentSitePlanSlug={ currentSitePlanSlug }
 					manageHref={ manageHref }
 					canUserPurchasePlan={ canUserPurchasePlan }
-					selectedSiteSlug={ selectedSiteSlug }
 					onUpgradeClick={ handleUpgradeClick }
 					siteId={ siteId }
 					selectedPlan={ selectedPlan }
@@ -222,7 +220,6 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 					isLargeCurrency={ isLargeCurrency }
 					canUserPurchasePlan={ canUserPurchasePlan }
 					manageHref={ manageHref }
-					selectedSiteSlug={ selectedSiteSlug }
 					translate={ translate }
 					handleUpgradeClick={ handleUpgradeClick }
 				/>
@@ -244,7 +241,6 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 					isLargeCurrency={ isLargeCurrency }
 					canUserPurchasePlan={ canUserPurchasePlan }
 					manageHref={ manageHref }
-					selectedSiteSlug={ selectedSiteSlug }
 					translate={ translate }
 					handleUpgradeClick={ handleUpgradeClick }
 				/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Partly addresses https://github.com/Automattic/wp-calypso/issues/78994

## Proposed Changes

Stops propagating `selectedSiteSlug` through props as not needed outside of computing `manageRef` in the main index file.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* code review
* just general sanity checks on `/plans/[ site ]` and `/start/plans`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?