### PR TITLE
Update copy for home domain upsell card

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -4,6 +4,7 @@ import {
 	isFreePlanProduct,
 	getIntervalTypeForTerm,
 	is100YearPlan,
+	domainProductSlugs,
 } from '@automattic/calypso-products';
 import { Button, Card, Gridicon } from '@automattic/components';
 import { useDomainSuggestions } from '@automattic/domain-picker/src';
@@ -16,6 +17,7 @@ import page from 'page';
 import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import domainUpsellIllustration from 'calypso/assets/images/customer-home/illustration--feature-domain-upsell.svg';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -25,6 +27,7 @@ import { isStagingSite } from 'calypso/sites-dashboard/utils';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getDomainsBySite } from 'calypso/state/sites/domains/selectors';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -113,6 +116,11 @@ export function RenderDomainUpsell( {
 	const domainSuggestionName = domainSuggestion?.domain_name ?? '';
 
 	const domainSuggestionProductSlug = domainSuggestion?.product_slug;
+
+	const domainRegistrationProduct = useSelector( ( state ) =>
+		getProductBySlug( state, domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION )
+	);
+	const domainProductCost = domainRegistrationProduct?.combined_cost_display;
 
 	const searchLink = addQueryArgs(
 		{
@@ -221,6 +229,7 @@ export function RenderDomainUpsell( {
 
 	return (
 		<Card className="domain-upsell__card customer-home__card">
+			<QueryProductsList />
 			<TrackComponentView eventName="calypso_my_home_domain_upsell_impression" />
 			<div>
 				<div className="domain-upsell__card-dismiss">
@@ -232,7 +241,19 @@ export function RenderDomainUpsell( {
 					</button>
 				</div>
 				<h3>{ cardTitle }</h3>
-				<p>{ cardSubtitle }</p>
+				<p className="domain-upsell-subtitle">{ cardSubtitle }</p>
+				{ domainProductCost && (
+					<p className="domain-upsell-description">
+						{ translate(
+							'Don’t worry about expensive domain renewals—.com, .net, and .org start at just %(domainPrice)s.',
+							{
+								args: {
+									domainPrice: domainProductCost,
+								},
+							}
+						) }
+					</p>
+				) }
 				<div className="domain-upsell-illustration">
 					{ illustrationHeader && <> { illustrationHeader } </> }
 					<img src={ domainUpsellIllustration } alt="" />

--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -37,6 +37,15 @@ body .customer-home__layout .domain-upsell__card {
 
 	}
 
+	.domain-upsell-subtitle {
+		margin-bottom: 12px;
+	}
+
+	.domain-upsell-description {
+		font-size: rem(14px);
+		font-style: italic;
+	}
+
 	.domain-upsell-actions {
 		display: flex;
 		flex-direction: column;

--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import DomainUpsell from '../';
 
 const initialState = {
@@ -52,6 +53,9 @@ const initialState = {
 			primary_blog: 1,
 		},
 	},
+	productsList: {
+		isFetching: false,
+	},
 };
 
 jest.mock( '@automattic/domain-picker/src', () => {
@@ -79,7 +83,7 @@ const searchForDomainCta = 'Search for a domain';
 
 describe( 'index', () => {
 	test( 'Should show H3 content for the Home domain upsell and test search domain button link', async () => {
-		const mockStore = configureStore();
+		const mockStore = configureStore( [ thunk ] );
 		const store = mockStore( initialState );
 
 		render(
@@ -108,7 +112,7 @@ describe( 'index', () => {
 			.post( '/rest/v1.1/me/shopping-cart/1' )
 			.reply( 200 );
 
-		const mockStore = configureStore();
+		const mockStore = configureStore( [ thunk ] );
 		const store = mockStore( initialState );
 
 		render(
@@ -153,7 +157,7 @@ describe( 'index', () => {
 			},
 		};
 
-		const mockStore = configureStore();
+		const mockStore = configureStore( [ thunk ] );
 		const store = mockStore( newInitialState );
 
 		render(
@@ -190,7 +194,7 @@ describe( 'index', () => {
 			},
 		};
 
-		const mockStore = configureStore();
+		const mockStore = configureStore( [ thunk ] );
 		const store = mockStore( newInitialState );
 
 		render(
@@ -245,7 +249,7 @@ describe( 'index', () => {
 			},
 		};
 
-		const mockStore = configureStore();
+		const mockStore = configureStore( [ thunk ] );
 		const store = mockStore( newInitialState );
 
 		render(
@@ -269,7 +273,7 @@ describe( 'index', () => {
 			},
 		};
 
-		const mockStore = configureStore();
+		const mockStore = configureStore( [ thunk ] );
 		const store = mockStore( newInitialState );
 
 		render(

--- a/test/e2e/specs/tools/advertising__promote.ts
+++ b/test/e2e/specs/tools/advertising__promote.ts
@@ -105,7 +105,7 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 
 		it( 'Enter title and snippet', async function () {
 			await blazeCampaignPage.enterText( 'Page title', pageTitle );
-			await blazeCampaignPage.enterText( 'Article Snippet', snippet );
+			await blazeCampaignPage.enterText( 'Ad text', snippet );
 		} );
 
 		it( 'Validate preview', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/4026

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/b8a66e77-928f-4f5e-b50c-0bcc4e8752d2">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/b2de0c16-83e0-4726-959d-0fa52c10521f">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to an unlaunched site's /home
* Check if the new copy is present

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?